### PR TITLE
made parquet writer parallel over columns.

### DIFF
--- a/polars/polars-arrow/src/trusted_len/mod.rs
+++ b/polars/polars-arrow/src/trusted_len/mod.rs
@@ -13,6 +13,8 @@ use std::slice::Iter;
 /// This is re-defined here and implemented for some iterators until `std::iter::TrustedLen`
 /// is stabilized.
 /// *Implementation from Jorge Leitao on Arrow2
+/// # Safety
+/// length of the iterator must be correct
 pub unsafe trait TrustedLen: Iterator {}
 
 unsafe impl<T> TrustedLen for Iter<'_, T> {}

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -756,7 +756,7 @@ class DataFrame:
         self,
         file: Union[str, Path],
         compression: str = "snappy",
-        use_pyarrow: bool = _PYARROW_AVAILABLE,
+        use_pyarrow: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -767,7 +767,14 @@ class DataFrame:
         file
             File path to which the file should be written.
         compression
-            Compression method (only supported if `use_pyarrow`).
+            Compression method. Choose one of:
+                - "uncompressed" (not supported by pyarrow)
+                - "snappy"
+                - "gzip"
+                - "lzo"
+                - "brotli"
+                - "lz4"
+                - "zstd"
         use_pyarrow
             Use C++ parquet implementation vs rust parquet implementation.
             At the moment C++ supports more features.
@@ -804,7 +811,7 @@ class DataFrame:
                 table=tbl, where=file, compression=compression, **kwargs
             )
         else:
-            self._df.to_parquet(file)
+            self._df.to_parquet(file, compression)
 
     def to_numpy(self) -> np.ndarray:
         """


### PR DESCRIPTION
Thanks @jorgecarleitao for the example. 

Ran a benchmark on a `DataFrame` with 10M rows and 9 columns on a laptop with 12 virtual threads.

```python
>>> df.dtypes
[polars.datatypes.Utf8,
 polars.datatypes.Utf8,
 polars.datatypes.Utf8,
 polars.datatypes.Int32,
 polars.datatypes.Int32,
 polars.datatypes.Int32,
 polars.datatypes.Int32,
 polars.datatypes.Int32,
 polars.datatypes.Float64]
 >>> print(df)
 shape: (10000000, 9)
┌───────┬───────┬──────────────┬─────┬─────┬───────┬─────┬─────┬───────────┐
│ id1   ┆ id2   ┆ id3          ┆ id4 ┆ ... ┆ id6   ┆ v1  ┆ v2  ┆ v3        │
│ ---   ┆ ---   ┆ ---          ┆ --- ┆     ┆ ---   ┆ --- ┆ --- ┆ ---       │
│ str   ┆ str   ┆ str          ┆ i32 ┆     ┆ i32   ┆ i32 ┆ i32 ┆ f64       │
╞═══════╪═══════╪══════════════╪═════╪═════╪═══════╪═════╪═════╪═══════════╡
│ id046 ┆ id007 ┆ id0000043878 ┆ 51  ┆ ... ┆ 59276 ┆ 1   ┆ 2   ┆ 9.33179   │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id041 ┆ id026 ┆ id0000068300 ┆ 12  ┆ ... ┆ 78315 ┆ 4   ┆ 2   ┆ 24.555835 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id036 ┆ id078 ┆ id0000012244 ┆ 25  ┆ ... ┆ 27300 ┆ 4   ┆ 15  ┆ 15.146486 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id067 ┆ id100 ┆ id0000006157 ┆ 54  ┆ ... ┆ 65416 ┆ 2   ┆ 8   ┆ 68.837472 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ ...   ┆ ...   ┆ ...          ┆ ... ┆ ... ┆ ...   ┆ ... ┆ ... ┆ ...       │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id042 ┆ id015 ┆ id0000029816 ┆ 65  ┆ ... ┆ 17454 ┆ 3   ┆ 1   ┆ 75.332103 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id040 ┆ id064 ┆ id0000061208 ┆ 23  ┆ ... ┆ 36440 ┆ 5   ┆ 15  ┆ 20.273509 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id093 ┆ id074 ┆ id0000085438 ┆ 99  ┆ ... ┆ 39035 ┆ 1   ┆ 15  ┆ 69.669523 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id096 ┆ id025 ┆ id0000082486 ┆ 4   ┆ ... ┆ 26294 ┆ 2   ┆ 1   ┆ 52.233312 │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ id026 ┆ id088 ┆ id0000097669 ┆ 37  ┆ ... ┆ 12765 ┆ 1   ┆ 8   ┆ 79.16019  │
└───────┴───────┴──────────────┴─────┴─────┴───────┴─────┴─────┴───────────┘

```

## Results

This is the runtime in seconds. Lower is better.

```
parallel 
0.7561395168304443

single-threaded
1.8336927890777588

pyarrow
1.631545066833496
```