### PR TITLE
uppercase env var for MAX_ROWS

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1176,7 +1176,7 @@ class DataFrame:
         * POLARS_FMT_MAX_ROWS: set the number of rows
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
-        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", 25))
+        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=25))
         return "\n".join(NotebookFormatter(self, max_cols, max_rows).render())
 
     def rename(self, mapping: Dict[str, str]) -> "DataFrame":

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1176,7 +1176,7 @@ class DataFrame:
         * POLARS_FMT_MAX_ROWS: set the number of rows
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
-        max_rows = int(os.environ.get("POLARS_FMT_MAX_rows", 25))
+        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", 25))
         return "\n".join(NotebookFormatter(self, max_cols, max_rows).render())
 
     def rename(self, mapping: Dict[str, str]) -> "DataFrame":


### PR DESCRIPTION
The environment variable casing used for max rows is `POLARS_FMT_MAX_rows`, which doesn't match the one used for cols. This aligns them.