### PR TITLE
Fix test_groupby output ordering in assertion

### DIFF
--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -148,8 +148,8 @@ def test_groupby():
     df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
     out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
 
-    expected = pl.DataFrame({"groups": ["b", "a"], "a_mean": [3.5, 1.0]})
-    assert out.frame_equal(expected)
+    expected = pl.DataFrame({"groups": ["a", "b"], "a_mean": [1.0, 3.5]})
+    assert out.sort(by="groups").frame_equal(expected)
 
 
 def test_shift_and_fill():


### PR DESCRIPTION
PR #1695 introduced an assertion on the groupby result. However, the order of the results is not consistently the same, causing the Linux tests on #1697 to fail. This is solved by sorting the output to ensure it always matches the `expected` dataframe.