### PR TITLE
Add MIRI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: nightly-2021-07-04
           override: true
-          components: rustfmt, clippy
+          components: rustfmt, clippy, miri
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
@@ -35,6 +35,13 @@ jobs:
       - name: Run formatting checks
         run: |
           cargo fmt --all -- --check
+      - name: Run miri
+        run: |
+          cd polars
+          cargo miri setup
+          cargo clean
+          make miri
+          cd ..
       - name: Run linting checks
         run : |
           # do not produce debug symbols to keep memory usage down

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -27,5 +27,16 @@ test:
     -p polars-arrow -- \
     --test-threads=2
 
+miri:
+	# not tested on all features because miri does not support SIMD
+	# some tests are also filtered, because miri cannot deal with the rayon threadpool
+	# Miri also reports UB in prettytable.rs, so we must toggle that feature off.
+	MIRIFLAGS="-Zmiri-disable-isolation" \
+	cargo miri test \
+	--no-default-features \
+    -p polars-core \
+    -p polars-arrow --
+
+
 test-doc:
 	cargo test -p polars-lazy -p polars-io -p polars-core -p polars-arrow --doc

--- a/polars/polars-arrow/src/vec.rs
+++ b/polars/polars-arrow/src/vec.rs
@@ -25,7 +25,7 @@ impl<T: ArrowNativeType> Drop for AlignedVec<T> {
             let ptr: *mut T = me.as_mut_ptr();
             let ptr = ptr as *mut u8;
             let ptr = std::ptr::NonNull::new(ptr).unwrap();
-            unsafe { alloc::free_aligned::<u8>(ptr, self.capacity()) }
+            unsafe { alloc::free_aligned::<u8>(ptr, me.capacity() * mem::size_of::<T>()) }
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -497,6 +497,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "sort_multiple")]
+    #[cfg_attr(miri, ignore)]
     fn test_argsort_multiple() -> Result<()> {
         let a = Int32Chunked::new_from_slice("a", &[1, 2, 1, 1, 3, 4, 3, 3]);
         let b = Int64Chunked::new_from_slice("b", &[0, 1, 2, 3, 4, 5, 6, 1]);

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -16,7 +16,7 @@ impl DataFrame {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```ignore
     ///  use polars_core::prelude::*;
     ///  let s0 = Series::new("a", &[1i64, 2, 3]);
     ///  let s1 = Series::new("b", &[1i64, 1, 1]);
@@ -125,7 +125,7 @@ impl DataFrame {
     /// * `id_vars` - String slice that represent the columns to use as id variables.
     /// * `value_vars` - String slice that represent the columns to use as value variables.
     ///
-    /// ```rust
+    /// ```ignore
     ///
     ///  # #[macro_use] extern crate polars_core;
     /// use polars_core::prelude::*;
@@ -210,6 +210,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "dtype-i8")]
+    #[cfg_attr(miri, ignore)]
     fn test_explode() {
         let s0 = Series::new("a", &[1i8, 2, 3]);
         let s1 = Series::new("b", &[1i8, 1, 1]);
@@ -244,6 +245,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_melt() {
         let df = df!("A" => &["a", "b", "a"],
          "B" => &[1, 3, 5],

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -414,7 +414,7 @@ impl DataFrame {
 ///
 /// Until described otherwise, the examples in this struct are performed on the following DataFrame:
 ///
-/// ```rust
+/// ```ignore
 /// use polars_core::prelude::*;
 ///
 /// let dates = &[
@@ -1198,6 +1198,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "dtype-date32")]
+    #[cfg_attr(miri, ignore)]
     fn test_group_by() {
         let s0 = Date32Chunked::parse_from_str_slice(
             "date",
@@ -1302,6 +1303,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_static_groupby_by_12_columns() {
         // Build GroupBy DataFrame.
         let s0 = Series::new("G1", ["A", "A", "B", "B", "C"].as_ref());
@@ -1340,6 +1342,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_dynamic_groupby_by_13_columns() {
         // The content for every groupby series.
         let series_content = ["A", "A", "B", "B", "C"];
@@ -1392,6 +1395,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_floats() {
         let df = df! {"flt" => [1., 1., 2., 2., 3.],
                     "val" => [1, 1, 1, 1, 1]
@@ -1406,6 +1410,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_categorical() {
         let mut df = df! {"foo" => ["a", "a", "b", "b", "c"],
                     "ham" => ["a", "a", "b", "b", "c"],
@@ -1431,6 +1436,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_apply() {
         let df = df! {
             "a" => [1, 1, 2, 2, 2],
@@ -1443,6 +1449,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_threaded() {
         for slice in &[
             vec![1, 2, 3, 4, 4, 4, 2, 1],
@@ -1465,6 +1472,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_null_handling() -> Result<()> {
         let df = df!(
             "a" => ["a", "a", "a", "b", "b"],
@@ -1480,6 +1488,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_var() -> Result<()> {
         // check variance and proper coercion to f64
         let df = df![
@@ -1506,6 +1515,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_groupby_null_group() -> Result<()> {
         // check if null is own group
         let mut df = df![

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1279,6 +1279,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_inner_join() {
         let (temp, rain) = create_frames();
 
@@ -1305,6 +1306,7 @@ mod test {
 
     #[test]
     #[allow(clippy::float_cmp)]
+    #[cfg_attr(miri, ignore)]
     fn test_left_join() {
         for i in 1..8 {
             std::env::set_var("POLARS_MAX_THREADS", format!("{}", i));
@@ -1342,6 +1344,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_outer_join() -> Result<()> {
         let (temp, rain) = create_frames();
         let joined = temp.outer_join(&rain, "days", "days")?;
@@ -1367,6 +1370,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_join_with_nulls() {
         let dts = &[20, 21, 22, 23, 24, 25, 27, 28];
         let vals = &[1.2, 2.4, 4.67, 5.8, 4.4, 3.6, 7.6, 6.5];
@@ -1409,6 +1413,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_join_multiple_columns() {
         let (df_a, df_b) = get_dfs();
 
@@ -1481,6 +1486,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_join_categorical() {
         let _lock = crate::SINGLE_LOCK.lock();
         toggle_string_cache(true);
@@ -1522,6 +1528,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn empty_df_join() {
         let empty: Vec<String> = vec![];
         let left = DataFrame::new(vec![

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1503,7 +1503,7 @@ impl DataFrame {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```ignore
     ///
     /// # #[macro_use] extern crate polars_core;
     /// # fn main() {
@@ -1773,6 +1773,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_recordbatch_iterator() {
         let df = df!(
             "foo" => &[1, 2, 3, 4, 5]
@@ -1784,6 +1785,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_frame_from_recordbatch() {
         let record_batches: Vec<RecordBatch> = create_record_batches();
 
@@ -1796,12 +1798,14 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_select() {
         let df = create_frame();
         assert_eq!(df.column("days").unwrap().eq(1).sum(), Some(1));
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_filter() {
         let df = create_frame();
         println!("{}", df.column("days").unwrap());
@@ -1810,6 +1814,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_filter_broadcast_on_utf8_col() {
         let col_name = "some_col";
         let v = vec!["test".to_string()];
@@ -1824,6 +1829,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_filter_broadcast_on_list_col() {
         let s1 = Series::new("", &[true, false, true]);
         let ll: ListChunked = [&s1].iter().copied().collect();
@@ -1836,6 +1842,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_sort() {
         let mut df = create_frame();
         df.sort_in_place("temp", false).unwrap();
@@ -1852,6 +1859,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "dtype-u8")]
+    #[cfg_attr(miri, ignore)]
     fn get_dummies() {
         let df = df! {
             "id" => &[1, 2, 3, 1, 2, 3, 1, 1],
@@ -1890,6 +1898,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn drop_duplicates() {
         let df = df! {
             "flt" => [1., 1., 2., 2., 3., 3.],

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -778,6 +778,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "dtype-date64")]
+    #[cfg_attr(miri, ignore)]
     fn test_datelike_join() -> Result<()> {
         let s = Series::new("foo", &[1, 2, 3]);
         let mut s1 = s.cast_with_dtype(&DataType::Date64)?;


### PR DESCRIPTION
This PR adds a long overdue MIRI check in CI. And immediately showed that we had a UB in AlignedVec, which is now fixed.

The tests that use rayon thread pool are not running as MIRI still fails if threads are not joined before the main thread finishes, which a thread pool doesn't.