### PR TITLE
Python: add pickling support (Fix binary serde)

### DIFF
--- a/polars/polars-core/src/serde/chunked_array.rs
+++ b/polars/polars-core/src/serde/chunked_array.rs
@@ -1,6 +1,6 @@
 use super::DeDataType;
 use crate::prelude::*;
-use serde::ser::SerializeStruct;
+use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 use std::cell::RefCell;
 
@@ -53,11 +53,11 @@ where
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("series", 3)?;
-        state.serialize_field("name", self.name())?;
+        let mut state = serializer.serialize_map(Some(3))?;
+        state.serialize_entry("name", self.name())?;
         let dtype: DeDataType = self.dtype().into();
-        state.serialize_field("datatype", &dtype)?;
-        state.serialize_field("values", &IterSer::new(self.into_iter()))?;
+        state.serialize_entry("datatype", &dtype)?;
+        state.serialize_entry("values", &IterSer::new(self.into_iter()))?;
         state.end()
     }
 }
@@ -72,11 +72,11 @@ macro_rules! impl_serialize {
             where
                 S: Serializer,
             {
-                let mut state = serializer.serialize_struct("series", 3)?;
-                state.serialize_field("name", self.name())?;
+                let mut state = serializer.serialize_map(Some(3))?;
+                state.serialize_entry("name", self.name())?;
                 let dtype: DeDataType = self.dtype().into();
-                state.serialize_field("datatype", &dtype)?;
-                state.serialize_field("values", &IterSer::new(self.into_iter()))?;
+                state.serialize_entry("datatype", &dtype)?;
+                state.serialize_entry("values", &IterSer::new(self.into_iter()))?;
                 state.end()
             }
         }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -109,6 +109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1117,7 @@ name = "py-polars"
 version = "0.8.20"
 dependencies = [
  "ahash",
+ "bincode",
  "libc",
  "mimalloc",
  "ndarray",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -24,6 +24,7 @@ ndarray = "0.15"
 mimalloc = { version = "*", default-features = false}
 serde_json = { version = "1", optional = true }
 ahash = "0.7"
+bincode = "1.3"
 
 # features are only there to enable building a slim binary for the benchmark in CI
 [features]

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -799,6 +799,12 @@ class DataFrame:
             [self.select_at_idx(i).to_numpy() for i in range(self.width)]
         ).T
 
+    def __getstate__(self):  # type: ignore
+        return self.get_columns()
+
+    def __setstate__(self, state):  # type: ignore
+        self._df = DataFrame(state)._df
+
     def __mul__(self, other: Any) -> "DataFrame":
         other = _prepare_other_arg(other)
         return wrap_df(self._df.mul(other._s))

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -263,6 +263,13 @@ class Series:
     def inner(self) -> "PySeries":
         return self._s
 
+    def __getstate__(self):  # type: ignore
+        return self._s.__getstate__()
+
+    def __setstate__(self, state):  # type: ignore
+        self._s = sequence_to_pyseries("", [], Float32)
+        self._s.__setstate__(state)
+
     def __str__(self) -> str:
         return self._s.as_str()
 

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -1,5 +1,6 @@
 import gzip
 import io
+import pickle
 import zlib
 
 import numpy as np
@@ -153,3 +154,14 @@ def test_empty_bytes():
     b = b""
     with pytest.raises(ValueError):
         pl.read_csv(b)
+
+
+def test_pickle():
+    a = pl.Series("a", [1, 2])
+    b = pickle.dumps(a)
+    out = pickle.loads(b)
+    assert a.series_equal(out)
+    df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
+    b = pickle.dumps(df)
+    out = pickle.loads(b)
+    assert df.frame_equal(out, null_equal=True)


### PR DESCRIPTION
This implements pickle for `Series` and `DataFrame`. The serialization method is `bincode` which seems to be fastest.

Does work on all types except `PolarsObject`.