### PR TITLE
python pl.arange accepts low: series, high: series

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -113,7 +113,7 @@ def sequence_to_pyseries(
         if dtype_ == date or dtype_ == datetime:
             return arrow_to_pyseries(name, pa.array(values))
 
-        elif dtype_ == list or dtype_ == tuple:
+        elif dtype_ == list or dtype_ == tuple or dtype_ == pl.Series:
             nested_value = _get_first_non_none(value)
             nested_dtype = type(nested_value) if value is not None else float
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -971,7 +971,7 @@ fn binary_lambda(lambda: &PyObject, a: Series, b: Series) -> Result<Series> {
     let result_series_wrapper =
         match lambda.call1(py, (python_series_wrapper_a, python_series_wrapper_b)) {
             Ok(pyobj) => pyobj,
-            Err(e) => panic!("UDF failed: {}", e.pvalue(py).to_string()),
+            Err(e) => panic!("custom python function failed: {}", e.pvalue(py).to_string()),
         };
     // unpack the wrapper in a PySeries
     let py_pyseries = result_series_wrapper

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -34,6 +34,7 @@ def test_init_inputs():
     assert pl.Series(values=np.array([True, False])).dtype == pl.Boolean
     assert pl.Series(values=np.array(["foo", "bar"])).dtype == pl.Utf8
     assert pl.Series(values=["foo", "bar"]).dtype == pl.Utf8
+    assert pl.Series("a", [pl.Series([1, 2, 4]), pl.Series([3, 2, 1])]).dtype == pl.List
 
     # Bad inputs
     with pytest.raises(ValueError):
@@ -394,6 +395,10 @@ def test_arange_expr():
     # eager arange
     out = pl.arange(0, 10, 2, eager=True)
     assert out == [0, 2, 4, 8, 8]
+
+    out = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), 2, eager=True)
+    assert out.dtype == pl.List
+    assert out[0].to_list() == [0, 1, 2]
 
 
 def test_strftime():


### PR DESCRIPTION
Allows for:

```python
df = pl.DataFrame({'start':[1,2],'end':[3,5],'value':['a','b']})

out = df.select([
    pl.map_binary("start", "end", lambda a, b: pl.arange(a, b, eager=True)).alias("expanded"),
    "value"
]).explode("expanded")

print(out)
```

```
shape: (5, 2)
┌──────────┬───────┐
│ expanded ┆ value │
│ ---      ┆ ---   │
│ i64      ┆ str   │
╞══════════╪═══════╡
│ 1        ┆ "a"   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2        ┆ "a"   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2        ┆ "b"   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 3        ┆ "b"   │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 4        ┆ "b"   │
└──────────┴───────┘

```