### PR TITLE
round date32/date64 by SampleRule

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/conversions_utils.rs
+++ b/polars/polars-core/src/chunked_array/temporal/conversions_utils.rs
@@ -4,7 +4,7 @@
 use chrono::{NaiveDateTime, NaiveTime, Timelike};
 
 /// Number of seconds in a day
-const SECONDS_IN_DAY: i64 = 86_400;
+pub(crate) const SECONDS_IN_DAY: i64 = 86_400;
 /// Number of milliseconds in a second
 const MILLISECONDS_IN_SECOND: i64 = 1_000;
 /// Number of microseconds in a second

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1732,6 +1732,28 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.nanosecond())
 
+    def round(self, rule: str, n: int) -> Expr:
+        """
+        Round the datetime.
+
+        Parameters
+        ----------
+        rule
+            Units of the downscaling operation.
+
+            Any of:
+                - "month"
+                - "week"
+                - "day"
+                - "hour"
+                - "minute"
+                - "second"
+
+        n
+            Number of units (e.g. 5 "day", 15 "minute".
+        """
+        return wrap_expr(self._pyexpr).map(lambda s: s.dt.round(rule, n), None)
+
 
 def expr_to_lit_or_expr(
     expr: Union[Expr, int, float, str, List[Expr]], str_to_lit: bool = True

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1844,6 +1844,28 @@ class DateTimeNameSpace:
         out = int(s.mean())
         return _to_python_datetime(out, s.dtype)
 
+    def round(self, rule: str, n: int) -> Series:
+        """
+        Round the datetime.
+
+        Parameters
+        ----------
+        rule
+            Units of the downscaling operation.
+
+            Any of:
+                - "month"
+                - "week"
+                - "day"
+                - "hour"
+                - "minute"
+                - "second"
+
+        n
+            Number of units (e.g. 5 "day", 15 "minute".
+        """
+        return wrap_s(self._s.round_datetime(rule, n))
+
 
 def _to_python_datetime(value: Union[int, float], dtype: Type[DataType]) -> datetime:
     if dtype == Date32:

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -11,7 +11,7 @@ use crate::arrow_interop::to_rust::array_to_rust;
 use crate::dataframe::PyDataFrame;
 use crate::datatypes::PyDataType;
 use crate::error::PyPolarsEr;
-use crate::utils::str_to_polarstype;
+use crate::utils::{str_to_polarstype, downsample_str_to_rule};
 use crate::{arrow_interop, npy::aligned_array, prelude::*};
 
 #[pyclass]
@@ -1055,6 +1055,19 @@ impl PySeries {
     pub fn nanosecond(&self) -> PyResult<Self> {
         let s = self.series.nanosecond().map_err(PyPolarsEr::from)?;
         Ok(s.into_series().into())
+    }
+
+    pub fn round_datetime(&self, rule: &str, n: u32) -> PyResult<Self> {
+        let rule = downsample_str_to_rule(rule, n)?;
+        match self.series.dtype() {
+            DataType::Date32 => {
+                Ok(self.series.date32().unwrap().round(rule).into_series().into())
+            }
+            DataType::Date64 => {
+                Ok(self.series.date64().unwrap().round(rule).into_series().into())
+            },
+            dt => Err(PyPolarsEr::Other(format!("type: {:?} is not a date. Please use Date32 or Date64", dt)).into())
+        }
     }
 
     pub fn peak_max(&self) -> Self {

--- a/py-polars/src/utils.rs
+++ b/py-polars/src/utils.rs
@@ -1,4 +1,7 @@
 use polars::prelude::*;
+use polars::frame::groupby::resample::SampleRule;
+use crate::error::PyPolarsEr;
+use pyo3::PyResult;
 
 pub fn str_to_polarstype(s: &str) -> DataType {
     match s {
@@ -21,4 +24,19 @@ pub fn str_to_polarstype(s: &str) -> DataType {
         "<class 'polars.datatypes.Object'>" => DataType::Object("object"),
         tp => panic!("Type {} not implemented in str_to_polarstype", tp),
     }
+}
+
+pub fn downsample_str_to_rule(rule: &str, n: u32) -> PyResult<SampleRule>{
+    let rule = match rule {
+        "month" => SampleRule::Month(n),
+        "week" => SampleRule::Week(n),
+        "day" => SampleRule::Day(n),
+        "hour" => SampleRule::Hour(n),
+        "minute" => SampleRule::Minute(n),
+        "second" => SampleRule::Second(n),
+        a => {
+            return Err(PyPolarsEr::Other(format!("rule {} not supported", a)).into());
+        }
+    };
+    Ok(rule)
 }

--- a/py-polars/tests/test_pandas.py
+++ b/py-polars/tests/test_pandas.py
@@ -17,3 +17,9 @@ def test_from_pandas_datetime():
     s = pl.from_pandas(date_times)
     assert s[0] == 1624492800000
     assert s[-1] == 1624525200000
+    # checks dispatch
+    s.dt.round("hour", 2)
+    s.dt.round("day", 5)
+
+    # checks lazy dispatch
+    pl.DataFrame([s.rename("foo")])[pl.col("foo").dt.round("hour", 2)]


### PR DESCRIPTION
closes #877 

This adds the proposed round methods in `dt` namespace. 

Some food for thought:
There might be an extra iteration needed. For instance, how do we deal with offsets? The round operation creates buckets. But the current bucket starts might feel arbitrary. Pherhaps we need an extra offset argument to tune the start of the buckets. 