### PR TITLE
Make groupby on objects possible 

### DIFF
--- a/polars/polars-core/src/chunked_array/object/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/mod.rs
@@ -6,9 +6,11 @@ pub use crate::prelude::*;
 use crate::utils::arrow::array::ArrayData;
 use arrow::array::{Array, ArrayRef, BooleanBufferBuilder, JsonEqual};
 use arrow::bitmap::Bitmap;
+use polars_arrow::is_valid::IsValid;
 use serde_json::Value;
 use std::any::Any;
 use std::fmt::{Debug, Display};
+use std::hash::Hash;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -23,7 +25,9 @@ where
     pub(crate) len: usize,
 }
 
-pub trait PolarsObject: Any + Debug + Clone + Send + Sync + Default + Display {
+pub trait PolarsObject:
+    Any + Debug + Clone + Send + Sync + Default + Display + Hash + PartialEq + Eq
+{
     fn type_name() -> &'static str;
 }
 
@@ -49,6 +53,28 @@ where
     /// the size of the array.
     pub unsafe fn value_unchecked(&self, index: usize) -> &T {
         self.values.get_unchecked(index)
+    }
+
+    /// Check validity
+    ///
+    /// # Safety
+    /// No bounds checks
+    #[inline]
+    pub unsafe fn is_valid_unchecked(&self, i: usize) -> bool {
+        if let Some(b) = &self.null_bitmap {
+            b.buffer_ref().is_valid_unchecked(self.offset + i)
+        } else {
+            true
+        }
+    }
+
+    /// Check validity
+    ///
+    /// # Safety
+    /// No bounds checks
+    #[inline]
+    pub unsafe fn is_null_unchecked(&self, i: usize) -> bool {
+        !self.is_valid_unchecked(i)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/polars/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -6,6 +6,8 @@ use crate::chunked_array::ops::take::take_random::{
     BoolTakeRandom, BoolTakeRandomSingleChunk, NumTakeRandomChunked, NumTakeRandomCont,
     NumTakeRandomSingleChunk, Utf8TakeRandom, Utf8TakeRandomSingleChunk,
 };
+#[cfg(feature = "object")]
+use crate::chunked_array::ops::take::take_random::{ObjectTakeRandom, ObjectTakeRandomSingleChunk};
 use crate::prelude::*;
 use std::cmp::{Ordering, PartialEq};
 
@@ -282,5 +284,48 @@ impl<'a> IntoPartialOrdInner<'a> for &'a ListChunked {
 impl<'a> IntoPartialOrdInner<'a> for &'a CategoricalChunked {
     fn into_partial_ord_inner(self) -> Box<dyn PartialOrdInner> {
         unimplemented!()
+    }
+}
+
+#[cfg(feature = "object")]
+impl<'a, T> PartialEqInner for ObjectTakeRandom<'a, T>
+where
+    T: PolarsObject,
+{
+    #[inline]
+    unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool {
+        self.get(idx_a) == self.get(idx_b)
+    }
+}
+
+#[cfg(feature = "object")]
+impl<'a, T> PartialEqInner for ObjectTakeRandomSingleChunk<'a, T>
+where
+    T: PolarsObject,
+{
+    #[inline]
+    unsafe fn eq_element_unchecked(&self, idx_a: usize, idx_b: usize) -> bool {
+        self.get(idx_a) == self.get(idx_b)
+    }
+}
+
+#[cfg(feature = "object")]
+impl<'a, T: PolarsObject> IntoPartialEqInner<'a> for &'a ObjectChunked<T> {
+    fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a> {
+        match self.chunks.len() {
+            1 => {
+                let arr = self.downcast_iter().next().unwrap();
+                let t = ObjectTakeRandomSingleChunk { arr };
+                Box::new(t)
+            }
+            _ => {
+                let chunks = self.downcast_chunks();
+                let t = ObjectTakeRandom {
+                    chunks,
+                    chunk_lens: self.chunks.iter().map(|a| a.len() as u32).collect(),
+                };
+                Box::new(t)
+            }
+        }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/take/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/mod.rs
@@ -21,6 +21,7 @@ use crate::chunked_array::kernels::take::{
     take_utf8_opt_iter_unchecked, take_utf8_unchecked,
 };
 use crate::prelude::*;
+use crate::utils::NoNull;
 
 mod take_every;
 pub(crate) mod take_random;
@@ -354,14 +355,24 @@ impl ChunkTake for ListChunked {
             }
             // todo! fast path for single chunk
             TakeIdx::Iter(iter) => {
-                let mut ca: ListChunked = take_iter_n_chunks_unchecked!(self, iter);
-                ca.rename(self.name());
-                ca
+                if self.chunks.len() == 1 {
+                    let idx: NoNull<UInt32Chunked> = iter.map(|v| v as u32).collect();
+                    self.take_unchecked((&idx.into_inner()).into())
+                } else {
+                    let mut ca: ListChunked = take_iter_n_chunks_unchecked!(self, iter);
+                    ca.rename(self.name());
+                    ca
+                }
             }
             TakeIdx::IterNulls(iter) => {
-                let mut ca: ListChunked = take_opt_iter_n_chunks_unchecked!(self, iter);
-                ca.rename(self.name());
-                ca
+                if self.chunks.len() == 1 {
+                    let idx: UInt32Chunked = iter.map(|v| v.map(|v| v as u32)).collect();
+                    self.take_unchecked((&idx).into())
+                } else {
+                    let mut ca: ListChunked = take_opt_iter_n_chunks_unchecked!(self, iter);
+                    ca.rename(self.name());
+                    ca
+                }
             }
         }
     }

--- a/polars/polars-core/src/chunked_array/ops/take/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_random.rs
@@ -444,8 +444,8 @@ impl<'a> TakeRandom for ListTakeRandomSingleChunk<'a> {
 
 #[cfg(feature = "object")]
 pub struct ObjectTakeRandom<'a, T: PolarsObject> {
-    chunks: Vec<&'a ObjectArray<T>>,
-    chunk_lens: Vec<u32>,
+    pub(crate) chunks: Chunks<'a, ObjectArray<T>>,
+    pub(crate) chunk_lens: Vec<u32>,
 }
 
 #[cfg(feature = "object")]
@@ -465,7 +465,7 @@ impl<'a, T: PolarsObject> TakeRandom for ObjectTakeRandom<'a, T> {
 
 #[cfg(feature = "object")]
 pub struct ObjectTakeRandomSingleChunk<'a, T: PolarsObject> {
-    arr: &'a ObjectArray<T>,
+    pub(crate) arr: &'a ObjectArray<T>,
 }
 
 #[cfg(feature = "object")]
@@ -493,15 +493,15 @@ impl<'a, T: PolarsObject> IntoTakeRandom<'a> for &'a ObjectChunked<T> {
     type TakeRandom = TakeRandBranch2<ObjectTakeRandomSingleChunk<'a, T>, ObjectTakeRandom<'a, T>>;
 
     fn take_rand(&self) -> Self::TakeRandom {
-        let mut chunks = self.downcast_iter();
+        let chunks = self.downcast_chunks();
         if self.chunks.len() == 1 {
             let t = ObjectTakeRandomSingleChunk {
-                arr: chunks.next().unwrap(),
+                arr: chunks.get(0).unwrap(),
             };
             TakeRandBranch2::Single(t)
         } else {
             let t = ObjectTakeRandom {
-                chunks: chunks.collect(),
+                chunks,
                 chunk_lens: self.chunks.iter().map(|a| a.len() as u32).collect(),
             };
             TakeRandBranch2::Multi(t)

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -171,7 +171,14 @@ impl IntoGroupTuples for CategoricalChunked {
 
 impl IntoGroupTuples for ListChunked {}
 #[cfg(feature = "object")]
-impl<T> IntoGroupTuples for ObjectChunked<T> {}
+impl<T> IntoGroupTuples for ObjectChunked<T>
+where
+    T: PolarsObject,
+{
+    fn group_tuples(&self, _multithreaded: bool) -> GroupTuples {
+        groupby(self.into_iter())
+    }
+}
 
 /// Used to tightly two 32 bit values and null information
 /// Only the bit values matter, not the meaning of the bits

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -1,8 +1,11 @@
+use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::chunked_array::ChunkIdIter;
 use crate::fmt::FmtList;
+use crate::frame::groupby::{GroupTuples, IntoGroupTuples};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
+use ahash::RandomState;
 use arrow::array::{ArrayData, ArrayRef};
 use arrow::buffer::Buffer;
 use std::any::Any;
@@ -33,6 +36,21 @@ where
             None => Cow::Borrowed("null"),
             Some(val) => Cow::Owned(format!("{}", val)),
         }
+    }
+    fn into_partial_eq_inner<'a>(&'a self) -> Box<dyn PartialEqInner + 'a> {
+        (&self.0).into_partial_eq_inner()
+    }
+
+    fn vec_hash(&self, random_state: RandomState) -> AlignedVec<u64> {
+        self.0.vec_hash(random_state)
+    }
+
+    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) {
+        self.0.vec_hash_combine(build_hasher, hashes)
+    }
+
+    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
+        IntoGroupTuples::group_tuples(&self.0, multithreaded)
     }
 }
 #[cfg(feature = "object")]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.8.13-beta.1"
+version = "0.8.14"
 dependencies = [
  "ahash",
  "libc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.8.13-beta.1"
+version = "0.8.14"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -579,7 +579,8 @@ class Expr:
         return_dtype: Optional[Type[DataType]] = None,
     ) -> "Expr":
         """
-        Apply a custom UDF. It is important that the UDF returns a Polars Series.
+        Apply a custom python function. This function must produce a `Series`. Any other value will be stored as
+        null/missing. If you want to apply a function over single values, consider using `apply`.
 
         [read more in the book](https://ritchie46.github.io/polars-book/how_can_i/use_custom_functions.html#lazy)
 
@@ -605,12 +606,22 @@ class Expr:
 
     def apply(
         self,
-        f: Callable[["pl.Series"], "pl.Series"],
+        f: Union[Callable[["pl.Series"], "pl.Series"], Callable[[Any], Any]],
         return_dtype: Optional[Type[DataType]] = None,
     ) -> "Expr":
         """
-        Apply a custom UDF in a GroupBy context. This is syntactic sugar for the `apply` method which operates on all
-        groups at once. The UDF passed to this expression will operate on a single group.
+        Apply a custom function in a GroupBy or Projection context.
+
+        Depending on the context it has the following behavior:
+
+        ## Context
+
+        * Select/Project
+            expected type `f`: Callable[[Any], Any]
+            Applies a python function over each individual value in the column.
+        * GroupBy
+            expected type `f`: Callable[[Series], Series]
+            Applies a python function over each group.
 
         Parameters
         ----------

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -516,10 +516,10 @@ impl PyDataFrame {
         }
     }
 
-    pub fn take(&self, indices: Vec<usize>) -> PyResult<Self> {
+    pub fn take(&self, indices: Vec<u32>) -> PyResult<Self> {
         let df = self
             .df
-            .take_iter(indices.iter().copied())
+            .take_iter(indices.iter().map(|i| *i as usize))
             .map_err(PyPolarsEr::from)?;
         Ok(PyDataFrame::new(df))
     }

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -952,3 +952,13 @@ def test_hash_rows():
     assert df.hash_rows().dtype == pl.UInt64
     assert df["a"].hash().dtype == pl.UInt64
     assert df[[col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64
+
+
+def test_hashing_on_python_objects():
+    # see if we can do a groupby, drop_duplicates on a DataFrame with objects.
+    # this requires that the hashing and aggregations are done on python objects
+
+    df = pl.DataFrame({"a": [1, 1, 3, 4], "b": [1, 1, 2, 2]})
+    df = df.with_column(col("a").apply(lambda x: datetime(2021, 1, 1)).alias("foo"))
+    assert df.groupby(["foo"]).first().shape == (1, 3)
+    assert df.drop_duplicates().shape == (3, 3)


### PR DESCRIPTION
This allows grouping on `PolarsObject` types, for python this means a `groupby` or a `drop_duplicates` is possible when you have objects in the DataFrame.