### PR TITLE
Optional reduction of memory usage

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,7 +1,6 @@
 name: Windows tests
 
 on:
-  - push
   - pull_request
 jobs:
   test:

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -15,7 +15,7 @@ avx512 = ["arrow/avx512"]
 docs = []
 temporal = ["chrono", "regex"]
 random = ["rand", "rand_distr"]
-default = ["docs", "temporal", "performant"]
+default = ["docs", "temporal", "performant", "private"]
 lazy = ["sort_multiple"]
 
 # commented out until UB is fixed

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -135,6 +135,14 @@ impl DataFrame {
         DataFrame::new_no_checks(cols)
     }
 
+    /// Shrink the capacity of this DataFrame to fit it's length.
+    pub fn shrink_to_fit(&mut self) {
+        // Don't parallelize this. Memory overhead
+        for s in &mut self.columns {
+            s.shrink_to_fit();
+        }
+    }
+
     /// Aggregate all the chunks in the DataFrame to a single chunk.
     pub fn as_single_chunk(&mut self) -> &mut Self {
         // Don't parallelize this. Memory overhead

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -286,6 +286,10 @@ macro_rules! impl_dyn_series {
                 self.0.chunks()
             }
 
+            fn shrink_to_fit(&mut self) {
+                self.0.shrink_to_fit()
+            }
+
             fn date32(&self) -> Result<&Date32Chunked> {
                 if matches!(self.0.dtype(), DataType::Date32) {
                     unsafe { Ok(&*(self as *const dyn SeriesTrait as *const Date32Chunked)) }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -227,6 +227,9 @@ macro_rules! impl_dyn_series {
             fn chunks(&self) -> &Vec<ArrayRef> {
                 self.0.chunks()
             }
+            fn shrink_to_fit(&mut self) {
+                self.0.shrink_to_fit()
+            }
 
             fn i8(&self) -> Result<&Int8Chunked> {
                 if matches!(self.0.dtype(), DataType::Int8) {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -226,6 +226,14 @@ pub trait SeriesTrait:
         self.chunks().len()
     }
 
+    /// Shrink the capacity of this array to fit it's length.
+    fn shrink_to_fit(&mut self) {
+        eprintln!(
+            "shrink to fit, not yet supported for this {:?}",
+            self.dtype()
+        )
+    }
+
     /// Unpack to ChunkedArray of dtype i8
     fn i8(&self) -> Result<&Int8Chunked> {
         Err(PolarsError::DataTypeMisMatch(
@@ -1140,6 +1148,11 @@ impl Series {
     pub fn rename(&mut self, name: &str) -> &mut Series {
         self.get_inner_mut().rename(name);
         self
+    }
+
+    /// Shrink the capacity of this array to fit it's length.
+    pub fn shrink_to_fit(&mut self) {
+        self.get_inner_mut().shrink_to_fit()
     }
 
     /// Append arrow array of same datatype.

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -369,6 +369,7 @@ impl<R: Read + Sync + Send> SequentialReader<R> {
 
                             // don't update running statistics if we try to reduce string memory usage.
                             if self.low_memory {
+                                local_df.shrink_to_fit();
                                 let (max, avg, last, size_hint) =
                                     str_capacities[str_index].update(str_bytes_len);
                                 if logging {

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2416,6 +2416,16 @@ class GBSelection:
 
         return df
 
+    def shrink_to_fit(self, in_place: bool = False) -> "Optional[DataFrame]":
+        """
+        Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
+        """
+        if in_place:
+            df = self.clone()
+            df._df.shrink_to_fit()
+            return df
+        self._df.shrink_to_fit()
+
 
 def _series_to_frame(self: "Series") -> "DataFrame":
     return wrap_df(PyDataFrame([self._s]))

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1489,6 +1489,16 @@ class Series:
         """
         return self._s.n_unique()
 
+    def shrink_to_fit(self, in_place: bool = False) -> "Optional[Series]":
+        """
+        Shrink memory usage of this Series to fit the exact capacity needed to hold the data.
+        """
+        if in_place:
+            series = self.clone()
+            series._s.shrink_to_fit()
+            return series
+        self._s.shrink_to_fit()
+
     @property
     def dt(self) -> "DateTimeNameSpace":
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -879,6 +879,10 @@ impl PyDataFrame {
 
         Ok(out.into())
     }
+
+    pub fn shrink_to_fit(&mut self)  {
+        self.df.shrink_to_fit();
+    }
 }
 
 fn finish_groupby(gb: GroupBy, agg: &str) -> PyResult<PyDataFrame> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1027,6 +1027,9 @@ impl PySeries {
         let n = self.series.n_unique().map_err(PyPolarsEr::from)?;
         Ok(n)
     }
+    pub fn shrink_to_fit(&mut self) {
+        self.series.shrink_to_fit();
+    }
 }
 
 macro_rules! impl_ufuncs {


### PR DESCRIPTION
Added `shrink_to_fit` to containers.

Parsing csv's with argument `low_memory` will repeatedly call `shrink_to_fit`.