### PR TITLE
Fix error message when unpacking to u64 in SeriesTrait

### DIFF
--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -405,7 +405,7 @@ pub trait SeriesTrait:
     /// Unpack to ChunkedArray of dtype u64
     fn u64(&self) -> Result<&UInt64Chunked> {
         Err(PolarsError::DataTypeMisMatch(
-            format!("Series dtype {:?} != u32", self.dtype()).into(),
+            format!("Series dtype {:?} != u64", self.dtype()).into(),
         ))
     }
 


### PR DESCRIPTION
I just noticed the error message in the `SeriesTrait` was incorrect when unpacking to `u64` as it referred to `u32`.

This fixes #1547