### PR TITLE
fix bug in Lazy::apply

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -76,6 +76,7 @@ impl PhysicalExpr for ApplyExpr {
             }
             ApplyOptions::ApplyFlat => {
                 let s = self.function.call_udf(&mut [ac.flat().into_owned()])?;
+                ac.with_update_groups(UpdateGroups::WithGroupsLen);
                 ac.with_series(s);
                 Ok(ac)
             }


### PR DESCRIPTION
The group tuples were not updated after a `AggrecationContext.get_flat` was called in `evaluate_on_groups`.