### PR TITLE
add reverse collect for numeric ChunkedArray

### DIFF
--- a/polars/polars-arrow/src/trusted_len/mod.rs
+++ b/polars/polars-arrow/src/trusted_len/mod.rs
@@ -1,9 +1,11 @@
 mod boolean;
+mod rev;
 
 use crate::utils::{FromTrustedLenIterator, TrustMyLength};
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow::buffer::MutableBuffer;
 use arrow::types::NativeType;
+pub use rev::FromIteratorReversed;
 use std::slice::Iter;
 
 /// An iterator of known, fixed size.

--- a/polars/polars-arrow/src/trusted_len/rev.rs
+++ b/polars/polars-arrow/src/trusted_len/rev.rs
@@ -1,0 +1,5 @@
+use crate::trusted_len::TrustedLen;
+
+pub trait FromIteratorReversed<T>: Sized {
+    fn from_trusted_len_iter_rev<I: TrustedLen<Item = T>>(iter: I) -> Self;
+}

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::trusted_len::{PushUnchecked, TrustedLen};
+use crate::trusted_len::{FromIteratorReversed, PushUnchecked, TrustedLen};
 use arrow::bitmap::Bitmap;
 use std::ops::BitAnd;
 
@@ -77,6 +77,13 @@ pub trait CustomIterTools: Iterator {
         Self: Sized + TrustedLen,
     {
         FromTrustedLenIterator::from_iter_trusted_length(self)
+    }
+
+    fn collect_reversed<T: FromIteratorReversed<Self::Item>>(self) -> T
+    where
+        Self: Sized + TrustedLen,
+    {
+        FromIteratorReversed::from_trusted_len_iter_rev(self)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -60,16 +60,21 @@ where
     fn cummax(&self, reverse: bool) -> ChunkedArray<T> {
         let init = Bounded::min_value();
         let mut ca: Self = match reverse {
-            false => self.into_iter().scan(init, det_max).collect(),
-            true => self.into_iter().rev().scan(init, det_max).collect(),
+            false => self
+                .into_iter()
+                .scan(init, det_max)
+                .trust_my_length(self.len())
+                .collect_trusted(),
+            true => self
+                .into_iter()
+                .rev()
+                .scan(init, det_max)
+                .trust_my_length(self.len())
+                .collect_reversed(),
         };
 
         ca.rename(self.name());
-        if reverse {
-            ca.reverse()
-        } else {
-            ca
-        }
+        ca
     }
 
     fn cummin(&self, reverse: bool) -> ChunkedArray<T> {
@@ -85,15 +90,11 @@ where
                 .rev()
                 .scan(init, det_min)
                 .trust_my_length(self.len())
-                .collect_trusted(),
+                .collect_reversed(),
         };
 
         ca.rename(self.name());
-        if reverse {
-            ca.reverse()
-        } else {
-            ca
-        }
+        ca
     }
 
     fn cumsum(&self, reverse: bool) -> ChunkedArray<T> {
@@ -109,15 +110,11 @@ where
                 .rev()
                 .scan(init, det_sum)
                 .trust_my_length(self.len())
-                .collect_trusted(),
+                .collect_reversed(),
         };
 
         ca.rename(self.name());
-        if reverse {
-            ca.reverse()
-        } else {
-            ca
-        }
+        ca
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -42,9 +42,7 @@ fn fill_backward<T>(ca: &ChunkedArray<T>) -> ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    // TODO! improve performance. This is a double scan
-    let ca: ChunkedArray<T> = ca
-        .into_iter()
+    ca.into_iter()
         .rev()
         .scan(None, |previous, opt_v| match opt_v {
             Some(value) => {
@@ -54,8 +52,7 @@ where
             None => Some(*previous),
         })
         .trust_my_length(ca.len())
-        .collect_trusted();
-    ca.into_iter().rev().collect_trusted()
+        .collect_reversed()
 }
 
 macro_rules! impl_fill_backward {
@@ -151,6 +148,7 @@ impl ChunkFillNull for BooleanChunked {
                 Ok(out)
             }
             FillNullStrategy::Backward => {
+                // TODO: still a double scan. impl collect_reversed for boolean
                 let mut out: Self = impl_fill_backward!(self, BooleanChunked);
                 out.rename(self.name());
                 Ok(out)


### PR DESCRIPTION
IFF an iterators length can be trusted we know exactly how much space to allocate. This allows for a `collect_reversed` implementation that fills the array in reversed order. 