### PR TITLE
change memmap2 version from 0.2.0 -> 0.5.0 to support wasm

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -38,7 +38,7 @@ num_cpus = "1.13.0"
 csv-core = {version = "0.1.10", optional=true}
 regex = "1.4"
 lazy_static = "1.4"
-memmap = { package = "memmap2", version = "0.2.0", optional=true}
+memmap = { package = "memmap2", version = "0.5.0", optional=true}
 anyhow = "1.0"
 rayon = "1.5"
 ahash = "0.7"


### PR DESCRIPTION
As mentioned here https://github.com/RazrFalcon/memmap2-rs/issues/17#issue-882254594, it's not possible to compile memmap2 0.2.0 for wasm-unknwon-unknwon, and this propagate to polars-io that has memmap as a dependency when the "csv-file" feature is enabled. Updating the version of memmap2 solves this problem.