### PR TITLE
Enforce Python type checking in CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -84,6 +84,9 @@ jobs:
       - name: Run linting
         run: |
           cd py-polars && flake8 && cd ..
+      - name: Run type checking
+        run: |
+          cd py-polars && mypy && cd ..
       - name: Run tests
         run: |
           export RUSTFLAGS="-C debuginfo=0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ We use github to host code, to track issues and feature requests, as well as acc
 6. Issue that pull request!
 
 ## Want to discuss something?
-I can imagine that some questions don't fit an issue. 
+I can imagine that some questions don't fit an issue.
 Therefore there is also a [chat on gitter](https://gitter.im/polars-rs/community).
 
 ## Any contributions you make will be under the MIT Software License
-In short, when you submit code changes, your submissions are understood to be under the same 
-[MIT License](http://choosealicense.com/licenses/mit/) that covers the project. 
+In short, when you submit code changes, your submissions are understood to be under the same
+[MIT License](http://choosealicense.com/licenses/mit/) that covers the project.
 Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's [issues](https://github.com/ritchie46/polars/issues)
@@ -44,8 +44,11 @@ We test the code formatting in the CI pipelines. If you don't want these to fail
 ## Linting
 We use linters to enforce code quality. This will be checked in CI.
 
-* **Rust** We use [clippy](https://github.com/rust-lang/rust-clippy) as linter. 
-* **Python** We use [flake8](https://flake8.pycqa.org/en/latest/) as linter. 
+* **Rust** We use [clippy](https://github.com/rust-lang/rust-clippy) as linter.
+* **Python** We use [flake8](https://flake8.pycqa.org/en/latest/) as linter.
+
+## Type checking
+For Python, type hints are enforced using [mypy](https://github.com/python/mypy). This will be checked in CI.
 
 ## Python setup
 If you want to contribute to the Python code, you also have to setup a Rust installation to be able to test your changes.

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -6,3 +6,4 @@ numpy
 ghp-import
 pandas
 flake8
+mypy~=0.910

--- a/py-polars/mypy.ini
+++ b/py-polars/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+disallow_untyped_defs = False
+files = polars

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -3,7 +3,7 @@ from .series import Series, wrap_s
 from .frame import DataFrame, wrap_df, StringCache
 from .functions import *
 from .lazy import *
-from .datatypes import *
+from .datatypes import *  # type: ignore
 
 # during docs building the binary code is not yet available
 try:

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,4 +1,7 @@
+from _ctypes import _SimpleCData
 import ctypes
+import typing
+from typing import Any, Dict, Type
 
 __pdoc__ = {
     "dtype_to_ctype": False,
@@ -129,7 +132,7 @@ class Categorical(DataType):
 
 
 # Don't change the order of these!
-dtypes = [
+dtypes: typing.List[Type[DataType]] = [
     Int8,
     Int16,
     Int32,
@@ -151,7 +154,7 @@ dtypes = [
     Object,
     Categorical,
 ]
-DTYPE_TO_FFINAME = {
+DTYPE_TO_FFINAME: Dict[Type[DataType], str] = {
     Int8: "i8",
     Int16: "i16",
     Int32: "i32",
@@ -175,7 +178,7 @@ DTYPE_TO_FFINAME = {
 }
 
 
-def dtype_to_primitive(dtype: "DataType") -> "DataType":
+def dtype_to_primitive(dtype: Type[DataType]) -> Type[DataType]:
     #  TODO: add more
     if dtype == Date32:
         return Int32
@@ -187,7 +190,8 @@ def dtype_to_primitive(dtype: "DataType") -> "DataType":
     return dtype
 
 
-def dtype_to_ctype(dtype: "DataType") -> "ctype":  # noqa: F821
+def dtype_to_ctype(dtype: Type[DataType]) -> Type[_SimpleCData]:  # noqa: F821
+    ptr_type: Type[_SimpleCData]
     if dtype == UInt8:
         ptr_type = ctypes.c_uint8
     elif dtype == UInt16:
@@ -217,21 +221,24 @@ def dtype_to_ctype(dtype: "DataType") -> "ctype":  # noqa: F821
     return ptr_type
 
 
-def dtype_to_int(dtype: "DataType") -> int:
+def dtype_to_int(dtype: Type[DataType]) -> int:
     i = 0
     for dt in dtypes:
         if dt == dtype:
             return i
         i += 1
-
-
-def pytype_to_polars_type(data_type):
-    if data_type == int:
-        data_type = Int64
-    elif data_type == str:
-        data_type = Utf8
-    elif data_type == float:
-        data_type = Float64
     else:
-        pass
-    return data_type
+        raise NotImplementedError
+
+
+def pytype_to_polars_type(data_type: Type[Any]) -> Type[DataType]:
+    polars_type: Type[DataType]
+    if data_type == int:
+        polars_type = Int64
+    elif data_type == str:
+        polars_type = Utf8
+    elif data_type == float:
+        polars_type = Float64
+    else:
+        polars_type = data_type
+    return polars_type

--- a/py-polars/polars/ffi.py
+++ b/py-polars/polars/ffi.py
@@ -25,8 +25,8 @@ def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
     View of memory block as numpy array.
 
     """
-    ptr = ctypes.cast(ptr, ctypes.POINTER(ptr_type))
-    return ctypeslib.as_array(ptr, (len,))
+    ptr_ctype = ctypes.cast(ptr, ctypes.POINTER(ptr_type))
+    return ctypeslib.as_array(ptr_ctype, (len,))
 
 
 def _as_float_ndarray(ptr, size):

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -27,6 +27,7 @@ from typing import (
     BinaryIO,
     Callable,
     Any,
+    Type
 )
 from .series import Series, wrap_s
 from . import datatypes
@@ -907,7 +908,7 @@ class DataFrame:
         self._df.set_column_names(columns)
 
     @property
-    def dtypes(self) -> "List[type]":
+    def dtypes(self) -> List[Type[DataType]]:
         """
         Get dtypes of columns in DataFrame. Dtypes can also be found in column headers when printing the DataFrame.
 

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -35,6 +35,7 @@ from .datatypes import DataType, pytype_to_polars_type
 from ._html import NotebookFormatter
 from .utils import coerce_arrow, _is_expr
 import polars
+import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet
 import pyarrow.feather
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
     from .lazy import LazyFrame, Expr
 
 
-def wrap_df(df: "PyDataFrame") -> "DataFrame":
+def wrap_df(df: PyDataFrame) -> "DataFrame":
     return DataFrame._from_pydf(df)
 
 
@@ -71,9 +72,9 @@ class DataFrame:
 
     def __init__(
         self,
-        data: "Union[Dict[str, Sequence], List[Series], np.ndarray]",
+        data: Union[Dict[str, Sequence], List[Series], np.ndarray],
         nullable: bool = True,
-    ):
+    ) -> None:
         """
         A DataFrame is a two dimensional data structure that represents data as a table with rows and columns.
         """
@@ -99,11 +100,11 @@ class DataFrame:
                 import pandas as pd
 
                 if isinstance(data, pd.DataFrame):
-                    for c in data.columns:
+                    for col in data.columns:
                         if nullable:
-                            s = Series(c, data[c].to_list(), nullable=True).inner()
+                            s = Series(col, data[col].to_list(), nullable=True).inner()
                         else:
-                            s = Series(c, data[c].values, nullable=False).inner()
+                            s = Series(col, data[col].values, nullable=False).inner()
                         columns.append(s)
                 else:
                     raise ValueError("A dictionary was expected.")
@@ -161,13 +162,13 @@ class DataFrame:
         ignore_errors: bool = False,
         stop_after_n_rows: Optional[int] = None,
         skip_rows: int = 0,
-        projection: "Optional[List[int]]" = None,
+        projection: Optional[List[int]] = None,
         sep: str = ",",
-        columns: "Optional[List[str]]" = None,
+        columns: Optional[List[str]] = None,
         rechunk: bool = True,
         encoding: str = "utf8",
         n_threads: Optional[int] = None,
-        dtype: "Optional[Dict[str, DataType]]" = None,
+        dtype: Optional[Dict[str, Type[DataType]]] = None,
         low_memory: bool = False,
     ) -> "DataFrame":
         """
@@ -221,16 +222,17 @@ class DataFrame:
         """
         self = DataFrame.__new__(DataFrame)
 
+        path: Optional[str]
         if isinstance(file, str):
             path = file
         else:
             path = None
 
+        dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
         if dtype is not None:
-            new_dtype = []
+            dtype_list = []
             for k, v in dtype.items():
-                new_dtype.append((k, pytype_to_polars_type(v)))
-            dtype = new_dtype
+                dtype_list.append((k, pytype_to_polars_type(v)))
 
         self._df = PyDataFrame.read_csv(
             file,
@@ -247,7 +249,7 @@ class DataFrame:
             encoding,
             n_threads,
             path,
-            dtype,
+            dtype_list,
             low_memory,
         )
         return self
@@ -367,7 +369,7 @@ class DataFrame:
 
     def to_json(
         self,
-        file: "Optional[Union[BytesIO, str, Path]]" = None,
+        file: Optional[Union[BytesIO, str, Path]] = None,
         pretty: bool = False,
         to_string: bool = False,
     ) -> Optional[str]:
@@ -388,11 +390,13 @@ class DataFrame:
             self._df.to_json(file, pretty)
             file.seek(0)
             return file.read().decode("utf8")
-        self._df.to_json(file, pretty)
+        else:
+            self._df.to_json(file, pretty)
+            return None
 
     def to_pandas(
         self, *args, date_as_object=False, **kwargs
-    ) -> "pd.DataFrame":  # noqa: F821
+    ) -> pd.DataFrame:  # noqa: F821
         """
         Cast to a Pandas DataFrame. This requires that Pandas is installed.
         This operation clones data.
@@ -1009,9 +1013,9 @@ class DataFrame:
 
     def sort(
         self,
-        by: "Union[str, Expr, List[Expr]]",
+        by: Union[str, "Expr", List["Expr"]],
         in_place: bool = False,
-        reverse: "Union[bool, List[bool]]" = False,
+        reverse: Union[bool, List[bool]] = False,
     ) -> Optional["DataFrame"]:
         """
         Sort the DataFrame by column.
@@ -1065,10 +1069,11 @@ class DataFrame:
             )
             if in_place:
                 self._df = df._df
-                return
+                return None
             return df
         if in_place:
             self._df.sort_in_place(by, reverse)
+            return None
         else:
             return wrap_df(self._df.sort(by, reverse))
 
@@ -1239,7 +1244,7 @@ class DataFrame:
         """
         return func(self, *args, **kwargs)
 
-    def groupby(self, by: "Union[str, List[str]]") -> "GroupBy":
+    def groupby(self, by: Union[str, List[str]]) -> "GroupBy":
         """
         Start a groupby operation.
 
@@ -1314,7 +1319,7 @@ class DataFrame:
             by = [by]
         return GroupBy(self._df, by, downsample=False)
 
-    def downsample(self, by: str, rule: str, n: int) -> "GroupBy":
+    def downsample(self, by: Union[str, List[str]], rule: str, n: int) -> "GroupBy":
         """
         Start a downsampling groupby operation.
 
@@ -1342,11 +1347,11 @@ class DataFrame:
     def join(
         self,
         df: "DataFrame",
-        left_on: "Optional[Union[str, List[str]], Expr, List[Expr]]" = None,
-        right_on: "Optional[Union[str, List[str]], Expr, List[Expr]]" = None,
-        on: "Optional[Union[str, List[str]]]" = None,
-        how="inner",
-    ) -> "DataFrame":
+        left_on: Optional[Union[str, List[str], "Expr", List["Expr"]]] = None,
+        right_on: Optional[Union[str, List[str], "Expr", List["Expr"]]] = None,
+        on: Optional[Union[str, List[str]]] = None,
+        how: str = "inner",
+    ) -> Union["DataFrame", "LazyFrame"]:
         """
         SQL like joins.
 
@@ -1426,7 +1431,7 @@ class DataFrame:
             right_on = on
         if left_on is None or right_on is None:
             raise ValueError("You should pass the column to join on as an argument.")
-        if _is_expr(left_on[0]) or _is_expr(right_on[0]):
+        if _is_expr(left_on[0]) or _is_expr(right_on[0]):  # type: ignore
             return self.lazy().join(df.lazy(), left_on, right_on, how=how)
 
         out = self._df.join(df._df, left_on, right_on, how)
@@ -1452,7 +1457,7 @@ class DataFrame:
         """
         return wrap_s(self._df.apply(f, return_dtype))
 
-    def with_column(self, column: "Union[Series, Expr]") -> "DataFrame":
+    def with_column(self, column: Union[Series, "Expr"]) -> "DataFrame":
         """
         Return a new DataFrame with the column added or replaced.
 
@@ -1462,11 +1467,12 @@ class DataFrame:
             Series, where the name of the Series refers to the column in the DataFrame.
         """
         if _is_expr(column):
-            return self.with_columns([column])
-        return wrap_df(self._df.with_column(column._s))
+            return self.with_columns([column])  # type: ignore
+        else:
+            return wrap_df(self._df.with_column(column._s))  # type: ignore
 
     def hstack(
-        self, columns: "Union[List[Series], DataFrame]", in_place=False
+        self, columns: Union[List[Series], "DataFrame"], in_place: bool = False
     ) -> Optional["DataFrame"]:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
@@ -1482,6 +1488,7 @@ class DataFrame:
             columns = columns.get_columns()
         if in_place:
             self._df.hstack_mut([s.inner() for s in columns])
+            return None
         else:
             return wrap_df(self._df.hstack([s.inner() for s in columns]))
 
@@ -1498,6 +1505,7 @@ class DataFrame:
         """
         if in_place:
             self._df.vstack_mut(df._df)
+            return None
         else:
             return wrap_df(self._df.vstack(df._df))
 
@@ -1577,7 +1585,7 @@ class DataFrame:
         """
         return list(map(lambda s: wrap_s(s), self._df.get_columns()))
 
-    def fill_none(self, strategy: "Union[str, Expr]") -> "DataFrame":
+    def fill_none(self, strategy: Union[str, "Expr"]) -> "DataFrame":
         """
         Fill None values by a filling strategy or an Expression evaluation.
 
@@ -1603,7 +1611,7 @@ class DataFrame:
         if not isinstance(strategy, str):
             from .lazy import lit
 
-            return self.fill_none(lit(strategy))
+            return self.fill_none(lit(strategy))  # type: ignore
         return wrap_df(self._df.fill_none(strategy))
 
     def explode(self, columns: "Union[str, List[str]]") -> "DataFrame":
@@ -1722,7 +1730,7 @@ class DataFrame:
             self.lazy().select(exprs).collect(no_optimization=True, string_cache=False)
         )
 
-    def with_columns(self, exprs: "List[Expr]") -> "DataFrame":
+    def with_columns(self, exprs: Union["Expr", List["Expr"]]) -> "DataFrame":
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -1816,7 +1824,7 @@ class DataFrame:
         return wrap_df(self._df.to_dummies())
 
     def drop_duplicates(
-        self, maintain_order=True, subset: "Optional[List[str]]" = None
+        self, maintain_order: bool = True, subset: Optional[Union[str, List[str]]] = None
     ) -> "DataFrame":
         """
         Drop duplicate rows from this DataFrame.
@@ -1940,7 +1948,7 @@ class DataFrame:
             function that takes two `Series` and returns a `Series`.
         """
         if self.width == 1:
-            return self
+            return self  # type: ignore
         df = self
         acc = operation(df.select_at_idx(0), df.select_at_idx(1))
 
@@ -1980,8 +1988,8 @@ class GroupBy:
 
     def __init__(
         self,
-        df: "PyDataFrame",
-        by: "List[str]",
+        df: PyDataFrame,
+        by: Union[str, List[str]],
         downsample: bool = False,
         rule=None,
         downsample_n: int = 0,
@@ -2064,7 +2072,7 @@ class GroupBy:
 
     def agg(
         self,
-        column_to_agg: "Union[List[Tuple[str, List[str]]], Dict[str, List[str]]], List[Expr]",
+        column_to_agg: Union[List[Tuple[str, List[str]]], Dict[str, Union[str, List[str]]], List["Expr"], "Expr"],
     ) -> DataFrame:
         """
         Use multiple aggregations on columns. This can be combined with complete lazy API.
@@ -2105,7 +2113,7 @@ class GroupBy:
         ```
         """
         if _is_expr(column_to_agg):
-            column_to_agg = [column_to_agg]
+            column_to_agg = [column_to_agg]  # type: ignore
         if isinstance(column_to_agg, dict):
             column_to_agg = [
                 (column, [agg] if isinstance(agg, str) else agg)
@@ -2116,7 +2124,7 @@ class GroupBy:
 
             if isinstance(column_to_agg[0], tuple):
                 column_to_agg = [
-                    (column, [agg] if isinstance(agg, str) else agg)
+                    (column, [agg] if isinstance(agg, str) else agg)  # type: ignore
                     for (column, agg) in column_to_agg
                 ]
 
@@ -2125,7 +2133,7 @@ class GroupBy:
                     wrap_df(self._df)
                     .lazy()
                     .groupby(self.by)
-                    .agg(column_to_agg)
+                    .agg(column_to_agg)  # type: ignore
                     .collect(no_optimization=True, string_cache=False)
                 )
 
@@ -2259,7 +2267,7 @@ class PivotOps:
     """
 
     def __init__(
-        self, df: DataFrame, by: "List[str]", pivot_column: str, values_column: str
+        self, df: DataFrame, by: Union[str, List[str]], pivot_column: str, values_column: str
     ):
         self._df = df
         self.by = by
@@ -2331,8 +2339,8 @@ class GBSelection:
     def __init__(
         self,
         df: DataFrame,
-        by: "List[str]",
-        selection: "Optional[List[str]]",
+        by: Union[str, List[str]],
+        selection: Optional[List[str]],
         downsample: bool = False,
         rule=None,
         downsample_n: int = 0,
@@ -2349,65 +2357,65 @@ class GBSelection:
         Aggregate the first values in the group.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "first"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "first"))  # type: ignore
 
-        return wrap_df(self._df.groupby(self.by, self.selection, "first"))
+        return wrap_df(self._df.groupby(self.by, self.selection, "first"))  # type: ignore
 
     def last(self) -> DataFrame:
         """
         Aggregate the last values in the group.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "last"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "last"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "last"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "last"))  # type: ignore
 
     def sum(self) -> DataFrame:
         """
         Reduce the groups to the sum.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "sum"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "sum"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "sum"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "sum"))  # type: ignore
 
     def min(self) -> DataFrame:
         """
         Reduce the groups to the minimal value.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "min"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "min"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "min"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "min"))  # type: ignore
 
     def max(self) -> DataFrame:
         """
         Reduce the groups to the maximal value.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "max"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "max"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "max"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "max"))  # type: ignore
 
     def count(self) -> DataFrame:
         """
         Count the number of values in each group.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "count"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "count"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "count"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "count"))  # type: ignore
 
     def mean(self) -> DataFrame:
         """
         Reduce the groups to the mean values.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "mean"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "mean"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "mean"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "mean"))  # type: ignore
 
     def n_unique(self) -> DataFrame:
         """
         Count the unique values per group.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "n_unique"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "n_unique"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "n_unique"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "n_unique"))  # type: ignore
 
     def quantile(self, quantile: float) -> DataFrame:
         """
@@ -2422,21 +2430,21 @@ class GBSelection:
         Return the median per group.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "median"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "median"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "median"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "median"))  # type: ignore
 
     def agg_list(self) -> DataFrame:
         """
         Aggregate the groups into Series.
         """
         if self.downsample:
-            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "agg_list"))
-        return wrap_df(self._df.groupby(self.by, self.selection, "agg_list"))
+            return wrap_df(self._df.downsample(self.by, self.rule, self.n, "agg_list"))  # type: ignore
+        return wrap_df(self._df.groupby(self.by, self.selection, "agg_list"))  # type: ignore
 
     def apply(
         self,
-        func: "Union[Callable[['Any'], 'Any'], Callable[['Any'], 'Any']]",
-        return_dtype: "Optional['DataType']" = None,
+        func: Union[Callable[['Any'], 'Any'], Callable[['Any'], 'Any']],
+        return_dtype: Optional[Type[DataType]] = None,
     ) -> "DataFrame":
         """
         Apply a function over the groups.
@@ -2446,29 +2454,31 @@ class GBSelection:
             selection = [self.selection]
         else:
             selection = self.selection
-        for name in selection:
+        for name in selection:  # type: ignore
             s = df.drop_in_place(name + "_agg_list").apply(func, return_dtype)
             s.rename(name, in_place=True)
             df[name] = s
 
         return df
 
-    def shrink_to_fit(self, in_place: bool = False) -> "Optional[DataFrame]":
+    def shrink_to_fit(self, in_place: bool = False) -> Optional["DataFrame"]:
         """
         Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
         """
         if in_place:
-            df = self.clone()
+            self._df.shrink_to_fit()
+            return None
+        else:
+            df = self.clone()  # type: ignore
             df._df.shrink_to_fit()
             return df
-        self._df.shrink_to_fit()
 
 
 def _series_to_frame(self: "Series") -> "DataFrame":
     return wrap_df(PyDataFrame([self._s]))
 
 
-Series.to_frame = _series_to_frame
+Series.to_frame = _series_to_frame  # type: ignore
 
 
 class StringCache:

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -27,7 +27,7 @@ from typing import (
     BinaryIO,
     Callable,
     Any,
-    Type
+    Type,
 )
 from .series import Series, wrap_s
 from . import datatypes
@@ -1824,7 +1824,9 @@ class DataFrame:
         return wrap_df(self._df.to_dummies())
 
     def drop_duplicates(
-        self, maintain_order: bool = True, subset: Optional[Union[str, List[str]]] = None
+        self,
+        maintain_order: bool = True,
+        subset: Optional[Union[str, List[str]]] = None,
     ) -> "DataFrame":
         """
         Drop duplicate rows from this DataFrame.
@@ -2072,7 +2074,12 @@ class GroupBy:
 
     def agg(
         self,
-        column_to_agg: Union[List[Tuple[str, List[str]]], Dict[str, Union[str, List[str]]], List["Expr"], "Expr"],
+        column_to_agg: Union[
+            List[Tuple[str, List[str]]],
+            Dict[str, Union[str, List[str]]],
+            List["Expr"],
+            "Expr",
+        ],
     ) -> DataFrame:
         """
         Use multiple aggregations on columns. This can be combined with complete lazy API.
@@ -2267,7 +2274,11 @@ class PivotOps:
     """
 
     def __init__(
-        self, df: DataFrame, by: Union[str, List[str]], pivot_column: str, values_column: str
+        self,
+        df: DataFrame,
+        by: Union[str, List[str]],
+        pivot_column: str,
+        values_column: str,
     ):
         self._df = df
         self.by = by
@@ -2443,7 +2454,7 @@ class GBSelection:
 
     def apply(
         self,
-        func: Union[Callable[['Any'], 'Any'], Callable[['Any'], 'Any']],
+        func: Union[Callable[["Any"], "Any"], Callable[["Any"], "Any"]],
         return_dtype: Optional[Type[DataType]] = None,
     ) -> "DataFrame":
         """

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -1,4 +1,4 @@
-from typing import Union, TextIO, Optional, List, BinaryIO, Sequence, Any
+from typing import Union, TextIO, Optional, List, BinaryIO, Sequence, Any, Type
 from io import StringIO, BytesIO
 import numpy as np
 from pathlib import Path
@@ -267,7 +267,7 @@ def scan_csv(
     skip_rows: int = 0,
     stop_after_n_rows: "Optional[int]" = None,
     cache: bool = True,
-    dtype: "Optional[Dict[str, DataType]]" = None,
+    dtype: Optional[Dict[str, Type[DataType]]] = None,
     low_memory: bool = False,
 ) -> "LazyFrame":
     """
@@ -468,7 +468,7 @@ def _from_pandas_helper(a: pd.Series) -> pa.Array:  # noqa: F821
 
 
 def from_pandas(
-    df: Union[pd.DataFrame, pd.Series, pd.DateTimeIndex], rechunk: bool = True  # noqa: F821
+    df: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex], rechunk: bool = True  # noqa: F821
 ) -> "DataFrame":
     """
     Convert from a pandas DataFrame to a polars DataFrame.

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -433,7 +433,9 @@ def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "DataFrame":
     return DataFrame.from_arrow(table, rechunk)
 
 
-def from_arrow(a: Union[pa.Table, pa.Array], rechunk: bool = True) -> Union[DataFrame, Series]:
+def from_arrow(
+    a: Union[pa.Table, pa.Array], rechunk: bool = True
+) -> Union[DataFrame, Series]:
     """
     Create a DataFrame from an arrow Table.
 
@@ -468,7 +470,8 @@ def _from_pandas_helper(a: pd.Series) -> pa.Array:  # noqa: F821
 
 
 def from_pandas(
-    df: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex], rechunk: bool = True  # noqa: F821
+    df: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex],
+    rechunk: bool = True,  # noqa: F821
 ) -> "DataFrame":
     """
     Convert from a pandas DataFrame to a polars DataFrame.

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -2070,9 +2070,7 @@ def last(column: Union[str, Series]) -> "Expr":
     return col(column).last()
 
 
-def head(
-    column: Union[str, Series], n: Optional[int] = None
-) -> Union["Expr", Series]:
+def head(column: Union[str, Series], n: Optional[int] = None) -> Union["Expr", Series]:
     """
     Get the first n rows of an Expression.
 
@@ -2354,9 +2352,7 @@ def arange(low: int, high: int, dtype: Optional[Type[DataType]] = None) -> "Expr
     return wrap_expr(pyrange(low, high, dtype))
 
 
-def argsort_by(
-    exprs: List["Expr"], reverse: Union[List[bool], bool] = False
-) -> "Expr":
+def argsort_by(exprs: List["Expr"], reverse: Union[List[bool], bool] = False) -> "Expr":
     """
     Find the indexes that would sort the columns.
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -2,7 +2,7 @@
 This module contains all expressions and classes needed for lazy computation/ query execution.
 """
 
-from typing import Union, List, Callable, Optional, Dict, Any
+from typing import Union, List, Callable, Optional, Dict, Any, Type
 
 from polars import Series
 from polars.frame import DataFrame, wrap_df
@@ -2105,8 +2105,8 @@ def lit_date(dt: "datetime") -> Expr:
 
 
 def lit(
-    value: "Optional[Union[float, int, str, datetime, Series]]",
-    dtype: "Optional[DataType]" = None,
+    value: Optional[Union[float, int, str, datetime, Series]],
+    dtype: Optional[Type[DataType]] = None,
 ) -> "Expr":
     """
     A literal value.

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1243,7 +1243,7 @@ class Series:
 
     def apply(
         self,
-        func: Union[Callable[[Any], Any], Callable[[Any], Any]],
+        func: Callable[[Any], Any],
         return_dtype: Optional[Type[DataType]] = None,
     ) -> "Series":
         """

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -14,7 +14,7 @@ except ImportError:
         "SeriesIter": False,
     }
 import numpy as np
-from typing import Optional, List, Sequence, Union, Any, Callable, Tuple
+from typing import Optional, List, Sequence, Union, Any, Callable, Tuple, Type
 from .ffi import _ptr_to_numpy
 from .datatypes import (
     Utf8,
@@ -50,12 +50,12 @@ if TYPE_CHECKING:
 
 
 class IdentityDict(dict):
-    def __missing__(self, key):
+    def __missing__(self, key: Any) -> Any:
         return key
 
 
 def get_ffi_func(
-    name: str, dtype: str, obj: Optional["Series"] = None, default: Optional = None
+    name: str, dtype: Type[DataType], obj: Optional["Series"] = None, default: Optional = None  # type: ignore
 ):
     """
     Dynamically obtain the proper ffi function/ method.
@@ -67,7 +67,7 @@ def get_ffi_func(
         for example
             "call_foo_<>"
     dtype
-        polars dtype str.
+        polars dtype.
     obj
         Optional object to find the method for. If none provided globals are used.
     default
@@ -85,11 +85,11 @@ def get_ffi_func(
         return globals().get(fname, default)
 
 
-def wrap_s(s: "PySeries") -> "Series":
+def wrap_s(s: PySeries) -> "Series":
     return Series._from_pyseries(s)
 
 
-def _find_first_non_none(a: "List[Optional[Any]]") -> Any:
+def _find_first_non_none(a: List[Optional[Any]]) -> Any:
     v = a[0]
     if v is None:
         return _find_first_non_none(a[1:])
@@ -101,9 +101,9 @@ class Series:
     def __init__(
         self,
         name: str,
-        values: "Union[np.array, List[Optional[Any]]]" = None,
+        values: Union["Series", np.ndarray, List[Any], None] = None,
         nullable: bool = True,
-        dtype: "Optional[DataType]" = None,
+        dtype: Optional[Type[DataType]] = None,
     ):
         """
 
@@ -125,11 +125,11 @@ class Series:
             values = name
             name = ""
         if values.__class__ == self.__class__:
-            values.rename(name, in_place=True)
-            self._s = values._s
+            values.rename(name, in_place=True)  # type: ignore
+            self._s = values._s  # type: ignore
             return
 
-        self._s: PySeries
+        self._s: PySeries  # type: ignore
         # series path
         if isinstance(values, Series):
             self._from_pyseries(values)
@@ -257,7 +257,7 @@ class Series:
                     self._s = PySeries.new_object(name, values)
 
     @staticmethod
-    def _from_pyseries(s: "PySeries") -> "Series":
+    def _from_pyseries(s: PySeries) -> "Series":
         self = Series.__new__(Series)
         self._s = s
         return self
@@ -270,7 +270,7 @@ class Series:
         return Series._from_pyseries(PySeries.repeat(name, val, n))
 
     @staticmethod
-    def from_arrow(name: str, array: "pa.Array"):
+    def from_arrow(name: str, array: pa.Array) -> "Series":
         """
         Create a Series from an arrow array.
 
@@ -293,13 +293,13 @@ class Series:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __and__(self, other):
+    def __and__(self, other: "Series") -> "Series":
         return wrap_s(self._s.bitand(other._s))
 
-    def __or__(self, other):
+    def __or__(self, other: "Series") -> "Series":
         return wrap_s(self._s.bitor(other._s))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> "Series":  # type: ignore
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -309,7 +309,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> "Series":  # type: ignore
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -319,7 +319,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> "Series":
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -329,7 +329,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> "Series":
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -339,7 +339,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __ge__(self, other) -> "Series":
+    def __ge__(self, other: Any) -> "Series":
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -349,7 +349,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __le__(self, other) -> "Series":
+    def __le__(self, other: Any) -> "Series":
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -359,7 +359,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __add__(self, other) -> "Series":
+    def __add__(self, other: Any) -> "Series":
         if isinstance(other, str):
             other = Series("", [other])
         if isinstance(other, Series):
@@ -370,7 +370,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __sub__(self, other) -> "Series":
+    def __sub__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(self._s.sub(other._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -379,7 +379,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __truediv__(self, other) -> "Series":
+    def __truediv__(self, other: Any) -> "Series":
         primitive = dtype_to_primitive(self.dtype)
         if self.dtype != primitive:
             return self.__floordiv__(other)
@@ -390,14 +390,14 @@ class Series:
             out_dtype = self.dtype
         return np.true_divide(self, other, dtype=out_dtype)
 
-    def __floordiv__(self, other) -> "Series":
+    def __floordiv__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(self._s.div(other._s))
         dtype = dtype_to_primitive(self.dtype)
         f = get_ffi_func("div_<>", dtype, self._s)
         return wrap_s(f(other))
 
-    def __mul__(self, other) -> "Series":
+    def __mul__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(self._s.mul(other._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -406,7 +406,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __radd__(self, other):
+    def __radd__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(self._s.add(other._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -415,7 +415,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(other._s.sub(self._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -424,7 +424,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __invert__(self):
+    def __invert__(self) -> "Series":
         if self.dtype == Boolean:
             return wrap_s(self._s._not())
         return NotImplemented
@@ -632,13 +632,13 @@ class Series:
         return polars.frame.wrap_df(self._s.value_counts())
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         Get the name of this Series.
         """
         return self._s.name()
 
-    def rename(self, name: str, in_place=False) -> "Optional[Series]":
+    def rename(self, name: str, in_place: bool = False) -> Optional["Series"]:
         """
         Rename this Series.
 
@@ -651,6 +651,7 @@ class Series:
         """
         if in_place:
             self._s.rename(name)
+            return None
         else:
             s = self.clone()
             s._s.rename(name)
@@ -790,6 +791,7 @@ class Series:
         """
         if in_place:
             self._s.sort_in_place(reverse)
+            return None
         else:
             return wrap_s(self._s.sort(reverse))
 
@@ -1001,7 +1003,7 @@ class Series:
     def __len__(self):
         return self.len()
 
-    def cast(self, data_type: "DataType"):
+    def cast(self, data_type: Type[DataType]) -> "Series":
         if data_type == int:
             data_type = Int64
         elif data_type == str:
@@ -1034,7 +1036,9 @@ class Series:
             In place or not.
         """
         opt_s = self._s.rechunk(in_place)
-        if not in_place:
+        if in_place:
+            return None
+        else:
             return wrap_s(opt_s)
 
     def is_numeric(self) -> bool:
@@ -1239,9 +1243,9 @@ class Series:
 
     def apply(
         self,
-        func: "Union[Callable[['Any'], 'Any'], Callable[['Any'], 'Any']]",
-        return_dtype: "Optional['DataType']" = None,
-    ):
+        func: Union[Callable[[Any], Any], Callable[[Any], Any]],
+        return_dtype: Optional[Type[DataType]] = None,
+    ) -> "Series":
         """
         Apply a function over elements in this Series and return a new Series.
 
@@ -1435,7 +1439,7 @@ class Series:
 
     @staticmethod
     def parse_date(
-        name: str, values: Sequence[str], dtype: "DataType", fmt: str
+        name: str, values: Sequence[str], dtype: Type[DataType], fmt: str
     ) -> "Series":
         """
         .. deprecated::
@@ -1450,7 +1454,7 @@ class Series:
         n: "Optional[int]" = None,
         frac: "Optional[float]" = None,
         with_replacement: bool = False,
-    ) -> "DataFrame":
+    ) -> "Series":
         """
         Sample from this Series by setting either `n` or `frac`.
 
@@ -1485,15 +1489,17 @@ class Series:
         """
         return self._s.n_unique()
 
-    def shrink_to_fit(self, in_place: bool = False) -> "Optional[Series]":
+    def shrink_to_fit(self, in_place: bool = False) -> Optional["Series"]:
         """
         Shrink memory usage of this Series to fit the exact capacity needed to hold the data.
         """
         if in_place:
+            self._s.shrink_to_fit()
+            return None
+        else:
             series = self.clone()
             series._s.shrink_to_fit()
             return series
-        self._s.shrink_to_fit()
 
     @property
     def dt(self) -> "DateTimeNameSpace":
@@ -1833,13 +1839,15 @@ class DateTimeNameSpace:
         return _to_python_datetime(out, s.dtype)
 
 
-def _to_python_datetime(value: int, dtype: "DataType") -> "datetime":
+def _to_python_datetime(value: int, dtype: Type[DataType]) -> datetime:
     if dtype == Date32:
         # days to seconds
         return datetime.utcfromtimestamp(value * 3600 * 24)
-    if dtype == Date64:
+    elif dtype == Date64:
         # ms to seconds
         return datetime.utcfromtimestamp(value // 1000)
+    else:
+        raise NotImplementedError
 
 
 class SeriesIter:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,8 +1,9 @@
 import pyarrow as pa
+from typing import Any
 import warnings
 
 
-def coerce_arrow(array: "pa.Array") -> "pa.Array":
+def coerce_arrow(array: pa.Array) -> pa.Array:
     # also coerces timezone to naive representation
     # units are accounted for by pyarrow
     if "timestamp" in str(array.type):
@@ -37,5 +38,5 @@ def coerce_arrow(array: "pa.Array") -> "pa.Array":
     return array
 
 
-def _is_expr(arg) -> bool:
+def _is_expr(arg: Any) -> bool:
     return hasattr(arg, "_pyexpr")


### PR DESCRIPTION
The code base already utilizes type hints, but these are inconsistent and incomplete. This PR fixes and adds a lot of type hints, and introduces a type checking step to the CI pipeline. 

Changes:
* Add `mypy` type checking step to the pipeline
* Add `mypy` settings file to the `py-polars` folder
* Add and fix a lot of type hints (the type checking job now passes)
* Fixed one bug I encountered in the `shrink_to_fit` method (see also my other PR; this PR includes that one)

To do in a future PR:
* Complete type hints for all functions
* Fix some worrying errors that are now explicitly ignored with `# type: ignore`.
