### PR TITLE
Lazy: window expr use groupby aggregation expr.

### DIFF
--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -2302,4 +2302,26 @@ mod test {
         );
         Ok(())
     }
+
+    #[test]
+    fn test_fill_forward() -> Result<()> {
+        let df = df![
+            "a" => ["a", "b", "a"],
+            "b" => [Some(1), None, None]
+        ]?;
+
+        let out = df
+            .lazy()
+            .select(vec![col("b").forward_fill().over(vec![col("a")])])
+            .collect()?;
+        let agg = out.column("b")?.list()?;
+
+        let a: Series = agg.get(0).unwrap();
+        assert!(a.series_equal(&Series::new("b", &[1, 1])));
+        let a: Series = agg.get(2).unwrap();
+        assert!(a.series_equal(&Series::new("b", &[1, 1])));
+        let a: Series = agg.get(1).unwrap();
+        assert_eq!(a.null_count(), 1);
+        Ok(())
+    }
 }

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -401,6 +401,8 @@ impl DefaultPlanner {
                 // TODO! Order by
                 let group_by =
                     self.create_physical_expressions(&partition_by, Context::Default, expr_arena)?;
+                let phys_function =
+                    self.create_physical_expr(function, Context::Aggregation, expr_arena)?;
                 let mut out_name = None;
                 let mut apply_columns = aexpr_to_root_names(function, expr_arena);
                 if apply_columns.len() > 1 {
@@ -421,6 +423,7 @@ impl DefaultPlanner {
                     apply_column,
                     out_name,
                     function,
+                    phys_function,
                 }))
             }
             Literal(value) => Ok(Arc::new(LiteralExpr::new(


### PR DESCRIPTION
Window functions used their own aggregation of custom
functions. By using the same as in groupby expression
all logic is central and they handle aggregation over
groups better