### PR TITLE
use C++ boost hash combine and determine groupby keys in parallel 

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -78,6 +78,7 @@ num_cpus = "1.13"
 lazy_static = "1.4"
 hashbrown = {version = "0.11", features = ["rayon"] }
 polars-arrow = {version = "0.13.3", path = "../polars-arrow"}
+smallvec = {version = "1.6", features = ["union"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -109,8 +109,13 @@ impl DataFrame {
         Ok(df)
     }
 
-    // doesn't check Series sizes.
-    // todo! make private
+    /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the `Series`.
+    ///
+    /// It is adviced to use [Series::new](Series::new) in favor of this method.
+    ///
+    /// # Panic
+    /// It is the callers responsibility to uphold the contract of all `Series`
+    /// having an equal length, if not this may panic down the line.
     pub fn new_no_checks(columns: Vec<Series>) -> DataFrame {
         DataFrame { columns }
     }

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -21,68 +21,6 @@ pub trait VecHash {
     }
 }
 
-pub trait VecHashId {
-    /// Compute the hash id by interpreting the bits as 64 bits.
-    ///
-    /// Watch out for [accidental quadratic behavior](https://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion)
-    fn vec_hash_id(&self) -> UInt64Chunked {
-        unimplemented!()
-    }
-}
-
-/// A random u64 used for the None case
-/// the other values hash `T` instead of `Option<T>`
-const RANDOM_U64: u64 = 4352984574;
-
-impl VecHashId for UInt64Chunked {
-    fn vec_hash_id(&self) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
-            None => RANDOM_U64,
-            Some(v) => v,
-        })
-    }
-}
-
-impl VecHashId for UInt32Chunked {
-    fn vec_hash_id(&self) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
-            None => RANDOM_U64,
-            Some(v) => v as u64,
-        })
-    }
-}
-
-impl VecHashId for Int32Chunked {
-    fn vec_hash_id(&self) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
-            None => RANDOM_U64,
-            Some(v) => (unsafe { std::mem::transmute::<i32, u32>(v) }) as u64,
-        })
-    }
-}
-
-impl VecHashId for Int64Chunked {
-    fn vec_hash_id(&self) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
-            None => RANDOM_U64,
-            Some(v) => unsafe { std::mem::transmute::<i64, u64>(v) },
-        })
-    }
-}
-
-impl Series {
-    pub fn vec_hash_id(&self) -> UInt64Chunked {
-        use DataType::*;
-        match self.dtype() {
-            UInt64 => self.u64().unwrap().vec_hash_id(),
-            Int64 => self.i64().unwrap().vec_hash_id(),
-            Int32 => self.i32().unwrap().vec_hash_id(),
-            UInt32 => self.u32().unwrap().vec_hash_id(),
-            _ => unimplemented!(),
-        }
-    }
-}
-
 impl<T> VecHash for ChunkedArray<T>
 where
     T: PolarsIntegerType,

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -234,7 +234,7 @@ class LazyFrame:
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
-        string_cache: bool = True,
+        string_cache: bool = False,
         no_optimization: bool = False,
     ) -> DataFrame:
         """
@@ -253,6 +253,10 @@ class LazyFrame:
         string_cache
             Use a global string cache in this query.
             This is needed if you want to join on categorical columns.
+
+            Caution!
+                If you already have set a global string cache, set this to `False` as this will reset the
+                global cache when the query is finished.
         no_optimization
             Turn off optimizations
 


### PR DESCRIPTION
The keys of groupby operation were still collected in sequentially. In q10 of db-benchmark this was approximately half of the query time. This improved hashcombine performance by 2.5x