### PR TITLE
ListChunked iterator that amortizes allocations

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -70,6 +70,8 @@ cum_agg = []
 # rolling window functions
 rolling_window = []
 interpolate = []
+# additional list utils
+list = []
 
 
 # opt-in datatypes for Series

--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -40,7 +40,7 @@ pub(crate) unsafe fn take_primitive_unchecked<T: PolarsNumericType>(
     let mut validity = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
     let validity_slice = validity.as_slice_mut();
 
-    let arr = if let Some(validity_indices) = indices.data_ref().null_buffer() {
+    if let Some(validity_indices) = indices.data_ref().null_buffer() {
         index_values.iter().enumerate().for_each(|(i, idx)| {
             // i is iteration count
             // idx is the index that we take from the values array.
@@ -51,7 +51,6 @@ pub(crate) unsafe fn take_primitive_unchecked<T: PolarsNumericType>(
                 unset_bit(validity_slice, i)
             }
         });
-        values.into_primitive_array(Some(validity.into()))
     } else {
         index_values.iter().enumerate().for_each(|(i, idx)| {
             let idx = *idx as usize;
@@ -59,8 +58,8 @@ pub(crate) unsafe fn take_primitive_unchecked<T: PolarsNumericType>(
                 unset_bit(validity_slice, i)
             }
         });
-        values.into_primitive_array(Some(validity.into()))
     };
+    let arr = values.into_primitive_array(Some(validity.into()));
 
     Arc::new(arr)
 }

--- a/polars/polars-core/src/chunked_array/list/mod.rs
+++ b/polars/polars-core/src/chunked_array/list/mod.rs
@@ -1,0 +1,108 @@
+//! Special list utility methods
+use crate::prelude::*;
+use crate::utils::CustomIterTools;
+use arrow::array::ArrayRef;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::pin::Pin;
+
+/// A wrapper type that should make it a bit more clear that we should not clone T
+pub(crate) struct NoClone<T>(T);
+
+impl<T> Deref for NoClone<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub(crate) struct AmortizedListIter<'a, I: Iterator<Item = Option<ArrayRef>>> {
+    series_container: Pin<Box<Series>>,
+    inner: *mut ArrayRef,
+    lifetime: PhantomData<&'a ArrayRef>,
+    iter: I,
+}
+
+impl<'a, I: Iterator<Item = Option<ArrayRef>>> Iterator for AmortizedListIter<'a, I> {
+    type Item = Option<NoClone<&'a Series>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|opt_val| {
+            opt_val.map(|array_ref| {
+                unsafe { *self.inner = array_ref };
+                // Safety
+                // we cannot control the lifetime of an iterators `next` method.
+                // but as long as self is alive the reference to the series container is valid
+                let refer = &*self.series_container;
+                NoClone(unsafe { std::mem::transmute::<&Series, &'a Series>(refer) })
+            })
+        })
+    }
+}
+
+impl ListChunked {
+    /// This is an iterator over a ListChunked that save allocations.
+    /// A Series is:
+    ///     1. Arc<ChunkedArray>
+    ///     ChunkedArray is:
+    ///         2. Vec< 3. ArrayRef>
+    ///
+    /// The ArrayRef we indicated with 3. will be updated during iteration.
+    /// The Series will be pinned in memory, saving an allocation for
+    /// 1. Arc<..>
+    /// 2. Vec<...>
+    ///
+    /// # Warning
+    /// Though memory safe in the sense that it will not read unowned memory, UB, or memory leaks
+    /// this function still needs precautions. The returned should never be cloned or taken longer
+    /// than a single iteration, as every call on `next` of the iterator will change the contents of
+    /// that Series.
+    #[allow(dead_code)]
+    pub(crate) fn amortized_iter(
+        &self,
+    ) -> AmortizedListIter<impl Iterator<Item = Option<ArrayRef>> + '_> {
+        let series_container = if self.is_empty() {
+            // in case of no data, the actual Series does not matter
+            Box::pin(Series::new("", &[true]))
+        } else {
+            Box::pin(self.get(0).unwrap())
+        };
+
+        let ptr = &series_container.chunks()[0] as *const ArrayRef as *mut ArrayRef;
+
+        AmortizedListIter {
+            series_container,
+            inner: ptr,
+            lifetime: PhantomData,
+            iter: self
+                .downcast_iter()
+                .map(|arr| arr.iter())
+                .flatten()
+                .trust_my_length(self.len()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::chunked_array::builder::get_list_builder;
+    use std::mem::ManuallyDrop;
+    use std::ops::DerefMut;
+
+    #[test]
+    fn test_iter_list() {
+        let mut builder = get_list_builder(&DataType::Int32, 10, 10, "");
+        builder.append_series(&Series::new("", &[1, 2, 3]));
+        builder.append_series(&Series::new("", &[3, 2, 1]));
+        builder.append_series(&Series::new("", &[1, 1]));
+        let ca = builder.finish();
+
+        ca.amortized_iter()
+            .zip(ca.into_iter())
+            .for_each(|(s1, s2)| {
+                assert!(s1.unwrap().series_equal(&s2.unwrap()));
+            });
+    }
+}

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -44,6 +44,8 @@ pub mod temporal;
 mod trusted_len;
 pub mod upstream_traits;
 
+pub(crate) mod list;
+
 use arrow::array::{
     Array, ArrayData, Date32Array, DurationMillisecondArray, DurationNanosecondArray,
     LargeListArray, PrimitiveArray,

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -419,6 +419,7 @@ where
         let series_container =
             ChunkedArray::<T>::new_from_slice("", &[T::Native::zero()]).into_series();
         let array_ptr = &series_container.chunks()[0];
+        let ptr = Arc::as_ptr(array_ptr) as *mut dyn Array as *mut PrimitiveArray<T>;
         let mut builder = PrimitiveChunkedBuilder::<T>::new(self.name(), self.len());
         for _ in 0..window_size - 1 {
             builder.append_null();
@@ -431,10 +432,7 @@ where
             // ptr is not dropped as we are in scope
             // We are also the only owner of the contents of the Arc
             // we do this to reduce heap allocs.
-            unsafe {
-                let ptr = Arc::as_ptr(array_ptr) as *mut dyn Array as *mut PrimitiveArray<T>;
-                *ptr = PrimitiveArray::from(ad)
-            }
+            unsafe { *ptr = PrimitiveArray::from(ad) }
 
             let s = f(&series_container);
             let out = self.unpack_series_matching_type(&s)?;


### PR DESCRIPTION
 This is an iterator over a ListChunked that save allocations.
 A Series is:
     1. Arc<ChunkedArray>
     ChunkedArray is:
         2. Vec< 3. ArrayRef>

 The ArrayRef we indicated with 3. will be updated during iteration.
 The Series will be pinned in memory, saving an allocation for
 1. Arc<..>
 2. Vec<...>

 on every .next() call