### PR TITLE
manually implement `dyn Series`

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -95,6 +95,7 @@ diff = ["polars-core/diff", "polars-lazy/diff"]
 moment = ["polars-core/moment", "polars-lazy/moment"]
 arange = ["polars-lazy/arange"]
 true_div = ["polars-lazy/true_div"]
+series_bitwise = ["polars-core/series_bitwise"]
 
 # don't use this
 private = []

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -75,6 +75,7 @@ list = []
 rank = []
 diff = []
 moment = []
+series_bitwise = []
 
 
 # opt-in datatypes for Series

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -237,9 +237,6 @@ impl ChunkAgg<u32> for BooleanChunked {
     }
 }
 
-impl ChunkAgg<Series> for ListChunked {}
-impl ChunkAgg<String> for Utf8Chunked {}
-
 // Needs the same trait bounds as the implementation of ChunkedArray<T> of dyn Series
 impl<T> ChunkAggSeries for ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -102,15 +102,6 @@ where
     }
 }
 
-#[cfg(feature = "dtype-categorical")]
-impl ChunkCumAgg<CategoricalType> for CategoricalChunked {}
-impl ChunkCumAgg<Utf8Type> for Utf8Chunked {}
-impl ChunkCumAgg<ListType> for ListChunked {}
-impl ChunkCumAgg<BooleanType> for BooleanChunked {}
-
-#[cfg(feature = "object")]
-impl<T> ChunkCumAgg<ObjectType<T>> for ObjectChunked<T> {}
-
 #[cfg(test)]
 mod test {
     use crate::prelude::*;

--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -122,29 +122,6 @@ where
     }
 }
 
-macro_rules! interpolate {
-    ($ca:ty) => {
-        impl Interpolate for $ca {
-            fn interpolate(&self) -> Self {
-                self.clone()
-            }
-        }
-    };
-}
-
-interpolate!(Utf8Chunked);
-interpolate!(ListChunked);
-interpolate!(BooleanChunked);
-#[cfg(feature = "dtype-categorical")]
-interpolate!(CategoricalChunked);
-
-#[cfg(feature = "object")]
-impl<T: PolarsObject> Interpolate for ObjectChunked<T> {
-    fn interpolate(&self) -> Self {
-        self.clone()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -174,17 +151,6 @@ mod test {
         assert_eq!(
             Vec::from(&out),
             &[None, Some(1), Some(2), Some(3), Some(4), Some(5), None]
-        );
-
-        let ca = Utf8Chunked::new_from_opt_slice(
-            "",
-            &[None, Some("foo"), None, None, Some("bar"), None, None],
-        );
-
-        let out = ca.interpolate();
-        assert_eq!(
-            Vec::from(&out),
-            &[None, Some("foo"), None, None, Some("bar"), None, None]
         );
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -184,8 +184,6 @@ impl IsIn for CategoricalChunked {
     }
 }
 
-impl IsIn for ListChunked {}
-
 #[cfg(test)]
 mod test {
     use crate::prelude::*;

--- a/polars/polars-core/src/chunked_array/ops/peaks.rs
+++ b/polars/polars-core/src/chunked_array/ops/peaks.rs
@@ -19,15 +19,3 @@ where
             & (self.shift_and_fill(-1, Some(Zero::zero())).gt(self))
     }
 }
-
-impl ChunkPeaks for BooleanChunked {}
-impl ChunkPeaks for Utf8Chunked {}
-#[cfg(feature = "dtype-categorical")]
-impl ChunkPeaks for CategoricalChunked {}
-impl ChunkPeaks for ListChunked {}
-
-#[cfg(feature = "object")]
-impl<T> ChunkPeaks for ObjectChunked<T> where
-    T: 'static + std::fmt::Debug + Clone + Send + Sync + Default
-{
-}

--- a/polars/polars-core/src/chunked_array/ops/repeat_by.rs
+++ b/polars/polars-core/src/chunked_array/ops/repeat_by.rs
@@ -63,8 +63,6 @@ impl RepeatBy for Utf8Chunked {
     }
 }
 
-impl RepeatBy for ListChunked {}
-
 #[cfg(feature = "dtype-categorical")]
 impl RepeatBy for CategoricalChunked {
     fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
@@ -73,5 +71,3 @@ impl RepeatBy for CategoricalChunked {
         ca
     }
 }
-#[cfg(feature = "object")]
-impl<T> RepeatBy for ObjectChunked<T> {}

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -401,14 +401,6 @@ where
     }
 }
 
-impl ChunkWindow for ListChunked {}
-impl ChunkWindow for Utf8Chunked {}
-impl ChunkWindow for BooleanChunked {}
-#[cfg(feature = "dtype-categorical")]
-impl ChunkWindow for CategoricalChunked {}
-#[cfg(feature = "object")]
-impl<T> ChunkWindow for ObjectChunked<T> {}
-
 impl<T> ChunkRollApply for ChunkedArray<T>
 where
     T: PolarsNumericType,

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -581,14 +581,6 @@ where
     }
 }
 
-impl ChunkRollApply for ListChunked {}
-impl ChunkRollApply for Utf8Chunked {}
-impl ChunkRollApply for BooleanChunked {}
-#[cfg(feature = "dtype-categorical")]
-impl ChunkRollApply for CategoricalChunked {}
-#[cfg(feature = "object")]
-impl<T> ChunkRollApply for ObjectChunked<T> {}
-
 #[cfg(test)]
 mod test {
     use crate::prelude::*;

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -397,21 +397,6 @@ impl ChunkSort<CategoricalType> for CategoricalChunked {
     }
 }
 
-#[cfg(feature = "object")]
-impl<T> ChunkSort<ObjectType<T>> for ObjectChunked<T> {
-    fn sort(&self, _reverse: bool) -> Self {
-        unimplemented!()
-    }
-
-    fn sort_in_place(&mut self, _reverse: bool) {
-        unimplemented!()
-    }
-
-    fn argsort(&self, _reverse: bool) -> UInt32Chunked {
-        unimplemented!()
-    }
-}
-
 impl ChunkSort<BooleanType> for BooleanChunked {
     fn sort(&self, reverse: bool) -> BooleanChunked {
         sort!(self, reverse)

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -397,20 +397,6 @@ impl ChunkSort<CategoricalType> for CategoricalChunked {
     }
 }
 
-impl ChunkSort<ListType> for ListChunked {
-    fn sort(&self, _reverse: bool) -> Self {
-        unimplemented!()
-    }
-
-    fn sort_in_place(&mut self, _reverse: bool) {
-        unimplemented!()
-    }
-
-    fn argsort(&self, _reverse: bool) -> UInt32Chunked {
-        unimplemented!()
-    }
-}
-
 #[cfg(feature = "object")]
 impl<T> ChunkSort<ObjectType<T>> for ObjectChunked<T> {
     fn sort(&self, _reverse: bool) -> Self {

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -91,19 +91,6 @@ macro_rules! is_unique_duplicated {
     }};
 }
 
-impl ChunkUnique<ListType> for ListChunked {
-    fn unique(&self) -> Result<ChunkedArray<ListType>> {
-        Err(PolarsError::InvalidOperation(
-            "unique not supported for list".into(),
-        ))
-    }
-
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
-        Err(PolarsError::InvalidOperation(
-            "unique not supported for list".into(),
-        ))
-    }
-}
 #[cfg(feature = "object")]
 impl<T> ChunkUnique<ObjectType<T>> for ObjectChunked<T> {
     fn unique(&self) -> Result<ChunkedArray<ObjectType<T>>> {
@@ -397,7 +384,6 @@ where
     }
 }
 
-impl ToDummies<ListType> for ListChunked {}
 #[cfg(feature = "object")]
 impl<T> ToDummies<ObjectType<T>> for ObjectChunked<T> {}
 impl ToDummies<Float32Type> for Float32Chunked {}

--- a/polars/polars-core/src/series/arithmetic.rs
+++ b/polars/polars-core/src/series/arithmetic.rs
@@ -104,9 +104,6 @@ impl NumOpsDispatch for Utf8Chunked {
         Ok(out.into_series())
     }
 }
-impl NumOpsDispatch for BooleanChunked {}
-impl NumOpsDispatch for ListChunked {}
-impl NumOpsDispatch for CategoricalChunked {}
 
 #[cfg(feature = "checked_arithmetic")]
 pub mod checked {

--- a/polars/polars-core/src/series/arithmetic.rs
+++ b/polars/polars-core/src/series/arithmetic.rs
@@ -226,11 +226,6 @@ pub mod checked {
         }
     }
 
-    impl NumOpsDispatchChecked for BooleanChunked {}
-    impl NumOpsDispatchChecked for ListChunked {}
-    impl NumOpsDispatchChecked for CategoricalChunked {}
-    impl NumOpsDispatchChecked for Utf8Chunked {}
-
     impl NumOpsDispatchChecked for Series {
         fn checked_div(&self, rhs: &Series) -> Result<Series> {
             let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -17,8 +17,6 @@ use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
 use crate::prelude::*;
-#[cfg(feature = "checked_arithmetic")]
-use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 use crate::series::implementations::SeriesWrap;
 use ahash::RandomState;
 use arrow::array::ArrayRef;
@@ -37,21 +35,6 @@ impl IntoSeries for BooleanChunked {
 impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cummax(&self, reverse: bool) -> Series {
-        self.0.cummax(reverse).into_series()
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cummin(&self, reverse: bool) -> Series {
-        self.0.cummin(reverse).into_series()
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cumsum(&self, reverse: bool) -> Series {
-        self.0.cumsum(reverse).into_series()
     }
 
     #[cfg(feature = "asof_join")]
@@ -192,7 +175,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
     #[cfg(feature = "interpolate")]
     fn interpolate(&self) -> Series {
-        self.0.interpolate().into_series()
+        self.0.clone().into_series()
     }
 
     #[cfg(feature = "series_bitwise")]
@@ -480,14 +463,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         }
     }
 
-    fn peak_max(&self) -> BooleanChunked {
-        self.0.peak_max()
-    }
-
-    fn peak_min(&self) -> BooleanChunked {
-        self.0.peak_min()
-    }
-
     #[cfg(feature = "is_in")]
     fn is_in(&self, other: &Series) -> Result<BooleanChunked> {
         IsIn::is_in(&self.0, other)
@@ -495,11 +470,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
     #[cfg(feature = "repeat_by")]
     fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
         RepeatBy::repeat_by(&self.0, by)
-    }
-
-    #[cfg(feature = "checked_arithmetic")]
-    fn checked_div(&self, rhs: &Series) -> Result<Series> {
-        self.0.checked_div(rhs)
     }
 
     #[cfg(feature = "is_first")]

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -142,11 +142,6 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<CategoricalChunked> {
-    #[cfg(feature = "rolling_window")]
-    fn rolling_apply(&self, _window_size: usize, _f: &dyn Fn(&Series) -> Series) -> Result<Series> {
-        ChunkRollApply::rolling_apply(&self.0, _window_size, _f).map(|ca| ca.into_series())
-    }
-
     #[cfg(feature = "interpolate")]
     fn interpolate(&self) -> Series {
         self.0.interpolate().into_series()

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -17,8 +17,6 @@ use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
 use crate::prelude::*;
-#[cfg(feature = "checked_arithmetic")]
-use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 use crate::series::implementations::SeriesWrap;
 use ahash::RandomState;
 use arrow::array::ArrayRef;
@@ -138,11 +136,6 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<ListChunked> {
-    #[cfg(feature = "rolling_window")]
-    fn rolling_apply(&self, _window_size: usize, _f: &dyn Fn(&Series) -> Series) -> Result<Series> {
-        ChunkRollApply::rolling_apply(&self.0, _window_size, _f).map(|ca| ca.into_series())
-    }
-
     #[cfg(feature = "interpolate")]
     fn interpolate(&self) -> Series {
         self.0.clone().into_series()
@@ -358,28 +351,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
             DataType::Float32 => Ok(self.0.pow_f32(exponent as f32).into_series()),
             _ => Ok(self.0.pow_f64(exponent).into_series()),
         }
-    }
-
-    fn peak_max(&self) -> BooleanChunked {
-        self.0.peak_max()
-    }
-
-    fn peak_min(&self) -> BooleanChunked {
-        self.0.peak_min()
-    }
-
-    #[cfg(feature = "is_in")]
-    fn is_in(&self, other: &Series) -> Result<BooleanChunked> {
-        IsIn::is_in(&self.0, other)
-    }
-    #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
-        RepeatBy::repeat_by(&self.0, by)
-    }
-
-    #[cfg(feature = "checked_arithmetic")]
-    fn checked_div(&self, rhs: &Series) -> Result<Series> {
-        self.0.checked_div(rhs)
     }
 
     #[cfg(feature = "is_first")]

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -69,7 +69,7 @@ where
 {
     #[cfg(feature = "interpolate")]
     fn interpolate(&self) -> Series {
-        self.0.interpolate().into_series()
+        self.0.clone().into_series()
     }
 
     fn rename(&mut self, name: &str) {
@@ -186,19 +186,6 @@ where
     fn get(&self, index: usize) -> AnyValue {
         ObjectChunked::get_any_value(&self.0, index)
     }
-
-    fn sort_in_place(&mut self, reverse: bool) {
-        ChunkSort::sort_in_place(&mut self.0, reverse)
-    }
-
-    fn sort(&self, reverse: bool) -> Series {
-        ChunkSort::sort(&self.0, reverse).into_series()
-    }
-
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
-        ChunkSort::argsort(&self.0, reverse)
-    }
-
     fn null_count(&self) -> usize {
         ObjectChunked::null_count(&self.0)
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -6,7 +6,6 @@ use crate::chunked_array::{
     ops::{
         compare_inner::{IntoPartialEqInner, IntoPartialOrdInner, PartialEqInner, PartialOrdInner},
         explode::ExplodeByOffsets,
-        ChunkFullNull,
     },
     AsSinglePtr, ChunkIdIter,
 };
@@ -23,18 +22,34 @@ use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 use crate::series::implementations::SeriesWrap;
 use ahash::RandomState;
 use arrow::array::ArrayRef;
+#[cfg(feature = "object")]
 use std::any::Any;
 use std::borrow::Cow;
 
-impl IntoSeries for CategoricalChunked {
+impl IntoSeries for Utf8Chunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
 }
 
-impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
+impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
+    }
+
+    #[cfg(feature = "cum_agg")]
+    fn _cummax(&self, reverse: bool) -> Series {
+        self.0.cummax(reverse).into_series()
+    }
+
+    #[cfg(feature = "cum_agg")]
+    fn _cummin(&self, reverse: bool) -> Series {
+        self.0.cummin(reverse).into_series()
+    }
+
+    #[cfg(feature = "cum_agg")]
+    fn _cumsum(&self, reverse: bool) -> Series {
+        self.0.cumsum(reverse).into_series()
     }
 
     #[cfg(feature = "asof_join")]
@@ -69,12 +84,36 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
+    fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_mean(groups)
+    }
+
+    fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_min(groups)
+    }
+
+    fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_max(groups)
+    }
+
+    fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_sum(groups)
+    }
+
     fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
         self.0.agg_first(groups)
     }
 
     fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
         self.0.agg_last(groups)
+    }
+
+    fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_std(groups)
+    }
+
+    fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_var(groups)
     }
 
     fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
@@ -85,6 +124,13 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.agg_list(groups)
     }
 
+    fn agg_quantile(&self, groups: &[(u32, Vec<u32>)], quantile: f64) -> Option<Series> {
+        self.0.agg_quantile(groups, quantile)
+    }
+
+    fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        self.0.agg_median(groups)
+    }
     #[cfg(feature = "lazy")]
     fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
         self.0.agg_valid_count(groups)
@@ -126,6 +172,21 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     ) -> Series {
         ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
     }
+    fn subtract(&self, rhs: &Series) -> Result<Series> {
+        NumOpsDispatch::subtract(&self.0, rhs)
+    }
+    fn add_to(&self, rhs: &Series) -> Result<Series> {
+        NumOpsDispatch::add_to(&self.0, rhs)
+    }
+    fn multiply(&self, rhs: &Series) -> Result<Series> {
+        NumOpsDispatch::multiply(&self.0, rhs)
+    }
+    fn divide(&self, rhs: &Series) -> Result<Series> {
+        NumOpsDispatch::divide(&self.0, rhs)
+    }
+    fn remainder(&self, rhs: &Series) -> Result<Series> {
+        NumOpsDispatch::remainder(&self.0, rhs)
+    }
     fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
         IntoGroupTuples::group_tuples(&self.0, multithreaded)
     }
@@ -141,15 +202,15 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     }
 }
 
-impl SeriesTrait for SeriesWrap<CategoricalChunked> {
+impl SeriesTrait for SeriesWrap<Utf8Chunked> {
+    #[cfg(feature = "interpolate")]
+    fn interpolate(&self) -> Series {
+        self.0.clone().into_series()
+    }
+
     #[cfg(feature = "rolling_window")]
     fn rolling_apply(&self, _window_size: usize, _f: &dyn Fn(&Series) -> Series) -> Result<Series> {
         ChunkRollApply::rolling_apply(&self.0, _window_size, _f).map(|ca| ca.into_series())
-    }
-
-    #[cfg(feature = "interpolate")]
-    fn interpolate(&self) -> Series {
-        self.0.interpolate().into_series()
     }
 
     fn rename(&mut self, name: &str) {
@@ -174,13 +235,13 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn categorical(&self) -> Result<&CategoricalChunked> {
-        if matches!(self.0.dtype(), DataType::Categorical) {
-            unsafe { Ok(&*(self as *const dyn SeriesTrait as *const CategoricalChunked)) }
+    fn utf8(&self) -> Result<&Utf8Chunked> {
+        if matches!(self.0.dtype(), DataType::Utf8) {
+            unsafe { Ok(&*(self as *const dyn SeriesTrait as *const Utf8Chunked)) }
         } else {
             Err(PolarsError::DataTypeMisMatch(
                 format!(
-                    "cannot unpack Series: {:?} of type {:?} into categorical",
+                    "cannot unpack Series: {:?} of type {:?} into utf8",
                     self.name(),
                     self.dtype(),
                 )
@@ -211,6 +272,14 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
 
     fn filter(&self, filter: &BooleanChunked) -> Result<Series> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
+    }
+
+    fn mean(&self) -> Option<f64> {
+        self.0.mean()
+    }
+
+    fn median(&self) -> Option<f64> {
+        self.0.median()
     }
 
     fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
@@ -321,6 +390,14 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         ChunkUnique::arg_unique(&self.0)
     }
 
+    fn arg_min(&self) -> Option<usize> {
+        ArgAgg::arg_min(&self.0)
+    }
+
+    fn arg_max(&self) -> Option<usize> {
+        ArgAgg::arg_max(&self.0)
+    }
+
     fn is_null(&self) -> BooleanChunked {
         self.0.is_null()
     }
@@ -354,28 +431,28 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     }
 
     fn sum_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        ChunkAggSeries::sum_as_series(&self.0)
     }
     fn max_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        ChunkAggSeries::max_as_series(&self.0)
     }
     fn min_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        ChunkAggSeries::min_as_series(&self.0)
     }
     fn mean_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        ChunkAggSeries::mean_as_series(&self.0)
     }
     fn median_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        ChunkAggSeries::median_as_series(&self.0)
     }
     fn var_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        VarAggSeries::var_as_series(&self.0)
     }
     fn std_as_series(&self) -> Series {
-        CategoricalChunked::full_null(self.name(), 1).into_series()
+        VarAggSeries::std_as_series(&self.0)
     }
-    fn quantile_as_series(&self, _quantile: f64) -> Result<Series> {
-        Ok(CategoricalChunked::full_null(self.name(), 1).into_series())
+    fn quantile_as_series(&self, quantile: f64) -> Result<Series> {
+        ChunkAggSeries::quantile_as_series(&self.0, quantile)
     }
 
     fn fmt_list(&self) -> String {
@@ -399,6 +476,28 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0
             .sample_frac(frac, with_replacement)
             .map(|ca| ca.into_series())
+    }
+
+    fn pow(&self, exponent: f64) -> Result<Series> {
+        let f_err = || {
+            Err(PolarsError::InvalidOperation(
+                format!("power operation not supported on dtype {:?}", self.dtype()).into(),
+            ))
+        };
+
+        match self.dtype() {
+            DataType::Utf8 | DataType::List(_) | DataType::Boolean => f_err(),
+            DataType::Float32 => Ok(self.0.pow_f32(exponent as f32).into_series()),
+            _ => Ok(self.0.pow_f64(exponent).into_series()),
+        }
+    }
+
+    fn peak_max(&self) -> BooleanChunked {
+        self.0.peak_max()
+    }
+
+    fn peak_min(&self) -> BooleanChunked {
+        self.0.peak_min()
     }
 
     #[cfg(feature = "is_in")]
@@ -427,17 +526,5 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     #[cfg(feature = "mode")]
     fn mode(&self) -> Result<Series> {
         Ok(self.0.mode()?.into_series())
-    }
-}
-
-impl private::PrivateSeriesNumeric for SeriesWrap<CategoricalChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        CategoricalChunked::bit_repr_is_large()
-    }
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
-    }
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0.bit_repr_small()
     }
 }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -17,8 +17,6 @@ use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
 use crate::prelude::*;
-#[cfg(feature = "checked_arithmetic")]
-use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 use crate::series::implementations::SeriesWrap;
 use ahash::RandomState;
 use arrow::array::ArrayRef;
@@ -35,21 +33,6 @@ impl IntoSeries for Utf8Chunked {
 impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cummax(&self, reverse: bool) -> Series {
-        self.0.cummax(reverse).into_series()
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cummin(&self, reverse: bool) -> Series {
-        self.0.cummin(reverse).into_series()
-    }
-
-    #[cfg(feature = "cum_agg")]
-    fn _cumsum(&self, reverse: bool) -> Series {
-        self.0.cumsum(reverse).into_series()
     }
 
     #[cfg(feature = "asof_join")]
@@ -208,11 +191,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.clone().into_series()
     }
 
-    #[cfg(feature = "rolling_window")]
-    fn rolling_apply(&self, _window_size: usize, _f: &dyn Fn(&Series) -> Series) -> Result<Series> {
-        ChunkRollApply::rolling_apply(&self.0, _window_size, _f).map(|ca| ca.into_series())
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }
@@ -272,14 +250,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
 
     fn filter(&self, filter: &BooleanChunked) -> Result<Series> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
-    }
-
-    fn mean(&self) -> Option<f64> {
-        self.0.mean()
-    }
-
-    fn median(&self) -> Option<f64> {
-        self.0.median()
     }
 
     fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
@@ -492,14 +462,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         }
     }
 
-    fn peak_max(&self) -> BooleanChunked {
-        self.0.peak_max()
-    }
-
-    fn peak_min(&self) -> BooleanChunked {
-        self.0.peak_min()
-    }
-
     #[cfg(feature = "is_in")]
     fn is_in(&self, other: &Series) -> Result<BooleanChunked> {
         IsIn::is_in(&self.0, other)
@@ -507,11 +469,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
     #[cfg(feature = "repeat_by")]
     fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
         RepeatBy::repeat_by(&self.0, by)
-    }
-
-    #[cfg(feature = "checked_arithmetic")]
-    fn checked_div(&self, rhs: &Series) -> Result<Series> {
-        self.0.checked_div(rhs)
     }
 
     #[cfg(feature = "is_first")]

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -41,6 +41,18 @@ pub trait IntoSeries {
         Self: Sized;
 }
 
+macro_rules! invalid_operation {
+    ($s:expr) => {
+        Err(PolarsError::InvalidOperation(
+            format!(
+                "argsort_multiple is not implemented for this dtype: {:?}",
+                $s.dtype()
+            )
+            .into(),
+        ))
+    };
+}
+
 pub(crate) mod private {
     use super::*;
     #[cfg(feature = "pivot")]
@@ -282,10 +294,38 @@ pub trait SeriesTrait:
     Send + Sync + private::PrivateSeries + private::PrivateSeriesNumeric
 {
     #[cfg(feature = "interpolate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "interpolate")))]
     fn interpolate(&self) -> Series;
 
     /// Rename the Series.
     fn rename(&mut self, name: &str);
+
+    #[cfg(feature = "series_bitwise")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "series_bitwise")))]
+    fn bitand(&self, _other: &Series) -> Result<Series> {
+        panic!(
+            "bitwise and operation not supported for dtype {:?}",
+            self.dtype()
+        )
+    }
+
+    #[cfg(feature = "series_bitwise")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "series_bitwise")))]
+    fn bitor(&self, _other: &Series) -> Result<Series> {
+        panic!(
+            "bitwise or operation not fit supported for dtype {:?}",
+            self.dtype()
+        )
+    }
+
+    #[cfg(feature = "series_bitwise")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "series_bitwise")))]
+    fn bitxor(&self, _other: &Series) -> Result<Series> {
+        panic!(
+            "bitwise xor operation not fit supported for dtype {:?}",
+            self.dtype()
+        )
+    }
 
     /// Get the lengths of the underlying chunks
     fn chunk_lengths(&self) -> ChunkIdIter {
@@ -318,10 +358,7 @@ pub trait SeriesTrait:
 
     /// Shrink the capacity of this array to fit it's length.
     fn shrink_to_fit(&mut self) {
-        eprintln!(
-            "shrink to fit, not yet supported for this {:?}",
-            self.dtype()
-        )
+        panic!("shrink to fit not supported for dtype {:?}", self.dtype())
     }
 
     /// Unpack to ChunkedArray of dtype i8
@@ -672,7 +709,7 @@ pub trait SeriesTrait:
 
     /// Get unique values in the Series.
     fn unique(&self) -> Result<Series> {
-        unimplemented!()
+        invalid_operation!(self)
     }
 
     /// Get unique values in the Series.


### PR DESCRIPTION
This removes the need of empty trait implementations and allows more specific logic per dtype.