### PR TITLE
Arrow2 cherry pick and improve hashing performance

### DIFF
--- a/polars/polars-arrow/src/trusted_len/mod.rs
+++ b/polars/polars-arrow/src/trusted_len/mod.rs
@@ -3,6 +3,7 @@ mod boolean;
 use crate::utils::{FromTrustedLenIterator, TrustMyLength};
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow::buffer::MutableBuffer;
+use arrow::types::NativeType;
 use std::slice::Iter;
 
 /// An iterator of known, fixed size.
@@ -81,6 +82,34 @@ pub trait PushUnchecked<T> {
 
     /// Extend the array with an iterator who's length can be trusted
     fn extend_trusted_len<I: IntoIterator<Item = T> + TrustedLen>(&mut self, iter: I);
+}
+
+impl<T: NativeType> PushUnchecked<T> for MutableBuffer<T> {
+    unsafe fn push_unchecked(&mut self, value: T) {
+        let end = self.as_mut_ptr().add(self.len());
+        std::ptr::write(end, value);
+        self.set_len(self.len() + 1);
+    }
+
+    unsafe fn push_unchecked_no_len_set(&mut self, value: T) {
+        let end = self.as_mut_ptr().add(self.len());
+        std::ptr::write(end, value);
+    }
+
+    fn extend_trusted_len<I: IntoIterator<Item = T> + TrustedLen>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        let upper = iter.size_hint().1.expect("must have an upper bound");
+        self.reserve(upper);
+
+        unsafe {
+            let mut dst = self.as_mut_ptr().add(self.len());
+            for value in iter {
+                std::ptr::write(dst, value);
+                dst = dst.add(1)
+            }
+            self.set_len(self.len() + upper)
+        }
+    }
 }
 
 impl<T> PushUnchecked<T> for Vec<T> {

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -15,6 +15,7 @@ use crate::prelude::*;
 use crate::utils::NoNull;
 use arrow::array::ArrayRef;
 use arrow::buffer::MutableBuffer;
+use polars_arrow::trusted_len::PushUnchecked;
 use std::convert::TryFrom;
 
 pub(crate) trait NumericAggSync {
@@ -541,8 +542,10 @@ where
                         list_values.extend_from_trusted_len_iter(
                             idx.iter().map(|idx| *values.get_unchecked(*idx as usize)),
                         );
+                        // Safety:
+                        // we know that offsets has allocated enough slots
+                        offsets.push_unchecked(length_so_far);
                     }
-                    offsets.push(length_so_far);
                 });
                 let array =
                     PrimitiveArray::from_data(T::get_dtype().to_arrow(), list_values.into(), None);

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -26,6 +26,17 @@ pub trait VecHash {
     }
 }
 
+fn get_null_hash_value(random_state: RandomState) -> u64 {
+    // we just start with a large prime number and hash that twice
+    // to get a constant hash value for null/None
+    let mut hasher = random_state.build_hasher();
+    3188347919usize.hash(&mut hasher);
+    let first = hasher.finish();
+    let mut hasher = random_state.build_hasher();
+    first.hash(&mut hasher);
+    hasher.finish()
+}
+
 impl<T> VecHash for ChunkedArray<T>
 where
     T: PolarsIntegerType,
@@ -48,13 +59,7 @@ where
             }));
         });
 
-        // We need a random number that will be our null hash value
-        // just take the memory addresses and hash those
-        let null_h = av.as_ptr() as u64 ^ self as *const Self as u64;
-        let mut hasher = random_state.build_hasher();
-        null_h.hash(&mut hasher);
-        let null_h = hasher.finish();
-
+        let null_h = get_null_hash_value(random_state);
         let hashes = av.as_mut_slice();
 
         let mut offset = 0;
@@ -76,12 +81,7 @@ where
     }
 
     fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
-        // We need a random number that will be our null hash value
-        // just take the memory addresses and hash those
-        let null_h = hashes.as_ptr() as u64 ^ self as *const Self as u64;
-        let mut hasher = random_state.build_hasher();
-        null_h.hash(&mut hasher);
-        let null_h = hasher.finish();
+        let null_h = get_null_hash_value(random_state.clone());
 
         let mut offset = 0;
         self.downcast_iter().for_each(|arr| {

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -235,32 +235,6 @@ class Series:
         """
         return cls._from_pyseries(pandas_to_pyseries(name, values))
 
-    @classmethod
-    def from_arrow(cls, name: str, array: pa.Array) -> "Series":
-        """
-        .. deprecated:: 0.8.13
-            `Series.from_arrow` will be removed in Polars 0.9.0. Use `pl.from_arrow`
-            instead, or call the Series constructor directly.
-
-        Create a Series from an arrow array.
-
-        Parameters
-        ----------
-        name
-            name of the Series.
-        array
-            Arrow array.
-        """
-        import warnings
-
-        warnings.warn(
-            "Series.from_arrow is deprecated, Use `pl.from_arrow` instead, "
-            "or call the Series constructor directly.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls._from_arrow(name, array)
-
     def inner(self) -> "PySeries":
         return self._s
 
@@ -1957,13 +1931,6 @@ class Series:
         """
         return wrap_s(self._s.zip_with(mask._s, other._s))
 
-    def as_duration(self) -> "Series":
-        """
-        .. deprecated::
-        If Series is a date32 or a date64 it can be turned into a duration.
-        """
-        return wrap_s(self._s.as_duration())
-
     def rolling_min(
         self,
         window_size: int,
@@ -2151,18 +2118,6 @@ class Series:
         return wrap_s(
             self._s.rolling_sum(window_size, weight, ignore_null, min_periods)
         )
-
-    @staticmethod
-    def parse_date(
-        name: str, values: Sequence[str], dtype: Type[DataType], fmt: str
-    ) -> "Series":
-        """
-        .. deprecated::
-        """
-        f = get_ffi_func("parse_<>_from_str_slice", dtype, PySeries)
-        if f is None:
-            return NotImplemented
-        return wrap_s(f(name, values, fmt))
 
     def sample(
         self,

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -14,7 +14,7 @@ except ImportError:
     _DOCUMENTING = True
 
 from ..datatypes import Boolean, DataType, Date32, Date64, Float64, Int64, Utf8
-from .functions import UDF, col, lit
+from .functions import col, lit
 
 __all__ = [
     "Expr",
@@ -904,7 +904,7 @@ class Expr:
 
     def map(
         self,
-        f: Union["UDF", Callable[["pl.Series"], "pl.Series"]],
+        f: Callable[["pl.Series"], "pl.Series"],
         return_dtype: Optional[Type[DataType]] = None,
         agg_list: bool = False,
     ) -> "Expr":
@@ -921,9 +921,6 @@ class Expr:
         return_dtype
             Dtype of the output Series.
         """
-        if isinstance(f, UDF):
-            return_dtype = f.return_dtype
-            f = f.f
         if return_dtype == str:
             return_dtype = Utf8
         elif return_dtype == int:
@@ -1468,17 +1465,6 @@ class ExprStringNameSpace:
             return wrap_expr(self._pyexpr.str_parse_date64(fmt))
         else:
             raise NotImplementedError
-
-    def parse_date(
-        self,
-        datatype: Union[Date32, Date64],
-        fmt: Optional[str] = None,
-    ) -> Expr:
-        """
-        .. deprecated:: 0.8.7
-        use `strptime`
-        """
-        return self.strptime(datatype, fmt)
 
     def lengths(self) -> Expr:
         """

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from ..datatypes import DataType, pytype_to_polars_type
 from ..utils import _process_null_values
-from .expr import UDF, Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
+from .expr import Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
 
 __all__ = [
     "LazyFrame",
@@ -851,13 +851,13 @@ class LazyFrame:
 
     def map(
         self,
-        f: Union["UDF", Callable[["pl.DataFrame"], "pl.DataFrame"]],
+        f: Callable[["pl.DataFrame"], "pl.DataFrame"],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         no_optimizations: bool = False,
     ) -> "LazyFrame":
         """
-        Apply a custom UDF. It is important that the UDF returns a Polars DataFrame.
+        Apply a custom function. It is important that the function returns a Polars DataFrame.
 
         Parameters
         ----------

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -54,8 +54,6 @@ __all__ = [
     "arange",
     "argsort_by",
     "concat_str",
-    "UDF",  # deprecated
-    "udf",  # deprecated
 ]
 
 
@@ -555,25 +553,6 @@ def quantile(column: str, quantile: float) -> "pl.Expr":
     Syntactic sugar for `column("foo").quantile(..)`.
     """
     return col(column).quantile(quantile)
-
-
-class UDF:
-    """
-    Deprecated: don't use me
-    """
-
-    def __init__(
-        self, f: Callable[["pl.Series"], "pl.Series"], return_dtype: Type[DataType]
-    ):
-        self.f = f
-        self.return_dtype = return_dtype
-
-
-def udf(f: Callable[["pl.Series"], "pl.Series"], return_dtype: Type[DataType]) -> UDF:
-    """
-    Deprecated: don't use me
-    """
-    return UDF(f, return_dtype)
 
 
 def arange(

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use crate::series::PySeries;
 use polars::chunked_array::object::PolarsObjectSafe;
 use polars::frame::row::Row;
+use polars::frame::NullStrategy;
 use polars::prelude::AnyValue;
 use polars_core::utils::arrow::types::NativeType;
 use pyo3::basic::CompareOp;
@@ -14,7 +15,6 @@ use pyo3::types::PySequence;
 use pyo3::{PyAny, PyResult};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use polars::frame::NullStrategy;
 
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -16,6 +16,7 @@ use crate::conversion::{ObjectValue, Wrap};
 use crate::datatypes::PyDataType;
 use crate::file::get_mmap_bytes_reader;
 use crate::lazy::dataframe::PyLazyFrame;
+use crate::prelude::str_to_null_strategy;
 use crate::utils::{downsample_str_to_rule, str_to_polarstype};
 use crate::{
     arrow_interop,
@@ -24,7 +25,6 @@ use crate::{
     series::{to_pyseries_collection, to_series_collection, PySeries},
 };
 use polars::frame::row::{rows_to_schema, Row};
-use crate::prelude::str_to_null_strategy;
 
 #[pyclass]
 #[repr(transparent)]

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -132,22 +132,6 @@ impl From<Series> for PySeries {
     }
 }
 
-macro_rules! parse_temporal_from_str_slice {
-    ($name:ident, $ca_type:ident) => {
-        #[pymethods]
-        impl PySeries {
-            #[staticmethod]
-            pub fn $name(name: &str, val: Vec<&str>, fmt: &str) -> Self {
-                let parsed = $ca_type::parse_from_str_slice(name, &val, fmt);
-                PySeries::new(parsed.into_series())
-            }
-        }
-    };
-}
-
-// TODO: add other temporals
-parse_temporal_from_str_slice!(parse_date32_from_str_slice, Date32Chunked);
-
 #[pymethods]
 #[allow(
     clippy::wrong_self_convention,
@@ -922,28 +906,6 @@ impl PySeries {
     pub fn timestamp(&self) -> PyResult<Self> {
         let ca = self.series.timestamp().map_err(PyPolarsEr::from)?;
         Ok(ca.into_series().into())
-    }
-
-    pub fn as_duration(&self) -> PyResult<Self> {
-        match self.series.dtype() {
-            DataType::Date64 => Ok(self
-                .series
-                .cast::<DurationMillisecondType>()
-                .unwrap()
-                .into_series()
-                .into()),
-            DataType::Date32 => {
-                let s = self.series.cast::<Date64Type>().unwrap() * 3600 * 24 * 1000;
-                Ok(s.cast::<DurationMillisecondType>()
-                    .unwrap()
-                    .into_series()
-                    .into())
-            }
-            _ => Err(PyPolarsEr::Other(
-                "Only date32 and date64 can be transformed as duration".into(),
-            )
-            .into()),
-        }
     }
 
     pub fn to_dummies(&self) -> PyResult<PyDataFrame> {

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -264,17 +264,6 @@ def test_shift():
     assert a.shift(-2) == [1, None, None]
 
 
-@pytest.mark.parametrize(
-    "dtype, fmt, null_values", [(Date32, "%d-%m-%Y", 0), (Date32, "%Y-%m-%d", 3)]
-)
-def test_parse_date(dtype, fmt, null_values):
-    dates = ["25-08-1988", "20-01-1993", "25-09-2020"]
-    result = pl.Series.parse_date("dates", dates, dtype, fmt)
-    # Why results Date64 into `nan`?
-    assert result.dtype == dtype
-    assert result.is_null().sum() == null_values
-
-
 def test_rolling():
     a = pl.Series("a", [1, 2, 3, 2, 1])
     assert a.rolling_min(2) == [None, 1, 2, 2, 1]


### PR DESCRIPTION
Improves hashing of data with and without nulls for numeric columns.


# vec_hash

```
bench vec hash null rate: 0%                                                                            
                        time:   [71.386 us 71.394 us 71.403 us]
                        change: [-10.711% -10.525% -10.359%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 27 outliers among 100 measurements (27.00%)
  20 (20.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe

bench vec hash null rate: 20%                                                                            
                        time:   [168.02 us 168.23 us 168.46 us]
                        change: [-21.523% -21.441% -21.336%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

bench vec hash null rate: 50%                                                                            
                        time:   [247.60 us 247.68 us 247.78 us]
                        change: [-16.209% -15.960% -15.762%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

bench vec hash null rate: 80%                                                                            
                        time:   [173.88 us 174.69 us 175.69 us]
                        change: [-8.4531% -7.7813% -6.7419%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```

# vec_hash_combine

```
bench vec hash null rate: 0%                                                                            
                        time:   [86.693 us 86.774 us 86.865 us]
                        change: [-35.625% -35.426% -35.189%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  6 (6.00%) low severe
  5 (5.00%) high mild
  7 (7.00%) high severe

bench vec hash null rate: 20%                                                                            
                        time:   [219.04 us 219.39 us 219.77 us]
                        change: [-12.193% -12.008% -11.803%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

bench vec hash null rate: 50%                                                                            
                        time:   [291.01 us 291.09 us 291.16 us]
                        change: [-15.787% -15.603% -15.438%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

bench vec hash null rate: 80%                                                                            
                        time:   [176.61 us 176.66 us 176.70 us]
                        change: [-25.989% -25.894% -25.798%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  ```