### PR TITLE
Export `pl.exclude()`

### DIFF
--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -57,7 +57,7 @@ __all__ = [
     "concat_str",
     "concat_list",
     "collect_all",
-    "exclude"
+    "exclude",
 ]
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -355,16 +355,12 @@ def test_regex_selection():
 
     assert df.select([col("^foo.*$")]).columns == ["foo", "fooey", "foobar"]
 
+
 def test_exclude_selection():
-    df = pl.DataFrame(
-        {
-            "a": [1],
-            "b": [1],
-            "c": [1]
-        }
-    ).lazy()
+    df = pl.DataFrame({"a": [1], "b": [1], "c": [1]}).lazy()
 
     assert df.select([pl.exclude("a")]).columns == ["b", "c"]
+
 
 def test_literal_projection():
     df = pl.DataFrame({"a": [1, 2]})


### PR DESCRIPTION
Makes `exclude()` available through the polars module.