### PR TITLE
more constistency of aggregation expressions

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -452,6 +452,11 @@ pub trait ChunkApply<'a, A, B> {
     where
         F: Fn(A) -> B + Copy;
 
+    fn try_apply<F>(&'a self, f: F) -> Result<Self>
+    where
+        F: Fn(A) -> Result<B> + Copy,
+        Self: Sized;
+
     /// Apply a closure elementwise including null values.
     fn apply_on_opt<F>(&'a self, f: F) -> Self
     where

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -158,8 +158,11 @@ where
         let mut it = iter.into_iter();
         let capacity = get_iter_capacity(&it);
 
-        // first take one to get the dtype. We panic if we have an empty iterator
-        let v = it.next().unwrap();
+        // first take one to get the dtype.
+        let v = match it.next() {
+            Some(v) => v,
+            None => return ListChunked::full_null("", 0),
+        };
         // We don't know the needed capacity. We arbitrarily choose an average of 5 elements per series.
         let mut builder = get_list_builder(v.borrow().dtype(), capacity * 5, capacity, "collected");
 
@@ -194,7 +197,7 @@ where
                 // end of iterator
                 None => {
                     // type is not known
-                    panic!("Type of Series cannot be determined as they are all null")
+                    return ListChunked::full_null("", 0);
                 }
             }
         }

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1200,7 +1200,7 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     /// Get a mask of the first unique value.
     pub fn is_first(self) -> Expr {
-        self.map(
+        self.apply(
             |s| s.is_first().map(|ca| ca.into_series()),
             Some(DataType::Boolean),
         )
@@ -1218,9 +1218,9 @@ impl Expr {
 
     #[cfg(feature = "mode")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mode")))]
-    /// Compute the mode(s) of this column. These is the most occurring value.
+    /// Compute the mode(s) of this column. This is the most occurring value.
     pub fn mode(self) -> Expr {
-        self.map(|s| s.mode().map(|ca| ca.into_series()), None)
+        self.apply(|s| s.mode().map(|ca| ca.into_series()), None)
     }
 
     /// Keep the original root name

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -894,7 +894,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyGroups,
                 }))
             }
             Duplicated(expr) => {
@@ -908,7 +908,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyGroups,
                 }))
             }
             IsUnique(expr) => {
@@ -922,7 +922,7 @@ impl DefaultPlanner {
                     function,
                     output_type: None,
                     expr: node_to_exp(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyFlat,
+                    collect_groups: ApplyOptions::ApplyGroups,
                 }))
             }
             Explode(expr) => {

--- a/polars/polars-lazy/src/test.rs
+++ b/polars/polars-lazy/src/test.rs
@@ -1542,3 +1542,24 @@ fn test_exploded_window_function() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn test_reverse_in_groups() -> Result<()> {
+    let df = fruits_cars();
+
+    let out = df
+        .lazy()
+        .sort("fruits", false)
+        .select(vec![col("B")
+            .reverse()
+            .over(vec![col("fruits")])
+            .explode()
+            .alias("rev")])
+        .collect()?;
+
+    assert_eq!(
+        Vec::from(out.column("rev")?.i32()?),
+        &[Some(2), Some(3), Some(1), Some(4), Some(5)]
+    );
+    Ok(())
+}

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -17,3 +17,15 @@ def df() -> pl.DataFrame:
             "strings_nulls": ["foo", None, "ham"],
         }
     )
+
+
+@pytest.fixture
+def fruits_cars() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "A": [1, 2, 3, 4, 5],
+            "fruits": ["banana", "banana", "apple", "apple", "banana"],
+            "B": [5, 4, 3, 2, 1],
+            "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+        }
+    )

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import polars as pl
 from polars.datatypes import *
@@ -379,3 +380,22 @@ def test_fill_nan():
     df = pl.DataFrame({"a": [1.0, np.nan, 3.0]})
     assert df.fill_nan(2.0)["a"] == [1.0, 2.0, 3.0]
     assert df.lazy().fill_nan(2.0).collect()["a"] == [1.0, 2.0, 3.0]
+
+
+def test_take(fruits_cars):
+    df = fruits_cars
+
+    # out of bounds error
+    with pytest.raises(RuntimeError):
+        (
+            df.sort("fruits").select(
+                [col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]
+            )
+        )
+
+    out = df.sort("fruits").select(
+        [col("B").reverse().take([0, 1]).list().over("fruits"), "fruits"]
+    )
+
+    out[0, "B"] == [2, 3]
+    out[4, "B"] == [1, 4]


### PR DESCRIPTION
Some expressions, like reverse, n_unique, etc.
still were executed on flat series in aggregation context
they now run on groups.

Furthermore this fixes the take expr in aggregation context