### PR TITLE
add flattened window expr. Also add flatten as alias for explode

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1668,6 +1668,7 @@ impl DataFrame {
 
     /// Hash and combine the row values
     #[cfg(feature = "row_hash")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "row_hash")))]
     pub fn hash_rows(&self, hasher_builder: Option<RandomState>) -> Result<UInt64Chunked> {
         let dfs = split_df(self, POOL.current_num_threads())?;
         let (cas, _) = df_rows_to_hashes_threaded(&dfs, hasher_builder);
@@ -1678,6 +1679,14 @@ impl DataFrame {
             acc_ca.append(&ca);
         }
         Ok(acc_ca.rechunk())
+    }
+
+    /// Aggregate the column horizontally to their max values
+    #[cfg(feature = "interpolate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "interpolate")))]
+    pub fn interpolate(&self) -> Self {
+        let columns = self.columns.par_iter().map(|s| s.interpolate()).collect();
+        DataFrame::new_no_checks(columns)
     }
 }
 

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -76,7 +76,7 @@ pub fn argsort_by(by: Vec<Expr>, reverse: &[bool]) -> Expr {
         function,
         output_type: Some(DataType::UInt32),
         options: FunctionOptions {
-            collect_groups: ApplyOption::ApplyFlat,
+            collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: false,
         },
     }
@@ -94,7 +94,7 @@ pub fn concat_str(s: Vec<Expr>, delimiter: &str) -> Expr {
         function,
         output_type: Some(DataType::Utf8),
         options: FunctionOptions {
-            collect_groups: ApplyOption::ApplyFlat,
+            collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: false,
         },
     }

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -83,6 +83,7 @@ pub enum AExpr {
         function: Node,
         partition_by: Vec<Node>,
         order_by: Option<Node>,
+        options: WindowOptions,
     },
     Wildcard,
     Slice {

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -115,10 +115,12 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             function,
             partition_by,
             order_by,
+            options,
         } => AExpr::Window {
             function: to_aexpr(*function, arena),
             partition_by: to_aexprs(partition_by, arena),
             order_by: order_by.map(|ob| to_aexpr(*ob, arena)),
+            options,
         },
         Expr::Slice {
             input,
@@ -553,6 +555,7 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             function,
             partition_by,
             order_by,
+            options,
         } => {
             let function = Box::new(node_to_exp(function, expr_arena));
             let partition_by = nodes_to_exprs(&partition_by, expr_arena);
@@ -561,6 +564,7 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 function,
                 partition_by,
                 order_by,
+                options,
             }
         }
         AExpr::Slice {

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -65,6 +65,7 @@ macro_rules! push_expr {
                 function,
                 partition_by,
                 order_by,
+                ..
             } => {
                 $push(function);
                 for e in partition_by {
@@ -218,6 +219,7 @@ impl AExpr {
                 function,
                 partition_by,
                 order_by,
+                options: _,
             } => {
                 push(function);
                 for e in partition_by {

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -392,6 +392,7 @@ impl DefaultPlanner {
                 mut function,
                 partition_by,
                 order_by: _,
+                options,
             } => {
                 // TODO! Order by
                 let group_by =
@@ -434,6 +435,7 @@ impl DefaultPlanner {
                     out_name,
                     function,
                     phys_function,
+                    options,
                 }))
             }
             Literal(value) => Ok(Arc::new(LiteralExpr::new(
@@ -535,7 +537,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -557,7 +559,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -579,7 +581,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -601,7 +603,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -623,7 +625,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -647,7 +649,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -669,7 +671,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -691,7 +693,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -713,7 +715,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -752,7 +754,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: Some(DataType::UInt32),
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -775,7 +777,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: None,
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -809,7 +811,7 @@ impl DefaultPlanner {
                                     function,
                                     output_type: Some(DataType::UInt32),
                                     expr: node_to_exp(expression, expr_arena),
-                                    collect_groups: ApplyOption::ApplyFlat,
+                                    collect_groups: ApplyOptions::ApplyFlat,
                                 }))
                             }
                         }
@@ -892,7 +894,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOption::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyFlat,
                 }))
             }
             Duplicated(expr) => {
@@ -906,7 +908,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOption::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyFlat,
                 }))
             }
             IsUnique(expr) => {
@@ -920,7 +922,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOption::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyFlat,
                 }))
             }
             Explode(expr) => {
@@ -934,7 +936,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOption::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyFlat,
                 }))
             }
             Wildcard => panic!("should be no wildcard at this point"),

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -120,6 +120,7 @@ Manipulation/ selection
 
     Expr.slice
     Expr.explode
+    Expr.flatten
     Expr.take_every
     Expr.repeat_by
     Expr.round

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -466,6 +466,8 @@ class Series:
         return out
 
     def __setitem__(self, key: Any, value: Any) -> None:
+        if isinstance(value, list):
+            raise ValueError("cannot set with a list as value, use a primitive value")
         if isinstance(key, Series):
             if key.dtype == Boolean:
                 self._s = self.set(key, value)._s

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -846,6 +846,19 @@ class Expr:
 
         return self.map(wrap_f, agg_list=True)
 
+    def flatten(self) -> "Expr":
+        """
+        Alias for explode.
+
+        Explode a list or utf8 Series. This means that every item is expanded to a new row.
+
+        Returns
+        -------
+        Exploded Series of same dtype
+        """
+
+        return wrap_expr(self._pyexpr.explode())
+
     def explode(self) -> "Expr":
         """
         Explode a list or utf8 Series. This means that every item is expanded to a new row.


### PR DESCRIPTION
This allows for the following.

Given this dataframe:

```python
df = pl.DataFrame(
    {
        "A": [1, 2, 3, 4, 5],
        "fruits": ["banana", "banana", "apple", "apple", "banana"],
        "B": [5, 4, 3, 2, 1],
        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
    }
)
```

And that we wanted to lag a column by groups.

A window expression would lead to an aggregated list per group:

```python
(df.sort("fruits")
 .select([
    col("fruits"),
    col("B").shift().over("fruits")
]))
```

```
shape: (5, 2)
╭──────────┬──────────────╮
│ fruits   ┆ B            │
│ ---      ┆ ---          │
│ str      ┆ list [i64]   │
╞══════════╪══════════════╡
│ "apple"  ┆ [null, 3]    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ "apple"  ┆ [null, 3]    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ "banana" ┆ [null, 5, 4] │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ "banana" ┆ [null, 5, 4] │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ "banana" ┆ [null, 5, 4] │
╰──────────┴──────────────╯

```


Now we can `explode/flatten` this column directly. This leads to:

```python
(df.sort("fruits")
 .select([
    col("fruits"),
    col("B").shift().over("fruits").flatten()
])))
```

```
shape: (5, 2)
╭──────────┬──────╮
│ fruits   ┆ B    │
│ ---      ┆ ---  │
│ str      ┆ i64  │
╞══════════╪══════╡
│ "apple"  ┆ null │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ "apple"  ┆ 3    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ "banana" ┆ null │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ "banana" ┆ 5    │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ "banana" ┆ 4    │
╰──────────┴──────╯
```