### PR TITLE
Arrow2: WIP: h-agg min test

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -50,6 +50,7 @@ impl ChunkExplode for Utf8Chunked {
             .next()
             .ok_or_else(|| PolarsError::NoData("cannot explode empty str".into()))?;
         let values = array.values();
+        let old_offsets = array.offsets().clone();
 
         // Because the strings are u8 stored but really are utf8 data we need to traverse the utf8 to
         // get the chars indexes
@@ -95,6 +96,6 @@ impl ChunkExplode for Utf8Chunked {
         let new_arr = Arc::new(array) as ArrayRef;
 
         let s = Series::try_from((self.name(), new_arr)).unwrap();
-        Ok((s, offsets))
+        Ok((s, old_offsets))
     }
 }


### PR DESCRIPTION
The zip kernel on master ignores the `validtity` of the `mask`. This behaviour is built upon in horizontal aggregation.

Added a utility to set the `null` bits to in a `BooleanArray` to `true`, meaning that we take from the lhs in `if_then_else` kernel. This should fix the aggregation, but now there seems to be a strange panic upstream.

```
running 1 test
thread 'frame::test::test_h_agg' panicked at 'range end index 8 out of range for slice of length 3', /home/ritchie46/.cargo/git/checkouts/arrow2-8a2ad61d97265680/7f2c3c1/src/array/growable/primitive.rs:67:40
stack backtrace:
   0: rust_begin_unwind
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/panicking.rs:92:14
   2: core::slice::index::slice_end_index_len_fail
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/slice/index.rs:41:5
   3: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/slice/index.rs:238:13
   4: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/slice/index.rs:15:9
   5: <arrow2::array::growable::primitive::GrowablePrimitive<T> as arrow2::array::growable::Growable>::extend
             at /home/ritchie46/.cargo/git/checkouts/arrow2-8a2ad61d97265680/7f2c3c1/src/array/growable/primitive.rs:67:40
   6: arrow2::compute::if_then_else::if_then_else
             at /home/ritchie46/.cargo/git/checkouts/arrow2-8a2ad61d97265680/7f2c3c1/src/compute/if_then_else.rs:64:13
   7: polars_core::chunked_array::ops::zip::<impl polars_core::chunked_array::ops::ChunkZip<T> for polars_core::chunked_array::ChunkedArray<T>>::zip_with::{{closure}}
             at ./src/chunked_array/ops/zip.rs:86:31
   8: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/adapters/map.rs:89:28
   9: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/traits/iterator.rs:1993:21
  10: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/adapters/map.rs:115:9
  11: <core::iter::adapters::ResultShunt<I,E> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/adapters/mod.rs:170:9
  12: core::iter::traits::iterator::Iterator::find
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/traits/iterator.rs:2346:9
  13: <core::iter::adapters::ResultShunt<I,E> as core::iter::traits::iterator::Iterator>::next
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/adapters/mod.rs:152:9
  14: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/alloc/src/vec/spec_from_iter_nested.rs:23:32
  15: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/alloc/src/vec/spec_from_iter.rs:36:9
  16: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/alloc/src/vec/mod.rs:2401:9
  17: core::iter::traits::iterator::Iterator::collect
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/traits/iterator.rs:1775:9
  18: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/result.rs:1589:53
  19: core::iter::adapters::process_results
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/adapters/mod.rs:141:17
  20: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/result.rs:1589:9
  21: core::iter::traits::iterator::Iterator::collect
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/traits/iterator.rs:1775:9
  22: polars_core::chunked_array::ops::zip::<impl polars_core::chunked_array::ops::ChunkZip<T> for polars_core::chunked_array::ChunkedArray<T>>::zip_with
             at ./src/chunked_array/ops/zip.rs:80:26
  23: <polars_core::series::implementations::SeriesWrap<polars_core::chunked_array::ChunkedArray<polars_core::datatypes::Int32Type>> as polars_core::series::private::PrivateSeries>::zip_with_same_type
             at ./src/series/implementations/mod.rs:73:17
  24: polars_core::series::Series::zip_with
             at ./src/series/mod.rs:1327:9
  25: polars_core::frame::DataFrame::hmin::{{closure}}
             at ./src/frame/mod.rs:1368:35
  26: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/iter/traits/iterator.rs:1993:21
  27: polars_core::frame::DataFrame::hmin
             at ./src/frame/mod.rs:1364:17
  28: polars_core::frame::test::test_h_agg
             at ./src/frame/mod.rs:1936:23
  29: polars_core::frame::test::test_h_agg::{{closure}}
             at ./src/frame/mod.rs:1921:5
  30: core::ops::function::FnOnce::call_once
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/ops/function.rs:227:5
  31: core::ops::function::FnOnce::call_once
             at /rustc/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test frame::test::test_h_agg ... FAILED

failures:

```