### PR TITLE
update schema when projections are pushed down to the dataframe level

### DIFF
--- a/polars/polars-lazy/src/test.rs
+++ b/polars/polars-lazy/src/test.rs
@@ -2024,3 +2024,18 @@ fn test_binary_expr() -> Result<()> {
     assert_eq!(out.dtypes(), &[DataType::Float64]);
     Ok(())
 }
+
+#[test]
+fn test_drop_and_select() -> Result<()> {
+    let df = fruits_cars();
+
+    let out = df
+        .lazy()
+        .drop_columns(["A", "B"])
+        .select([col("fruits")])
+        .collect()?;
+
+    assert_eq!(out.get_column_names(), &["fruits"]);
+
+    Ok(())
+}


### PR DESCRIPTION
This fixes #1659. The issue was that projections were pushed down to the scan level, being a csv-scan, parquet-scan or a DataFrame, without updating the schema. This meant that upstream nodes assumed non-projected columns were still available.