### PR TITLE
Bugfix in Series/DataFrame: shrink_to_fit in-place

### DIFF
--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2452,15 +2452,17 @@ class GBSelection:
 
         return df
 
-    def shrink_to_fit(self, in_place: bool = False) -> "Optional[DataFrame]":
+    def shrink_to_fit(self, in_place: bool = False) -> Optional["DataFrame"]:
         """
         Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
         """
         if in_place:
+            self._df.shrink_to_fit()
+            return None
+        else:
             df = self.clone()
             df._df.shrink_to_fit()
             return df
-        self._df.shrink_to_fit()
 
 
 def _series_to_frame(self: "Series") -> "DataFrame":

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1485,15 +1485,17 @@ class Series:
         """
         return self._s.n_unique()
 
-    def shrink_to_fit(self, in_place: bool = False) -> "Optional[Series]":
+    def shrink_to_fit(self, in_place: bool = False) -> Optional["Series"]:
         """
         Shrink memory usage of this Series to fit the exact capacity needed to hold the data.
         """
         if in_place:
+            self._s.shrink_to_fit()
+            return None
+        else:
             series = self.clone()
             series._s.shrink_to_fit()
             return series
-        self._s.shrink_to_fit()
 
     @property
     def dt(self) -> "DateTimeNameSpace":


### PR DESCRIPTION
The `shrink_to_fit` function in both `series.py` and `frame.py` seemed to execute in-place code when `in_place` was set to `False`, and vice versa. This change fixes that, along with the correct type hints for the function.

EDIT: My other PR includes this one. If you intend to merge that one, it might be easier to close this one.