### PR TITLE
improve performance of rolling_var/ rolling_std

### DIFF
--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1483,6 +1483,52 @@ impl Expr {
         )
     }
 
+    /// Apply a rolling variance
+    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
+    #[cfg(feature = "rolling_window")]
+    pub fn rolling_var(self, window_size: usize) -> Expr {
+        self.apply(
+            move |s| match s.dtype() {
+                DataType::Float32 => Ok(s.f32().unwrap().rolling_var(window_size).into_series()),
+                DataType::Float64 => Ok(s.f64().unwrap().rolling_var(window_size).into_series()),
+                _ => Ok(s
+                    .cast_with_dtype(&DataType::Float64)?
+                    .f64()
+                    .unwrap()
+                    .rolling_var(window_size)
+                    .into_series()),
+            },
+            GetOutput::map_field(|field| match field.data_type() {
+                DataType::Float64 => field.clone(),
+                DataType::Float32 => Field::new(field.name(), DataType::Float32),
+                _ => Field::new(field.name(), DataType::Float64),
+            }),
+        )
+    }
+
+    /// Apply a rolling std-dev
+    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
+    #[cfg(feature = "rolling_window")]
+    pub fn rolling_std(self, window_size: usize) -> Expr {
+        self.apply(
+            move |s| match s.dtype() {
+                DataType::Float32 => Ok(s.f32().unwrap().rolling_std(window_size).into_series()),
+                DataType::Float64 => Ok(s.f64().unwrap().rolling_std(window_size).into_series()),
+                _ => Ok(s
+                    .cast_with_dtype(&DataType::Float64)?
+                    .f64()
+                    .unwrap()
+                    .rolling_std(window_size)
+                    .into_series()),
+            },
+            GetOutput::map_field(|field| match field.data_type() {
+                DataType::Float64 => field.clone(),
+                DataType::Float32 => Field::new(field.name(), DataType::Float32),
+                _ => Field::new(field.name(), DataType::Float64),
+            }),
+        )
+    }
+
     #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     /// Apply a custom function over a rolling/ moving window of the array.

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -170,9 +170,8 @@ impl ToPyObject for Wrap<DataType> {
             DataType::Boolean => pl.getattr("Boolean").unwrap().into(),
             DataType::Utf8 => pl.getattr("Utf8").unwrap().into(),
             DataType::List(_) => pl.getattr("List").unwrap().into(),
-            dt => panic!("{} not supported", dt)
+            dt => panic!("{} not supported", dt),
         }
-
     }
 }
 
@@ -192,8 +191,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Utf8(v).into())
         } else if let Ok(v) = ob.extract::<bool>() {
             Ok(AnyValue::Boolean(v).into())
-        }
-        else if ob.get_type().name()?.contains("datetime") {
+        } else if ob.get_type().name()?.contains("datetime") {
             let gil = Python::acquire_gil();
             let py = gil.python();
 
@@ -205,10 +203,10 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                 let dt = ob.call_method("replace", (), Some(kwargs))?;
 
                 let pytz = PyModule::import(py, "pytz")?;
-                let tz = pytz.call_method("timezone", ("UTC", ), None)?;
+                let tz = pytz.call_method("timezone", ("UTC",), None)?;
                 let kwargs = PyDict::new(py);
                 kwargs.set_item("is_dst", py.None())?;
-                let loc_tz = tz.call_method("localize", (dt, ), Some(kwargs))?;
+                let loc_tz = tz.call_method("localize", (dt,), Some(kwargs))?;
                 loc_tz.call_method0("timestamp")?;
                 // s to ms
                 let v = ts.extract::<f64>()? as i64;

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -98,7 +98,7 @@ impl PyDataFrame {
         low_memory: bool,
         comment_char: Option<&str>,
         null_values: Option<Wrap<NullValues>>,
-        parse_dates: bool
+        parse_dates: bool,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let comment_char = comment_char.map(|s| s.as_bytes()[0]);

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -764,63 +764,38 @@ impl PyExpr {
             .into()
     }
 
-    pub fn rolling_std(
-        &self,
-        window_size: usize,
-    ) -> Self {
+    pub fn rolling_std(&self, window_size: usize) -> Self {
+        self.inner.clone().rolling_std(window_size).into()
+    }
+
+    pub fn rolling_var(&self, window_size: usize) -> Self {
+        self.inner.clone().rolling_var(window_size).into()
+    }
+
+    pub fn rolling_median(&self, window_size: usize) -> Self {
         self.inner
             .clone()
-            .rolling_apply_float(window_size, |ca| ca.std()
-            )
+            .rolling_apply_float(window_size, |ca| ChunkAgg::median(ca))
             .into()
     }
 
-    pub fn rolling_var(
-        &self,
-        window_size: usize,
-    ) -> Self {
+    pub fn rolling_quantile(&self, window_size: usize, quantile: f64) -> Self {
         self.inner
             .clone()
-            .rolling_apply_float(window_size, |ca| ca.var()
-            )
+            .rolling_apply_float(window_size, move |ca| {
+                ChunkAgg::quantile(ca, quantile).unwrap()
+            })
             .into()
     }
 
-    pub fn rolling_median(
-        &self,
-        window_size: usize,
-    ) -> Self {
+    pub fn rolling_skew(&self, window_size: usize, bias: bool) -> Self {
         self.inner
             .clone()
-            .rolling_apply_float(window_size, |ca| ChunkAgg::median(ca)
-            )
+            .rolling_apply_float(window_size, move |ca| {
+                ca.clone().into_series().skew(bias).unwrap()
+            })
             .into()
     }
-
-    pub fn rolling_quantile(
-        &self,
-        window_size: usize,
-        quantile: f64
-    ) -> Self {
-        self.inner
-            .clone()
-            .rolling_apply_float(window_size, move |ca| ChunkAgg::quantile(ca, quantile).unwrap()
-            )
-            .into()
-    }
-
-    pub fn rolling_skew(
-        &self,
-        window_size: usize,
-        bias: bool
-    ) -> Self {
-        self.inner
-            .clone()
-            .rolling_apply_float(window_size, move |ca| ca.clone().into_series().skew(bias).unwrap()
-            )
-            .into()
-    }
-
 
     fn lst_max(&self) -> Self {
         self.inner


### PR DESCRIPTION
This adds a direct implementation of `rolling_std` and `rolling_var` instead of using dispatch of `ChunkedArray`. This is ~100x performance improvement.