### PR TITLE
don't compile lazy when temporal is activated

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = ["polars-core/ndarray"]
 # serde support for dataframes and series
 serde = ["polars-core/serde"]
 parquet = ["polars-io", "polars-core/parquet", "polars-lazy/parquet", "polars-io/parquet"]
-lazy = ["polars-core/lazy", "polars-lazy"]
+lazy = ["polars-core/lazy", "polars-lazy", "polars-lazy/compile"]
 # commented out until UB is fixed
 #parallel = ["polars-core/parallel"]
 

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/ritchie46/polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+# make sure we don't compile unneeded things even though
+# this dependency gets activated
+compile = []
+default = ["compile"]
 parquet = ["polars-core/parquet", "polars-io/parquet"]
 csv-file = ["polars-io/csv-file"]
 temporal = ["polars-core/temporal"]

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -185,15 +185,23 @@
 //! }
 //! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#[cfg(feature = "datafusion")]
+#[cfg(all(feature = "datafusion", feature = "compile"))]
 mod datafusion;
+#[cfg(feature = "compile")]
 pub mod dsl;
+#[cfg(feature = "compile")]
 mod dummies;
+#[cfg(feature = "compile")]
 pub mod frame;
+#[cfg(feature = "compile")]
 pub mod functions;
+#[cfg(feature = "compile")]
 pub mod logical_plan;
+#[cfg(feature = "compile")]
 pub mod physical_plan;
+#[cfg(feature = "compile")]
 pub mod prelude;
+#[cfg(feature = "compile")]
 pub(crate) mod utils;
 
 #[cfg(test)]


### PR DESCRIPTION
Any feature that needed activation both in polars-core and in polars-lazy lead to full compilation of lazy, even if only core is needed. This makes sure that polars-lazy only compiles when we activate the `lazy` feature.

#847 