### PR TITLE
No null count cache

### DIFF
--- a/polars/benches/groupby.rs
+++ b/polars/benches/groupby.rs
@@ -14,11 +14,11 @@ lazy_static! {
             .with_stop_after_n_rows(Some(1000000))
             .finish()
             .unwrap();
-        df.may_apply("id1", |s| s.cast::<CategoricalType>())
+        df.may_apply("id1", |s| s.cast(DataType::Categorical)())
             .unwrap();
-        df.may_apply("id2", |s| s.cast::<CategoricalType>())
+        df.may_apply("id2", |s| s.cast(DataType::Categorical)())
             .unwrap();
-        df.may_apply("id3", |s| s.cast::<CategoricalType>())
+        df.may_apply("id3", |s| s.cast(DataType::Categorical)())
             .unwrap();
         df
     };

--- a/polars/benches/groupby.rs
+++ b/polars/benches/groupby.rs
@@ -14,11 +14,11 @@ lazy_static! {
             .with_stop_after_n_rows(Some(1000000))
             .finish()
             .unwrap();
-        df.may_apply("id1", |s| s.cast(DataType::Categorical)())
+        df.may_apply("id1", |s| s.cast(&DataType::Categorical))
             .unwrap();
-        df.may_apply("id2", |s| s.cast(DataType::Categorical)())
+        df.may_apply("id2", |s| s.cast(&DataType::Categorical))
             .unwrap();
-        df.may_apply("id3", |s| s.cast(DataType::Categorical)())
+        df.may_apply("id3", |s| s.cast(&DataType::Categorical))
             .unwrap();
         df
     };
@@ -129,7 +129,7 @@ fn q8(c: &mut Criterion) {
                 .sort("v3", true)
                 .groupby([col("id6")])
                 .agg([col("v3").head(Some(2)).alias("v3_top_2")])
-                .explode(&[col("v3_top_2")])
+                .explode(vec![col("v3_top_2")])
                 .collect()
                 .unwrap();
         })

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -9,9 +9,9 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-#arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "326fc9d89340ccd22cf0f981a98f56be582d8192", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "58db4c55722e0bcd29740be4e475161074b75e46", default-features = false }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", branch="dev", default-features = false }
-arrow = { package = "arrow2", version = "0.7", default-features=false}
+#arrow = { package = "arrow2", version = "0.7", default-features=false}
 thiserror = "^1.0"
 num = "^0.4"
 

--- a/polars/polars-arrow/src/array/mod.rs
+++ b/polars/polars-arrow/src/array/mod.rs
@@ -1,7 +1,7 @@
 pub mod default_arrays;
 
 use crate::utils::CustomIterTools;
-use arrow::array::{ArrayRef, BooleanArray, ListArray, PrimitiveArray, Utf8Array};
+use arrow::array::{Array, ArrayRef, BooleanArray, ListArray, PrimitiveArray, Utf8Array};
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::MutableBuffer;
 use arrow::datatypes::DataType;
@@ -171,3 +171,11 @@ pub trait ListFromIter {
     }
 }
 impl ListFromIter for ListArray<i64> {}
+
+pub trait PolarsArray: Array {
+    fn has_validity(&self) -> bool {
+        self.validity().is_some()
+    }
+}
+
+impl<A: Array> PolarsArray for A {}

--- a/polars/polars-arrow/src/array/mod.rs
+++ b/polars/polars-arrow/src/array/mod.rs
@@ -178,4 +178,4 @@ pub trait PolarsArray: Array {
     }
 }
 
-impl<A: Array> PolarsArray for A {}
+impl<A: Array + ?Sized> PolarsArray for A {}

--- a/polars/polars-arrow/src/kernels/set.rs
+++ b/polars/polars-arrow/src/kernels/set.rs
@@ -1,11 +1,11 @@
 use crate::array::default_arrays::FromData;
 use crate::error::{PolarsError, Result};
 use crate::kernels::BinaryMaskedSliceIterator;
+use crate::prelude::PolarsArray;
 use arrow::array::*;
 use arrow::buffer::MutableBuffer;
 use arrow::{datatypes::DataType, types::NativeType};
 use std::ops::BitOr;
-use crate::prelude::PolarsArray;
 
 /// Set values in a primitive array where the primitive array has null values.
 /// this is faster because we don't have to invert and combine bitmaps

--- a/polars/polars-arrow/src/kernels/set.rs
+++ b/polars/polars-arrow/src/kernels/set.rs
@@ -5,6 +5,7 @@ use arrow::array::*;
 use arrow::buffer::MutableBuffer;
 use arrow::{datatypes::DataType, types::NativeType};
 use std::ops::BitOr;
+use crate::prelude::PolarsArray;
 
 /// Set values in a primitive array where the primitive array has null values.
 /// this is faster because we don't have to invert and combine bitmaps
@@ -13,7 +14,7 @@ where
     T: NativeType,
 {
     let values = array.values();
-    if array.null_count() == 0 {
+    if !array.has_validity() {
         return array.clone();
     }
 

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -60,7 +60,7 @@ pub unsafe fn take_no_null_primitive<T: NativeType>(
     arr: &PrimitiveArray<T>,
     indices: &UInt32Array,
 ) -> Arc<PrimitiveArray<T>> {
-    assert_eq!(arr.null_count(), 0);
+    debug_assert_eq!(arr.has_validity(), false);
 
     let array_values = arr.values().as_slice();
     let index_values = indices.values().as_slice();
@@ -87,7 +87,7 @@ pub unsafe fn take_no_null_primitive_iter_unchecked<
     arr: &PrimitiveArray<T>,
     indices: I,
 ) -> Arc<PrimitiveArray<T>> {
-    assert_eq!(arr.null_count(), 0);
+    debug_assert_eq!(arr.has_validity(), false);
 
     let array_values = arr.values().as_slice();
 
@@ -189,7 +189,7 @@ pub unsafe fn take_no_null_bool_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &BooleanArray,
     indices: I,
 ) -> Arc<BooleanArray> {
-    debug_assert_eq!(arr.null_count(), 0);
+    debug_assert_eq!(arr.has_validity(), false);
     let iter = indices
         .into_iter()
         .map(|idx| Some(arr.values().get_bit_unchecked(idx)));

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -358,7 +358,7 @@ pub unsafe fn take_utf8_unchecked(
     let mut values_buf = AlignedVec::<u8>::with_capacity(values_capacity);
 
     // both 0 nulls
-    if arr.null_count() == 0 && indices.null_count() == 0 {
+    if !arr.has_validity() && !indices.has_validity() {
         offset_typed
             .iter_mut()
             .skip(1)
@@ -377,7 +377,7 @@ pub unsafe fn take_utf8_unchecked(
                 values_buf.extend_from_slice(s.as_bytes())
             });
         validity = None;
-    } else if arr.null_count() == 0 {
+    } else if !arr.has_validity() {
         offset_typed
             .iter_mut()
             .skip(1)
@@ -402,7 +402,7 @@ pub unsafe fn take_utf8_unchecked(
         let mut builder = MutableUtf8Array::with_capacities(data_len, length_so_far as usize);
         let validity_arr = arr.validity().expect("should have nulls");
 
-        if indices.null_count() == 0 {
+        if !indices.has_validity() {
             (0..data_len).for_each(|idx| {
                 let index = indices.value_unchecked(idx) as usize;
                 builder.push(if validity_arr.get_bit_unchecked(index) {
@@ -469,7 +469,7 @@ pub unsafe fn take_value_indices_from_list(
 
     let indices_values = indices.values();
 
-    if indices.null_count() == 0 {
+    if !indices.has_validity() {
         for i in 0..indices.len() {
             let idx = *indices_values.get_unchecked(i) as usize;
             let start = *offsets.get_unchecked(idx);

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -60,7 +60,7 @@ pub unsafe fn take_no_null_primitive<T: NativeType>(
     arr: &PrimitiveArray<T>,
     indices: &UInt32Array,
 ) -> Arc<PrimitiveArray<T>> {
-    debug_assert_eq!(arr.has_validity(), false);
+    debug_assert!(!arr.has_validity());
 
     let array_values = arr.values().as_slice();
     let index_values = indices.values().as_slice();
@@ -87,7 +87,7 @@ pub unsafe fn take_no_null_primitive_iter_unchecked<
     arr: &PrimitiveArray<T>,
     indices: I,
 ) -> Arc<PrimitiveArray<T>> {
-    debug_assert_eq!(arr.has_validity(), false);
+    debug_assert!(!arr.has_validity());
 
     let array_values = arr.values().as_slice();
 
@@ -189,7 +189,7 @@ pub unsafe fn take_no_null_bool_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &BooleanArray,
     indices: I,
 ) -> Arc<BooleanArray> {
-    debug_assert_eq!(arr.has_validity(), false);
+    debug_assert!(!arr.has_validity());
     let iter = indices
         .into_iter()
         .map(|idx| Some(arr.values().get_bit_unchecked(idx)));

--- a/polars/polars-arrow/src/kernels/take_agg.rs
+++ b/polars/polars-arrow/src/kernels/take_agg.rs
@@ -1,4 +1,5 @@
 //! kernels that combine take and aggregations.
+use crate::array::PolarsArray;
 use arrow::array::{Array, PrimitiveArray};
 use arrow::types::NativeType;
 
@@ -16,7 +17,7 @@ pub unsafe fn take_agg_no_null_primitive_iter_unchecked<
     f: F,
     init: T,
 ) -> T {
-    debug_assert_eq!(arr.null_count(), 0);
+    debug_assert_eq!(arr.has_validity(), false);
 
     let array_values = arr.values().as_slice();
 
@@ -39,10 +40,6 @@ pub unsafe fn take_agg_primitive_iter_unchecked<
     f: F,
     init: T,
 ) -> Option<T> {
-    if arr.null_count() == arr.len() {
-        return None;
-    }
-
     let array_values = arr.values().as_slice();
     let validity = arr.validity().expect("null buffer should be there");
 
@@ -74,10 +71,6 @@ pub unsafe fn take_agg_primitive_iter_unchecked_count_nulls<
     f: F,
     init: T,
 ) -> Option<(T, u32)> {
-    if arr.null_count() == arr.len() {
-        return None;
-    }
-
     let array_values = arr.values().as_slice();
     let validity = arr.validity().expect("null buffer should be there");
 

--- a/polars/polars-arrow/src/kernels/take_agg.rs
+++ b/polars/polars-arrow/src/kernels/take_agg.rs
@@ -1,6 +1,6 @@
 //! kernels that combine take and aggregations.
 use crate::array::PolarsArray;
-use arrow::array::{Array, PrimitiveArray};
+use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
 
 /// Take kernel for single chunk without nulls and an iterator as index.
@@ -17,7 +17,7 @@ pub unsafe fn take_agg_no_null_primitive_iter_unchecked<
     f: F,
     init: T,
 ) -> T {
-    debug_assert_eq!(arr.has_validity(), false);
+    debug_assert!(!arr.has_validity());
 
     let array_values = arr.values().as_slice();
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -126,9 +126,9 @@ docs-selection = [
 ]
 
 [dependencies]
-#arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "326fc9d89340ccd22cf0f981a98f56be582d8192", default-features = false, features=["compute"] }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "58db4c55722e0bcd29740be4e475161074b75e46", default-features = false, features=["compute"] }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features=["compute"], branch="dev" }
-arrow = { package = "arrow2", version="0.7", default-features = false, features=["compute"]}
+#arrow = { package = "arrow2", version="0.7", default-features = false, features=["compute"]}
 polars-arrow = {version = "0.17.0", path = "../polars-arrow"}
 thiserror = "1.0"
 num = "^0.4"

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -1,4 +1,5 @@
 use super::*;
+use polars_arrow::prelude::PolarsArray;
 
 pub trait ListBuilderTrait {
     fn append_opt_series(&mut self, opt_s: Option<&Series>);
@@ -130,7 +131,7 @@ where
         arrays.iter().for_each(|x| {
             let arr = x.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
-            if arr.null_count() == 0 {
+            if !arr.has_validity() {
                 values.extend_from_slice(arr.values().as_slice())
             } else {
                 // Safety:

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -39,7 +39,7 @@ impl ChunkCast for CategoricalChunked {
 
                 let f = |idx: u32| mapping.get(idx);
 
-                if self.null_count() == 0 {
+                if !self.has_validity() {
                     self.into_no_null_iter()
                         .for_each(|idx| builder.append_value(f(idx)));
                 } else {

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -44,8 +44,8 @@ where
 
 macro_rules! impl_eq_missing {
     ($self:ident, $rhs:ident) => {{
-        match ($self.null_count(), $rhs.null_count()) {
-            (0, 0) => $self
+        match ($self.has_validity(), $rhs.has_validity()) {
+            (false, false) => $self
                 .into_no_null_iter()
                 .zip($rhs.into_no_null_iter())
                 .map(|(opt_a, opt_b)| opt_a == opt_b)
@@ -535,22 +535,22 @@ impl ChunkCompare<&str> for Utf8Chunked {
 
 macro_rules! impl_cmp_list {
     ($self:ident, $rhs:ident, $cmp_method:ident) => {{
-        match ($self.null_count(), $rhs.null_count()) {
-            (0, 0) => $self
+        match ($self.has_validity(), $rhs.has_validity()) {
+            (false, false) => $self
                 .into_no_null_iter()
                 .zip($rhs.into_no_null_iter())
                 .map(|(left, right)| left.$cmp_method(&right))
-                .collect(),
-            (0, _) => $self
+                .collect_trusted(),
+            (false, _) => $self
                 .into_no_null_iter()
                 .zip($rhs.into_iter())
                 .map(|(left, opt_right)| opt_right.map(|right| left.$cmp_method(&right)))
-                .collect(),
-            (_, 0) => $self
+                .collect_trusted(),
+            (_, false) => $self
                 .into_iter()
                 .zip($rhs.into_no_null_iter())
                 .map(|(opt_left, right)| opt_left.map(|left| left.$cmp_method(&right)))
-                .collect(),
+                .collect_trusted(),
             (_, _) => $self
                 .into_iter()
                 .zip($rhs.into_iter())

--- a/polars/polars-core/src/chunked_array/iterator/par/macros.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/macros.rs
@@ -557,7 +557,7 @@ macro_rules! impl_into_par_iter {
                 let chunks = self.downcast_iter();
                 match chunks.len() {
                     1 => {
-                        if self.null_count() == 0 {
+                        if !self.has_validity() {
                             $dispatcher::SingleChunk(
                                 <$single_chunk_return_option>::new(self),
                             )
@@ -568,7 +568,7 @@ macro_rules! impl_into_par_iter {
                         }
                     }
                     _ => {
-                        if self.null_count() == 0 {
+                        if !self.has_validity() {
                             $dispatcher::ManyChunk(
                                 <$many_chunk_return_option>::new(self),
                             )

--- a/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
@@ -635,7 +635,7 @@ where
         let chunks = self.downcast_iter();
         match chunks.len() {
             1 => {
-                if self.null_count() == 0 {
+                if !self.has_validity() {
                     NumParIterDispatcher::SingleChunk(NumParIterSingleChunkReturnOption::new(self))
                 } else {
                     NumParIterDispatcher::SingleChunkNullCheck(
@@ -644,7 +644,7 @@ where
                 }
             }
             _ => {
-                if self.null_count() == 0 {
+                if !self.has_validity() {
                     NumParIterDispatcher::ManyChunk(NumParIterManyChunkReturnOption::new(self))
                 } else {
                     NumParIterDispatcher::ManyChunkNullCheck(

--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use arrow::bitmap::MutableBitmap;
+use polars_arrow::array::PolarsArray;
 use polars_arrow::bit_util::unset_bit_raw;
 use polars_arrow::kernels::take::take_value_indices_from_list;
 use std::convert::TryFrom;
@@ -52,7 +53,8 @@ pub(crate) unsafe fn take_list_unchecked(
     let taken = taken.chunks()[0].clone();
 
     let validity =
-        if values.null_count() > 0 || indices.null_count() > 0 {
+        // if null count > 0
+        if values.has_validity() || indices.has_validity() {
             // determine null buffer, which are a function of `values` and `indices`
             let mut validity = MutableBitmap::with_capacity(indices.len());
             let validity_ptr = validity.as_slice().as_ptr() as *mut u8;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -180,14 +180,14 @@ impl<T> ChunkedArray<T> {
     /// Get the index of the first non null value in this ChunkedArray.
     pub fn first_non_null(&self) -> Option<usize> {
         let mut offset = 0;
-        for (_, null_bitmap) in self.null_bits() {
-            if let Some(null_bitmap) = null_bitmap {
-                for (idx, is_valid) in null_bitmap.iter().enumerate() {
+        for validity in self.iter_validities() {
+            if let Some(validity) = validity {
+                for (idx, is_valid) in validity.iter().enumerate() {
                     if is_valid {
                         return Some(offset + idx);
                     }
                 }
-                offset += null_bitmap.len()
+                offset += validity.len()
             } else {
                 return Some(offset);
             }
@@ -196,10 +196,8 @@ impl<T> ChunkedArray<T> {
     }
 
     /// Get the buffer of bits representing null values
-    pub fn null_bits(&self) -> impl Iterator<Item = (usize, Option<&Bitmap>)> + '_ {
-        self.chunks
-            .iter()
-            .map(|arr| (arr.null_count(), arr.validity()))
+    pub fn iter_validities(&self) -> impl Iterator<Item = Option<&Bitmap>> + '_ {
+        self.chunks.iter().map(|arr| arr.validity())
     }
 
     /// Shrink the capacity of this array to fit it's length.

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -196,8 +196,16 @@ impl<T> ChunkedArray<T> {
     }
 
     /// Get the buffer of bits representing null values
+    #[inline]
     pub fn iter_validities(&self) -> impl Iterator<Item = Option<&Bitmap>> + '_ {
         self.chunks.iter().map(|arr| arr.validity())
+    }
+
+    #[inline]
+    /// Return if any the chunks in this `[ChunkedArray]` have a validity bitmap.
+    /// no bitmap means no null values.
+    pub fn has_validity(&self) -> bool {
+        self.iter_validities().any(|valid| valid.is_some())
     }
 
     /// Shrink the capacity of this array to fit it's length.

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -285,7 +285,7 @@ impl<T> ChunkedArray<T> {
 
     /// Returns true if contains a single chunk and has no null values
     pub fn is_optimal_aligned(&self) -> bool {
-        self.chunks.len() == 1 && self.null_count() == 0
+        self.chunks.len() == 1 && !self.has_validity()
     }
 
     /// Count the null values.
@@ -378,7 +378,7 @@ impl<T> ChunkedArray<T> {
 
     /// Get a mask of the null values.
     pub fn is_null(&self) -> BooleanChunked {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             return BooleanChunked::full("is_null", false, self.len());
         }
         let chunks = self
@@ -397,7 +397,7 @@ impl<T> ChunkedArray<T> {
 
     /// Get a mask of the valid values.
     pub fn is_not_null(&self) -> BooleanChunked {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             return BooleanChunked::full("is_not_null", true, self.len());
         }
         let chunks = self
@@ -579,7 +579,7 @@ where
 {
     /// Contiguous slice
     pub fn cont_slice(&self) -> Result<&[T::Native]> {
-        if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
+        if self.chunks.len() == 1 && !self.chunks[0].has_validity() {
             Ok(self.downcast_iter().next().map(|arr| arr.values()).unwrap())
         } else {
             Err(PolarsError::NoSlice)

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -261,12 +261,8 @@ where
         ca.into_series()
     }
     fn mean_as_series(&self) -> Series {
-        if self.null_count() == self.len() {
-            Self::full_null(self.name(), 1).into_series()
-        } else {
-            let val = [self.mean()];
-            Series::new(self.name(), val)
-        }
+        let val = [self.mean()];
+        Series::new(self.name(), val)
     }
     fn median_as_series(&self) -> Series {
         let val = [self.median()];
@@ -605,6 +601,6 @@ mod test {
         // all null values case
         let ca = Float32Chunked::full_null("", 3);
         assert_eq!(ca.mean(), None);
-        assert_eq!(ca.mean_as_series().f32().unwrap().get(0), None);
+        assert_eq!(ca.mean_as_series().f64().unwrap().get(0), None);
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -2,9 +2,9 @@
 use crate::prelude::*;
 use crate::utils::{CustomIterTools, NoNull};
 use arrow::array::{Array, ArrayRef, BooleanArray, PrimitiveArray};
+use polars_arrow::array::PolarsArray;
 use std::borrow::Cow;
 use std::convert::TryFrom;
-use polars_arrow::array::PolarsArray;
 
 macro_rules! try_apply {
     ($self:expr, $f:expr) => {{

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -60,8 +60,8 @@ where
     {
         let chunks = self
             .data_views()
-            .zip(self.null_bits())
-            .map(|(slice, (_, validity))| {
+            .zip(self.iter_validities())
+            .map(|(slice, validity)| {
                 let values = AlignedVec::<_>::from_trusted_len_iter(slice.iter().map(|&v| f(v)));
                 to_array::<S>(values, validity.cloned())
             })
@@ -97,8 +97,8 @@ where
         let chunks = self
             .data_views()
             .into_iter()
-            .zip(self.null_bits())
-            .map(|(slice, (_, validity))| {
+            .zip(self.iter_validities())
+            .map(|(slice, validity)| {
                 let values = slice.iter().copied().map(f);
                 let values = AlignedVec::<_>::from_trusted_len_iter(values);
                 to_array::<T>(values, validity.cloned())
@@ -114,8 +114,8 @@ where
         let mut ca: ChunkedArray<T> = self
             .data_views()
             .into_iter()
-            .zip(self.null_bits())
-            .map(|(slice, (_null_count, validity))| {
+            .zip(self.iter_validities())
+            .map(|(slice, validity)| {
                 let vec: Result<AlignedVec<_>> = slice.iter().copied().map(f).collect();
                 Ok((vec?, validity.cloned()))
             })

--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -112,7 +112,7 @@ where
 
             // todo! use iterators once implemented
             // no_null path
-            if self.null_count() == 0 {
+            if !self.has_validity() {
                 for arr in chunks {
                     for idx in 0..arr.len() {
                         builder.append_value(arr.value(idx).clone())

--- a/polars/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/polars/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -100,7 +100,7 @@ where
         if self.chunks.len() == 1 {
             let arr = chunks.next().unwrap();
 
-            if self.null_count() == 0 {
+            if !self.has_validity() {
                 let t = NumTakeRandomCont {
                     slice: arr.values(),
                 };
@@ -213,7 +213,7 @@ where
         if self.chunks.len() == 1 {
             let arr = chunks.next().unwrap();
 
-            if self.null_count() == 0 {
+            if !self.has_validity() {
                 let t = NumTakeRandomCont {
                     slice: arr.values(),
                 };

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use arrow::{array::*, bitmap::MutableBitmap, buffer::Buffer};
+use polars_arrow::array::PolarsArray;
 use polars_arrow::bit_util::unset_bit_raw;
 use polars_arrow::prelude::{FromDataUtf8, ValueSize};
 use std::convert::TryFrom;
@@ -37,7 +38,7 @@ where
         // value and collect the indices.
         // because the length of the array is not known, we first collect the null indexes, offsetted
         // with the insertion of empty rows (as None) and later create a validity bitmap
-        if arr.null_count() > 0 {
+        if arr.has_validity() {
             let validity_values = arr.validity().unwrap();
 
             for &o in &offsets[1..] {

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -81,7 +81,7 @@ where
 {
     fn fill_null(&self, strategy: FillNullStrategy) -> Result<Self> {
         // nothing to fill
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             return Ok(self.clone());
         }
         let mut ca = match strategy {
@@ -126,7 +126,7 @@ where
 impl ChunkFillNull for BooleanChunked {
     fn fill_null(&self, strategy: FillNullStrategy) -> Result<Self> {
         // nothing to fill
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             return Ok(self.clone());
         }
         match strategy {
@@ -171,7 +171,7 @@ impl ChunkFillNullValue<bool> for BooleanChunked {
 impl ChunkFillNull for Utf8Chunked {
     fn fill_null(&self, strategy: FillNullStrategy) -> Result<Self> {
         // nothing to fill
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             return Ok(self.clone());
         }
         match strategy {

--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -17,7 +17,7 @@ where
     fn interpolate(&self) -> Self {
         // This implementation differs from pandas as that boundary None's are not removed
         // this prevents a lot of errors due to expressions leading to different lengths
-        if self.null_count() == 0 || self.null_count() == self.len() {
+        if !self.has_validity() || self.null_count() == self.len() {
             return self.clone();
         }
 

--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -17,7 +17,7 @@ where
     fn interpolate(&self) -> Self {
         // This implementation differs from pandas as that boundary None's are not removed
         // this prevents a lot of errors due to expressions leading to different lengths
-        if !self.has_validity() || self.null_count() == self.len() {
+        if !self.has_validity() {
             return self.clone();
         }
 

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -48,8 +48,8 @@ mod inner_mod {
                     check_input(options.window_size, options.min_periods)?;
                     let ca = self.rechunk();
                     let arr = ca.downcast_iter().next().unwrap();
-                    let arr = match self.null_count() {
-                        0 => rolling::no_nulls::rolling_mean(
+                    let arr = match self.has_validity() {
+                        false => rolling::no_nulls::rolling_mean(
                             arr.values(),
                             options.window_size,
                             options.min_periods,
@@ -94,8 +94,8 @@ mod inner_mod {
             }
 
             let arr = ca.downcast_iter().next().unwrap();
-            let arr = match self.null_count() {
-                0 => rolling::no_nulls::rolling_sum(
+            let arr = match self.has_validity() {
+                false => rolling::no_nulls::rolling_sum(
                     arr.values(),
                     options.window_size,
                     options.min_periods,
@@ -128,8 +128,8 @@ mod inner_mod {
             }
 
             let arr = ca.downcast_iter().next().unwrap();
-            let arr = match self.null_count() {
-                0 => rolling::no_nulls::rolling_min(
+            let arr = match self.has_validity() {
+                false => rolling::no_nulls::rolling_min(
                     arr.values(),
                     options.window_size,
                     options.min_periods,
@@ -162,8 +162,8 @@ mod inner_mod {
             }
 
             let arr = ca.downcast_iter().next().unwrap();
-            let arr = match self.null_count() {
-                0 => rolling::no_nulls::rolling_max(
+            let arr = match self.has_validity() {
+                false => rolling::no_nulls::rolling_max(
                     arr.values(),
                     options.window_size,
                     options.min_periods,
@@ -304,8 +304,8 @@ mod inner_mod {
             }
 
             let arr = ca.downcast_iter().next().unwrap();
-            let arr = match self.null_count() {
-                0 => rolling::no_nulls::rolling_var(
+            let arr = match self.has_validity() {
+                false => rolling::no_nulls::rolling_var(
                     arr.values(),
                     options.window_size,
                     options.min_periods,

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -59,7 +59,7 @@ where
         idx: I,
         value: Option<T::Native>,
     ) -> Result<Self> {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             if let Some(value) = value {
                 // fast path uses kernel
                 if self.chunks.len() == 1 {

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -105,7 +105,7 @@ where
         check_bounds!(self, mask);
 
         // Fast path uses the kernel in polars-arrow
-        if let (Some(value), 0) = (value, mask.null_count()) {
+        if let (Some(value), false) = (value, mask.has_validity()) {
             let (left, mask) = align_chunks_binary(self, mask);
 
             // apply binary kernel.

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -142,7 +142,7 @@ where
     T: PolarsNumericType,
 {
     fn sort(&self, reverse: bool) -> ChunkedArray<T> {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             let mut vals = memcpy_values(self);
 
             sort_branch(vals.as_mut_slice(), reverse, order_default, order_reverse);
@@ -173,7 +173,7 @@ where
     }
 
     fn argsort(&self, reverse: bool) -> UInt32Chunked {
-        let ca: NoNull<UInt32Chunked> = if self.null_count() == 0 {
+        let ca: NoNull<UInt32Chunked> = if !self.has_validity() {
             let mut vals = Vec::with_capacity(self.len());
             let mut count: u32 = 0;
             self.downcast_iter().for_each(|arr| {

--- a/polars/polars-core/src/chunked_array/ops/take/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "dtype-categorical")]
 use std::ops::Deref;
 
-use arrow::array::{Array, ArrayRef};
+use arrow::array::ArrayRef;
 use arrow::compute::take::take;
 use polars_arrow::kernels::take::*;
 

--- a/polars/polars-core/src/chunked_array/ops/take/take_every.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_every.rs
@@ -8,7 +8,7 @@ where
     T: PolarsNumericType,
 {
     fn take_every(&self, n: usize) -> ChunkedArray<T> {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             let a: NoNull<_> = self.into_no_null_iter().step_by(n).collect();
             a.into_inner()
         } else {
@@ -19,7 +19,7 @@ where
 
 impl ChunkTakeEvery<BooleanType> for BooleanChunked {
     fn take_every(&self, n: usize) -> BooleanChunked {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()
@@ -29,7 +29,7 @@ impl ChunkTakeEvery<BooleanType> for BooleanChunked {
 
 impl ChunkTakeEvery<Utf8Type> for Utf8Chunked {
     fn take_every(&self, n: usize) -> Utf8Chunked {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()
@@ -39,7 +39,7 @@ impl ChunkTakeEvery<Utf8Type> for Utf8Chunked {
 
 impl ChunkTakeEvery<ListType> for ListChunked {
     fn take_every(&self, n: usize) -> ListChunked {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()

--- a/polars/polars-core/src/chunked_array/ops/take/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_random.rs
@@ -141,7 +141,7 @@ where
         if self.chunks.len() == 1 {
             let arr = chunks.next().unwrap();
 
-            if self.null_count() == 0 {
+            if !self.has_validity() {
                 let t = NumTakeRandomCont {
                     slice: arr.values(),
                 };

--- a/polars/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/traits.rs
@@ -1,6 +1,6 @@
 //! Traits that indicate the allowed arguments in a ChunkedArray::take operation.
 use crate::prelude::*;
-use arrow::array::{Array, UInt32Array};
+use arrow::array::UInt32Array;
 use polars_arrow::array::PolarsArray;
 
 // Utility traits

--- a/polars/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/traits.rs
@@ -1,6 +1,7 @@
 //! Traits that indicate the allowed arguments in a ChunkedArray::take operation.
 use crate::prelude::*;
 use arrow::array::{Array, UInt32Array};
+use polars_arrow::array::PolarsArray;
 
 // Utility traits
 pub trait TakeIterator: Iterator<Item = usize> {
@@ -96,7 +97,7 @@ where
             TakeIdx::Array(arr) => {
                 let mut inbounds = true;
                 let len = bound as u32;
-                if arr.null_count() == 0 {
+                if !arr.has_validity() {
                     for &i in arr.values().as_slice() {
                         if i >= len {
                             inbounds = false;

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -162,8 +162,8 @@ where
 
 macro_rules! arg_unique_ca {
     ($ca:expr) => {{
-        match $ca.null_count() {
-            0 => arg_unique($ca.into_no_null_iter(), $ca.len()),
+        match $ca.has_validity() {
+            false => arg_unique($ca.into_no_null_iter(), $ca.len()),
             _ => arg_unique($ca.into_iter(), $ca.len()),
         }
     }};

--- a/polars/polars-core/src/chunked_array/strings/mod.rs
+++ b/polars/polars-core/src/chunked_array/strings/mod.rs
@@ -22,7 +22,7 @@ impl Utf8Chunked {
     pub fn contains(&self, pat: &str) -> Result<BooleanChunked> {
         let reg = Regex::new(pat)?;
         let f = |s| reg.is_match(s);
-        let mut ca: BooleanChunked = if self.null_count() == 0 {
+        let mut ca: BooleanChunked = if !self.has_validity() {
             self.into_no_null_iter().map(f).collect()
         } else {
             self.into_iter().map(|opt_s| opt_s.map(f)).collect()

--- a/polars/polars-core/src/chunked_array/temporal/utf8.rs
+++ b/polars/polars-core/src/chunked_array/temporal/utf8.rs
@@ -103,8 +103,8 @@ impl Utf8Chunked {
             None => self.sniff_fmt_time()?,
         };
 
-        let mut ca: Int64Chunked = match self.null_count() {
-            0 => self
+        let mut ca: Int64Chunked = match self.has_validity() {
+            false => self
                 .into_no_null_iter()
                 .map(|s| {
                     NaiveTime::parse_from_str(s, fmt)
@@ -141,8 +141,8 @@ impl Utf8Chunked {
             None => self.sniff_fmt_date()?,
         };
 
-        let mut ca: Int32Chunked = match self.null_count() {
-            0 => self
+        let mut ca: Int32Chunked = match self.has_validity() {
+            false => self
                 .into_no_null_iter()
                 .map(|s| {
                     NaiveDate::parse_from_str(s, fmt)
@@ -177,8 +177,8 @@ impl Utf8Chunked {
             None => self.sniff_fmt_datetime()?,
         };
 
-        let mut ca: Int64Chunked = match self.null_count() {
-            0 => self
+        let mut ca: Int64Chunked = match self.has_validity() {
+            false => self
                 .into_no_null_iter()
                 .map(|s| {
                     NaiveDateTime::parse_from_str(s, fmt)

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -14,6 +14,7 @@ use std::borrow::{Borrow, Cow};
 use std::collections::LinkedList;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 impl<T> Default for ChunkedArray<T> {
@@ -24,6 +25,7 @@ impl<T> Default for ChunkedArray<T> {
             phantom: PhantomData,
             categorical_map: None,
             bit_settings: 0,
+            null_count: AtomicU64::new(u64::MAX),
         }
     }
 }
@@ -246,6 +248,7 @@ impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
             phantom: PhantomData,
             categorical_map: None,
             bit_settings: 0,
+            null_count: AtomicU64::new(u64::MAX),
         }
     }
 }

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -48,7 +48,7 @@ where
             debug_assert!(idx.len() <= self.len());
             if idx.is_empty() {
                 None
-            } else if self.null_count() == 0 {
+            } else if !self.has_validity() {
                 Some(idx.len() as u32)
             } else {
                 let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -76,8 +76,8 @@ where
             } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
-                match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => Some(unsafe {
+                match (self.has_validity(), self.chunks.len()) {
+                    (false, 1) => Some(unsafe {
                         take_agg_no_null_primitive_iter_unchecked(
                             self.downcast_iter().next().unwrap(),
                             idx.iter().map(|i| *i as usize),
@@ -111,8 +111,8 @@ where
             } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
-                match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => Some(unsafe {
+                match (self.has_validity(), self.chunks.len()) {
+                    (false, 1) => Some(unsafe {
                         take_agg_no_null_primitive_iter_unchecked(
                             self.downcast_iter().next().unwrap(),
                             idx.iter().map(|i| *i as usize),
@@ -146,8 +146,8 @@ where
             } else if idx.len() == 1 {
                 self.get(*first as usize)
             } else {
-                match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => Some(unsafe {
+                match (self.has_validity(), self.chunks.len()) {
+                    (false, 1) => Some(unsafe {
                         take_agg_no_null_primitive_iter_unchecked(
                             self.downcast_iter().next().unwrap(),
                             idx.iter().map(|i| *i as usize),
@@ -196,8 +196,8 @@ where
             } else if idx.len() == 1 {
                 self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
             } else {
-                match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => unsafe {
+                match (self.has_validity(), self.chunks.len()) {
+                    (false, 1) => unsafe {
                         take_agg_no_null_primitive_iter_unchecked(
                             self.downcast_iter().next().unwrap(),
                             idx.iter().map(|i| *i as usize),
@@ -287,8 +287,8 @@ where
             } else if idx.len() == 1 {
                 self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
             } else {
-                match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => unsafe {
+                match (self.has_validity(), self.chunks.len()) {
+                    (false, 1) => unsafe {
                         take_agg_no_null_primitive_iter_unchecked(
                             self.downcast_iter().next().unwrap(),
                             idx.iter().map(|i| *i as usize),

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -62,7 +62,7 @@ where
 
         // use the arrays as iterators
         if ca.chunks.len() == 1 {
-            if ca.null_count() == 0 {
+            if !ca.has_validity() {
                 let keys = vec![ca.cont_slice().unwrap()];
                 groupby_threaded_num(keys, group_size_hint, n_partitions)
             } else {
@@ -73,14 +73,14 @@ where
                 groupby_threaded_num(keys, group_size_hint, n_partitions)
             }
             // use the polars-iterators
-        } else if ca.null_count() == 0 {
+        } else if !ca.has_validity() {
             let keys = vec![ca.into_no_null_iter().collect::<Vec<_>>()];
             groupby_threaded_num(keys, group_size_hint, n_partitions)
         } else {
             let keys = vec![ca.into_iter().collect::<Vec<_>>()];
             groupby_threaded_num(keys, group_size_hint, n_partitions)
         }
-    } else if ca.null_count() == 0 {
+    } else if !ca.has_validity() {
         groupby(ca.into_no_null_iter())
     } else {
         groupby(ca.into_iter())

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -504,12 +504,12 @@ where
     let splitted_a = split_ca(a, n_threads).unwrap();
     let splitted_b = split_ca(b, n_threads).unwrap();
     match (
-        left.null_count(),
-        right.null_count(),
+        left.has_validity(),
+        right.has_validity(),
         left.chunks.len(),
         right.chunks.len(),
     ) {
-        (0, 0, 1, 1) => {
+        (false, false, 1, 1) => {
             let keys_a = splitted_a
                 .iter()
                 .map(|ca| ca.cont_slice().unwrap())
@@ -520,7 +520,7 @@ where
                 .collect::<Vec<_>>();
             hash_join_tuples_inner(keys_a, keys_b, swap)
         }
-        (0, 0, _, _) => {
+        (false, false, _, _) => {
             let keys_a = splitted_a
                 .iter()
                 .map(|ca| ca.into_no_null_iter().collect::<Vec<_>>())
@@ -580,12 +580,12 @@ where
     let splitted_a = split_ca(left, n_threads).unwrap();
     let splitted_b = split_ca(right, n_threads).unwrap();
     match (
-        left.null_count(),
-        right.null_count(),
+        left.has_validity(),
+        right.has_validity(),
         left.chunks.len(),
         right.chunks.len(),
     ) {
-        (0, 0, 1, 1) => {
+        (false, false, 1, 1) => {
             let keys_a = splitted_a
                 .iter()
                 .map(|ca| ca.cont_slice().unwrap())
@@ -596,7 +596,7 @@ where
                 .collect::<Vec<_>>();
             hash_join_tuples_left(keys_a, keys_b)
         }
-        (0, 0, _, _) => {
+        (false, false, _, _) => {
             let keys_a = splitted_a
                 .iter()
                 .map(|ca| ca.into_no_null_iter().collect_trusted::<Vec<_>>())
@@ -749,8 +749,8 @@ where
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 
-        match (a.null_count(), b.null_count()) {
-            (0, 0) => {
+        match (a.has_validity(), b.has_validity()) {
+            (false, false) => {
                 let iters_a = splitted_a
                     .iter()
                     .map(|ca| ca.into_no_null_iter())
@@ -794,8 +794,8 @@ impl HashJoin<BooleanType> for BooleanChunked {
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 
-        match (a.null_count(), b.null_count()) {
-            (0, 0) => {
+        match (a.has_validity(), b.has_validity()) {
+            (false, false) => {
                 let iters_a = splitted_a
                     .iter()
                     .map(|ca| ca.into_no_null_iter())
@@ -867,8 +867,8 @@ impl HashJoin<Utf8Type> for Utf8Chunked {
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 
-        match (a.null_count(), b.null_count()) {
-            (0, 0) => {
+        match (a.has_validity(), b.has_validity()) {
+            (false, false) => {
                 let iters_a = splitted_a
                     .iter()
                     .map(|ca| ca.into_no_null_iter())

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -37,10 +37,10 @@ use crate::vector_hasher::boost_hash_combine;
 use crate::vector_hasher::df_rows_to_hashes_threaded;
 use crate::POOL;
 use hashbrown::HashMap;
+use polars_arrow::array::PolarsArray;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::hash::{BuildHasher, Hash, Hasher};
-use polars_arrow::array::PolarsArray;
 
 #[derive(Copy, Clone, Debug)]
 pub enum NullStrategy {

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -37,7 +37,6 @@ use crate::vector_hasher::boost_hash_combine;
 use crate::vector_hasher::df_rows_to_hashes_threaded;
 use crate::POOL;
 use hashbrown::HashMap;
-use polars_arrow::array::PolarsArray;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::hash::{BuildHasher, Hash, Hasher};

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -322,6 +322,10 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.null_count()
     }
 
+    fn has_validity(&self) -> bool {
+        self.0.has_validity()
+    }
+
     fn unique(&self) -> Result<Series> {
         ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -301,6 +301,10 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.null_count()
     }
 
+    fn has_validity(&self) -> bool {
+        self.0.has_validity()
+    }
+
     fn unique(&self) -> Result<Series> {
         ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -484,6 +484,10 @@ macro_rules! impl_dyn_series {
                 self.0.null_count()
             }
 
+            fn has_validity(&self) -> bool {
+                self.0.has_validity()
+            }
+
             fn unique(&self) -> Result<Series> {
                 self.0.unique().map(|ca| ca.$into_logical().into_series())
             }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -467,6 +467,10 @@ macro_rules! impl_dyn_series {
                 self.0.null_count()
             }
 
+            fn has_validity(&self) -> bool {
+                self.0.has_validity()
+            }
+
             fn unique(&self) -> Result<Series> {
                 ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -244,6 +244,10 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         self.0.null_count()
     }
 
+    fn has_validity(&self) -> bool {
+        self.0.has_validity()
+    }
+
     fn is_null(&self) -> BooleanChunked {
         self.0.is_null()
     }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -628,6 +628,10 @@ macro_rules! impl_dyn_series {
                 self.0.null_count()
             }
 
+            fn has_validity(&self) -> bool {
+                self.0.has_validity()
+            }
+
             fn unique(&self) -> Result<Series> {
                 ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
             }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -185,6 +185,10 @@ where
         ObjectChunked::null_count(&self.0)
     }
 
+    fn has_validity(&self) -> bool {
+        ObjectChunked::has_validity(&self.0)
+    }
+
     fn unique(&self) -> Result<Series> {
         ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -314,6 +314,10 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.null_count()
     }
 
+    fn has_validity(&self) -> bool {
+        self.0.has_validity()
+    }
+
     fn unique(&self) -> Result<Series> {
         ChunkUnique::unique(&self.0).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -597,7 +597,7 @@ pub trait SeriesTrait:
 
     /// Drop all null values and return a new Series.
     fn drop_nulls(&self) -> Series {
-        if self.null_count() == 0 {
+        if !self.has_validity() {
             Series(self.clone_inner())
         } else {
             self.filter(&self.is_not_null()).unwrap()

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -677,6 +677,10 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
+    /// Return if any the chunks in this `[ChunkedArray]` have a validity bitmap.
+    /// no bitmap means no null values.
+    fn has_validity(&self) -> bool;
+
     /// Get unique values in the Series.
     fn unique(&self) -> Result<Series> {
         invalid_operation!(self)

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -29,7 +29,8 @@ impl Series {
         if self.get_data_ptr() == other.get_data_ptr() {
             return true;
         }
-        if self.len() != other.len() || self.null_count() != other.null_count() {
+        let null_count_left = self.null_count();
+        if self.len() != other.len() || null_count_left != other.null_count() {
             return false;
         }
         if self.dtype() != other.dtype()
@@ -40,7 +41,7 @@ impl Series {
             return false;
         }
         // if all null and previous check did not return (so other is also all null)
-        if self.null_count() == self.len() {
+        if null_count_left == self.len() {
             return true;
         }
         match self.eq_missing(other).sum() {

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -29,9 +29,9 @@ temporal = ["polars-core/dtype-date", "polars-core/dtype-datetime"]
 private = []
 
 [dependencies]
-#arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "326fc9d89340ccd22cf0f981a98f56be582d8192", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "58db4c55722e0bcd29740be4e475161074b75e46", default-features = false }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, branch="dev"}
-arrow = { package = "arrow2", version="0.7", --default-features=false }
+#arrow = { package = "arrow2", version="0.7", --default-features=false }
 polars-core = {version = "0.17.0", path = "../polars-core", features = ["private"], default-features=false}
 polars-arrow = {version = "0.17.0", path = "../polars-arrow"}
 lexical = {version = "6", optional = true, default-features=false, features = ["std", "parse-floats", "parse-integers"]}

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1137,7 +1137,7 @@ impl Expr {
             self,
             fill_value,
             |a, b| {
-                if a.null_count() == 0 {
+                if !a.has_validity() {
                     Ok(a)
                 } else {
                     let st = get_supertype(a.dtype(), b.dtype())?;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -73,8 +73,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d873e2775c3d87a4e8d77aa544cbd43f34a0779d5164c59e7c6a1dd0678eb395"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=58db4c55722e0bcd29740be4e475161074b75e46#58db4c55722e0bcd29740be4e475161074b75e46"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1329,7 +1329,6 @@ class Series:
         """
         return self._s.null_count()
 
-
     def has_validity(self) -> bool:
         """
         Returns True if the Series has a validity bitmask. If there is none, it means that there are no null values.

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1329,6 +1329,14 @@ class Series:
         """
         return self._s.null_count()
 
+
+    def has_validity(self) -> bool:
+        """
+        Returns True if the Series has a validity bitmask. If there is none, it means that there are no null values.
+        Use this to swiftly assert a Series does not have null values.
+        """
+        return self._s.has_validity()
+
     def is_null(self) -> "Series":
         """
         Get mask of null values.
@@ -1801,7 +1809,7 @@ class Series:
 
         """
         if not ignore_nulls:
-            assert self.null_count() == 0
+            assert not self.has_validity()
 
         ptr_type = dtype_to_ctype(self.dtype)
         ptr = self._s.as_single_ptr()
@@ -1884,7 +1892,7 @@ class Series:
                 *args, zero_copy_only=zero_copy_only, **kwargs
             )
         else:
-            if self.null_count() == 0:
+            if not self.has_validity():
                 return self.view(ignore_nulls=True)
             return self._s.to_numpy()
 

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -185,7 +185,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -222,7 +222,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -259,7 +259,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -298,7 +298,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let skip = 1;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -340,7 +340,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -459,7 +459,7 @@ where
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -496,7 +496,7 @@ where
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -533,7 +533,7 @@ where
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -572,7 +572,7 @@ where
         let skip = 1;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -614,7 +614,7 @@ where
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -728,7 +728,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -765,7 +765,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -802,7 +802,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -840,7 +840,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let skip = 1;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -882,7 +882,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1050,7 +1050,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         match self.dtype() {
             DataType::List(dt) => {
                 let mut builder = get_list_builder(dt, self.len() * 5, self.len(), self.name());
-                if self.null_count() == 0 {
+                if !self.has_validity() {
                     let mut it = self.into_no_null_iter();
                     // use first value to get dtype and replace default builder
                     if let Some(series) = it.next() {
@@ -1118,7 +1118,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         let pypolars = PyModule::import(py, "polars")?;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1178,7 +1178,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         let pypolars = PyModule::import(py, "polars")?;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1240,7 +1240,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
 
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1301,7 +1301,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         let pypolars = PyModule::import(py, "polars")?;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1341,7 +1341,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         let pypolars = PyModule::import(py, "polars")?;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1470,7 +1470,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1507,7 +1507,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1544,7 +1544,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1583,7 +1583,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let skip = 1;
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
@@ -1625,7 +1625,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let skip = if first_value.is_some() { 1 } else { 0 };
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name(), self.len()))
-        } else if self.null_count() == 0 {
+        } else if !self.has_validity() {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -507,6 +507,10 @@ impl PySeries {
         Ok(self.series.null_count())
     }
 
+    pub fn has_validity(&self) -> bool {
+        self.series.has_validity()
+    }
+
     pub fn is_null(&self) -> PySeries {
         Self::new(self.series.is_null().into_series())
     }


### PR DESCRIPTION
reduces dependency of arrow2's null_count cache. Additionally this adds an atomic null count cache, so that if it is computed, we don't have to compute it again.