### PR TITLE
Python: Add strict casting and Series creation

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1679,6 +1679,23 @@ impl Series {
     pub fn rank(&self, method: RankMethod) -> Series {
         rank(self, method)
     }
+
+    /// Cast throws an error if conversion had overflows
+    pub fn strict_cast(&self, data_type: &DataType) -> Result<Series> {
+        let s = self.cast_with_dtype(data_type)?;
+        if self.null_count() != s.null_count() {
+            Err(PolarsError::ComputeError(
+                format!(
+                    "strict conversion of cast from {:?} to {:?} failed. consider non-strict cast.",
+                    self.dtype(),
+                    data_type
+                )
+                .into(),
+            ))
+        } else {
+            Ok(s)
+        }
+    }
 }
 
 impl Deref for Series {

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -260,6 +260,7 @@ pub enum Expr {
     Cast {
         expr: Box<Expr>,
         data_type: DataType,
+        strict: bool,
     },
     Sort {
         expr: Box<Expr>,
@@ -414,7 +415,9 @@ impl fmt::Debug for Expr {
                     Quantile { expr, .. } => write!(f, "AGG QUANTILE {:?}", expr),
                 }
             }
-            Cast { expr, data_type } => write!(f, "CAST {:?} TO {:?}", expr, data_type),
+            Cast {
+                expr, data_type, ..
+            } => write!(f, "CAST {:?} TO {:?}", expr, data_type),
             Ternary {
                 predicate,
                 truthy,
@@ -795,10 +798,21 @@ impl Expr {
     }
 
     /// Cast expression to another data type.
+    /// Throws an error if conversion had overflows
+    pub fn strict_cast(self, data_type: DataType) -> Self {
+        Expr::Cast {
+            expr: Box::new(self),
+            data_type,
+            strict: true,
+        }
+    }
+
+    /// Cast expression to another data type.
     pub fn cast(self, data_type: DataType) -> Self {
         Expr::Cast {
             expr: Box::new(self),
             data_type,
+            strict: false,
         }
     }
 
@@ -1815,6 +1829,7 @@ pub fn cast(expr: Expr, data_type: DataType) -> Expr {
     Expr::Cast {
         expr: Box::new(expr),
         data_type,
+        strict: false,
     }
 }
 

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -45,6 +45,7 @@ pub enum AExpr {
     Cast {
         expr: Node,
         data_type: DataType,
+        strict: bool,
     },
     Sort {
         expr: Node,
@@ -284,7 +285,9 @@ impl AExpr {
                 };
                 Ok(field)
             }
-            Cast { expr, data_type } => {
+            Cast {
+                expr, data_type, ..
+            } => {
                 let field = arena.get(*expr).to_field(schema, ctxt, arena)?;
                 Ok(Field::new(field.name(), data_type.clone()))
             }

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -28,9 +28,14 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         Expr::IsNotNull(e) => AExpr::IsNotNull(to_aexpr(*e, arena)),
         Expr::IsNull(e) => AExpr::IsNull(to_aexpr(*e, arena)),
 
-        Expr::Cast { expr, data_type } => AExpr::Cast {
+        Expr::Cast {
+            expr,
+            data_type,
+            strict,
+        } => AExpr::Cast {
             expr: to_aexpr(*expr, arena),
             data_type,
+            strict,
         },
         Expr::Take { expr, idx } => AExpr::Take {
             expr: to_aexpr(*expr, arena),
@@ -409,11 +414,16 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             let exp = node_to_exp(expr, expr_arena);
             Expr::IsNull(Box::new(exp))
         }
-        AExpr::Cast { expr, data_type } => {
+        AExpr::Cast {
+            expr,
+            data_type,
+            strict,
+        } => {
             let exp = node_to_exp(expr, expr_arena);
             Expr::Cast {
                 expr: Box::new(exp),
                 data_type,
+                strict,
             }
         }
         AExpr::Sort { expr, reverse } => {

--- a/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
@@ -72,6 +72,7 @@ impl OptimizationRule for TypeCoercionRule {
                             expr_arena.add(AExpr::Cast {
                                 expr: truthy_node,
                                 data_type: st.clone(),
+                                strict: false,
                             })
                         } else {
                             truthy_node
@@ -81,6 +82,7 @@ impl OptimizationRule for TypeCoercionRule {
                             expr_arena.add(AExpr::Cast {
                                 expr: falsy_node,
                                 data_type: st,
+                                strict: false,
                             })
                         } else {
                             falsy_node
@@ -171,6 +173,7 @@ impl OptimizationRule for TypeCoercionRule {
                             expr_arena.add(AExpr::Cast {
                                 expr: node_left,
                                 data_type: st.clone(),
+                                strict: false,
                             })
                         } else {
                             node_left
@@ -179,6 +182,7 @@ impl OptimizationRule for TypeCoercionRule {
                             expr_arena.add(AExpr::Cast {
                                 expr: node_right,
                                 data_type: st,
+                                strict: false,
                             })
                         } else {
                             node_right

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -8,6 +8,7 @@ pub struct CastExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,
     pub(crate) data_type: DataType,
     pub(crate) expr: Expr,
+    pub(crate) strict: bool,
 }
 
 impl CastExpr {
@@ -22,7 +23,11 @@ impl CastExpr {
                 return Ok(ListChunked::full_null(input.name(), input.len()).into_series());
             }
         }
-        input.cast_with_dtype(&self.data_type)
+        if self.strict {
+            input.strict_cast(&self.data_type)
+        } else {
+            input.cast_with_dtype(&self.data_type)
+        }
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -824,12 +824,17 @@ impl DefaultPlanner {
                     }
                 }
             }
-            Cast { expr, data_type } => {
+            Cast {
+                expr,
+                data_type,
+                strict,
+            } => {
                 let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
                 Ok(Arc::new(CastExpr {
                     input: phys_expr,
                     data_type,
                     expr: node_to_exp(expression, expr_arena),
+                    strict,
                 }))
             }
             Ternary {

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -285,7 +285,7 @@ if not _DOCUMENTING:
 
 def polars_type_to_constructor(
     dtype: Type[DataType],
-) -> Callable[[str, Sequence[Any]], "PySeries"]:
+) -> Callable[[str, Sequence[Any], bool], "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1476,17 +1476,24 @@ class Series:
     def __len__(self) -> int:
         return self.len()
 
-    def cast(self, data_type: Type[DataType]) -> "Series":
-        if data_type == int:
-            data_type = Int64
-        elif data_type == str:
-            data_type = Utf8
-        elif data_type == float:
-            data_type = Float64
-        f = get_ffi_func("cast_<>", data_type, self._s)
-        if f is None:
-            return NotImplemented
-        return wrap_s(f())
+    def cast(self, dtype: Type[DataType], strict: bool = True) -> "Series":
+        """
+        Cast between data types.
+
+        Parameters
+        ----------
+        dtype
+            DataType to cast to
+        strict
+            Throw an error if a cast could not be done for instance due to an overflow
+        """
+        if dtype == int:
+            dtype = Int64
+        elif dtype == str:
+            dtype = Utf8
+        elif dtype == float:
+            dtype = Float64
+        return wrap_s(self._s.cast(str(dtype), strict))
 
     def to_list(self) -> tp.List[Optional[Any]]:
         """

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -125,12 +125,11 @@ class Series:
         One-dimensional data in various forms. Supported are: Sequence, Series,
         pyarrow Array, and numpy ndarray.
     nullable : bool, default True
-        If set to True, Sequence values will be parsed with None interpreted as missing,
-        and numpy arrays will be parsed with NaN interpreted as missing. Note that
-        missing and NaN is not the same in Polars. If your data does not contain null
-        values, set to False to speed up Series creation.
+        deprecated: does not do a thing
     dtype : DataType, default None
         Polars dtype of the Series data. If not specified, the dtype is inferred.
+    strict
+        Throw error on numeric overflow
 
     Examples
     --------
@@ -185,6 +184,7 @@ class Series:
         values: Optional[ArrayLike] = None,
         nullable: bool = True,
         dtype: Optional[Type[DataType]] = None,
+        strict: bool = True,
     ):
         # Handle case where values are passed as the first argument
         if name is not None and not isinstance(name, str):
@@ -202,15 +202,12 @@ class Series:
             self._s = sequence_to_pyseries(name, [], dtype=dtype)
         elif isinstance(values, Series):
             self._s = series_to_pyseries(name, values)
-        elif isinstance(values, np.ndarray):
-            self._s = numpy_to_pyseries(name, values)
         elif isinstance(values, pa.Array):
             self._s = arrow_to_pyseries(name, values)
+        elif isinstance(values, np.ndarray):
+            self._s = numpy_to_pyseries(name, values, strict)
         elif isinstance(values, Sequence):
-            if nullable:
-                self._s = sequence_to_pyseries(name, values, dtype=dtype)
-            else:
-                self._s = numpy_to_pyseries(name, np.array(values))
+            self._s = sequence_to_pyseries(name, values, dtype=dtype, strict=strict)
         elif _PANDAS_AVAILABLE and isinstance(values, (pd.Series, pd.DatetimeIndex)):
             self._s = pandas_to_pyseries(name, values)
         else:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -55,9 +55,7 @@ def arrow_to_pyseries(name: str, values: pa.Array) -> "PySeries":
 
 
 def numpy_to_pyseries(
-    name: str,
-    values: np.ndarray,
-    nullable: bool = True,
+    name: str, values: np.ndarray, nullable: bool = True, strict: bool = True
 ) -> "PySeries":
     """
     Construct a PySeries from a numpy array.
@@ -71,7 +69,7 @@ def numpy_to_pyseries(
         if dtype == np.float32 or dtype == np.float64:
             return constructor(name, values, nullable)
         else:
-            return constructor(name, values)
+            return constructor(name, values, strict)
     else:
         return PySeries.new_object(name, values)
 
@@ -89,6 +87,7 @@ def sequence_to_pyseries(
     name: str,
     values: Sequence[Any],
     dtype: Optional[Type[DataType]] = None,
+    strict: bool = True,
 ) -> "PySeries":
     """
     Construct a PySeries from a sequence.
@@ -99,7 +98,7 @@ def sequence_to_pyseries(
 
     if dtype is not None:
         constructor = polars_type_to_constructor(dtype)
-        pyseries = constructor(name, values)
+        pyseries = constructor(name, values, strict)
         if dtype == Date32:
             pyseries = pyseries.cast(str(pl.Date32), True)
         elif dtype == Date64:
@@ -133,7 +132,7 @@ def sequence_to_pyseries(
 
         else:
             constructor = py_type_to_constructor(dtype_)
-            return constructor(name, values)
+            return constructor(name, values, strict)
 
 
 def _pandas_series_to_arrow(values: Union["pd.Series", "pd.DatetimeIndex"]) -> pa.Array:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -101,9 +101,9 @@ def sequence_to_pyseries(
         constructor = polars_type_to_constructor(dtype)
         pyseries = constructor(name, values)
         if dtype == Date32:
-            pyseries = pyseries.cast_date32()
+            pyseries = pyseries.cast(str(pl.Date32), True)
         elif dtype == Date64:
-            pyseries = pyseries.cast_date64()
+            pyseries = pyseries.cast(str(pl.Date64), True)
         return pyseries
 
     else:

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -609,14 +609,16 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.mode())
 
-    def cast(self, dtype: Type[Any]) -> "Expr":
+    def cast(self, dtype: Type[Any], strict: bool = True) -> "Expr":
         """
-        Cast an expression to a different data types.
+        Cast between data types.
 
         Parameters
         ----------
-        dtype
-            Output data type.
+        data_type
+            DataType to cast to
+        strict
+            Throw an error if a cast could not be done for instance due to an overflow
         """
         if dtype == str:
             dtype = Utf8
@@ -626,7 +628,7 @@ class Expr:
             dtype = Float64
         elif dtype == int:
             dtype = Int64
-        return wrap_expr(self._pyexpr.cast(dtype))
+        return wrap_expr(self._pyexpr.cast(dtype, strict))
 
     def sort(self, reverse: bool = False) -> "Expr":
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -164,10 +164,14 @@ impl PyExpr {
     pub fn count(&self) -> PyExpr {
         self.clone().inner.count().into()
     }
-    pub fn cast(&self, data_type: &PyAny) -> PyExpr {
+    pub fn cast(&self, data_type: &PyAny, strict: bool) -> PyExpr {
         let str_repr = data_type.str().unwrap().to_str().unwrap();
         let dt = str_to_polarstype(str_repr);
-        let expr = self.inner.clone().cast(dt);
+        let expr = if strict {
+            self.inner.clone().strict_cast(dt)
+        } else {
+            self.inner.clone().cast(dt)
+        };
         expr.into()
     }
     pub fn sort(&self, reverse: bool) -> PyExpr {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1146,6 +1146,17 @@ impl PySeries {
         let out = self.series.kurtosis(fisher, bias).map_err(PyPolarsEr::from)?;
         Ok(out)
     }
+
+    pub fn cast(&self, dtype: &str, strict: bool) -> PyResult<Self> {
+        let dtype = str_to_polarstype(dtype);
+        let out = if strict {
+            self.series.strict_cast(&dtype)
+        } else {
+            self.series.cast_with_dtype(&dtype)
+        };
+        let out = out.map_err(PyPolarsEr::from)?;
+        Ok(out.into())
+    }
 }
 
 macro_rules! impl_ufuncs {
@@ -1326,35 +1337,6 @@ impl_unsafe_from_ptr!(unsafe_from_ptr_i8, Int8Type);
 impl_unsafe_from_ptr!(unsafe_from_ptr_i16, Int16Type);
 impl_unsafe_from_ptr!(unsafe_from_ptr_i32, Int32Type);
 impl_unsafe_from_ptr!(unsafe_from_ptr_i64, Int64Type);
-
-macro_rules! impl_cast {
-    ($name:ident, $type:ty) => {
-        #[pymethods]
-        impl PySeries {
-            pub fn $name(&self) -> PyResult<PySeries> {
-                let s = self.series.cast::<$type>().map_err(PyPolarsEr::from)?;
-                Ok(PySeries::new(s))
-            }
-        }
-    };
-}
-
-impl_cast!(cast_u8, UInt8Type);
-impl_cast!(cast_u16, UInt16Type);
-impl_cast!(cast_u32, UInt32Type);
-impl_cast!(cast_u64, UInt64Type);
-impl_cast!(cast_i8, Int8Type);
-impl_cast!(cast_i16, Int16Type);
-impl_cast!(cast_i32, Int32Type);
-impl_cast!(cast_i64, Int64Type);
-impl_cast!(cast_f32, Float32Type);
-impl_cast!(cast_f64, Float64Type);
-impl_cast!(cast_date32, Date32Type);
-impl_cast!(cast_date64, Date64Type);
-impl_cast!(cast_time64ns, Time64NanosecondType);
-impl_cast!(cast_duration_ns, DurationNanosecondType);
-impl_cast!(cast_str, Utf8Type);
-impl_cast!(cast_categorical, CategoricalType);
 
 macro_rules! impl_arithmetic {
     ($name:ident, $type:ty, $operand:tt) => {

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -41,6 +41,8 @@ def test_init_inputs():
         pl.Series([1, 2, 3], [1, 2, 3])
     with pytest.raises(ValueError):
         pl.Series({"a": [1, 2, 3]})
+    with pytest.raises(OverflowError):
+        pl.Series("bigint", [2 ** 64])
 
 
 def test_to_frame():

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -533,3 +533,10 @@ def test_range():
     assert s[2:5].series_equal(s[range(2, 5)])
     df = pl.DataFrame([s])
     assert df[2:5].frame_equal(df[range(2, 5)])
+
+
+def test_strict_cast():
+    with pytest.raises(RuntimeError):
+        pl.Series("a", [2 ** 16]).cast(dtype=pl.Int16, strict=True)
+    with pytest.raises(RuntimeError):
+        pl.DataFrame({"a": [2 ** 16]}).select([pl.col("a").cast(pl.Int16, strict=True)])


### PR DESCRIPTION
Strict casting also in Rust. For series creation we've got the type system.

#1293