### PR TITLE
Convert dictionary encoded arrow arrays to large Utf8.

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -32,9 +32,9 @@ def coerce_arrow(array: pa.Array) -> pa.Array:
 
     # simplest solution is to cast to (large)-string arrays
     # this is copy and expensive
-    elif isinstance(array, pa.DictionaryArray):
-        if array.dictionary.type == pa.string():
-            array = pa.compute.cast(pa.compute.cast(array, pa.utf8()), pa.large_utf8())
+    elif isinstance(array.type, pa.DictionaryType):
+        if pa.types.is_string(array.type.value_type):
+            array = pa.compute.cast(array, pa.large_utf8())
         else:
             raise ValueError(
                 "polars does not support dictionary encoded types other than strings"

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -1,5 +1,6 @@
 import datetime
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 
@@ -31,3 +32,17 @@ def test_from_pandas_datetime():
 def test_arrow_list_roundtrip():
     # https://github.com/pola-rs/polars/issues/1064
     pl.from_arrow(pa.table({"a": [1], "b": [[1, 2]]})).to_arrow()
+
+
+def test_arrow_dict_to_polars():
+    pa_dict = pa.DictionaryArray.from_arrays(
+        indices=np.array([0, 1, 2, 3, 1, 0, 2, 3, 3, 2]),
+        dictionary=np.array(["AAA", "BBB", "CCC", "DDD"]),
+    ).cast(pa.large_utf8())
+
+    s = pl.Series(
+        name="s",
+        values=["AAA", "BBB", "CCC", "DDD", "BBB", "AAA", "CCC", "DDD", "DDD", "CCC"],
+    )
+
+    assert s.series_equal(pl.Series("pa_dict", pa_dict))


### PR DESCRIPTION
Convert dictionary encoded arrow arrays to large Utf8.

The old code that checked for a dictionary encode arrow array was
never true (probably because the array is a pyarrow.lib.ChunkedArray).

Test case:

   pd_df_with_categorical = pd.DataFrame({'a': pd.Categorical(['a', 'b', 'c', 'c', 'a', 'b']), 'b': [2, 6, 8, 1, 3, 6]})
   pl.DataFrame(pd_df_with_categorical)

Old code:

shape: (6, 2)
╭─────┬─────╮
│ a   ┆ b   │
│ --- ┆ --- │
│ i8  ┆ i64 │
╞═════╪═════╡
│ 0   ┆ 2   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ 1   ┆ 6   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ 2   ┆ 8   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ 2   ┆ 1   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ 0   ┆ 3   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ 1   ┆ 6   │
╰─────┴─────╯

New code:

shape: (6, 2)
╭─────┬─────╮
│ a   ┆ b   │
│ --- ┆ --- │
│ str ┆ i64 │
╞═════╪═════╡
│ "a" ┆ 2   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ "b" ┆ 6   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ "c" ┆ 8   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ "c" ┆ 1   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ "a" ┆ 3   │
├╌╌╌╌╌┼╌╌╌╌╌┤
│ "b" ┆ 6   │
╰─────┴─────╯