### PR TITLE
python __copy__, __deepcopy__

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1840,6 +1840,12 @@ class DataFrame:
         """
         return wrap_df(self._df.clone())
 
+    def __copy__(self) -> "DataFrame":
+        return self.clone()
+
+    def __deepcopy__(self, memodict={}) -> "DataFrame":  # type: ignore
+        return self.clone()
+
     def get_columns(self) -> tp.List["pl.Series"]:
         """
         Get the DataFrame as a List of Series.

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1214,6 +1214,12 @@ class Series:
         """
         return wrap_s(self._s.clone())
 
+    def __copy__(self) -> "Series":  # type: ignore
+        return self.clone()
+
+    def __deepcopy__(self, memodict={}) -> "Series":  # type: ignore
+        return self.clone()
+
     def fill_none(self, strategy: str) -> "Series":
         """
         Fill null values with a filling strategy.

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -1,3 +1,4 @@
+import copy
 import gzip
 import io
 import pickle
@@ -165,3 +166,13 @@ def test_pickle():
     b = pickle.dumps(df)
     out = pickle.loads(b)
     assert df.frame_equal(out, null_equal=True)
+
+
+def test_copy():
+    df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
+    copy.copy(df).frame_equal(df, True)
+    copy.deepcopy(df).frame_equal(df, True)
+
+    a = pl.Series("a", [1, 2])
+    copy.copy(a).series_equal(a, True)
+    copy.deepcopy(a).series_equal(a, True)


### PR DESCRIPTION
This makes sure that python does not pickle the dataframe, series to implement a deep copy. All data is immutable so we can just increment a ref counter to deep copy.

closes #1120 