### PR TITLE
make AnyValue::Object printable

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -600,12 +600,12 @@ where
                 let s = Series::try_from(("", v));
                 AnyValue::List(s.unwrap())
             }
-            #[cfg(feature = "object")]
-            DataType::Object(_) => AnyValue::Object("object"),
             DataType::Categorical => {
                 let v = downcast!(UInt32Array);
                 AnyValue::Utf8(self.categorical_map.as_ref().expect("should be set").get(v))
             }
+            #[cfg(feature = "object")]
+            DataType::Object(_) => panic!("should not be here"),
             _ => unimplemented!(),
         }
     }

--- a/polars/polars-core/src/chunked_array/object/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/mod.rs
@@ -25,10 +25,25 @@ where
     pub(crate) len: usize,
 }
 
+/// Trimmed down object safe polars object
+pub trait PolarsObjectSafe: Any + Debug + Send + Sync + Display {
+    fn type_name(&self) -> &'static str
+    where
+        Self: Sized;
+}
+
+/// Values need to implement this so that they can be stored into a Series and DataFrame
 pub trait PolarsObject:
     Any + Debug + Clone + Send + Sync + Default + Display + Hash + PartialEq + Eq
 {
+    /// This should be used as type information. Consider this a part of the type system.
     fn type_name() -> &'static str;
+}
+
+impl<T: PolarsObject> PolarsObjectSafe for T {
+    fn type_name(&self) -> &'static str {
+        T::type_name()
+    }
 }
 
 impl<T> ObjectArray<T>
@@ -166,14 +181,28 @@ impl<T> ObjectChunked<T>
 where
     T: PolarsObject,
 {
+    /// Get a hold to an object that can be formatted or downcasted via the Any trait.
     ///
     /// # Safety
     ///
     /// No bounds checks
-    pub unsafe fn get_as_any(&self, index: usize) -> &dyn Any {
+    pub unsafe fn get_object_unchecked(&self, index: usize) -> Option<&dyn PolarsObjectSafe> {
         let chunks = self.downcast_chunks();
         let (chunk_idx, idx) = self.index_to_chunked_index(index);
         let arr = chunks.get_unchecked(chunk_idx);
-        arr.value(idx)
+        if arr.is_valid_unchecked(idx) {
+            Some(arr.value(idx))
+        } else {
+            None
+        }
+    }
+
+    /// Get a hold to an object that can be formatted or downcasted via the Any trait.
+    pub fn get_object(&self, index: usize) -> Option<&dyn PolarsObjectSafe> {
+        if index < self.len() {
+            unsafe { self.get_object_unchecked(index) }
+        } else {
+            None
+        }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -83,10 +83,16 @@ impl ChunkAnyValue for CategoricalChunked {
 impl<T: PolarsObject> ChunkAnyValue for ObjectChunked<T> {
     #[inline]
     unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {
-        get_any_value_unchecked!(self, index)
+        match self.get_object_unchecked(index) {
+            None => AnyValue::Null,
+            Some(v) => AnyValue::Object(v),
+        }
     }
 
     fn get_any_value(&self, index: usize) -> AnyValue {
-        get_any_value!(self, index)
+        match self.get_object(index) {
+            None => AnyValue::Null,
+            Some(v) => AnyValue::Object(v),
+        }
     }
 }

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -6,6 +6,8 @@
 //! [See the AnyValue variants](enum.AnyValue.html#variants) for the data types that
 //! are currently supported.
 //!
+#[cfg(feature = "object")]
+use crate::chunked_array::object::PolarsObjectSafe;
 use crate::prelude::*;
 use ahash::RandomState;
 pub use arrow::datatypes::DataType as ArrowDataType;
@@ -230,8 +232,8 @@ pub enum AnyValue<'a> {
     /// Nested type, contains arrays that are filled with one of the datetypes.
     List(Series),
     #[cfg(feature = "object")]
-    /// Use as_any to get a dyn Any
-    Object(&'a str),
+    /// Can be used to fmt and implements Any, so can be downcasted to the proper value type.
+    Object(&'a dyn PolarsObjectSafe),
 }
 
 impl From<f64> for AnyValue<'_> {

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -1,4 +1,5 @@
 use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
+use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ChunkIdIter;
 use crate::fmt::FmtList;
 use crate::frame::groupby::{GroupTuples, IntoGroupTuples};
@@ -258,9 +259,8 @@ where
         ObjectChunked::sample_frac(&self.0, frac, with_replacement).map(|ca| ca.into_series())
     }
 
-    fn get_as_any(&self, index: usize) -> &dyn Any {
-        debug_assert!(index < self.0.len());
-        unsafe { ObjectChunked::get_as_any(&self.0, index) }
+    fn get_object(&self, index: usize) -> Option<&dyn PolarsObjectSafe> {
+        ObjectChunked::<T>::get_object(&self.0, index)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -7,6 +7,8 @@ mod comparison;
 pub mod implementations;
 pub(crate) mod iterator;
 
+#[cfg(feature = "object")]
+use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::{builder::get_list_builder, ChunkIdIter};
 #[cfg(feature = "groupby_list")]
 use crate::utils::Wrap;
@@ -19,6 +21,7 @@ use arrow::compute::cast;
 use itertools::Itertools;
 use num::NumCast;
 use rayon::prelude::*;
+#[cfg(feature = "object")]
 use std::any::Any;
 use std::convert::TryFrom;
 #[cfg(feature = "groupby_list")]
@@ -1005,14 +1008,17 @@ pub trait SeriesTrait:
     /// Sample a fraction between 0.0-1.0 of this ChunkedArray.
     fn sample_frac(&self, frac: f64, with_replacement: bool) -> Result<Series>;
 
+    #[cfg(feature = "object")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "object")))]
     /// Get the value at this index as a downcastable Any trait ref.
-    fn get_as_any(&self, _index: usize) -> &dyn Any {
+    fn get_object(&self, _index: usize) -> Option<&dyn PolarsObjectSafe> {
         unimplemented!()
     }
 
     /// Get a hold to self as `Any` trait reference.
     /// Only implemented for ObjectType
     #[cfg(feature = "object")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "object")))]
     fn as_any(&self) -> &dyn Any {
         unimplemented!()
     }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -1,6 +1,7 @@
 use crate::error::PyPolarsEr;
 use crate::prelude::*;
 use crate::series::PySeries;
+use polars::chunked_array::object::PolarsObjectSafe;
 use polars::frame::row::Row;
 use polars::prelude::AnyValue;
 use pyo3::basic::CompareOp;
@@ -8,7 +9,6 @@ use pyo3::conversion::{FromPyObject, IntoPy};
 use pyo3::prelude::*;
 use pyo3::types::PySequence;
 use pyo3::{PyAny, PyResult};
-use std::any::Any;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
@@ -134,7 +134,10 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
                     .unwrap();
                 python_series_wrapper.into()
             }
-            AnyValue::Object(v) => v.into_py(py),
+            AnyValue::Object(v) => {
+                let s = format!("{}", v);
+                s.into_py(py)
+            }
         }
     }
 }
@@ -244,9 +247,9 @@ impl<'a> FromPyObject<'a> for ObjectValue {
 /// # Safety
 ///
 /// The caller is responsible for checking that val is Object otherwise UB
-impl From<&dyn Any> for &ObjectValue {
-    fn from(val: &dyn Any) -> Self {
-        unsafe { &*(val as *const dyn Any as *const ObjectValue) }
+impl From<&dyn PolarsObjectSafe> for &ObjectValue {
+    fn from(val: &dyn PolarsObjectSafe) -> Self {
+        unsafe { &*(val as *const dyn PolarsObjectSafe as *const ObjectValue) }
     }
 }
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -238,8 +238,7 @@ impl PyDataFrame {
             py,
             self.df.get_columns().iter().map(|s| match s.dtype() {
                 DataType::Object(_) => {
-                    let any = s.get_as_any(idx);
-                    let obj: &ObjectValue = any.into();
+                    let obj: Option<&ObjectValue> = s.get_object(idx).map(|any| any.into());
                     obj.to_object(py)
                 }
                 _ => Wrap(s.get(idx)).into_py(py),
@@ -260,8 +259,7 @@ impl PyDataFrame {
                     py,
                     self.df.get_columns().iter().map(|s| match s.dtype() {
                         DataType::Object(_) => {
-                            let any = s.get_as_any(idx);
-                            let obj: &ObjectValue = any.into();
+                            let obj: Option<&ObjectValue> = s.get_object(idx).map(|any| any.into());
                             obj.to_object(py)
                         }
                         _ => Wrap(s.get(idx)).into_py(py),

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -191,9 +191,7 @@ impl PySeries {
         let gil = Python::acquire_gil();
         let python = gil.python();
         if matches!(self.series.dtype(), DataType::Object(_)) {
-            // we don't use the null bitmap in this context as T::default is pyobject None
-            let any = self.series.get_as_any(index);
-            let obj: &ObjectValue = any.into();
+            let obj: Option<&ObjectValue> = self.series.get_object(index).map(|any| any.into());
             obj.to_object(python)
         } else {
             python.None()
@@ -557,11 +555,8 @@ impl PySeries {
             DataType::Object(_) => {
                 let v = PyList::empty(python);
                 for i in 0..series.len() {
-                    let val = series
-                        .get_as_any(i)
-                        .downcast_ref::<ObjectValue>()
-                        .map(|obj| obj.inner.clone())
-                        .unwrap_or_else(|| python.None());
+                    let obj: Option<&ObjectValue> = self.series.get_object(i).map(|any| any.into());
+                    let val = obj.to_object(python);
 
                     v.append(val).unwrap();
                 }


### PR DESCRIPTION
This allows the `AnyValue` to return a trait object to the `PolarsObject` type, this can be used to 

* format, convert to String using `Display` and `Debug`
* Convert to concrete type via `Any`
* Get static type str, via `type_name` (useful to know how to downcast)