### PR TITLE
Python context free `select`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ You have to follow these steps:
 - install rust nightly via [rustup](https://www.rust-lang.org/tools/install)
 - run `$ rustup override set nightly` from the root of the repo.
 - from [./py-polars](./py-polars) run `$ pip3 install -r build.requirements.txt`
-- from [./py-polars](./py-polars) run `$ make build-and-test pre-commit`
+- **tests:** from [./py-polars](./py-polars) run `$ make test`
+- **formatting + linting:** from [./py-polars](./py-polars) run `$ make pre-commit`
 
 The last step installs a (slow) development build in your current environment and runs pytest.
 

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -89,7 +89,7 @@ Manipulation/ selection
     DataFrame.drop_nulls
     DataFrame.drop
     DataFrame.drop_in_place
-    DataFrame.select_at_idx
+    DataFrame.to_series
     DataFrame.clone
     DataFrame.get_columns
     DataFrame.get_column

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -11,6 +11,7 @@ These functions can be used as expression and sometimes also in eager contexts.
 .. autosummary::
    :toctree: api/
 
+   select
    col
    count
    list

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -29,20 +29,12 @@ def _selection_to_pyexpr_list(
     exprs: Union[str, "Expr", Sequence[str], Sequence["Expr"]]
 ) -> tp.List["PyExpr"]:
     pyexpr_list: tp.List[PyExpr]
-    if isinstance(exprs, str):
-        pyexpr_list = [col(exprs)._pyexpr]
-    elif isinstance(exprs, (bool, int, float)):
-        pyexpr_list = [lit(exprs)._pyexpr]
-    elif isinstance(exprs, Expr):
-        pyexpr_list = [exprs._pyexpr]
-    else:
+    if isinstance(exprs, Sequence) and not isinstance(exprs, str):
         pyexpr_list = []
         for expr in exprs:
-            if isinstance(expr, str):
-                expr = col(expr)
-            elif isinstance(expr, (bool, int, float)):
-                expr = lit(expr)
-            pyexpr_list.append(expr._pyexpr)
+            pyexpr_list.append(expr_to_lit_or_expr(expr, str_to_lit=False)._pyexpr)
+    else:
+        pyexpr_list = [expr_to_lit_or_expr(exprs, str_to_lit=False)._pyexpr]
     return pyexpr_list
 
 

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -1,7 +1,7 @@
 import typing as tp
 from datetime import date, datetime, timezone
 from inspect import isclass
-from typing import Any, Callable, Optional, Type, Union
+from typing import Any, Callable, Optional, Sequence, Type, Union
 
 import numpy as np
 
@@ -69,6 +69,7 @@ __all__ = [
     "format",
     "_datetime",
     "_date",
+    "select",
 ]
 
 
@@ -994,3 +995,43 @@ def collect_all(
         result.append(pl.eager.frame.wrap_df(pydf))
 
     return result
+
+
+def select(
+    exprs: Union[str, "pl.Expr", Sequence[str], Sequence["pl.Expr"]]
+) -> "pl.DataFrame":
+    """
+    Run polars expressions without a context.
+
+    This is syntactic sugar for running `df.select` on an empty DataFrame.
+
+    Parameters
+    ----------
+    exprs
+        Expressions to run
+    Returns
+    -------
+    DataFrame
+
+    Examples
+    --------
+
+    >>> foo = pl.Series("foo", [1, 2, 3])
+    >>> bar = pl.Series("bar", [3, 2, 1])
+    >>> pl.select([
+    >>>     pl.min([foo, bar])
+    >>> ])
+    shape: (3, 1)
+    ┌─────┐
+    │ min │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 1   │
+    ├╌╌╌╌╌┤
+    │ 2   │
+    ├╌╌╌╌╌┤
+    │ 1   │
+    └─────┘
+    """
+    return pl.DataFrame([]).select(exprs)


### PR DESCRIPTION
This makes it easier to utilize polars expressions on `Series`. You don't need to wrap them in a `DataFrame` first.

```python
foo = pl.Series("foo", [1, 2, 3])
bar = pl.Series("bar", [3, 2, 1])

ham = pl.select([
    pl.min([foo, bar])
]).to_series()
```