### PR TITLE
Fix two Python test warnings

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -86,10 +86,11 @@ def test_init_ndarray():
 
 # TODO: Remove this test case when removing deprecated behaviour
 def test_init_ndarray_deprecated():
-    # 2D array - default to row orientation
-    df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
-    truth = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
-    assert df.frame_equal(truth)
+    with pytest.deprecated_call():
+        # 2D array - default to row orientation
+        df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
+        truth = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
+        assert df.frame_equal(truth)
 
 
 def test_init_arrow():

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -545,7 +545,7 @@ def test_extract_regex():
             "http://vote.com/ballon_dor?candidate=ronaldo&ref=polars",
         ]
     )
-    assert s.str.extract("candidate=(\w+)", 1).to_list() == [
+    assert s.str.extract(r"candidate=(\w+)", 1).to_list() == [
         "messi",
         None,
         "ronaldo",


### PR DESCRIPTION
Whilst running the Python test suite, some warnings were generated.

* `test_init_ndarray_deprecated`: the test is expected to trigger a deprecation warning. I have added a pytest context manager to 1) ensure it does and 2) remove the deprecation warning from the test output

* `test_extract_regex`: use a raw format string to deal with the \w sequence