### PR TITLE
add conversion between categorical <-> arrow dictionary

### DIFF
--- a/polars/polars-core/src/chunked_array/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/categorical/mod.rs
@@ -1,0 +1,55 @@
+use crate::chunked_array::RevMapping;
+use crate::prelude::*;
+use arrow::array::DictionaryArray;
+
+impl From<&CategoricalChunked> for DictionaryArray<u32> {
+    fn from(ca: &CategoricalChunked) -> Self {
+        let ca = ca.rechunk();
+        let keys = ca.downcast_iter().next().unwrap();
+        let map = &**ca.categorical_map.as_ref().unwrap();
+        match map {
+            RevMapping::Local(arr) => {
+                DictionaryArray::from_data(keys.clone(), Arc::new(arr.clone()))
+            }
+            RevMapping::Global(reverse_map, values, _uuid) => {
+                let iter = keys
+                    .into_iter()
+                    .map(|opt_k| opt_k.map(|k| *reverse_map.get(k).unwrap()));
+                let keys = PrimitiveArray::from_trusted_len_iter(iter);
+
+                DictionaryArray::from_data(keys, Arc::new(values.clone()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{reset_string_cache, SINGLE_LOCK};
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_categorical_round_trip() -> Result<()> {
+        let _lock = SINGLE_LOCK.lock();
+        reset_string_cache();
+        let slice = &[
+            Some("foo"),
+            None,
+            Some("bar"),
+            Some("foo"),
+            Some("foo"),
+            Some("bar"),
+        ];
+        let ca = Utf8Chunked::new_from_opt_slice("a", slice);
+        let ca = ca.cast::<CategoricalType>()?;
+
+        let arr: DictionaryArray<u32> = (&ca).into();
+        let s = Series::try_from(("foo", Arc::new(arr) as ArrayRef))?;
+        assert_eq!(s.dtype(), &DataType::Categorical);
+        assert_eq!(s.null_count(), 1);
+        assert_eq!(s.len(), 6);
+
+        Ok(())
+    }
+}

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -36,7 +36,10 @@ pub mod temporal;
 mod trusted_len;
 pub mod upstream_traits;
 use arrow::array::Array;
+#[cfg(feature = "dtype-categorical")]
+pub(crate) mod categorical;
 pub(crate) mod list;
+
 use polars_arrow::prelude::*;
 
 #[cfg(feature = "dtype-categorical")]


### PR DESCRIPTION
This allows for round trips between polars
categorical and arrow. This means
that serde to/from parquet and IPC now
also works as expected.

@ghuls another FYI. As you work a lot with categoricals and binary files.