### PR TITLE
use fast csv parser for more input types

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -42,6 +42,7 @@
 //! ```
 //!
 use crate::csv_core::csv::{build_csv_reader, SequentialReader};
+use crate::mmap::MmapBytesReader;
 use crate::utils::{resolve_homedir, to_arrow_compatible_df};
 use crate::{SerReader, SerWriter};
 pub use arrow::csv::WriterBuilder;
@@ -149,7 +150,7 @@ pub enum CsvEncoding {
 /// ```
 pub struct CsvReader<'a, R>
 where
-    R: Read + Seek,
+    R: Read + Seek + MmapBytesReader,
 {
     /// File or Stream object
     reader: R,
@@ -180,7 +181,7 @@ where
 
 impl<'a, R> CsvReader<'a, R>
 where
-    R: 'static + Read + Seek + Sync + Send,
+    R: Read + Seek + Sync + Send + MmapBytesReader,
 {
     /// Sets the chunk size used by the parser. This influences performance
     pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
@@ -343,7 +344,7 @@ impl<'a> CsvReader<'a, File> {
 
 impl<'a, R> SerReader<R> for CsvReader<'a, R>
 where
-    R: 'static + Read + Seek + Sync + Send,
+    R: Read + Seek + Sync + Send + MmapBytesReader,
 {
     /// Create a new CsvReader from a file/ stream
     fn new(reader: R) -> Self {

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -486,7 +486,8 @@ mod test {
  4.6,3.1,1.5,.2,"Setosa"
  5,3.6,1.4,.2,"Setosa"
  5.4,3.9,1.7,.4,"Setosa"
- 4.6,3.4,1.4,.3,"Setosa""#;
+ 4.6,3.4,1.4,.3,"Setosa"
+"#;
 
         let file = Cursor::new(s);
         let df = CsvReader::new(file)
@@ -500,7 +501,8 @@ mod test {
         let s = r#"
          "sepal.length","sepal.width","petal.length","petal.width","variety"
          5.1,3.5,1.4,.2,"Setosa"
-         5.1,3.5,1.4,.2,"Setosa""#;
+         5.1,3.5,1.4,.2,"Setosa"
+ "#;
 
         let file = Cursor::new(s);
 
@@ -520,7 +522,8 @@ mod test {
         4.6,3.1,1.5,.2,"Setosa"
         5,3.6,1.4,.2,"Setosa"
         5.4,3.9,1.7,.4,"Setosa"
-        4.6,3.4,1.4,.3,"Setosa""#;
+        4.6,3.4,1.4,.3,"Setosa"
+"#;
 
         let file = Cursor::new(s);
         let df = CsvReader::new(file)
@@ -561,7 +564,8 @@ mod test {
 1003000126	ENKESHAFI	ARDALAN		M.D.	M	I	900 SETON DR		CUMBERLAND	21502	MD	US	Internal Medicine	Y	F	99222	Initial hospital inpatient care, typically 50 minutes per day	N	17	17	17	138.04588235	625	108.22529412	109.22
 1003000126	ENKESHAFI	ARDALAN		M.D.	M	I	900 SETON DR		CUMBERLAND	21502	MD	US	Internal Medicine	Y	F	99223	Initial hospital inpatient care, typically 70 minutes per day	N	86	82	86	204.85395349	1093.5	159.25906977	161.78093023
 1003000126	ENKESHAFI	ARDALAN		M.D.	M	I	900 SETON DR		CUMBERLAND	21502	MD	US	Internal Medicine	Y	F	99232	Subsequent hospital inpatient care, typically 25 minutes per day	N	360	206	360	73.565666667	360.57222222	57.670305556	58.038833333
-1003000126	ENKESHAFI	ARDALAN		M.D.	M	I	900 SETON DR		CUMBERLAND	21502	MD	US	Internal Medicine	Y	F	99233	Subsequent hospital inpatient care, typically 35 minutes per day	N	284	148	284	105.34971831	576.98943662	82.512992958	82.805774648"#.as_ref();
+1003000126	ENKESHAFI	ARDALAN		M.D.	M	I	900 SETON DR		CUMBERLAND	21502	MD	US	Internal Medicine	Y	F	99233	Subsequent hospital inpatient care, typically 35 minutes per day	N	284	148	284	105.34971831	576.98943662	82.512992958	82.805774648
+"#.as_ref();
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
@@ -593,7 +597,8 @@ mod test {
         // missing data should not lead to parser error.
         let csv = r#"column_1,column_2,column_3
         1,2,3
-        1,,3"#;
+        1,,3
+"#;
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).finish().unwrap();
@@ -615,7 +620,8 @@ mod test {
     fn test_escape_comma() {
         let csv = r#"column_1,column_2,column_3
 -86.64408227,"Autauga, Alabama, US",11
--86.64408227,"Autauga, Alabama, US",12"#;
+-86.64408227,"Autauga, Alabama, US",12
+"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).finish().unwrap();
         assert_eq!(df.shape(), (2, 3));
@@ -629,7 +635,8 @@ mod test {
     fn test_escape_double_quotes() {
         let csv = r#"column_1,column_2,column_3
 -86.64408227,"with ""double quotes"" US",11
--86.64408227,"with ""double quotes followed"", by comma",12"#;
+-86.64408227,"with ""double quotes followed"", by comma",12
+"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).finish().unwrap();
         assert_eq!(df.shape(), (2, 3));
@@ -654,7 +661,8 @@ mod test {
         let csv = r#"hello,","," ",world,"!"
 hello,","," ",world,"!"
 hello,","," ",world,"!"
-hello,","," ",world,"!""#;
+hello,","," ",world,"!"
+"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
             .has_header(false)
@@ -686,7 +694,8 @@ a type specimen book. It has survived not only five centuries, but also the leap
 into electronic typesetting, remaining essentially unchanged. It was popularised
 in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
 and more recently with desktop publishing software like Aldus PageMaker including
-versions of Lorem Ipsum.",11"#;
+versions of Lorem Ipsum.",11
+"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).finish().unwrap();
 
@@ -711,7 +720,8 @@ versions of Lorem Ipsum."#,
         let csv = r#"id1,id2,id3,id4,id5,id6,v1,v2,v3
 id047,id023,id0000084849,90,96,35790,2,9,93.348148
 ,id022,id0000031441,50,44,71525,3,11,81.013682
-id090,id048,id0000067778,24,2,51862,4,9,"#;
+id090,id048,id0000067778,24,2,51862,4,9,
+"#;
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
@@ -728,7 +738,8 @@ id090,id048,id0000067778,24,2,51862,4,9,"#;
  "sepal.length","sepal.width","petal.length","petal.width","variety"
  5.1,3.5,1.4,.2,"Setosa
  texts after new line character"
- 4.9,3,1.4,.2,"Setosa""#;
+ 4.9,3,1.4,.2,"Setosa"
+ "#;
 
         let file = Cursor::new(s);
         let _df = CsvReader::new(file).has_header(true).finish().unwrap();
@@ -739,7 +750,8 @@ id090,id048,id0000067778,24,2,51862,4,9,"#;
         // CSV fields may be quoted
         let s = r#""foo","bar"
 "4.9","3"
-"1.4","2""#;
+"1.4","2"
+"#;
 
         let file = Cursor::new(s);
         let df = CsvReader::new(file).has_header(true).finish().unwrap();
@@ -782,7 +794,8 @@ id090,id048,id0000067778,24,2,51862,4,9,"#;
         let csv = r#"foo,bar,ham
 1,2,3
 1,2,3
-1,2"#;
+1,2
+"#;
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
@@ -803,7 +816,8 @@ id090,id048,id0000067778,24,2,51862,4,9,"#;
         let csv = r#"a,b,c,d,e
 AUDCAD,1616455919,0.91212,0.95556,1
 AUDCAD,1616455920,0.92212,0.95556,1
-AUDCAD,1616455921,0.96212,0.95666,1"#;
+AUDCAD,1616455921,0.96212,0.95666,1
+"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
             .has_header(true)
@@ -830,7 +844,8 @@ AUDCAD,1616455921,0.96212,0.95666,1"#;
 #beta : 0.1
 0 NA 0 0 57 0
 0 NA 0 0 57 0
-0 NA 5 5 513 0";
+0 NA 5 5 513 0
+";
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
@@ -847,7 +862,8 @@ AUDCAD,1616455921,0.96212,0.95666,1"#;
     fn test_projection_idx() -> Result<()> {
         let csv = r"#0 NA 0 0 57 0
 0 NA 0 0 57 0
-0 NA 5 5 513 0";
+0 NA 5 5 513 0
+";
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)
@@ -875,7 +891,8 @@ AUDCAD,1616455921,0.96212,0.95666,1"#;
         let csv = r"1,2,3,4,5
 1,2,3
 1,2,3,4,5
-1,3,5";
+1,3,5
+";
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).has_header(false).finish()?;
@@ -896,7 +913,8 @@ AUDCAD,1616455921,0.96212,0.95666,1"#;
         let csv = r"1,2,3,4,5
 # this is a comment
 1,2,3,4,5
-1,2,3,4,5";
+1,2,3,4,5
+";
 
         let file = Cursor::new(csv);
         let df = CsvReader::new(file)

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -12,6 +12,8 @@ pub mod ipc;
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
+#[cfg(feature = "csv-file")]
+pub mod mmap;
 #[cfg(feature = "parquet")]
 #[cfg_attr(docsrs, doc(cfg(feature = "feature")))]
 pub mod parquet;

--- a/polars/polars-io/src/mmap.rs
+++ b/polars/polars-io/src/mmap.rs
@@ -1,0 +1,39 @@
+use std::fs::File;
+use std::io::{Cursor, Read, Seek};
+
+/// Trait used to get a hold to file handler or to the underlying bytes
+/// without performing a Read.
+pub trait MmapBytesReader: Read + Seek + Send + Sync {
+    fn to_file(&self) -> Option<&File> {
+        None
+    }
+
+    fn to_bytes(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+impl MmapBytesReader for File {
+    fn to_file(&self) -> Option<&File> {
+        Some(self)
+    }
+}
+
+impl<T> MmapBytesReader for Cursor<T>
+where
+    T: AsRef<[u8]> + Send + Sync,
+{
+    fn to_bytes(&self) -> Option<&[u8]> {
+        Some(self.get_ref().as_ref())
+    }
+}
+
+impl<T: MmapBytesReader + ?Sized> MmapBytesReader for Box<T> {
+    fn to_file(&self) -> Option<&File> {
+        T::to_file(self)
+    }
+
+    fn to_bytes(&self) -> Option<&[u8]> {
+        T::to_bytes(self)
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -17,7 +17,7 @@ use crate::logical_plan::FETCH_ROWS;
 use itertools::Itertools;
 use polars_core::POOL;
 use rayon::prelude::*;
-use std::io::{Read, Seek};
+use std::io::Seek;
 use std::path::PathBuf;
 
 const POLARS_VERBOSE: &str = "POLARS_VERBOSE";

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::logical_plan::CsvParserOptions;
 use crate::utils::try_path_to_str;
+use polars_io::mmap::MmapBytesReader;
 use polars_io::prelude::*;
 use polars_io::{csv::CsvEncoding, ScanAggregation};
 use std::mem;
@@ -14,7 +15,7 @@ trait FinishScanOps {
     ) -> Result<DataFrame>;
 }
 
-impl<'a, R: 'static + Read + Seek + Sync + Send> FinishScanOps for CsvReader<'a, R> {
+impl<'a, R: 'static + Seek + Sync + Send + MmapBytesReader> FinishScanOps for CsvReader<'a, R> {
     fn finish_with_scan_ops(
         self,
         predicate: Option<Arc<dyn PhysicalExpr>>,

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -3,6 +3,8 @@ Module containing logic related to eager DataFrames
 """
 from io import BytesIO
 
+import io
+
 try:
     from .polars import (  # noqa: F401
         PyDataFrame,
@@ -158,7 +160,7 @@ class DataFrame:
 
     @staticmethod
     def read_csv(
-        file: Union[str, BinaryIO],
+        file: Union[str, BinaryIO, bytes],
         infer_schema_length: int = 100,
         batch_size: int = 64,
         has_headers: bool = True,
@@ -233,6 +235,10 @@ class DataFrame:
             path = file
         else:
             path = None
+            if isinstance(file, io.BytesIO):
+                file = file.getvalue()
+            if isinstance(file, io.StringIO):
+                file = file.getvalue().encode()
 
         dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
         if dtype is not None:

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -1,4 +1,5 @@
 // Credits to https://github.com/omerbenamram/pyo3-file
+use polars::io::mmap::MmapBytesReader;
 #[cfg(feature = "parquet")]
 use polars::io::parquet::SliceableCursor;
 use pyo3::exceptions::PyTypeError;
@@ -190,6 +191,7 @@ pub trait FileLike: Read + Write + Seek + Sync + Send {}
 
 impl FileLike for File {}
 impl FileLike for PyFileLikeObject {}
+impl MmapBytesReader for PyFileLikeObject {}
 
 pub enum EitherRustPythonFile {
     Py(PyFileLikeObject),
@@ -223,5 +225,44 @@ pub fn get_file_like(f: PyObject, truncate: bool) -> PyResult<Box<dyn FileLike>>
     match get_either_file(f, truncate)? {
         Py(f) => Ok(Box::new(f)),
         Rust(f) => Ok(Box::new(f)),
+    }
+}
+
+pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesReader + 'a>> {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    // string so read file
+    if let Ok(pstring) = py_f.downcast::<PyString>() {
+        let rstring = pstring.to_string();
+        let str_slice: &str = rstring.borrow();
+        let f = File::open(str_slice)?;
+        Ok(Box::new(f))
+    }
+    // bytes object
+    else if let Ok(bytes) = py_f.downcast::<PyBytes>() {
+        Ok(Box::new(Cursor::new(bytes.as_bytes())))
+    }
+    // a normal python file: with open(...) as f:.
+    else if py_f.getattr("read").is_ok() {
+        if let Ok(filename) = py_f.getattr("name") {
+            let filename = filename.downcast::<PyString>()?;
+            let f = File::open(filename.to_str()?)?;
+            Ok(Box::new(f))
+        }
+        // don't really know what we got here, just read.
+        else {
+            let f = PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)?;
+            Ok(Box::new(f))
+        }
+    // a bytesIO
+    } else if let Ok(bytes) = py_f.call_method0("getvalue") {
+        let bytes = bytes.downcast::<PyBytes>()?;
+        Ok(Box::new(Cursor::new(bytes.as_bytes())))
+    }
+    // don't really know what we got here, just read.
+    else {
+        let f = PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)?;
+        Ok(Box::new(f))
     }
 }


### PR DESCRIPTION
@ghuls @olivier-lacroix 

This will probably also improve performance of `ffspec` related code. All csv-parsing will use multiple threads and in memory buffers as `bytes` of `io.BytesIO` will have no redundant copy. 

Next up lazy csv parsing.