### PR TITLE
Categorical type append

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -154,9 +154,9 @@ docs-selection = [
 ]
 
 [dependencies]
-polars-core = {version = "0.15.0", path = "./polars-core", features= ["docs", "private"], default-features = false}
-polars-io = {version = "0.15.0", path = "./polars-io", features = ["private"], default-features = false, optional=true}
-polars-lazy = {version = "0.15.0", path = "./polars-lazy", features=["private"], default-features = false, optional=true}
+polars-core = {version = "0.15.1", path = "./polars-core", features= ["docs", "private"], default-features = false}
+polars-io = {version = "0.15.1", path = "./polars-io", features = ["private"], default-features = false, optional=true}
+polars-lazy = {version = "0.15.1", path = "./polars-lazy", features=["private"], default-features = false, optional=true}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-arrow"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-core"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -112,7 +112,7 @@ docs-selection = [
 arrow = {version = "5.0", default-features = false }
 #parquet = {optional = true, git = "https://github.com/apache/arrow-rs", rev = "a1aace846f29dc4346b01289cad246dd99c2e3ed"}
 parquet = {version = "5.0", default-features = false, optional = true }
-polars-arrow = {version = "0.15.0", path = "../polars-arrow"}
+polars-arrow = {version = "0.15.1", path = "../polars-arrow"}
 thiserror = "1.0"
 num = "^0.4"
 itertools = "0.10"

--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -191,17 +191,15 @@ mod test {
     fn test_categorical_rev() -> Result<()> {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        let ca = Utf8Chunked::new_from_opt_slice(
-            "a",
-            &[
-                Some("foo"),
-                None,
-                Some("bar"),
-                Some("foo"),
-                Some("foo"),
-                Some("bar"),
-            ],
-        );
+        let slice = &[
+            Some("foo"),
+            None,
+            Some("bar"),
+            Some("foo"),
+            Some("foo"),
+            Some("bar"),
+        ];
+        let ca = Utf8Chunked::new_from_opt_slice("a", slice);
         let out = ca.cast::<CategoricalType>()?;
         assert_eq!(out.categorical_map.unwrap().len(), 2);
 
@@ -213,6 +211,14 @@ mod test {
         // full global cache
         let out = ca.cast::<CategoricalType>()?;
         assert_eq!(out.categorical_map.unwrap().len(), 2);
+
+        // Check that we don't panic if we append two categorical arrays
+        // build under the same string cache
+        // https://github.com/pola-rs/polars/issues/1115
+        let mut ca1 = Utf8Chunked::new_from_opt_slice("a", slice).cast::<CategoricalType>()?;
+        let ca2 = Utf8Chunked::new_from_opt_slice("a", slice).cast::<CategoricalType>()?;
+        ca1.append(&ca2);
+
         Ok(())
     }
 }

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-io"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -30,8 +30,8 @@ private = []
 arrow = {version = "5.0", default-features = false }
 #parquet_lib = {optional = true, package="parquet", git = "https://github.com/apache/arrow-rs", rev = "a1aace846f29dc4346b01289cad246dd99c2e3ed"}
 parquet_lib = {version = "5.0", package="parquet", optional = true}
-polars-core = {version = "0.15.0", path = "../polars-core", features = ["private"], default-features=false}
-polars-arrow = {version = "0.15.0", path = "../polars-arrow"}
+polars-core = {version = "0.15.1", path = "../polars-core", features = ["private"], default-features=false}
+polars-arrow = {version = "0.15.1", path = "../polars-arrow"}
 lexical = {version = "5.2", optional = true}
 num_cpus = "1.13.0"
 csv-core = {version = "0.1.10", optional=true}

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-lazy"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -50,9 +50,9 @@ rayon = "1.5"
 itertools = "0.10"
 regex = {version = "1.4", optional = true}
 
-polars-io = {version = "0.15.0", path = "../polars-io", features = ["lazy", "csv-file"], default-features=false}
-polars-core = {version = "0.15.0", path = "../polars-core", features = ["lazy", "private", "zip_with"], default-features=false}
-polars-arrow = {version = "0.15.0", path = "../polars-arrow"}
+polars-io = {version = "0.15.1", path = "../polars-io", features = ["lazy", "csv-file"], default-features=false}
+polars-core = {version = "0.15.1", path = "../polars-core", features = ["lazy", "private", "zip_with"], default-features=false}
+polars-arrow = {version = "0.15.1", path = "../polars-arrow"}
 # uncomment to have datafusion integration
 # when uncommenting we both need to point to the same arrow version
 # datafusion = {version="4.0.0-SNAPSHOT", git = "https://github.com/apache/arrow-datafusion", rev = "88222b7", default-features=false, optional=true}

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(feature = "private")]
 pub(crate) fn equal_aexprs(left: &[Node], right: &[Node], expr_arena: &Arena<AExpr>) -> bool {
     left.iter()
         .zip(right.iter())

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arrow",
  "num",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ahash",
  "itertools",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "ahash",
  "libc",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.8.18"
+version = "0.8.19"
 dependencies = [
  "ahash",
  "libc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.8.19"
+version = "0.8.20"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.8.18"
+version = "0.8.19"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -974,3 +974,14 @@ def test_hashing_on_python_objects():
 def test_drop_duplicates_unit_rows():
     # simply test if we don't panic.
     pl.DataFrame({"a": [1], "b": [None]}).drop_duplicates(subset="a")
+
+
+def test_panic():
+    # may contain some tests that yielded a panic in polars or arrow
+    # https://github.com/pola-rs/polars/issues/1110
+    a = pl.DataFrame(
+        {
+            "col1": ["a"] * 500 + ["b"] * 500,
+        }
+    )
+    a.filter(pl.col("col1") != "b")


### PR DESCRIPTION
Allows this example:

```python
pl.toggle_string_cache(True)
df1 = pl.DataFrame({"A":pl.Series(["a", "b", "c"]).cast(pl.Categorical)})
df2 = pl.DataFrame({"A":pl.Series(["a", "b"]).cast(pl.Categorical)})
df1.vstack(df2)
```
