### PR TITLE
Modify df! macro to allow for a trailing comma

### DIFF
--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -914,7 +914,7 @@ mod test {
     }
 
     #[test]
-    fn test_df_macro_trailing_commas() -> Result<()>{
+    fn test_df_macro_trailing_commas() -> Result<()> {
         let a = df! {
             "a" => &["a one", "a two"],
             "b" => &["b one", "b two"],

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -463,7 +463,7 @@ macro_rules! static_zip {
 
 #[macro_export]
 macro_rules! df {
-    ($($col_name:expr => $slice:expr), +) => {
+    ($($col_name:expr => $slice:expr), + $(,)?) => {
         {
             DataFrame::new(vec![$(Series::new($col_name, $slice),)+])
         }
@@ -911,5 +911,23 @@ mod test {
             a.chunk_id().collect::<Vec<_>>(),
             b.chunk_id().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_df_macro_trailing_commas() -> Result<()>{
+        let a = df! {
+            "a" => &["a one", "a two"],
+            "b" => &["b one", "b two"],
+            "c" => &[1, 2]
+        }?;
+
+        let b = df! {
+            "a" => &["a one", "a two"],
+            "b" => &["b one", "b two"],
+            "c" => &[1, 2],
+        }?;
+
+        assert!(a.frame_equal(&b));
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes issue #1727 by modifying the `df!` macro to allow for a trailing comma.

I also added a single test to the same file just to verify the changes, but I am not sure it is a good idea to keep the test long-term since it may add unnecessary time to testing. Many tests already use the `df!` macro so the same verification could be accomplished by modifying some existing uses to have a trailing comma.

I'm open to any opinions and I'd appreciate any feedback. Thanks