### PR TITLE
Improve indexing performance in of chunkedarrays that contain multiple chunks

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -394,27 +394,6 @@ impl<T> ChunkedArray<T> {
         self.field.data_type()
     }
 
-    /// Get the index of the chunk and the index of the value in that chunk
-    #[inline]
-    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
-        if self.chunks.len() == 1 {
-            return (0, index);
-        }
-        let mut index_remainder = index;
-        let mut current_chunk_idx = 0;
-
-        for chunk in &self.chunks {
-            let chunk_len = chunk.len();
-            if chunk_len > index_remainder {
-                break;
-            } else {
-                index_remainder -= chunk_len;
-                current_chunk_idx += 1;
-            }
-        }
-        (current_chunk_idx, index_remainder)
-    }
-
     /// Get the head of the ChunkedArray
     pub fn head(&self, length: Option<usize>) -> Self {
         match length {
@@ -591,28 +570,6 @@ where
             }
             _ => unimplemented!(),
         }
-    }
-
-    /// Get a single value. Beware this is slow.
-    /// If you need to use this slightly performant, cast Categorical to UInt32
-    #[inline]
-    pub(crate) unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
-        let (chunk_idx, idx) = self.index_to_chunked_index(index);
-        debug_assert!(chunk_idx < self.chunks.len());
-        let arr = &**self.chunks.get_unchecked(chunk_idx);
-        debug_assert!(idx < arr.len());
-        self.arr_to_any_value(arr, idx)
-    }
-
-    /// Get a single value. Beware this is slow.
-    /// If you need to use this slightly performant, cast Categorical to UInt32
-    pub(crate) fn get_any_value(&self, index: usize) -> AnyValue {
-        let (chunk_idx, idx) = self.index_to_chunked_index(index);
-        let arr = &*self.chunks[chunk_idx];
-        assert!(idx < arr.len());
-        // SAFETY
-        // bounds are checked
-        unsafe { self.arr_to_any_value(arr, idx) }
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -1,0 +1,92 @@
+use crate::prelude::*;
+
+macro_rules! get_any_value_unchecked {
+    ($self:ident, $index:expr) => {{
+        let (chunk_idx, idx) = $self.index_to_chunked_index($index);
+        debug_assert!(chunk_idx < $self.chunks.len());
+        let arr = &**$self.chunks.get_unchecked(chunk_idx);
+        debug_assert!(idx < arr.len());
+        $self.arr_to_any_value(arr, idx)
+    }};
+}
+
+macro_rules! get_any_value {
+    ($self:ident, $index:expr) => {{
+        let (chunk_idx, idx) = $self.index_to_chunked_index($index);
+        let arr = &*$self.chunks[chunk_idx];
+        assert!(idx < arr.len());
+        // SAFETY
+        // bounds are checked
+        unsafe { $self.arr_to_any_value(arr, idx) }
+    }};
+}
+
+impl<T> ChunkAnyValue for ChunkedArray<T>
+where
+    T: PolarsNumericType,
+{
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}
+
+impl ChunkAnyValue for BooleanChunked {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}
+
+impl ChunkAnyValue for Utf8Chunked {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}
+
+impl ChunkAnyValue for ListChunked {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}
+
+impl ChunkAnyValue for CategoricalChunked {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}
+
+#[cfg(feature = "object")]
+impl<T: PolarsObject> ChunkAnyValue for ObjectChunked<T> {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
+        get_any_value_unchecked!(self, index)
+    }
+
+    fn get_any_value(&self, index: usize) -> AnyValue {
+        get_any_value!(self, index)
+    }
+}

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
+use crate::utils::index_to_chunked_index;
 use arrow::array::{
     Array, ArrayRef, BooleanArray, LargeListArray, LargeStringArray, PrimitiveArray,
 };
@@ -50,6 +51,15 @@ where
     pub fn downcast_chunks(&self) -> Chunks<'_, PrimitiveArray<T>> {
         Chunks::new(&self.chunks)
     }
+
+    /// Get the index of the chunk and the index of the value in that chunk
+    #[inline]
+    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
+        if self.chunks.len() == 1 {
+            return (0, index);
+        }
+        index_to_chunked_index(self.downcast_iter().map(|arr| arr.len()), index)
+    }
 }
 
 impl BooleanChunked {
@@ -61,6 +71,14 @@ impl BooleanChunked {
     }
     pub fn downcast_chunks(&self) -> Chunks<'_, BooleanArray> {
         Chunks::new(&self.chunks)
+    }
+
+    #[inline]
+    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
+        if self.chunks.len() == 1 {
+            return (0, index);
+        }
+        index_to_chunked_index(self.downcast_iter().map(|arr| arr.len()), index)
     }
 }
 
@@ -74,6 +92,14 @@ impl Utf8Chunked {
     pub fn downcast_chunks(&self) -> Chunks<'_, LargeStringArray> {
         Chunks::new(&self.chunks)
     }
+
+    #[inline]
+    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
+        if self.chunks.len() == 1 {
+            return (0, index);
+        }
+        index_to_chunked_index(self.downcast_iter().map(|arr| arr.len()), index)
+    }
 }
 
 impl ListChunked {
@@ -85,6 +111,14 @@ impl ListChunked {
     }
     pub fn downcast_chunks(&self) -> Chunks<'_, LargeListArray> {
         Chunks::new(&self.chunks)
+    }
+
+    #[inline]
+    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
+        if self.chunks.len() == 1 {
+            return (0, index);
+        }
+        index_to_chunked_index(self.downcast_iter().map(|arr| arr.len()), index)
     }
 }
 
@@ -101,5 +135,13 @@ where
     }
     pub fn downcast_chunks(&self) -> Chunks<'_, ObjectArray<T>> {
         Chunks::new(&self.chunks)
+    }
+
+    #[inline]
+    pub(crate) fn index_to_chunked_index(&self, index: usize) -> (usize, usize) {
+        if self.chunks.len() == 1 {
+            return (0, index);
+        }
+        index_to_chunked_index(self.downcast_iter().map(|arr| arr.len()), index)
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -9,6 +9,7 @@ use arrow::array::{ArrayRef, UInt32Array};
 use std::marker::Sized;
 
 pub(crate) mod aggregate;
+pub(crate) mod any_value;
 pub(crate) mod apply;
 pub(crate) mod chunkops;
 pub(crate) mod cum_agg;
@@ -29,6 +30,18 @@ pub(crate) mod take_single;
 pub(crate) mod unique;
 pub(crate) mod window;
 pub(crate) mod zip;
+
+pub trait ChunkAnyValue {
+    /// Get a single value. Beware this is slow.
+    /// If you need to use this slightly performant, cast Categorical to UInt32
+    ///
+    /// # Safety
+    /// Does not do any bounds checking.
+    unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue;
+
+    /// Get a single value. Beware this is slow.
+    fn get_any_value(&self, index: usize) -> AnyValue;
+}
 
 pub trait ChunkCumAgg<T> {
     /// Get an array with the cumulative max computed at every element

--- a/polars/polars-core/src/chunked_array/ops/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take_random.rs
@@ -9,7 +9,8 @@ use unsafe_unwrap::UnsafeUnwrap;
 
 macro_rules! take_random_get {
     ($self:ident, $index:ident) => {{
-        let (chunk_idx, arr_idx) = crate::utils::index_to_chunked_index(&$self.chunk_lens, $index);
+        let (chunk_idx, arr_idx) =
+            crate::utils::index_to_chunked_index($self.chunk_lens.iter().copied(), $index);
         let arr = $self.chunks.get(chunk_idx);
         match arr {
             Some(arr) => {
@@ -28,7 +29,8 @@ macro_rules! take_random_get {
 
 macro_rules! take_random_get_unchecked {
     ($self:ident, $index:ident) => {{
-        let (chunk_idx, arr_idx) = crate::utils::index_to_chunked_index(&$self.chunk_lens, $index);
+        let (chunk_idx, arr_idx) =
+            crate::utils::index_to_chunked_index($self.chunk_lens.iter().copied(), $index);
         $self
             .chunks
             .get_unchecked(chunk_idx)
@@ -166,10 +168,7 @@ impl<'a> TakeRandom for Utf8TakeRandom<'a> {
 
     #[inline]
     unsafe fn get_unchecked(&self, index: usize) -> Self::Item {
-        let (chunk_idx, arr_idx) = crate::utils::index_to_chunked_index(&self.chunk_lens, index);
-        self.chunks
-            .get_unchecked(chunk_idx)
-            .value_unchecked(arr_idx)
+        take_random_get_unchecked!(self, index)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take_single.rs
@@ -43,7 +43,7 @@ macro_rules! impl_take_random_get_unchecked {
 
 impl<T> TakeRandom for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
 {
     type Item = T::Native;
 
@@ -60,7 +60,7 @@ where
 
 impl<'a, T> TakeRandom for &'a ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
 {
     type Item = T::Native;
 

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -164,7 +164,7 @@ macro_rules! set_limit {
 
 impl<T> Debug for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let limit = set_limit!(self);
@@ -585,7 +585,7 @@ pub(crate) trait FmtList {
 
 impl<T> FmtList for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
     T::Native: fmt::Display,
 {
     fn fmt_list(&self) -> String {

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -280,7 +280,7 @@ macro_rules! impl_agg_first {
 
 impl<T> AggFirst for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType + Send,
+    T: PolarsNumericType + Send,
     ChunkedArray<T>: IntoSeries,
 {
     fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
@@ -361,7 +361,7 @@ macro_rules! impl_agg_last {
 
 impl<T> AggLast for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType + Send,
+    T: PolarsNumericType + Send,
     ChunkedArray<T>: IntoSeries,
 {
     fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -884,3 +884,23 @@ impl<T> IntoVec<T> for Vec<T> {
         self
     }
 }
+
+/// This logic is same as the impl on ChunkedArray
+/// The difference is that there is less indirection because the caller should preallocate
+/// `chunk_lens` once. On the `ChunkedArray` we indicrect through an `ArrayRef` which is an indirection
+/// and a vtable.
+#[inline]
+pub(crate) fn index_to_chunked_index(chunk_lens: &[usize], index: usize) -> (usize, usize) {
+    let mut index_remainder = index;
+    let mut current_chunk_idx = 0;
+
+    for &chunk_len in chunk_lens {
+        if chunk_len > index_remainder {
+            break;
+        } else {
+            index_remainder -= chunk_len;
+            current_chunk_idx += 1;
+        }
+    }
+    (current_chunk_idx, index_remainder)
+}

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -890,11 +890,14 @@ impl<T> IntoVec<T> for Vec<T> {
 /// `chunk_lens` once. On the `ChunkedArray` we indicrect through an `ArrayRef` which is an indirection
 /// and a vtable.
 #[inline]
-pub(crate) fn index_to_chunked_index(chunk_lens: &[usize], index: usize) -> (usize, usize) {
+pub(crate) fn index_to_chunked_index<I: Iterator<Item = usize>>(
+    chunk_lens: I,
+    index: usize,
+) -> (usize, usize) {
     let mut index_remainder = index;
     let mut current_chunk_idx = 0;
 
-    for &chunk_len in chunk_lens {
+    for chunk_len in chunk_lens {
         if chunk_len > index_remainder {
             break;
         } else {


### PR DESCRIPTION
Computing the index required to go through `ArrayRef`
which is a vtable and indirected by `Arc`.

```
bench takerand          time:   [288.37 ms 291.90 ms 296.76 ms]
                        change: [-56.554% -56.026% -55.149%] (p = 0.00 < 0.05)
                        Performance has improved.
```