### PR TITLE
Fix test_cum_agg + add example Series.cumprod

### DIFF
--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1041,6 +1041,19 @@ class Series:
         ----------
         reverse
             reverse the operation.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s.cumprod()
+        shape: (3,)
+        Series: 'b' [i64]
+        [
+                1
+                2
+                6
+        ]
+
         """
         return wrap_s(self._s.cumprod(reverse))
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -12,10 +12,11 @@ def create_series() -> pl.Series:
 
 
 def test_cum_agg():
-    s = create_series()
-    assert s.cumsum() == [1, 2]
-    assert s.cummin() == [1, 1]
-    assert s.cummax() == [1, 2]
+    s = pl.Series("a", [1, 2, 3, 2])
+    assert s.cumsum().series_equal(pl.Series([1, 3, 6, 8]))
+    assert s.cummin().series_equal(pl.Series([1, 1, 1, 1]))
+    assert s.cummax().series_equal(pl.Series([1, 2, 3, 3]))
+    assert s.cumprod().series_equal(pl.Series([1, 2, 6, 12]))
 
 
 def test_init_inputs():


### PR DESCRIPTION
The current version of `test_cum_agg`, operating on the series `[1, 2]`, compares the output of the `cum*` functions to a list using `==`, which results in a new series which may have both True's and False's; assert gives it a pass. This is most visible with the original asserted output of cumsum to be `[1, 2]` whilst it should be `[1, 3]` obviously.

This PR:
* uses `.series_equal` to prevent the wrong comparison
* adds an assertion on `cumprod`, which was not covered yet
* adds an example to the docstring of cumprod
* makes the test case slightly more interesting by using a 4 item series as input