### PR TITLE
Use "sep" instead of "delimiter" in pl.Dataframe().to_csv().

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -768,7 +768,7 @@ class DataFrame:
         self,
         file: Optional[Union[TextIO, str, Path]] = None,
         has_headers: bool = True,
-        delimiter: str = ",",
+        sep: str = ",",
     ) -> Optional[str]:
         """
         Write Dataframe to comma-separated values file (csv).
@@ -779,7 +779,7 @@ class DataFrame:
             File path to which the file should be written.
         has_headers
             Whether or not to include header in the CSV output.
-        delimiter
+        sep
             Separate CSV fields with this symbol.
 
         Examples
@@ -795,13 +795,13 @@ class DataFrame:
         """
         if file is None:
             buffer = BytesIO()
-            self._df.to_csv(buffer, has_headers, ord(delimiter))
+            self._df.to_csv(buffer, has_headers, ord(sep))
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, Path):
             file = str(file)
 
-        self._df.to_csv(file, has_headers, ord(delimiter))
+        self._df.to_csv(file, has_headers, ord(sep))
         return None
 
     def to_ipc(self, file: Union[BinaryIO, str, Path]) -> None:

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -230,11 +230,11 @@ impl PyDataFrame {
         Ok(pydf)
     }
 
-    pub fn to_csv(&self, py_f: PyObject, has_headers: bool, delimiter: u8) -> PyResult<()> {
+    pub fn to_csv(&self, py_f: PyObject, has_headers: bool, sep: u8) -> PyResult<()> {
         let mut buf = get_file_like(py_f, true)?;
         CsvWriter::new(&mut buf)
             .has_headers(has_headers)
-            .with_delimiter(delimiter)
+            .with_delimiter(sep)
             .finish(&self.df)
             .map_err(PyPolarsEr::from)?;
         Ok(())


### PR DESCRIPTION
Use "sep" instead of "delimiter" in pl.Dataframe().to_csv()
to be constent with pl.read_csv() and pl.scan_csv().