### PR TITLE
Python add connector-x as db backend

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.8.12"
+version = "0.8.13-beta.1"
 dependencies = [
  "ahash",
  "libc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.8.12"
+version = "0.8.13-beta.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Sequence, Union
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute
 
 import polars as pl
 


### PR DESCRIPTION
This PR adds fast database query support using [connector-x](https://github.com/sfu-db/connector-x) as backend.

Supported database sources:

  * Postgres
  * Mysql
  * Sqlite
  * Redshift (through postgres protocol)
  * Clickhouse (through mysql protocol)
 
and more coming up.

A quick local performance check showed ~2.5x/3x the performance of `pandas.read_sql` on the single threaded query on a postgres backend.

More info on the connector-x project.