### PR TITLE
Add Asof join type

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -72,6 +72,7 @@ checked_arithmetic = ["polars-core/checked_arithmetic"]
 repeat_by = ["polars-core/repeat_by", "polars-lazy/repeat_by"]
 is_first = ["polars-core/is_first", "polars-lazy/is_first"]
 is_last = ["polars-core/is_last"]
+asof_join = ["polars-core/asof_join", "polars-lazy/asof_join"]
 
 # don't use this
 private = []
@@ -131,7 +132,8 @@ docs-selection = [
     "downsample",
     "repeat_by",
     "is_first",
-    "is_last"
+    "is_last",
+    "asof_join"
 ]
 
 [dependencies]

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -54,6 +54,7 @@ checked_arithmetic = []
 repeat_by = []
 is_first = []
 is_last = []
+asof_join = []
 
 
 # opt-in datatypes for Series
@@ -87,6 +88,7 @@ docs-selection = [
     "repeat_by",
     "is_first",
     "is_last",
+    "asof_join"
 ]
 
 [dependencies]

--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -177,6 +177,7 @@ impl CategoricalChunkedBuilder {
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: Some(Arc::new(self.reverse_mapping.finish())),
+            ..Default::default()
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/builder/mod.rs
+++ b/polars/polars-core/src/chunked_array/builder/mod.rs
@@ -53,6 +53,7 @@ impl ChunkedBuilder<bool, BooleanType> for BooleanChunkedBuilder {
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 }
@@ -100,6 +101,7 @@ where
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 }
@@ -164,6 +166,7 @@ impl Utf8ChunkedBuilder {
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 }
@@ -308,6 +311,7 @@ where
             chunks: vec![Arc::new(builder.finish())],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 
@@ -364,6 +368,7 @@ macro_rules! finish_list_builder {
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }};
 }

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -159,11 +159,13 @@ pub struct ChunkedArray<T> {
 }
 
 impl<T> ChunkedArray<T> {
-    pub fn is_sorted(&self) -> bool {
+    #[cfg(feature = "asof_join")]
+    pub(crate) fn is_sorted(&self) -> bool {
         self.bit_settings & 1 != 0
     }
 
-    pub fn is_sorted_reverse(&self) -> bool {
+    #[cfg(feature = "asof_join")]
+    pub(crate) fn is_sorted_reverse(&self) -> bool {
         self.bit_settings & 1 << 1 != 0
     }
 

--- a/polars/polars-core/src/chunked_array/object/builder.rs
+++ b/polars/polars-core/src/chunked_array/object/builder.rs
@@ -82,6 +82,7 @@ where
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 }
@@ -147,6 +148,7 @@ where
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            ..Default::default()
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -178,6 +178,7 @@ where
             );
             let mut ca: Self = v.into_iter().collect();
             ca.rename(self.name());
+            ca.set_sorted(reverse);
             ca
         }
     }
@@ -287,8 +288,9 @@ where
             },
         );
         let ca: NoNull<UInt32Chunked> = vals.into_iter().map(|(idx, _v)| idx).collect();
-
-        Ok(ca.into_inner())
+        let mut ca = ca.into_inner();
+        ca.set_sorted(reverse[0]);
+        Ok(ca)
     }
 }
 
@@ -338,7 +340,9 @@ impl ChunkSort<Utf8Type> for Utf8Chunked {
         // We don't collect from an iterator because we know the total value size
         let mut builder = Utf8ChunkedBuilder::new(self.name(), self.len(), self.get_values_size());
         v.into_iter().for_each(|opt_v| builder.append_option(opt_v));
-        builder.finish()
+        let mut ca = builder.finish();
+        ca.set_sorted(reverse);
+        ca
     }
 
     fn sort_in_place(&mut self, reverse: bool) {
@@ -394,8 +398,9 @@ impl ChunkSort<Utf8Type> for Utf8Chunked {
             },
         );
         let ca: NoNull<UInt32Chunked> = vals.into_iter().map(|(idx, _v)| idx).collect();
-
-        Ok(ca.into_inner())
+        let mut ca = ca.into_inner();
+        ca.set_sorted(reverse[0]);
+        Ok(ca)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -26,6 +26,7 @@ impl<T> Default for ChunkedArray<T> {
             chunks: Default::default(),
             phantom: PhantomData,
             categorical_map: None,
+            bit_settings: 0,
         }
     }
 }
@@ -265,6 +266,7 @@ impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
             chunks: vec![arr],
             phantom: PhantomData,
             categorical_map: None,
+            bit_settings: 0,
         }
     }
 }

--- a/polars/polars-core/src/frame/asof_join.rs
+++ b/polars/polars-core/src/frame/asof_join.rs
@@ -1,0 +1,185 @@
+use crate::prelude::*;
+use crate::utils::CustomIterTools;
+use num::Bounded;
+use polars_arrow::trusted_len::PushUnchecked;
+
+pub(crate) trait JoinAsof<T: PolarsDataType> {
+    fn join_asof(&self, _other: &ChunkedArray<T>) -> Result<Vec<Option<u32>>> {
+        Err(PolarsError::InvalidOperation(
+            format!(
+                "asof join not implemented for key with dtype: {:?}",
+                T::get_dtype()
+            )
+            .into(),
+        ))
+    }
+}
+
+impl<T> JoinAsof<T> for ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    T::Native: Bounded,
+{
+    fn join_asof(&self, other: &ChunkedArray<T>) -> Result<Vec<Option<u32>>> {
+        let mut rhs_iter = other.into_iter();
+        let mut tuples = Vec::with_capacity(self.len());
+        if self.null_count() > 0 {
+            return Err(PolarsError::Other(
+                "keys of asof join should not have null values".into(),
+            ));
+        }
+        if !(other.is_sorted_reverse() | other.is_sorted()) {
+            eprintln!("right key of asof join is not explicitly sorted, this may lead to unexpected results");
+        }
+
+        let mut count = 0;
+        let mut rhs_idx = 0;
+
+        let mut previous_rhs_val: T::Native = Bounded::min_value();
+        let mut previous_lhs_val: T::Native = Bounded::min_value();
+
+        for arr in self.downcast_iter() {
+            for &lhs_val in arr.values() {
+                if lhs_val < previous_lhs_val {
+                    return Err(PolarsError::Other(
+                        "left key of asof join must be sorted".into(),
+                    ));
+                }
+                previous_lhs_val = lhs_val;
+
+                loop {
+                    match rhs_iter.next() {
+                        Some(Some(rhs_val)) => {
+                            if rhs_val > lhs_val {
+                                if previous_rhs_val <= lhs_val && rhs_idx > 0 {
+                                    tuples.push(Some(rhs_idx - 1));
+                                    rhs_idx += 1;
+                                    previous_rhs_val = rhs_val;
+                                    break;
+                                } else {
+                                    rhs_idx += 1;
+                                    previous_rhs_val = rhs_val;
+                                    tuples.push(None);
+                                    break;
+                                }
+                            }
+                            previous_rhs_val = rhs_val;
+                            rhs_idx += 1;
+                        }
+                        Some(None) => {
+                            rhs_idx += 1;
+                        }
+                        // exhausted rhs
+                        None => {
+                            let mut remaining = self.len() - count;
+                            if previous_rhs_val < lhs_val {
+                                remaining -= 1;
+                                tuples.push(Some(rhs_idx - 1));
+                            }
+
+                            let iter = std::iter::repeat(None)
+                                .take(remaining)
+                                .trust_my_length(remaining);
+                            tuples.extend_trusted_len(iter);
+                            return Ok(tuples);
+                        }
+                    }
+                }
+                count += 1;
+            }
+        }
+
+        Ok(tuples)
+    }
+}
+
+impl JoinAsof<BooleanType> for BooleanChunked {}
+impl JoinAsof<Utf8Type> for Utf8Chunked {}
+impl JoinAsof<ListType> for ListChunked {}
+impl JoinAsof<CategoricalType> for CategoricalChunked {}
+
+impl DataFrame {
+    /// This is similar to a left-join except that we match on nearest key rather than equal keys.
+    /// The keys must be sorted to perform an asof join
+    pub fn join_asof(&self, other: &DataFrame, left_on: &str, right_on: &str) -> Result<DataFrame> {
+        let left_key = self.column(left_on)?;
+        let right_key = other.column(right_on)?;
+
+        let take_idx = left_key.join_asof(right_key)?;
+        // Safety:
+        // join tuples are in bounds
+        let right_df = unsafe {
+            other.take_opt_iter_unchecked(
+                take_idx
+                    .into_iter()
+                    .map(|opt_idx| opt_idx.map(|idx| idx as usize)),
+            )
+        };
+
+        self.finish_join(self.clone(), right_df)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::df;
+
+    #[test]
+    fn test_join_asof() -> Result<()> {
+        let left = df![
+            "a" => [1, 5, 10],
+            "left_val" => ["a", "b", "c"]
+        ]?;
+
+        let right = df![
+            "b" => [1, 2, 3, 6, 7],
+            "right_val" => [1, 2, 3, 6, 7]
+        ]?;
+
+        let out = left.join_asof(&right, "a", "b")?;
+        let expected = df![
+            "a" => [1, 5, 10],
+            "left_val" => ["a", "b", "c"],
+            "b" => [1, 3, 7],
+            "right_val" => [1, 3, 7]
+        ]?;
+        assert!(out.frame_equal_missing(&expected));
+
+        let left = df![
+            "a" => [2, 5, 10, 12],
+            "left_val" => ["a", "b", "c", "d"]
+        ]?;
+
+        let right = df![
+            "b" => [1, 2, 3],
+            "right_val" => [1, 2, 3]
+        ]?;
+        let out = left.join_asof(&right, "a", "b")?;
+        let expected = df![
+            "a" => [2, 5, 10, 12],
+            "left_val" => ["a", "b", "c", "d"],
+            "b" => [Some(2), Some(3), None, None],
+            "right_val" => [Some(2), Some(3), None, None]
+        ]?;
+        assert!(out.frame_equal_missing(&expected));
+
+        let left = df![
+            "a" => [-10, 5, 10],
+            "left_val" => ["a", "b", "c"]
+        ]?;
+
+        let right = df![
+            "b" => [1, 2, 3, 6, 7]
+        ]?;
+
+        let out = left.join_asof(&right, "a", "b")?;
+        let expected = df![
+            "a" => [-10, 5, 10],
+            "left_val" => ["a", "b", "c"],
+            "b" => [None, Some(3), Some(7)]
+        ]?;
+        assert!(out.frame_equal_missing(&expected));
+        Ok(())
+    }
+}

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -861,6 +861,8 @@ impl DataFrame {
 
     /// This is the dispatch of Self::sort, and exists to reduce compile bloat by monomorphization.
     fn sort_impl(&self, by_column: Vec<&str>, reverse: Vec<bool>) -> Result<Self> {
+        let first_reverse = reverse[0];
+        let first_by_column = by_column[0];
         let take = match by_column.len() {
             1 => {
                 let s = self.column(by_column[0])?;
@@ -885,7 +887,16 @@ impl DataFrame {
         }
         // Safety:
         // the created indices are in bounds
-        Ok(unsafe { self.take_unchecked(&take) })
+        let mut df = unsafe { self.take_unchecked(&take) };
+        // Mark the first sort column as sorted
+        df.apply(first_by_column, |s| {
+            let mut s = s.clone();
+            let inner = s.get_inner_mut();
+            inner.set_sorted(first_reverse);
+            s
+        })
+        .expect("column is present");
+        Ok(df)
     }
 
     /// Return a sorted clone of this DataFrame.

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -18,6 +18,8 @@ use crate::utils::{
 };
 
 mod arithmetic;
+#[cfg(feature = "asof_join")]
+pub(crate) mod asof_join;
 pub mod explode;
 pub mod groupby;
 pub mod hash_join;
@@ -25,6 +27,7 @@ pub mod hash_join;
 pub mod row;
 pub mod select;
 mod upstream_traits;
+
 #[cfg(feature = "sort_multiple")]
 use crate::prelude::sort::prepare_argsort;
 use crate::POOL;

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -105,6 +105,10 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+            fn set_sorted(&mut self, reverse: bool) {
+                self.0.set_sorted(reverse)
+            }
+
             unsafe fn equal_element(
                 &self,
                 idx_self: usize,

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -105,6 +105,11 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+            #[cfg(feature = "asof_join")]
+            fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+                cast_and_apply!(self, join_asof, other)
+            }
+
             fn set_sorted(&mut self, reverse: bool) {
                 self.0.set_sorted(reverse)
             }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -60,6 +60,10 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+            fn set_sorted(&mut self, reverse: bool) {
+                self.0.set_sorted(reverse)
+            }
+
             unsafe fn equal_element(
                 &self,
                 idx_self: usize,

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -21,6 +21,8 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
+#[cfg(feature = "asof_join")]
+use crate::frame::asof_join::JoinAsof;
 #[cfg(feature = "pivot")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
@@ -60,6 +62,11 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+            #[cfg(feature = "asof_join")]
+            fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+                self.0.join_asof(other.as_ref().as_ref())
+            }
+
             fn set_sorted(&mut self, reverse: bool) {
                 self.0.set_sorted(reverse)
             }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -49,6 +49,10 @@ pub(crate) mod private {
     }
 
     pub trait PrivateSeries {
+        fn set_sorted(&mut self, _reverse: bool) {
+            unimplemented!()
+        }
+
         unsafe fn equal_element(
             &self,
             _idx_self: usize,
@@ -1166,7 +1170,7 @@ impl<'a> (dyn SeriesTrait + 'a) {
 pub struct Series(pub Arc<dyn SeriesTrait>);
 
 impl Series {
-    fn get_inner_mut(&mut self) -> &mut dyn SeriesTrait {
+    pub(crate) fn get_inner_mut(&mut self) -> &mut dyn SeriesTrait {
         if Arc::weak_count(&self.0) + Arc::strong_count(&self.0) != 1 {
             self.0 = self.0.clone_inner();
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -49,6 +49,11 @@ pub(crate) mod private {
     }
 
     pub trait PrivateSeries {
+        #[cfg(feature = "asof_join")]
+        fn join_asof(&self, _other: &Series) -> Result<Vec<Option<u32>>> {
+            unimplemented!()
+        }
+
         fn set_sorted(&mut self, _reverse: bool) {
             unimplemented!()
         }

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -36,6 +36,7 @@ is_in = ["polars-core/is_in"]
 repeat_by = ["polars-core/repeat_by"]
 round_series = ["polars-core/round_series"]
 is_first = ["polars-core/is_first"]
+asof_join = ["polars-core/asof_join"]
 
 # no guarantees whatsoever
 private = []

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -111,6 +111,7 @@
 //!     - `sort_multiple` - Allow sorting a `DataFrame` on multiple columns
 //!     - `rows` - Create `DataFrame` from rows and extract rows from `DataFrames`.
 //!     - `downsample` - [downsample operation](crate::frame::DataFrame::downsample) on `DataFrame`s
+//!     - `asof_join` - Join as of, to join on nearest keys instead of exact equality match.
 //! * `Series` operations:
 //!     - `is_in` - [Check for membership in `Series`](crate::chunked_array::ops::IsIn)
 //!     - `zip_with` - [Zip two Series/ ChunkedArrays](crate::chunked_array::ops::ChunkZip)

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -52,7 +52,8 @@ features = [
     "rows",
     "private",
     "round_series",
-    "is_first"
+    "is_first",
+    "asof_join"
 ]
 
 #[patch.crates-io]

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -1378,6 +1378,7 @@ class DataFrame:
                 - "inner"
                 - "left"
                 - "outer"
+                - "asof"
 
         Example
         ---
@@ -1421,6 +1422,10 @@ class DataFrame:
         │ 3    ┆ 8    ┆ "c" ┆ null  │
         ╰──────┴──────┴─────┴───────╯
         ```
+
+        # Asof joins
+        This is similar to a left-join except that we match on nearest key rather than equal keys.
+        The keys must be sorted to perform an asof join
 
         Returns
         -------

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -478,10 +478,17 @@ class LazyFrame:
                 "inner"
                 "left"
                 "outer"
+                "join"
+
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both DataFrames up to the join in parallel.
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel.
+
+        # Asof joins
+        This is similar to a left-join except that we match on nearest key rather than equal keys.
+        The keys must be sorted to perform an asof join
+
         """
         if isinstance(left_on, str):
             left_on = [left_on]

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -229,6 +229,12 @@ class Series:
                     self._s = PySeries.new_opt_f64(name, values)
                 elif isinstance(dtype, str):
                     self._s = PySeries.new_str(name, values)
+                elif isinstance(dtype, datetime):
+                    arrow_array = pa.array(values)
+                    from .functions import from_arrow
+
+                    s = from_arrow(arrow_array)
+                    self._s = s._s
                 # make list array
                 elif isinstance(dtype, (list, tuple)):
                     value_dtype = _find_first_non_none(dtype)

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -387,6 +387,7 @@ impl PyDataFrame {
             "left" => JoinType::Left,
             "inner" => JoinType::Inner,
             "outer" => JoinType::Outer,
+            "asof" => JoinType::AsOf,
             _ => panic!("not supported"),
         };
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -220,6 +220,7 @@ impl PyLazyFrame {
             "left" => JoinType::Left,
             "inner" => JoinType::Inner,
             "outer" => JoinType::Outer,
+            "asof" => JoinType::AsOf,
             _ => panic!("not supported"),
         };
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -736,3 +736,15 @@ def test_join_dates():
         }
     )
     df.join(df, on="datetime")
+
+
+def test_asof_join():
+    left = pl.DataFrame({"a": [-10, 5, 10], "left_val": ["a", "b", "c"]})
+    right = pl.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
+
+    # only test dispatch
+    out = left.join(right, on="a", how="asof")
+    assert out.shape == (3, 4)
+
+    left.lazy().join(right.lazy(), on="a", how="asof").collect()
+    assert out.shape == (3, 4)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -4,6 +4,7 @@ import polars as pl
 import numpy as np
 import pytest
 import pyarrow as pa
+from datetime import datetime
 
 
 def create_series() -> "Series":
@@ -369,6 +370,18 @@ def test_timestamp():
     df = pl.DataFrame([out])
     # test if rows returns objects
     assert isinstance(df.row(0)[0], datetime)
+
+
+def test_from_pydatetime():
+    dates = [
+        datetime(2021, 1, 1),
+        datetime(2021, 1, 2),
+        datetime(2021, 1, 3),
+        datetime(2021, 1, 4, 12, 12),
+        None,
+    ]
+    s = pl.Series("", dates)
+    assert s.dtype == pl.Date64
 
 
 def test_round():


### PR DESCRIPTION
This PR adds the **asof** join type, which is similar to `merge_asof` in pandas.
This also makes it possible to create a `Date64` Series from a sequence of python datetime objects.