### PR TITLE
python: expose hash expr and row hash

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -76,6 +76,7 @@ asof_join = ["polars-core/asof_join"]
 cross_join = ["polars-core/cross_join", "polars-lazy/cross_join"]
 dot_product = ["polars-core/dot_product", "polars-lazy/dot_product"]
 concat_str = ["polars-core/concat_str", "polars-lazy/concat_str"]
+row_hash = ["polars-core/row_hash"]
 
 # don't use this
 private = []

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -58,6 +58,7 @@ asof_join = []
 cross_join = []
 dot_product = []
 concat_str = []
+row_hash = []
 
 
 # opt-in datatypes for Series
@@ -94,7 +95,8 @@ docs-selection = [
     "asof_join",
     "cross_join",
     "dot_product",
-    "concat_str"
+    "concat_str",
+    "row_hash"
 ]
 
 [dependencies]

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1501,6 +1501,12 @@ impl Series {
     pub fn dot(&self, other: &Series) -> Option<f64> {
         (self * other).sum::<f64>()
     }
+
+    #[cfg(feature = "row_hash")]
+    /// Get a hash of this Series
+    pub fn hash(&self, build_hasher: ahash::RandomState) -> UInt64Chunked {
+        UInt64Chunked::new_from_aligned_vec(self.name(), self.0.vec_hash(build_hasher))
+    }
 }
 
 impl Deref for Series {

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -127,6 +127,7 @@
 //! * `DataFrame` pretty printing (Choose one or none, but not both):
 //!     - `plain_fmt` - no overflowing (less compilation times)
 //!     - `pretty_fmt` - cell overflow (increased compilation times)
+//!     - `row_hash` - Utility to hash DataFrame rows to UInt64Chunked
 //!
 //! ## Compile times and opt-in data types
 //! As mentioned above, Polars `Series` are wrappers around

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
 name = "py-polars"
 version = "0.8.11"
 dependencies = [
+ "ahash",
  "libc",
  "mimalloc",
  "ndarray",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -23,6 +23,7 @@ numpy = "0.13.0"
 ndarray = "0.14"
 mimalloc = { version = "*", default-features = false}
 serde_json = { version = "1", optional = true }
+ahash = "0.7"
 
 # features are only there to enable building a slim binary for the benchmark in CI
 [features]
@@ -56,7 +57,8 @@ features = [
     "asof_join",
     "cross_join",
     "dot_product",
-    "concat_str"
+    "concat_str",
+    "row_hash"
 ]
 
 #[patch.crates-io]

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -2035,6 +2035,14 @@ class DataFrame:
             df._df.shrink_to_fit()
             return df
 
+    def hash_rows(self) -> "pl.Series":
+        """
+        Hash and combine the rows in this DataFrame.
+
+        Hash value is UInt64
+        """
+        return pl.wrap_s(self._df.hash_rows())
+
 
 class GroupBy:
     """

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1554,6 +1554,25 @@ class Series:
         """
         return StringNameSpace(self)
 
+    def hash(self, k0: int = 0, k1: int = 1, k2: int = 2, k3: int = 3) -> "pl.Series":
+        """
+        Hash the Series.
+
+        The hash value is of type `Date64`
+
+        Parameters
+        ----------
+        k0
+            seed parameter
+        k1
+            seed parameter
+        k2
+            seed parameter
+        k3
+            seed parameter
+        """
+        return wrap_s(self._s.hash(k0, k1, k2, k3))
+
 
 class StringNameSpace:
     """

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -761,6 +761,25 @@ class Expr:
         """
         return ExprStringNameSpace(self)
 
+    def hash(self, k0: int = 0, k1: int = 1, k2: int = 2, k3: int = 3) -> "pl.Expr":
+        """
+        Hash the Series.
+
+        The hash value is of type `Date64`
+
+        Parameters
+        ----------
+        k0
+            seed parameter
+        k1
+            seed parameter
+        k2
+            seed parameter
+        k3
+            seed parameter
+        """
+        return wrap_expr(self._pyexpr.hash(k0, k1, k2, k3))
+
 
 class ExprStringNameSpace:
     """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -885,6 +885,11 @@ impl PyDataFrame {
     pub fn shrink_to_fit(&mut self) {
         self.df.shrink_to_fit();
     }
+
+    pub fn hash_rows(&self) -> PyResult<PySeries> {
+        let hash = self.df.hash_rows().map_err(PyPolarsEr::from)?;
+        Ok(hash.into_series().into())
+    }
 }
 
 fn finish_groupby(gb: GroupBy, agg: &str) -> PyResult<PyDataFrame> {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -438,6 +438,16 @@ impl PyExpr {
     pub fn dot(&self, other: PyExpr) -> PyExpr {
         self.inner.clone().dot(other.inner).into()
     }
+    pub fn hash(&self, k0: u64, k1: u64, k2: u64, k3: u64) -> PyExpr {
+        let function = move |s: Series| {
+            let hb = ahash::RandomState::with_seeds(k0, k1, k2, k3);
+            Ok(s.hash(hb).into_series())
+        };
+        self.clone()
+            .inner
+            .map(function, Some(DataType::UInt64))
+            .into()
+    }
 }
 
 impl From<dsl::Expr> for PyExpr {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1116,6 +1116,11 @@ impl PySeries {
     pub fn dot(&self, other: &PySeries) -> Option<f64> {
         self.series.dot(&other.series)
     }
+
+    pub fn hash(&self, k0: u64, k1: u64, k2: u64, k3: u64) -> Self {
+        let hb = ahash::RandomState::with_seeds(k0, k1, k2, k3);
+        self.series.hash(hb).into_series().into()
+    }
 }
 
 macro_rules! impl_ufuncs {

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -778,3 +778,10 @@ def dot_product():
 
     assert df["a"].dot(df["b"]) == 20
     assert df[[col("a").dot("b")]][0, "a"] == 20
+
+
+def test_hash_rows():
+    df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
+    assert df.hash_rows().dtype == pl.UInt64
+    assert df["a"].hash().dtype == pl.UInt64
+    assert df[[col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64


### PR DESCRIPTION
Following discussion #983. This PR exposes fast ways to hash the rows of a DataFrame using expressions or `DataFrame.hash_rows` on eager. The latter is multi-threaded.

```python
  df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
  assert df.hash_rows().dtype == pl.UInt64
  assert df["a"].hash().dtype == pl.UInt64
  assert df[[col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64
```

@potter420 Then you only need a way to map `Uint64` to `Int64`.