### PR TITLE
resolve "~" to homedir in CsvReader

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -43,6 +43,7 @@ anyhow = "1.0"
 rayon = "1.5"
 ahash = "0.7"
 num = "^0.4.0"
+dirs = "3.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -55,7 +55,7 @@
 //! ```
 //!
 use crate::csv_core::csv::{build_csv_reader, SequentialReader};
-use crate::utils::to_arrow_compatible_df;
+use crate::utils::{resolve_homedir, to_arrow_compatible_df};
 use crate::{SerReader, SerWriter};
 pub use arrow::csv::WriterBuilder;
 use polars_core::prelude::*;
@@ -348,7 +348,7 @@ where
 impl<'a> CsvReader<'a, File> {
     /// This is the recommended way to create a csv reader as this allows for fastest parsing.
     pub fn from_path<P: Into<PathBuf>>(path: P) -> Result<Self> {
-        let path = path.into();
+        let path = resolve_homedir(&path.into());
         let f = std::fs::File::open(&path)?;
         Ok(Self::new(f).with_path(Some(path)))
     }

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -31,6 +31,7 @@ mod tests {
     use super::resolve_homedir;
     use std::path::PathBuf;
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_resolve_homedir() {
         let paths: Vec<PathBuf> = vec![
@@ -49,5 +50,22 @@ mod tests {
         assert_eq!(resolved[2], paths[2]);
         assert_eq!(resolved[3], paths[3]);
         assert!(resolved[4].is_absolute());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_resolve_homedir_windows() {
+        let paths: Vec<PathBuf> = vec![
+            r#"c:\Users\user1\test.csv"#.into(),
+            r#"~\user1\test.csv"#.into(),
+            "~".into(),
+        ];
+
+        let resolved: Vec<PathBuf> = paths.iter().map(|x| resolve_homedir(x)).collect();
+
+        assert_eq!(resolved[0], paths[0]);
+        assert_eq!(resolved[1].file_name(), paths[1].file_name());
+        assert!(resolved[1].is_absolute());
+        assert!(resolved[2].is_absolute());
     }
 }

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -1,4 +1,6 @@
+use dirs::home_dir;
 use polars_core::prelude::*;
+use std::path::{Path, PathBuf};
 
 pub(crate) fn to_arrow_compatible_df(df: &DataFrame) -> DataFrame {
     // Our categorical type is not known to arrow/ parquet, so we coerce to large-utf8.
@@ -11,4 +13,41 @@ pub(crate) fn to_arrow_compatible_df(df: &DataFrame) -> DataFrame {
         })
         .collect::<Vec<_>>();
     DataFrame::new_no_checks(cols)
+}
+
+pub(crate) fn resolve_homedir(path: &Path) -> PathBuf {
+    // replace "~" with home directory
+    if path.starts_with("~") {
+        if let Some(homedir) = home_dir() {
+            return homedir.join(path.strip_prefix("~").unwrap());
+        }
+    }
+
+    path.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_homedir;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_resolve_homedir() {
+        let paths: Vec<PathBuf> = vec![
+            "~/dir1/dir2/test.csv".into(),
+            "/abs/path/test.csv".into(),
+            "rel/path/test.csv".into(),
+            "/".into(),
+            "~".into(),
+        ];
+
+        let resolved: Vec<PathBuf> = paths.iter().map(|x| resolve_homedir(x)).collect();
+
+        assert_eq!(resolved[0].file_name(), paths[0].file_name());
+        assert!(resolved[0].is_absolute());
+        assert_eq!(resolved[1], paths[1]);
+        assert_eq!(resolved[2], paths[2]);
+        assert_eq!(resolved[3], paths[3]);
+        assert!(resolved[4].is_absolute());
+    }
 }


### PR DESCRIPTION
This allows you to read CSVs with a "~" in the path. 
I know that we typically don't want to add dependencies but `dirs` is very small and shouldn't add much overhead. Let me know if you want me to rather use no additional dependencies. 

Todos before removing draft flag:
- manually test on Windows
- add this functionality to other io functions (json etc)

Fixes #882

let me know if you have any change requests so far