### PR TITLE
Csv parser low memory usage

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -187,6 +187,7 @@ where
     schema_overwrite: Option<&'a Schema>,
     sample_size: usize,
     chunk_size: usize,
+    low_memory: bool,
 }
 
 impl<'a, R> CsvReader<'a, R>
@@ -302,6 +303,12 @@ where
         self
     }
 
+    /// Reduce memory consumption at the expense of performance
+    pub fn low_memory(mut self, toggle: bool) -> Self {
+        self.low_memory = toggle;
+        self
+    }
+
     pub fn build_inner_reader(self) -> Result<SequentialReader<R>> {
         build_csv_reader(
             self.reader,
@@ -320,6 +327,7 @@ where
             self.schema_overwrite,
             self.sample_size,
             self.chunk_size,
+            self.low_memory,
         )
     }
 }
@@ -357,6 +365,7 @@ where
             schema_overwrite: None,
             sample_size: 1024,
             chunk_size: 8192,
+            low_memory: false,
         }
     }
 
@@ -410,6 +419,7 @@ where
                 Some(&schema),
                 self.sample_size,
                 self.chunk_size,
+                self.low_memory,
             )?;
             let mut df = csv_reader.as_df(None, None)?;
 

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -33,6 +33,7 @@ pub struct LazyCsvReader<'a> {
     cache: bool,
     schema: Option<SchemaRef>,
     schema_overwrite: Option<&'a Schema>,
+    low_memory: bool,
 }
 
 impl<'a> LazyCsvReader<'a> {
@@ -47,6 +48,7 @@ impl<'a> LazyCsvReader<'a> {
             cache: true,
             schema: None,
             schema_overwrite: None,
+            low_memory: false,
         }
     }
 
@@ -100,6 +102,12 @@ impl<'a> LazyCsvReader<'a> {
         self
     }
 
+    /// Reduce memory usage in expensive of performance
+    pub fn low_memory(mut self, toggle: bool) -> Self {
+        self.low_memory = toggle;
+        self
+    }
+
     pub fn finish(self) -> LazyFrame {
         let mut lf: LazyFrame = LogicalPlanBuilder::scan_csv(
             self.path,
@@ -111,6 +119,7 @@ impl<'a> LazyCsvReader<'a> {
             self.cache,
             self.schema,
             self.schema_overwrite,
+            self.low_memory,
         )
         .build()
         .into();

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -41,6 +41,7 @@ pub enum ALogicalPlan {
         predicate: Option<Node>,
         aggregate: Vec<Node>,
         cache: bool,
+        low_memory: bool,
     },
     #[cfg(feature = "parquet")]
     ParquetScan {
@@ -350,6 +351,7 @@ impl ALogicalPlan {
                 with_columns,
                 predicate,
                 cache,
+                low_memory,
                 ..
             } => {
                 let mut new_predicate = None;
@@ -368,6 +370,7 @@ impl ALogicalPlan {
                     predicate: new_predicate,
                     aggregate: exprs,
                     cache: *cache,
+                    low_memory: *low_memory,
                 }
             }
             DataFrameScan {

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -173,6 +173,7 @@ pub(crate) fn to_alp(
             predicate,
             aggregate,
             cache,
+            low_memory,
         } => ALogicalPlan::CsvScan {
             path,
             schema,
@@ -188,6 +189,7 @@ pub(crate) fn to_alp(
                 .map(|expr| to_aexpr(expr, expr_arena))
                 .collect(),
             cache,
+            low_memory,
         },
         #[cfg(feature = "parquet")]
         LogicalPlan::ParquetScan {
@@ -623,6 +625,7 @@ pub(crate) fn node_to_lp(
             predicate,
             aggregate,
             cache,
+            low_memory,
         } => LogicalPlan::CsvScan {
             path,
             schema,
@@ -635,6 +638,7 @@ pub(crate) fn node_to_lp(
             predicate: predicate.map(|n| node_to_exp(n, expr_arena)),
             aggregate: nodes_to_exprs(&aggregate, expr_arena),
             cache,
+            low_memory,
         },
         #[cfg(feature = "parquet")]
         ALogicalPlan::ParquetScan {

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -158,6 +158,7 @@ pub enum LogicalPlan {
         /// Aggregations at the scan level
         aggregate: Vec<Expr>,
         cache: bool,
+        low_memory: bool,
     },
     #[cfg(feature = "parquet")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
@@ -273,6 +274,7 @@ impl Default for LogicalPlan {
             predicate: None,
             aggregate: vec![],
             cache: true,
+            low_memory: false,
         }
     }
 }
@@ -960,6 +962,7 @@ impl LogicalPlanBuilder {
         cache: bool,
         schema: Option<Arc<Schema>>,
         schema_overwrite: Option<&Schema>,
+        low_memory: bool,
     ) -> Self {
         let path = path.into();
         let mut file = std::fs::File::open(&path).expect("could not open file");
@@ -987,6 +990,7 @@ impl LogicalPlanBuilder {
             predicate: None,
             aggregate: vec![],
             cache,
+            low_memory,
         }
         .into()
     }

--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
@@ -124,6 +124,7 @@ impl OptimizationRule for AggregatePushdown {
                 predicate,
                 aggregate,
                 cache,
+                low_memory,
             } => match self.accumulated_projections.is_empty() {
                 true => {
                     lp_arena.replace(
@@ -140,6 +141,7 @@ impl OptimizationRule for AggregatePushdown {
                             predicate,
                             aggregate,
                             cache,
+                            low_memory,
                         },
                     );
                     None
@@ -158,6 +160,7 @@ impl OptimizationRule for AggregatePushdown {
                         predicate,
                         aggregate,
                         cache,
+                        low_memory,
                     })
                 }
             },

--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
@@ -155,6 +155,7 @@ impl OptimizationRule for AggScanProjection {
                     aggregate,
                     with_columns,
                     cache,
+                    low_memory,
                 } = lp
                 {
                     let new_with_columns = self
@@ -174,6 +175,7 @@ impl OptimizationRule for AggScanProjection {
                             aggregate,
                             with_columns,
                             cache,
+                            low_memory,
                         };
                         lp_arena.replace(node, lp);
                         return None;
@@ -190,6 +192,7 @@ impl OptimizationRule for AggScanProjection {
                         predicate,
                         aggregate,
                         cache,
+                        low_memory,
                     };
                     Some(self.finish_rewrite(lp, expr_arena, lp_arena, &path, with_columns))
                 } else {

--- a/polars/polars-lazy/src/logical_plan/optimizer/join_pruning.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/join_pruning.rs
@@ -122,6 +122,7 @@ fn combine_lp_nodes(
             predicate,
             aggregate,
             cache,
+            low_memory
         },
             CsvScan {path: path_r, with_columns: with_columns_r, ..})
         if canonicalize(path_l).unwrap() == canonicalize(path_r).unwrap()
@@ -145,7 +146,8 @@ fn combine_lp_nodes(
                 predicate: *predicate,
                 with_columns,
                 aggregate: aggregate.clone(),
-                cache: *cache
+                cache: *cache,
+                low_memory: *low_memory
             })
 
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
@@ -379,6 +379,7 @@ impl PredicatePushDown {
                 predicate,
                 aggregate,
                 cache,
+                low_memory,
             } => {
                 let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
 
@@ -394,6 +395,7 @@ impl PredicatePushDown {
                     predicate,
                     aggregate,
                     cache,
+                    low_memory,
                 };
                 Ok(lp)
             }

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -330,6 +330,7 @@ impl ProjectionPushDown {
                 predicate,
                 aggregate,
                 cache,
+                low_memory,
                 ..
             } => {
                 let with_columns = get_scan_columns(&mut acc_projections, expr_arena);
@@ -345,6 +346,7 @@ impl ProjectionPushDown {
                     predicate,
                     aggregate,
                     cache,
+                    low_memory,
                 };
                 Ok(lp)
             }

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -121,48 +121,18 @@ impl Executor for ParquetExec {
 }
 
 pub struct CsvExec {
-    path: PathBuf,
-    schema: SchemaRef,
-    has_header: bool,
-    delimiter: u8,
-    ignore_errors: bool,
-    skip_rows: usize,
-    stop_after_n_rows: Option<usize>,
-    with_columns: Option<Vec<String>>,
-    predicate: Option<Arc<dyn PhysicalExpr>>,
-    aggregate: Vec<ScanAggregation>,
-    cache: bool,
-}
-
-impl CsvExec {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        path: PathBuf,
-        schema: SchemaRef,
-        has_header: bool,
-        delimiter: u8,
-        ignore_errors: bool,
-        skip_rows: usize,
-        stop_after_n_rows: Option<usize>,
-        with_columns: Option<Vec<String>>,
-        predicate: Option<Arc<dyn PhysicalExpr>>,
-        aggregate: Vec<ScanAggregation>,
-        cache: bool,
-    ) -> Self {
-        CsvExec {
-            path,
-            schema,
-            has_header,
-            delimiter,
-            ignore_errors,
-            skip_rows,
-            stop_after_n_rows,
-            with_columns,
-            predicate,
-            aggregate,
-            cache,
-        }
-    }
+    pub path: PathBuf,
+    pub schema: SchemaRef,
+    pub has_header: bool,
+    pub delimiter: u8,
+    pub ignore_errors: bool,
+    pub skip_rows: usize,
+    pub stop_after_n_rows: Option<usize>,
+    pub with_columns: Option<Vec<String>>,
+    pub predicate: Option<Arc<dyn PhysicalExpr>>,
+    pub aggregate: Vec<ScanAggregation>,
+    pub cache: bool,
+    pub low_memory: bool,
 }
 
 impl Executor for CsvExec {
@@ -201,6 +171,7 @@ impl Executor for CsvExec {
             .with_skip_rows(self.skip_rows)
             .with_stop_after_n_rows(stop_after_n_rows)
             .with_columns(with_columns)
+            .low_memory(self.low_memory)
             .with_encoding(CsvEncoding::LossyUtf8);
 
         let aggregate = if self.aggregate.is_empty() {

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -127,12 +127,13 @@ impl DefaultPlanner {
                 predicate,
                 aggregate,
                 cache,
+                low_memory,
             } => {
                 let predicate = predicate
                     .map(|pred| self.create_physical_expr(pred, Context::Default, expr_arena))
                     .map_or(Ok(None), |v| v.map(Some))?;
                 let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
-                Ok(Box::new(CsvExec::new(
+                Ok(Box::new(CsvExec {
                     path,
                     schema,
                     has_header,
@@ -144,7 +145,8 @@ impl DefaultPlanner {
                     predicate,
                     aggregate,
                     cache,
-                )))
+                    low_memory,
+                }))
             }
             #[cfg(feature = "parquet")]
             ParquetScan {

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -129,6 +129,7 @@ class DataFrame:
         encoding: str = "utf8",
         n_threads: Optional[int] = None,
         dtype: "Optional[Dict[str, DataType]]" = None,
+        low_memory: bool = False,
     ) -> "DataFrame":
         """
         Read a CSV file into a Dataframe.
@@ -185,6 +186,7 @@ class DataFrame:
             n_threads,
             path,
             dtype,
+            low_memory,
         )
         return self
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -96,6 +96,7 @@ def read_csv(
     dtype: "Optional[Dict[str, DataType]]" = None,
     new_columns: "Optional[List[str]]" = None,
     use_pyarrow: bool = True,
+    low_memory: bool = False,
 ) -> "DataFrame":
     """
     Read into a DataFrame from a csv file.
@@ -137,6 +138,8 @@ def read_csv(
         Overwrite the dtypes during inference
     use_pyarrow
         Use pyarrow's native CSV parser.
+    low_memory
+        Reduce memory usage in expense of performance
 
     Returns
     -------
@@ -155,6 +158,7 @@ def read_csv(
         and not ignore_errors
         and n_threads is None
         and encoding == "utf8"
+        and not low_memory
     ):
         tbl = pa.csv.read_csv(file, pa.csv.ReadOptions(skip_rows=skip_rows))
         return from_arrow(tbl, rechunk)
@@ -174,6 +178,7 @@ def read_csv(
         encoding=encoding,
         n_threads=n_threads,
         dtype=dtype,
+        low_memory=low_memory,
     )
     if new_columns:
         df.columns = new_columns

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -74,6 +74,7 @@ impl PyDataFrame {
         mut n_threads: Option<usize>,
         path: Option<String>,
         overwrite_dtype: Option<Vec<(&str, &PyAny)>>,
+        low_memory: bool
     ) -> PyResult<Self> {
         let encoding = match encoding {
             "utf8" => CsvEncoding::Utf8,
@@ -122,6 +123,7 @@ impl PyDataFrame {
             .with_n_threads(n_threads)
             .with_path(path)
             .with_dtypes(overwrite_dtype.as_ref())
+            .low_memory(low_memory)
             .finish()
             .map_err(PyPolarsEr::from)?;
         Ok(df.into())


### PR DESCRIPTION
This PR adds an option to turn off utf8-parsing statistics and thereby reducing memory usage.

Later, we can add shrink to fit calls as well.