### PR TITLE
Add Extract json path single function

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -78,6 +78,7 @@ dot_product = ["polars-core/dot_product", "polars-lazy/dot_product"]
 concat_str = ["polars-core/concat_str", "polars-lazy/concat_str"]
 row_hash = ["polars-core/row_hash"]
 reinterpret = ["polars-core/reinterpret", "polars-core/dtype-u64"]
+extract_jsonpath = ["polars-core/extract_jsonpath", "polars-core/strings"]
 
 # don't use this
 private = []

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -60,6 +60,7 @@ dot_product = []
 concat_str = []
 row_hash = []
 reinterpret = []
+extract_jsonpath = ["serde_json", "jsonpath_lib"]
 
 
 # opt-in datatypes for Series
@@ -119,6 +120,7 @@ rand_distr = {version = "0.3", optional = true}
 ndarray = {version = "0.13", optional = true, default_features = false}
 regex = {version = "1.4", optional = true}
 serde_json = {version = "1.0", optional = true }
+jsonpath_lib = {version = "0.3.0", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = {version = "1", features=["derive"], optional = true }
 anyhow = "1.0"

--- a/polars/polars-core/src/chunked_array/strings.rs
+++ b/polars/polars-core/src/chunked_array/strings.rs
@@ -2,6 +2,36 @@ use crate::chunked_array::kernels::strings::string_lengths;
 use crate::prelude::*;
 use arrow::compute::kernels::substring::substring;
 use regex::Regex;
+#[cfg(feature = "extract_jsonpath")]
+use {
+    jsonpath_lib::Compiled,
+    serde_json::{from_str, Value},
+    std::borrow::Cow,
+    std::string::String,
+};
+
+#[cfg(feature = "extract_jsonpath")]
+fn extract_json<'a>(expr: &'a Compiled, json_str: Option<&'a str>) -> Option<Cow<'a, str>> {
+    if let Some(value) = json_str {
+        let json: Value = from_str(value).unwrap();
+        let result = expr.select(&json).unwrap();
+        if result.is_empty() {
+            None
+        } else if result[0].is_string() {
+            Some(Cow::Owned(String::from(result[0].as_str().unwrap())))
+        } else if result[0].is_i64() {
+            Some(Cow::Owned(result[0].as_i64().unwrap().to_string()))
+        } else if result[0].is_f64() {
+            Some(Cow::Owned(result[0].as_f64().unwrap().to_string()))
+        } else if result[0].is_boolean() {
+            Some(Cow::Owned(result[0].as_bool().unwrap().to_string()))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
 
 impl Utf8Chunked {
     /// Get the length of the string values.
@@ -20,6 +50,13 @@ impl Utf8Chunked {
         };
         ca.rename(self.name());
         Ok(ca)
+    }
+    /// Extract json path, first match
+    /// Refer to https://goessner.net/articles/JsonPath/
+    #[cfg(feature = "extract_jsonpath")]
+    pub fn extract_json_path_single(&self, json_path: &str) -> Result<Utf8Chunked> {
+        let pat = Compiled::compile(json_path).unwrap();
+        Ok(self.apply_on_opt(|str_val| extract_json(&pat, str_val)))
     }
 
     /// Replace the leftmost (sub)string by a regex pattern

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -565,6 +565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1022,7 @@ dependencies = [
  "comfy-table",
  "hashbrown 0.11.2",
  "itertools",
+ "jsonpath_lib",
  "lazy_static",
  "num",
  "num_cpus",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -59,7 +59,8 @@ features = [
     "dot_product",
     "concat_str",
     "row_hash",
-    "reinterpret"
+    "reinterpret",
+    "extract_jsonpath"
 ]
 
 #[patch.crates-io]

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1645,6 +1645,37 @@ class StringNameSpace:
         """
         return wrap_s(self._s.str_contains(pattern))
 
+    def json_path_extract_single(self, json_path: str) -> Series:
+        """
+        Extract the first match of json string with provided JSONPath expression.
+        Throw errors if encounter invalid json strings.
+        All return value will be casted to Utf8 regardless of the original value.
+        Documentation on JSONPath standard: https://goessner.net/articles/JsonPath/
+
+        Parameters
+        ----------
+        json_path
+            A valid JSON path query string
+
+        Returns
+        -------
+        Utf8 array. Contain null if original value is null or the json_path return nothing.
+
+        Examples
+        --------
+        >>> pl.Series(['{"a":"1"}',None,'{"a":2}', '{"a":2.1}', '{"a":true}']).str.json_path_extract_single('$.a')
+        shape: (5,)
+        Series: '' [str]
+        [
+            "1"
+            null
+            "2"
+            "2.1"
+            "true"
+        ]
+        """
+        return wrap_s(self._s.str_json_path_extract_single(json_path))
+
     def replace(self, pattern: str, value: str) -> Series:
         """
         Replace first regex match with a string value.

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -864,6 +864,40 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_contains(pattern))
 
+    def json_path_extract_single(self, json_path: str) -> Expr:
+        """
+        Extract the first match of json string with provided JSONPath expression.
+        Throw errors if encounter invalid json strings.
+        All return value will be casted to Utf8 regardless of the original value.
+        Documentation on JSONPath standard: https://goessner.net/articles/JsonPath/
+
+        Parameters
+        ----------
+        json_path
+            A valid JSON path query string
+
+        Returns
+        -------
+        Utf8 array. Contain null if original value is null or the json_path return nothing.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({
+        >>>    'json_val' = ['{"a":"1"}',None,'{"a":2}', '{"a":2.1}', '{"a":true}']
+        >>> })
+        >>> df.select(pl.col('json_val').str.json_path_extract_single('$.a')
+        shape: (5,)
+        Series: '' [str]
+        [
+            "1"
+            null
+            "2"
+            "2.1"
+            "true"
+        ]
+        """
+        return wrap_expr(self._pyexpr.str_json_path_extract_single(json_path))
+
     def replace(self, pattern: str, value: str) -> Expr:
         """
         Replace first regex match with a string value.

--- a/py-polars/rust-toolchain
+++ b/py-polars/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-07-06
+nightly

--- a/py-polars/rust-toolchain
+++ b/py-polars/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-07-06

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -367,6 +367,20 @@ impl PyExpr {
             .into()
     }
 
+    pub fn str_json_path_extract_single(&self, pat: String) -> PyExpr {
+        let function = move |s: Series| {
+            let ca = s.utf8()?;
+            match ca.extract_json_path_single(&pat) {
+                Ok(ca) => Ok(ca.into_series()),
+                Err(e) => Err(PolarsError::Other(format!("{:?}", e).into())),
+            }
+        };
+        self.clone()
+            .inner
+            .map(function, Some(DataType::Boolean))
+            .into()
+    }
+
     pub fn strftime(&self, fmt: String) -> PyExpr {
         let function = move |s: Series| s.strftime(&fmt);
         self.clone()

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -850,6 +850,12 @@ impl PySeries {
         Ok(s.into())
     }
 
+    pub fn str_json_path_extract_single(&self, pat: &str) -> PyResult<Self> {
+        let ca = self.series.utf8().map_err(PyPolarsEr::from)?;
+        let s = ca.extract_json_path_single(pat).map_err(PyPolarsEr::from)?.into_series();
+        Ok(s.into())
+    }
+
     pub fn str_replace(&self, pat: &str, val: &str) -> PyResult<Self> {
         let ca = self.series.utf8().map_err(PyPolarsEr::from)?;
         let s = ca

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -451,3 +451,14 @@ def test_reinterpret():
     assert s.reinterpret(signed=True).dtype == pl.Int64
     df = pl.DataFrame([s])
     assert df[[pl.col("a").reinterpret(signed=True)]]["a"].dtype == pl.Int64
+
+
+def test_jsonpath_single():
+    s = pl.Series(['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}'])
+    assert s.str.json_path_extract_single("$.a").to_list() == [
+        "1",
+        None,
+        "2",
+        "2.1",
+        "true",
+    ]


### PR DESCRIPTION
@ritchie46 
Added feature flag `extract_jsonpath` for `extract_json_path_single` function in strings module.
Python function will be in string name space.
I'm using this library here https://github.com/freestrings/jsonpath for jsonPath extraction.

Also added docstrings for Python on how this function behave and some example.

I still not decided yet to extract all results of jsonPath into a list or a frame. Perhap laters