### PR TITLE
Turn on flake8 for tests

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -3,5 +3,5 @@
 max-line-length = 180
 # E203, W504: due to black fmt
 ignore = E203,W503,W605
-exclude = tests, legacy, docs
+exclude = legacy, docs
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,3 +1,4 @@
+# flake8: noqa: W191,E101
 from builtins import range
 from datetime import datetime
 from io import BytesIO
@@ -9,8 +10,6 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import *
-from polars.lazy import *
 
 
 def test_version():
@@ -316,7 +315,7 @@ def test_downsample():
             946685880000,
             946685940000,
         ],
-    ).cast(Datetime)
+    ).cast(pl.Datetime)
     s2 = s.clone()
     df = pl.DataFrame({"a": s, "b": s2})
     out = df.downsample("a", rule="minute", n=5).first()
@@ -621,7 +620,7 @@ def test_custom_groupby():
     out = (
         df.lazy()
         .groupby("b")
-        .agg([col("a").apply(lambda x: x.sum(), return_dtype=int)])
+        .agg([pl.col("a").apply(lambda x: x.sum(), return_dtype=int)])
         .collect()
     )
     assert out.shape == (3, 2)
@@ -805,7 +804,7 @@ def test_lazy_functions():
 
 def test_multiple_column_sort():
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [2, 2, 3], "c": [1.0, 2.0, 3.0]})
-    out = df.sort([col("b"), col("c").reverse()])
+    out = df.sort([pl.col("b"), pl.col("c").reverse()])
     assert out["c"] == [2, 3, 1]
     assert out["b"] == [2, 2, 3]
 
@@ -995,14 +994,14 @@ def dot_product():
     df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
 
     assert df["a"].dot(df["b"]) == 20
-    assert df[[col("a").dot("b")]][0, "a"] == 20
+    assert df[[pl.col("a").dot("b")]][0, "a"] == 20
 
 
 def test_hash_rows():
     df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
     assert df.hash_rows().dtype == pl.UInt64
     assert df["a"].hash().dtype == pl.UInt64
-    assert df[[col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64
+    assert df[[pl.col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64
 
 
 def test_create_df_from_object():
@@ -1019,7 +1018,7 @@ def test_hashing_on_python_objects():
     # this requires that the hashing and aggregations are done on python objects
 
     df = pl.DataFrame({"a": [1, 1, 3, 4], "b": [1, 1, 2, 2]})
-    df = df.with_column(col("a").apply(lambda x: datetime(2021, 1, 1)).alias("foo"))
+    df = df.with_column(pl.col("a").apply(lambda x: datetime(2021, 1, 1)).alias("foo"))
     assert df.groupby(["foo"]).first().shape == (1, 3)
     assert df.drop_duplicates().shape == (3, 3)
 
@@ -1084,7 +1083,7 @@ def test_apply_list_return():
     assert out.to_list() == [[1, 2, 3], [2, 3, 4, 5]]
 
 
-def test_groupby_cat_list():
+def test_groupby_cat_list():  # noqa: W191,E101
     grouped = (
         pl.DataFrame(
             [

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -1,3 +1,4 @@
+# flake8: noqa: W191,E101
 import copy
 import gzip
 import io
@@ -7,7 +8,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 import pytest
 
 import polars as pl

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -4,16 +4,15 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.datatypes import *
-from polars.lazy import *
+from polars.lazy import col, lit, map_binary, when
 
 
 def test_lazy():
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    ldf = df.lazy().with_column(lit(1).alias("foo")).select([col("a"), col("foo")])
+    _ = df.lazy().with_column(lit(1).alias("foo")).select([col("a"), col("foo")])
 
     # test if it executes
-    new = (
+    _ = (
         df.lazy()
         .with_column(
             when(col("a").gt(lit(2))).then(lit(10)).otherwise(lit(1)).alias("new")

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -6,7 +6,6 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import *
 
 
 def create_series() -> pl.Series:
@@ -168,12 +167,12 @@ def test_filter():
 def test_cast():
     a = pl.Series("a", range(20))
 
-    assert a.cast(Float32).dtype == Float32
-    assert a.cast(Float64).dtype == Float64
-    assert a.cast(Int32).dtype == Int32
-    assert a.cast(UInt32).dtype == UInt32
-    assert a.cast(Datetime).dtype == Datetime
-    assert a.cast(Date).dtype == Date
+    assert a.cast(pl.Float32).dtype == pl.Float32
+    assert a.cast(pl.Float64).dtype == pl.Float64
+    assert a.cast(pl.Int32).dtype == pl.Int32
+    assert a.cast(pl.UInt32).dtype == pl.UInt32
+    assert a.cast(pl.Datetime).dtype == pl.Datetime
+    assert a.cast(pl.Date).dtype == pl.Date
 
 
 def test_to_python():
@@ -206,16 +205,16 @@ def test_rechunk():
 def test_indexing():
     a = pl.Series("a", [1, 2, None])
     assert a[1] == 2
-    assert a[2] == None
+    assert a[2] is None
     b = pl.Series("b", [True, False])
     assert b[0]
     assert not b[1]
     a = pl.Series("a", ["a", None])
     assert a[0] == "a"
-    assert a[1] == None
+    assert a[1] is None
     a = pl.Series("a", [0.1, None])
     assert a[0] == 0.1
-    assert a[1] == None
+    assert a[1] is None
 
 
 def test_arrow():


### PR DESCRIPTION
* removed wildcard imports
* removed unused imports and fixed other errors
* in two test files, string output with a mix of spaces and tabs is being asserted, triggering flake8 warnings. Thus I have turned off the two flake8 warnings generated for the specific files using `noqa` flags