### PR TITLE
Fix typing errors for Python>=3.8

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -56,6 +56,9 @@ jobs:
   test-python:
     name: Build and test Python
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.6", "3.9" ]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest Rust nightly
@@ -67,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/py-polars/mypy.ini
+++ b/py-polars/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-disallow_untyped_defs = True
-files = polars

--- a/py-polars/polars/ffi.py
+++ b/py-polars/polars/ffi.py
@@ -35,5 +35,4 @@ def _as_float_ndarray(ptr: int, size: int) -> np.ndarray:
 
     Turn a float* to a numpy array.
     """
-
-    return np.core.multiarray.int_asbuffer(ptr, size * np.float32.itemsize)
+    return np.core.multiarray.int_asbuffer(ptr, size * np.float32.itemsize)  # type: ignore

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2172,7 +2172,7 @@ class GroupBy:
 
             if isinstance(column_to_agg[0], tuple):
                 column_to_agg = [  # type: ignore
-                    (column, [agg] if isinstance(agg, str) else agg)
+                    (column, [agg] if isinstance(agg, str) else agg)  # type: ignore
                     for (column, agg) in column_to_agg
                 ]
 

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2171,8 +2171,8 @@ class GroupBy:
             from .lazy import Expr
 
             if isinstance(column_to_agg[0], tuple):
-                column_to_agg = [
-                    (column, [agg] if isinstance(agg, str) else agg)  # type: ignore
+                column_to_agg = [  # type: ignore
+                    (column, [agg] if isinstance(agg, str) else agg)
                     for (column, agg) in column_to_agg
                 ]
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1448,7 +1448,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.pow(exponent))
 
-    def is_in(self, other: "Expr") -> "Expr":
+    def is_in(self, other: Union["Expr", List[Any]]) -> "Expr":
         """
         Check if elements of this Series are in the right Series, or List values of the right Series.
 
@@ -1461,7 +1461,7 @@ class Expr:
         -------
         Expr that evaluates to a Boolean Series.
         """
-        if type(other) is list:
+        if isinstance(other, list):
             other = lit(Series("", other))
         return wrap_expr(self._pyexpr.is_in(other._pyexpr))
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
     # (which the Rust libraries use to take advantage of Rust API changes).
     "pyarrow==4.0.*"
 ]
+
+[tool.mypy]
+ignore_missing_imports = true
+disallow_untyped_defs = true
+files = "polars"


### PR DESCRIPTION
Changes:
* Fixed typing errors found only in newer versions of Python (previously, only Python 3.6 was tested)
* Moved `mypy` settings from `mypy.ini` to `pyproject.toml`
* Expanded the CI `test-python` pipeline to run both Python versions 3.6 and 3.9.