### PR TITLE
Remove code branches on datelike types

### DIFF
--- a/polars/polars-core/src/series/arithmetic.rs
+++ b/polars/polars-core/src/series/arithmetic.rs
@@ -412,18 +412,13 @@ where
     type Output = Series;
 
     fn sub(self, rhs: T) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! sub {
             ($ca:expr) => {{
                 $ca.sub(rhs).into_series()
             }};
         }
 
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(self, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(self, sub)
     }
 }
 
@@ -445,18 +440,12 @@ where
     type Output = Series;
 
     fn add(self, rhs: T) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! add {
             ($ca:expr) => {{
                 $ca.add(rhs).into_series()
             }};
         }
-
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(self, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(self, add)
     }
 }
 
@@ -478,18 +467,13 @@ where
     type Output = Series;
 
     fn div(self, rhs: T) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! div {
             ($ca:expr) => {{
                 $ca.div(rhs).into_series()
             }};
         }
 
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(self, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(self, div)
     }
 }
 
@@ -511,18 +495,12 @@ where
     type Output = Series;
 
     fn mul(self, rhs: T) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! mul {
             ($ca:expr) => {{
                 $ca.mul(rhs).into_series()
             }};
         }
-
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(self, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(self, mul)
     }
 }
 
@@ -544,18 +522,12 @@ where
     type Output = Series;
 
     fn rem(self, rhs: T) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! rem {
             ($ca:expr) => {{
                 $ca.rem(rhs).into_series()
             }};
         }
-
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(self, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(self, rem)
     }
 }
 
@@ -619,50 +591,33 @@ where
         rhs + self
     }
     fn sub(self, rhs: &Series) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! sub {
             ($rhs:expr) => {{
                 $rhs.lhs_sub(self).into_series()
             }};
         }
-
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(rhs, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(rhs, sub)
     }
     fn div(self, rhs: &Series) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! div {
             ($rhs:expr) => {{
                 $rhs.lhs_div(self).into_series()
             }};
         }
-
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(rhs, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(rhs, div)
     }
     fn mul(self, rhs: &Series) -> Self::Output {
         // order doesn't matter, dispatch to rhs * lhs
         rhs * self
     }
     fn rem(self, rhs: &Series) -> Self::Output {
-        macro_rules! numeric {
+        macro_rules! rem {
             ($rhs:expr) => {{
                 $rhs.lhs_rem(self).into_series()
             }};
         }
 
-        macro_rules! noop {
-            ($ca:expr) => {{
-                unimplemented!()
-            }};
-        }
-        match_arrow_data_type_apply_macro_ca!(rhs, numeric, noop, noop)
+        match_arrow_data_type_apply_macro_ca_logical_num!(rhs, rem)
     }
 }
 
@@ -734,20 +689,6 @@ mod test {
         assert_eq!((&s * &s).name(), "foo");
         assert_eq!((&s * 1).name(), "foo");
         assert_eq!((1.div(&s)).name(), "foo");
-    }
-
-    #[test]
-    #[cfg(feature = "dtype-date64")]
-    fn test_arithmetic_series_date() {
-        // Date Series have a different dispatch, so let's test that.
-        let s = Date64Chunked::new_from_slice("foo", &[0, 1, 2, 3]).into_series();
-
-        // test if it runs.
-        let _ = &s * &s;
-
-        let _ = s.minute().map(|m| &m / 5);
-        let _ = s.minute().map(|m| m / 5);
-        let _ = s.minute().map(|m| m.into_series() / 5);
     }
 
     #[test]

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -258,6 +258,7 @@ impl<T: Default> Arena<T> {
     }
 }
 
+/// Apply a macro on the Series
 #[macro_export]
 macro_rules! match_arrow_data_type_apply_macro {
     ($obj:expr, $macro:ident, $macro_utf8:ident, $macro_bool:ident $(, $opt_args:expr)*) => {{
@@ -294,6 +295,7 @@ macro_rules! match_arrow_data_type_apply_macro {
     }};
 }
 
+/// Apply a macro on the Downcasted ChunkedArray's
 #[macro_export]
 macro_rules! match_arrow_data_type_apply_macro_ca {
     ($self:expr, $macro:ident, $macro_utf8:ident, $macro_bool:ident $(, $opt_args:expr)*) => {{
@@ -325,6 +327,32 @@ macro_rules! match_arrow_data_type_apply_macro_ca {
             DataType::Duration(TimeUnit::Nanosecond) => $macro!($self.duration_nanosecond().unwrap() $(, $opt_args)*),
             #[cfg(feature = "dtype-duration-ms")]
             DataType::Duration(TimeUnit::Millisecond) => $macro!($self.duration_millisecond().unwrap() $(, $opt_args)*),
+            _ => unimplemented!(),
+        }
+    }};
+}
+
+/// Apply a macro on the Downcasted ChunkedArray's of DataTypes that are logical numerics.
+/// So no dates.
+#[macro_export]
+macro_rules! match_arrow_data_type_apply_macro_ca_logical_num {
+    ($self:expr, $macro:ident $(, $opt_args:expr)*) => {{
+        match $self.dtype() {
+            #[cfg(feature = "dtype-u8")]
+            DataType::UInt8 => $macro!($self.u8().unwrap() $(, $opt_args)*),
+            #[cfg(feature = "dtype-u16")]
+            DataType::UInt16 => $macro!($self.u16().unwrap() $(, $opt_args)*),
+            DataType::UInt32 => $macro!($self.u32().unwrap() $(, $opt_args)*),
+            #[cfg(feature = "dtype-u64")]
+            DataType::UInt64 => $macro!($self.u64().unwrap() $(, $opt_args)*),
+            #[cfg(feature = "dtype-i8")]
+            DataType::Int8 => $macro!($self.i8().unwrap() $(, $opt_args)*),
+            #[cfg(feature = "dtype-i16")]
+            DataType::Int16 => $macro!($self.i16().unwrap() $(, $opt_args)*),
+            DataType::Int32 => $macro!($self.i32().unwrap() $(, $opt_args)*),
+            DataType::Int64 => $macro!($self.i64().unwrap() $(, $opt_args)*),
+            DataType::Float32 => $macro!($self.f32().unwrap() $(, $opt_args)*),
+            DataType::Float64 => $macro!($self.f64().unwrap() $(, $opt_args)*),
             _ => unimplemented!(),
         }
     }};


### PR DESCRIPTION
A lot of operations don't make sense, so let's
not do them. E.g. no variance of dates, no
summing etc.

#843 