### PR TITLE
Implement DataFrame Upsampling

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1924,9 +1924,6 @@ class DataFrame:
         low: datetime = bounds[0, "low"]
         high: datetime = bounds[0, "high"]
         upsampled = pl.date_range(low, high, interval, name=by)
-        # pl.date_range excludes 'high'. Include it when relevant
-        if (high - low) % interval == timedelta(0):
-            upsampled.append(pl.Series(values=[high]))
         return pl.DataFrame(upsampled).join(self, on=by, how="left")
 
     def join(

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -3,7 +3,7 @@ Module containing logic related to eager DataFrames
 """
 import os
 import typing as tp
-from datetime import datetime, timedelta
+from datetime import timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
@@ -1916,13 +1916,10 @@ class DataFrame:
                 f"Column {by} should be of type datetime. Got {self[by].dtype}"
             )
         bounds = self.select(
-            [
-                pl.col(by).min().alias("low").dt.to_python_datetime(),
-                pl.col(by).max().alias("high").dt.to_python_datetime(),
-            ]
+            [pl.col(by).min().alias("low"), pl.col(by).max().alias("high")]
         )
-        low: datetime = bounds[0, "low"]
-        high: datetime = bounds[0, "high"]
+        low = bounds["low"].dt[0]
+        high = bounds["high"].dt[0]
         upsampled = pl.date_range(low, high, interval, name=by)
         return pl.DataFrame(upsampled).join(self, on=by, how="left")
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -96,7 +96,11 @@ def arg_where(mask: "pl.Series") -> "pl.Series":
 
 
 def date_range(
-    low: datetime, high: datetime, interval: timedelta, name: Optional[str] = None
+    low: datetime,
+    high: datetime,
+    interval: timedelta,
+    closed: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> pl.Series:
     """
     Create a date range of type `Datetime`.
@@ -109,6 +113,8 @@ def date_range(
         Upper bound of the date range
     interval
         Interval periods
+    closed {None, 'left', 'right'}
+        Make the interval closed to the 'left', 'right', or both sides (None, the default).
     name
         Name of the output Series
     Returns
@@ -150,7 +156,9 @@ def date_range(
         2015-06-30 12:00:00
     ]
     """
-    return pl.Series(
-        name=name,
-        values=np.arange(low, high, interval, dtype="datetime64[ms]").astype(int),
-    ).cast(pl.Datetime)
+    values = np.arange(low, high, interval, dtype="datetime64[ms]")
+    if closed in (None, "right") and (high - low) % interval == timedelta(0):
+        values = np.append(values, np.array(high, dtype="datetime64[ms]"))
+    if closed == "right":
+        values = values[1:]
+    return pl.Series(name=name, values=values.astype(int)).cast(pl.Datetime)


### PR DESCRIPTION
As mentioned in https://github.com/pola-rs/polars/issues/1555

Also added a 'closed' arg to date_range to allow closing the range on 'left', 'right', or both sides (default to both sides as pandas, which differs from the current 'left' behaviour). Having a closed interval on both sides is the most sensible when upsampling (and in many other cases).

A couple of comments:

- Only works for a column of type datetime, and not of type date, as pl.date_range only returns datetime. It could make sense to have pl.date_range returns dates when interval is a multiple of `timedelta(days=1)` and when low & high are dates?
- pl.date_range is fairly minimal. It would be great to have the ability to specify frequency with something else than a timedelta; for instance to return all month ends in range. This would be similar to pandas [DateOffset](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects)
- It seems converting a datetime / date series to numpy returns integers: shouldn't they be converted to numpy datetime types? (I have switched to `to_python_datetime`)
