### PR TITLE
fix replacing strings with None expr

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -210,7 +210,7 @@ impl ChunkCast for BooleanChunked {
     where
         N: PolarsDataType,
     {
-        if matches!(N::get_dtype(), Utf8Type) {
+        if matches!(N::get_dtype(), DataType::Utf8) {
             let mut ca = boolean_to_utf8(self);
             Ok(ChunkedArray::new_from_chunks(
                 self.name(),
@@ -221,7 +221,7 @@ impl ChunkCast for BooleanChunked {
         }
     }
     fn cast_with_dtype(&self, data_type: &DataType) -> Result<Series> {
-        if matches!(data_type, Utf8Type) {
+        if matches!(data_type, DataType::Utf8) {
             let mut ca = boolean_to_utf8(self);
             ca.rename(self.name());
             Ok(ca.into_series())

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -2250,4 +2250,21 @@ mod test {
         let out = df.lazy().filter(lit(true)).collect().unwrap();
         assert_eq!(out.shape(), (100, 1));
     }
+
+    #[test]
+    fn test_ternary_null() -> Result<()> {
+        let df = df![
+            "a" => ["a", "b", "c"]
+        ]?;
+
+        let out = df
+            .lazy()
+            .select(vec![when(col("a").eq(lit("c")))
+                .then(Null {}.lit())
+                .otherwise(col("a"))])
+            .collect()?;
+
+        dbg!(out);
+        Ok(())
+    }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -17,6 +17,16 @@ impl CastExpr {
 impl PhysicalExpr for CastExpr {
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
         let series = self.input.evaluate(df, state)?;
+        // this is quite dirty
+        // We use the booleanarray as null series, because we have no null array.
+        // in a ternary or binary operation, we then do type coercion to matching supertype.
+        // here we create a null array for the types we cannot cast to from a booleanarray
+        if matches!(self.data_type, DataType::List(_)) {
+            // the booleanarray is hacked as null type
+            if series.bool().is_ok() && series.null_count() == series.len() {
+                return Ok(ListChunked::full_null(series.name(), series.len()).into_series());
+            }
+        }
         series.cast_with_dtype(&self.data_type)
     }
     fn to_field(&self, input_schema: &Schema) -> Result<Field> {


### PR DESCRIPTION
Fixes #799 

We hack a `BooleanArray` as null array. To make that work, it should be able to cast to all types. 
It still is a bit hacky. Should implement a proper null-typed array.