### PR TITLE
Last type fixes

### DIFF
--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -1988,7 +1988,7 @@ class DataFrame:
             function that takes two `Series` and returns a `Series`.
         """
         if self.width == 1:
-            return self  # type: ignore
+            return self.select_at_idx(0)
         df = self
         acc = operation(df.select_at_idx(0), df.select_at_idx(1))
 

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -2522,13 +2522,6 @@ class GBSelection:
         return df
 
 
-def _series_to_frame(self: Series) -> DataFrame:
-    return wrap_df(PyDataFrame([self._s]))
-
-
-Series.to_frame = _series_to_frame  # type: ignore
-
-
 class StringCache:
     """
     Context manager that allows data sources to share the same categorical features.

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -50,6 +50,13 @@ def _process_http_file(path: str) -> BytesIO:
 
 @overload
 def _prepare_file_arg(
+    file: Union[str, tp.List[str], Path, BinaryIO], **kwargs: Any
+) -> ContextManager[Union[str, BinaryIO]]:
+    ...
+
+
+@overload
+def _prepare_file_arg(
     file: Union[str, TextIO, Path, BinaryIO], **kwargs: Any
 ) -> ContextManager[Union[str, BinaryIO]]:
     ...
@@ -58,7 +65,7 @@ def _prepare_file_arg(
 @overload
 def _prepare_file_arg(
     file: Union[str, tp.List[str], TextIO, Path, BinaryIO], **kwargs: Any
-) -> ContextManager[Union[str, BinaryIO, tp.List[str], tp.List[BinaryIO]]]:
+) -> ContextManager[Union[str, tp.List[str], BinaryIO, tp.List[BinaryIO]]]:
     ...
 
 
@@ -418,7 +425,7 @@ def read_ipc(
 
 
 def read_parquet(
-    source: Union[str, BinaryIO],
+    source: Union[str, tp.List[str], Path, BinaryIO],
     stop_after_n_rows: Optional[int] = None,
     memory_map: bool = True,
     columns: Optional[tp.List[str]] = None,

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1835,7 +1835,7 @@ def expr_to_lit_or_expr(
     elif isinstance(expr, (int, float, str)):
         return lit(expr)
     elif isinstance(expr, list):
-        return [expr_to_lit_or_expr(e, str_to_lit=str_to_lit) for e in expr]  # type: ignore
+        return [expr_to_lit_or_expr(e, str_to_lit=str_to_lit) for e in expr]  # type: ignore[return-value]
     else:
         return expr
 

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -45,7 +45,7 @@ from .ffi import _ptr_to_numpy
 from .utils import coerce_arrow
 
 try:
-    from .polars import PySeries
+    from .polars import PyDataFrame, PySeries
 except ImportError:
     import warnings
 
@@ -534,8 +534,7 @@ class Series:
         """
         Cast this Series to a DataFrame.
         """
-        # implementation is in .frame due to circular imports
-        pass
+        return pl.wrap_df(PyDataFrame([self._s]))
 
     @property
     def dtype(self) -> Type[DataType]:


### PR DESCRIPTION
Changes:
* Calling `fold` on a `DataFrame` with a single column now returns a `Series` instead of a `DataFrame`.
* Moved `Series.to_frame` logic from `frame.py` to the `Series` class. This doesn't seem to give any problems with circular imports.
* Expand type hints for `read_parquet` function.