### PR TITLE
fix lazy schema names and proper test them

### DIFF
--- a/polars/polars-core/src/chunked_array/list/iterator.rs
+++ b/polars/polars-core/src/chunked_array/list/iterator.rs
@@ -121,6 +121,7 @@ impl ListChunked {
             })
             .collect_trusted();
 
+        ca.rename(self.name());
         if fast_explode {
             ca.set_fast_explode();
         }
@@ -151,6 +152,7 @@ impl ListChunked {
                     .transpose()
             })
             .collect::<Result<_>>()?;
+        ca.rename(self.name());
         if fast_explode {
             ca.set_fast_explode();
         }

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -162,17 +162,37 @@ impl DefaultPlanner {
                     cache,
                 )))
             }
-            Projection { expr, input, .. } => {
+            Projection {
+                expr,
+                input,
+                schema: _schema,
+                ..
+            } => {
                 let input = self.create_initial_physical_plan(input, lp_arena, expr_arena)?;
                 let phys_expr =
                     self.create_physical_expressions(&expr, Context::Default, expr_arena)?;
-                Ok(Box::new(ProjectionExec::new(input, phys_expr)))
+                Ok(Box::new(ProjectionExec {
+                    input,
+                    expr: phys_expr,
+                    #[cfg(test)]
+                    schema: _schema,
+                }))
             }
-            LocalProjection { expr, input, .. } => {
+            LocalProjection {
+                expr,
+                input,
+                schema: _schema,
+                ..
+            } => {
                 let input = self.create_initial_physical_plan(input, lp_arena, expr_arena)?;
                 let phys_expr =
                     self.create_physical_expressions(&expr, Context::Default, expr_arena)?;
-                Ok(Box::new(ProjectionExec::new(input, phys_expr)))
+                Ok(Box::new(ProjectionExec {
+                    input,
+                    expr: phys_expr,
+                    #[cfg(test)]
+                    schema: _schema,
+                }))
             }
             DataFrameScan {
                 df,

--- a/polars/polars-lazy/src/test.rs
+++ b/polars/polars-lazy/src/test.rs
@@ -686,8 +686,8 @@ fn test_lazy_update_column() {
 #[test]
 fn test_lazy_fill_null() {
     let df = df! {
-        "a" => &[None, Some(2)],
-        "b" => &[Some(1), None]
+        "a" => &[None, Some(2.0)],
+        "b" => &[Some(1.0), None]
     }
     .unwrap();
     let out = df.lazy().fill_null(lit(10.0)).collect().unwrap();
@@ -1996,6 +1996,15 @@ pub fn test_select_by_dtypes() -> Result<()> {
         .select([dtype_cols([DataType::Float32, DataType::Utf8])])
         .collect()?;
     assert_eq!(out.dtypes(), &[DataType::Float32, DataType::Utf8]);
+
+    Ok(())
+}
+
+#[test]
+fn test_binary_expr() -> Result<()> {
+    // test panic in schema names
+    let df = fruits_cars();
+    let out = df.lazy().select([col("A").neq(lit(1))]).collect()?;
 
     Ok(())
 }


### PR DESCRIPTION
This improves the statically determined schema correctness. We also test the correct names. The dtypes still fail, so that needs still to be done.

fixes #1644 