### PR TITLE
Improve groupby on multiple keys

### DIFF
--- a/polars/polars-arrow/src/vec.rs
+++ b/polars/polars-arrow/src/vec.rs
@@ -169,6 +169,10 @@ impl<T> AlignedVec<T> {
         self.inner.as_mut_slice()
     }
 
+    pub fn as_slice(&self) -> &[T] {
+        self.inner.as_slice()
+    }
+
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -125,6 +125,23 @@ where
             .map(f)
             .collect()
     }
+    fn apply_to_slice<F, V>(&'a self, f: F, slice: &mut [V])
+    where
+        F: Fn(Option<T::Native>, &V) -> V,
+    {
+        assert!(slice.len() >= self.len());
+
+        let mut idx = 0;
+        self.downcast_iter().for_each(|arr| {
+            arr.into_iter().for_each(|opt_val| {
+                // Safety:
+                // length asserted above
+                let item = unsafe { slice.get_unchecked_mut(idx) };
+                *item = f(opt_val, item);
+                idx += 1;
+            })
+        });
+    }
 }
 
 impl<'a> ChunkApply<'a, bool, bool> for BooleanChunked {
@@ -179,6 +196,24 @@ impl<'a> ChunkApply<'a, bool, bool> for BooleanChunked {
         F: Fn((usize, Option<bool>)) -> Option<bool> + Copy,
     {
         self.into_iter().enumerate().map(f).collect()
+    }
+
+    fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
+    where
+        F: Fn(Option<bool>, &T) -> T,
+    {
+        assert!(slice.len() >= self.len());
+
+        let mut idx = 0;
+        self.downcast_iter().for_each(|arr| {
+            arr.into_iter().for_each(|opt_val| {
+                // Safety:
+                // length asserted above
+                let item = unsafe { slice.get_unchecked_mut(idx) };
+                *item = f(opt_val, item);
+                idx += 1;
+            })
+        });
     }
 }
 
@@ -245,6 +280,24 @@ impl<'a> ChunkApply<'a, &'a str, Cow<'a, str>> for Utf8Chunked {
         F: Fn((usize, Option<&'a str>)) -> Option<Cow<'a, str>> + Copy,
     {
         self.into_iter().enumerate().map(f).collect()
+    }
+
+    fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
+    where
+        F: Fn(Option<&'a str>, &T) -> T,
+    {
+        assert!(slice.len() >= self.len());
+
+        let mut idx = 0;
+        self.downcast_iter().for_each(|arr| {
+            arr.into_iter().for_each(|opt_val| {
+                // Safety:
+                // length asserted above
+                let item = unsafe { slice.get_unchecked_mut(idx) };
+                *item = f(opt_val, item);
+                idx += 1;
+            })
+        });
     }
 }
 
@@ -395,5 +448,25 @@ impl<'a> ChunkApply<'a, Series, Series> for ListChunked {
         F: Fn((usize, Option<Series>)) -> Option<Series> + Copy,
     {
         self.into_iter().enumerate().map(f).collect()
+    }
+
+    fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
+    where
+        F: Fn(Option<Series>, &T) -> T,
+    {
+        assert!(slice.len() >= self.len());
+
+        let mut idx = 0;
+        self.downcast_iter().for_each(|arr| {
+            arr.iter().for_each(|opt_val| {
+                let opt_val = opt_val.map(|arrayref| Series::try_from(("", arrayref)).unwrap());
+
+                // Safety:
+                // length asserted above
+                let item = unsafe { slice.get_unchecked_mut(idx) };
+                *item = f(opt_val, item);
+                idx += 1;
+            })
+        });
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/polars/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -1,0 +1,145 @@
+//!
+//! Used to speed up PartialEq and PartialOrd of elements within an array
+//!
+
+use super::take_random::{
+    BoolTakeRandom, BoolTakeRandomSingleChunk, NumTakeRandomChunked, NumTakeRandomCont,
+    NumTakeRandomSingleChunk, Utf8TakeRandom, Utf8TakeRandomSingleChunk,
+};
+use crate::prelude::*;
+use std::cmp::PartialEq;
+
+pub trait PartialEqInner: Send + Sync {
+    /// Safety:
+    /// Does not do any bound checks
+    unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool;
+}
+
+macro_rules! impl_traits {
+    ($struct:ty) => {
+        impl PartialEqInner for $struct {
+            #[inline]
+            unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool {
+                self.get(idx_a) == self.get(idx_b)
+            }
+        }
+    };
+    ($struct:ty, $T:tt) => {
+        impl<$T> PartialEqInner for $struct
+        where
+            $T: PolarsNumericType + Sync,
+            $T::Native: Copy + PartialEq,
+        {
+            #[inline]
+            unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool {
+                self.get(idx_a) == self.get(idx_b)
+            }
+        }
+    };
+}
+
+impl_traits!(Utf8TakeRandom<'_>);
+impl_traits!(Utf8TakeRandomSingleChunk<'_>);
+impl_traits!(BoolTakeRandom<'_>);
+impl_traits!(BoolTakeRandomSingleChunk<'_>);
+impl_traits!(NumTakeRandomSingleChunk<'_, T>, T);
+impl_traits!(NumTakeRandomChunked<'_, T>, T);
+
+impl<T> PartialEqInner for NumTakeRandomCont<'_, T>
+where
+    T: Copy + PartialEq + Sync,
+{
+    unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool {
+        // no nulls so we can do unchecked
+        self.get_unchecked(idx_a) == self.get_unchecked(idx_b)
+    }
+}
+
+/// Create a type that implements PartialEqInner
+pub(crate) trait IntoPartialEqInner<'a> {
+    /// Create a type that implements `TakeRandom`.
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a>;
+}
+
+/// We use a trait object because we want to call this from Series and cannot use a typed enum.
+impl<'a, T> IntoPartialEqInner<'a> for &'a ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    T::Native: PartialEq,
+{
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a> {
+        let mut chunks = self.downcast_iter();
+
+        if self.chunks.len() == 1 {
+            let arr = chunks.next().unwrap();
+
+            if self.null_count() == 0 {
+                let t = NumTakeRandomCont {
+                    slice: arr.values(),
+                };
+                Box::new(t)
+            } else {
+                let t = NumTakeRandomSingleChunk { arr };
+                Box::new(t)
+            }
+        } else {
+            let t = NumTakeRandomChunked {
+                chunks: chunks.collect(),
+                chunk_lens: self.chunks.iter().map(|a| a.len() as u32).collect(),
+            };
+            Box::new(t)
+        }
+    }
+}
+
+impl<'a> IntoPartialEqInner<'a> for &'a Utf8Chunked {
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a> {
+        match self.chunks.len() {
+            1 => {
+                let arr = self.downcast_iter().next().unwrap();
+                let t = Utf8TakeRandomSingleChunk { arr };
+                Box::new(t)
+            }
+            _ => {
+                let chunks = self.downcast_chunks();
+                let t = Utf8TakeRandom {
+                    chunks,
+                    chunk_lens: self.chunks.iter().map(|a| a.len() as u32).collect(),
+                };
+                Box::new(t)
+            }
+        }
+    }
+}
+
+impl<'a> IntoPartialEqInner<'a> for &'a BooleanChunked {
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a> {
+        match self.chunks.len() {
+            1 => {
+                let arr = self.downcast_iter().next().unwrap();
+                let t = BoolTakeRandomSingleChunk { arr };
+                Box::new(t)
+            }
+            _ => {
+                let chunks = self.downcast_chunks();
+                let t = BoolTakeRandom {
+                    chunks,
+                    chunk_lens: self.chunks.iter().map(|a| a.len() as u32).collect(),
+                };
+                Box::new(t)
+            }
+        }
+    }
+}
+
+impl<'a> IntoPartialEqInner<'a> for &'a ListChunked {
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner> {
+        unimplemented!()
+    }
+}
+
+impl<'a> IntoPartialEqInner<'a> for &'a CategoricalChunked {
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner> {
+        unimplemented!()
+    }
+}

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -474,6 +474,12 @@ pub trait ChunkApply<'a, A, B> {
     fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
     where
         F: Fn((usize, Option<A>)) -> Option<B> + Copy;
+
+    /// Apply a closure elementwise and write results to a mutable slice.
+    fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
+    // (value of chunkedarray, value of slice) -> value of slice
+    where
+        F: Fn(Option<A>, &T) -> T;
 }
 
 /// Aggregation operations

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod any_value;
 pub(crate) mod apply;
 pub(crate) mod bit_repr;
 pub(crate) mod chunkops;
+pub(crate) mod compare_inner;
 pub(crate) mod cum_agg;
 pub(crate) mod downcast;
 pub(crate) mod explode;

--- a/polars/polars-core/src/chunked_array/ops/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take_random.rs
@@ -154,8 +154,8 @@ where
 }
 
 pub struct Utf8TakeRandom<'a> {
-    chunks: Chunks<'a, LargeStringArray>,
-    chunk_lens: Vec<u32>,
+    pub(crate) chunks: Chunks<'a, LargeStringArray>,
+    pub(crate) chunk_lens: Vec<u32>,
 }
 
 impl<'a> TakeRandom for Utf8TakeRandom<'a> {
@@ -173,7 +173,7 @@ impl<'a> TakeRandom for Utf8TakeRandom<'a> {
 }
 
 pub struct Utf8TakeRandomSingleChunk<'a> {
-    arr: &'a LargeStringArray,
+    pub(crate) arr: &'a LargeStringArray,
 }
 
 impl<'a> TakeRandom for Utf8TakeRandomSingleChunk<'a> {
@@ -263,8 +263,8 @@ pub struct NumTakeRandomChunked<'a, T>
 where
     T: PolarsNumericType,
 {
-    chunks: Vec<&'a PrimitiveArray<T>>,
-    chunk_lens: Vec<u32>,
+    pub(crate) chunks: Vec<&'a PrimitiveArray<T>>,
+    pub(crate) chunk_lens: Vec<u32>,
 }
 
 impl<'a, T> TakeRandom for NumTakeRandomChunked<'a, T>
@@ -285,7 +285,7 @@ where
 }
 
 pub struct NumTakeRandomCont<'a, T> {
-    slice: &'a [T],
+    pub(crate) slice: &'a [T],
 }
 
 impl<'a, T> TakeRandom for NumTakeRandomCont<'a, T>
@@ -309,7 +309,7 @@ pub struct NumTakeRandomSingleChunk<'a, T>
 where
     T: PolarsNumericType,
 {
-    arr: &'a PrimitiveArray<T>,
+    pub(crate) arr: &'a PrimitiveArray<T>,
 }
 
 impl<'a, T> TakeRandom for NumTakeRandomSingleChunk<'a, T>
@@ -330,8 +330,8 @@ where
 }
 
 pub struct BoolTakeRandom<'a> {
-    chunks: Chunks<'a, BooleanArray>,
-    chunk_lens: Vec<u32>,
+    pub(crate) chunks: Chunks<'a, BooleanArray>,
+    pub(crate) chunk_lens: Vec<u32>,
 }
 
 impl<'a> TakeRandom for BoolTakeRandom<'a> {
@@ -349,7 +349,7 @@ impl<'a> TakeRandom for BoolTakeRandom<'a> {
 }
 
 pub struct BoolTakeRandomSingleChunk<'a> {
-    arr: &'a BooleanArray,
+    pub(crate) arr: &'a BooleanArray,
 }
 
 impl<'a> TakeRandom for BoolTakeRandomSingleChunk<'a> {

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -119,7 +119,7 @@ macro_rules! impl_dyn_series {
                 try_physical_dispatch!(self, zip_with_same_type, mask, other)
             }
 
-            fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+            fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
                 cast_and_apply!(self, vec_hash, random_state)
             }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -78,8 +78,12 @@ macro_rules! impl_dyn_series {
                 (&self.0).into_partial_eq_inner()
             }
 
-            fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+            fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
                 self.0.vec_hash(random_state)
+            }
+
+            fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) {
+                self.0.vec_hash_combine(build_hasher, hashes)
             }
 
             fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -14,7 +14,10 @@ use super::IntoSeries;
 use super::SeriesTrait;
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::{
-    ops::aggregate::{ChunkAggSeries, VarAggSeries},
+    ops::{
+        aggregate::{ChunkAggSeries, VarAggSeries},
+        compare_inner::{IntoPartialEqInner, PartialEqInner},
+    },
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
@@ -70,6 +73,9 @@ macro_rules! impl_dyn_series {
             fn zip_with_same_type(&self, mask: &BooleanChunked, other: &Series) -> Result<Series> {
                 ChunkZip::zip_with(&self.0, mask, other.as_ref().as_ref())
                     .map(|ca| ca.into_series())
+            }
+            fn into_partial_eq_inner<'a>(&'a self) -> Box<dyn PartialEqInner + 'a> {
+                (&self.0).into_partial_eq_inner()
             }
 
             fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod private {
     use crate::frame::groupby::pivot::PivotAgg;
     use crate::frame::groupby::GroupTuples;
 
+    use crate::chunked_array::ops::compare_inner::PartialEqInner;
     use ahash::RandomState;
     use std::borrow::Cow;
 
@@ -54,6 +55,10 @@ pub(crate) mod private {
             _idx_other: usize,
             _other: &Series,
         ) -> bool {
+            unimplemented!()
+        }
+        #[allow(clippy::wrong_self_convention)]
+        fn into_partial_eq_inner<'a>(&'a self) -> Box<dyn PartialEqInner + 'a> {
             unimplemented!()
         }
         fn vec_hash(&self, _build_hasher: RandomState) -> UInt64Chunked {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -61,7 +61,10 @@ pub(crate) mod private {
         fn into_partial_eq_inner<'a>(&'a self) -> Box<dyn PartialEqInner + 'a> {
             unimplemented!()
         }
-        fn vec_hash(&self, _build_hasher: RandomState) -> UInt64Chunked {
+        fn vec_hash(&self, _build_hasher: RandomState) -> AlignedVec<u64> {
+            unimplemented!()
+        }
+        fn vec_hash_combine(&self, _build_hasher: RandomState, _hashes: &mut [u64]) {
             unimplemented!()
         }
         fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -17,7 +17,11 @@ pub trait VecHash {
     /// Compute the hash for all values in the array.
     ///
     /// This currently only works with the AHash RandomState hasher builder.
-    fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
+    fn vec_hash(&self, _random_state: RandomState) -> AlignedVec<u64> {
+        unimplemented!()
+    }
+
+    fn vec_hash_combine(&self, _random_state: RandomState, _hashes: &mut [u64]) {
         unimplemented!()
     }
 }
@@ -27,59 +31,117 @@ where
     T: PolarsIntegerType,
     T::Native: Hash,
 {
-    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+    fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
         // Note that we don't use the no null branch! This can break in unexpected ways.
         // for instance with threading we split an array in n_threads, this may lead to
         // splits that have no nulls and splits that have nulls. Then one array is hashed with
         // Option<T> and the other array with T.
         // Meaning that they cannot be compared. By always hashing on Option<T> the random_state is
         // the only deterministic seed.
-        self.branch_apply_cast_numeric_no_null(|opt_v| {
-            let mut hasher = random_state.build_hasher();
-            opt_v.hash(&mut hasher);
-            hasher.finish()
-        })
+        let mut av = AlignedVec::with_capacity_aligned(self.len());
+
+        self.downcast_iter().for_each(|arr| {
+            av.extend(arr.into_iter().map(|opt_v| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                hasher.finish()
+            }))
+        });
+        av
+    }
+
+    fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
+        self.apply_to_slice(
+            |opt_v, h| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                boost_hash_combine(hasher.finish(), *h)
+            },
+            hashes,
+        )
     }
 }
 
 impl VecHash for Utf8Chunked {
-    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| {
-            let mut hasher = random_state.build_hasher();
-            opt_v.hash(&mut hasher);
-            hasher.finish()
-        })
+    fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
+        let mut av = AlignedVec::with_capacity_aligned(self.len());
+        self.downcast_iter().for_each(|arr| {
+            av.extend(arr.into_iter().map(|opt_v| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                hasher.finish()
+            }))
+        });
+        av
+    }
+
+    fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
+        self.apply_to_slice(
+            |opt_v, h| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                boost_hash_combine(hasher.finish(), *h)
+            },
+            hashes,
+        )
     }
 }
 
 impl VecHash for BooleanChunked {
-    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| {
-            let mut hasher = random_state.build_hasher();
-            opt_v.hash(&mut hasher);
-            hasher.finish()
-        })
+    fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
+        let mut av = AlignedVec::with_capacity_aligned(self.len());
+        self.downcast_iter().for_each(|arr| {
+            av.extend(arr.into_iter().map(|opt_v| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                hasher.finish()
+            }))
+        });
+        av
+    }
+
+    fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
+        self.apply_to_slice(
+            |opt_v, h| {
+                let mut hasher = random_state.build_hasher();
+                opt_v.hash(&mut hasher);
+                boost_hash_combine(hasher.finish(), *h)
+            },
+            hashes,
+        )
     }
 }
 
 impl VecHash for Float32Chunked {
-    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| {
-            let opt_v = opt_v.map(|v| v.to_bits());
-            let mut hasher = random_state.build_hasher();
-            opt_v.hash(&mut hasher);
-            hasher.finish()
-        })
+    fn vec_hash(&self, _random_state: RandomState) -> AlignedVec<u64> {
+        panic!("should already be coerced to u32")
+    }
+
+    fn vec_hash_combine(&self, _random_state: RandomState, _hashes: &mut [u64]) {
+        panic!("should already be coerced to u32")
     }
 }
 impl VecHash for Float64Chunked {
-    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        self.branch_apply_cast_numeric_no_null(|opt_v| {
-            let opt_v = opt_v.map(|v| v.to_bits());
-            let mut hasher = random_state.build_hasher();
-            opt_v.hash(&mut hasher);
-            hasher.finish()
-        })
+    fn vec_hash(&self, _random_state: RandomState) -> AlignedVec<u64> {
+        #[cfg(not(feature = "dtype-u64"))]
+        {
+            let mut av = AlignedVec::with_capacity_aligned(self.len());
+            self.downcast_iter().for_each(|arr| {
+                av.extend(arr.into_iter().map(|opt_v| {
+                    let mut hasher = _random_state.build_hasher();
+                    opt_v.map(|v| v.to_bits()).hash(&mut hasher);
+                    hasher.finish()
+                }))
+            });
+            av
+        }
+        #[cfg(feature = "dtype-u64")]
+        {
+            panic!("should already be coerced to u64")
+        }
+    }
+    fn vec_hash_combine(&self, _random_state: RandomState, _hashes: &mut [u64]) {
+        panic!("should already be coerced to u64")
     }
 }
 
@@ -397,6 +459,7 @@ where
 }
 
 // hash combine from c++' boost lib
+#[inline]
 fn boost_hash_combine(l: u64, r: u64) -> u64 {
     l ^ r.wrapping_add(0x9e3779b9u64.wrapping_add(l << 6).wrapping_add(r >> 2))
 }
@@ -424,80 +487,16 @@ pub(crate) fn df_rows_to_hashes(
     build_hasher: Option<RandomState>,
 ) -> (UInt64Chunked, RandomState) {
     let build_hasher = build_hasher.unwrap_or_default();
-    let hashes: Vec<_> = keys
-        .columns
-        .iter()
-        .map(|s| {
-            let h = s.vec_hash(build_hasher.clone());
-            // if this fails we have unexpected groupby results.
-            debug_assert_eq!(h.null_count(), 0);
-            h
-        })
-        .collect();
 
-    let n_chunks = hashes[0].chunks().len();
-    let mut av = AlignedVec::with_capacity_aligned(keys.height());
+    let mut iter = keys.iter();
+    let first = iter.next().expect("at least one key");
+    let mut hashes = first.vec_hash(build_hasher.clone());
+    let hslice = hashes.as_mut_slice();
 
-    // two code paths, one has one layer of indirection less.
-    if n_chunks == 1 {
-        let chunks: Vec<&[u64]> = hashes
-            .iter()
-            .map(|ca| {
-                ca.downcast_iter()
-                    .map(|arr| arr.values())
-                    .collect::<Vec<_>>()[0]
-            })
-            .collect();
-        unsafe {
-            let chunk_len = chunks.get_unchecked(0).len();
-
-            // over chunk length in column direction
-            for idx in 0..chunk_len {
-                let hslice = chunks.get_unchecked(0);
-                let mut h = *hslice.get_unchecked(idx);
-
-                // in row direction
-                for column_i in 1..hashes.len() {
-                    let hslice = chunks.get_unchecked(column_i);
-                    let h_ = *hslice.get_unchecked(idx);
-                    h = boost_hash_combine(h, h_)
-                }
-
-                av.push(h);
-            }
-        }
-    // path with more indirection
-    } else {
-        let chunks: Vec<Vec<&[u64]>> = hashes
-            .iter()
-            .map(|ca| {
-                ca.downcast_iter()
-                    .map(|arr| arr.values())
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-        unsafe {
-            for chunk_i in 0..n_chunks {
-                let chunk_len = chunks.get_unchecked(0).get_unchecked(chunk_i).len();
-
-                // over chunk length in column direction
-                for idx in 0..chunk_len {
-                    let hslice = chunks.get_unchecked(0).get_unchecked(chunk_i);
-                    let mut h = *hslice.get_unchecked(idx);
-
-                    // in row direction
-                    for column_i in 1..hashes.len() {
-                        let hslice = chunks.get_unchecked(column_i).get_unchecked(chunk_i);
-                        let h_ = *hslice.get_unchecked(idx);
-                        h = boost_hash_combine(h, h_)
-                    }
-
-                    av.push(h);
-                }
-            }
-        }
+    for keys in iter {
+        keys.vec_hash_combine(build_hasher.clone(), hslice);
     }
 
-    let chunks = vec![Arc::new(av.into_primitive_array::<UInt64Type>(None)) as ArrayRef];
+    let chunks = vec![Arc::new(hashes.into_primitive_array::<UInt64Type>(None)) as ArrayRef];
     (UInt64Chunked::new_from_chunks("", chunks), build_hasher)
 }


### PR DESCRIPTION
* Reduce memory usage by writing all hashes to the same memory chunk instead of first computing N hashes arrays, where N is the number of keys.

* Use a utility box trait to compare values within arrays. This will likely speed up the groupby for multiple chunks.