### PR TITLE
Use fsspec to open file in eager read_* functions

### DIFF
--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -158,7 +158,7 @@ class DataFrame:
 
     @staticmethod
     def read_csv(
-        file: Union[str, TextIO],
+        file: Union[str, BinaryIO],
         infer_schema_length: int = 100,
         batch_size: int = 64,
         has_headers: bool = True,

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -84,9 +84,9 @@ def _prepare_file_arg(
 
     compression = kwargs.pop("compression", "infer")
 
-    # Small helper to use a string as context
+    # Small helper to use a variable as context
     @contextmanager
-    def managed_file(file: Union[str, List[str]]) -> Iterator[Union[str, List[str]]]:
+    def managed_file(file: Any) -> Iterator[Any]:
         try:
             yield file
         finally:


### PR DESCRIPTION
Hi @ritchie46 ,

This PR
- adds a dependency on [fsspec](https://github.com/intake/filesystem_spec);
- relies on fsspec to open files passed as string arguments to polars read_* functions;
- defaults to inferring file compression format

This offloads to fsspec the handling of (de)compression, and remote protocls (e.g. s3://, gs://)