### PR TITLE
drop GroupTuples in window exprs

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -75,6 +75,8 @@ impl PhysicalExpr for WindowExpr {
                 Ok(DataFrame::new_no_checks(cols))
             }
         }?;
+        // drop the group tuples before we do the left join to reduce allocated memory.
+        drop(gb);
 
         // 3. get the join tuples and use them to take the new Series
         let out_column = out.select_at_idx(out.width() - 1).unwrap();


### PR DESCRIPTION
Reduces memory usage in window expressions. When we are done with the groupby, the group tuples can be dropped before we execute the left join. #1646 