### PR TITLE
Allow multiple subreleases of pyarrow 4.0.x.

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -65,7 +65,7 @@ crate-type = ["cdylib"]
 name = "polars"
 # the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS
 # (which the Rust libraries use to take advantage of Rust API changes).
-requires-dist = ["numpy", "pyarrow==4.0"]
+requires-dist = ["numpy", "pyarrow==4.0.*"]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Before only pyarrow 4.0.0 was allowed and pip would complain if you upgrade pyarrow to 4.0.1:

    polars 0.8.6 requires pyarrow==4.0, but you have pyarrow 4.0.1 which is incompatible.