### PR TITLE
Complete type hints coverage for Python code

### DIFF
--- a/py-polars/mypy.ini
+++ b/py-polars/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-disallow_untyped_defs = False
+disallow_untyped_defs = True
 files = polars

--- a/py-polars/polars/ffi.py
+++ b/py-polars/polars/ffi.py
@@ -29,7 +29,7 @@ def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
     return ctypeslib.as_array(ptr_ctype, (len,))
 
 
-def _as_float_ndarray(ptr, size):
+def _as_float_ndarray(ptr: int, size: int) -> np.ndarray:
     """
     https://github.com/maciejkula/python-rustlearn
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -108,8 +108,8 @@ def read_csv(
     rechunk: bool = True,
     encoding: str = "utf8",
     n_threads: Optional[int] = None,
-    dtype: "Optional[Dict[str, DataType]]" = None,
-    new_columns: "Optional[List[str]]" = None,
+    dtype: Optional[Dict[str, Type[DataType]]] = None,
+    new_columns: Optional[List[str]] = None,
     use_pyarrow: bool = True,
     low_memory: bool = False,
 ) -> "DataFrame":
@@ -222,7 +222,7 @@ def read_csv(
 
         return from_arrow(tbl, rechunk)  # type: ignore
 
-    def read_csv_to_df(file):
+    def read_csv_to_df(file: Union[str, TextIO]) -> DataFrame:
         return DataFrame.read_csv(
             file=file,
             infer_schema_length=infer_schema_length,
@@ -252,7 +252,7 @@ def read_csv(
         with gzip_mod.open(file, "rb") as fh:
             df = read_csv_to_df(fh)
     else:
-        df = read_csv_to_df(file)
+        df = read_csv_to_df(file)  # type: ignore
 
     if new_columns:
         df.columns = new_columns
@@ -265,11 +265,11 @@ def scan_csv(
     ignore_errors: bool = False,
     sep: str = ",",
     skip_rows: int = 0,
-    stop_after_n_rows: "Optional[int]" = None,
+    stop_after_n_rows: Optional[int] = None,
     cache: bool = True,
     dtype: Optional[Dict[str, Type[DataType]]] = None,
     low_memory: bool = False,
-) -> "LazyFrame":
+) -> LazyFrame:
     """
     Lazily read from a csv file.
 
@@ -316,9 +316,9 @@ def scan_csv(
 
 def scan_parquet(
     file: Union[str, Path],
-    stop_after_n_rows: "Optional[int]" = None,
+    stop_after_n_rows: Optional[int] = None,
     cache: bool = True,
-) -> "LazyFrame":
+) -> LazyFrame:
     """
     Lazily read from a parquet file.
 
@@ -363,10 +363,10 @@ def read_ipc(file: Union[str, BinaryIO, Path], use_pyarrow: bool = True) -> Data
 def read_parquet(
     source: Union[str, BinaryIO, Path, List[str]],
     stop_after_n_rows: Optional[int] = None,
-    memory_map=True,
+    memory_map: bool = True,
     columns: Optional[List[str]] = None,
-    **kwargs,
-) -> "DataFrame":
+    **kwargs: Any,
+) -> DataFrame:
     """
     Read into a DataFrame from a parquet file.
 
@@ -400,7 +400,7 @@ def read_parquet(
         )
 
 
-def arg_where(mask: "Series"):
+def arg_where(mask: Series) -> Series:
     """
     Get index values where Boolean mask evaluate True.
 
@@ -416,7 +416,7 @@ def arg_where(mask: "Series"):
     return mask.arg_true()
 
 
-def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "DataFrame":
+def from_arrow_table(table: pa.Table, rechunk: bool = True) -> DataFrame:
     """
     .. deprecated:: 7.3
         use `from_arrow`
@@ -530,7 +530,7 @@ def concat(dfs: List[DataFrame], rechunk: bool = True) -> DataFrame:
 
 
 def repeat(
-    val: "Union[int, float, str]", n: int, name: Optional[str] = None
+    val: Union[int, float, str], n: int, name: Optional[str] = None
 ) -> "Series":
     """
     Repeat a single value n times and collect into a Series.
@@ -593,7 +593,7 @@ def from_rows(
     return DataFrame.from_rows(rows, column_names, column_name_mapping)
 
 
-def read_sql(sql: str, engine) -> DataFrame:
+def read_sql(sql: str, engine: Any) -> DataFrame:
     """
     # Preface
     Deprecated by design. Will not have a long future support and no guarantees given whatsoever.

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -112,7 +112,7 @@ def read_csv(
     new_columns: Optional[List[str]] = None,
     use_pyarrow: bool = True,
     low_memory: bool = False,
-) -> "DataFrame":
+) -> DataFrame:
     """
     Read into a DataFrame from a csv file.
 
@@ -472,7 +472,7 @@ def _from_pandas_helper(a: pd.Series) -> pa.Array:  # noqa: F821
 def from_pandas(
     df: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex],
     rechunk: bool = True,  # noqa: F821
-) -> "DataFrame":
+) -> DataFrame:
     """
     Convert from a pandas DataFrame to a polars DataFrame.
 
@@ -529,9 +529,7 @@ def concat(dfs: List[DataFrame], rechunk: bool = True) -> DataFrame:
     return df
 
 
-def repeat(
-    val: Union[int, float, str], n: int, name: Optional[str] = None
-) -> "Series":
+def repeat(val: Union[int, float, str], n: int, name: Optional[str] = None) -> Series:
     """
     Repeat a single value n times and collect into a Series.
 

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -284,7 +284,7 @@ class Series:
         array = coerce_arrow(array)
         return Series._from_pyseries(PySeries.from_arrow(name, array))
 
-    def inner(self) -> "PySeries":
+    def inner(self) -> PySeries:
         return self._s
 
     def __str__(self) -> str:
@@ -659,7 +659,7 @@ class Series:
             s._s.rename(name)
             return s
 
-    def chunk_lengths(self) -> "List[int]":
+    def chunk_lengths(self) -> List[int]:
         """
         Get the length of each individual chunk.
         """
@@ -845,7 +845,7 @@ class Series:
         """
         return wrap_s(self._s.unique())
 
-    def take(self, indices: "Union[np.ndarray, List[int]]") -> "Series":
+    def take(self, indices: Union[np.ndarray, List[int]]) -> "Series":
         """
         Take values by index.
 
@@ -1104,7 +1104,9 @@ class Series:
         array.setflags(write=False)
         return array
 
-    def __array_ufunc__(self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any) -> "Series":
+    def __array_ufunc__(
+        self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
+    ) -> "Series":
         """
         Numpy universal functions.
         """
@@ -1132,7 +1134,9 @@ class Series:
         else:
             return NotImplemented
 
-    def to_numpy(self, *args: Any, zero_copy_only: bool = False, **kwargs: Any) -> np.ndarray:
+    def to_numpy(
+        self, *args: Any, zero_copy_only: bool = False, **kwargs: Any
+    ) -> np.ndarray:
         """
         Convert this Series to numpy. This operation clones data but is completely safe.
 
@@ -1314,9 +1318,9 @@ class Series:
     def rolling_min(
         self,
         window_size: int,
-        weight: "Optional[List[float]]" = None,
+        weight: Optional[List[float]] = None,
         ignore_null: bool = True,
-        min_periods: "Optional[int]" = None,
+        min_periods: Optional[int] = None,
     ) -> "Series":
         """
         apply a rolling min (moving min) over the values in this array.
@@ -1346,9 +1350,9 @@ class Series:
     def rolling_max(
         self,
         window_size: int,
-        weight: "Optional[List[float]]" = None,
+        weight: Optional[List[float]] = None,
         ignore_null: bool = True,
-        min_periods: "Optional[int]" = None,
+        min_periods: Optional[int] = None,
     ) -> "Series":
         """
         Apply a rolling max (moving max) over the values in this array.
@@ -1378,9 +1382,9 @@ class Series:
     def rolling_mean(
         self,
         window_size: int,
-        weight: "Optional[List[float]]" = None,
+        weight: Optional[List[float]] = None,
         ignore_null: bool = True,
-        min_periods: "Optional[int]" = None,
+        min_periods: Optional[int] = None,
     ) -> "Series":
         """
         Apply a rolling mean (moving mean) over the values in this array.
@@ -1410,9 +1414,9 @@ class Series:
     def rolling_sum(
         self,
         window_size: int,
-        weight: "Optional[List[float]]" = None,
+        weight: Optional[List[float]] = None,
         ignore_null: bool = True,
-        min_periods: "Optional[int]" = None,
+        min_periods: Optional[int] = None,
     ) -> "Series":
         """
         Apply a rolling sum (moving sum) over the values in this array.
@@ -1453,8 +1457,8 @@ class Series:
 
     def sample(
         self,
-        n: "Optional[int]" = None,
-        frac: "Optional[float]" = None,
+        n: Optional[int] = None,
+        frac: Optional[float] = None,
         with_replacement: bool = False,
     ) -> "Series":
         """
@@ -1526,7 +1530,7 @@ class StringNameSpace:
     def __init__(self, series: "Series"):
         self._s = series._s
 
-    def strptime(self, datatype: "DataType", fmt: Optional[str] = None) -> "Series":
+    def strptime(self, datatype: DataType, fmt: Optional[str] = None) -> Series:
         """
         Parse a Series of dtype Utf8 to a Date32/Date64 Series.
 
@@ -1547,7 +1551,7 @@ class StringNameSpace:
             return wrap_s(self._s.str_parse_date64(fmt))
         raise NotImplementedError
 
-    def lengths(self) -> "Series":
+    def lengths(self) -> Series:
         """
         Get length of the string values in the Series.
 
@@ -1557,7 +1561,7 @@ class StringNameSpace:
         """
         return wrap_s(self._s.str_lengths())
 
-    def contains(self, pattern: str) -> "Series":
+    def contains(self, pattern: str) -> Series:
         """
         Check if strings in Series contain regex pattern.
 
@@ -1572,7 +1576,7 @@ class StringNameSpace:
         """
         return wrap_s(self._s.str_contains(pattern))
 
-    def replace(self, pattern: str, value: str) -> "Series":
+    def replace(self, pattern: str, value: str) -> Series:
         """
         Replace first regex match with a string value.
 
@@ -1585,7 +1589,7 @@ class StringNameSpace:
         """
         return wrap_s(self._s.str_replace(pattern, value))
 
-    def replace_all(self, pattern: str, value: str) -> "Series":
+    def replace_all(self, pattern: str, value: str) -> Series:
         """
         Replace all regex matches with a string value.
 
@@ -1598,31 +1602,31 @@ class StringNameSpace:
         """
         return wrap_s(self._s.str_replace_all(pattern, value))
 
-    def to_lowercase(self) -> "Series":
+    def to_lowercase(self) -> Series:
         """
         Modify the strings to their lowercase equivalent.
         """
         return wrap_s(self._s.str_to_lowercase())
 
-    def to_uppercase(self) -> "Series":
+    def to_uppercase(self) -> Series:
         """
         Modify the strings to their uppercase equivalent.
         """
         return wrap_s(self._s.str_to_uppercase())
 
-    def rstrip(self) -> "Series":
+    def rstrip(self) -> Series:
         """
         Remove trailing whitespace.
         """
         return self.replace(r"[ \t]+$", "")
 
-    def lstrip(self) -> "Series":
+    def lstrip(self) -> Series:
         """
         Remove leading whitespace.
         """
         return self.replace(r"^\s*", "")
 
-    def slice(self, start: int, length: "Optional[int]" = None) -> "Series":
+    def slice(self, start: int, length: Optional[int] = None) -> Series:
         """
         Create subslices of the string values of a Utf8 Series.
 
@@ -1874,15 +1878,15 @@ class SeriesIter:
             raise StopIteration
 
 
-def out_to_dtype(out: Any) -> "Union[datatypes.DataType, np.ndarray]":
+def out_to_dtype(out: Any) -> Union[DataType, np.ndarray]:
     if isinstance(out, float):
-        return datatypes.Float64
+        return Float64
     if isinstance(out, int):
-        return datatypes.Int64
+        return Int64
     if isinstance(out, str):
-        return datatypes.Utf8
+        return Utf8
     if isinstance(out, bool):
-        return datatypes.Boolean
+        return Boolean
     if isinstance(out, Series):
         return datatypes.List
     if isinstance(out, np.ndarray):

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -14,7 +14,7 @@ except ImportError:
         "SeriesIter": False,
     }
 import numpy as np
-from typing import Optional, List, Sequence, Union, Any, Callable, Tuple, Type
+from typing import Optional, List, Sequence, Union, Any, Callable, Tuple, Type, Dict
 from .ffi import _ptr_to_numpy
 from .datatypes import (
     Utf8,
@@ -56,7 +56,7 @@ class IdentityDict(dict):
 
 def get_ffi_func(
     name: str, dtype: Type[DataType], obj: Optional["Series"] = None, default: Optional = None  # type: ignore
-):
+) -> Callable[..., Any]:
     """
     Dynamically obtain the proper ffi function/ method.
 
@@ -384,6 +384,7 @@ class Series:
         if self.dtype != primitive:
             return self.__floordiv__(other)
 
+        out_dtype: Type[DataType]
         if not self.is_float():
             out_dtype = Float64
         else:
@@ -429,19 +430,20 @@ class Series:
             return wrap_s(self._s._not())
         return NotImplemented
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other: Any) -> np.ndarray:
 
         primitive = dtype_to_primitive(self.dtype)
         if self.dtype != primitive:
             self.__rfloordiv__(other)
 
+        out_dtype: Union[Type[Float64], str]
         if not self.is_float():
             out_dtype = Float64
         else:
             out_dtype = DTYPE_TO_FFINAME[self.dtype]
         return np.true_divide(other, self, dtype=out_dtype)
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(other._s.div(self._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -450,7 +452,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: Any) -> "Series":
         if isinstance(other, Series):
             return Series._from_pyseries(self._s.mul(other._s))
         dtype = dtype_to_primitive(self.dtype)
@@ -459,7 +461,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> Any:
         if isinstance(item, int):
             if item >= self.len():
                 raise IndexError
@@ -482,14 +484,14 @@ class Series:
             return wrap_s(out)
         return out
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: Any) -> None:
         if isinstance(key, Series):
             if key.dtype == Boolean:
                 self._s = self.set(key, value)._s
             elif key.dtype == UInt64:
                 self._s = self.set_at_idx(key, value)._s
             elif key.dtype == UInt32:
-                self._s = self.set_at_idx(key.cast_u64(), value)._s
+                self._s = self.set_at_idx(key.cast_u64(), value)._s  # type: ignore
         # TODO: implement for these types without casting to series
         elif isinstance(key, (np.ndarray, list, tuple)):
             s = wrap_s(PySeries.new_u64("", np.array(key, np.uint64)))
@@ -513,13 +515,13 @@ class Series:
         pass
 
     @property
-    def dtype(self):
+    def dtype(self) -> Type[DataType]:
         """
         Get the data type of this Series.
         """
         return dtypes[self._s.dtype()]
 
-    def describe(self):
+    def describe(self) -> Dict[str, Union[int, float]]:
         """
         Quick summary statistics of a series. Series with mixed datatypes will return summary statistics for the datatype of the first value.
 
@@ -557,25 +559,25 @@ class Series:
         else:
             raise TypeError("This type is not supported")
 
-    def sum(self):
+    def sum(self) -> Union[int, float]:
         """
         Reduce this Series to the sum value.
         """
         return self._s.sum()
 
-    def mean(self):
+    def mean(self) -> Union[int, float]:
         """
         Reduce this Series to the mean value.
         """
         return self._s.mean()
 
-    def min(self):
+    def min(self) -> Union[int, float]:
         """
         Get the minimal value in this Series.
         """
         return self._s.min()
 
-    def max(self):
+    def max(self) -> Union[int, float]:
         """
         Get the maximum value in this Series.
         """
@@ -669,7 +671,7 @@ class Series:
         """
         return self._s.n_chunks()
 
-    def cum_sum(self, reverse: bool = False):
+    def cum_sum(self, reverse: bool = False) -> Union[int, float]:
         """
         Get an array with the cumulative sum computed at every element.
 
@@ -680,7 +682,7 @@ class Series:
         """
         return self._s.cum_sum(reverse)
 
-    def cum_min(self, reverse: bool = False):
+    def cum_min(self, reverse: bool = False) -> Union[int, float]:
         """
         Get an array with the cumulative min computed at every element.
 
@@ -691,7 +693,7 @@ class Series:
         """
         return self._s.cum_min(reverse)
 
-    def cum_max(self, reverse: bool = False):
+    def cum_max(self, reverse: bool = False) -> Union[int, float]:
         """
         Get an array with the cumulative max computed at every element.
 
@@ -726,7 +728,7 @@ class Series:
         """
         return Series._from_pyseries(self._s.slice(offset, length))
 
-    def append(self, other: "Series"):
+    def append(self, other: "Series") -> None:
         """
         Append a Series to this one.
 
@@ -1000,7 +1002,7 @@ class Series:
         """
         return (self._s.len(),)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.len()
 
     def cast(self, data_type: Type[DataType]) -> "Series":
@@ -1015,7 +1017,7 @@ class Series:
             return NotImplemented
         return wrap_s(f())
 
-    def to_list(self) -> "List[Optional[Any]]":
+    def to_list(self) -> List[Optional[Any]]:
         """
         Convert this Series to a Python List. This operation clones data.
         """
@@ -1023,7 +1025,7 @@ class Series:
             return self.to_arrow().to_pylist()
         return self._s.to_list()
 
-    def __iter__(self):
+    def __iter__(self) -> "SeriesIter":
         return SeriesIter(self.len(), self)
 
     def rechunk(self, in_place: bool = False) -> Optional["Series"]:
@@ -1102,7 +1104,7 @@ class Series:
         array.setflags(write=False)
         return array
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+    def __array_ufunc__(self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any) -> "Series":
         """
         Numpy universal functions.
         """
@@ -1130,7 +1132,7 @@ class Series:
         else:
             return NotImplemented
 
-    def to_numpy(self, *args, zero_copy_only=False, **kwargs) -> np.ndarray:
+    def to_numpy(self, *args: Any, zero_copy_only: bool = False, **kwargs: Any) -> np.ndarray:
         """
         Convert this Series to numpy. This operation clones data but is completely safe.
 
@@ -1643,10 +1645,10 @@ class DateTimeNameSpace:
     Series.dt namespace.
     """
 
-    def __init__(self, series: "Series"):
+    def __init__(self, series: Series) -> None:
         self._s = series._s
 
-    def strftime(self, fmt: str):
+    def strftime(self, fmt: str) -> Series:
         """
         Format date32/date64 with a formatting rule: See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
 
@@ -1656,7 +1658,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.strftime(fmt))
 
-    def year(self):
+    def year(self) -> Series:
         """
         Extract the year from the underlying Date representation.
         Can be performed on Date32 and Date64.
@@ -1669,7 +1671,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.year())
 
-    def month(self):
+    def month(self) -> Series:
         """
         Extract the month from the underlying Date representation.
         Can be performed on Date32 and Date64
@@ -1683,7 +1685,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.month())
 
-    def week(self):
+    def week(self) -> Series:
         """
         Extract the week from the underlying Date representation.
         Can be performed on Date32 and Date64
@@ -1697,7 +1699,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.week())
 
-    def weekday(self):
+    def weekday(self) -> Series:
         """
         Extract the week day from the underlying Date representation.
         Can be performed on Date32 and Date64.
@@ -1710,7 +1712,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.week())
 
-    def day(self):
+    def day(self) -> Series:
         """
         Extract the day from the underlying Date representation.
         Can be performed on Date32 and Date64.
@@ -1724,7 +1726,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.day())
 
-    def ordinal_day(self):
+    def ordinal_day(self) -> Series:
         """
         Extract ordinal day from underlying Date representation.
         Can be performed on Date32 and Date64.
@@ -1738,7 +1740,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.ordinal_day())
 
-    def hour(self):
+    def hour(self) -> Series:
         """
         Extract the hour from the underlying DateTime representation.
         Can be performed on Date64.
@@ -1751,7 +1753,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.hour())
 
-    def minute(self):
+    def minute(self) -> Series:
         """
         Extract the minutes from the underlying DateTime representation.
         Can be performed on Date64.
@@ -1764,7 +1766,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.minute())
 
-    def second(self):
+    def second(self) -> Series:
         """
         Extract the seconds the from underlying DateTime representation.
         Can be performed on Date64.
@@ -1777,7 +1779,7 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.second())
 
-    def nanosecond(self):
+    def nanosecond(self) -> Series:
         """
         Extract the nanoseconds from the underlying DateTime representation.
         Can be performed on Date64.
@@ -1791,13 +1793,13 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.nanosecond())
 
-    def timestamp(self) -> "Series":
+    def timestamp(self) -> Series:
         """
         Return timestamp in ms as Int64 type.
         """
         return wrap_s(self._s.timestamp())
 
-    def to_python_datetime(self) -> "Series":
+    def to_python_datetime(self) -> Series:
         """
         Go from Date32/Date64 to python DateTime objects
         """
@@ -1806,7 +1808,7 @@ class DateTimeNameSpace:
             lambda ts: datetime.utcfromtimestamp(ts), datatypes.Object
         )
 
-    def min(self) -> "datetime":
+    def min(self) -> datetime:
         """
         Return minimum as python DateTime
         """
@@ -1814,7 +1816,7 @@ class DateTimeNameSpace:
         out = s.min()
         return _to_python_datetime(out, s.dtype)
 
-    def max(self) -> "datetime":
+    def max(self) -> datetime:
         """
         Return maximum as python DateTime
         """
@@ -1822,7 +1824,7 @@ class DateTimeNameSpace:
         out = s.max()
         return _to_python_datetime(out, s.dtype)
 
-    def median(self) -> "datetime":
+    def median(self) -> datetime:
         """
         Return median as python DateTime
         """
@@ -1830,7 +1832,7 @@ class DateTimeNameSpace:
         out = int(s.median())
         return _to_python_datetime(out, s.dtype)
 
-    def mean(self) -> "datetime":
+    def mean(self) -> datetime:
         """
         Return mean as python DateTime
         """
@@ -1839,7 +1841,7 @@ class DateTimeNameSpace:
         return _to_python_datetime(out, s.dtype)
 
 
-def _to_python_datetime(value: int, dtype: Type[DataType]) -> datetime:
+def _to_python_datetime(value: Union[int, float], dtype: Type[DataType]) -> datetime:
     if dtype == Date32:
         # days to seconds
         return datetime.utcfromtimestamp(value * 3600 * 24)
@@ -1855,15 +1857,15 @@ class SeriesIter:
     Utility class that allows slow iteration over a `Series`.
     """
 
-    def __init__(self, length: int, s: "Series"):
+    def __init__(self, length: int, s: Series) -> None:
         self.len = length
         self.i = 0
         self.s = s
 
-    def __iter__(self):
+    def __iter__(self) -> "SeriesIter":
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         if self.i < self.len:
             i = self.i
             self.i += 1


### PR DESCRIPTION
This PR sets `mypy` to require all functions to be typed, and adds type hints for all functions that did not have type hints yet.

Changes:
* Changed `mypy` settings
* Add full type hint coverage
* Changed all forward references (quoted types) to normal references where possible

To do in a future PR:
* Fix type hints for lines that are explicitly ignored with `# type: ignore`

EDIT: GitHub seems to have some trouble with the Python job... I don't think it's my fault (everything ran fine on my fork).