### PR TITLE
Conversions

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -6,7 +6,8 @@ from polars.eager.series import Series, wrap_s
 from polars.lazy.expr import Expr, wrap_expr
 from polars.lazy.frame import LazyFrame, wrap_ldf
 
-from . import datatypes, eager, functions, io, lazy, string_cache
+from . import convert, datatypes, eager, functions, io, lazy, string_cache
+from .convert import *
 from .datatypes import *
 from .eager import *
 from .functions import *
@@ -23,7 +24,8 @@ except ImportError:
     pass
 
 __all__ = (
-    datatypes.__all__
+    convert.__all__
+    + datatypes.__all__
     + eager.__all__
     + functions.__all__
     + io.__all__

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "from_dict",
+    "from_records",
     "from_rows",
     "from_arrow",
     "from_pandas",
@@ -61,6 +62,59 @@ def from_dict(
     ```
     """
     return pl.DataFrame._from_dict(data=data, columns=columns, nullable=nullable)
+
+
+def from_records(
+    data: Union[np.ndarray, Sequence[Sequence[Any]]],
+    columns: Optional[Sequence[str]] = None,
+    orient: Optional[str] = None,
+    nullable: bool = True,
+) -> "pl.DataFrame":
+    """
+    Construct a DataFrame from a numpy ndarray or sequence of sequences.
+
+    Parameters
+    ----------
+    data : numpy ndarray or Sequence of sequences
+        Two-dimensional data represented as numpy ndarray or sequence of sequences.
+    columns : Sequence of str, default None
+        Column labels to use for resulting DataFrame. Must match data dimensions.
+        If not specified, columns will be named `column_0`, `column_1`, etc.
+    orient : {'col', 'row'}, default None
+        Whether to interpret two-dimensional data as columns or as rows. If None,
+        the orientation is infered by matching the columns and data dimensions. If
+        this does not yield conclusive results, column orientation is used.
+    nullable : bool, default True
+        If your data does not contain null values, set to False to speed up
+        DataFrame creation.
+
+    Returns
+    -------
+    DataFrame
+
+    Examples
+    --------
+    ```python
+    >>> data = [[1, 2, 3], [4, 5, 6]]
+    >>> df = pl.from_records(data, columns=['a', 'b'])
+    >>> df
+    shape: (3, 2)
+    ╭─────┬─────╮
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ i64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1   ┆ 4   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 2   ┆ 5   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 3   ┆ 6   │
+    ╰─────┴─────╯
+    ```
+    """
+    return pl.DataFrame._from_records(
+        data, columns=columns, orient=orient, nullable=nullable
+    )
 
 
 def from_rows(

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
 
 import numpy as np
 import pyarrow as pa
@@ -6,10 +6,8 @@ import pyarrow.compute
 
 import polars as pl
 
-try:
+if TYPE_CHECKING:
     import pandas as pd
-except ImportError:
-    pass
 
 __all__ = [
     "from_rows",
@@ -98,6 +96,11 @@ def from_pandas(
     -------
     A Polars DataFrame
     """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError("from_pandas requires pandas to be installed.") from e
+
     if isinstance(df, pd.Series) or isinstance(df, pd.DatetimeIndex):
         return from_arrow(_from_pandas_helper(df))
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,0 +1,132 @@
+from typing import Any, Dict, Optional, Sequence, Union
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute
+
+import polars as pl
+
+try:
+    import pandas as pd
+except ImportError:
+    pass
+
+__all__ = [
+    "from_rows",
+    "from_arrow",
+    "from_pandas",
+    "from_arrow_table",  # deprecated
+]
+
+
+def from_rows(
+    rows: Sequence[Sequence[Any]],
+    column_names: Optional[Sequence[str]] = None,
+    column_name_mapping: Optional[Dict[int, str]] = None,
+) -> "pl.DataFrame":
+    """
+    Create a DataFrame from rows. This should only be used as a last resort, as this is
+    more expensive than creating from columnar data.
+
+    Parameters
+    ----------
+    rows
+        rows.
+    column_names
+        column names to use for the DataFrame.
+    column_name_mapping
+        map column index to a new name:
+        Example:
+        ```python
+            column_mapping: {0: "first_column, 3: "fourth column"}
+        ```
+    """
+    return pl.DataFrame.from_rows(rows, column_names, column_name_mapping)
+
+
+def from_arrow(
+    a: Union[pa.Table, pa.Array], rechunk: bool = True
+) -> Union["pl.DataFrame", "pl.Series"]:
+    """
+    Create a DataFrame from an arrow Table.
+
+    Parameters
+    ----------
+    a
+        Arrow Table.
+    rechunk
+        Make sure that all data is contiguous.
+    """
+    if isinstance(a, pa.Table):
+        return pl.DataFrame.from_arrow(a, rechunk)
+    elif isinstance(a, pa.Array):
+        return pl.Series.from_arrow("", a)
+    else:
+        raise ValueError(f"expected arrow table / array, got {a}")
+
+
+def _from_pandas_helper(a: "pd.Series") -> pa.Array:  # noqa: F821
+    dtype = a.dtype
+    if dtype == "datetime64[ns]":
+        # We first cast to ms because that's the unit of Date64,
+        # Then we cast to via int64 to date64. Casting directly to Date64 lead to
+        # loss of time information https://github.com/ritchie46/polars/issues/476
+        arr = pa.array(np.array(a.values, dtype="datetime64[ms]"))
+        arr = pa.compute.cast(arr, pa.int64())
+        return pa.compute.cast(arr, pa.date64())
+    elif dtype == "object" and isinstance(a.iloc[0], str):
+        return pa.array(a, pa.large_utf8())
+    else:
+        return pa.array(a)
+
+
+def from_pandas(
+    df: Union["pd.DataFrame", "pd.Series", "pd.DatetimeIndex"],
+    rechunk: bool = True,  # noqa: F821
+) -> Union["pl.Series", "pl.DataFrame"]:
+    """
+    Convert from a pandas DataFrame to a polars DataFrame.
+
+    Parameters
+    ----------
+    df
+        DataFrame to convert.
+    rechunk
+        Make sure that all data is contiguous.
+
+    Returns
+    -------
+    A Polars DataFrame
+    """
+    if isinstance(df, pd.Series) or isinstance(df, pd.DatetimeIndex):
+        return from_arrow(_from_pandas_helper(df))
+
+    # Note: we first tried to infer the schema via pyarrow and then modify the schema if
+    # needed. However arrow 3.0 determines the type of a string like this:
+    #       pa.array(array).type
+    # Needlessly allocating and failing when the string is too large for the string dtype.
+    data = {}
+
+    for name in df.columns:
+        s = df[name]
+        data[name] = _from_pandas_helper(s)
+
+    table = pa.table(data)
+    return from_arrow(table, rechunk)
+
+
+def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "pl.DataFrame":
+    """
+    .. deprecated:: 7.3
+        use `from_arrow`
+
+    Create a DataFrame from an arrow Table.
+
+    Parameters
+    ----------
+    a
+        Arrow Table.
+    rechunk
+        Make sure that all data is contiguous.
+    """
+    return pl.DataFrame.from_arrow(table, rechunk)

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -10,11 +10,57 @@ if TYPE_CHECKING:
     import pandas as pd
 
 __all__ = [
+    "from_dict",
     "from_rows",
     "from_arrow",
     "from_pandas",
     "from_arrow_table",  # deprecated
 ]
+
+
+def from_dict(
+    data: Dict[str, Sequence[Any]],
+    columns: Optional[Sequence[str]] = None,
+    nullable: bool = True,
+) -> "pl.DataFrame":
+    """
+    Construct a DataFrame from a dictionary of sequences.
+
+    Parameters
+    ----------
+    data : dict of sequences
+        Two-dimensional data represented as a dictionary. dict must contain
+        Sequences.
+    columns : Sequence of str, default None
+        Column labels to use for resulting DataFrame. If specified, overrides any
+        labels already present in the data. Must match data dimensions.
+    nullable : bool, default True
+        If your data does not contain null values, set to False to speed up
+        DataFrame creation.
+
+    Returns
+    -------
+    DataFrame
+
+    Examples
+    --------
+    ```python
+    >>> data = {'a': [1, 2], 'b': [3, 4]}
+    >>> df = pl.DataFrame.from_dict(data)
+    >>> df
+    shape: (2, 2)
+    ╭─────┬─────╮
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ i64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1   ┆ 3   │
+    ├╌╌╌╌╌┼╌╌╌╌╌┤
+    │ 2   ┆ 4   │
+    ╰─────┴─────╯
+    ```
+    """
+    return pl.DataFrame._from_dict(data=data, columns=columns, nullable=nullable)
 
 
 def from_rows(
@@ -108,6 +154,7 @@ def from_pandas(
     # needed. However arrow 3.0 determines the type of a string like this:
     #       pa.array(array).type
     # Needlessly allocating and failing when the string is too large for the string dtype.
+
     data = {}
 
     for name in df.columns:

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 __all__ = [
     "from_dict",
     "from_records",
-    "from_rows",
     "from_arrow",
     "from_pandas",
+    "from_rows",  # deprecated
     "from_arrow_table",  # deprecated
 ]
 
@@ -47,7 +47,7 @@ def from_dict(
     --------
     ```python
     >>> data = {'a': [1, 2], 'b': [3, 4]}
-    >>> df = pl.DataFrame.from_dict(data)
+    >>> df = pl.from_dict(data)
     >>> df
     shape: (2, 2)
     ╭─────┬─────╮
@@ -115,31 +115,6 @@ def from_records(
     return pl.DataFrame._from_records(
         data, columns=columns, orient=orient, nullable=nullable
     )
-
-
-def from_rows(
-    rows: Sequence[Sequence[Any]],
-    column_names: Optional[Sequence[str]] = None,
-    column_name_mapping: Optional[Dict[int, str]] = None,
-) -> "pl.DataFrame":
-    """
-    Create a DataFrame from rows. This should only be used as a last resort, as this is
-    more expensive than creating from columnar data.
-
-    Parameters
-    ----------
-    rows
-        rows.
-    column_names
-        column names to use for the DataFrame.
-    column_name_mapping
-        map column index to a new name:
-        Example:
-        ```python
-            column_mapping: {0: "first_column, 3: "fourth column"}
-        ```
-    """
-    return pl.DataFrame.from_rows(rows, column_names, column_name_mapping)
 
 
 def from_arrow(
@@ -217,6 +192,31 @@ def from_pandas(
 
     table = pa.table(data)
     return from_arrow(table, rechunk)
+
+
+def from_rows(
+    rows: Sequence[Sequence[Any]],
+    column_names: Optional[Sequence[str]] = None,
+    column_name_mapping: Optional[Dict[int, str]] = None,
+) -> "pl.DataFrame":
+    """
+    Create a DataFrame from rows. This should only be used as a last resort, as this is
+    more expensive than creating from columnar data.
+
+    Parameters
+    ----------
+    rows
+        rows.
+    column_names
+        column names to use for the DataFrame.
+    column_name_mapping
+        map column index to a new name:
+        Example:
+        ```python
+            column_mapping: {0: "first_column, 3: "fourth column"}
+        ```
+    """
+    return pl.DataFrame.from_rows(rows, column_names, column_name_mapping)
 
 
 def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "pl.DataFrame":

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -63,7 +63,7 @@ def from_arrow(
         raise ValueError(f"expected arrow table / array, got {a}")
 
 
-def _from_pandas_helper(a: "pd.Series") -> pa.Array:
+def _from_pandas_helper(a: Union["pd.Series", "pd.DatetimeIndex"]) -> pa.Array:
     dtype = a.dtype
     if dtype == "datetime64[ns]":
         # We first cast to ms because that's the unit of Date64,
@@ -101,7 +101,7 @@ def from_pandas(
     except ImportError as e:
         raise ImportError("from_pandas requires pandas to be installed.") from e
 
-    if isinstance(df, pd.Series) or isinstance(df, pd.DatetimeIndex):
+    if isinstance(df, (pd.Series, pd.DatetimeIndex)):
         return from_arrow(_from_pandas_helper(df))
 
     # Note: we first tried to infer the schema via pyarrow and then modify the schema if

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -200,6 +200,11 @@ def from_rows(
     column_name_mapping: Optional[Dict[int, str]] = None,
 ) -> "pl.DataFrame":
     """
+    .. deprecated:: 0.8.13
+          `from_rows` will be removed in Polars 0.9.0, it is replaced by
+          `from_records` because the latter offers more versatility. To keep the same
+          functionality, call `from_records` with `orient='row'`
+
     Create a DataFrame from rows. This should only be used as a last resort, as this is
     more expensive than creating from columnar data.
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -63,7 +63,7 @@ def from_arrow(
         raise ValueError(f"expected arrow table / array, got {a}")
 
 
-def _from_pandas_helper(a: "pd.Series") -> pa.Array:  # noqa: F821
+def _from_pandas_helper(a: "pd.Series") -> pa.Array:
     dtype = a.dtype
     if dtype == "datetime64[ns]":
         # We first cast to ms because that's the unit of Date64,
@@ -80,7 +80,7 @@ def _from_pandas_helper(a: "pd.Series") -> pa.Array:  # noqa: F821
 
 def from_pandas(
     df: Union["pd.DataFrame", "pd.Series", "pd.DatetimeIndex"],
-    rechunk: bool = True,  # noqa: F821
+    rechunk: bool = True,
 ) -> Union["pl.Series", "pl.DataFrame"]:
     """
     Convert from a pandas DataFrame to a polars DataFrame.
@@ -132,4 +132,11 @@ def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "pl.DataFrame":
     rechunk
         Make sure that all data is contiguous.
     """
+    import warnings
+
+    warnings.warn(
+        "from_arrow_table is deprecated, use DataFrame.from_arrow instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return pl.DataFrame.from_arrow(table, rechunk)

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -384,6 +384,11 @@ class DataFrame:
         column_name_mapping: Optional[Dict[int, str]] = None,
     ) -> "DataFrame":
         """
+        .. deprecated:: 0.8.13
+          `from_rows` will be removed in Polars 0.9.0, it is replaced by
+          `from_records` because the latter offers more versatility. To keep the same
+          functionality, call `from_records` with `orient='row'`
+
         Create a DataFrame from rows. This should only be used as a last resort,
         as this is more expensive than creating from columnar data.
 

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -294,26 +294,6 @@ class DataFrame:
         Returns
         -------
         DataFrame
-
-        Examples
-        --------
-        ```python
-        >>> data = [[1, 2, 3], [4, 5, 6]]
-        >>> df = pl.DataFrame.from_records(data, columns=['a', 'b'])
-        >>> df
-        shape: (3, 2)
-        ╭─────┬─────╮
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 4   │
-        ├╌╌╌╌╌┼╌╌╌╌╌┤
-        │ 2   ┆ 5   │
-        ├╌╌╌╌╌┼╌╌╌╌╌┤
-        │ 3   ┆ 6   │
-        ╰─────┴─────╯
-        ```
         """
         return cls(data, columns=columns, orient=orient, nullable=nullable)
 
@@ -352,7 +332,7 @@ class DataFrame:
         return self
 
     @classmethod
-    def from_pandas(
+    def _from_pandas(
         cls,
         data: "pd.DataFrame",
         columns: Optional[Sequence[str]] = None,
@@ -420,6 +400,12 @@ class DataFrame:
                 column_mapping: {0: "first_column, 3: "fourth column"}
             ```
         """
+        warnings.warn(
+            "from_rows is deprecated, use from_records with orient='row'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         df = DataFrame.__new__(DataFrame)
         df._df = PyDataFrame.read_rows(rows)
         if column_names is not None:

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -27,6 +27,13 @@ import pyarrow.feather
 import pyarrow.parquet
 
 import polars as pl
+from polars.internals.construction import (
+    dict_to_pydf,
+    numpy_to_pydf,
+    pandas_to_pydf,
+    sequence_to_pydf,
+    series_to_pydf,
+)
 
 from .._html import NotebookFormatter
 from ..datatypes import DTYPES, Boolean, DataType, UInt32, pytype_to_polars_type
@@ -196,123 +203,42 @@ class DataFrame:
             nullable = columns
             columns = None
 
-        # Parse data into a list of Series
-        data_series: tp.List["pl.Series"]
-
         if data is None:
-            data_series = []
+            self._df = dict_to_pydf({}, columns=columns, nullable=nullable)
 
         elif isinstance(data, dict):
-            data_series = [
-                pl.Series(k, v, nullable=nullable).inner() for k, v in data.items()
-            ]
+            self._df = dict_to_pydf(data, columns=columns, nullable=nullable)
 
         elif isinstance(data, np.ndarray):
-            shape = data.shape
-
-            if shape == (0,):
-                data_series = []
-
-            elif len(shape) == 1:
-                s = pl.Series("column_0", data, nullable=False).inner()
-                data_series = [s]
-
-            elif len(shape) == 2:
-                # Infer orientation
-                if orient is None:
-                    warnings.warn(
-                        "Default orientation for constructing DataFrame from numpy "
-                        'array will change from "row" to "column" in a future version. '
-                        "Specify orientation explicitly to silence this warning.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                    orient = "row"
-                # Exchange if-block above for block below when removing warning
-                # if orientation is None and columns is not None:
-                #     orientation = "col" if len(columns) == shape[0] else "row"
-
-                if orient == "row":
-                    data_series = [
-                        pl.Series(f"column_{i}", data[:, i], nullable=False).inner()
-                        for i in range(shape[1])
-                    ]
-                else:
-                    data_series = [
-                        pl.Series(f"column_{i}", data[i], nullable=False).inner()
-                        for i in range(shape[0])
-                    ]
-
-            else:
-                raise ValueError("A numpy array should have more than two dimensions.")
+            self._df = numpy_to_pydf(
+                data, columns=columns, orient=orient, nullable=nullable
+            )
 
         elif isinstance(data, Sequence) and not isinstance(data, str):
-            if len(data) == 0:
-                data_series = []
-
-            elif isinstance(data[0], pl.Series):
-                data_series = []
-                for i, s in enumerate(data):
-                    if not s.name:  # TODO: Replace by `if s.name is None` once allowed
-                        s.rename(f"column_{i}", in_place=True)
-                    data_series.append(s.inner())
-
-            elif isinstance(data[0], Sequence) and not isinstance(data[0], str):
-                # Infer orientation
-                if orient is None and columns is not None:
-                    orient = "col" if len(columns) == len(data) else "row"
-
-                if orient == "row":
-                    self._df = PyDataFrame.read_rows(data)
-                    if columns is not None:
-                        self.columns = list(columns)
-                    return
-                else:
-                    data_series = [
-                        pl.Series(f"column_{i}", data[i], nullable=nullable).inner()
-                        for i in range(len(data))
-                    ]
-
-            else:
-                s = pl.Series("column_0", data, nullable=nullable).inner()
-                data_series = [s]
+            self._df = sequence_to_pydf(
+                data, columns=columns, orient=orient, nullable=nullable
+            )
 
         elif isinstance(data, pl.Series):
-            data_series = [data.inner()]
+            self._df = series_to_pydf(data, columns=columns)
 
         elif _PANDAS_AVAILABLE and isinstance(data, pd.DataFrame):
-            if nullable:
-                data_series = [
-                    pl.Series(str(col), data[col].to_list(), nullable=True).inner()
-                    for col in data.columns
-                ]
-            else:
-                data_series = [
-                    pl.Series(str(col), data[col].values, nullable=False).inner()
-                    for col in data.columns
-                ]
+            self._df = pandas_to_pydf(data, columns=columns, nullable=nullable)
 
         else:
             raise ValueError("DataFrame constructor not called properly.")
 
-        # Handle the resulting list of Series
-        if not data_series and columns is not None:
-            for c in columns:
-                data_series.append(pl.Series(c, [], nullable=nullable).inner())
-
-        self._df = PyDataFrame(data_series)
-
-        if columns is not None:
-            self.columns = list(columns)
-
-    @staticmethod
-    def _from_pydf(df: "PyDataFrame") -> "DataFrame":
-        self = DataFrame.__new__(DataFrame)
-        self._df = df
-        return self
+    @classmethod
+    def _from_pydf(cls, py_df: "PyDataFrame") -> "DataFrame":
+        """
+        Construct Polars DataFrame from FFI PyDataFrame object.
+        """
+        df = cls.__new__(cls)
+        df._df = py_df
+        return df
 
     @classmethod
-    def from_dict(
+    def _from_dict(
         cls,
         data: Dict[str, Sequence[Any]],
         columns: Optional[Sequence[str]] = None,
@@ -336,29 +262,11 @@ class DataFrame:
         Returns
         -------
         DataFrame
-
-        Examples
-        --------
-        ```python
-        >>> data = {'a': [1, 2], 'b': [3, 4]}
-        >>> df = pl.DataFrame.from_dict(data)
-        >>> df
-        shape: (2, 2)
-        ╭─────┬─────╮
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 3   │
-        ├╌╌╌╌╌┼╌╌╌╌╌┤
-        │ 2   ┆ 4   │
-        ╰─────┴─────╯
-        ```
         """
         return cls(data, columns=columns, nullable=nullable)
 
     @classmethod
-    def from_records(
+    def _from_records(
         cls,
         data: Union[np.ndarray, Sequence[Sequence[Any]]],
         columns: Optional[Sequence[str]] = None,
@@ -1255,7 +1163,7 @@ class DataFrame:
         return self._df.columns()
 
     @columns.setter
-    def columns(self, columns: tp.List[str]) -> None:
+    def columns(self, columns: Sequence[str]) -> None:
         """
         Change the column names of the `DataFrame`.
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -1,25 +1,15 @@
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Optional, Sequence, Union
 
-import numpy as np
 import pyarrow as pa
 import pyarrow.compute
 
 import polars as pl
-
-try:
-    import pandas as pd
-except ImportError:
-    pass
 
 __all__ = [
     "get_dummies",
     "concat",
     "repeat",
     "arg_where",
-    "from_rows",
-    "from_arrow",
-    "from_pandas",
-    "from_arrow_table",  # deprecated
 ]
 
 
@@ -99,115 +89,3 @@ def arg_where(mask: "pl.Series") -> "pl.Series":
     UInt32 Series
     """
     return mask.arg_true()
-
-
-def from_rows(
-    rows: Sequence[Sequence[Any]],
-    column_names: Optional[Sequence[str]] = None,
-    column_name_mapping: Optional[Dict[int, str]] = None,
-) -> "pl.DataFrame":
-    """
-    Create a DataFrame from rows. This should only be used as a last resort, as this is more expensive than
-    creating from columnar data.
-    Parameters
-    ----------
-    rows
-        rows.
-    column_names
-        column names to use for the DataFrame.
-    column_name_mapping
-        map column index to a new name:
-        Example:
-        ```python
-            column_mapping: {0: "first_column, 3: "fourth column"}
-        ```
-    """
-    return pl.DataFrame.from_rows(rows, column_names, column_name_mapping)
-
-
-def from_arrow(
-    a: Union[pa.Table, pa.Array], rechunk: bool = True
-) -> Union["pl.DataFrame", "pl.Series"]:
-    """
-    Create a DataFrame from an arrow Table.
-
-    Parameters
-    ----------
-    a
-        Arrow Table.
-    rechunk
-        Make sure that all data is contiguous.
-    """
-    if isinstance(a, pa.Table):
-        return pl.DataFrame.from_arrow(a, rechunk)
-    elif isinstance(a, pa.Array):
-        return pl.Series.from_arrow("", a)
-    else:
-        raise ValueError(f"expected arrow table / array, got {a}")
-
-
-def _from_pandas_helper(a: "pd.Series") -> pa.Array:  # noqa: F821
-    dtype = a.dtype
-    if dtype == "datetime64[ns]":
-        # We first cast to ms because that's the unit of Date64,
-        # Then we cast to via int64 to date64. Casting directly to Date64 lead to
-        # loss of time information https://github.com/ritchie46/polars/issues/476
-        arr = pa.array(np.array(a.values, dtype="datetime64[ms]"))
-        arr = pa.compute.cast(arr, pa.int64())
-        return pa.compute.cast(arr, pa.date64())
-    elif dtype == "object" and isinstance(a.iloc[0], str):
-        return pa.array(a, pa.large_utf8())
-    else:
-        return pa.array(a)
-
-
-def from_pandas(
-    df: Union["pd.DataFrame", "pd.Series", "pd.DatetimeIndex"],
-    rechunk: bool = True,  # noqa: F821
-) -> Union["pl.Series", "pl.DataFrame"]:
-    """
-    Convert from a pandas DataFrame to a polars DataFrame.
-
-    Parameters
-    ----------
-    df
-        DataFrame to convert.
-    rechunk
-        Make sure that all data is contiguous.
-
-    Returns
-    -------
-    A Polars DataFrame
-    """
-    if isinstance(df, pd.Series) or isinstance(df, pd.DatetimeIndex):
-        return from_arrow(_from_pandas_helper(df))
-
-    # Note: we first tried to infer the schema via pyarrow and then modify the schema if needed.
-    # However arrow 3.0 determines the type of a string like this:
-    #       pa.array(array).type
-    # needlessly allocating and failing when the string is too large for the string dtype.
-    data = {}
-
-    for name in df.columns:
-        s = df[name]
-        data[name] = _from_pandas_helper(s)
-
-    table = pa.table(data)
-    return from_arrow(table, rechunk)
-
-
-def from_arrow_table(table: pa.Table, rechunk: bool = True) -> "pl.DataFrame":
-    """
-    .. deprecated:: 7.3
-        use `from_arrow`
-
-    Create a DataFrame from an arrow Table.
-
-    Parameters
-    ----------
-    a
-        Arrow Table.
-    rechunk
-        Make sure that all data is contiguous.
-    """
-    return pl.DataFrame.from_arrow(table, rechunk)

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1,0 +1,183 @@
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+import polars as pl
+
+try:
+    from ..polars import PyDataFrame, PySeries
+except ImportError:
+    warnings.warn("binary files missing")
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+# DataFrame constructor interface
+
+
+def _handle_columns_arg(
+    data: List["PySeries"],
+    columns: Optional[Sequence[str]] = None,
+    nullable: bool = True,
+) -> List["PySeries"]:
+    """
+    Rename data according to columns argument.
+    """
+    if columns is None:
+        return data
+    else:
+        if not data:
+            return [pl.Series(c, None, nullable=nullable).inner() for c in columns]
+        elif len(data) == len(columns):
+            for i, c in enumerate(columns):
+                data[i].rename(c)
+            return data
+        else:
+            raise ValueError("Dimensions of columns arg must match data dimensions.")
+
+
+def dict_to_pydf(
+    data: Dict[str, Sequence[Any]],
+    columns: Optional[Sequence[str]] = None,
+    nullable: bool = True,
+) -> "PyDataFrame":
+    """
+    Construct a PyDataFrame from a dictionary of sequences.
+    """
+    data_series = [
+        pl.Series(name, values, nullable=nullable).inner()
+        for name, values in data.items()
+    ]
+    data_series = _handle_columns_arg(data_series, columns=columns, nullable=nullable)
+    return PyDataFrame(data_series)
+
+
+def numpy_to_pydf(
+    data: np.ndarray,
+    columns: Optional[Sequence[str]] = None,
+    orient: Optional[str] = None,
+    nullable: bool = True,
+) -> "PyDataFrame":
+    """
+    Construct a PyDataFrame from a numpy ndarray.
+    """
+    shape = data.shape
+
+    if shape == (0,):
+        data_series = []
+
+    elif len(shape) == 1:
+        s = pl.Series("column_0", data, nullable=False).inner()
+        data_series = [s]
+
+    elif len(shape) == 2:
+        # Infer orientation
+        if orient is None:
+            warnings.warn(
+                "Default orientation for constructing DataFrame from numpy "
+                'array will change from "row" to "column" in a future version. '
+                "Specify orientation explicitly to silence this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            orient = "row"
+        # Exchange if-block above for block below when removing warning
+        # if orientation is None and columns is not None:
+        #     orientation = "col" if len(columns) == shape[0] else "row"
+
+        if orient == "row":
+            data_series = [
+                pl.Series(f"column_{i}", data[:, i], nullable=False).inner()
+                for i in range(shape[1])
+            ]
+        else:
+            data_series = [
+                pl.Series(f"column_{i}", data[i], nullable=False).inner()
+                for i in range(shape[0])
+            ]
+    else:
+        raise ValueError("A numpy array should not have more than two dimensions.")
+
+    data_series = _handle_columns_arg(data_series, columns=columns, nullable=nullable)
+
+    return PyDataFrame(data_series)
+
+
+def sequence_to_pydf(
+    data: Sequence[Any],
+    columns: Optional[Sequence[str]] = None,
+    orient: Optional[str] = None,
+    nullable: bool = True,
+) -> "PyDataFrame":
+    """
+    Construct a PyDataFrame from a sequence.
+    """
+    data_series: List["PySeries"]
+    if len(data) == 0:
+        data_series = []
+
+    elif isinstance(data[0], pl.Series):
+        data_series = []
+        for i, s in enumerate(data):
+            if not s.name:  # TODO: Replace by `if s.name is None` once allowed
+                s.rename(f"column_{i}", in_place=True)
+            data_series.append(s.inner())
+
+    elif isinstance(data[0], Sequence) and not isinstance(data[0], str):
+        # Infer orientation
+        if orient is None and columns is not None:
+            orient = "col" if len(columns) == len(data) else "row"
+
+        if orient == "row":
+            pydf = PyDataFrame.read_rows(data)
+            if columns is not None:
+                pydf.set_column_names(columns)
+            return pydf
+        else:
+            data_series = [
+                pl.Series(f"column_{i}", data[i], nullable=nullable).inner()
+                for i in range(len(data))
+            ]
+
+    else:
+        s = pl.Series("column_0", data, nullable=nullable).inner()
+        data_series = [s]
+
+    data_series = _handle_columns_arg(data_series, columns=columns, nullable=nullable)
+    return PyDataFrame(data_series)
+
+
+def pandas_to_pydf(
+    data: "pd.DataFrame",
+    columns: Optional[Sequence[str]] = None,
+    nullable: bool = True,
+) -> "PyDataFrame":
+    """
+    Construct a PyDataFrame from a pandas DataFrame.
+    """
+    if nullable:
+        data_series = [
+            pl.Series(str(col), data[col].to_list(), nullable=nullable).inner()
+            for col in data.columns
+        ]
+    else:
+        data_series = [
+            pl.Series(str(col), data[col].values, nullable=nullable).inner()
+            for col in data.columns
+        ]
+    data_series = _handle_columns_arg(data_series, columns=columns, nullable=nullable)
+    return PyDataFrame(data_series)
+
+
+def series_to_pydf(
+    data: "pl.Series",
+    columns: Optional[Sequence[str]] = None,
+) -> "PyDataFrame":
+    """
+    Construct a PyDataFrame from a Polars Series.
+    """
+    data_series = [data.inner()]
+    data_series = _handle_columns_arg(data_series, columns=columns)
+    return PyDataFrame(data_series)

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -23,7 +23,7 @@ import pyarrow.parquet
 
 import polars as pl
 
-from .functions import from_arrow
+from .convert import from_arrow
 
 try:
     import connectorx as cx

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -55,7 +55,7 @@ def test_init_ndarray():
     assert df.frame_equal(pl.DataFrame())
 
     # 1D array
-    df = pl.DataFrame(np.array([1, 2, 3]), columns="a")
+    df = pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
     truth = pl.DataFrame({"a": [1, 2, 3]})
     assert df.frame_equal(truth)
 
@@ -76,7 +76,7 @@ def test_init_ndarray():
     # assert df.frame_equal(truth)
 
     # 2D array - orientation conflicts with columns
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"], orient="row")
 
     # 3D array

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -77,9 +77,7 @@ def test_init_ndarray():
 
     # 2D array - orientation conflicts with columns
     with pytest.raises(RuntimeError):
-        pl.DataFrame(
-            np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"], orientation="row"
-        )
+        pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"], orient="row")
 
     # 3D array
     with pytest.raises(ValueError):
@@ -129,7 +127,7 @@ def test_init_seq_of_seq():
     assert df.frame_equal(truth)
 
     # Row orientation
-    df = pl.DataFrame(((1, 2), (3, 4)), columns=("a", "b"), orientation="row")
+    df = pl.DataFrame(((1, 2), (3, 4)), columns=("a", "b"), orient="row")
     truth = pl.DataFrame({"a": [1, 3], "b": [2, 4]})
     assert df.frame_equal(truth)
 


### PR DESCRIPTION
See discussion in issue #1011

Changes:
* Move `from_x` methods from `functions.py` to `convert.py`. Makes sense to have all conversion logic in one place.
* Move `DataFrame` constructor logic to `internals/construction.py`. Improves readability of DataFrame constructor and makes it easier to unittest the code (tests still go through the constructor at the moment).
* Small change to DataFrame constructor for brevity: `orientation` arg renamed to `orient`, and it takes values `'row'` and `'col'` now instead of `'row'` and `'column'` 
* Add DataFrame classmethods `_from_dict`, `_from_records`, `_from_pandas` that call the DataFrame constructor
* Add DeprecationWarning to `from_rows` and `from_arrow_table`.
* Changed some `@staticmethod` to `@classmethod`

To do in a future PR:
* Support `arrow` in DataFrame constructor
* Unify functionality of `pl.from_pandas` and `DataFrame._from_pandas`; both do different things at the moment.
* Clean up `Series` constructor and move the construction logic to `construction.py`