### PR TITLE
Fix Series constructor when values are empty sequence

### DIFF
--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -144,11 +144,12 @@ class Series:
             raise ValueError(
                 f"Constructing a Series with a dict is not supported for {values}"
             )
-        elif values is None and dtype is None:
+
+        # Handle empty values in constructor
+        if values is None:
+            values = []
+        if dtype is None and isinstance(values, Sequence) and len(values) == 0:
             dtype = Float32
-            values = []
-        elif values is None:
-            values = []
 
         # castable to numpy
         if not isinstance(values, np.ndarray) and not nullable:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -321,6 +321,10 @@ def test_empty():
     assert a.dtype == pl.Int8
     a = pl.Series()
     assert a.dtype == pl.Float32
+    a = pl.Series("name", [])
+    assert a.dtype == pl.Float32
+    a = pl.Series(values=(), dtype=pl.Int8)
+    assert a.dtype == pl.Int8
 
 
 def test_describe():


### PR DESCRIPTION
In response to #998 and #999 :

The merged fix works when values is `None`, but not when it is initialized with an actual empty sequence. I fixed this and expanded the tests.