### PR TITLE
Many Python type hint fixes

### DIFF
--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -15,7 +15,7 @@ class Tag:
         elements: tp.List[str],
         tag: str,
         attributes: Optional[Dict[str, str]] = None,
-    ) -> None:
+    ):
         self.tag = tag
         self.elements = elements
         self.attributes = attributes

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -130,10 +130,11 @@ class HTMLFormatter:
     def write(self, inner: str) -> None:
         self.elements.append(inner)
 
-    def render(self) -> None:
+    def render(self) -> tp.List[str]:
         with Tag(self.elements, "table", {"border": "1", "class": "dataframe"}):
             self.write_header()
             self.write_body()
+        return self.elements
 
 
 class NotebookFormatter(HTMLFormatter):
@@ -166,7 +167,7 @@ class NotebookFormatter(HTMLFormatter):
         template = dedent("\n".join((template_first, template_mid, template_last)))
         self.write(template)
 
-    def render(self) -> tp.List[str]:  # type: ignore
+    def render(self) -> tp.List[str]:
         """
         Return the lines needed to render a HTML table.
         """

--- a/py-polars/polars/ffi.py
+++ b/py-polars/polars/ffi.py
@@ -26,12 +26,3 @@ def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
     """
     ptr_ctype = ctypes.cast(ptr, ctypes.POINTER(ptr_type))
     return np.ctypeslib.as_array(ptr_ctype, (len,))
-
-
-def _as_float_ndarray(ptr: int, size: int) -> np.ndarray:
-    """
-    https://github.com/maciejkula/python-rustlearn
-
-    Turn a float* to a numpy array.
-    """
-    return np.core.multiarray.int_asbuffer(ptr, size * np.float32.itemsize)  # type: ignore

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2491,7 +2491,7 @@ class GBSelection:
 
     def apply(
         self,
-        func: Union[Callable[[Any], Any], Callable[[Any], Any]],
+        func: Callable[[Any], Any],
         return_dtype: Optional[Type[DataType]] = None,
     ) -> DataFrame:
         """

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2498,11 +2498,11 @@ class GBSelection:
         Apply a function over the groups.
         """
         df = self.agg_list()
-        if isinstance(self.selection, str):
-            selection = [self.selection]
-        else:
-            selection = self.selection
-        for name in selection:  # type: ignore
+        if self.selection is None:
+            raise TypeError(
+                "apply not available for Groupby.select_all(). Use select() instead."
+            )
+        for name in self.selection:
             s = df.drop_in_place(name + "_agg_list").apply(func, return_dtype)
             s.rename(name, in_place=True)
             df[name] = s

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -74,7 +74,7 @@ class DataFrame:
         self,
         data: Union[Dict[str, Sequence], tp.List[Series], np.ndarray],
         nullable: bool = True,
-    ) -> None:
+    ):
         """
         A DataFrame is a two dimensional data structure that represents data as a table with rows and columns.
         """
@@ -1366,8 +1366,8 @@ class DataFrame:
     def join(
         self,
         df: "DataFrame",
-        left_on: Optional[Union[str, tp.List[str], "Expr", tp.List["Expr"]]] = None,
-        right_on: Optional[Union[str, tp.List[str], "Expr", tp.List["Expr"]]] = None,
+        left_on: Optional[Union[str, "Expr", tp.List[str], tp.List["Expr"]]] = None,
+        right_on: Optional[Union[str, "Expr", tp.List[str], tp.List["Expr"]]] = None,
         on: Optional[Union[str, tp.List[str]]] = None,
         how: str = "inner",
     ) -> Union["DataFrame", "LazyFrame"]:
@@ -2033,7 +2033,7 @@ class GroupBy:
         downsample: bool = False,
         rule: Optional[str] = None,
         downsample_n: int = 0,
-    ) -> None:
+    ):
         self._df = df
         self.by = by
         self.downsample = downsample
@@ -2316,7 +2316,7 @@ class PivotOps:
         by: Union[str, tp.List[str]],
         pivot_column: str,
         values_column: str,
-    ) -> None:
+    ):
         self._df = df
         self.by = by
         self.pivot_column = pivot_column
@@ -2392,7 +2392,7 @@ class GBSelection:
         downsample: bool = False,
         rule: Optional[str] = None,
         downsample_n: int = 0,
-    ) -> None:
+    ):
         self._df = df
         self.by = by
         self.selection = selection

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2167,8 +2167,8 @@ class GroupBy:
         elif isinstance(column_to_agg, list):
 
             if isinstance(column_to_agg[0], tuple):
-                column_to_agg = [  # type: ignore
-                    (column, [agg] if isinstance(agg, str) else agg)  # type: ignore
+                column_to_agg = [  # type: ignore[misc]
+                    (column, [agg] if isinstance(agg, str) else agg)  # type: ignore[misc]
                     for (column, agg) in column_to_agg
                 ]
 
@@ -2177,7 +2177,7 @@ class GroupBy:
                     wrap_df(self._df)
                     .lazy()
                     .groupby(self.by)
-                    .agg(column_to_agg)  # type: ignore
+                    .agg(column_to_agg)  # type: ignore[arg-type]
                     .collect(no_optimization=True, string_cache=False)
                 )
 

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -723,8 +723,8 @@ class DataFrame:
         if isinstance(item, Sequence):
             if isinstance(item[0], str):
                 return wrap_df(self._df.select(item))
-            if hasattr(item[0], "_pyexpr"):
-                return self.select(item)  # type: ignore
+            elif isinstance(item[0], pl.Expr):
+                return self.select(item)
 
         # select rows by mask or index
         # df[[1, 2, 3]]
@@ -1742,7 +1742,7 @@ class DataFrame:
         return wrap_ldf(self._df.lazy())
 
     def select(
-        self, exprs: Union[str, "Expr", tp.List[str], tp.List["Expr"]]
+        self, exprs: Union[str, "Expr", Sequence[str], Sequence["Expr"]]
     ) -> "DataFrame":
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -248,7 +248,7 @@ class DataFrame:
             for k, v in dtype.items():
                 dtype_list.append((k, pytype_to_polars_type(v)))
 
-        null_values = _process_null_values(null_values)  # type: ignore
+        processed_null_values = _process_null_values(null_values)
 
         self._df = PyDataFrame.read_csv(
             file,
@@ -268,7 +268,7 @@ class DataFrame:
             dtype_list,
             low_memory,
             comment_char,
-            null_values,
+            processed_null_values,
         )
         return self
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -268,7 +268,7 @@ def read_csv(
                 [f"column_{int(column[1:]) + 1}" for column in tbl.column_names]
             )
 
-        return from_arrow(tbl, rechunk)  # type: ignore
+        return from_arrow(tbl, rechunk)  # type: ignore[return-value]
 
     with _prepare_file_arg(file, **storage_options) as data:
         df = DataFrame.read_csv(
@@ -456,7 +456,7 @@ def read_parquet(
             return DataFrame.read_parquet(
                 source_prep, stop_after_n_rows=stop_after_n_rows
             )
-        return from_arrow(  # type: ignore
+        return from_arrow(  # type: ignore[return-value]
             pa.parquet.read_table(
                 source_prep, memory_map=memory_map, columns=columns, **kwargs
             )
@@ -582,7 +582,7 @@ def concat(dfs: Sequence[DataFrame], rechunk: bool = True) -> DataFrame:
     df = dfs[0].clone()
     for i in range(1, len(dfs)):
         try:
-            df = df.vstack(dfs[i], in_place=False)  # type: ignore
+            df = df.vstack(dfs[i], in_place=False)  # type: ignore[assignment]
         # could have a double borrow (one mutable one ref)
         except RuntimeError:
             df.vstack(dfs[i].clone(), in_place=True)
@@ -682,7 +682,7 @@ def read_sql(sql: str, engine: Any) -> DataFrame:
         # conversion from pandas to arrow is very cheap compared to db driver
         import pandas as pd
 
-        return from_pandas(pd.read_sql(sql, engine))  # type: ignore
+        return from_pandas(pd.read_sql(sql, engine))  # type: ignore[return-value]
     except ImportError:
         from sqlalchemy import text
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -414,11 +414,11 @@ def read_ipc(
     """
     storage_options = storage_options or {}
     with _prepare_file_arg(file, **storage_options) as data:
-        return DataFrame.read_ipc(data, use_pyarrow)  # type: ignore
+        return DataFrame.read_ipc(data, use_pyarrow)
 
 
 def read_parquet(
-    source: Union[str, BinaryIO, Path, tp.List[str]],
+    source: Union[str, BinaryIO],
     stop_after_n_rows: Optional[int] = None,
     memory_map: bool = True,
     columns: Optional[tp.List[str]] = None,
@@ -453,7 +453,9 @@ def read_parquet(
     storage_options = storage_options or {}
     with _prepare_file_arg(source, **storage_options) as source_prep:
         if stop_after_n_rows is not None:
-            return DataFrame.read_parquet(source_prep, stop_after_n_rows=stop_after_n_rows)  # type: ignore
+            return DataFrame.read_parquet(
+                source_prep, stop_after_n_rows=stop_after_n_rows
+            )
         return from_arrow(  # type: ignore
             pa.parquet.read_table(
                 source_prep, memory_map=memory_map, columns=columns, **kwargs
@@ -533,7 +535,7 @@ def _from_pandas_helper(a: pd.Series) -> pa.Array:  # noqa: F821
 def from_pandas(
     df: Union[pd.DataFrame, pd.Series, pd.DatetimeIndex],
     rechunk: bool = True,  # noqa: F821
-) -> DataFrame:
+) -> Union[Series, DataFrame]:
     """
     Convert from a pandas DataFrame to a polars DataFrame.
 
@@ -549,7 +551,7 @@ def from_pandas(
     A Polars DataFrame
     """
     if isinstance(df, pd.Series) or isinstance(df, pd.DatetimeIndex):
-        return from_arrow(_from_pandas_helper(df))  # type: ignore
+        return from_arrow(_from_pandas_helper(df))
 
     # Note: we first tried to infer the schema via pyarrow and then modify the schema if needed.
     # However arrow 3.0 determines the type of a string like this:
@@ -562,10 +564,10 @@ def from_pandas(
         data[name] = _from_pandas_helper(s)
 
     table = pa.table(data)
-    return from_arrow(table, rechunk)  # type: ignore
+    return from_arrow(table, rechunk)
 
 
-def concat(dfs: tp.List[DataFrame], rechunk: bool = True) -> DataFrame:
+def concat(dfs: Sequence[DataFrame], rechunk: bool = True) -> DataFrame:
     """
     Aggregate all the Dataframes in a List of DataFrames to a single DataFrame.
 
@@ -613,9 +615,7 @@ def repeat(val: Union[int, float, str], n: int, name: Optional[str] = None) -> S
         return Series.from_arrow(name, pa.repeat(val, n))
 
 
-def read_json(
-    source: Union[str, StringIO, Path],
-) -> DataFrame:
+def read_json(source: Union[str, BytesIO]) -> DataFrame:
     """
     Read into a DataFrame from JSON format.
 
@@ -624,7 +624,7 @@ def read_json(
     source
         Path to a file or a file like object.
     """
-    return DataFrame.read_json(source)  # type: ignore
+    return DataFrame.read_json(source)
 
 
 def from_rows(
@@ -682,7 +682,7 @@ def read_sql(sql: str, engine: Any) -> DataFrame:
         # conversion from pandas to arrow is very cheap compared to db driver
         import pandas as pd
 
-        return from_pandas(pd.read_sql(sql, engine))
+        return from_pandas(pd.read_sql(sql, engine))  # type: ignore
     except ImportError:
         from sqlalchemy import text
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -145,7 +145,7 @@ class LazyFrame:
             dtype_list = []
             for k, v in dtype.items():
                 dtype_list.append((k, pytype_to_polars_type(v)))
-        null_values = _process_null_values(null_values)  # type: ignore
+        processed_null_values = _process_null_values(null_values)
 
         self = LazyFrame.__new__(LazyFrame)
         self._ldf = PyLazyFrame.new_from_csv(
@@ -159,7 +159,7 @@ class LazyFrame:
             dtype_list,
             low_memory,
             comment_char,
-            null_values,
+            processed_null_values,
         )
         return self
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1389,7 +1389,7 @@ class Expr:
 
     def apply(
         self,
-        f: Union["UDF", Callable[[Series], Series]],
+        f: Callable[[Series], Series],
         return_dtype: Optional[Type[DataType]] = None,
     ) -> "Expr":
         """
@@ -1437,7 +1437,7 @@ class Expr:
 
         # input x: Series of type list containing the group values
         def wrap_f(x: "Series") -> "Series":
-            return x.apply(f, return_dtype=return_dtype)  # type: ignore
+            return x.apply(f, return_dtype=return_dtype)
 
         return self.map(wrap_f)
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -462,9 +462,9 @@ class LazyFrame:
     def join(
         self,
         ldf: "LazyFrame",
-        left_on: Optional[Union["Expr", str, tp.List["Expr"], tp.List[str]]] = None,
-        right_on: Optional[Union["Expr", str, tp.List["Expr"], tp.List[str]]] = None,
-        on: Optional[Union["Expr", str, tp.List["Expr"], tp.List[str]]] = None,
+        left_on: Optional[Union[str, "Expr", tp.List[str], tp.List["Expr"]]] = None,
+        right_on: Optional[Union[str, "Expr", tp.List[str], tp.List["Expr"]]] = None,
+        on: Optional[Union[str, "Expr", tp.List[str], tp.List["Expr"]]] = None,
         how: str = "inner",
         allow_parallel: bool = True,
         force_parallel: bool = False,

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -505,26 +505,35 @@ class LazyFrame:
                 self._ldf.join(ldf._ldf, [], [], allow_parallel, force_parallel, how)
             )
 
-        if isinstance(left_on, str):
-            left_on = [left_on]
-        if isinstance(right_on, str):
-            right_on = [right_on]
+        left_on_: Union[tp.List[str], tp.List[Expr], None]
+        if isinstance(left_on, (str, Expr)):
+            left_on_ = [left_on]  # type: ignore[assignment]
+        else:
+            left_on_ = left_on
+
+        right_on_: Union[tp.List[str], tp.List[Expr], None]
+        if isinstance(right_on, (str, Expr)):
+            right_on_ = [right_on]  # type: ignore[assignment]
+        else:
+            right_on_ = right_on
+
         if isinstance(on, str):
-            left_on = [on]
-            right_on = [on]
+            left_on_ = [on]
+            right_on_ = [on]
         elif isinstance(on, list):
-            left_on = on
-            right_on = on
-        if left_on is None or right_on is None:
+            left_on_ = on
+            right_on_ = on
+
+        if left_on_ is None or right_on_ is None:
             raise ValueError("You should pass the column to join on as an argument.")
 
         new_left_on = []
-        for column in left_on:  # type: ignore
+        for column in left_on_:
             if isinstance(column, str):
                 column = col(column)
             new_left_on.append(column._pyexpr)
         new_right_on = []
-        for column in right_on:  # type: ignore
+        for column in right_on_:
             if isinstance(column, str):
                 column = col(column)
             new_right_on.append(column._pyexpr)

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -884,10 +884,10 @@ class Expr:
     def __le__(self, other: Any) -> "Expr":
         return self.lt_eq(self.__to_expr(other))
 
-    def __eq__(self, other: Any) -> "Expr":  # type: ignore
+    def __eq__(self, other: Any) -> "Expr":  # type: ignore[override]
         return self.eq(self.__to_expr(other))
 
-    def __ne__(self, other: Any) -> "Expr":  # type: ignore
+    def __ne__(self, other: Any) -> "Expr":  # type: ignore[override]
         return self.neq(self.__to_expr(other))
 
     def __lt__(self, other: Any) -> "Expr":

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1836,7 +1836,7 @@ class WhenThenThen:
     Utility class. See the `when` function.
     """
 
-    def __init__(self, pywhenthenthen: "PyWhenThenThen"):  # type: ignore # noqa F821
+    def __init__(self, pywhenthenthen: Any):
         self.pywenthenthen = pywhenthenthen
 
     def when(self, predicate: Expr) -> "WhenThenThen":
@@ -1869,7 +1869,7 @@ class WhenThen:
     Utility class. See the `when` function.
     """
 
-    def __init__(self, pywhenthen: "PyWhenThen"):  # type: ignore # noqa F821
+    def __init__(self, pywhenthen: Any):
         self._pywhenthen = pywhenthen
 
     def when(self, predicate: Expr) -> WhenThenThen:
@@ -1903,8 +1903,8 @@ class When:
         See Also: the `when` function.
         """
         expr = expr_to_lit_or_expr(expr)
-        whenthen = self._pywhen.then(expr._pyexpr)
-        return WhenThen(whenthen)
+        pywhenthen = self._pywhen.then(expr._pyexpr)
+        return WhenThen(pywhenthen)
 
 
 def when(expr: Expr) -> When:
@@ -2427,11 +2427,11 @@ def arange(
         return Series._from_pyseries(_series_from_range(low, high, step, dtype))
 
     if isinstance(low, int):
-        low = lit(low)  # type: ignore
+        low = lit(low)
     if isinstance(high, int):
-        high = lit(high)  # type: ignore
+        high = lit(high)
 
-    return map_binary(low, high, create_range, return_dtype=dtype)  # type: ignore
+    return map_binary(low, high, create_range, return_dtype=dtype)
 
 
 def argsort_by(

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1836,7 +1836,7 @@ class WhenThenThen:
     Utility class. See the `when` function.
     """
 
-    def __init__(self, pywhenthenthen: "PyWhenThenThen") -> None:  # type: ignore # noqa F821
+    def __init__(self, pywhenthenthen: "PyWhenThenThen"):  # type: ignore # noqa F821
         self.pywenthenthen = pywhenthenthen
 
     def when(self, predicate: Expr) -> "WhenThenThen":
@@ -2363,9 +2363,7 @@ class UDF:
     Deprecated: don't use me
     """
 
-    def __init__(
-        self, f: Callable[[Series], Series], return_dtype: Type[DataType]
-    ) -> None:
+    def __init__(self, f: Callable[[Series], Series], return_dtype: Type[DataType]):
         self.f = f
         self.return_dtype = return_dtype
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import typing as tp
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 
@@ -44,12 +44,12 @@ except ImportError:
 
 
 def _selection_to_pyexpr_list(
-    exprs: Union[str, tp.List[str], "Expr", tp.List["Expr"]]
+    exprs: Union[str, "Expr", Sequence[str], Sequence["Expr"]]
 ) -> tp.List[PyExpr]:
     pyexpr_list: tp.List[PyExpr]
-    if not isinstance(exprs, list):
-        if isinstance(exprs, str):
-            exprs = col(exprs)
+    if isinstance(exprs, str):
+        pyexpr_list = [col(exprs)._pyexpr]
+    elif isinstance(exprs, Expr):
         pyexpr_list = [exprs._pyexpr]
     else:
         pyexpr_list = []
@@ -421,7 +421,7 @@ class LazyFrame:
         return wrap_ldf(self._ldf.filter(predicate._pyexpr))
 
     def select(
-        self, exprs: Union[str, "Expr", tp.List[str], tp.List["Expr"]]
+        self, exprs: Union[str, "Expr", Sequence[str], Sequence["Expr"]]
     ) -> "LazyFrame":
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1692,7 +1692,7 @@ class DateTimeNameSpace:
     Series.dt namespace.
     """
 
-    def __init__(self, series: Series) -> None:
+    def __init__(self, series: Series):
         self._s = series._s
 
     def strftime(self, fmt: str) -> Series:
@@ -1926,7 +1926,7 @@ class SeriesIter:
     Utility class that allows slow iteration over a `Series`.
     """
 
-    def __init__(self, length: int, s: Series) -> None:
+    def __init__(self, length: int, s: Series):
         self.len = length
         self.i = 0
         self.s = s

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -68,7 +68,10 @@ class IdentityDict(dict):
 
 
 def get_ffi_func(
-    name: str, dtype: Type[DataType], obj: Optional["Series"] = None, default: Optional = None  # type: ignore
+    name: str,
+    dtype: Type[DataType],
+    obj: Optional["Series"] = None,
+    default: Optional[Callable[[Any], Any]] = None,
 ) -> Callable[..., Any]:
     """
     Dynamically obtain the proper ffi function/ method.
@@ -513,7 +516,7 @@ class Series:
             elif key.dtype == UInt64:
                 self._s = self.set_at_idx(key, value)._s
             elif key.dtype == UInt32:
-                self._s = self.set_at_idx(key.cast_u64(), value)._s  # type: ignore
+                self._s = self.set_at_idx(key.cast(UInt64), value)._s
         # TODO: implement for these types without casting to series
         elif isinstance(key, (np.ndarray, list, tuple)):
             s = wrap_s(PySeries.new_u64("", np.array(key, np.uint64)))

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -409,11 +409,10 @@ class Series:
         if self.dtype != primitive:
             return self.__floordiv__(other)
 
-        out_dtype: Type[DataType]
-        if not self.is_float():
-            out_dtype = Float64
-        else:
+        if self.is_float():
             out_dtype = self.dtype
+        else:
+            out_dtype = Float64
         return np.true_divide(self, other, dtype=out_dtype)  # type: ignore
 
     def __floordiv__(self, other: Any) -> "Series":
@@ -461,11 +460,10 @@ class Series:
         if self.dtype != primitive:
             self.__rfloordiv__(other)
 
-        out_dtype: Union[Type[Float64], str]
-        if not self.is_float():
-            out_dtype = Float64
+        if self.is_float():
+            out_dtype = self.dtype
         else:
-            out_dtype = DTYPE_TO_FFINAME[self.dtype]
+            out_dtype = Float64
         return np.true_divide(other, self, dtype=out_dtype)  # type: ignore
 
     def __rfloordiv__(self, other: Any) -> "Series":

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -324,7 +324,7 @@ class Series:
     def __or__(self, other: "Series") -> "Series":
         return wrap_s(self._s.bitor(other._s))
 
-    def __eq__(self, other: Any) -> "Series":  # type: ignore
+    def __eq__(self, other: Any) -> "Series":  # type: ignore[override]
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -334,7 +334,7 @@ class Series:
             return NotImplemented
         return wrap_s(f(other))
 
-    def __ne__(self, other: Any) -> "Series":  # type: ignore
+    def __ne__(self, other: Any) -> "Series":  # type: ignore[override]
         if isinstance(other, Sequence) and not isinstance(other, str):
             other = Series("", other, nullable=True)
         if isinstance(other, Series):
@@ -413,7 +413,7 @@ class Series:
             out_dtype = self.dtype
         else:
             out_dtype = Float64
-        return np.true_divide(self, other, dtype=out_dtype)  # type: ignore
+        return np.true_divide(self, other, dtype=out_dtype)  # type: ignore[call-overload]
 
     def __floordiv__(self, other: Any) -> "Series":
         if isinstance(other, Series):
@@ -464,7 +464,7 @@ class Series:
             out_dtype = self.dtype
         else:
             out_dtype = Float64
-        return np.true_divide(other, self, dtype=out_dtype)  # type: ignore
+        return np.true_divide(other, self, dtype=out_dtype)  # type: ignore[call-overload]
 
     def __rfloordiv__(self, other: Any) -> "Series":
         if isinstance(other, Series):

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -43,9 +43,7 @@ def coerce_arrow(array: pa.Array) -> pa.Array:
 def _process_null_values(
     null_values: Union[None, str, tp.List[str], Dict[str, str]] = None,
 ) -> Union[None, str, tp.List[str], tp.List[Tuple[str, str]]]:
-    processed_null_values: Union[None, str, tp.List[str], tp.List[Tuple[str, str]]]
     if isinstance(null_values, dict):
-        processed_null_values = list(null_values.items())
+        return list(null_values.items())
     else:
-        processed_null_values = null_values
-    return processed_null_values
+        return null_values

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,6 +1,6 @@
 import typing as tp
 import warnings
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Tuple, Union
 
 import pyarrow as pa
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -41,11 +41,11 @@ def coerce_arrow(array: pa.Array) -> pa.Array:
 
 
 def _process_null_values(
-    null_values: Optional[Union[str, tp.List[str], Dict[str, str]]] = None,
-) -> Optional[Union[str, tp.List[str], tp.List[Tuple[str, str]]]]:  # type: ignore
-    processed_null_values = null_values  # type: ignore
-    if null_values is not None and isinstance(null_values, dict):
-        processed_null_values = []
-        for k, v in null_values.items():
-            processed_null_values.append((k, v))  # type: ignore
-    return processed_null_values  # type: ignore
+    null_values: Union[None, str, tp.List[str], Dict[str, str]] = None,
+) -> Union[None, str, tp.List[str], tp.List[Tuple[str, str]]]:
+    processed_null_values: Union[None, str, tp.List[str], tp.List[Tuple[str, str]]]
+    if isinstance(null_values, dict):
+        processed_null_values = list(null_values.items())
+    else:
+        processed_null_values = null_values
+    return processed_null_values


### PR DESCRIPTION
Changes:
* Fixed many type hints that were previously ignored with `# type: ignore`
* Some of these ignores were masking bugs/unwanted behaviour. Fixes included in this PR:
    * `DataFrame`/`LazyFrame.join` now properly handles `Expr` arguments for `left_on`/`right_on`.
    * `Series.__setitem__` now uses `.cast(UInt64)` instead of the non-existant `.cast_u64()`
    * `GBSelection.apply` now catches an Error when `selection=None` (result of call from `select_all`)
* Some lines require `# type: ignore` due to limitations in `mypy`. For these lines, the error code has been included, e.g. `# type: ignore[override]`. This means that unintended type errors are still caught.
* Removed return type hint from `__init__` functions, as this is not required in the latest `mypy` versions (since it is always `None`).
* Unused private function `_as_float_ndarray` deleted from `utils.py`

To do in a future PR:
* Fix the last three nasty '# type: ignore` statements
* Properly type hint all the file IO functions; these appear to be incomplete at times