### PR TITLE
Fix empty group aggregation

### DIFF
--- a/.github/deploy_manylinux.sh
+++ b/.github/deploy_manylinux.sh
@@ -4,10 +4,9 @@
 pwd
 ls -la
 
-rustup override set nightly-2020-11-12
-
 rm py-polars/README.md
 cp README.md py-polars/README.md
 cd py-polars
+rustup override set nightly-2021-03-24
 maturin publish \
 --username ritchie46

--- a/.github/workflows/create-py-release-test.yaml
+++ b/.github/workflows/create-py-release-test.yaml
@@ -11,28 +11,30 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: [ "3.6", "3.7" ]
     steps:
-        - uses: actions/checkout@v2
-        - name: Install latest Rust nightly
-          uses: actions-rs/toolchain@v1
-          with:
-            toolchain: nightly-2021-03-25
-            override: true
-            components: rustfmt, clippy
-        - name: Set up Python
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install maturin==0.9.4 pytest pandas
-        - name: Run tests
-          run: |
-            cd py-polars
-            ./tasks.sh build-run-tests
-            rm wheels/*
+      - uses: actions/checkout@v2
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-03-25
+          override: true
+          components: rustfmt, clippy
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install maturin==0.9.4 pytest pandas
+      - name: Run tests
+        run: |
+          cd py-polars
+          rustup override set nightly-2021-03-24
+          ./tasks.sh build-run-tests
+          rm wheels/*
+
   build:
     needs: build_manylinux
     name: Create Release
@@ -46,7 +48,7 @@ jobs:
         - name: Install latest Rust nightly
           uses: actions-rs/toolchain@v1
           with:
-            toolchain: nightly
+            toolchain: nightly-2021-03-24
             override: true
             components: rustfmt, clippy
         - name: Set up Python
@@ -65,6 +67,7 @@ jobs:
             rm py-polars/README.md
             cp README.md py-polars/README.md
             cd py-polars
+            rustup override set nightly-2021-03-24
             maturin publish \
             -o wheels \
             -i python \

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -75,7 +75,9 @@ where
 {
     fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<Float64Type, _>(groups, |(first, idx)| {
-            if idx.len() == 1 {
+            if idx.is_empty() {
+                None
+            } else if idx.len() == 1 {
                 self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
             } else {
                 match (self.null_count(), self.chunks.len()) {
@@ -115,7 +117,9 @@ where
 
     fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<T, _>(groups, |(first, idx)| {
-            if idx.len() == 1 {
+            if idx.is_empty() {
+                None
+            } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
                 match (self.null_count(), self.chunks.len()) {
@@ -147,7 +151,9 @@ where
 
     fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<T, _>(groups, |(first, idx)| {
-            if idx.len() == 1 {
+            if idx.is_empty() {
+                None
+            } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
                 match (self.null_count(), self.chunks.len()) {
@@ -179,7 +185,9 @@ where
 
     fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<T, _>(groups, |(first, idx)| {
-            if idx.len() == 1 {
+            if idx.is_empty() {
+                None
+            } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
                 match (self.null_count(), self.chunks.len()) {
@@ -210,6 +218,9 @@ where
     }
     fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<T, _>(groups, |(_first, idx)| {
+            if idx.is_empty() {
+                return None;
+            }
             let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
             take.into_series()
                 .var_as_series()
@@ -220,6 +231,9 @@ where
     }
     fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<T, _>(groups, |(_first, idx)| {
+            if idx.is_empty() {
+                return None;
+            }
             let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
             take.into_series()
                 .std_as_series()
@@ -231,7 +245,9 @@ where
     #[cfg(feature = "lazy")]
     fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<UInt32Type, _>(groups, |(_first, idx)| {
-            if self.null_count() == 0 {
+            if idx.is_empty() {
+                None
+            } else if self.null_count() == 0 {
                 Some(idx.len() as u32)
             } else {
                 let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
@@ -249,7 +265,12 @@ macro_rules! impl_agg_first {
     ($self:ident, $groups:ident, $ca_type:ty) => {{
         let mut ca = $groups
             .iter()
-            .map(|(first, _idx)| $self.get(*first as usize))
+            .map(|(first, idx)| {
+                if idx.is_empty() {
+                    return None;
+                }
+                $self.get(*first as usize)
+            })
             .collect::<$ca_type>();
 
         ca.categorical_map = $self.categorical_map.clone();
@@ -314,7 +335,13 @@ macro_rules! impl_agg_last {
     ($self:ident, $groups:ident, $ca_type:ty) => {{
         let mut ca = $groups
             .iter()
-            .map(|(_first, idx)| $self.get(idx[idx.len() - 1] as usize))
+            .map(|(_first, idx)| {
+                if idx.is_empty() {
+                    return None;
+                }
+
+                $self.get(idx[idx.len() - 1] as usize)
+            })
             .collect::<$ca_type>();
 
         ca.categorical_map = $self.categorical_map.clone();
@@ -378,6 +405,10 @@ macro_rules! impl_agg_n_unique {
         $groups
             .into_par_iter()
             .map(|(_first, idx)| {
+                if idx.is_empty() {
+                    return 0;
+                }
+
                 if $self.null_count() == 0 {
                     let mut set = HashSet::with_hasher(RandomState::new());
                     for i in idx {
@@ -531,6 +562,10 @@ where
 {
     fn agg_quantile(&self, groups: &[(u32, Vec<u32>)], quantile: f64) -> Option<Series> {
         agg_helper::<T, _>(groups, |(_first, idx)| {
+            if idx.is_empty() {
+                return None;
+            }
+
             let group_vals = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
             let sorted_idx_ca = group_vals.argsort(false);
             let sorted_idx = sorted_idx_ca.downcast_iter().next().unwrap().values();
@@ -542,6 +577,10 @@ where
 
     fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         agg_helper::<Float64Type, _>(groups, |(_first, idx)| {
+            if idx.is_empty() {
+                return None;
+            }
+
             let group_vals = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
             group_vals.median()
         })

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -73,6 +73,9 @@ fn groupby_helper(
 
 impl Executor for GroupByExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
+        if state.verbose {
+            eprintln!("aggregates are not partitionable: running default HASH AGGREGATION")
+        }
         let df = self.input.execute(state)?;
         let keys = self
             .keys

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -932,7 +932,8 @@ dependencies = [
 [[package]]
 name = "packed_simd_2"
 version = "0.3.4"
-source = "git+https://github.com/JohnTitor/packed_simd/?branch=fix-build#58ba720df859b8d8a4c685a7984266e6f237b75e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
 dependencies = [
  "cfg-if 0.1.10",
  "libm 0.1.4",
@@ -1125,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "libc",
  "mimalloc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.7.15"
+version = "0.7.16"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -44,7 +44,7 @@ features = [
 ]
 
 #[patch.crates-io]
-#packed_simd_2 = { git = 'https://github.com/JohnTitor/packed_simd/', branch="fix-build"}
+#packed_simd_2 = { git = 'https://github.com/rust-lang/packed_simd' }
 
 [lib]
 name = "polars"

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -1395,6 +1395,10 @@ class DataFrame:
         """
         if _is_expr(strategy):
             return self.lazy().fill_none(strategy).collect()
+        if not isinstance(strategy, str):
+            from .lazy import lit
+
+            return self.fill_none(lit(strategy))
         return wrap_df(self._df.fill_none(strategy))
 
     def explode(self, columns: "Union[str, List[str]]") -> "DataFrame":

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -229,6 +229,8 @@ def test_groupby():
 
     # Use lazy API in eager groupby
     assert df.groupby("a").agg([pl.sum("b")]).shape == (3, 2)
+    # test if it accepts a single expression
+    assert df.groupby("a").agg(pl.sum("b")).shape == (3, 2)
 
 
 def test_join():


### PR DESCRIPTION
Due to the versatility of the expressions it is
possible to have empty groups, where in a normal
groupby a group always contains the value as its
member. Check in aggregations on empty sets and
return None accordingly. Fixes #640