### PR TITLE
python: allow empty series creation

### DIFF
--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -144,8 +144,11 @@ class Series:
             raise ValueError(
                 f"Constructing a Series with a dict is not supported for {values}"
             )
+        elif values is None and dtype is None:
+            dtype = Float32
+            values = []
         elif values is None:
-            raise ValueError("Series values cannot be None.")
+            values = []
 
         # castable to numpy
         if not isinstance(values, np.ndarray) and not nullable:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -21,12 +21,10 @@ def test_init_inputs():
 
     pl.Series([1, 2])
     pl.Series(values=[1, 2])
+    pl.Series()
+    pl.Series("a")
 
     # Bad inputs
-    with pytest.raises(ValueError):
-        pl.Series()
-    with pytest.raises(ValueError):
-        pl.Series("a")
     with pytest.raises(ValueError):
         pl.Series([1, 2, 3], [1, 2, 3])
     with pytest.raises(ValueError):
@@ -316,6 +314,13 @@ def test_iter():
     assert iter.__next__() == 2
     assert iter.__next__() == 3
     assert sum(s) == 6
+
+
+def test_empty():
+    a = pl.Series(dtype=pl.Int8)
+    assert a.dtype == pl.Int8
+    a = pl.Series()
+    assert a.dtype == pl.Float32
 
 
 def test_describe():


### PR DESCRIPTION
@stinodego FYI.

This is allows the creation of an empty Series by just not passing any argument or only `name` and/or `dtype` to the Series constructor. The default `dtype` is chose to be a `Float32`. This is rather arbitrary chosen and may be something else if I am convinced.