### PR TITLE
Rust documentation: new example for the `new_no_checks` method of DataFrame

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -185,7 +185,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///   let df1: DataFrame = df!("Name" => &["James", "Mary", "John", "Patricia"])?;
     ///   assert_eq!(df1.shape(), (4, 1));
     ///
@@ -1491,7 +1491,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1529,7 +1529,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1566,7 +1566,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1604,7 +1604,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1642,7 +1642,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1680,7 +1680,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));
@@ -1722,7 +1722,7 @@ impl DataFrame {
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
-    /// fn main() -> Result<()> {
+    /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
     ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
     ///     assert_eq!(df1.shape(), (5, 2));

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -233,6 +233,25 @@ impl DataFrame {
     /// # Panic
     /// It is the callers responsibility to uphold the contract of all `Series`
     /// having an equal length, if not this may panic down the line.
+    ///
+    /// # Example
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let s1: Series = Series::new("Country", &["France", "Netherlands", "United States"]);
+    ///     let s2: Series = Series::new("Capital", &["Paris", "Amsterdam", "Washington"]);
+    ///     assert_eq!(s1.utf8()?.len(), s2.utf8()?.len());
+    ///
+    ///     let df1: DataFrame = DataFrame::new_no_checks(vec![s1, s2]);
+    ///     let df2: DataFrame = df!("Country" => &["France", "Netherlands", "United States"],
+    ///                              "Capital" => &["Paris", "Amsterdam", "Washington"])?;
+    ///     assert!(df1.frame_equal(&df2));
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn new_no_checks(columns: Vec<Series>) -> DataFrame {
         DataFrame { columns }
     }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1484,35 +1484,227 @@ impl DataFrame {
     }
 
     /// Aggregate the columns to their maximum values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.max();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | i32     | i32     |
+    /// +=========+=========+
+    /// | 6       | 5       |
+    /// +---------+---------+
+    /// ```
     pub fn max(&self) -> Self {
         let columns = self.columns.par_iter().map(|s| s.max_as_series()).collect();
         DataFrame::new_no_checks(columns)
     }
 
     /// Aggregate the columns to their standard deviation values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.std();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +-------------------+--------------------+
+    /// | Die n°1           | Die n°2            |
+    /// | ---               | ---                |
+    /// | f64               | f64                |
+    /// +===================+====================+
+    /// | 2.280350850198276 | 1.0954451150103321 |
+    /// +-------------------+--------------------+
+    /// ```
     pub fn std(&self) -> Self {
         let columns = self.columns.par_iter().map(|s| s.std_as_series()).collect();
         DataFrame::new_no_checks(columns)
     }
     /// Aggregate the columns to their variation values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.var();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | f64     | f64     |
+    /// +=========+=========+
+    /// | 5.2     | 1.2     |
+    /// +---------+---------+
+    /// ```
     pub fn var(&self) -> Self {
         let columns = self.columns.par_iter().map(|s| s.var_as_series()).collect();
         DataFrame::new_no_checks(columns)
     }
 
     /// Aggregate the columns to their minimum values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.min();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | i32     | i32     |
+    /// +=========+=========+
+    /// | 1       | 2       |
+    /// +---------+---------+
+    /// ```
     pub fn min(&self) -> Self {
         let columns = self.columns.par_iter().map(|s| s.min_as_series()).collect();
         DataFrame::new_no_checks(columns)
     }
 
     /// Aggregate the columns to their sum values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.sum();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | i32     | i32     |
+    /// +=========+=========+
+    /// | 16      | 16      |
+    /// +---------+---------+
+    /// ```
     pub fn sum(&self) -> Self {
         let columns = self.columns.par_iter().map(|s| s.sum_as_series()).collect();
         DataFrame::new_no_checks(columns)
     }
 
     /// Aggregate the columns to their mean values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.mean();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | f64     | f64     |
+    /// +=========+=========+
+    /// | 3.2     | 3.2     |
+    /// +---------+---------+
+    /// ```
     pub fn mean(&self) -> Self {
         let columns = self
             .columns
@@ -1523,6 +1715,38 @@ impl DataFrame {
     }
 
     /// Aggregate the columns to their median values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn main() -> Result<()> {
+    ///     let df1: DataFrame = df!("Die n°1" => &[1, 3, 1, 5, 6],
+    ///                              "Die n°2" => &[3, 2, 3, 5, 3])?;
+    ///     assert_eq!(df1.shape(), (5, 2));
+    ///
+    ///     let df2: DataFrame = df1.median();
+    ///     assert_eq!(df2.shape(), (1, 2));
+    ///     println!("{}", df2);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (1, 2)
+    /// +---------+---------+
+    /// | Die n°1 | Die n°2 |
+    /// | ---     | ---     |
+    /// | i32     | i32     |
+    /// +=========+=========+
+    /// | 3       | 3       |
+    /// +---------+---------+
+    /// ```
     pub fn median(&self) -> Self {
         let columns = self
             .columns


### PR DESCRIPTION
Adding a new example for the `new_no_checks` method of the DataFrame structure using the rustdoc features.

```rust
use polars_core::df;
use polars_core::prelude::*;

fn main() -> Result<()> {
    let s1: Series = Series::new("Country", &["France", "Netherlands", "United States"]);
    let s2: Series = Series::new("Capital", &["Paris", "Amsterdam", "Washington"]);
    assert_eq!(s1.utf8()?.len(), s2.utf8()?.len());

    let df1: DataFrame = DataFrame::new_no_checks(vec![s1, s2]);
    let df2: DataFrame = df!("Country" => &["France", "Netherlands", "United States"],
                             "Capital" => &["Paris", "Amsterdam", "Washington"])?;
    assert!(df1.frame_equal(&df2));

    Ok(())
}
```

By the way, is it necessary to use the `ChunkedArray` to compute the Series length, or can we create a method `len` for the `Series` ? Or there might be another better way to do so that I don't know.