### PR TITLE
Improve Series constructor behaviour

### DIFF
--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -12,6 +12,27 @@ def create_series() -> pl.Series:
     return pl.Series("a", [1, 2])
 
 
+def test_init_inputs():
+    # Good inputs
+    pl.Series("a", [1, 2])
+    pl.Series("a", values=[1, 2])
+    pl.Series(name="a", values=[1, 2])
+    pl.Series(values=[1, 2], name="a")
+
+    pl.Series([1, 2])
+    pl.Series(values=[1, 2])
+
+    # Bad inputs
+    with pytest.raises(ValueError):
+        pl.Series()
+    with pytest.raises(ValueError):
+        pl.Series("a")
+    with pytest.raises(ValueError):
+        pl.Series([1, 2, 3], [1, 2, 3])
+    with pytest.raises(ValueError):
+        pl.Series({"a": [1, 2, 3]})
+
+
 def test_to_frame():
     assert create_series().to_frame().shape == (2, 1)
 


### PR DESCRIPTION
Changes:
* Expand type hints for the `name` argument in order to handle `values` passed to it (see issue #960).
* Changed the `name` argument to an optional keyword argument with default value `""`
* Removed the second check for `isinstance(values, Series)`. It could never be reached.
* Added `ValueError` for when `name` or `values` end up as `None`.
* Added a test checking good and bad constructor inputs

These changes introduce some new behaviour / fix some bad old behaviour. Examples:

* `pl.Series(values=[1,2,3])` now gives the same result as `pl.Series([1,2,3])`. Old behaviour:
```
>>> pl.Series(values=[1,2,3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() missing 1 required positional argument: 'name'
```

* `pl.Series(name=[1,2,3], values=[1,2,3])` now results in a ValueError. Old behaviour:
```
>>> pl.Series(name=[1,2,3], values=[1,2,3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stijn/.cache/pypoetry/virtualenvs/dataframe-typing-3etD3Smm-py3.9/lib/python3.9/site-packages/polars/series.py", line 227, in __init__
    self._s = PySeries.new_opt_i64(name, values)
TypeError: argument 'name': 'list' object cannot be converted to 'PyString'
```

* `pl.Series('name')` now results in a ValueError. Old behaviour:
```
>>> pl.Series('a')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stijn/.cache/pypoetry/virtualenvs/dataframe-typing-3etD3Smm-py3.9/lib/python3.9/site-packages/polars/series.py", line 222, in __init__
    dtype = _find_first_non_none(values)
  File "/home/stijn/.cache/pypoetry/virtualenvs/dataframe-typing-3etD3Smm-py3.9/lib/python3.9/site-packages/polars/series.py", line 93, in _find_first_non_none
    v = a[0]
TypeError: 'NoneType' object is not subscriptable
```

That's most of it, I believe!
