### PR TITLE
Fix date_range function

### DIFF
--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -177,4 +177,4 @@ def date_range(
         values = np.append(values, np.array(high, dtype="datetime64[ms]"))
     if closed == "right":
         values = values[1:]
-    return pl.Series(name=name, values=values.astype(int)).cast(pl.Datetime)
+    return pl.Series(name=name, values=values.astype(np.int64)).cast(pl.Datetime)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -783,3 +783,12 @@ def test_trigonometry_functions():
     assert np.allclose(srs_float.arcsin(), np.array([1.571, 0.0, -1.571]), atol=0.01)
     assert np.allclose(srs_float.arccos(), np.array([0.0, 1.571, 3.142]), atol=0.01)
     assert np.allclose(srs_float.arctan(), np.array([0.785, 0.0, -0.785]), atol=0.01)
+
+
+def test_date_range():
+    result = pl.date_range(datetime(1985, 1, 1), datetime(2015, 7, 1), timedelta(days=1, hours=12))
+    assert len(result) == 7426
+    assert result.dt[0] == datetime(1985, 1, 1)
+    assert result.dt[1] == datetime(1985, 1, 2, 12, 0)
+    assert result.dt[2] == datetime(1985, 1, 4, 0, 0)
+    assert result.dt[-1] == datetime(2015, 7, 1)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -793,4 +793,4 @@ def test_date_range():
     assert result.dt[0] == datetime(1985, 1, 1)
     assert result.dt[1] == datetime(1985, 1, 2, 12, 0)
     assert result.dt[2] == datetime(1985, 1, 4, 0, 0)
-    assert result.dt[-1] == datetime(2015, 7, 1)
+    assert result.dt[-1] == datetime(2015, 6, 30, 12, 0)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -786,7 +786,9 @@ def test_trigonometry_functions():
 
 
 def test_date_range():
-    result = pl.date_range(datetime(1985, 1, 1), datetime(2015, 7, 1), timedelta(days=1, hours=12))
+    result = pl.date_range(
+        datetime(1985, 1, 1), datetime(2015, 7, 1), timedelta(days=1, hours=12)
+    )
     assert len(result) == 7426
     assert result.dt[0] == datetime(1985, 1, 1)
     assert result.dt[1] == datetime(1985, 1, 2, 12, 0)


### PR DESCRIPTION
On my machine, the `.astype(int)` causes overflow as it is using only 32-bits, resulting in the wrong dates being returned. Casting to a (numpy) int64 prevents this.

I have added the example in the docstring of `date_range` as a test, which fails without this fix, and passes with the fix.