### PR TITLE
change format to format_args

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -501,7 +501,7 @@ impl Display for AnyValue<'_> {
             AnyValue::Float32(v) => fmt_float(f, width, *v),
             AnyValue::Float64(v) => fmt_float(f, width, *v),
             AnyValue::Boolean(v) => write!(f, "{}", *v),
-            AnyValue::Utf8(v) => write!(f, "{}", format!("\"{}\"", v)),
+            AnyValue::Utf8(v) => write!(f, "{}", format_args!("\"{}\"", v)),
             #[cfg(feature = "dtype-date")]
             AnyValue::Date(v) => write!(f, "{}", date32_to_date(*v)),
             #[cfg(feature = "dtype-datetime")]


### PR DESCRIPTION
Fix the following warning while running clippy on the latest nightly 

```
warning: `format!` in `write!` args
   --> polars/polars-core/src/fmt.rs:504:34
    |
504 |             AnyValue::Utf8(v) => write!(f, "{}", format!("\"{}\"", v)),
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::format_in_format_args)]` on by default
    = help: combine the `format!(..)` arguments with the outer `write!(..)` call
    = help: or consider changing `format!` to `format_args!`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_in_format_args

warning: `polars-core` (lib) generated 1 warning

```