### PR TITLE
Attempt to make dtype conversions more centralized

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -11,7 +11,6 @@ except ImportError:
 
 from _ctypes import _SimpleCData
 
-
 __all__ = [
     "DataType",
     "Int8",

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,8 +1,6 @@
 import ctypes
 import typing as tp
-from typing import Any, Callable, Dict, Sequence, Type
-
-import numpy as np
+from typing import Any, Dict, Type
 
 try:
     import pyarrow as pa
@@ -13,12 +11,6 @@ except ImportError:
 
 from _ctypes import _SimpleCData
 
-try:
-    from polars.polars import PySeries
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 __all__ = [
     "DataType",
@@ -44,7 +36,7 @@ __all__ = [
     "DTYPE_TO_FFINAME",
     "date_like_to_physical",
     "dtype_to_ctype",
-    "pytype_to_polars_type",
+    "py_type_to_dtype",
 ]
 
 
@@ -166,127 +158,22 @@ DTYPE_TO_FFINAME: Dict[Type[DataType], str] = {
     Categorical: "categorical",
 }
 
+DTYPE_TO_CTYPE = {
+    UInt8: ctypes.c_uint8,
+    UInt16: ctypes.c_uint16,
+    UInt32: ctypes.c_uint32,
+    UInt64: ctypes.c_uint64,
+    Int8: ctypes.c_int8,
+    Int16: ctypes.c_int16,
+    Int32: ctypes.c_int32,
+    Date: ctypes.c_int32,
+    Int64: ctypes.c_int64,
+    Float32: ctypes.c_float,
+    Float64: ctypes.c_double,
+    Datetime: ctypes.c_int64,
+    Time: ctypes.c_int64,
+}
 
-def date_like_to_physical(dtype: Type[DataType]) -> Type[DataType]:
-    #  TODO: add more
-    if dtype == Date:
-        return Int32
-    if dtype == Datetime:
-        return Int64
-    if dtype == Time:
-        return Int64
-    return dtype
-
-
-def dtype_to_ctype(dtype: Type[DataType]) -> Type[_SimpleCData]:  # noqa: F821
-    ptr_type: Type[_SimpleCData]
-    if dtype == UInt8:
-        ptr_type = ctypes.c_uint8
-    elif dtype == UInt16:
-        ptr_type = ctypes.c_uint16
-    elif dtype == UInt32:
-        ptr_type = ctypes.c_uint32
-    elif dtype == UInt64:
-        ptr_type = ctypes.c_uint64
-    elif dtype == Int8:
-        ptr_type = ctypes.c_int8
-    elif dtype == Int16:
-        ptr_type = ctypes.c_int16
-    elif dtype == Int32 or dtype == Date:
-        ptr_type = ctypes.c_int32
-    elif dtype == Int64:
-        ptr_type = ctypes.c_int64
-    elif dtype == Float32:
-        ptr_type = ctypes.c_float
-    elif dtype == Float64:
-        ptr_type = ctypes.c_double
-    elif dtype == Datetime or dtype == Time:
-        ptr_type = ctypes.c_int64
-    else:
-        raise NotImplementedError
-    return ptr_type
-
-
-def pytype_to_polars_type(data_type: Type[Any]) -> Type[DataType]:
-    polars_type: Type[DataType]
-    if data_type == int:
-        polars_type = Int64
-    elif data_type == str:
-        polars_type = Utf8
-    elif data_type == float:
-        polars_type = Float64
-    else:
-        polars_type = data_type
-    return polars_type
-
-
-if not _DOCUMENTING:
-    _POLARS_TYPE_TO_CONSTRUCTOR = {
-        Float32: PySeries.new_opt_f32,
-        Float64: PySeries.new_opt_f64,
-        Int8: PySeries.new_opt_i8,
-        Int16: PySeries.new_opt_i16,
-        Int32: PySeries.new_opt_i32,
-        Int64: PySeries.new_opt_i64,
-        UInt8: PySeries.new_opt_u8,
-        UInt16: PySeries.new_opt_u16,
-        UInt32: PySeries.new_opt_u32,
-        UInt64: PySeries.new_opt_u64,
-        Date: PySeries.new_opt_i32,
-        Datetime: PySeries.new_opt_i32,
-        Boolean: PySeries.new_opt_bool,
-        Utf8: PySeries.new_str,
-        Object: PySeries.new_object,
-    }
-
-
-def polars_type_to_constructor(
-    dtype: Type[DataType],
-) -> Callable[[str, Sequence[Any], bool], "PySeries"]:
-    """
-    Get the right PySeries constructor for the given Polars dtype.
-    """
-    try:
-        return _POLARS_TYPE_TO_CONSTRUCTOR[dtype]
-    except KeyError:
-        raise ValueError(f"Cannot construct PySeries for type {dtype}.")
-
-
-if not _DOCUMENTING:
-    _NUMPY_TYPE_TO_CONSTRUCTOR = {
-        np.float32: PySeries.new_f32,
-        np.float64: PySeries.new_f64,
-        np.int8: PySeries.new_i8,
-        np.int16: PySeries.new_i16,
-        np.int32: PySeries.new_i32,
-        np.int64: PySeries.new_i64,
-        np.uint8: PySeries.new_u8,
-        np.uint16: PySeries.new_u16,
-        np.uint32: PySeries.new_u32,
-        np.uint64: PySeries.new_u64,
-        np.str_: PySeries.new_str,
-        np.bool_: PySeries.new_bool,
-    }
-
-
-def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., "PySeries"]:
-    """
-    Get the right PySeries constructor for the given Polars dtype.
-    """
-    try:
-        return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]
-    except KeyError:
-        return PySeries.new_object
-
-
-# watch out putting stuff in this branch, it may break the docs build
-if not _DOCUMENTING:
-    _PY_TYPE_TO_CONSTRUCTOR = {
-        float: PySeries.new_opt_f64,
-        int: PySeries.new_opt_i64,
-        str: PySeries.new_str,
-        bool: PySeries.new_opt_bool,
-    }
 
 _PY_TYPE_TO_DTYPE = {
     float: Float64,
@@ -294,6 +181,7 @@ _PY_TYPE_TO_DTYPE = {
     str: Utf8,
     bool: Boolean,
 }
+
 
 _DTYPE_TO_PY_TYPE = {
     Float64: float,
@@ -310,24 +198,42 @@ _DTYPE_TO_PY_TYPE = {
     Boolean: bool,
 }
 
-
-def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
-    """
-    Get the right PySeries constructor for the given Python dtype.
-    """
-    try:
-        return _PY_TYPE_TO_CONSTRUCTOR[dtype]
-    except KeyError:
-        return PySeries.new_object
-
-
-if _PYARROW_AVAILABLE and not _DOCUMENTING:
+if _PYARROW_AVAILABLE:
     _PY_TYPE_TO_ARROW_TYPE = {
         float: pa.float64(),
         int: pa.int64(),
         str: pa.large_utf8(),
         bool: pa.bool_(),
     }
+
+
+def date_like_to_physical(dtype: Type[DataType]) -> Type[DataType]:
+    #  TODO: add more
+    if dtype == Date:
+        return Int32
+    if dtype == Datetime:
+        return Int64
+    if dtype == Time:
+        return Int64
+    return dtype
+
+
+def dtype_to_ctype(dtype: Type[DataType]) -> Type[_SimpleCData]:
+    try:
+        return DTYPE_TO_CTYPE[dtype]
+    except KeyError:
+        raise NotImplementedError
+
+
+def py_type_to_dtype(data_type: Type[Any]) -> Type[DataType]:
+    # when the passed in is already a Polars datatype, return that
+    if issubclass(data_type, DataType):
+        return data_type
+
+    try:
+        return _PY_TYPE_TO_DTYPE[data_type]
+    except KeyError:
+        raise NotImplementedError
 
 
 def py_type_to_arrow_type(dtype: Type[Any]) -> "pa.lib.DataType":
@@ -340,11 +246,8 @@ def py_type_to_arrow_type(dtype: Type[Any]) -> "pa.lib.DataType":
         raise ValueError(f"Cannot parse dtype {dtype} into Arrow dtype.")
 
 
-def py_type_to_polars_type(dtype: Type[Any]) -> "Type[DataType]":
-    """
-    Convert a Python dtype to a Polars dtype.
-    """
-    try:
-        return _PY_TYPE_TO_DTYPE[dtype]
-    except KeyError:
-        raise ValueError(f"Cannot parse dtype {dtype} into Polars dtype.")
+def _maybe_cast(el: Type[DataType], dtype: Type) -> Type[DataType]:
+    # cast el if it doesn't match
+    if not isinstance(el, _DTYPE_TO_PY_TYPE[dtype]):
+        el = _DTYPE_TO_PY_TYPE[dtype](el)
+    return el

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -1,26 +1,26 @@
-from typing import Type, Callable, Sequence, Any
+from typing import Any, Callable, Sequence, Type
 
 import numpy as np
-from polars.polars import PySeries
 
 from polars.datatypes import (
+    Boolean,
+    DataType,
+    Date,
+    Datetime,
     Float32,
     Float64,
     Int8,
     Int16,
     Int32,
     Int64,
+    Object,
     UInt8,
     UInt16,
     UInt32,
     UInt64,
-    Date,
-    Datetime,
-    Boolean,
     Utf8,
-    Object,
-    DataType,
 )
+from polars.polars import PySeries
 
 _POLARS_TYPE_TO_CONSTRUCTOR = {
     Float32: PySeries.new_opt_f32,

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -1,0 +1,97 @@
+from typing import Type, Callable, Sequence, Any
+
+import numpy as np
+from polars.polars import PySeries
+
+from polars.datatypes import (
+    Float32,
+    Float64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Date,
+    Datetime,
+    Boolean,
+    Utf8,
+    Object,
+    DataType,
+)
+
+_POLARS_TYPE_TO_CONSTRUCTOR = {
+    Float32: PySeries.new_opt_f32,
+    Float64: PySeries.new_opt_f64,
+    Int8: PySeries.new_opt_i8,
+    Int16: PySeries.new_opt_i16,
+    Int32: PySeries.new_opt_i32,
+    Int64: PySeries.new_opt_i64,
+    UInt8: PySeries.new_opt_u8,
+    UInt16: PySeries.new_opt_u16,
+    UInt32: PySeries.new_opt_u32,
+    UInt64: PySeries.new_opt_u64,
+    Date: PySeries.new_opt_i32,
+    Datetime: PySeries.new_opt_i32,
+    Boolean: PySeries.new_opt_bool,
+    Utf8: PySeries.new_str,
+    Object: PySeries.new_object,
+}
+
+
+def polars_type_to_constructor(
+    dtype: Type[DataType],
+) -> Callable[[str, Sequence[Any], bool], PySeries]:
+    """
+    Get the right PySeries constructor for the given Polars dtype.
+    """
+    try:
+        return _POLARS_TYPE_TO_CONSTRUCTOR[dtype]
+    except KeyError:
+        raise ValueError(f"Cannot construct PySeries for type {dtype}.")
+
+
+_NUMPY_TYPE_TO_CONSTRUCTOR = {
+    np.float32: PySeries.new_f32,
+    np.float64: PySeries.new_f64,
+    np.int8: PySeries.new_i8,
+    np.int16: PySeries.new_i16,
+    np.int32: PySeries.new_i32,
+    np.int64: PySeries.new_i64,
+    np.uint8: PySeries.new_u8,
+    np.uint16: PySeries.new_u16,
+    np.uint32: PySeries.new_u32,
+    np.uint64: PySeries.new_u64,
+    np.str_: PySeries.new_str,
+    np.bool_: PySeries.new_bool,
+}
+
+
+def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., PySeries]:
+    """
+    Get the right PySeries constructor for the given Polars dtype.
+    """
+    try:
+        return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]
+    except KeyError:
+        return PySeries.new_object
+
+
+_PY_TYPE_TO_CONSTRUCTOR = {
+    float: PySeries.new_opt_f64,
+    int: PySeries.new_opt_i64,
+    str: PySeries.new_str,
+    bool: PySeries.new_opt_bool,
+}
+
+
+def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., PySeries]:
+    """
+    Get the right PySeries constructor for the given Python dtype.
+    """
+    try:
+        return _PY_TYPE_TO_CONSTRUCTOR[dtype]
+    except KeyError:
+        return PySeries.new_object

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -20,30 +20,38 @@ from polars.datatypes import (
     UInt64,
     Utf8,
 )
-from polars.polars import PySeries
 
-_POLARS_TYPE_TO_CONSTRUCTOR = {
-    Float32: PySeries.new_opt_f32,
-    Float64: PySeries.new_opt_f64,
-    Int8: PySeries.new_opt_i8,
-    Int16: PySeries.new_opt_i16,
-    Int32: PySeries.new_opt_i32,
-    Int64: PySeries.new_opt_i64,
-    UInt8: PySeries.new_opt_u8,
-    UInt16: PySeries.new_opt_u16,
-    UInt32: PySeries.new_opt_u32,
-    UInt64: PySeries.new_opt_u64,
-    Date: PySeries.new_opt_i32,
-    Datetime: PySeries.new_opt_i32,
-    Boolean: PySeries.new_opt_bool,
-    Utf8: PySeries.new_str,
-    Object: PySeries.new_object,
-}
+try:
+    from polars.polars import PySeries
+
+    _DOCUMENTING = False
+except ImportError:
+    _DOCUMENTING = True
+
+
+if not _DOCUMENTING:
+    _POLARS_TYPE_TO_CONSTRUCTOR = {
+        Float32: PySeries.new_opt_f32,
+        Float64: PySeries.new_opt_f64,
+        Int8: PySeries.new_opt_i8,
+        Int16: PySeries.new_opt_i16,
+        Int32: PySeries.new_opt_i32,
+        Int64: PySeries.new_opt_i64,
+        UInt8: PySeries.new_opt_u8,
+        UInt16: PySeries.new_opt_u16,
+        UInt32: PySeries.new_opt_u32,
+        UInt64: PySeries.new_opt_u64,
+        Date: PySeries.new_opt_i32,
+        Datetime: PySeries.new_opt_i32,
+        Boolean: PySeries.new_opt_bool,
+        Utf8: PySeries.new_str,
+        Object: PySeries.new_object,
+    }
 
 
 def polars_type_to_constructor(
     dtype: Type[DataType],
-) -> Callable[[str, Sequence[Any], bool], PySeries]:
+) -> Callable[[str, Sequence[Any], bool], "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
@@ -53,23 +61,24 @@ def polars_type_to_constructor(
         raise ValueError(f"Cannot construct PySeries for type {dtype}.")
 
 
-_NUMPY_TYPE_TO_CONSTRUCTOR = {
-    np.float32: PySeries.new_f32,
-    np.float64: PySeries.new_f64,
-    np.int8: PySeries.new_i8,
-    np.int16: PySeries.new_i16,
-    np.int32: PySeries.new_i32,
-    np.int64: PySeries.new_i64,
-    np.uint8: PySeries.new_u8,
-    np.uint16: PySeries.new_u16,
-    np.uint32: PySeries.new_u32,
-    np.uint64: PySeries.new_u64,
-    np.str_: PySeries.new_str,
-    np.bool_: PySeries.new_bool,
-}
+if not _DOCUMENTING:
+    _NUMPY_TYPE_TO_CONSTRUCTOR = {
+        np.float32: PySeries.new_f32,
+        np.float64: PySeries.new_f64,
+        np.int8: PySeries.new_i8,
+        np.int16: PySeries.new_i16,
+        np.int32: PySeries.new_i32,
+        np.int64: PySeries.new_i64,
+        np.uint8: PySeries.new_u8,
+        np.uint16: PySeries.new_u16,
+        np.uint32: PySeries.new_u32,
+        np.uint64: PySeries.new_u64,
+        np.str_: PySeries.new_str,
+        np.bool_: PySeries.new_bool,
+    }
 
 
-def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., PySeries]:
+def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., "PySeries"]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
@@ -79,15 +88,16 @@ def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., PySeries]:
         return PySeries.new_object
 
 
-_PY_TYPE_TO_CONSTRUCTOR = {
-    float: PySeries.new_opt_f64,
-    int: PySeries.new_opt_i64,
-    str: PySeries.new_str,
-    bool: PySeries.new_opt_bool,
-}
+if not _DOCUMENTING:
+    _PY_TYPE_TO_CONSTRUCTOR = {
+        float: PySeries.new_opt_f64,
+        int: PySeries.new_opt_i64,
+        str: PySeries.new_str,
+        bool: PySeries.new_opt_bool,
+    }
 
 
-def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., PySeries]:
+def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
     """
     Get the right PySeries constructor for the given Python dtype.
     """

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -50,7 +50,7 @@ except ImportError:
     _DOCUMENTING = True
 
 from .._html import NotebookFormatter
-from ..datatypes import DTYPES, Boolean, DataType, UInt32, pytype_to_polars_type
+from ..datatypes import DTYPES, Boolean, DataType, UInt32, py_type_to_dtype
 from ..utils import _process_null_values
 
 try:
@@ -450,7 +450,7 @@ class DataFrame:
             if isinstance(dtype, dict):
                 dtype_list = []
                 for k, v in dtype.items():
-                    dtype_list.append((k, pytype_to_polars_type(v)))
+                    dtype_list.append((k, py_type_to_dtype(v)))
             elif isinstance(dtype, list):
                 dtype_slice = dtype
             else:

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -4,6 +4,7 @@ from numbers import Number
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
+from polars.datatypes import py_type_to_dtype, _maybe_cast
 
 try:
     import pyarrow as pa
@@ -29,7 +30,6 @@ except ImportError:
     _DOCUMENTING = True
 
 from ..datatypes import (
-    _DTYPE_TO_PY_TYPE,
     DTYPE_TO_FFINAME,
     DTYPES,
     Boolean,
@@ -112,13 +112,6 @@ def get_ffi_func(
 
 def wrap_s(s: "PySeries") -> "Series":
     return Series._from_pyseries(s)
-
-
-def _maybe_cast(el: "Type[DataType]", dtype: Type) -> "Type[DataType]":
-    # cast el if it doesn't match
-    if not isinstance(el, _DTYPE_TO_PY_TYPE[dtype]):
-        el = _DTYPE_TO_PY_TYPE[dtype](el)
-    return el
 
 
 ArrayLike = Union[
@@ -1717,13 +1710,8 @@ class Series:
         ]
 
         """
-        if dtype == int:
-            dtype = Int64
-        elif dtype == str:
-            dtype = Utf8
-        elif dtype == float:
-            dtype = Float64
-        return wrap_s(self._s.cast(str(dtype), strict))
+        pl_dtype = py_type_to_dtype(dtype)
+        return wrap_s(self._s.cast(str(pl_dtype), strict))
 
     def to_list(self, use_pyarrow: bool = False) -> tp.List[Optional[Any]]:
         """
@@ -2292,16 +2280,11 @@ class Series:
         -------
         Series
         """
-        if return_dtype == str:
-            return_dtype = Utf8
-        elif return_dtype == int:
-            return_dtype = Int64
-        elif return_dtype == float:
-            return_dtype = Float64
-        elif return_dtype == bool:
-            return_dtype = Boolean
-
-        return wrap_s(self._s.apply_lambda(func, return_dtype))
+        if return_dtype is None:
+            pl_return_dtype = None
+        else:
+            pl_return_dtype = py_type_to_dtype(return_dtype)
+        return wrap_s(self._s.apply_lambda(func, pl_return_dtype))
 
     def shift(self, periods: int = 1) -> "Series":
         """

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -4,7 +4,8 @@ from numbers import Number
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
-from polars.datatypes import py_type_to_dtype, _maybe_cast
+
+from polars.datatypes import _maybe_cast, py_type_to_dtype
 
 try:
     import pyarrow as pa

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -6,7 +6,7 @@ import numpy as np
 import polars as pl
 
 try:
-    from polars.datatypes import py_type_to_polars_type
+    from polars.datatypes import py_type_to_dtype
     from polars.polars import concat_df as _concat_df
     from polars.polars import concat_lf as _concat_lf
     from polars.polars import concat_series as _concat_series
@@ -95,7 +95,7 @@ def repeat(
     if name is None:
         name = ""
 
-    dtype = py_type_to_polars_type(type(val))
+    dtype = py_type_to_dtype(type(val))
     s = pl.Series._repeat(name, val, n, dtype)
     return s
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -10,11 +10,13 @@ from polars.datatypes import (
     Date,
     Datetime,
     Float32,
-    numpy_type_to_constructor,
-    polars_type_to_constructor,
     py_type_to_arrow_type,
+    py_type_to_dtype,
+)
+from polars.datatypes_constructor import (
+    polars_type_to_constructor,
+    numpy_type_to_constructor,
     py_type_to_constructor,
-    py_type_to_polars_type,
 )
 
 try:
@@ -129,7 +131,7 @@ def sequence_to_pyseries(
             nested_dtype = type(nested_value) if value is not None else float
 
             if not _PYARROW_AVAILABLE:
-                dtype = py_type_to_polars_type(nested_dtype)
+                dtype = py_type_to_dtype(nested_dtype)
                 return PySeries.new_list(name, values, dtype)
 
             try:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -14,8 +14,8 @@ from polars.datatypes import (
     py_type_to_dtype,
 )
 from polars.datatypes_constructor import (
-    polars_type_to_constructor,
     numpy_type_to_constructor,
+    polars_type_to_constructor,
     py_type_to_constructor,
 )
 

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
-from ..datatypes import DataType, pytype_to_polars_type
+from ..datatypes import DataType, py_type_to_dtype
 from ..utils import _process_null_values
 from .expr import Expr, _selection_to_pyexpr_list, col, expr_to_lit_or_expr, lit
 
@@ -67,7 +67,7 @@ class LazyFrame:
         if dtype is not None:
             dtype_list = []
             for k, v in dtype.items():
-                dtype_list.append((k, pytype_to_polars_type(v)))
+                dtype_list.append((k, py_type_to_dtype(v)))
         processed_null_values = _process_null_values(null_values)
 
         self = LazyFrame.__new__(LazyFrame)


### PR DESCRIPTION
Aims to solve the following:
1. dtype conversions were scattered in multiple places (`datatypes.py`, `series.py`, `frame.py`), now it is all in `datatypes.py`. Note that py_type_to_dtype` still supports a Polars dtype as input, as it is used as such in multiple places. Strictly speaking it should only accept Python types.
2. use dicts rather than long if-else trees
3. break the circular import by factoring out the datatypes for `construction.py` into `datatypes_constructor.py`. Should this be moved into `construction.py`? I think this also removes the need for the `if DOCUMENTING` clause, but I may be wrong here.

Any feedback welcome.