### PR TITLE
improve aggregation to list performance

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -70,8 +70,8 @@ zip_with = ["polars-core/zip_with"]
 round_series = ["polars-core/round_series", "polars-lazy/round_series"]
 checked_arithmetic = ["polars-core/checked_arithmetic"]
 
-# dont use this
-private = ["polars-core/private", "polars-lazy/private"]
+# don't use this
+private = []
 
 # all opt-in datatypes
 dtype-full = [
@@ -129,9 +129,9 @@ docs-selection = [
 ]
 
 [dependencies]
-polars-core = {version = "0.14.1", path = "./polars-core", features= ["docs"], default-features = false}
+polars-core = {version = "0.14.1", path = "./polars-core", features= ["docs", "private"], default-features = false}
 polars-io = {version = "0.14.1", path = "./polars-io", default-features = false, optional=true}
-polars-lazy = {version = "0.14.1", path = "./polars-lazy", default-features = false, optional=true}
+polars-lazy = {version = "0.14.1", path = "./polars-lazy", features=["private"], default-features = false, optional=true}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -108,3 +108,23 @@ pub fn combine_null_buffers(
         (None, None) => None,
     }
 }
+
+pub trait CustomIterTools: Iterator {
+    fn fold_first_<F>(mut self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+    {
+        let first = self.next()?;
+        Some(self.fold(first, f))
+    }
+
+    fn trust_my_length(self, length: usize) -> TrustMyLength<Self, Self::Item>
+    where
+        Self: Sized,
+    {
+        TrustMyLength::new(self, length)
+    }
+}
+
+impl<T: ?Sized> CustomIterTools for T where T: Iterator {}

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -1,7 +1,7 @@
 use crate::POOL;
 use ahash::RandomState;
 use num::{Bounded, Num, NumCast, ToPrimitive, Zero};
-use polars_arrow::prelude::*;
+use polars_arrow::array::ListFromIter;
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -11,7 +11,9 @@ use crate::chunked_array::kernels::take_agg::{
     take_agg_primitive_iter_unchecked_count_nulls,
 };
 use crate::prelude::*;
-use crate::utils::NoNull;
+use crate::utils::{CustomIterTools, NoNull};
+use arrow::array::{ArrayRef, LargeListArray};
+use std::convert::TryFrom;
 
 pub(crate) trait NumericAggSync {
     fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
@@ -491,78 +493,60 @@ impl AggNUnique for Utf8Chunked {
     }
 }
 
-pub(crate) trait AggList {
+pub trait AggList {
     fn agg_list(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         None
     }
 }
+
 impl<T> AggList for ChunkedArray<T>
 where
-    T: PolarsDataType,
-    ChunkedArray<T>: IntoSeries + ChunkCast,
+    T: PolarsNumericType,
 {
     fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        let s = match self.dtype() {
-            DataType::Categorical => self.cast::<Utf8Type>().unwrap().into_series(),
-            _ => self.clone().into_series(),
-        };
-
-        // TODO! use collect, can be faster
-        // needed capacity for the list
-        let values_cap = self.len();
-
-        macro_rules! impl_gb {
-            ($type:ty, $agg_col:expr) => {{
-                let values_builder = PrimitiveArrayBuilder::<$type>::new(values_cap);
-                let mut builder =
-                    ListPrimitiveChunkedBuilder::new("", values_builder, groups.len());
-                for (_first, idx) in groups {
-                    let s = unsafe {
-                        $agg_col.take_iter_unchecked(&mut idx.into_iter().map(|i| *i as usize))
-                    };
-                    builder.append_opt_series(Some(&s))
-                }
-                builder.finish().into_series()
-            }};
-        }
-
-        macro_rules! impl_gb_utf8 {
-            ($agg_col:expr) => {{
-                let values_builder = LargeStringBuilder::with_capacity(values_cap * 5, values_cap);
-                let mut builder = ListUtf8ChunkedBuilder::new("", values_builder, groups.len());
-                for (_first, idx) in groups {
-                    let s = unsafe {
-                        $agg_col.take_iter_unchecked(&mut idx.into_iter().map(|i| *i as usize))
-                    };
-                    builder.append_series(&s)
-                }
-                builder.finish().into_series()
-            }};
-        }
-
-        macro_rules! impl_gb_bool {
-            ($agg_col:expr) => {{
-                let values_builder = BooleanArrayBuilder::new(values_cap);
-                let mut builder = ListBooleanChunkedBuilder::new("", values_builder, groups.len());
-                for (_first, idx) in groups {
-                    let s = unsafe {
-                        $agg_col.take_iter_unchecked(&mut idx.into_iter().map(|i| *i as usize))
-                    };
-                    builder.append_series(&s)
-                }
-                builder.finish().into_series()
-            }};
-        }
-
-        Some(match_arrow_data_type_apply_macro!(
-            s.dtype(),
-            impl_gb,
-            impl_gb_utf8,
-            impl_gb_bool,
-            s
-        ))
+        let taker = self.take_rand();
+        let iter = groups
+            .iter()
+            .map(|(_, idx)| Some(idx.iter().map(|idx| taker.get(*idx as usize))))
+            .trust_my_length(groups.len());
+        // Safety:
+        // The length of the iterator is trusted
+        let arr = unsafe { LargeListArray::from_iter_primitive_trusted_len::<T, _, _>(iter) };
+        Series::try_from((self.name(), Arc::new(arr) as ArrayRef)).ok()
     }
 }
+
+impl AggList for BooleanChunked {
+    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        let taker = self.take_rand();
+        let iter = groups
+            .iter()
+            .map(|(_, idx)| Some(idx.iter().map(|idx| taker.get(*idx as usize))))
+            .trust_my_length(groups.len());
+        // Safety:
+        // The length of the iterator is trusted
+        let arr = unsafe { LargeListArray::from_iter_bool_trusted_len(iter) };
+        Series::try_from((self.name(), Arc::new(arr) as ArrayRef)).ok()
+    }
+}
+
+impl AggList for Utf8Chunked {
+    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        let taker = self.take_rand();
+        let iter = groups
+            .iter()
+            .map(|(_, idx)| Some(idx.iter().map(|idx| taker.get(*idx as usize))))
+            .trust_my_length(groups.len());
+        // Safety:
+        // The length of the iterator is trusted
+        let arr = unsafe { LargeListArray::from_iter_utf8_trusted_len(iter, self.len()) };
+        Series::try_from((self.name(), Arc::new(arr) as ArrayRef)).ok()
+    }
+}
+
+impl AggList for ListChunked {}
+#[cfg(feature = "object")]
+impl<T> AggList for ObjectChunked<T> {}
 
 pub(crate) trait AggQuantile {
     fn agg_quantile(&self, _groups: &[(u32, Vec<u32>)], _quantile: f64) -> Option<Series> {

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -5,6 +5,7 @@ pub use arrow;
 pub use chrono;
 pub use num_cpus;
 pub use polars_arrow::utils::TrustMyLength;
+pub use polars_arrow::utils::*;
 pub use rayon;
 use rayon::prelude::*;
 use std::borrow::Cow;
@@ -682,26 +683,6 @@ where
 
     f(out)
 }
-
-pub trait CustomIterTools: Iterator {
-    fn fold_first_<F>(mut self, f: F) -> Option<Self::Item>
-    where
-        Self: Sized,
-        F: FnMut(Self::Item, Self::Item) -> Self::Item,
-    {
-        let first = self.next()?;
-        Some(self.fold(first, f))
-    }
-
-    fn trust_my_length(self, length: usize) -> TrustMyLength<Self, Self::Item>
-    where
-        Self: Sized,
-    {
-        TrustMyLength::new(self, length)
-    }
-}
-
-impl<T: ?Sized> CustomIterTools for T where T: Iterator {}
 
 pub(crate) fn align_chunks_binary<'a, T, B>(
     left: &'a ChunkedArray<T>,


### PR DESCRIPTION
Aggregate 100k uint32array to 10k:

```
Gnuplot not found, using plotters backend
bench take              time:   [768.03 us 769.39 us 771.78 us]                       
                        change: [-76.048% -75.999% -75.943%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe
```