### PR TITLE
Some optimizations

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -9,8 +9,8 @@ use itertools::Itertools;
 use std::convert::TryFrom;
 
 /// Convert Arrow array offsets to indexes of the original list
-pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> Vec<usize> {
-    let mut idx = Vec::with_capacity(capacity);
+pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> AlignedVec<u32> {
+    let mut idx = AlignedVec::with_capacity_aligned(capacity);
 
     let mut count = 0;
     let mut last_idx = 0;

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -94,7 +94,10 @@ impl DataFrame {
                 // expand all the other columns based the exploded first column
                 if i == 0 {
                     let row_idx = offsets_to_indexes(offsets, exploded.len());
-                    df = unsafe { df.take_iter_unchecked(row_idx.into_iter()) };
+                    let row_idx = UInt32Chunked::new_from_aligned_vec("", row_idx);
+                    // Safety
+                    // We just created indices that are in bounds.
+                    df = unsafe { df.take_unchecked(&row_idx) };
                 }
                 if exploded.len() == df.height() {
                     df.columns.insert(col_idx, exploded);

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -891,7 +891,9 @@ impl DataFrame {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
             return Ok(unsafe { self.take_unchecked_vectical(&take) });
         }
-        Ok(self.take(&take))
+        // Safety:
+        // the created indices are in bounds
+        Ok(unsafe { self.take_unchecked(&take) })
     }
 
     /// Return a sorted clone of this DataFrame.

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -454,7 +454,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// Out of bounds access doesn't Error but will return a Null value
+    /// Out of bounds access doesn't Error but will return a Null value for that element.
     fn take_iter(&self, _iter: &mut dyn Iterator<Item = usize>) -> Series {
         unimplemented!()
     }
@@ -463,7 +463,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// This doesn't check any bounds or null validity.
+    /// This doesn't check any bounds.
     unsafe fn take_iter_unchecked(&self, _iter: &mut dyn Iterator<Item = usize>) -> Series {
         unimplemented!()
     }
@@ -471,7 +471,7 @@ pub trait SeriesTrait:
     /// Take by index if ChunkedArray contains a single chunk.
     ///
     /// # Safety
-    /// This doesn't check any bounds. Null validity is checked.
+    /// This doesn't check any bounds.
     unsafe fn take_unchecked(&self, _idx: &UInt32Chunked) -> Result<Series> {
         unimplemented!()
     }
@@ -480,7 +480,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// This doesn't check any bounds or null validity.
+    /// This doesn't check any bounds.
     unsafe fn take_opt_iter_unchecked(
         &self,
         _iter: &mut dyn Iterator<Item = Option<usize>>,
@@ -492,7 +492,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// Out of bounds access doesn't Error but will return a Null value
+    /// Out of bounds access doesn't Error but will return a Null value for that element
     fn take_opt_iter(&self, _iter: &mut dyn Iterator<Item = Option<usize>>) -> Series {
         unimplemented!()
     }
@@ -501,7 +501,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// Out of bounds access doesn't Error but will return a Null value
+    /// Out of bounds access doesn't Error but will return a Null value for that element.
     fn take(&self, _indices: &UInt32Chunked) -> Series {
         unimplemented!()
     }


### PR DESCRIPTION
Some code could call take_unchecked instead of take.
Also create an Uint32CHunked instead of a Vec in explode
will reduce a double alloc.

Correct docstring of Series::take(_unchecked)