### PR TITLE
test join logicaltype dispatch + update arrow

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -167,6 +167,10 @@ docs-selection = [
     "arange"
 ]
 
+bench = [
+    "lazy"
+]
+
 [dependencies]
 polars-core = {version = "0.17.0", path = "./polars-core", features= ["docs", "private"], default-features = false}
 polars-io = {version = "0.17.0", path = "./polars-io", features = ["private"], default-features = false, optional=true}

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -9,7 +9,7 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "0dda942c055cd6a195cac7060c33b0779a178935", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "f146097350512aa28a2bf54181c49361b97a8053", default-features = false }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", branch="dev", default-features = false }
 #arrow = { package = "arrow2", version = "0.7", default-features=false}
 thiserror = "^1.0"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -128,7 +128,7 @@ docs-selection = [
 ]
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "0dda942c055cd6a195cac7060c33b0779a178935", default-features = false, features=["compute"] }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "f146097350512aa28a2bf54181c49361b97a8053", default-features = false, features=["compute"] }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features=["compute"], branch="dev" }
 #arrow = { package = "arrow2", version="0.7", default-features = false, features=["compute"]}
 polars-arrow = {version = "0.17.0", path = "../polars-arrow"}

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -29,7 +29,7 @@ temporal = ["polars-core/dtype-date", "polars-core/dtype-datetime"]
 private = []
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "0dda942c055cd6a195cac7060c33b0779a178935", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "f146097350512aa28a2bf54181c49361b97a8053", default-features = false }
 #arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, branch="dev"}
 #arrow = { package = "arrow2", version="0.7", --default-features=false }
 polars-core = {version = "0.17.0", path = "../polars-core", features = ["private"], default-features=false}

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -34,6 +34,7 @@
 //! ```
 use super::{finish_reader, ArrowReader, ArrowResult, RecordBatch};
 use crate::prelude::*;
+use arrow::io::ipc::write::WriteOptions;
 use arrow::io::ipc::{read, write};
 use polars_core::prelude::*;
 use std::io::{Read, Seek, Write};
@@ -129,7 +130,11 @@ where
     }
 
     fn finish(mut self, df: &DataFrame) -> Result<()> {
-        let mut ipc_writer = write::FileWriter::try_new(&mut self.writer, &df.schema().to_arrow())?;
+        let mut ipc_writer = write::FileWriter::try_new(
+            &mut self.writer,
+            &df.schema().to_arrow(),
+            WriteOptions { compression: None },
+        )?;
 
         let iter = df.iter_record_batches();
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.7.0"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=0dda942c055cd6a195cac7060c33b0779a178935#0dda942c055cd6a195cac7060c33b0779a178935"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=f146097350512aa28a2bf54181c49361b97a8053#f146097350512aa28a2bf54181c49361b97a8053"
 dependencies = [
  "ahash",
  "arrow-format",


### PR DESCRIPTION
This adds a test that tests the dispatch of logical types in join operations.

Arrow update has the improved bitmap performance from trusted len iter. This is also slightly visible in the global benchmarks.

```
groupby q1              time:   [2.6551 ms 2.6871 ms 2.7232 ms]                        
                        change: [-6.8637% -4.8010% -2.5699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

groupby q2              time:   [12.918 ms 12.975 ms 13.035 ms]                       
                        change: [-0.5351% +0.0905% +0.6703%] (p = 0.77 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

groupby q3              time:   [4.4449 ms 4.4670 ms 4.4897 ms]                        
                        change: [-2.2556% -1.5157% -0.7770%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

groupby q4              time:   [17.878 ms 17.989 ms 18.097 ms]                       
                        change: [-1.2654% -0.3800% +0.4893%] (p = 0.40 > 0.05)
                        No change in performance detected.

groupby q5              time:   [36.408 ms 36.678 ms 36.961 ms]                       
                        change: [-2.3609% -1.4333% -0.4680%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

groupby q6              time:   [43.633 ms 43.732 ms 43.834 ms]                       
                        change: [-0.6973% -0.2681% +0.1361%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild

groupby q7              time:   [11.742 ms 11.796 ms 11.850 ms]                       
                        change: [-1.8108% -1.0972% -0.3974%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking groupby q8: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, or reduce sample count to 70.
groupby q8              time:   [70.656 ms 71.044 ms 71.446 ms]                       
                        change: [-0.4185% +0.3724% +1.1741%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

groupby q9              time:   [33.033 ms 33.231 ms 33.428 ms]                       
                        change: [-3.6870% -2.7519% -1.8005%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

Benchmarking groupby q10: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 12.7s, or reduce sample count to 30.
groupby q10             time:   [128.04 ms 129.38 ms 130.77 ms]                        
                        change: [-6.4436% -4.8610% -3.2868%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

```