### PR TITLE
Rust documentation: new examples for `head` and `tail` methods of `DataFrame`

### DIFF
--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1045,16 +1045,16 @@ impl DataFrame {
     /// Generic join method. Can be used to join on multiple columns.
     ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// use polars_core::df;
     /// use polars_core::prelude::*;
     ///
     /// fn example() -> Result<()> {
     ///     let df1: DataFrame = df!("Fruit" => &["Apple", "Banana", "Pear"],
-    ///                              "Phosphorus (mg)" => &[11, 22, 12])?;
+    ///                              "Phosphorus (mg/100g)" => &[11, 22, 12])?;
     ///     let df2: DataFrame = df!("Name" => &["Apple", "Banana", "Pear"],
-    ///                              "Potassium (mg)" => &[107, 358, 115])?;
+    ///                              "Potassium (mg/100g)" => &[107, 358, 115])?;
     ///
     ///     let df3: DataFrame = df1.join(&df2, "Fruit", "Name", JoinType::Inner, None)?;
     ///     assert_eq!(df3.shape(), (3, 3));
@@ -1068,17 +1068,17 @@ impl DataFrame {
     ///
     /// ```text
     /// shape: (3, 3)
-    /// +--------+-----------------+----------------+
-    /// | Fruit  | Phosphorus (mg) | Potassium (mg) |
-    /// | ---    | ---             | ---            |
-    /// | str    | i32             | i32            |
-    /// +========+=================+================+
-    /// | Apple  | 11              | 107            |
-    /// +--------+-----------------+----------------+
-    /// | Banana | 22              | 358            |
-    /// +--------+-----------------+----------------+
-    /// | Pear   | 12              | 115            |
-    /// +--------+-----------------+----------------+
+    /// +--------+----------------------+---------------------+
+    /// | Fruit  | Phosphorus (mg/100g) | Potassium (mg/100g) |
+    /// | ---    | ---                  | ---                 |
+    /// | str    | i32                  | i32                 |
+    /// +========+======================+=====================+
+    /// | Apple  | 11                   | 107                 |
+    /// +--------+----------------------+---------------------+
+    /// | Banana | 22                   | 358                 |
+    /// +--------+----------------------+---------------------+
+    /// | Pear   | 12                   | 115                 |
+    /// +--------+----------------------+---------------------+
     /// ```
     pub fn join<'a, J, S1: Selection<'a, J>, S2: Selection<'a, J>>(
         &self,

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1043,6 +1043,43 @@ impl DataFrame {
     }
 
     /// Generic join method. Can be used to join on multiple columns.
+    ///
+    /// # Example
+    /// 
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn example() -> Result<()> {
+    ///     let df1: DataFrame = df!("Fruit" => &["Apple", "Banana", "Pear"],
+    ///                              "Phosphorus (mg)" => &[11, 22, 12])?;
+    ///     let df2: DataFrame = df!("Name" => &["Apple", "Banana", "Pear"],
+    ///                              "Potassium (mg)" => &[107, 358, 115])?;
+    ///
+    ///     let df3: DataFrame = df1.join(&df2, "Fruit", "Name", JoinType::Inner, None)?;
+    ///     assert_eq!(df3.shape(), (3, 3));
+    ///     println!("{}", df3);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (3, 3)
+    /// +--------+-----------------+----------------+
+    /// | Fruit  | Phosphorus (mg) | Potassium (mg) |
+    /// | ---    | ---             | ---            |
+    /// | str    | i32             | i32            |
+    /// +========+=================+================+
+    /// | Apple  | 11              | 107            |
+    /// +--------+-----------------+----------------+
+    /// | Banana | 22              | 358            |
+    /// +--------+-----------------+----------------+
+    /// | Pear   | 12              | 115            |
+    /// +--------+-----------------+----------------+
+    /// ```
     pub fn join<'a, J, S1: Selection<'a, J>, S2: Selection<'a, J>>(
         &self,
         other: &DataFrame,

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1416,6 +1416,43 @@ impl DataFrame {
     }
 
     /// Get the head of the DataFrame
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn example() -> Result<()> {
+    ///     let countries: DataFrame =
+    ///         df!("Rank by GDP (2021)" => &[1, 2, 3, 4, 5],
+    ///          "Continent" => &["North America", "Asia", "Asia", "Europe", "Europe"],
+    ///          "Country" => &["United States", "China", "Japan", "Germany", "United Kingdom"],
+    ///          "Capital" => &["Washington", "Beijing", "Tokyo", "Berlin", "London"])?;
+    ///     assert_eq!(countries.shape(), (5, 4));
+    ///
+    ///     println!("{}", countries.head(Some(3)));
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (3, 4)
+    /// +--------------------+---------------+---------------+------------+
+    /// | Rank by GDP (2021) | Continent     | Country       | Capital    |
+    /// | ---                | ---           | ---           | ---        |
+    /// | i32                | str           | str           | str        |
+    /// +====================+===============+===============+============+
+    /// | 1                  | North America | United States | Washington |
+    /// +--------------------+---------------+---------------+------------+
+    /// | 2                  | Asia          | China         | Beijing    |
+    /// +--------------------+---------------+---------------+------------+
+    /// | 3                  | Asia          | Japan         | Tokyo      |
+    /// +--------------------+---------------+---------------+------------+
+    /// ```
     pub fn head(&self, length: Option<usize>) -> Self {
         let col = self
             .columns
@@ -1426,6 +1463,40 @@ impl DataFrame {
     }
 
     /// Get the tail of the DataFrame
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;
+    /// use polars_core::prelude::*;
+    ///
+    /// fn example() -> Result<()> {
+    ///     let countries: DataFrame =
+    ///         df!("Rank (2021)" => &[105, 106, 107, 108, 109],
+    ///             "Apple Price (€/kg)" => &[0.76, 0.72, 0.70, 0.63],
+    ///             "Country" => &["Kosovo", "Moldova", "North Macedonia", "Syria", "Turkey"])?;
+    ///     assert_eq!(countries.shape(), (5, 3));
+    ///
+    ///     println!("{}", countries.tail(Some(2)));
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// shape: (2, 3)
+    /// +-------------+--------------------+---------+
+    /// | Rank (2021) | Apple Price (€/kg) | Country |
+    /// | ---         | ---                | ---     |
+    /// | i32         | f64                | str     |
+    /// +=============+====================+=========+
+    /// | 108         | 0.63               | Syria   |
+    /// +-------------+--------------------+---------+
+    /// | 109         | 0.63               | Turkey  |
+    /// +-------------+--------------------+---------+
+    /// ```
     pub fn tail(&self, length: Option<usize>) -> Self {
         let col = self
             .columns


### PR DESCRIPTION
Adding new examples for the `head` and `tail` methods of the `DataFrame` structure using the rustdoc features.

# `head`

```rust
use polars_core::df;
use polars_core::prelude::*;

fn example() -> Result<()> {
    let countries: DataFrame =
        df!("Rank by GDP (2021)" => &[1, 2, 3, 4, 5],
         "Continent" => &["North America", "Asia", "Asia", "Europe", "Europe"],
         "Country" => &["United States", "China", "Japan", "Germany", "United Kingdom"],
         "Capital" => &["Washington", "Beijing", "Tokyo", "Berlin", "London"])?;
    assert_eq!(countries.shape(), (5, 4));

    println!("{}", countries.head(Some(3)));

    Ok(())
}
```
Output:
```text
shape: (3, 4)
+--------------------+---------------+---------------+------------+
| Rank by GDP (2021) | Continent     | Country       | Capital    |
| ---                | ---           | ---           | ---        |
| i32                | str           | str           | str        |
+====================+===============+===============+============+
| 1                  | North America | United States | Washington |
+--------------------+---------------+---------------+------------+
| 2                  | Asia          | China         | Beijing    |
+--------------------+---------------+---------------+------------+
| 3                  | Asia          | Japan         | Tokyo      |
+--------------------+---------------+---------------+------------+
```

# `tail`

```rust
use polars_core::df;
use polars_core::prelude::*;

fn example() -> Result<()> {
    let countries: DataFrame =
        df!("Rank (2021)" => &[105, 106, 107, 108, 109],
            "Apple Price (€/kg)" => &[0.76, 0.72, 0.70, 0.63],
            "Country" => &["Kosovo", "Moldova", "North Macedonia", "Syria", "Turkey"])?;
    assert_eq!(countries.shape(), (5, 3));

    println!("{}", countries.tail(Some(2)));

    Ok(())
}
```
Output:
```text
shape: (2, 3)
+-------------+--------------------+---------+
| Rank (2021) | Apple Price (€/kg) | Country |
| ---         | ---                | ---     |
| i32         | f64                | str     |
+=============+====================+=========+
| 108         | 0.63               | Syria   |
+-------------+--------------------+---------+
| 109         | 0.63               | Turkey  |
+-------------+--------------------+---------+
```