### PR TITLE
Dataframe constructor improvements

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -3,6 +3,7 @@ Module containing logic related to eager DataFrames
 """
 import os
 import typing as tp
+import warnings
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
@@ -34,8 +35,6 @@ from ..utils import _process_null_values, coerce_arrow
 try:
     from ..polars import PyDataFrame, PySeries
 except ImportError:
-    import warnings
-
     warnings.warn("binary files missing")
 
 try:

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -84,8 +84,8 @@ class DataFrame:
             ]
         ] = None,
         columns: Optional[Sequence[str]] = None,
-        nullable: bool = True,
         orientation: Optional[Literal["column", "row"]] = None,
+        nullable: bool = True,
     ):
         # Handle positional arguments for old constructor
         if isinstance(columns, bool):

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -98,6 +98,7 @@ class DataFrame:
             nullable = columns
             columns = None
 
+        # Parse data into a list of Series
         data_series: tp.List["pl.Series"]
 
         if data is None:
@@ -174,7 +175,7 @@ class DataFrame:
         self._df = PyDataFrame(data_series)
 
         if columns is not None:
-            self.columns = list(columns)  # TODO: ValueError needed?
+            self.columns = list(columns)
 
     @staticmethod
     def _from_pydf(df: "PyDataFrame") -> "DataFrame":

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -67,7 +67,107 @@ def _prepare_other_arg(other: Any) -> "pl.Series":
 
 class DataFrame:
     """
-    A DataFrame is a two dimensional data structure that represents data as a table with rows and columns.
+    A DataFrame is a two-dimensional data structure that represents data as a table
+    with rows and columns.
+
+    Parameters
+    ----------
+    data : dict, Sequence, ndarray, Series, or pandas.DataFrame
+        Two-dimensional data in various forms. dict may contain Series or Sequences.
+        Sequence may contain Series or other Sequences.
+    columns : Sequence of str, default None
+        Column labels to use for resulting DataFrame. If specified, overrides any
+        labels already present in the data. Must match data dimensions.
+    orientation : {'column', 'row'}, default None
+        Whether to interpret two-dimensional data as columns or as rows. If None,
+        the orientation is infered by matching the columns and data dimensions. If this
+        does not yield conclusive results, 'column' orientation is used.
+    nullable : bool, default True
+        If your data does not contain null values, set to False to speed up
+        DataFrame creation.
+
+    Examples
+    --------
+    Constructing a DataFrame from a dictionary:
+
+    ```python
+    >>> data = {'a': [1, 2], 'b': [3, 4]}
+    >>> df = pl.DataFrame(data)
+    >>> df
+    shape: (2, 2)
+    ╭─────┬─────╮
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ i64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1   ┆ 3   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 2   ┆ 4   │
+    ╰─────┴─────╯
+    ```
+
+    Notice that the dtype is automatically inferred as a polars Int64:
+
+    ```python
+    >>> df.dtypes
+    [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Int64'>]
+    ```
+
+    In order to specify dtypes for your columns, initialize the DataFrame with a list
+    of Series instead:
+
+    ```python
+    >>> data = [pl.Series('col1', [1, 2], dtype=pl.Float32),
+    ...         pl.Series('col2', [3, 4], dtype=pl.Int64)]
+    >>> df2 = pl.DataFrame(series)
+    >>> df2
+    shape: (2, 2)
+    ╭──────┬──────╮
+    │ col1 ┆ col2 │
+    │ ---  ┆ ---  │
+    │ f32  ┆ i64  │
+    ╞══════╪══════╡
+    │ 1    ┆ 3    │
+    ├╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+    │ 2    ┆ 4    │
+    ╰──────┴──────╯
+    ```
+
+    Constructing a DataFrame from a numpy ndarray, specifying column names:
+
+    ```python
+    >>> data = np.array([(1, 2), (3, 4)])
+    >>> df3 = pl.DataFrame(data, columns=['a', 'b'], orientation='column')
+    >>> df3
+    shape: (2, 2)
+    ╭─────┬─────╮
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ i64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1   ┆ 3   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 2   ┆ 4   │
+    ╰─────┴─────╯
+    ```
+
+    Constructing a DataFrame from a list of lists, row orientation inferred:
+
+    ```python
+    >>> data = [[1, 2, 3], [4, 5, 6]]
+    >>> df4 = pl.DataFrame(data, columns=['a', 'b', 'c'])
+    >>> df4
+    shape: (2, 3)
+    ╭─────┬─────┬─────╮
+    │ a   ┆ b   ┆ c   │
+    │ --- ┆ --- ┆ --- │
+    │ i64 ┆ i64 ┆ i64 │
+    ╞═════╪═════╪═════╡
+    │ 1   ┆ 2   ┆ 3   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 4   ┆ 5   ┆ 6   │
+    ╰─────┴─────┴─────╯
+    ```
     """
 
     def __init__(

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -12,7 +12,6 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
-    Literal,
     Optional,
     Sequence,
     TextIO,
@@ -84,7 +83,7 @@ class DataFrame:
             ]
         ] = None,
         columns: Optional[Sequence[str]] = None,
-        orientation: Optional[Literal["column", "row"]] = None,
+        orientation: Optional[str] = None,
         nullable: bool = True,
     ):
         # Handle positional arguments for old constructor
@@ -121,8 +120,18 @@ class DataFrame:
 
             elif len(shape) == 2:
                 # Infer orientation
-                if orientation is None and columns is not None:
-                    orientation = "column" if len(columns) == shape[0] else "row"
+                if orientation is None:
+                    warnings.warn(
+                        "Default orientation for constructing DataFrame from numpy "
+                        'array will change from "row" to "column" in a future version. '
+                        "Specify orientation explicitly to silence this warning.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    orientation = "row"
+                # Exchange if-block above for block below when removing warning
+                # if orientation is None and columns is not None:
+                #     orientation = "column" if len(columns) == shape[0] else "row"
 
                 if orientation == "row":
                     data_series = [

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -129,7 +129,9 @@ class DataFrame:
                     data_series.append(s.inner())
 
             elif isinstance(data[0], Sequence):
-                self._df = DataFrame.from_rows(data, column_names=columns)
+                self._df = PyDataFrame.read_rows(data)
+                if columns is not None:
+                    self.columns = list(columns)
                 return
 
             else:
@@ -162,7 +164,7 @@ class DataFrame:
         self._df = PyDataFrame(data_series)
 
         if columns is not None:
-            self.columns = columns  # TODO: ValueError needed?
+            self.columns = list(columns)  # TODO: ValueError needed?
 
     @staticmethod
     def _from_pydf(df: "PyDataFrame") -> "DataFrame":

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -129,7 +129,6 @@ class DataFrame:
                         pl.Series(f"column_{i}", data[:, i], nullable=False).inner()
                         for i in range(shape[1])
                     ]
-
                 else:
                     data_series = [
                         pl.Series(f"column_{i}", data[i], nullable=False).inner()

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -26,7 +26,7 @@ def test_init():
 
     df = pl.DataFrame(np.random.randn(3, 5))
     assert df.shape == (3, 5)
-    assert df.columns == ["0", "1", "2", "3", "4"]
+    assert df.columns == ["column_0", "column_1", "column_2", "column_3", "column_4"]
 
 
 def test_selection():

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -23,11 +23,11 @@ def test_init_empty():
     assert df1.shape == (0, 0)
 
 
-# def test_init_only_columns():
-#     df = pl.DataFrame(columns=["a", "b", "c"])
-#     truth = pl.DataFrame({"a": [], "b": [], "c": []})
-#     assert df.shape == (0, 3)
-#     assert df.frame_equal(truth)
+def test_init_only_columns():
+    df = pl.DataFrame(columns=["a", "b", "c"])
+    truth = pl.DataFrame({"a": [], "b": [], "c": []})
+    assert df.shape == (0, 3)
+    assert df.frame_equal(truth)
 
 
 def test_init_dict():

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -17,6 +17,16 @@ def test_version():
 
 
 def test_init():
+    # Empty intialization
+    df1 = pl.DataFrame()
+    df2 = pl.DataFrame([])
+    df3 = pl.DataFrame({})
+    assert df1.shape == df2.shape == df3.shape == (0, 0)
+
+    # Only columns specified
+    df = pl.DataFrame(columns=["a", "b", "c"])
+    assert df.shape == (0, 3)
+
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     assert df.shape == (3, 2)
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -59,20 +59,21 @@ def test_init_ndarray():
     truth = pl.DataFrame({"a": [1, 2, 3]})
     assert df.frame_equal(truth)
 
-    # 2D array - default to column orientation
-    df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
-    truth = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
-    assert df.frame_equal(truth)
+    # TODO: Uncomment tests below when removing deprecation warning
+    # # 2D array - default to column orientation
+    # df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
+    # truth = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
+    # assert df.frame_equal(truth)
 
-    # 2D array - row orientation inferred
-    df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b", "c"])
-    truth = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
-    assert df.frame_equal(truth)
+    # # 2D array - row orientation inferred
+    # df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b", "c"])
+    # truth = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+    # assert df.frame_equal(truth)
 
-    # 2D array - column orientation inferred
-    df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"])
-    truth = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    assert df.frame_equal(truth)
+    # # 2D array - column orientation inferred
+    # df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"])
+    # truth = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    # assert df.frame_equal(truth)
 
     # 2D array - orientation conflicts with columns
     with pytest.raises(RuntimeError):
@@ -83,6 +84,14 @@ def test_init_ndarray():
     # 3D array
     with pytest.raises(ValueError):
         df = pl.DataFrame(np.random.randn(2, 2, 2))
+
+
+# TODO: Remove this test case when removing deprecated behaviour
+def test_init_ndarray_deprecated():
+    # 2D array - default to row orientation
+    df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
+    truth = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
+    assert df.frame_equal(truth)
 
 
 def test_init_series():

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -27,7 +27,7 @@ def test_init_only_columns():
     df = pl.DataFrame(columns=["a", "b", "c"])
     truth = pl.DataFrame({"a": [], "b": [], "c": []})
     assert df.shape == (0, 3)
-    assert df.frame_equal(truth)
+    assert df.frame_equal(truth, null_equal=True)
 
 
 def test_init_dict():


### PR DESCRIPTION
__This PR needs #1004 to be merged before the last test case will pass.__

Fixes #993 

Refer to the test cases to see exactly which cases are now implemented and what the corresponding behaviour is. The only one I have not implemented yet is np.ndarray with labeled columns; seems quite niche. Might take a look at that later. Otherwise, there's a whole bunch of new possibilities, and implemented quite elegantly too, if I say so myself.

I introduced a DeprecationWarning which catches and handles the case when `nullable` was defined as a positional argument, e.g. `DataFrame({'a': [1,2,3]}, False)`.

I did break one thing, which is the column names for the `ndarray` input; these were `0`, `1`, `2`, etc; which was inconsistent with the other automatic column naming of `column_0`, `column_1`, etc. As discussed we went with the latter option, but now the first one will change. I don't really know how to deprecate this prettily.

I will add a generous documentation docstring in a future pull request, together with Series.