### PR TITLE
remove string indirection in logical plan

### DIFF
--- a/polars/polars-core/src/frame/select.rs
+++ b/polars/polars-core/src/frame/select.rs
@@ -35,9 +35,9 @@ pub trait AsRefPolars<T: ?Sized> {
     fn as_ref_p(&self) -> &T;
 }
 
-impl AsRefPolars<str> for std::sync::Arc<String> {
+impl AsRefPolars<str> for std::sync::Arc<str> {
     fn as_ref_p(&self) -> &str {
-        &**self
+        &*self
     }
 }
 

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -245,8 +245,8 @@ impl From<AggExpr> for Expr {
 /// Queries consists of multiple expressions.
 #[derive(Clone, PartialEq)]
 pub enum Expr {
-    Alias(Box<Expr>, Arc<String>),
-    Column(Arc<String>),
+    Alias(Box<Expr>, Arc<str>),
+    Column(Arc<str>),
     Columns(Vec<String>),
     DtypeColumn(Vec<DataType>),
     Literal(LiteralValue),
@@ -328,7 +328,7 @@ pub enum Expr {
         output_field: NoEq<Arc<dyn BinaryUdfOutputField>>,
     },
     /// Can be used in a select statement to exclude a column from selection
-    Exclude(Box<Expr>, Vec<Arc<String>>),
+    Exclude(Box<Expr>, Vec<Arc<str>>),
     /// Set root name as Alias
     KeepName(Box<Expr>),
     SufPreFix {
@@ -641,7 +641,7 @@ impl Expr {
 
     /// Rename Column.
     pub fn alias(self, name: &str) -> Expr {
-        Expr::Alias(Box::new(self), Arc::new(name.into()))
+        Expr::Alias(Box::new(self), Arc::from(name))
     }
 
     /// Run is_null operation on `Expr`.
@@ -1433,7 +1433,7 @@ impl Expr {
         let v = columns
             .to_selection_vec()
             .iter()
-            .map(|s| Arc::new(s.to_string()))
+            .map(|s| Arc::from(*s))
             .collect();
         Expr::Exclude(Box::new(self), v)
     }
@@ -1668,7 +1668,7 @@ impl Expr {
 pub fn col(name: &str) -> Expr {
     match name {
         "*" => Expr::Wildcard,
-        _ => Expr::Column(Arc::new(name.to_owned())),
+        _ => Expr::Column(Arc::from(name)),
     }
 }
 

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -31,8 +31,8 @@ pub enum AExpr {
     Duplicated(Node),
     Reverse(Node),
     Explode(Node),
-    Alias(Node, Arc<String>),
-    Column(Arc<String>),
+    Alias(Node, Arc<str>),
+    Column(Arc<str>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Node,

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -676,7 +676,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
         let schema_right = self.lp_arena.get(other).schema(self.lp_arena);
 
         // column names of left table
-        let mut names: HashSet<&String, RandomState> = HashSet::with_capacity_and_hasher(
+        let mut names: HashSet<&str, RandomState> = HashSet::with_capacity_and_hasher(
             schema_left.len() + schema_right.len(),
             Default::default(),
         );
@@ -684,7 +684,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
         let mut fields = Vec::with_capacity(schema_left.len() + schema_right.len());
 
         for f in schema_left.fields() {
-            names.insert(f.name());
+            names.insert(f.name().as_ref());
             fields.push(f.clone());
         }
 
@@ -699,8 +699,8 @@ impl<'a> ALogicalPlanBuilder<'a> {
 
         for f in schema_right.fields() {
             let name = f.name();
-            if !right_names.contains(name) {
-                if names.contains(name) {
+            if !right_names.contains(name.as_str()) {
+                if names.contains(name.as_str()) {
                     let new_name = format!("{}_right", name);
                     let field = Field::new(&new_name, f.data_type().clone());
                     fields.push(field)

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -978,7 +978,7 @@ impl LogicalPlanBuilder {
             .iter()
             .map(|e| {
                 if let Expr::Column(name) = e {
-                    (**name).clone()
+                    (**name).to_owned()
                 } else {
                     panic!("expected column expression")
                 }
@@ -1048,7 +1048,7 @@ impl LogicalPlanBuilder {
         for f in schema_right.fields() {
             let name = f.name();
 
-            if !right_names.contains(name) {
+            if !right_names.iter().any(|s| s.as_ref() == name) {
                 if names.contains(name) {
                     let new_name = format!("{}_right", name);
                     let field = Field::new(&new_name, f.data_type().clone());

--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
@@ -69,7 +69,7 @@ impl AggScanProjection {
 
                 let projections = with_columns
                     .into_iter()
-                    .map(|s| expr_arena.add(AExpr::Column(Arc::new(s))))
+                    .map(|s| expr_arena.add(AExpr::Column(Arc::from(s))))
                     .collect();
 
                 lp = ALogicalPlanBuilder::new(node, expr_arena, lp_arena)

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -24,8 +24,8 @@ impl Dsl for Node {
 
 /// Don't overwrite predicates but combine them.
 pub(super) fn insert_and_combine_predicate(
-    acc_predicates: &mut PlHashMap<Arc<String>, Node>,
-    name: Arc<String>,
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
+    name: Arc<str>,
     predicate: Node,
     arena: &mut Arena<AExpr>,
 ) {
@@ -61,7 +61,7 @@ where
 }
 
 pub(super) fn predicate_at_scan(
-    acc_predicates: PlHashMap<Arc<String>, Node>,
+    acc_predicates: PlHashMap<Arc<str>, Node>,
     predicate: Option<Node>,
     expr_arena: &mut Arena<AExpr>,
 ) -> Option<Node> {
@@ -78,7 +78,7 @@ pub(super) fn predicate_at_scan(
 }
 
 /// Determine the hashmap key by combining all the root column names of a predicate
-pub(super) fn roots_to_key(roots: &[Arc<String>]) -> Arc<String> {
+pub(super) fn roots_to_key(roots: &[Arc<str>]) -> Arc<str> {
     if roots.len() == 1 {
         roots[0].clone()
     } else {
@@ -86,7 +86,7 @@ pub(super) fn roots_to_key(roots: &[Arc<String>]) -> Arc<String> {
         for name in roots {
             new.push_str(name);
         }
-        Arc::new(new)
+        Arc::from(new)
     }
 }
 
@@ -94,14 +94,14 @@ pub(super) fn get_insertion_name(
     expr_arena: &Arena<AExpr>,
     predicate: Node,
     schema: &Schema,
-) -> Arc<String> {
-    Arc::new(
+) -> Arc<str> {
+    Arc::from(
         expr_arena
             .get(predicate)
             .to_field(schema, Context::Default, expr_arena)
             .unwrap()
             .name()
-            .clone(),
+            .as_ref(),
     )
 }
 
@@ -139,7 +139,7 @@ pub(super) fn is_pushdown_boundary(node: Node, expr_arena: &Arena<AExpr>) -> boo
 pub(super) fn rewrite_projection_node(
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<ALogicalPlan>,
-    acc_predicates: &mut PlHashMap<Arc<String>, Node>,
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
     expr: Vec<Node>,
     input: Node,
 ) -> (Vec<Node>, Vec<Node>)
@@ -237,7 +237,7 @@ pub(super) fn no_pushdown_preds<F>(
     matches: F,
     // predicates that will be filtered at this node in the LP
     local_predicates: &mut Vec<Node>,
-    acc_predicates: &mut PlHashMap<Arc<String>, Node>,
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
 ) where
     F: Fn(&AExpr) -> bool,
 {
@@ -246,7 +246,7 @@ pub(super) fn no_pushdown_preds<F>(
         // columns that are projected. We check if we can push down the predicates past this projection
         let columns = aexpr_to_root_names(node, arena);
 
-        let condition = |name: Arc<String>| columns.contains(&name);
+        let condition = |name: Arc<str>| columns.contains(&name);
         local_predicates.extend(transfer_to_local(arena, acc_predicates, condition));
     }
 }
@@ -255,11 +255,11 @@ pub(super) fn no_pushdown_preds<F>(
 /// to a local_predicates vec based on a condition.
 pub(super) fn transfer_to_local<F>(
     expr_arena: &Arena<AExpr>,
-    acc_predicates: &mut PlHashMap<Arc<String>, Node>,
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
     mut condition: F,
 ) -> Vec<Node>
 where
-    F: FnMut(Arc<String>) -> bool,
+    F: FnMut(Arc<str>) -> bool,
 {
     let mut remove_keys = Vec::with_capacity(acc_predicates.len());
 

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -3,7 +3,7 @@ use super::*;
 
 /// This replace the wilcard Expr with a Column Expr. It also removes the Exclude Expr from the
 /// expression chain.
-pub(super) fn replace_wildcard_with_column(mut expr: Expr, column_name: Arc<String>) -> Expr {
+pub(super) fn replace_wildcard_with_column(mut expr: Expr, column_name: Arc<str>) -> Expr {
     expr.mutate().apply(|e| {
         match &e {
             Expr::Wildcard => {
@@ -46,7 +46,7 @@ fn rewrite_keep_name_and_sufprefix(expr: Expr) -> Expr {
                     format!("{}{}", value, name)
                 };
 
-                Expr::Alias(expr, Arc::new(name))
+                Expr::Alias(expr, Arc::from(name))
             }
             _ => panic!("`keep_name`, `suffix`, `prefix` should be last expression"),
         }
@@ -58,11 +58,11 @@ fn rewrite_keep_name_and_sufprefix(expr: Expr) -> Expr {
 /// Take an expression with a root: col("*") and copies that expression for all columns in the schema,
 /// with the exclusion of the `names` in the exclude expression.
 /// The resulting expressions are written to result.
-fn replace_wilcard(expr: &Expr, result: &mut Vec<Expr>, exclude: &[Arc<String>], schema: &Schema) {
+fn replace_wilcard(expr: &Expr, result: &mut Vec<Expr>, exclude: &[Arc<str>], schema: &Schema) {
     for field in schema.fields() {
         let name = field.name();
         if !exclude.iter().any(|exluded| &**exluded == name) {
-            let new_expr = replace_wildcard_with_column(expr.clone(), Arc::new(name.clone()));
+            let new_expr = replace_wildcard_with_column(expr.clone(), Arc::from(name.as_str()));
             let new_expr = rewrite_keep_name_and_sufprefix(new_expr);
             result.push(new_expr)
         }
@@ -82,7 +82,7 @@ fn expand_regex(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema, pattern: &
 
             new_expr.mutate().apply(|e| match &e {
                 Expr::Column(_) => {
-                    *e = Expr::Column(Arc::new(name.clone()));
+                    *e = Expr::Column(Arc::from(name.as_str()));
                     false
                 }
                 _ => true,
@@ -102,7 +102,7 @@ fn replace_regex(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema) {
     // only in simple expression (no binary expression)
     // we pattern match regex columns
     if roots.len() == 1 {
-        let name = &**roots[0];
+        let name = &*roots[0];
         if name.starts_with('^') && name.ends_with('$') {
             expand_regex(expr, result, schema, name)
         } else {
@@ -121,7 +121,7 @@ fn expand_columns(expr: &Expr, result: &mut Vec<Expr>, names: &[String]) {
         let mut new_expr = expr.clone();
         new_expr.mutate().apply(|e| {
             if let Expr::Columns(_) = &e {
-                *e = Expr::Column(Arc::new(name.clone()));
+                *e = Expr::Column(Arc::from(name.as_str()));
             }
             // always keep iterating all inputs
             true
@@ -141,7 +141,7 @@ fn expand_dtypes(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema, dtypes: &
             let mut new_expr = expr.clone();
             new_expr.mutate().apply(|e| {
                 if let Expr::DtypeColumn(_) = &e {
-                    *e = Expr::Column(Arc::new(name.clone()));
+                    *e = Expr::Column(Arc::from(name.as_str()));
                 }
                 // always keep iterating all inputs
                 true
@@ -153,7 +153,7 @@ fn expand_dtypes(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema, dtypes: &
     }
 }
 
-fn prepare_excluded(expr: &Expr, schema: &Schema) -> Vec<Arc<String>> {
+fn prepare_excluded(expr: &Expr, schema: &Schema) -> Vec<Arc<str>> {
     let mut exclude = vec![];
     expr.into_iter().for_each(|e| {
         if let Expr::Exclude(_, names) = e {
@@ -208,13 +208,13 @@ pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema) -> Vec<Expr
 
             // if count wildcard. count one column
             if has_expr(&expr, |e| matches!(e, Expr::Agg(AggExpr::Count(_)))) {
-                let new_name = Arc::new(schema.field(0).unwrap().name().clone());
+                let new_name = Arc::from(schema.field(0).unwrap().name().as_str());
                 let expr = rename_expr_root_name(&expr, new_name).unwrap();
 
                 let expr = if let Expr::Alias(_, _) = &expr {
                     expr
                 } else {
-                    Expr::Alias(Box::new(expr), Arc::new("count".to_string()))
+                    Expr::Alias(Box::new(expr), Arc::from("count"))
                 };
                 result.push(expr);
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -177,7 +177,7 @@ fn run_partitions(
 fn get_outer_agg_exprs(
     exec: &PartitionGroupByExec,
     df: &DataFrame,
-) -> Result<(Vec<(Node, Arc<String>)>, Vec<Arc<dyn PhysicalExpr>>)> {
+) -> Result<(Vec<(Node, Arc<str>)>, Vec<Arc<dyn PhysicalExpr>>)> {
     // Due to the PARTITIONED GROUPBY the column names are be changed.
     // To make sure sure we can select the columns with the new names, we re-create the physical
     // aggregations with new root column names (being the output of the partitioned aggregation)j
@@ -189,7 +189,7 @@ fn get_outer_agg_exprs(
         .iter()
         .map(|e| {
             let out_field = e.to_field(&schema, Context::Aggregation)?;
-            let out_name = Arc::new(out_field.name().clone());
+            let out_name: Arc<str> = Arc::from(out_field.name().as_str());
             let node = to_aexpr(e.clone(), &mut expr_arena);
             rename_aexpr_root_name(node, &mut expr_arena, out_name.clone())?;
             Ok((node, out_name))

--- a/polars/polars-lazy/src/physical_plan/expressions/alias.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/alias.rs
@@ -7,12 +7,12 @@ use std::sync::Arc;
 
 pub struct AliasExpr {
     pub(crate) physical_expr: Arc<dyn PhysicalExpr>,
-    pub(crate) name: Arc<String>,
+    pub(crate) name: Arc<str>,
     expr: Expr,
 }
 
 impl AliasExpr {
-    pub fn new(physical_expr: Arc<dyn PhysicalExpr>, name: Arc<String>, expr: Expr) -> Self {
+    pub fn new(physical_expr: Arc<dyn PhysicalExpr>, name: Arc<str>, expr: Expr) -> Self {
         Self {
             physical_expr,
             name,

--- a/polars/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/column.rs
@@ -5,10 +5,10 @@ use polars_core::prelude::*;
 use std::borrow::Cow;
 use std::sync::Arc;
 
-pub struct ColumnExpr(Arc<String>, Expr);
+pub struct ColumnExpr(Arc<str>, Expr);
 
 impl ColumnExpr {
-    pub fn new(name: Arc<String>, expr: Expr) -> Self {
+    pub fn new(name: Arc<str>, expr: Expr) -> Self {
         Self(name, expr)
     }
 }
@@ -18,7 +18,7 @@ impl PhysicalExpr for ColumnExpr {
         &self.1
     }
     fn evaluate(&self, df: &DataFrame, _state: &ExecutionState) -> Result<Series> {
-        let column = match &**self.0 {
+        let column = match &*self.0 {
             "" => df.select_at_idx(0).ok_or_else(|| {
                 PolarsError::NoData("could not select a column from an empty DataFrame".into())
             })?,

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -10,8 +10,8 @@ pub struct WindowExpr {
     /// the root column that the Function will be applied on.
     /// This will be used to create a smaller DataFrame to prevent taking unneeded columns by index
     pub(crate) group_by: Vec<Arc<dyn PhysicalExpr>>,
-    pub(crate) apply_columns: Vec<Arc<String>>,
-    pub(crate) out_name: Option<Arc<String>>,
+    pub(crate) apply_columns: Vec<Arc<str>>,
+    pub(crate) out_name: Option<Arc<str>>,
     /// A function Expr. i.e. Mean, Median, Max, etc.
     pub(crate) function: Expr,
     pub(crate) phys_function: Arc<dyn PhysicalExpr>,
@@ -46,7 +46,7 @@ impl PhysicalExpr for WindowExpr {
         }
 
         // 2. create GroupBy object and apply aggregation
-        let apply_columns = self.apply_columns.iter().map(|s| s.as_str()).collect();
+        let apply_columns = self.apply_columns.iter().map(|s| s.as_ref()).collect();
         let gb = GroupBy::new(df, groupby_columns.clone(), groups, Some(apply_columns));
 
         let out = match self.phys_function.as_agg_expr() {
@@ -83,7 +83,7 @@ impl PhysicalExpr for WindowExpr {
         if self.options.explode {
             let mut out = out_column.clone();
             if let Some(name) = &self.out_name {
-                out.rename(name.as_str());
+                out.rename(name.as_ref());
             }
             return Ok(out);
         }
@@ -104,7 +104,7 @@ impl PhysicalExpr for WindowExpr {
 
         let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
         if let Some(name) = &self.out_name {
-            out.rename(name.as_str());
+            out.rename(name.as_ref());
         }
         Ok(out)
     }

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -26,28 +26,28 @@ fn aggregate_expr_to_scan_agg(
             let mut alias = None;
             if let AExpr::Alias(e, name) = expr_arena.get(expr) {
                 expr = *e;
-                alias = Some((**name).clone())
+                alias = Some((*name).to_string())
             };
             if let AExpr::Agg(agg) = expr_arena.get(expr) {
                 match agg {
                     AAggExpr::Min(e) => ScanAggregation::Min {
-                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).clone(),
+                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).to_string(),
                         alias,
                     },
                     AAggExpr::Max(e) => ScanAggregation::Max {
-                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).clone(),
+                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).to_string(),
                         alias,
                     },
                     AAggExpr::Sum(e) => ScanAggregation::Sum {
-                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).clone(),
+                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).to_string(),
                         alias,
                     },
                     AAggExpr::First(e) => ScanAggregation::First {
-                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).clone(),
+                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).to_string(),
                         alias,
                     },
                     AAggExpr::Last(e) => ScanAggregation::Last {
-                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).clone(),
+                        column: (*aexpr_to_root_names(*e, expr_arena).pop().unwrap()).to_string(),
                         alias,
                     },
                     _ => todo!(),

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -103,7 +103,7 @@ pub(crate) fn has_wildcard(current_expr: &Expr) -> bool {
 }
 
 /// output name of expr
-pub(crate) fn output_name(expr: &Expr) -> Result<Arc<String>> {
+pub(crate) fn output_name(expr: &Expr) -> Result<Arc<str>> {
     for e in expr {
         match e {
             Expr::Column(name) => return Ok(name.clone()),
@@ -126,7 +126,7 @@ pub(crate) fn rename_field(field: &Field, name: &str) -> Field {
 
 /// This function should be used to find the name of the start of an expression
 /// Normal iteration would just return the first root column it found
-pub(crate) fn get_single_root(expr: &Expr) -> Result<Arc<String>> {
+pub(crate) fn get_single_root(expr: &Expr) -> Result<Arc<str>> {
     for e in expr {
         match e {
             Expr::Filter { input, .. } => return get_single_root(input),
@@ -143,7 +143,7 @@ pub(crate) fn get_single_root(expr: &Expr) -> Result<Arc<String>> {
 }
 
 /// This should gradually replace expr_to_root_column as this will get all names in the tree.
-pub(crate) fn expr_to_root_column_names(expr: &Expr) -> Vec<Arc<String>> {
+pub(crate) fn expr_to_root_column_names(expr: &Expr) -> Vec<Arc<str>> {
     expr_to_root_column_exprs(expr)
         .into_iter()
         .map(|e| expr_to_root_column_name(&e).unwrap())
@@ -151,7 +151,7 @@ pub(crate) fn expr_to_root_column_names(expr: &Expr) -> Vec<Arc<String>> {
 }
 
 /// unpack alias(col) to name of the root column name
-pub(crate) fn expr_to_root_column_name(expr: &Expr) -> Result<Arc<String>> {
+pub(crate) fn expr_to_root_column_name(expr: &Expr) -> Result<Arc<str>> {
     let mut roots = expr_to_root_column_exprs(expr);
     match roots.len() {
         0 => Err(PolarsError::ComputeError(
@@ -186,7 +186,7 @@ pub(crate) fn aexpr_to_root_nodes(root: Node, arena: &Arena<AExpr>) -> Vec<Node>
 pub(crate) fn rename_aexpr_root_name(
     node: Node,
     arena: &mut Arena<AExpr>,
-    new_name: Arc<String>,
+    new_name: Arc<str>,
 ) -> Result<()> {
     let roots = aexpr_to_root_nodes(node, arena);
     match roots.len() {
@@ -216,7 +216,7 @@ pub(crate) fn expr_to_root_column_exprs(expr: &Expr) -> Vec<Expr> {
     out
 }
 
-pub(crate) fn rename_expr_root_name(expr: &Expr, new_name: Arc<String>) -> Result<Expr> {
+pub(crate) fn rename_expr_root_name(expr: &Expr, new_name: Arc<str>) -> Result<Expr> {
     let mut arena = Arena::with_capacity(32);
     let root = to_aexpr(expr.clone(), &mut arena);
     rename_aexpr_root_name(root, &mut arena, new_name)?;
@@ -261,7 +261,7 @@ pub(crate) fn try_path_to_str(path: &Path) -> Result<&str> {
     })
 }
 
-pub(crate) fn aexpr_to_root_names(node: Node, arena: &Arena<AExpr>) -> Vec<Arc<String>> {
+pub(crate) fn aexpr_to_root_names(node: Node, arena: &Arena<AExpr>) -> Vec<Arc<str>> {
     aexpr_to_root_nodes(node, arena)
         .into_iter()
         .map(|node| aexpr_to_root_column_name(node, arena).unwrap())
@@ -269,7 +269,7 @@ pub(crate) fn aexpr_to_root_names(node: Node, arena: &Arena<AExpr>) -> Vec<Arc<S
 }
 
 /// unpack alias(col) to name of the root column name
-pub(crate) fn aexpr_to_root_column_name(root: Node, arena: &Arena<AExpr>) -> Result<Arc<String>> {
+pub(crate) fn aexpr_to_root_column_name(root: Node, arena: &Arena<AExpr>) -> Result<Arc<str>> {
     let mut roots = aexpr_to_root_nodes(root, arena);
     match roots.len() {
         0 => Err(PolarsError::ComputeError(


### PR DESCRIPTION
Removes a layer of indirection in logicalplan. `Arc<String>` to `Arc<str>`.