### PR TITLE
improve vec_hash performance

### DIFF
--- a/polars/polars-arrow/src/bitmap.rs
+++ b/polars/polars-arrow/src/bitmap.rs
@@ -1,0 +1,82 @@
+use crate::bit_util::get_bit_raw;
+use crate::trusted_len::TrustedLen;
+use arrow::bitmap::Bitmap;
+
+pub trait AddIterBitmap {
+    /// constructs a new iterator
+    fn iter(&self) -> BitmapIter<'_>;
+}
+
+impl AddIterBitmap for Bitmap {
+    fn iter(&self) -> BitmapIter<'_> {
+        let slice = self.buffer_ref().as_slice();
+        BitmapIter::new(slice, 0, self.len())
+    }
+}
+
+/// An iterator over bits according to the [LSB](https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit),
+/// i.e. the bytes `[4u8, 128u8]` correspond to `[false, false, true, false, ..., true]`.
+#[derive(Debug, Clone)]
+pub struct BitmapIter<'a> {
+    bytes: &'a [u8],
+    index: usize,
+    end: usize,
+}
+
+impl<'a> BitmapIter<'a> {
+    #[inline]
+    pub fn new(slice: &'a [u8], offset: usize, len: usize) -> Self {
+        // example:
+        // slice.len() = 4
+        // offset = 9
+        // len = 23
+        // result:
+        let bytes = &slice[offset / 8..];
+        // bytes.len() = 3
+        let index = offset % 8;
+        // index = 9 % 8 = 1
+        let end = len + index;
+        // end = 23 + 1 = 24
+        assert!(end <= bytes.len() * 8);
+        // maximum read before UB in bits: bytes.len() * 8 = 24
+        // the first read from the end is `end - 1`, thus, end = 24 is ok
+
+        Self { bytes, index, end }
+    }
+}
+
+impl<'a> Iterator for BitmapIter<'a> {
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        // See comment in `new`
+        Some(unsafe { get_bit_raw(self.bytes.as_ptr(), old) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = self.end - self.index;
+        (exact, Some(exact))
+    }
+}
+
+impl<'a> DoubleEndedIterator for BitmapIter<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<bool> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            // See comment in `new`; end was first decreased
+            Some(unsafe { get_bit_raw(self.bytes.as_ptr(), self.end) })
+        }
+    }
+}
+
+unsafe impl TrustedLen for BitmapIter<'_> {}

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod bit_util;
+pub mod bitmap;
 pub mod builder;
 pub mod error;
 pub mod is_valid;

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -1,10 +1,12 @@
 use crate::datatypes::UInt64Chunked;
 use crate::prelude::*;
+use crate::utils::arrow::array::Array;
 use crate::POOL;
 use ahash::RandomState;
 use arrow::array::ArrayRef;
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 use itertools::Itertools;
+use polars_arrow::bitmap::AddIterBitmap;
 use rayon::prelude::*;
 use std::convert::TryInto;
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
@@ -41,24 +43,76 @@ where
         let mut av = AlignedVec::with_capacity(self.len());
 
         self.downcast_iter().for_each(|arr| {
-            av.extend(arr.into_iter().map(|opt_v| {
+            av.extend(arr.values().iter().map(|v| {
                 let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
+                v.hash(&mut hasher);
                 hasher.finish()
-            }))
+            }));
         });
+
+        // We need a random number that will be our null hash value
+        // just take the memory addresses and hash those
+        let null_h = av.as_ptr() as u64 ^ self as *const Self as u64;
+        let mut hasher = random_state.build_hasher();
+        null_h.hash(&mut hasher);
+        let null_h = hasher.finish();
+
+        let hashes = av.as_mut_slice();
+
+        let mut offset = 0;
+        self.downcast_iter().for_each(|arr| {
+            if let Some(validity) = arr.data_ref().null_bitmap() {
+                validity
+                    .iter()
+                    .zip(&mut hashes[offset..])
+                    .for_each(|(valid, h)| {
+                        if !valid {
+                            *h = null_h;
+                        }
+                    })
+            }
+            offset += arr.len();
+        });
+
         av
     }
 
     fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
-        self.apply_to_slice(
-            |opt_v, h| {
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                boost_hash_combine(hasher.finish(), *h)
-            },
-            hashes,
-        )
+        // We need a random number that will be our null hash value
+        // just take the memory addresses and hash those
+        let null_h = hashes.as_ptr() as u64 ^ self as *const Self as u64;
+        let mut hasher = random_state.build_hasher();
+        null_h.hash(&mut hasher);
+        let null_h = hasher.finish();
+
+        let mut offset = 0;
+        self.downcast_iter().for_each(|arr| {
+            match arr.null_count() {
+                0 => arr
+                    .values()
+                    .iter()
+                    .zip(&mut hashes[offset..])
+                    .for_each(|(v, h)| {
+                        let mut hasher = random_state.build_hasher();
+                        v.hash(&mut hasher);
+                        *h = boost_hash_combine(hasher.finish(), *h)
+                    }),
+                _ => arr
+                    .iter()
+                    .zip(&mut hashes[offset..])
+                    .for_each(|(opt_v, h)| match opt_v {
+                        Some(v) => {
+                            let mut hasher = random_state.build_hasher();
+                            v.hash(&mut hasher);
+                            *h = boost_hash_combine(hasher.finish(), *h)
+                        }
+                        None => {
+                            *h = boost_hash_combine(null_h, *h);
+                        }
+                    }),
+            }
+            offset += arr.len();
+        });
     }
 }
 


### PR DESCRIPTION
```
Gnuplot not found, using plotters backend
bench vec hash null rate: 0%                                                                            
                        time:   [64.121 us 64.133 us 64.149 us]
                        change: [-64.831% -64.661% -64.479%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe

bench vec hash null rate: 20%                                                                            
                        time:   [73.032 us 73.165 us 73.330 us]
                        change: [-72.295% -72.236% -72.171%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  6 (6.00%) low severe
  4 (4.00%) low mild
  6 (6.00%) high mild
  7 (7.00%) high severe

bench vec hash null rate: 50%                                                                            
                        time:   [81.263 us 81.345 us 81.414 us]
                        change: [-78.007% -77.995% -77.984%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

bench vec hash null rate: 80%                                                                            
                        time:   [74.022 us 74.117 us 74.218 us]
                        change: [-70.255% -70.109% -69.970%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Benchmarking bench vec hash combine null rate: 0%: Collecting 100 samples in estimated 5.1689 s (61k iterati                                                                                                            bench vec hash combine null rate: 0%                        
                        time:   [85.254 us 85.282 us 85.316 us]
                        change: [-63.589% -63.402% -63.284%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

Benchmarking bench vec hash combine null rate: 20%: Collecting 100 samples in estimated 5.1072 s (20k iterat                                                                                                            bench vec hash combine null rate: 20%                        
                        time:   [252.55 us 252.95 us 253.35 us]
                        change: [-18.249% -17.611% -16.926%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Benchmarking bench vec hash combine null rate: 50%: Collecting 100 samples in estimated 5.0704 s (15k iterat                                                                                                            bench vec hash combine null rate: 50%                        
                        time:   [333.56 us 333.76 us 333.99 us]
                        change: [-18.121% -18.058% -17.982%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

Benchmarking bench vec combine hash null rate: 80%: Collecting 100 samples in estimated 5.3235 s (25k iterat                                                                                                            bench vec combine hash null rate: 80%                        
                        time:   [210.59 us 210.63 us 210.66 us]
                        change: [-24.217% -24.190% -24.160%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  8 (8.00%) high mild
  4 (4.00%) high severe


```