### PR TITLE
allow wildcard in fold exprs

### DIFF
--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -2411,4 +2411,25 @@ mod test {
         assert_eq!(out.shape(), (6, 4));
         Ok(())
     }
+
+    #[test]
+    fn test_fold_wildcard() -> Result<()> {
+        let df1 = df![
+        "a" => [1, 2, 3],
+        "b" => [1, 2, 3]
+        ]?;
+
+        let out = df1
+            .lazy()
+            .select(vec![
+                fold_exprs(lit(0), |a, b| Ok(&a + &b), vec![col("*")]).alias("foo")
+            ])
+            .collect()?;
+
+        assert_eq!(
+            Vec::from(out.column("foo")?.i32()?),
+            &[Some(2), Some(4), Some(6)]
+        );
+        Ok(())
+    }
 }

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -75,7 +75,10 @@ pub fn argsort_by(by: Vec<Expr>, reverse: &[bool]) -> Expr {
         input: by,
         function,
         output_type: Some(DataType::UInt32),
-        collect_groups: true,
+        options: FunctionOptions {
+            collect_groups: true,
+            input_wildcard_expansion: false,
+        },
     }
 }
 
@@ -90,6 +93,9 @@ pub fn concat_str(s: Vec<Expr>, delimiter: &str) -> Expr {
         input: s,
         function,
         output_type: Some(DataType::Utf8),
-        collect_groups: false,
+        options: FunctionOptions {
+            collect_groups: false,
+            input_wildcard_expansion: false,
+        },
     }
 }

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -73,7 +73,7 @@ pub enum AExpr {
         input: Vec<Node>,
         function: NoEq<Arc<dyn SeriesUdf>>,
         output_type: Option<DataType>,
-        collect_groups: bool,
+        options: FunctionOptions,
     },
     Shift {
         input: Node,

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -89,12 +89,12 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             input,
             function,
             output_type,
-            collect_groups,
+            options,
         } => AExpr::Function {
             input: to_aexprs(input, arena),
             function,
             output_type,
-            collect_groups,
+            options,
         },
         Expr::BinaryFunction {
             input_a,
@@ -530,12 +530,12 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             input,
             function,
             output_type,
-            collect_groups,
+            options,
         } => Expr::Function {
             input: nodes_to_exprs(&input, expr_arena),
             function,
             output_type,
-            collect_groups,
+            options,
         },
         AExpr::BinaryFunction {
             input_a,

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -814,7 +814,7 @@ impl DefaultPlanner {
                 input,
                 function,
                 output_type,
-                collect_groups,
+                options,
             } => {
                 let input = self.create_physical_expressions(&input, ctxt, expr_arena)?;
                 Ok(Arc::new(ApplyExpr {
@@ -822,7 +822,7 @@ impl DefaultPlanner {
                     function,
                     output_type,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups,
+                    collect_groups: options.collect_groups,
                 }))
             }
             BinaryFunction {

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -98,6 +98,11 @@ where
     current_expr.into_iter().any(|e| matches(e))
 }
 
+// this one is used so much that it has its own function, to reduce inlining
+pub(crate) fn has_wildcard(current_expr: &Expr) -> bool {
+    has_expr(current_expr, |e| matches!(e, Expr::Wildcard))
+}
+
 /// output name of expr
 pub(crate) fn output_name(expr: &Expr) -> Result<Arc<String>> {
     for e in expr {

--- a/py-polars/src/lazy/utils.rs
+++ b/py-polars/src/lazy/utils.rs
@@ -2,5 +2,7 @@ use crate::lazy::dsl::PyExpr;
 use polars::lazy::dsl::Expr;
 
 pub fn py_exprs_to_exprs(py_exprs: Vec<PyExpr>) -> Vec<Expr> {
-    py_exprs.into_iter().map(|expr| expr.inner).collect()
+    // Safety:
+    // transparent struct
+    unsafe { std::mem::transmute(py_exprs) }
 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -57,6 +57,11 @@ fn binary_expr(l: dsl::PyExpr, op: u8, r: dsl::PyExpr) -> dsl::PyExpr {
 }
 
 #[pyfunction]
+pub fn fold(acc: PyExpr, lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
+    dsl::fold(acc, lambda, exprs)
+}
+
+#[pyfunction]
 fn binary_function(
     a: dsl::PyExpr,
     b: dsl::PyExpr,
@@ -141,6 +146,7 @@ fn polars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<dsl::PyExpr>().unwrap();
     m.add_wrapped(wrap_pyfunction!(col)).unwrap();
     m.add_wrapped(wrap_pyfunction!(lit)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(fold)).unwrap();
     m.add_wrapped(wrap_pyfunction!(binary_expr)).unwrap();
     m.add_wrapped(wrap_pyfunction!(binary_function)).unwrap();
     m.add_wrapped(wrap_pyfunction!(pearson_corr)).unwrap();

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -55,6 +55,11 @@ def test_fold():
     out = df.lazy().select(pl.sum(["a", "b"])).collect()
     assert out["sum"].series_equal(pl.Series("sum", [2, 4, 6]))
 
+    out = df.select(
+        pl.fold(acc=lit(0), f=lambda acc, x: acc + x, exprs=pl.col("*")).alias("foo")
+    )
+    assert out["foo"] == [2, 4, 6]
+
 
 def test_or():
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})


### PR DESCRIPTION

```python
df.select(
        pl.fold(acc=lit(0), f=lambda acc, x: acc + x, exprs=pl.col("*"))
    )
```

will recursively apply `f(acc, x)` on all columns `x` in `df`. This makes a fold much more usable in a lazy query, where due to projection pushdown it may not be known which columns remain in DataFrame.