### PR TITLE
fix bug in take_unchecked

### DIFF
--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -36,7 +36,7 @@ pub(crate) unsafe fn take_primitive_unchecked<T: PolarsNumericType>(
     // in later checks
     // this is in the assumption that most values will be valid.
     // Maybe we could add another branch based on the null count
-    let num_bytes = indices.len() * std::mem::size_of::<i32>() / 8;
+    let num_bytes = bit_util::ceil(indices.len(), 8);
     let mut validity = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
     let validity_slice = validity.as_slice_mut();
 

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1550,4 +1550,27 @@ mod test {
         right.inner_join(&left, "key", "key").unwrap();
         right.outer_join(&left, "key", "key").unwrap();
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn unit_df_join() -> Result<()> {
+        let df1 = df![
+            "a" => [1],
+            "b" => [2]
+        ]?;
+
+        let df2 = df![
+            "a" => [1, 2, 3, 4],
+            "b" => [Some(1), None, Some(3), Some(4)]
+        ]?;
+
+        let out = df1.left_join(&df2, "a", "a")?;
+        let expected = df![
+            "a" => [1],
+            "b" => [2],
+            "b_right" => [1]
+        ]?;
+        assert!(out.frame_equal(&expected));
+        Ok(())
+    }
 }

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -962,3 +962,8 @@ def test_hashing_on_python_objects():
     df = df.with_column(col("a").apply(lambda x: datetime(2021, 1, 1)).alias("foo"))
     assert df.groupby(["foo"]).first().shape == (1, 3)
     assert df.drop_duplicates().shape == (3, 3)
+
+
+def test_drop_duplicates_unit_rows():
+    # simply test if we don't panic.
+    pl.DataFrame({"a": [1], "b": [None]}).drop_duplicates(subset="a")


### PR DESCRIPTION
The null buffer's size was incorrectly set.
This lead to a too small null buffer in case
of small DataFrames (anything lower than 8 rows).

Fixes #1076 and #1077 