### PR TITLE
improve csv-parser performance

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 dependencies = [
  "libc",
  "mimalloc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.8.10"
+version = "0.8.11-beta.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -148,7 +148,7 @@ def read_csv(
     n_threads: Optional[int] = None,
     dtype: Optional[Dict[str, Type[DataType]]] = None,
     new_columns: Optional[tp.List[str]] = None,
-    use_pyarrow: bool = True,
+    use_pyarrow: bool = False,
     low_memory: bool = False,
     comment_char: Optional[str] = None,
     storage_options: Optional[Dict] = None,


### PR DESCRIPTION
This PR improves the performance of the csv-parser a lot. Its now faster than the csv-parser of pyarrow.

To readers, if you want maximum performance, activate `simdutf8` feature.

## Incremental improvements of avg of 10 csv reads without reallocation:
```
> master 
took 201 ms

## master + simdutf8
took 185 ms

## proper-alloc + simdutf8
took 160 ms

## improve splitlines
>> before
+   18,52%     0,00%  memcheck  memcheck            [.] <polars_io::csv_core::parser::SplitLines as core::iter::traits::iterator::Iterator>::next (inlined)

>> after
+   11,82%     0,00%  memcheck  memcheck            [.] <polars_io::csv_core::parser::SplitLines as core::iter::traits::iterator::Iterator>::next (inlined)   

took 150 ms

## improve splitfields
>> before
+    6,86%     0,00%  memcheck  memcheck            [.] <polars_io::csv_core::parser::SplitFields as core::iter::traits::iterator::Iterator>::next (inlined)                            ▒>> after
+    5,50%     0,00%  memcheck  memcheck            [.] <polars_io::csv_core::parser::SplitFields as core::iter::traits::iterator::Iterator>::next (inlined)

took 147 ms

## don't escape strings that do not start with `"`
took 137 ms
```


## CSV schema:

```
shape: (5429252, 5)
╭──────────┬───────────┬──────┬───────────┬──────────╮
│ anzsic06 ┆ Area      ┆ year ┆ geo_count ┆ ec_count │
│ ---      ┆ ---       ┆ ---  ┆ ---       ┆ ---      │
│ str      ┆ str       ┆ i64  ┆ i64       ┆ i64      │
╞══════════╪═══════════╪══════╪═══════════╪══════════╡
│ "A"      ┆ "A100100" ┆ 2000 ┆ 96        ┆ 130      │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "A"      ┆ "A100200" ┆ 2000 ┆ 198       ┆ 110      │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "A"      ┆ "A100300" ┆ 2000 ┆ 42        ┆ 25       │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "A"      ┆ "A100400" ┆ 2000 ┆ 66        ┆ 40       │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ ...      ┆ ...       ┆ ...  ┆ ...       ┆ ...      │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "Total"  ┆ "T073"    ┆ 2020 ┆ 6939      ┆ 16300    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "Total"  ┆ "T074"    ┆ 2020 ┆ 2037      ┆ 6500     │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "Total"  ┆ "T075"    ┆ 2020 ┆ 5286      ┆ 28200    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "Total"  ┆ "T076"    ┆ 2020 ┆ 206058    ┆ 807400   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
│ "Total"  ┆ "TTotal"  ┆ 2020 ┆ 593592    ┆ 2317000  │
╰──────────┴───────────┴──────┴───────────┴──────────╯

```

## pyarrow time
pyarrow hot start: `took 155 ms`
polars hot start: `took 127 ms`


@olivier-lacroix @ghuls  FYI.