### PR TITLE
proposal: implement __bool__ for pl.Expr

### DIFF
--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -78,8 +78,10 @@ class Expr:
         return lit(other)
 
     def __bool__(self) -> "Expr":
-        raise ValueError("Since Expr are lazy, the truthiness of an Expr is ambiguous. \
-            Hint: use '&' or '|' to chain Expr together, not and/or.")
+        raise ValueError(
+            "Since Expr are lazy, the truthiness of an Expr is ambiguous. \
+            Hint: use '&' or '|' to chain Expr together, not and/or."
+        )
 
     def __invert__(self) -> "Expr":
         return self.is_not()

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -77,6 +77,10 @@ class Expr:
             return other
         return lit(other)
 
+    def __bool__(self) -> "Expr":
+        raise ValueError("Since Expr are lazy, the truthiness of an Expr is ambiguous. \
+            Hint: use '&' or '|' to chain Expr together, not and/or.")
+
     def __invert__(self) -> "Expr":
         return self.is_not()
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -549,3 +549,22 @@ def test_argminmax():
     )
     assert out["max"][0] == 4
     assert out["min"][0] == 0
+
+
+def test_expr_bool_cmp():
+    # Since expressions are lazy they should not be evaluated as 
+    # bool(x), this has the nice side effect of throwing an error
+    # if someone tries to chain them via the and|or operators
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
+
+    with pytest.raises(ValueError):
+        df[[
+            pl.col("a").gt(pl.col("b")) and
+            pl.col("b").gt(pl.col("b"))
+        ]]
+    
+    with pytest.raises(ValueError):
+        df[[
+            pl.col("a").gt(pl.col("b")) or
+            pl.col("b").gt(pl.col("b"))
+        ]]

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -552,19 +552,13 @@ def test_argminmax():
 
 
 def test_expr_bool_cmp():
-    # Since expressions are lazy they should not be evaluated as 
+    # Since expressions are lazy they should not be evaluated as
     # bool(x), this has the nice side effect of throwing an error
     # if someone tries to chain them via the and|or operators
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
 
     with pytest.raises(ValueError):
-        df[[
-            pl.col("a").gt(pl.col("b")) and
-            pl.col("b").gt(pl.col("b"))
-        ]]
-    
+        df[[pl.col("a").gt(pl.col("b")) and pl.col("b").gt(pl.col("b"))]]
+
     with pytest.raises(ValueError):
-        df[[
-            pl.col("a").gt(pl.col("b")) or
-            pl.col("b").gt(pl.col("b"))
-        ]]
+        df[[pl.col("a").gt(pl.col("b")) or pl.col("b").gt(pl.col("b"))]]


### PR DESCRIPTION
It can be confusing to newcomers to polars on how to chain multiple expressions together if they are coming from other libraries. In polars, only bitwise operators are supported for chaining expressions (like `&` and `|`). To combat this we can actually throw an error if someone does the following: 

```py
df[[
    pl.col("a").gt(pl.col("b")) and
    pl.col("b").gt(pl.col("b"))
]]
```

[Borrowing a bit from numpy](https://github.com/numpy/numpy/blob/main/numpy/ma/API_CHANGES.txt#L110-L114), this is done by implementing `__bool__` which is the function invoked by the short-circuiting `and` and `or` keywords. Furthermore, I'd argue that the boolean-ness (is that a word?) of a lazily evaluated expression is ambiguous (we don't know the result yet) and doesn't really have any good use cases on it's own.  