### PR TITLE
Improve logic around recordbatches

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -534,7 +534,7 @@ impl Display for AnyValue<'_> {
             }
             AnyValue::Duration(v, TimeUnit::Nanosecond) => write!(f, "{}", v),
             AnyValue::Duration(v, TimeUnit::Millisecond) => write!(f, "{}", v),
-            AnyValue::List(s) => write!(f, "{:?}", s.fmt_list()),
+            AnyValue::List(s) => write!(f, "{}", s.fmt_list()),
             #[cfg(feature = "object")]
             AnyValue::Object(_) => write!(f, "object"),
             _ => unimplemented!(),

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1233,23 +1233,8 @@ impl DataFrame {
 
     /// Transform the underlying chunks in the DataFrame to Arrow RecordBatches
     pub fn as_record_batches(&self) -> Result<Vec<RecordBatch>> {
-        let n_chunks = self.n_chunks()?;
-        let width = self.width();
-
-        let schema = Arc::new(self.schema().to_arrow());
-
-        let mut record_batches = Vec::with_capacity(n_chunks);
-        for i in 0..n_chunks {
-            // the columns of a single recorbatch
-            let mut rb_cols = Vec::with_capacity(width);
-
-            for col in &self.columns {
-                rb_cols.push(Arc::clone(&col.chunks()[i]))
-            }
-            let rb = RecordBatch::try_new(Arc::clone(&schema), rb_cols)?;
-            record_batches.push(rb)
-        }
-        Ok(record_batches)
+        self.n_chunks()?;
+        Ok(self.iter_record_batches().collect())
     }
 
     /// Iterator over the rows in this DataFrame as Arrow RecordBatches.

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -55,6 +55,7 @@
 //! ```
 //!
 use crate::csv_core::csv::{build_csv_reader, SequentialReader};
+use crate::utils::to_arrow_compatible_df;
 use crate::{SerReader, SerWriter};
 pub use arrow::csv::WriterBuilder;
 use polars_core::prelude::*;
@@ -82,7 +83,8 @@ where
         }
     }
 
-    fn finish(self, df: &mut DataFrame) -> Result<()> {
+    fn finish(self, df: &DataFrame) -> Result<()> {
+        let df = to_arrow_compatible_df(df);
         let mut csv_writer = self.writer_builder.build(self.buffer);
 
         let iter = df.iter_record_batches();

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -69,7 +69,6 @@ pub struct CsvWriter<'a, W: Write> {
     buffer: &'a mut W,
     /// Builds an Arrow CSV Writer
     writer_builder: WriterBuilder,
-    buffer_size: usize,
 }
 
 impl<'a, W> SerWriter<'a, W> for CsvWriter<'a, W>
@@ -80,14 +79,13 @@ where
         CsvWriter {
             buffer,
             writer_builder: WriterBuilder::new(),
-            buffer_size: 1000,
         }
     }
 
     fn finish(self, df: &mut DataFrame) -> Result<()> {
         let mut csv_writer = self.writer_builder.build(self.buffer);
 
-        let iter = df.iter_record_batches(self.buffer_size);
+        let iter = df.iter_record_batches();
         for batch in iter {
             csv_writer.write(&batch)?
         }
@@ -129,9 +127,9 @@ where
         self
     }
 
+    #[deprecated(since = "0.14.1", note = "is a no-op")]
     /// Set the size of the write buffers. Batch size is the amount of rows written at once.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
-        self.buffer_size = batch_size;
+    pub fn with_batch_size(self, _batch_size: usize) -> Self {
         self
     }
 }

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -34,6 +34,7 @@
 //! ```
 use super::{finish_reader, ArrowReader, ArrowResult, RecordBatch};
 use crate::prelude::*;
+use crate::utils::to_arrow_compatible_df;
 use arrow::ipc::{
     reader::FileReader as ArrowIPCFileReader, writer::FileWriter as ArrowIPCFileWriter,
 };
@@ -129,7 +130,8 @@ where
         IpcWriter { writer }
     }
 
-    fn finish(self, df: &mut DataFrame) -> Result<()> {
+    fn finish(self, df: &DataFrame) -> Result<()> {
+        let df = to_arrow_compatible_df(df);
         let mut ipc_writer = ArrowIPCFileWriter::try_new(self.writer, &df.schema().to_arrow())?;
 
         let iter = df.iter_record_batches();

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -132,7 +132,7 @@ where
     fn finish(self, df: &mut DataFrame) -> Result<()> {
         let mut ipc_writer = ArrowIPCFileWriter::try_new(self.writer, &df.schema().to_arrow())?;
 
-        let iter = df.iter_record_batches(df.height());
+        let iter = df.iter_record_batches();
 
         for batch in iter {
             ipc_writer.write(&batch)?

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -16,6 +16,7 @@ pub mod json;
 #[cfg_attr(docsrs, doc(cfg(feature = "feature")))]
 pub mod parquet;
 pub mod prelude;
+pub(crate) mod utils;
 
 use arrow::{
     error::Result as ArrowResult, json::Reader as ArrowJsonReader, record_batch::RecordBatch,
@@ -52,7 +53,7 @@ where
     W: Write,
 {
     fn new(writer: &'a mut W) -> Self;
-    fn finish(self, df: &mut DataFrame) -> Result<()>;
+    fn finish(self, df: &DataFrame) -> Result<()>;
 }
 
 pub trait ArrowReader {

--- a/polars/polars-io/src/parquet.rs
+++ b/polars/polars-io/src/parquet.rs
@@ -16,6 +16,7 @@
 //!
 use super::{finish_reader, ArrowReader, ArrowResult, RecordBatch};
 use crate::prelude::*;
+use crate::utils::to_arrow_compatible_df;
 use crate::{PhysicalIoExpr, ScanAggregation};
 use arrow::{compute::cast, record_batch::RecordBatchReader};
 use parquet_lib::file::reader::{FileReader, SerializedFileReader};
@@ -171,6 +172,7 @@ where
 
     /// Write the given DataFrame in the the writer `W`.
     pub fn finish(self, df: &DataFrame) -> Result<()> {
+        let df = to_arrow_compatible_df(df);
         let mut fields = df.schema().to_arrow().fields().clone();
 
         // date64 is not supported by parquet and will be be truncated to date32

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -1,0 +1,14 @@
+use polars_core::prelude::*;
+
+pub(crate) fn to_arrow_compatible_df(df: &DataFrame) -> DataFrame {
+    // Our categorical type is not known to arrow/ parquet, so we coerce to large-utf8.
+    let cols = df
+        .get_columns()
+        .iter()
+        .map(|s| match s.dtype() {
+            DataType::Categorical => s.cast::<Utf8Type>().unwrap(),
+            _ => s.clone(),
+        })
+        .collect::<Vec<_>>();
+    DataFrame::new_no_checks(cols)
+}

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1281,7 +1281,6 @@ impl Rem for Expr {
 mod test {
     use super::*;
     use polars_core::df;
-    use polars_core::prelude::*;
 
     #[test]
     #[cfg(feature = "is_in")]

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -2177,7 +2177,7 @@ mod test {
         );
 
         // check if this runs
-        let out = df
+        let _out = df
             .lazy()
             .select(vec![argsort_by(
                 vec![col("str"), col("flt")],

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -327,7 +327,6 @@ class DataFrame:
     def to_csv(
         self,
         file: "Optional[Union[TextIO, str, Path]]" = None,
-        batch_size: int = 100000,
         has_headers: bool = True,
         delimiter: str = ",",
     ):
@@ -338,8 +337,6 @@ class DataFrame:
         ---
         file
             File path to which the file should be written.
-        batch_size
-            Size of the write buffer. Increase to have faster io.
         has_headers
             Whether or not to include header in the CSV output.
         delimiter
@@ -358,13 +355,13 @@ class DataFrame:
         """
         if file is None:
             buffer = BytesIO()
-            self._df.to_csv(buffer, batch_size, has_headers, ord(delimiter))
+            self._df.to_csv(buffer, has_headers, ord(delimiter))
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, Path):
             file = str(file)
 
-        self._df.to_csv(file, batch_size, has_headers, ord(delimiter))
+        self._df.to_csv(file, has_headers, ord(delimiter))
 
     def to_ipc(self, file: Union[BinaryIO, str, Path]):
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -165,7 +165,6 @@ impl PyDataFrame {
     pub fn to_csv(
         &mut self,
         py_f: PyObject,
-        batch_size: usize,
         has_headers: bool,
         delimiter: u8,
     ) -> PyResult<()> {
@@ -173,7 +172,6 @@ impl PyDataFrame {
         CsvWriter::new(&mut buf)
             .has_headers(has_headers)
             .with_delimiter(delimiter)
-            .with_batch_size(batch_size)
             .finish(&mut self.df)
             .map_err(PyPolarsEr::from)?;
         Ok(())


### PR DESCRIPTION
Do not rechunk when creating recorbatches but create a batch per chunk. Also cast `Categorical` to `Large-utf8`. This will prevent data loss during round trips.

Should fix #672 