### PR TITLE
IO: add csv-file decompression

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -78,6 +78,7 @@ dot_product = ["polars-core/dot_product", "polars-lazy/dot_product"]
 concat_str = ["polars-core/concat_str", "polars-lazy/concat_str"]
 row_hash = ["polars-core/row_hash"]
 reinterpret = ["polars-core/reinterpret", "polars-core/dtype-u64"]
+decompress = ["polars-io/decompress"]
 
 # don't use this
 private = []
@@ -140,7 +141,8 @@ docs-selection = [
     "is_last",
     "asof_join",
     "cross_join",
-    "concat_str"
+    "concat_str",
+    "decompress"
 ]
 
 [dependencies]

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -23,6 +23,7 @@ dtype-date32 = ["polars-core/dtype-date32"]
 csv-file = ["csv", "csv-core", "memmap", "fast-float", "lexical", "arrow/csv"]
 #csv-file = ["csv", "csv-core", "memmap", "fast-float", "lexical"]
 fmt = ["polars-core/plain_fmt"]
+decompress = ["flate2"]
 
 [dependencies]
 arrow = {git = "https://github.com/apache/arrow-rs", rev = "a1aace846f29dc4346b01289cad246dd99c2e3ed", default-features=false}
@@ -45,6 +46,7 @@ ahash = "0.7"
 num = "^0.4.0"
 dirs = "3.0"
 simdutf8 = {version="0.1", optional=true}
+flate2 = {version = "1", optional=true}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -106,7 +106,11 @@
 //!     - `parquet` - Read Apache Parquet format
 //!     - `json` - JSON serialization
 //!     - `ipc` - Arrow's IPC format serialization
-//!     - `simdutf8` - Improve performance of utf8 validation during csv parsing by using [simdutf8 crate](https://github.com/rusticstuff/simdutf8)
+//!     - `decompress` - Automatically infer compression of csv-files and decompress them.
+//!                      Supported compressions:
+//!                         * zip
+//!                         * gzip
+//!
 //! * `DataFrame` operations:
 //!     - `pivot` - [pivot operation](crate::frame::groupby::GroupBy::pivot) on `DataFrame`s
 //!     - `sort_multiple` - Allow sorting a `DataFrame` on multiple columns

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "csv-core",
  "dirs 3.0.2",
  "fast-float",
+ "flate2",
  "lazy_static",
  "lexical",
  "memmap2",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -59,7 +59,8 @@ features = [
     "dot_product",
     "concat_str",
     "row_hash",
-    "reinterpret"
+    "reinterpret",
+    "decompress"
 ]
 
 #[patch.crates-io]

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -245,15 +245,8 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
     }
     // a normal python file: with open(...) as f:.
     else if py_f.getattr("read").is_ok() {
+        // we van still get a file name so open the file instead of go through read
         if let Ok(filename) = py_f.getattr("name") {
-            if let Ok(val) = py_f.getattr("compression") {
-                // read into bytes with fsspec
-                if !val.is_none() {
-                    let f =
-                        PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)?;
-                    return Ok(Box::new(f));
-                }
-            }
             let filename = filename.downcast::<PyString>()?;
             let f = File::open(filename.to_str()?)?;
             Ok(Box::new(f))


### PR DESCRIPTION
@ghuls @olivier-lacroix 

This adds zlib and gzip de-compression from the Rust side. Ffspec is only used for remote files right?