### PR TITLE
Add rolling apply; still have to expose to Series

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -31,13 +31,13 @@ pub(crate) mod is_in;
 pub(crate) mod peaks;
 #[cfg(feature = "repeat_by")]
 pub(crate) mod repeat_by;
+#[cfg(feature = "rolling_window")]
+pub(crate) mod rolling_window;
 pub(crate) mod set;
 pub(crate) mod shift;
 pub(crate) mod sort;
 pub(crate) mod take;
 pub(crate) mod unique;
-#[cfg(feature = "rolling_window")]
-pub(crate) mod window;
 #[cfg(feature = "zip_with")]
 pub(crate) mod zip;
 
@@ -261,6 +261,21 @@ pub trait ChunkWindowCustom<T> {
     where
         F: Fn(Option<T>, Option<T>) -> Option<T> + Copy,
         Self: std::marker::Sized,
+    {
+        Err(PolarsError::InvalidOperation(
+            "rolling mean not supported for this datatype".into(),
+        ))
+    }
+}
+
+/// This differs from ChunkWindowCustom and ChunkWindow
+/// by not using a fold aggregator, but reusing a `Series` wrapper and calling `Series` aggregators.
+/// This likely is a bit slower than ChunkWindow
+#[cfg(feature = "rolling_window")]
+pub trait ChunkRollApply {
+    fn rolling_apply(&self, _window_size: usize, _f: &dyn Fn(&Series) -> Series) -> Result<Self>
+    where
+        Self: Sized,
     {
         Err(PolarsError::InvalidOperation(
             "rolling mean not supported for this datatype".into(),

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use arrow::array::{Array, PrimitiveArray};
 use num::{Bounded, NumCast, One, Zero};
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
@@ -329,6 +330,8 @@ where
     }
 }
 
+/// This is similar to how rolling_min, sum, max, mean
+/// is implemented. It takes a window, weights it and applies a fold aggregator
 impl<T> ChunkWindowCustom<T::Native> for ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -402,6 +405,52 @@ impl ChunkWindow for BooleanChunked {}
 impl ChunkWindow for CategoricalChunked {}
 #[cfg(feature = "object")]
 impl<T> ChunkWindow for ObjectChunked<T> {}
+
+impl<T> ChunkRollApply for ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    T::Native: Zero,
+    Self: IntoSeries,
+{
+    fn rolling_apply(&self, window_size: usize, f: &dyn Fn(&Series) -> Series) -> Result<Self> {
+        let ca = self.rechunk();
+        let arr = ca.downcast_iter().next().unwrap();
+
+        let series_container =
+            ChunkedArray::<T>::new_from_slice("", &[T::Native::zero()]).into_series();
+        let array_ptr = &series_container.chunks()[0];
+        let mut builder = PrimitiveChunkedBuilder::<T>::new(self.name(), self.len());
+        for _ in 0..window_size - 1 {
+            builder.append_null();
+        }
+
+        for offset in 0..self.len() + 1 - window_size {
+            let ad = arr.data_ref().slice(offset, window_size);
+
+            // Safety.
+            // ptr is not dropped as we are in scope
+            // We are also the only owner of the contents of the Arc
+            // we do this to reduce heap allocs.
+            unsafe {
+                let ptr = Arc::as_ptr(array_ptr) as *mut dyn Array as *mut PrimitiveArray<T>;
+                *ptr = PrimitiveArray::from(ad)
+            }
+
+            let s = f(&series_container);
+            let out = self.unpack_series_matching_type(&s)?;
+            builder.append_option(out.get(0));
+        }
+
+        Ok(builder.finish())
+    }
+}
+
+impl ChunkRollApply for ListChunked {}
+impl ChunkRollApply for Utf8Chunked {}
+impl ChunkRollApply for BooleanChunked {}
+impl ChunkRollApply for CategoricalChunked {}
+#[cfg(feature = "object")]
+impl<T> ChunkRollApply for ObjectChunked<T> {}
 
 #[cfg(test)]
 mod test {
@@ -478,6 +527,36 @@ mod test {
                 Some(2.0),
                 Some(5.0),
                 Some(5.5)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_rolling_apply() {
+        let ca = Float64Chunked::new_from_opt_slice(
+            "foo",
+            &[
+                Some(0.0),
+                Some(1.0),
+                Some(2.0),
+                None,
+                None,
+                Some(5.0),
+                Some(6.0),
+            ],
+        );
+
+        let out = ca.rolling_apply(3, &|s| s.sum_as_series()).unwrap();
+        assert_eq!(
+            Vec::from(&out),
+            &[
+                None,
+                None,
+                Some(3.0),
+                Some(3.0),
+                Some(2.0),
+                Some(5.0),
+                Some(11.0)
             ]
         );
     }

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -43,4 +43,4 @@ pub use crate::{
 };
 
 #[cfg(feature = "rolling_window")]
-pub use crate::chunked_array::ops::window::InitFold;
+pub use crate::chunked_array::ops::rolling_window::InitFold;

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -111,6 +111,10 @@ Computations
     Expr.arg_unique
     Expr.unique
     Expr.pow
+    Expr.rolling_min
+    Expr.rolling_max
+    Expr.rolling_mean
+    Expr.rolling_sum
     Expr.hash
 
 Manipulation/ selection


### PR DESCRIPTION
This adds a custom rolling apply that can be used with `Fn(&Series) -> Series`. This makes it more generic, but is also slower.