### PR TITLE
Several fixes and improvements in type hints

### DIFF
--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -3150,7 +3150,7 @@ class DataFrame:
         """
         return self._df.row_tuple(index)
 
-    def rows(self) -> tp.List[Tuple[Any]]:
+    def rows(self) -> tp.List[Tuple]:
         """
         Convert columnar data to rows as python tuples.
         """

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1998,7 +1998,7 @@ class DataFrame:
         asof_by: Optional[Union[str, tp.List[str]]] = None,
         asof_by_left: Optional[Union[str, tp.List[str]]] = None,
         asof_by_right: Optional[Union[str, tp.List[str]]] = None,
-    ) -> Union["DataFrame", "pl.LazyFrame"]:
+    ) -> "DataFrame":
         """
         SQL like joins.
 

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Union, overload
 
 import numpy as np
 
@@ -29,6 +29,24 @@ def get_dummies(df: "pl.DataFrame") -> "pl.DataFrame":
         DataFrame to convert.
     """
     return df.to_dummies()
+
+
+@overload
+def concat(
+    items: Sequence["pl.DataFrame"],
+    rechunk: bool = True,
+    how: str = "vertical",
+) -> "pl.DataFrame":
+    ...
+
+
+@overload
+def concat(
+    items: Sequence["pl.Series"],
+    rechunk: bool = True,
+    how: str = "vertical",
+) -> "pl.Series":
+    ...
 
 
 def concat(

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -382,7 +382,7 @@ def tail(
 
 
 def lit(
-    value: Optional[Union[float, int, str, datetime, "pl.Series"]],
+    value: Optional[Union[float, int, str, date, datetime, "pl.Series"]],
     dtype: Optional[Type[DataType]] = None,
 ) -> "pl.Expr":
     """


### PR DESCRIPTION
- `concat` can be overloaded to return more precisely;
- `DataFrame.join` seems to return only the eager one;
- `DataFrame.rows` returns list of tuples of unknown length, not length 1;
- `lit` was recently modified to accept `date`.

I added a subdir `type_tests/` to test these type hints; they are not run (and does nothing other than imports when run) but are checked by mypy.  I have no idea about conventions for such tests, however.