### PR TITLE
python add dense rank

### DIFF
--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -629,11 +629,7 @@ where
             }
 
             let group_vals = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-            let sorted_idx_ca = group_vals.argsort(false);
-            let sorted_idx = sorted_idx_ca.downcast_iter().next().unwrap().values();
-            let quant_idx = (quantile * (sorted_idx.len() - 1) as f64) as usize;
-            let value_idx = sorted_idx[quant_idx];
-            group_vals.get(value_idx as usize)
+            group_vals.quantile(quantile).unwrap()
         })
     }
 

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -147,6 +147,7 @@ Manipulation/ selection
     Expr.reinterpret
     Expr.drop_nulls
     Expr.interpolate
+    Expr.argsort
 
 Column names
 ------------

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1048,8 +1048,6 @@ class Series:
 
     def argsort(self, reverse: bool = False) -> "Series":
         """
-        ..deprecate::
-
         Index location of the sorted variant of this Series.
 
         Returns
@@ -1061,6 +1059,8 @@ class Series:
 
     def arg_sort(self, reverse: bool = False) -> "Series":
         """
+        ..deprecate::
+
         Index location of the sorted variant of this Series.
 
         Returns

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -1325,6 +1325,16 @@ class Expr:
         """
         return self.map(lambda s: s.abs())
 
+    def argsort(self, reverse: bool = False) -> "Expr":
+        """
+        Index location of the sorted variant of this Series.
+        Parameters
+        ----------
+        reverse
+            Reverse the ordering. Default is from low to high.
+        """
+        return pl.argsort_by([self], [reverse])  # type: ignore
+
 
 class ExprListNameSpace:
     """


### PR DESCRIPTION
~closes #1207 ~

This is not correct. In select context there may be duplicates and the computed rank is invalid.