### PR TITLE
(Python) Refactor Series constructor

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -133,7 +133,7 @@ def from_arrow(
     if isinstance(a, pa.Table):
         return pl.DataFrame.from_arrow(a, rechunk)
     elif isinstance(a, pa.Array):
-        return pl.Series("", a)
+        return pl.Series._from_arrow("", a)
     else:
         raise ValueError(f"expected arrow table / array, got {a}")
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -133,7 +133,7 @@ def from_arrow(
     if isinstance(a, pa.Table):
         return pl.DataFrame.from_arrow(a, rechunk)
     elif isinstance(a, pa.Array):
-        return pl.Series.from_arrow("", a)
+        return pl.Series("", a)
     else:
         raise ValueError(f"expected arrow table / array, got {a}")
 

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -282,90 +282,94 @@ def pytype_to_polars_type(data_type: Type[Any]) -> Type[DataType]:
     return polars_type
 
 
+_POLARS_TYPE_TO_CONSTRUCTOR = {
+    Float32: PySeries.new_opt_f32,
+    Float64: PySeries.new_opt_f64,
+    Int8: PySeries.new_opt_i8,
+    Int16: PySeries.new_opt_i16,
+    Int32: PySeries.new_opt_i32,
+    Int64: PySeries.new_opt_i64,
+    UInt8: PySeries.new_opt_u8,
+    UInt16: PySeries.new_opt_u16,
+    UInt32: PySeries.new_opt_u32,
+    UInt64: PySeries.new_opt_u64,
+    Date32: PySeries.new_opt_i32,
+    Date64: PySeries.new_opt_i32,
+    Boolean: PySeries.new_opt_bool,
+    Utf8: PySeries.new_str,
+    Object: PySeries.new_object,
+}
+
+
 def polars_type_to_constructor(
     dtype: Type[DataType],
 ) -> Callable[[Optional[str], Sequence[Any]], "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
-    map = {
-        Float32: PySeries.new_opt_f32,
-        Float64: PySeries.new_opt_f64,
-        Int8: PySeries.new_opt_i8,
-        Int16: PySeries.new_opt_i16,
-        Int32: PySeries.new_opt_i32,
-        Int64: PySeries.new_opt_i64,
-        UInt8: PySeries.new_opt_u8,
-        UInt16: PySeries.new_opt_u16,
-        UInt32: PySeries.new_opt_u32,
-        UInt64: PySeries.new_opt_u64,
-        Date32: PySeries.new_opt_i32,
-        Date64: PySeries.new_opt_i32,
-        Boolean: PySeries.new_opt_bool,
-        Utf8: PySeries.new_str,
-        Object: PySeries.new_object,
-    }
-
     try:
-        return map[dtype]
+        return _POLARS_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:
         raise ValueError(f"Cannot construct PySeries for type {dtype}.")
+
+
+_NUMPY_TYPE_TO_CONSTRUCTOR = {
+    np.float32: PySeries.new_f32,
+    np.float64: PySeries.new_f64,
+    np.int8: PySeries.new_i8,
+    np.int16: PySeries.new_i16,
+    np.int32: PySeries.new_i32,
+    np.int64: PySeries.new_i64,
+    np.uint8: PySeries.new_u8,
+    np.uint16: PySeries.new_u16,
+    np.uint32: PySeries.new_u32,
+    np.uint64: PySeries.new_u64,
+    np.str_: PySeries.new_str,
+    bool: PySeries.new_bool,
+}
 
 
 def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
-    map = {
-        np.float32: PySeries.new_f32,
-        np.float64: PySeries.new_f64,
-        np.int8: PySeries.new_i8,
-        np.int16: PySeries.new_i16,
-        np.int32: PySeries.new_i32,
-        np.int64: PySeries.new_i64,
-        np.uint8: PySeries.new_u8,
-        np.uint16: PySeries.new_u16,
-        np.uint32: PySeries.new_u32,
-        np.uint64: PySeries.new_u64,
-        np.str_: PySeries.new_str,
-        bool: PySeries.new_bool,
-    }
-
     try:
-        return map[dtype]
+        return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:
         return PySeries.new_object
+
+
+_PY_TYPE_TO_CONSTRUCTOR = {
+    float: PySeries.new_opt_f64,
+    int: PySeries.new_opt_i64,
+    str: PySeries.new_str,
+    bool: PySeries.new_opt_bool,
+}
 
 
 def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
     """
     Get the right PySeries constructor for the given Python dtype.
     """
-    map = {
-        float: PySeries.new_opt_f64,
-        int: PySeries.new_opt_i64,
-        str: PySeries.new_str,
-        bool: PySeries.new_opt_bool,
-    }
-
     try:
-        return map[dtype]
+        return _PY_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:
         return PySeries.new_object
+
+
+_PY_TYPE_TO_ARROW_TYPE = {
+    float: pa.float64(),
+    int: pa.int64(),
+    str: pa.large_utf8(),
+    bool: pa.bool_(),
+}
 
 
 def py_type_to_arrow_type(dtype: Type[Any]) -> pa.lib.DataType:
     """
     Convert a Python dtype to an Arrow dtype.
     """
-    map = {
-        float: pa.float64(),
-        int: pa.int64(),
-        str: pa.large_utf8(),
-        bool: pa.bool_(),
-    }
-
     try:
-        return map[dtype]
+        return _PY_TYPE_TO_ARROW_TYPE[dtype]
     except KeyError:
         raise ValueError(f"Cannot parse dtype {dtype} into arrow dtype.")

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,6 +1,6 @@
 import ctypes
 import typing as tp
-from typing import Any, Callable, Dict, Optional, Sequence, Type
+from typing import Any, Callable, Dict, Sequence, Type
 
 import numpy as np
 import pyarrow as pa
@@ -303,7 +303,7 @@ _POLARS_TYPE_TO_CONSTRUCTOR = {
 
 def polars_type_to_constructor(
     dtype: Type[DataType],
-) -> Callable[[Optional[str], Sequence[Any]], "PySeries"]:
+) -> Callable[[str, Sequence[Any]], "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,8 +1,16 @@
 import ctypes
 import typing as tp
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Optional, Sequence, Type
 
+import numpy as np
 from _ctypes import _SimpleCData
+
+try:
+    from polars.polars import PySeries
+except ImportError:
+    import warnings
+
+    warnings.warn("binary files missing")
 
 __pdoc__ = {
     "dtype_to_ctype": False,
@@ -271,3 +279,58 @@ def pytype_to_polars_type(data_type: Type[Any]) -> Type[DataType]:
     else:
         polars_type = data_type
     return polars_type
+
+
+def polars_type_to_constructor(
+    dtype: Type[DataType],
+) -> Callable[[Optional[str], Sequence[Any]], "PySeries"]:
+    """
+    Get the right PySeries constructor for the given Polars dtype.
+    """
+    map = {
+        Float32: PySeries.new_opt_f32,
+        Float64: PySeries.new_opt_f64,
+        Int8: PySeries.new_opt_i8,
+        Int16: PySeries.new_opt_i16,
+        Int32: PySeries.new_opt_i32,
+        Int64: PySeries.new_opt_i64,
+        UInt8: PySeries.new_opt_u8,
+        UInt16: PySeries.new_opt_u16,
+        UInt32: PySeries.new_opt_u32,
+        UInt64: PySeries.new_opt_u64,
+        Date32: PySeries.new_opt_i32,
+        Date64: PySeries.new_opt_i32,
+        Boolean: PySeries.new_opt_bool,
+        Utf8: PySeries.new_str,
+        Object: PySeries.new_object,
+    }
+
+    try:
+        return map[dtype]
+    except KeyError:
+        raise ValueError(f"Cannot construct PySeries for type {dtype}.")
+
+
+def numpy_type_to_constructor(dtype: Type[DataType]) -> Callable[..., "PySeries"]:
+    """
+    Get the right PySeries constructor for the given Polars dtype.
+    """
+    map = {
+        np.float32: PySeries.new_f32,
+        np.float64: PySeries.new_f64,
+        np.int8: PySeries.new_i8,
+        np.int16: PySeries.new_i16,
+        np.int32: PySeries.new_i32,
+        np.int64: PySeries.new_i64,
+        np.uint8: PySeries.new_u8,
+        np.uint16: PySeries.new_u16,
+        np.uint32: PySeries.new_u32,
+        np.uint64: PySeries.new_u64,
+        np.str_: PySeries.new_str,
+        bool: PySeries.new_bool,
+    }
+
+    try:
+        return map[dtype]
+    except KeyError:
+        return PySeries.new_object

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -339,7 +339,7 @@ def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., "PySeries"
 
 def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
     """
-    Get the right PySeries constructor for the given Polars dtype.
+    Get the right PySeries constructor for the given Python dtype.
     """
     map = {
         float: PySeries.new_opt_f64,
@@ -355,6 +355,9 @@ def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
 
 
 def py_type_to_arrow_type(dtype: Type[Any]) -> pa.lib.DataType:
+    """
+    Convert a Python dtype to an Arrow dtype.
+    """
     map = {
         float: pa.float64(),
         int: pa.int64(),

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -263,7 +263,7 @@ class DataFrame:
         -------
         DataFrame
         """
-        return cls(data, columns=columns, nullable=nullable)
+        return cls._from_pydf(dict_to_pydf(data, columns=columns, nullable=nullable))
 
     @classmethod
     def _from_records(
@@ -295,7 +295,15 @@ class DataFrame:
         -------
         DataFrame
         """
-        return cls(data, columns=columns, orient=orient, nullable=nullable)
+        if isinstance(data, np.ndarray):
+            pydf = numpy_to_pydf(
+                data, columns=columns, orient=orient, nullable=nullable
+            )
+        else:
+            pydf = sequence_to_pydf(
+                data, columns=columns, orient=orient, nullable=nullable
+            )
+        return cls._from_pydf(pydf)
 
     @classmethod
     def from_arrow(cls, table: pa.Table, rechunk: bool = True) -> "DataFrame":
@@ -374,7 +382,7 @@ class DataFrame:
         ╰─────┴─────┴─────╯
         ```
         """
-        return cls(data, columns=columns, nullable=nullable)
+        return cls._from_pydf(pandas_to_pydf(data, columns=columns, nullable=nullable))
 
     @classmethod
     def from_rows(

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -37,7 +37,7 @@ from ..datatypes import (
     dtype_to_ctype,
     dtype_to_primitive,
 )
-from ..utils import _ptr_to_numpy, coerce_arrow
+from ..utils import _ptr_to_numpy
 
 try:
     from ..polars import PyDataFrame, PySeries
@@ -192,8 +192,6 @@ class Series:
         if name is None:
             name = ""
 
-        self._s: PySeries
-
         if values is None:
             self._s = sequence_to_pyseries(name, [], dtype=dtype)
         elif isinstance(values, Series):
@@ -206,8 +204,7 @@ class Series:
             if nullable:
                 self._s = sequence_to_pyseries(name, values, dtype=dtype)
             else:
-                values_numpy = np.array(values)
-                self._s = numpy_to_pyseries(name, values_numpy)
+                self._s = numpy_to_pyseries(name, np.array(values))
         else:
             raise ValueError("Series constructor not called properly.")
 
@@ -227,6 +224,10 @@ class Series:
     @classmethod
     def from_arrow(cls, name: str, array: pa.Array) -> "Series":
         """
+        .. deprecated:: 0.8.13
+            `Series.from_arrow` will be removed in Polars 0.9.0. Use `pl.from_arrow`
+            instead, or call the Series constructor directly.
+
         Create a Series from an arrow array.
 
         Parameters
@@ -236,8 +237,15 @@ class Series:
         array
             Arrow array.
         """
-        array = coerce_arrow(array)
-        return cls._from_pyseries(PySeries.from_arrow(name, array))
+        import warnings
+
+        warnings.warn(
+            "Series.from_arrow is deprecated, Use `pl.from_arrow` instead, "
+            "or call the Series constructor directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls(name, array)
 
     def inner(self) -> "PySeries":
         return self._s

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -222,7 +222,7 @@ class Series:
         return cls._from_pyseries(PySeries.repeat(name, val, n))
 
     @classmethod
-    def _from_arrow(cls, name: Optional[str], values: pa.Array) -> "Series":
+    def _from_arrow(cls, name: str, values: pa.Array) -> "Series":
         """
         Construct a Series from an Arrow array.
         """
@@ -607,7 +607,7 @@ class Series:
         """
         return self._s.name()
 
-    def rename(self, name: Optional[str], in_place: bool = False) -> Optional["Series"]:
+    def rename(self, name: str, in_place: bool = False) -> Optional["Series"]:
         """
         Rename this Series.
 

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -222,6 +222,13 @@ class Series:
         return cls._from_pyseries(PySeries.repeat(name, val, n))
 
     @classmethod
+    def _from_arrow(cls, name: Optional[str], values: pa.Array) -> "Series":
+        """
+        Construct a Series from an Arrow array.
+        """
+        return cls._from_pyseries(arrow_to_pyseries(name, values))
+
+    @classmethod
     def from_arrow(cls, name: str, array: pa.Array) -> "Series":
         """
         .. deprecated:: 0.8.13
@@ -245,7 +252,7 @@ class Series:
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls(name, array)
+        return cls._from_arrow(name, array)
 
     def inner(self) -> "PySeries":
         return self._s

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -72,7 +72,7 @@ def repeat(
         s.rename(name)
         return s
     else:
-        return pl.Series.from_arrow(name, pa.repeat(val, n))
+        return pl.Series(name, pa.repeat(val, n))
 
 
 def arg_where(mask: "pl.Series") -> "pl.Series":

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -72,7 +72,7 @@ def repeat(
         s.rename(name)
         return s
     else:
-        return pl.Series(name, pa.repeat(val, n))
+        return pl.Series._from_arrow(name, pa.repeat(val, n))
 
 
 def arg_where(mask: "pl.Series") -> "pl.Series":

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -10,6 +10,7 @@ from polars.datatypes import (
     DataType,
     Date32,
     Date64,
+    Float32,
     numpy_type_to_constructor,
     polars_type_to_constructor,
     py_type_to_arrow_type,
@@ -260,6 +261,10 @@ def sequence_to_pyseries(
     """
     Construct a PySeries from a sequence.
     """
+    # Empty sequence defaults to Float32 type
+    if not values and dtype is None:
+        dtype = Float32
+
     if dtype is not None:
         constructor = polars_type_to_constructor(dtype)
         pyseries = constructor(name, values)

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -206,11 +206,17 @@ def series_to_pyseries(
     name: Optional[str],
     values: "pl.Series",
 ) -> "PySeries":
+    """
+    Construct a PySeries from a Polars Series.
+    """
     values.rename(name, in_place=True)
     return values.inner()
 
 
 def arrow_to_pyseries(name: Optional[str], values: pa.Array) -> "PySeries":
+    """
+    Construct a PySeries from an Arrow array.
+    """
     array = coerce_arrow(values)
     return PySeries.from_arrow(name, array)
 
@@ -240,6 +246,8 @@ def numpy_to_pyseries(
 def _get_first_non_none(values: Sequence[Optional[Any]]) -> Any:
     """
     Return the first value from a sequence that isn't None.
+
+    If sequence doesn't contain non-None values, return None.
     """
     return next((v for v in values if v is not None), None)
 
@@ -249,6 +257,9 @@ def sequence_to_pyseries(
     values: Sequence[Any],
     dtype: Optional[Type[DataType]] = None,
 ) -> "PySeries":
+    """
+    Construct a PySeries from a sequence.
+    """
     if dtype is not None:
         constructor = polars_type_to_constructor(dtype)
         pyseries = constructor(name, values)

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -204,7 +204,7 @@ def series_to_pydf(
 
 
 def series_to_pyseries(
-    name: Optional[str],
+    name: str,
     values: "pl.Series",
 ) -> "PySeries":
     """
@@ -214,7 +214,7 @@ def series_to_pyseries(
     return values.inner()
 
 
-def arrow_to_pyseries(name: Optional[str], values: pa.Array) -> "PySeries":
+def arrow_to_pyseries(name: str, values: pa.Array) -> "PySeries":
     """
     Construct a PySeries from an Arrow array.
     """
@@ -223,7 +223,7 @@ def arrow_to_pyseries(name: Optional[str], values: pa.Array) -> "PySeries":
 
 
 def numpy_to_pyseries(
-    name: Optional[str],
+    name: str,
     values: np.ndarray,
     nullable: bool = True,
 ) -> "PySeries":
@@ -254,7 +254,7 @@ def _get_first_non_none(values: Sequence[Optional[Any]]) -> Any:
 
 
 def sequence_to_pyseries(
-    name: Optional[str],
+    name: str,
     values: Sequence[Any],
     dtype: Optional[Type[DataType]] = None,
 ) -> "PySeries":

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -320,9 +320,9 @@ def test_empty():
     a = pl.Series(dtype=pl.Int8)
     assert a.dtype == pl.Int8
     a = pl.Series()
-    assert a.dtype == pl.Float64
+    assert a.dtype == pl.Float32
     a = pl.Series("name", [])
-    assert a.dtype == pl.Float64
+    assert a.dtype == pl.Float32
     a = pl.Series(values=(), dtype=pl.Int8)
     assert a.dtype == pl.Int8
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -320,9 +320,9 @@ def test_empty():
     a = pl.Series(dtype=pl.Int8)
     assert a.dtype == pl.Int8
     a = pl.Series()
-    assert a.dtype == pl.Float32
+    assert a.dtype == pl.Float64
     a = pl.Series("name", [])
-    assert a.dtype == pl.Float32
+    assert a.dtype == pl.Float64
     a = pl.Series(values=(), dtype=pl.Int8)
     assert a.dtype == pl.Int8
 


### PR DESCRIPTION
Following up on #1017, and related to issue #1011, this PR is a refactor of the Series constructor.

Changes:
* Moved Series construction logic to `construction.py`.
* Added some type conversion utils to `datatypes.py` for use in Series construction
* Deprecated `Series.from_arrow`. Usage of `pl.from_arrow` is encouraged, which calls `Series._from_arrow`.
* ~~Default dtype for a Series of an empty sequence is now Float64 instead of Float32; which is consistent with the default type selected when constructing a Series for the Python built-in `float`.~~