### PR TITLE
improve hashing performance w/ specialized hashers 

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,6 +35,8 @@ jobs:
           cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0
+          echo "ON STRINGS"
           python main.py on_strings
+          echo "ON CATEGORICALS"
           python main.py
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/drop_nulls.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/drop_nulls.rs
@@ -43,7 +43,6 @@ impl OptimizationRule for ReplaceDropNulls {
                 let mut binary_and_count = 0;
                 let mut not_null_count = 0;
                 let mut column_count = 0;
-                let mut other_count = 0;
                 for (_, e) in iter {
                     if is_binary_and(e) {
                         binary_and_count += 1;
@@ -54,13 +53,16 @@ impl OptimizationRule for ReplaceDropNulls {
                     } else if is_lit_true(e) {
                         // do nothing
                     } else {
-                        other_count += 1;
+                        // only expected
+                        //  - binary and
+                        //  - column
+                        //  - is not null
+                        //  - lit true
+                        // so we can return early
+                        return None;
                     }
                 }
-                if not_null_count == column_count
-                    && binary_and_count < column_count
-                    && other_count == 0
-                {
+                if not_null_count == column_count && binary_and_count < column_count {
                     let subset = aexpr_to_root_names(*predicate, expr_arena)
                         .iter()
                         .map(|s| s.to_string())


### PR DESCRIPTION
```text
fn hash_all(vals: &[usize]) -> u64 {
    let mut h_acc = 0;
    let rs = RandomState::with_seeds(0, 0, 0, 0);
    for h in vals {
        h_acc |= usize::get_hash(h, &rs);
    }
    h_acc
}


Gnuplot not found, using plotters backend
bench hash              time:   [7.9598 us 7.9651 us 7.9711 us]                        
                        change: [-32.977% -32.815% -32.665%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe


# Vec hash

Gnuplot not found, using plotters backend
bench hash u32          time:   [7.2729 us 7.2772 us 7.2818 us]                            
                        change: [-48.429% -48.325% -48.219%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

bench hash u32 20% nulls       time:   [23.126 us 23.231 us 23.393 us]                               
                        change: [-22.062% -21.732% -21.261%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe

bench hash str          time:   [75.447 us 75.881 us 76.479 us]                           
                        change: [-20.408% -19.761% -18.942%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe


# grouptuples

Gnuplot not found, using plotters backend
bench hash u32          time:   [156.61 us 157.26 us 158.04 us]                           
                        change: [-4.6367% -2.0303% +1.0430%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

bench hash u32 20% nulls      time:   [207.24 us 209.54 us 211.92 us]                              
                        change: [-15.111% -12.912% -10.766%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
  
  
Gnuplot not found, using plotters backend
bench grouptules utf8   time:   [555.80 us 557.67 us 559.59 us]                                  
                        change: [-9.8478% -8.4883% -7.0408%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```