### PR TITLE
Improve groupby hashing and release python polars 0.7.19

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -9,7 +9,7 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = {git = "https://github.com/apache/arrow-rs", rev = "f042191578cbc2329957015fa0b8d2f01d51ddbd", default-features = false}
+arrow = {git = "https://github.com/apache/arrow-rs", rev = "f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570", default-features = false}
 #arrow = {version = "4.1", default-features = false }
 thiserror = "^1.0"
 num = "^0.4"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -60,9 +60,9 @@ dtype-u16 = []
 dtype-u64 = []
 
 [dependencies]
-arrow = {git = "https://github.com/apache/arrow-rs", rev = "f042191578cbc2329957015fa0b8d2f01d51ddbd", default-features=false}
+arrow = {git = "https://github.com/apache/arrow-rs", rev = "f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570", default-features=false}
 #arrow = {version = "4.1", default-features = false }
-parquet = {optional = true, git = "https://github.com/apache/arrow-rs", rev = "f042191578cbc2329957015fa0b8d2f01d51ddbd"}
+parquet = {optional = true, git = "https://github.com/apache/arrow-rs", rev = "f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570"}
 #parquet = {version = "4.1", default-features = false, optional = true }
 polars-arrow = {version = "0.13.4", path = "../polars-arrow"}
 thiserror = "1.0"

--- a/polars/polars-core/src/chunked_array/ops/unique.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique.rs
@@ -148,7 +148,7 @@ macro_rules! impl_value_counts {
 impl<T> ChunkUnique<T> for ChunkedArray<T>
 where
     T: PolarsIntegerType,
-    T::Native: Hash + Eq,
+    T::Native: Hash + Eq + NumCast,
     ChunkedArray<T>: ChunkOps + IntoSeries,
 {
     fn unique(&self) -> Result<Self> {
@@ -295,7 +295,7 @@ impl ToDummies<Utf8Type> for Utf8Chunked {
 impl<T> ToDummies<T> for ChunkedArray<T>
 where
     T: PolarsIntegerType + Sync,
-    T::Native: Hash + Eq + Display,
+    T::Native: Hash + Eq + Display + NumCast,
     ChunkedArray<T>: ChunkOps + ChunkCompare<T::Native> + ChunkUnique<T>,
 {
     fn to_dummies(&self) -> Result<DataFrame> {

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -127,6 +127,9 @@ impl Default for IdHasher {
 pub type IdBuildHasher = BuildHasherDefault<IdHasher>;
 
 #[derive(Debug)]
+/// Contains an idx of a row in a DataFrame and the precomputed hash of that row.
+/// That hash still needs to be used to create another hash to be able to resize hashmaps without
+/// accidental quadratic behavior. So do not use and Identity function!
 pub(crate) struct IdxHash {
     // idx in row of Series, DataFrame
     pub(crate) idx: u32,

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -13,18 +13,18 @@ repository = "https://github.com/ritchie46/polars"
 # support for arrows json parsing
 json = []
 # support for arrows ipc file parsing
-ipc = []
+ipc = ["arrow/ipc"]
 lazy = []
 parquet = ["polars-core/parquet", "parquet_lib"]
 dtype-u64 = ["polars-core/dtype-u64"]
 dtype-date64 = ["polars-core/dtype-date64"]
 dtype-date32 = ["polars-core/dtype-date32"]
-csv-file = ["csv", "csv-core", "memmap", "fast-float", "lexical"]
+csv-file = ["csv", "csv-core", "memmap", "fast-float", "lexical", "arrow/csv"]
 
 [dependencies]
-arrow = {git = "https://github.com/apache/arrow-rs", rev = "f042191578cbc2329957015fa0b8d2f01d51ddbd", default-features=false}
+arrow = {git = "https://github.com/apache/arrow-rs", rev = "f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570", default-features=false}
 #arrow = {version = "4.1", default-features = false }
-parquet_lib = {optional = true, package="parquet", git = "https://github.com/apache/arrow-rs", rev = "f042191578cbc2329957015fa0b8d2f01d51ddbd"}
+parquet_lib = {optional = true, package="parquet", git = "https://github.com/apache/arrow-rs", rev = "f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570"}
 #parquet_lib = {version = "4.1", package="parquet", optional = true}
 polars-arrow = {version = "0.13.4", path = "../polars-arrow"}
 csv = {version="1.1", optional=true}

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -18,9 +18,12 @@ pub mod parquet;
 pub mod prelude;
 
 use arrow::{
-    csv::Reader as ArrowCsvReader, error::Result as ArrowResult, json::Reader as ArrowJsonReader,
-    record_batch::RecordBatch,
+    error::Result as ArrowResult, json::Reader as ArrowJsonReader, record_batch::RecordBatch,
 };
+
+#[cfg(feature = "csv-file")]
+use arrow::csv::Reader as ArrowCsvReader;
+
 use polars_core::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
@@ -61,6 +64,7 @@ pub trait ArrowReader {
     fn schema(&self) -> Arc<Schema>;
 }
 
+#[cfg(feature = "csv-file")]
 impl<R: Read> ArrowReader for ArrowCsvReader<R> {
     fn next_record_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         self.next().map_or(Ok(None), |v| v.map(Some))

--- a/py-polars/CHANGELOG.md
+++ b/py-polars/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 The Rust crate `polars` has its own changelog.
 
-### polars 0.7.18
+### polars 0.7.19
 * feature
   - window function by multiple group columns
 
 * bug fix
   - fix bug in argsort multiple
+  - fix bug in filter with nulls (upstream)
+
+* performance
+  - improve numeric hashing in groupby
+  - fast paths for filters (upstream)
 
 ### polars 0.7.18
 * feature
@@ -22,8 +27,6 @@ The Rust crate `polars` has its own changelog.
       - zip
       - take -> join / groupby agg
       - agg first/ last
-
-* bug fix
 
 * performance
   - change memory usage of csv-parser

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -64,9 +64,8 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=f042191578cbc2329957015fa0b8d2f01d51ddbd#f042191578cbc2329957015fa0b8d2f01d51ddbd"
+source = "git+https://github.com/apache/arrow-rs?rev=f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570#f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570"
 dependencies = [
- "cfg_aliases",
  "chrono",
  "csv",
  "flatbuffers",
@@ -183,12 +182,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -923,7 +916,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=f042191578cbc2329957015fa0b8d2f01d51ddbd#f042191578cbc2329957015fa0b8d2f01d51ddbd"
+source = "git+https://github.com/apache/arrow-rs?rev=f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570#f26ffb3091ae355d246edc4a6fcc2c8e5b9bc570"
 dependencies = [
  "arrow",
  "base64",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "libc",
  "mimalloc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.7.18"
+version = "0.7.19"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
This PR:

* reduce code bloat, by only grouping u32, and u64 (rest are bit interpreted or cast)
* improve numeric hashing.  
    - do not preallocate hash table size. It is faster to start small in cache and grow to the needed size.
    - Hashbrown table has got gotcha's. Such as rehashing has another hashing seed, so using a precomputed hash is expensive as you are pointed to the wrong bucket after reallocation.
* for multiple keys we use a precomputed hash and a custom equality function. The precomputed hash is then again rehashed to be able to use the increase cache locality of a small hashtable.
* updated arrow: now we have a fast path in the filter operation.

Next up: 
* implement same for joins.
* for string data we can precompute the hash, and use the same tactic as with multiple keys (rehash the hash).

before: 
```
q1
0.04269552230834961
q2
0.26558470726013184
q3
0.3988018035888672
q4
0.05036044120788574
q5
0.4192225933074951
q6
0.3387420177459717
q7
0.3430898189544678
q8
0.959986686706543
q9
0.5825982093811035
q10
1.4149565696716309
```

after:
```
q1
0.03847789764404297
q2
0.32038307189941406
q3
0.39401769638061523
q4
0.056730031967163086
q5
0.25032830238342285
q6
0.3633391857147217
q7
0.18043041229248047
q8
0.7432305812835693
q9
0.5588171482086182
q10
1.2846043109893799
```