### PR TITLE
python: pl.format str format function

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -42,6 +42,7 @@ These functions can be used as expression and sometimes also in eager contexts.
    argsort_by
    concat_str
    concat_list
+   format
    when
    exclude
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -232,6 +232,10 @@ def test_concat_str():
     out = df[[pl.concat_str(["a", "b"], sep="-")]]
     assert out["a"] == ["a-1", "a-2", "a-3"]
 
+    out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
+
+    assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
+
 
 def test_fold_filter():
     df = pl.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
@@ -240,7 +244,7 @@ def test_fold_filter():
         pl.fold(
             acc=pl.lit(True),
             f=lambda a, b: a & b,
-            exprs=[col(c) > 1 for c in df.columns],
+            exprs=[pl.col(c) > 1 for c in df.columns],
         )
     )
 
@@ -250,7 +254,7 @@ def test_fold_filter():
         pl.fold(
             acc=pl.lit(True),
             f=lambda a, b: a | b,
-            exprs=[col(c) > 1 for c in df.columns],
+            exprs=[pl.col(c) > 1 for c in df.columns],
         )
     )
 


### PR DESCRIPTION
closes #1606 and is as close as it gets to `fstrings`.

```python
   >>> df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
    >>> df.select([
    >>>     pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")
    >>> ])
    shape: (3, 1)
    ┌─────────────┐
    │ fmt         │
    │ ---         │
    │ str         │
    ╞═════════════╡
    │ foo_a_bar_1 │
    ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ foo_b_bar_2 │
    ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ foo_c_bar_3 │
    └─────────────┘

```