### PR TITLE
Arrow2: update arrow and add primitive_take_unchecked kernel

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -9,6 +9,6 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "596bdda4d3c8fa45c112598832fcf88901ab95bc", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "1e54fd43ce9ce78958f9243a137acf15b3b57f5e", default-features = false }
 thiserror = "^1.0"
 num = "^0.4"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -86,7 +86,7 @@ docs-selection = [
 ]
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "596bdda4d3c8fa45c112598832fcf88901ab95bc", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "1e54fd43ce9ce78958f9243a137acf15b3b57f5e", default-features = false }
 polars-arrow = {version = "0.14.4", path = "../polars-arrow"}
 thiserror = "1.0"
 num = "^0.4"

--- a/polars/polars-core/src/chunked_array/ops/take.rs
+++ b/polars/polars-core/src/chunked_array/ops/take.rs
@@ -10,8 +10,8 @@ use crate::chunked_array::kernels::take::{
     take_no_null_primitive_opt_iter_unchecked, take_no_null_utf8_iter,
     take_no_null_utf8_iter_unchecked, take_no_null_utf8_opt_iter_unchecked, take_primitive_iter,
     take_primitive_iter_n_chunks, take_primitive_iter_unchecked, take_primitive_opt_iter_n_chunks,
-    take_primitive_opt_iter_unchecked, take_utf8, take_utf8_iter, take_utf8_iter_unchecked,
-    take_utf8_opt_iter_unchecked,
+    take_primitive_opt_iter_unchecked, take_primitive_unchecked, take_utf8, take_utf8_iter,
+    take_utf8_iter_unchecked, take_utf8_opt_iter_unchecked,
 };
 use crate::prelude::*;
 use crate::utils::NoNull;
@@ -76,7 +76,9 @@ where
                     (0, 1) => {
                         take_no_null_primitive::<T>(chunks.next().unwrap(), array) as ArrayRef
                     }
-                    (_, 1) => take::take(chunks.next().unwrap(), array).unwrap().into(),
+                    (_, 1) => {
+                        take_primitive_unchecked::<T>(chunks.next().unwrap(), array) as ArrayRef
+                    }
                     _ => {
                         return if array.null_count() == 0 {
                             let iter = array.values().iter().map(|i| *i as usize);

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -25,7 +25,7 @@ csv-file = ["csv", "csv-core", "memmap", "fast-float", "lexical", "arrow/io_csv"
 fmt = ["polars-core/plain_fmt"]
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "596bdda4d3c8fa45c112598832fcf88901ab95bc" }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "1e54fd43ce9ce78958f9243a137acf15b3b57f5e" }
 polars-core = {version = "0.14.4", path = "../polars-core", features = ["private"], default-features=false}
 polars-arrow = {version = "0.14.4", path = "../polars-arrow"}
 csv = {version="1.1", optional=true}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow2"
 version = "0.1.0"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=596bdda4d3c8fa45c112598832fcf88901ab95bc#596bdda4d3c8fa45c112598832fcf88901ab95bc"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=1e54fd43ce9ce78958f9243a137acf15b3b57f5e#1e54fd43ce9ce78958f9243a137acf15b3b57f5e"
 dependencies = [
  "ahash",
  "base64",


### PR DESCRIPTION
With this change the arrow2 branch is on par with master, and in fact is the fastest polars branch to date!

db-benchmark groupby 

# arrow2 with nulls
```
q1
0.031499624252319336
q2
0.11069488525390625
q3
0.17528486251831055
q4
0.11399030685424805
q5
0.30147838592529297
0.7024998664855957 easy
q6
0.23541498184204102
q7
0.15617656707763672
q8
0.7221078872680664
q9
0.4692988395690918
q10
1.3150479793548584
2.8986976146698 advanced
```

# master with nulls
```
q1
0.028807401657104492
q2
0.13731050491333008
q3
0.1823265552520752
q4
0.12175607681274414
q5
0.3322720527648926
0.7743632793426514 easy
q6
0.24984216690063477
q7
0.1691582202911377
q8
0.8459064960479736
q9
0.5596034526824951
q10
1.4306683540344238
3.2562143802642822 advanced
```

# arrow2 no nulls
```
q1
0.03441143035888672
q2
0.11415886878967285
q3
0.17808222770690918
q4
0.06368803977966309
q5
0.23902249336242676
0.5958507061004639 easy
q6
0.1971423625946045
q7
0.16079235076904297
q8
0.7129607200622559
q9
0.3787219524383545
q10
1.3118858337402344
2.7621068954467773 advanced
```

# master no nulls

```
q1
0.047788143157958984
q2
0.1311936378479004
q3
0.1885051727294922
q4
0.06720161437988281
q5
0.2355349063873291
0.6234002113342285 easy
q6
0.21099495887756348
q7
0.16602587699890137
q8
0.7083308696746826
q9
0.3734745979309082
q10
1.2791273593902588
2.7386696338653564 advanced
```