### PR TITLE
Remove duplicate binary import warnings

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -21,7 +21,9 @@ try:
 
     __version__ = version()
 except ImportError:
-    pass
+    import warnings
+
+    warnings.warn("Polars binary files missing!", UserWarning, stacklevel=2)
 
 __all__ = (
     convert.__all__

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -1,4 +1,8 @@
 # flake8: noqa
+try:
+    from polars.polars import version
+except ImportError as e:
+    raise ImportError("Polars binary files missing!") from e
 
 # mypy needs these imported explicitly
 from polars.eager.frame import DataFrame, wrap_df
@@ -15,16 +19,6 @@ from .io import *
 from .lazy import *
 from .string_cache import *
 
-# during docs building the binary code is not yet available
-try:
-    from .polars import version
-
-    __version__ = version()
-except ImportError:
-    import warnings
-
-    warnings.warn("Polars binary files missing!", UserWarning, stacklevel=2)
-
 __all__ = (
     convert.__all__
     + datatypes.__all__
@@ -34,3 +28,5 @@ __all__ = (
     + lazy.__all__
     + string_cache.__all__
 )
+
+__version__ = version()

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -6,10 +6,7 @@ import numpy as np
 import pyarrow as pa
 from _ctypes import _SimpleCData
 
-try:
-    from polars.polars import PySeries
-except ImportError:
-    pass
+from polars.polars import PySeries
 
 __pdoc__ = {
     "dtype_to_ctype": False,

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -9,9 +9,7 @@ from _ctypes import _SimpleCData
 try:
     from polars.polars import PySeries
 except ImportError:
-    import warnings
-
-    warnings.warn("binary files missing")
+    pass
 
 __pdoc__ = {
     "dtype_to_ctype": False,

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -8,13 +8,6 @@ from _ctypes import _SimpleCData
 
 from polars.polars import PySeries
 
-__pdoc__ = {
-    "dtype_to_ctype": False,
-    "dtype_to_int": False,
-    "dtype_to_primitive": False,
-    "pytype_to_polars_type": False,
-}
-
 __all__ = [
     "DataType",
     "Int8",

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -34,15 +34,11 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
+from polars.polars import PyDataFrame, PySeries
 
 from .._html import NotebookFormatter
 from ..datatypes import DTYPES, Boolean, DataType, UInt32, pytype_to_polars_type
 from ..utils import _process_null_values
-
-try:
-    from polars.polars import PyDataFrame, PySeries
-except ImportError:
-    pass
 
 try:
     import pandas as pd

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -40,9 +40,9 @@ from ..datatypes import DTYPES, Boolean, DataType, UInt32, pytype_to_polars_type
 from ..utils import _process_null_values
 
 try:
-    from ..polars import PyDataFrame, PySeries
+    from polars.polars import PyDataFrame, PySeries
 except ImportError:
-    warnings.warn("binary files missing")
+    pass
 
 try:
     import pandas as pd

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -40,11 +40,8 @@ from ..datatypes import (
 from ..utils import _ptr_to_numpy
 
 try:
-    from ..polars import PyDataFrame, PySeries
+    from polars.polars import PyDataFrame, PySeries
 except ImportError:
-    import warnings
-
-    warnings.warn("binary files missing")
     __pdoc__ = {
         "wrap_s": False,
         "find_first_non_none": False,

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -13,6 +13,7 @@ from polars.internals.construction import (
     sequence_to_pyseries,
     series_to_pyseries,
 )
+from polars.polars import PyDataFrame, PySeries
 
 from ..datatypes import (
     DTYPE_TO_FFINAME,
@@ -39,16 +40,13 @@ from ..datatypes import (
 )
 from ..utils import _ptr_to_numpy
 
-try:
-    from polars.polars import PyDataFrame, PySeries
-except ImportError:
-    __pdoc__ = {
-        "wrap_s": False,
-        "find_first_non_none": False,
-        "out_to_dtype": False,
-        "get_ffi_func": False,
-        "SeriesIter": False,
-    }
+__pdoc__ = {
+    "wrap_s": False,
+    "find_first_non_none": False,
+    "out_to_dtype": False,
+    "get_ffi_func": False,
+    "SeriesIter": False,
+}
 
 __all__ = [
     "Series",

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -40,14 +40,6 @@ from ..datatypes import (
 )
 from ..utils import _ptr_to_numpy
 
-__pdoc__ = {
-    "wrap_s": False,
-    "find_first_non_none": False,
-    "out_to_dtype": False,
-    "get_ffi_func": False,
-    "SeriesIter": False,
-}
-
 __all__ = [
     "Series",
 ]

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -21,7 +21,7 @@ from polars.utils import coerce_arrow
 try:
     from polars.polars import PyDataFrame, PySeries
 except ImportError:
-    warnings.warn("binary files missing")
+    pass
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -16,12 +16,8 @@ from polars.datatypes import (
     py_type_to_arrow_type,
     py_type_to_constructor,
 )
+from polars.polars import PyDataFrame, PySeries
 from polars.utils import coerce_arrow
-
-try:
-    from polars.polars import PyDataFrame, PySeries
-except ImportError:
-    pass
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -3,14 +3,12 @@ from datetime import datetime
 from typing import Any, Callable, Optional, Sequence, Type, Union
 
 import polars as pl
+from polars.polars import PyExpr
 
 from ..datatypes import Boolean, DataType, Date32, Date64, Float64, Int64, Utf8
 from .functions import UDF, col, lit
 
-try:
-    from polars.polars import PyExpr
-except ImportError:
-    __pdoc__ = {"wrap_expr": False}
+__pdoc__ = {"wrap_expr": False}
 
 __all__ = [
     "Expr",

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -8,11 +8,8 @@ from ..datatypes import Boolean, DataType, Date32, Date64, Float64, Int64, Utf8
 from .functions import UDF, col, lit
 
 try:
-    from ..polars import PyExpr
+    from polars.polars import PyExpr
 except ImportError:
-    import warnings
-
-    warnings.warn("Binary files missing.")
     __pdoc__ = {"wrap_expr": False}
 
 __all__ = [

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -8,8 +8,6 @@ from polars.polars import PyExpr
 from ..datatypes import Boolean, DataType, Date32, Date64, Float64, Int64, Utf8
 from .functions import UDF, col, lit
 
-__pdoc__ = {"wrap_expr": False}
-
 __all__ = [
     "Expr",
     "ExprStringNameSpace",

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -15,8 +15,6 @@ from ..datatypes import DataType, pytype_to_polars_type
 from ..utils import _process_null_values
 from .expr import UDF, Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
 
-__pdoc__ = {"wrap_ldf": False}
-
 __all__ = [
     "LazyFrame",
 ]

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -15,11 +15,8 @@ from ..utils import _process_null_values
 from .expr import UDF, Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
 
 try:
-    from ..polars import PyExpr, PyLazyFrame, PyLazyGroupBy
+    from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
 except ImportError:
-    import warnings
-
-    warnings.warn("Binary files missing.")
     __pdoc__ = {"wrap_ldf": False}
 
 __all__ = [

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -9,15 +9,13 @@ import typing as tp
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
 
 import polars as pl
+from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
 
 from ..datatypes import DataType, pytype_to_polars_type
 from ..utils import _process_null_values
 from .expr import UDF, Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
 
-try:
-    from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
-except ImportError:
-    __pdoc__ = {"wrap_ldf": False}
+__pdoc__ = {"wrap_ldf": False}
 
 __all__ = [
     "LazyFrame",

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -9,20 +9,18 @@ import polars as pl
 from ..datatypes import DataType, Date64, Int64
 
 try:
-    from ..polars import argsort_by as pyargsort_by
-    from ..polars import binary_function as pybinary_function
-    from ..polars import col as pycol
-    from ..polars import concat_str as _concat_str
-    from ..polars import cov as pycov
-    from ..polars import except_ as pyexcept
-    from ..polars import fold as pyfold
-    from ..polars import lit as pylit
-    from ..polars import pearson_corr as pypearson_corr
-    from ..polars import series_from_range as _series_from_range
+    from polars.polars import argsort_by as pyargsort_by
+    from polars.polars import binary_function as pybinary_function
+    from polars.polars import col as pycol
+    from polars.polars import concat_str as _concat_str
+    from polars.polars import cov as pycov
+    from polars.polars import except_ as pyexcept
+    from polars.polars import fold as pyfold
+    from polars.polars import lit as pylit
+    from polars.polars import pearson_corr as pypearson_corr
+    from polars.polars import series_from_range as _series_from_range
 except ImportError:
-    import warnings
-
-    warnings.warn("Binary files missing.")
+    pass
 
 __all__ = [
     "col",

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -5,22 +5,18 @@ from typing import Any, Callable, Optional, Type, Union
 import numpy as np
 
 import polars as pl
+from polars.polars import argsort_by as pyargsort_by
+from polars.polars import binary_function as pybinary_function
+from polars.polars import col as pycol
+from polars.polars import concat_str as _concat_str
+from polars.polars import cov as pycov
+from polars.polars import except_ as pyexcept
+from polars.polars import fold as pyfold
+from polars.polars import lit as pylit
+from polars.polars import pearson_corr as pypearson_corr
+from polars.polars import series_from_range as _series_from_range
 
 from ..datatypes import DataType, Date64, Int64
-
-try:
-    from polars.polars import argsort_by as pyargsort_by
-    from polars.polars import binary_function as pybinary_function
-    from polars.polars import col as pycol
-    from polars.polars import concat_str as _concat_str
-    from polars.polars import cov as pycov
-    from polars.polars import except_ as pyexcept
-    from polars.polars import fold as pyfold
-    from polars.polars import lit as pylit
-    from polars.polars import pearson_corr as pypearson_corr
-    from polars.polars import series_from_range as _series_from_range
-except ImportError:
-    pass
 
 __all__ = [
     "col",

--- a/py-polars/polars/lazy/whenthen.py
+++ b/py-polars/polars/lazy/whenthen.py
@@ -5,11 +5,9 @@ import polars as pl
 from .expr import expr_to_lit_or_expr
 
 try:
-    from ..polars import when as pywhen
+    from polars.polars import when as pywhen
 except ImportError:
-    import warnings
-
-    warnings.warn("Binary files missing.")
+    pass
 
 __all__ = ["when"]
 

--- a/py-polars/polars/lazy/whenthen.py
+++ b/py-polars/polars/lazy/whenthen.py
@@ -1,13 +1,9 @@
 from typing import Any, Union
 
 import polars as pl
+from polars.polars import when as pywhen
 
 from .expr import expr_to_lit_or_expr
-
-try:
-    from polars.polars import when as pywhen
-except ImportError:
-    pass
 
 __all__ = ["when"]
 

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -1,11 +1,7 @@
 from types import TracebackType
 from typing import Optional, Type
 
-try:
-    from polars.polars import toggle_string_cache as pytoggle_string_cache
-except ImportError:
-    pass
-
+from polars.polars import toggle_string_cache as pytoggle_string_cache
 
 __all__ = [
     "StringCache",

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -2,11 +2,9 @@ from types import TracebackType
 from typing import Optional, Type
 
 try:
-    from .polars import toggle_string_cache as pytoggle_string_cache
+    from polars.polars import toggle_string_cache as pytoggle_string_cache
 except ImportError:
-    import warnings
-
-    warnings.warn("binary files missing")
+    pass
 
 
 __all__ = [


### PR DESCRIPTION
I noticed we have a warning at every attempt at importing stuff from the Polars binaries, so when importing polars you'd get 10 of the same warnings right away. One warning is enough, I'd say. I added it in the top `__init__`, removed the others.

I also changed the relative imports of the binaries to absolute imports. It's error prone to have to specify the relative path, `from polars.polars import ...` always works.

I did also notice that when binary files are missing, `datatypes.py` now gives an error because of the global type maps to Pyseries constructor. Any suggestions on how to fix this? I thought we could just raise an ImportError if importing the binary fails; I mean, none of the functionality will work anyway...

```
>>> import polars
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stijn/code/polars/py-polars/polars/__init__.py", line 4, in <module>
    from polars.eager.frame import DataFrame, wrap_df
  File "/home/stijn/code/polars/py-polars/polars/eager/__init__.py", line 2, in <module>
    from . import frame, series
  File "/home/stijn/code/polars/py-polars/polars/eager/frame.py", line 29, in <module>
    from polars.internals.construction import (
  File "/home/stijn/code/polars/py-polars/polars/internals/construction.py", line 9, in <module>
    from polars.datatypes import (
  File "/home/stijn/code/polars/py-polars/polars/datatypes.py", line 284, in <module>
    Float32: PySeries.new_opt_f32,
NameError: name 'PySeries' is not defined
```