### PR TITLE
WIP: Partitioned groupby algorithm

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -19,7 +19,6 @@ pub use arrow::datatypes::{
 };
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::ops::Add;
 
 pub struct Utf8Type {}
 
@@ -263,11 +262,13 @@ impl From<i32> for AnyValue<'_> {
     }
 }
 impl<'a, T> From<Option<T>> for AnyValue<'a>
-where T: Into<AnyValue<'a>> {
+where
+    T: Into<AnyValue<'a>>,
+{
     fn from(a: Option<T>) -> Self {
         match a {
             None => AnyValue::Null,
-            Some(v) => v.into()
+            Some(v) => v.into(),
         }
     }
 }
@@ -284,7 +285,7 @@ impl<'a> AnyValue<'a> {
             (UInt64(l), UInt64(r)) => UInt64(l + r),
             (Float32(l), Float32(r)) => Float32(l + r),
             (Float64(l), Float64(r)) => Float64(l + r),
-            _ => todo!()
+            _ => todo!(),
         }
     }
 }
@@ -297,7 +298,7 @@ impl Into<Option<i64>> for AnyValue<'_> {
             Int32(v) => Some(v as i64),
             Int64(v) => Some(v as i64),
             UInt32(v) => Some(v as i64),
-            _ => todo!()
+            _ => todo!(),
         }
     }
 }

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -19,6 +19,7 @@ pub use arrow::datatypes::{
 };
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
+use std::ops::Add;
 
 pub struct Utf8Type {}
 
@@ -229,6 +230,63 @@ pub enum AnyValue<'a> {
     #[cfg(feature = "object")]
     /// Use as_any to get a dyn Any
     Object(&'a str),
+}
+
+impl From<f64> for AnyValue<'_> {
+    fn from(a: f64) -> Self {
+        AnyValue::Float64(a)
+    }
+}
+impl From<f32> for AnyValue<'_> {
+    fn from(a: f32) -> Self {
+        AnyValue::Float32(a)
+    }
+}
+impl From<u32> for AnyValue<'_> {
+    fn from(a: u32) -> Self {
+        AnyValue::UInt32(a)
+    }
+}
+impl From<u64> for AnyValue<'_> {
+    fn from(a: u64) -> Self {
+        AnyValue::UInt64(a)
+    }
+}
+impl From<i64> for AnyValue<'_> {
+    fn from(a: i64) -> Self {
+        AnyValue::Int64(a)
+    }
+}
+impl From<i32> for AnyValue<'_> {
+    fn from(a: i32) -> Self {
+        AnyValue::Int32(a)
+    }
+}
+impl<'a, T> From<Option<T>> for AnyValue<'a>
+where T: Into<AnyValue<'a>> {
+    fn from(a: Option<T>) -> Self {
+        match a {
+            None => AnyValue::Null,
+            Some(v) => v.into()
+        }
+    }
+}
+
+impl<'a> AnyValue<'a> {
+    pub fn add<'b>(&self, rhs: &AnyValue<'b>) -> AnyValue<'a> {
+        use AnyValue::*;
+        match (self, rhs) {
+            (Null, _) => Null,
+            (_, Null) => Null,
+            (Int32(l), Int32(r)) => Int32(l + r),
+            (Int64(l), Int64(r)) => Int64(l + r),
+            (UInt32(l), UInt32(r)) => UInt32(l + r),
+            (UInt64(l), UInt64(r)) => UInt64(l + r),
+            (Float32(l), Float32(r)) => Float32(l + r),
+            (Float64(l), Float64(r)) => Float64(l + r),
+            _ => todo!()
+        }
+    }
 }
 
 impl Display for DataType {

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -261,6 +261,28 @@ impl From<i32> for AnyValue<'_> {
         AnyValue::Int32(a)
     }
 }
+impl From<i16> for AnyValue<'_> {
+    fn from(a: i16) -> Self {
+        AnyValue::Int16(a)
+    }
+}
+impl From<u16> for AnyValue<'_> {
+    fn from(a: u16) -> Self {
+        AnyValue::UInt16(a)
+    }
+}
+
+impl From<i8> for AnyValue<'_> {
+    fn from(a: i8) -> Self {
+        AnyValue::Int8(a)
+    }
+}
+impl From<u8> for AnyValue<'_> {
+    fn from(a: u8) -> Self {
+        AnyValue::UInt8(a)
+    }
+}
+
 impl<'a, T> From<Option<T>> for AnyValue<'a>
 where
     T: Into<AnyValue<'a>>,
@@ -290,10 +312,10 @@ impl<'a> AnyValue<'a> {
     }
 }
 
-impl Into<Option<i64>> for AnyValue<'_> {
-    fn into(self) -> Option<i64> {
+impl<'a> From<AnyValue<'a>> for Option<i64> {
+    fn from(val: AnyValue<'a>) -> Self {
         use AnyValue::*;
-        match self {
+        match val {
             Null => None,
             Int32(v) => Some(v as i64),
             Int64(v) => Some(v as i64),

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -289,6 +289,19 @@ impl<'a> AnyValue<'a> {
     }
 }
 
+impl Into<Option<i64>> for AnyValue<'_> {
+    fn into(self) -> Option<i64> {
+        use AnyValue::*;
+        match self {
+            Null => None,
+            Int32(v) => Some(v as i64),
+            Int64(v) => Some(v as i64),
+            UInt32(v) => Some(v as i64),
+            _ => todo!()
+        }
+    }
+}
+
 impl Display for DataType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = match self {

--- a/polars/polars-core/src/frame/groupby/partition/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/partition/aggregations.rs
@@ -3,10 +3,8 @@ use crate::chunked_array::kernels::take_agg::{
 };
 use crate::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupedMap};
 use crate::prelude::*;
-use crate::utils::{CustomIterTools, NoNull};
 use crate::POOL;
 use ahash::RandomState;
-use arrow::ipc::Utf8;
 use hashbrown::HashMap;
 use num::{Bounded, Num, NumCast, Zero};
 use rayon::prelude::*;
@@ -55,9 +53,9 @@ impl AggState for SumAggState {
         while let Some(agg) = stack.pop() {
             for (k, l) in agg.iter_mut() {
                 for tbl in other.iter_mut() {
-                    tbl.agg[0].remove(k).map(|r| {
+                    if let Some(r) = tbl.agg[0].remove(k) {
                         *l = (l.0, l.1.add(&r.1));
-                    });
+                    }
                 }
             }
 

--- a/polars/polars-core/src/frame/groupby/partition/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/partition/aggregations.rs
@@ -1,36 +1,40 @@
-use crate::prelude::*;
-use super::*;
+use crate::chunked_array::kernels::take_agg::{
+    take_agg_no_null_primitive_iter_unchecked, take_agg_primitive_iter_unchecked,
+};
 use crate::frame::groupby::GroupedMap;
-use num::{Bounded, NumCast, Num, ToPrimitive, Zero};
-use rayon::prelude::*;
+use crate::prelude::*;
+use crate::utils::{CustomIterTools, NoNull};
 use crate::POOL;
-use crate::chunked_array::kernels::take_agg::{take_agg_no_null_primitive_iter_unchecked, take_agg_primitive_iter_unchecked_count_nulls};
-use hashbrown::HashMap;
 use ahash::RandomState;
+use hashbrown::HashMap;
+use num::{Bounded, Num, NumCast, Zero};
+use rayon::prelude::*;
 use std::any::Any;
 
-pub type AggMap = HashMap<Option<u64>, AnyValue<'static>, RandomState>;
-
 pub trait AggState {
-    fn merge(&mut self, other: Vec<&mut dyn AggState>);
+    fn merge(&mut self, other: Vec<Box<dyn AggState>>);
     fn as_any(&mut self) -> &mut dyn Any;
-    fn finish(self, dtype: DataType) -> Series;
+    fn keys(&self) -> UInt32Chunked;
+    fn finish(&mut self, dtype: DataType) -> Series;
 }
 
+// u32: an index of the group (can be used to get the keys)
+// AnyValue: the aggregation
+pub type AggMap = HashMap<Option<u64>, (u32, AnyValue<'static>), RandomState>;
 
 pub struct SumAggState {
-    agg: Vec<AggMap>
+    agg: Vec<AggMap>,
 }
 
 impl AggState for SumAggState {
-    fn merge(&mut self, other: Vec<&mut dyn AggState>) {
-
+    fn merge(&mut self, mut other: Vec<Box<dyn AggState>>) {
         let mut finished = Vec::with_capacity(other.len() + 1);
         let mut stack = Vec::with_capacity(other.len());
         stack.push(&mut self.agg[0]);
-        let mut other: Vec<_> = other.into_iter().map(|tbl| {
-            tbl.as_any().downcast_mut::<SumAggState>().unwrap()
-        }).collect();
+        let mut other: Vec<_> = other
+            .iter_mut()
+            .map(|tbl| tbl.as_any().downcast_mut::<SumAggState>().unwrap())
+            .collect();
 
         // Go from left to right
         // take keys from left and traverse other maps to collect and remove the values.
@@ -44,14 +48,16 @@ impl AggState for SumAggState {
             for (k, l) in agg.iter_mut() {
                 for tbl in other.iter_mut() {
                     tbl.agg[0].remove(k).map(|r| {
-                        *l = l.add(&r);
+                        *l = (l.0, l.1.add(&r.1));
                     });
                 }
+            }
 
-                if let Some(o) = other.pop() {
-                    stack.push(&mut o.agg[0])
-                }
-            };
+            // pop from the probe tables and add to the stack so it will be used
+            // next as the left table
+            if let Some(o) = other.pop() {
+                stack.push(&mut o.agg[0])
+            }
             finished.push(std::mem::take(agg));
         }
         self.agg = finished;
@@ -61,79 +67,87 @@ impl AggState for SumAggState {
         self
     }
 
-    fn finish(self, dtype: DataType) -> Series {
+    fn keys(&self) -> UInt32Chunked {
+        let len = self.agg.iter().map(|tbl| tbl.len()).sum();
+        let ca: NoNull<UInt32Chunked> = self
+            .agg
+            .iter()
+            .map(|tbl| tbl.iter().map(|(_, v)| v.0))
+            .flatten()
+            .trust_my_length(len)
+            .collect();
+        ca.into_inner()
+    }
+
+    fn finish(&mut self, dtype: DataType) -> Series {
         match dtype {
-            DataType::Int64 => {
-                self.agg.into_iter()
-                    .map(|tbl| tbl.into_iter().map(|(_, v)| {
-                        let i: Option<i64> = v.into();
+            DataType::Int64 => self
+                .agg
+                .iter()
+                .map(|tbl| {
+                    tbl.iter().map(|(_, v)| {
+                        let i: Option<i64> = v.1.clone().into();
                         i
-                    })).flatten().collect()
-            }
-            _ => todo!()
+                    })
+                })
+                .flatten()
+                .collect(),
+            _ => todo!(),
         }
     }
 }
 
 pub(crate) trait PartitionAgg {
-    fn agg_sum(&self, _groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+    fn part_agg_sum(&self, _groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
         None
     }
 }
 
-
 impl<T> PartitionAgg for ChunkedArray<T>
-    where
-        T: PolarsNumericType + Sync,
-        T::Native: std::ops::Add<Output = T::Native> + Num + NumCast + Bounded + Into<AnyValue<'static>>,
-        ChunkedArray<T>: IntoSeries,
+where
+    T: PolarsNumericType + Sync,
+    T::Native:
+        std::ops::Add<Output = T::Native> + Num + NumCast + Bounded + Into<AnyValue<'static>>,
+    ChunkedArray<T>: IntoSeries,
 {
-
-    fn agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+    fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
         let agg: AggMap = POOL.install(|| {
-            groups.into_par_iter()
+            groups
+                .into_par_iter()
                 .map(|(k, (first, idx))| {
                     let agg = if idx.len() == 1 {
-                        self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
+                        self.get(*first as usize)
                     } else {
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => unsafe {
-                                take_agg_no_null_primitive_iter_unchecked(
+                                Some(take_agg_no_null_primitive_iter_unchecked(
                                     self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
-                                )
-                            }
-                                .to_f64()
-                                .map(|sum| sum / idx.len() as f64),
+                                ))
+                            },
                             (_, 1) => unsafe {
-                                take_agg_primitive_iter_unchecked_count_nulls(
+                                take_agg_primitive_iter_unchecked(
                                     self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
                                 )
-                            }
-                                .map(|(sum, null_count)| {
-                                    sum.to_f64()
-                                        .map(|sum| sum / (idx.len() as f64 - null_count as f64))
-                                        .unwrap()
-                                }),
+                            },
                             _ => {
-                                let take =
-                                    unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                                let opt_sum: Option<T::Native> = take.sum();
-                                opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                                let take = unsafe {
+                                    self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                                };
+                                take.sum()
                             }
                         }
                     };
-                    (*k, agg.into())
-                }).collect()
+                    (*k, (*first, agg.into()))
+                })
+                .collect()
         });
 
-        Some(Box::new(SumAggState {
-            agg: vec![agg]
-        }))
+        Some(Box::new(SumAggState { agg: vec![agg] }))
     }
 }

--- a/polars/polars-core/src/frame/groupby/partition/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/partition/aggregations.rs
@@ -1,0 +1,127 @@
+use crate::prelude::*;
+use super::*;
+use crate::frame::groupby::GroupedMap;
+use num::{Bounded, NumCast, Num, ToPrimitive, Zero};
+use rayon::prelude::*;
+use crate::POOL;
+use crate::chunked_array::kernels::take_agg::{take_agg_no_null_primitive_iter_unchecked, take_agg_primitive_iter_unchecked_count_nulls};
+use hashbrown::HashMap;
+use ahash::RandomState;
+use std::any::Any;
+
+pub type AggMap = HashMap<Option<u64>, AnyValue<'static>, RandomState>;
+
+pub trait AggState {
+    fn merge(&mut self, other: Vec<&mut dyn AggState>);
+    fn as_any(&mut self) -> &mut dyn Any;
+    fn finish(self) -> Series;
+}
+
+
+pub struct SumAggState {
+    agg: AggMap
+}
+
+impl AggState for SumAggState {
+    fn merge(&mut self, other: Vec<&mut dyn AggState>) {
+
+        let mut stack = Vec::with_capacity(other.len());
+        stack.push(&mut self.agg);
+        let mut other: Vec<_> = other.into_iter().map(|tbl| {
+            tbl.as_any().downcast_mut::<SumAggState>().unwrap()
+        }).collect();
+
+        // Go from left to right
+        // take keys from left and traverse other maps to collect and remove the values.
+        // so if "foo" is in the first hashtable it will be removed from the others and added
+        // to the left table
+        // In a next hashtable we might find "bar", but we know it is not in the tables we already
+        // visited, otherwise it would have been removed
+        //
+        // in the end all hash tables should have unique keys.
+        while let Some(agg) = stack.pop() {
+            for (k, l) in agg.iter_mut() {
+                for tbl in other.iter_mut() {
+                    tbl.agg.remove(k).map(|r| {
+                        *l = l.add(&r);
+                    });
+                }
+
+                if let Some(o) = other.pop() {
+                    stack.push(&mut o.agg)
+                }
+            };
+        }
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn finish(self) -> Series {
+        todo!()
+    }
+}
+
+pub(crate) trait PartitionAgg {
+    fn agg_sum(&self, _groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+        None
+    }
+}
+
+
+impl<T> PartitionAgg for ChunkedArray<T>
+    where
+        T: PolarsNumericType + Sync,
+        T::Native: std::ops::Add<Output = T::Native> + Num + NumCast + Bounded + Into<AnyValue<'static>>,
+        ChunkedArray<T>: IntoSeries,
+{
+
+    fn agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+        let agg: AggMap = POOL.install(|| {
+            groups.into_par_iter()
+                .map(|(k, (first, idx))| {
+                    let agg = if idx.len() == 1 {
+                        self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
+                    } else {
+                        match (self.null_count(), self.chunks.len()) {
+                            (0, 1) => unsafe {
+                                take_agg_no_null_primitive_iter_unchecked(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                                .to_f64()
+                                .map(|sum| sum / idx.len() as f64),
+                            (_, 1) => unsafe {
+                                take_agg_primitive_iter_unchecked_count_nulls(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                                .map(|(sum, null_count)| {
+                                    sum.to_f64()
+                                        .map(|sum| sum / (idx.len() as f64 - null_count as f64))
+                                        .unwrap()
+                                }),
+                            _ => {
+                                let take =
+                                    unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                                let opt_sum: Option<T::Native> = take.sum();
+                                opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                            }
+                        }
+                    };
+                    (*k, agg.into())
+                }).collect()
+        });
+
+        Some(Box::new(SumAggState {
+            agg
+        }))
+    }
+}

--- a/polars/polars-core/src/frame/groupby/partition/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/partition/aggregations.rs
@@ -15,7 +15,6 @@ use std::any::Any;
 pub trait AggState {
     fn merge(&mut self, other: Vec<Box<dyn AggState>>);
     fn as_any(&mut self) -> &mut dyn Any;
-    fn keys(&self) -> UInt32Chunked;
     fn finish(&mut self, dtype: DataType) -> Series;
 }
 
@@ -72,18 +71,6 @@ impl AggState for SumAggState {
 
     fn as_any(&mut self) -> &mut dyn Any {
         self
-    }
-
-    fn keys(&self) -> UInt32Chunked {
-        let len = self.agg.iter().map(|tbl| tbl.len()).sum();
-        let ca: NoNull<UInt32Chunked> = self
-            .agg
-            .iter()
-            .map(|tbl| tbl.iter().map(|(_, v)| v.0))
-            .flatten()
-            .trust_my_length(len)
-            .collect();
-        ca.into_inner()
     }
 
     fn finish(&mut self, dtype: DataType) -> Series {

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -11,7 +11,7 @@ pub fn group_maps_to_group_index(g_maps: &[GroupedMap<Option<u64>>]) -> UInt32Ch
     let len = g_maps.iter().map(|tbl| tbl.len()).sum();
     let ca: NoNull<UInt32Chunked> = g_maps
         .iter()
-        .map(|tbl| tbl.iter().map(|(_, v)| v.0))
+        .map(|tbl| tbl.iter().map(|(_, v)| v[0]))
         .flatten()
         .trust_my_length(len)
         .collect();

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -4,6 +4,7 @@ use crate::frame::groupby::GroupedMap;
 use crate::prelude::UInt32Chunked;
 use crate::utils::{CustomIterTools, NoNull};
 pub use aggregations::{AggState, PartitionAgg};
+pub use split::IntoGroupMap;
 
 /// Get an index per group
 pub fn group_maps_to_group_index(g_maps: &[GroupedMap<Option<u64>>]) -> UInt32Chunked {
@@ -46,7 +47,7 @@ mod test {
         let keys_idx = group_maps_to_group_index(&g_maps);
         let key_sort = keys_idx.argsort(false);
         let keys = df.column("groups")?.take(&keys_idx.sort(false));
-        let values = first.finish(ca.dtype().clone()).take(&key_sort);
+        let values = first.finish().take(&key_sort);
 
         assert_eq!(Vec::from(keys.u32()?), [Some(1), Some(2), Some(3)]);
         assert_eq!(Vec::from(values.i64()?), [Some(7), Some(9), Some(5)]);

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -1,0 +1,2 @@
+mod split;
+mod aggregations;

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -43,7 +43,7 @@ mod test {
         let mut iter = g_maps.iter().map(|g_map| ca.part_agg_sum(g_map));
         let mut first = iter.next().unwrap().unwrap();
 
-        first.merge(iter.filter_map(|v| v).collect());
+        first.merge(iter.flatten().collect());
         let keys_idx = group_maps_to_group_index(&g_maps);
         let key_sort = keys_idx.argsort(false);
         let keys = df.column("groups")?.take(&keys_idx.sort(false));

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -1,5 +1,6 @@
 mod aggregations;
 mod split;
+pub use aggregations::{AggState, PartitionAgg};
 
 #[cfg(test)]
 mod test {

--- a/polars/polars-core/src/frame/groupby/partition/mod.rs
+++ b/polars/polars-core/src/frame/groupby/partition/mod.rs
@@ -1,2 +1,39 @@
-mod split;
 mod aggregations;
+mod split;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::df;
+    use crate::prelude::*;
+    use aggregations::PartitionAgg;
+    use split::IntoGroupMap;
+
+    #[test]
+    fn test_partition_groups() -> Result<()> {
+        // 1: 1, 2, 4
+        // 2: 3, 6
+        // 3: 5
+        let df = df![
+            "groups" => [1u32, 1, 2, 1, 3, 2],
+            "vals" => [1i64, 2, 3, 4, 5, 6]
+        ]?;
+
+        let g_maps = df.column("groups")?.u32()?.group_maps();
+
+        let ca = df.column("vals")?.i64()?;
+
+        let mut iter = g_maps.iter().map(|g_map| ca.part_agg_sum(g_map));
+        let mut first = iter.next().unwrap().unwrap();
+
+        first.merge(iter.filter_map(|v| v).collect());
+        let keys_idx = first.keys();
+        let key_sort = keys_idx.argsort(false);
+        let keys = df.column("groups")?.take(&keys_idx.sort(false));
+        let values = first.finish(ca.dtype().clone()).take(&key_sort);
+
+        assert_eq!(Vec::from(keys.u32()?), [Some(1), Some(2), Some(3)]);
+        assert_eq!(Vec::from(values.i64()?), [Some(7), Some(9), Some(5)]);
+        Ok(())
+    }
+}

--- a/polars/polars-core/src/frame/groupby/partition/split.rs
+++ b/polars/polars-core/src/frame/groupby/partition/split.rs
@@ -81,8 +81,23 @@ impl ToBitRepr for u8 {
 }
 
 pub trait IntoGroupMap<T> {
-    fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>>;
+    fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+        unimplemented!()
+    }
 }
+impl IntoGroupMap<bool> for BooleanChunked {}
+impl IntoGroupMap<String> for Utf8Chunked {}
+impl IntoGroupMap<Series> for ListChunked {}
+impl IntoGroupMap<f32> for Float32Chunked {}
+impl IntoGroupMap<f64> for Float64Chunked {}
+
+impl IntoGroupMap<u32> for CategoricalChunked {
+    fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+        self.cast::<UInt32Type>().unwrap().group_maps()
+    }
+}
+#[cfg(feature = "object")]
+impl<T> IntoGroupMap<T> for ObjectChunked<T> {}
 
 impl<T> IntoGroupMap<T::Native> for ChunkedArray<T>
 where

--- a/polars/polars-core/src/frame/groupby/partition/split.rs
+++ b/polars/polars-core/src/frame/groupby/partition/split.rs
@@ -1,0 +1,93 @@
+use crate::frame::groupby::{groupby_threaded, GroupedMap};
+use crate::prelude::*;
+use crate::utils::split_ca;
+use crate::vector_hasher::create_hash_and_keys_threaded_vectorized;
+use crate::POOL;
+use ahash::RandomState;
+use hashbrown::hash_map::RawEntryMut;
+use hashbrown::HashMap;
+use rayon::prelude::*;
+use std::hash::Hash;
+
+pub trait ToBitRepr {
+    fn to_bit_repr(self) -> u64;
+}
+
+impl ToBitRepr for f64 {
+    fn to_bit_repr(self) -> u64 {
+        self.to_bits()
+    }
+}
+
+impl ToBitRepr for f32 {
+    fn to_bit_repr(self) -> u64 {
+        self.to_bits() as u64
+    }
+}
+
+impl ToBitRepr for u32 {
+    fn to_bit_repr(self) -> u64 {
+        self as u64
+    }
+}
+
+impl ToBitRepr for u64 {
+    fn to_bit_repr(self) -> u64 {
+        self
+    }
+}
+
+impl ToBitRepr for i32 {
+    fn to_bit_repr(self) -> u64 {
+        let a: u32 = unsafe { std::mem::transmute(self) };
+        a.to_bit_repr()
+    }
+}
+
+impl ToBitRepr for i64 {
+    fn to_bit_repr(self) -> u64 {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+pub trait IntoGroupMap<T> {
+    fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>>;
+}
+
+impl<T> IntoGroupMap<T::Native> for ChunkedArray<T>
+where
+    T: PolarsIntegerType,
+    T::Native: Eq + Hash + Send + Copy + ToBitRepr,
+{
+    fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+        let group_size_hint = if let Some(m) = &self.categorical_map {
+            self.len() / m.len()
+        } else {
+            0
+        };
+        {
+            let n_threads = num_cpus::get();
+            let splitted = split_ca(self, n_threads).unwrap();
+
+            if self.chunks.len() == 1 {
+                let iters = splitted
+                    .iter()
+                    .map(|ca| {
+                        ca.downcast_iter()
+                            .map(|arr| arr.into_iter().map(|opt_v| opt_v.map(|v| v.to_bit_repr())))
+                    })
+                    .flatten()
+                    .collect();
+                groupby_threaded(iters, group_size_hint)
+            } else {
+                let iters = splitted
+                    .iter()
+                    .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bit_repr())))
+                    .collect();
+                groupby_threaded(iters, group_size_hint)
+            }
+        }
+    }
+}
+
+

--- a/polars/polars-core/src/frame/groupby/partition/split.rs
+++ b/polars/polars-core/src/frame/groupby/partition/split.rs
@@ -44,8 +44,39 @@ impl ToBitRepr for i32 {
 }
 
 impl ToBitRepr for i64 {
+    #[inline]
     fn into_bit_repr(self) -> u64 {
         unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl ToBitRepr for i16 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
+        let a: u16 = unsafe { std::mem::transmute(self) };
+        a.into_bit_repr()
+    }
+}
+
+impl ToBitRepr for u16 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
+        self as u64
+    }
+}
+
+impl ToBitRepr for i8 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
+        let a: u8 = unsafe { std::mem::transmute(self) };
+        a.into_bit_repr()
+    }
+}
+
+impl ToBitRepr for u8 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
+        self as u64
     }
 }
 

--- a/polars/polars-core/src/frame/groupby/partition/split.rs
+++ b/polars/polars-core/src/frame/groupby/partition/split.rs
@@ -1,51 +1,50 @@
 use crate::frame::groupby::{groupby_threaded, GroupedMap};
 use crate::prelude::*;
 use crate::utils::split_ca;
-use crate::vector_hasher::create_hash_and_keys_threaded_vectorized;
-use crate::POOL;
-use ahash::RandomState;
-use hashbrown::hash_map::RawEntryMut;
-use hashbrown::HashMap;
-use rayon::prelude::*;
 use std::hash::Hash;
 
 pub trait ToBitRepr {
-    fn to_bit_repr(self) -> u64;
+    fn into_bit_repr(self) -> u64;
 }
 
 impl ToBitRepr for f64 {
-    fn to_bit_repr(self) -> u64 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
         self.to_bits()
     }
 }
 
 impl ToBitRepr for f32 {
-    fn to_bit_repr(self) -> u64 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
         self.to_bits() as u64
     }
 }
 
 impl ToBitRepr for u32 {
-    fn to_bit_repr(self) -> u64 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
         self as u64
     }
 }
 
 impl ToBitRepr for u64 {
-    fn to_bit_repr(self) -> u64 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
         self
     }
 }
 
 impl ToBitRepr for i32 {
-    fn to_bit_repr(self) -> u64 {
+    #[inline]
+    fn into_bit_repr(self) -> u64 {
         let a: u32 = unsafe { std::mem::transmute(self) };
-        a.to_bit_repr()
+        a.into_bit_repr()
     }
 }
 
 impl ToBitRepr for i64 {
-    fn to_bit_repr(self) -> u64 {
+    fn into_bit_repr(self) -> u64 {
         unsafe { std::mem::transmute(self) }
     }
 }
@@ -73,8 +72,10 @@ where
                 let iters = splitted
                     .iter()
                     .map(|ca| {
-                        ca.downcast_iter()
-                            .map(|arr| arr.into_iter().map(|opt_v| opt_v.map(|v| v.to_bit_repr())))
+                        ca.downcast_iter().map(|arr| {
+                            arr.into_iter()
+                                .map(|opt_v| opt_v.map(|v| v.into_bit_repr()))
+                        })
                     })
                     .flatten()
                     .collect();
@@ -82,12 +83,10 @@ where
             } else {
                 let iters = splitted
                     .iter()
-                    .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bit_repr())))
+                    .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.into_bit_repr())))
                     .collect();
                 groupby_threaded(iters, group_size_hint)
             }
         }
     }
 }
-
-

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -241,6 +241,9 @@ macro_rules! impl_dyn_series {
             fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
                 cast_and_apply!(self, part_agg_sum, groups)
             }
+            fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+                cast_and_apply!(self, group_maps,)
+            }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -15,6 +15,7 @@ use crate::fmt::FmtList;
 #[cfg(feature = "pivot")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
+use crate::frame::groupby::{partition::*, GroupedMap};
 use crate::prelude::*;
 use ahash::RandomState;
 use arrow::array::{ArrayData, ArrayRef};
@@ -236,6 +237,9 @@ macro_rules! impl_dyn_series {
                 self.0
                     .unpack_series_matching_type(&s)?
                     .argsort_multiple(by, reverse)
+            }
+            fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+                cast_and_apply!(self, part_agg_sum, groups)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -21,6 +21,7 @@ use crate::fmt::FmtList;
 #[cfg(feature = "pivot")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
+use crate::frame::groupby::{partition::*, GroupedMap};
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
 use crate::prelude::*;
 use ahash::RandomState;
@@ -179,6 +180,9 @@ macro_rules! impl_dyn_series {
             #[cfg(feature = "sort_multiple")]
             fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
                 self.0.argsort_multiple(by, reverse)
+            }
+            fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+                self.0.part_agg_sum(groups)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -181,6 +181,9 @@ macro_rules! impl_dyn_series {
             fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
                 self.0.argsort_multiple(by, reverse)
             }
+            fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+                self.0.group_maps()
+            }
             fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
                 self.0.part_agg_sum(groups)
             }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod private {
     use super::*;
     #[cfg(feature = "pivot")]
     use crate::frame::groupby::pivot::PivotAgg;
-    use crate::frame::groupby::GroupTuples;
+    use crate::frame::groupby::{partition::AggState, GroupTuples, GroupedMap};
 
     use ahash::RandomState;
 
@@ -144,6 +144,9 @@ pub(crate) mod private {
             Err(PolarsError::InvalidOperation(
                 "argsort_multiple is not implemented for this Series".into(),
             ))
+        }
+        fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+            unimplemented!()
         }
     }
 }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -145,6 +145,9 @@ pub(crate) mod private {
                 "argsort_multiple is not implemented for this Series".into(),
             ))
         }
+        fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
+            unimplemented!()
+        }
         fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
             unimplemented!()
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -148,7 +148,7 @@ pub(crate) mod private {
         fn group_maps(&self) -> Vec<GroupedMap<Option<u64>>> {
             unimplemented!()
         }
-        fn part_agg_sum(&self, groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
+        fn part_agg_sum(&self, _groups: &GroupedMap<Option<u64>>) -> Option<Box<dyn AggState>> {
             unimplemented!()
         }
     }

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -228,16 +228,21 @@ where
         .enumerate()
         .for_each(|(idx, (h, t))| {
             let idx = (idx + offset) as u32;
-            hash_tbl
+
+            let entry = hash_tbl
                 .raw_entry_mut()
                 // uses the key to check equality to find and entry
-                .from_key_hashed_nocheck(h, &t)
-                // if entry is found modify it
-                .and_modify(|_k, v| {
+                .from_key_hashed_nocheck(h, &t);
+
+            match entry {
+                RawEntryMut::Vacant(entry) => {
+                    entry.insert_hashed_nocheck(h, t, vec![idx]);
+                }
+                RawEntryMut::Occupied(mut entry) => {
+                    let (_k, v) = entry.get_key_value_mut();
                     v.push(idx);
-                })
-                // otherwise we insert both the key and new Vec without hashing
-                .or_insert_with(|| (t, vec![idx]));
+                }
+            }
         });
     hash_tbl
 }

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -2020,4 +2020,28 @@ mod test {
             [Some(6), Some(0), Some(0)]
         );
     }
+
+    #[test]
+    fn test_lazy_partitioned_grouping() {
+        std::env::set_var("POLARS_NEW_PARTITION", "1");
+        let df = df! {
+            "a" => [1, 1, 1, 2, 2, 3, 1],
+            "b" => [1i64, 2, 3, 4, 5, 6, 7]
+        }
+        .unwrap();
+
+        // test if it runs in groupby context
+        let out = df
+            .lazy()
+            .groupby(vec![col("a")])
+            .agg(vec![col("b").sum()])
+            .sort("a", false)
+            .collect()
+            .unwrap();
+
+        assert_eq!(
+            Vec::from(out.column("b_sum").unwrap().i64().unwrap()),
+            [Some(13), Some(9), Some(6)]
+        );
+    }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -284,11 +284,7 @@ impl Executor for PartitionGroupByExec2 {
 
         let mut columns = Vec::with_capacity(agg_columns.len() + 1);
         columns.push(key);
-        for a in agg_columns {
-            if let Some(a) = a {
-                columns.push(a)
-            }
-        }
+        columns.extend(agg_columns.into_iter().flatten());
 
         Ok(DataFrame::new_no_checks(columns))
     }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -248,13 +248,17 @@ impl Executor for PartitionGroupByExec {
 /// Take an input Executor and a multiple expressions
 pub struct PartitionGroupByExec2 {
     input: Box<dyn Executor>,
-    keys: Vec<Arc<dyn PhysicalExpr>>,
+    key: Arc<dyn PhysicalExpr>,
     phys_aggs: Vec<Arc<dyn PhysicalExpr>>,
     aggs: Vec<Expr>,
 }
 
 impl Executor for PartitionGroupByExec2 {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
+        let df = self.input.execute(state)?;
+        let key = self.key.evaluate(&df, state)?;
+        let g_maps = key.group_maps();
+
         todo!()
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -240,3 +240,17 @@ impl Executor for PartitionGroupByExec {
         Ok(df)
     }
 }
+
+/// Take an input Executor and a multiple expressions
+pub struct PartitionGroupByExec2 {
+    input: Box<dyn Executor>,
+    keys: Vec<Arc<dyn PhysicalExpr>>,
+    phys_aggs: Vec<Arc<dyn PhysicalExpr>>,
+    aggs: Vec<Expr>,
+}
+
+impl Executor for PartitionGroupByExec2 {
+    fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
+        todo!()
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -121,6 +121,8 @@ impl Executor for PartitionGroupByExec {
             .map(|e| e.evaluate(&original_df, state))
             .collect::<Result<Vec<_>>>()?;
 
+        // We only do partitioned groupby's on single keys aggregation.
+        // This design choice seems ok, as cardinality rapidly increases with multiple columns
         debug_assert_eq!(keys.len(), 1);
         let s = &keys[0];
         if let Ok(ca) = s.categorical() {
@@ -133,6 +135,8 @@ impl Executor for PartitionGroupByExec {
                 return groupby_helper(original_df, keys, &self.phys_aggs, None, state);
             }
         }
+        if std::env::var("POLARS_NEW_PARTITION").is_ok() {}
+
         let mut expr_arena = Arena::with_capacity(64);
 
         // This will be the aggregation on the partition results. Due to the groupby

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -223,12 +223,12 @@ impl PhysicalAggregation for AggregationExpr {
         let mut iter = g_maps.iter().map(|g_map| series.part_agg_sum(g_map));
 
         // get the first result table
-        let mut first = iter.next().unwrap();
+        let first = iter.next().unwrap();
 
         // maps over option, dtypes that cannot be accumulated return None
         Ok(first.map(|mut first| {
             // merge the table with the other tables in a recursive manner
-            first.merge(iter.filter_map(|v| v).collect());
+            first.merge(iter.flatten().collect());
 
             first.finish()
         }))

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -210,7 +210,7 @@ impl PhysicalAggregation for AggregationExpr {
     }
 
     #[allow(clippy::ptr_arg)]
-    fn evaluate_partititioned2(
+    fn evaluate_partitioned_2(
         &self,
         df: &DataFrame,
         g_maps: &[GroupedMap<Option<u64>>],
@@ -230,7 +230,7 @@ impl PhysicalAggregation for AggregationExpr {
             // merge the table with the other tables in a recursive manner
             first.merge(iter.filter_map(|v| v).collect());
 
-            first.finish(series.dtype().clone())
+            first.finish()
         }))
     }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -3,7 +3,7 @@ use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
 use polars_arrow::array::ValueSize;
 use polars_core::chunked_array::builder::get_list_builder;
-use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupTuples};
+use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupTuples, GroupedMap};
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
 use std::sync::Arc;
@@ -207,6 +207,18 @@ impl PhysicalAggregation for AggregationExpr {
             }
             _ => PhysicalAggregation::aggregate(self, final_df, groups, state),
         }
+    }
+
+    #[allow(clippy::ptr_arg)]
+    fn evaluate_partititioned2(
+        &self,
+        df: &DataFrame,
+        g_map: &GroupedMap<Option<u64>>,
+        state: &ExecutionState,
+    ) -> Result<Option<Vec<Series>>> {
+        let series = self.expr.evaluate(df, state)?;
+
+        unimplemented!()
     }
 }
 impl PhysicalAggregation for AggQuantileExpr {

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod window;
 
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::{GroupTuples, GroupedMap};
 use polars_core::prelude::*;
 use polars_io::PhysicalIoExpr;
 use std::borrow::Cow;
@@ -110,5 +110,15 @@ pub trait PhysicalAggregation {
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         self.aggregate(final_df, groups, state)
+    }
+
+    #[allow(clippy::ptr_arg)]
+    fn evaluate_partititioned2(
+        &self,
+        _df: &DataFrame,
+        _g_map: &GroupedMap<Option<u64>>,
+        _state: &ExecutionState,
+    ) -> Result<Option<Vec<Series>>> {
+        unimplemented!()
     }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -118,7 +118,7 @@ pub trait PhysicalAggregation {
         _df: &DataFrame,
         _g_maps: &[GroupedMap<Option<u64>>],
         _state: &ExecutionState,
-    ) -> Result<Option<Vec<Series>>> {
+    ) -> Result<Option<Series>> {
         unimplemented!()
     }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -113,7 +113,7 @@ pub trait PhysicalAggregation {
     }
 
     #[allow(clippy::ptr_arg)]
-    fn evaluate_partititioned2(
+    fn evaluate_partitioned_2(
         &self,
         _df: &DataFrame,
         _g_maps: &[GroupedMap<Option<u64>>],

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -116,7 +116,7 @@ pub trait PhysicalAggregation {
     fn evaluate_partititioned2(
         &self,
         _df: &DataFrame,
-        _g_map: &GroupedMap<Option<u64>>,
+        _g_maps: &[GroupedMap<Option<u64>>],
         _state: &ExecutionState,
     ) -> Result<Option<Vec<Series>>> {
         unimplemented!()


### PR DESCRIPTION
Instead of `GroupTuples`, a `key` generates `GroupMaps`, which are `HashMap<Option<u64>, (u32, Vec<u32>), RandomState>`.

For the numeric keys, the bit representation is stored in a `u64`. 
For string values, we still have to figure something out.

