### PR TITLE
Proposal: Enable mypy on tests

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
 
 import numpy as np
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union, overload
 
 import numpy as np
 

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -740,7 +740,9 @@ class DataFrame:
         return None
 
     def to_ipc(
-        self, file: Union[BinaryIO, BytesIO, str, Path], compression: str = "uncompressed"
+        self,
+        file: Union[BinaryIO, BytesIO, str, Path],
+        compression: str = "uncompressed",
     ) -> None:
         """
         Write to Arrow IPC binary stream, or a feather file.

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -701,7 +701,7 @@ class DataFrame:
 
     def to_csv(
         self,
-        file: Optional[Union[TextIO, str, Path]] = None,
+        file: Optional[Union[TextIO, BytesIO, str, Path]] = None,
         has_headers: bool = True,
         sep: str = ",",
     ) -> Optional[str]:
@@ -740,7 +740,7 @@ class DataFrame:
         return None
 
     def to_ipc(
-        self, file: Union[BinaryIO, str, Path], compression: str = "uncompressed"
+        self, file: Union[BinaryIO, BytesIO, str, Path], compression: str = "uncompressed"
     ) -> None:
         """
         Write to Arrow IPC binary stream, or a feather file.
@@ -795,7 +795,7 @@ class DataFrame:
 
     def to_parquet(
         self,
-        file: Union[str, Path],
+        file: Union[str, Path, BytesIO],
         compression: str = "snappy",
         use_pyarrow: bool = False,
         **kwargs: Any,
@@ -1471,7 +1471,7 @@ class DataFrame:
 
     def sort(
         self,
-        by: Union[str, "pl.Expr", tp.List["pl.Expr"]],
+        by: Union[str, "pl.Expr", tp.List[str], tp.List["pl.Expr"]],
         reverse: Union[bool, tp.List[bool]] = False,
         in_place: bool = False,
     ) -> Optional["DataFrame"]:

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -2335,7 +2335,9 @@ class Series:
         """
         return wrap_s(self._s.shift(periods))
 
-    def shift_and_fill(self, periods: int, fill_value: Union[int, "pl.Expr"]) -> "Series":
+    def shift_and_fill(
+        self, periods: int, fill_value: Union[int, "pl.Expr"]
+    ) -> "Series":
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.

--- a/py-polars/polars/eager/series.py
+++ b/py-polars/polars/eager/series.py
@@ -1522,7 +1522,7 @@ class Series:
         """
         return Series._from_pyseries(self._s.is_not_nan())
 
-    def is_in(self, other: "Series") -> "Series":
+    def is_in(self, other: Union["Series", tp.List]) -> "Series":
         """
         Check if elements of this Series are in the right Series, or List values of the right Series.
 
@@ -1545,7 +1545,7 @@ class Series:
         """
         if type(other) is list:
             other = Series("", other)
-        return wrap_s(self._s.is_in(other._s))
+        return wrap_s(self._s.is_in(other._s))  # type: ignore
 
     def arg_true(self) -> "Series":
         """
@@ -2034,7 +2034,7 @@ class Series:
     def __deepcopy__(self, memodict={}) -> "Series":  # type: ignore
         return self.clone()
 
-    def fill_null(self, strategy: Union[str, "pl.Expr"]) -> "Series":
+    def fill_null(self, strategy: Union[str, int, "pl.Expr"]) -> "Series":
         """
         Fill null values with a filling strategy.
 
@@ -2335,7 +2335,7 @@ class Series:
         """
         return wrap_s(self._s.shift(periods))
 
-    def shift_and_fill(self, periods: int, fill_value: "pl.Expr") -> "Series":
+    def shift_and_fill(self, periods: int, fill_value: Union[int, "pl.Expr"]) -> "Series":
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.
@@ -2348,7 +2348,7 @@ class Series:
             Fill None values with the result of this expression.
         """
         return self.to_frame().select(
-            pl.col(self.name).shift_and_fill(periods, fill_value)
+            pl.col(self.name).shift_and_fill(periods, fill_value)  # type: ignore
         )[self.name]
 
     def zip_with(self, mask: "Series", other: "Series") -> "Series":
@@ -3015,7 +3015,7 @@ class StringNameSpace:
     def __init__(self, series: "Series"):
         self._s = series._s
 
-    def strptime(self, datatype: DataType, fmt: Optional[str] = None) -> Series:
+    def strptime(self, datatype: Type[DataType], fmt: Optional[str] = None) -> Series:
         """
         Parse a Series of dtype Utf8 to a Date/Datetime Series.
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -145,7 +145,7 @@ def update_columns(df: "pl.DataFrame", new_columns: List[str]) -> "pl.DataFrame"
 
 
 def read_csv(
-    file: Union[str, TextIO, Path, BinaryIO, bytes],
+    file: Union[str, TextIO, BytesIO, Path, BinaryIO, bytes],
     infer_schema_length: Optional[int] = 100,
     batch_size: int = 8192,
     has_headers: bool = True,
@@ -542,7 +542,7 @@ def read_ipc_schema(
 
 
 def read_ipc(
-    file: Union[str, BinaryIO, Path, bytes],
+    file: Union[str, BinaryIO, BytesIO, Path, bytes],
     columns: Optional[List[str]] = None,
     projection: Optional[List[int]] = None,
     stop_after_n_rows: Optional[int] = None,
@@ -609,7 +609,7 @@ def read_ipc(
 
 
 def read_parquet(
-    source: Union[str, List[str], Path, BinaryIO, bytes],
+    source: Union[str, List[str], Path, BinaryIO, BytesIO, bytes],
     columns: Optional[List[str]] = None,
     projection: Optional[List[int]] = None,
     stop_after_n_rows: Optional[int] = None,

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -1972,7 +1972,7 @@ class ExprStringNameSpace:
 
     def strptime(
         self,
-        datatype: Union[Date, Datetime],
+        datatype: Union[Type[Date], Type[Datetime]],
         fmt: Optional[str] = None,
     ) -> Expr:
         """
@@ -2329,7 +2329,7 @@ class ExprDateTimeNameSpace:
 
 
 def expr_to_lit_or_expr(
-    expr: Union[Expr, int, float, str, tp.List[Expr], "pl.Series"],
+    expr: Union[Expr, int, float, str, tp.List[Expr], tp.List[str], "pl.Series"],
     str_to_lit: bool = True,
 ) -> Expr:
     """

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -223,7 +223,7 @@ class LazyFrame:
 
     def sort(
         self,
-        by: Union[str, "Expr", tp.List["Expr"]],
+        by: Union[str, "Expr", tp.List[str], tp.List["Expr"]],
         reverse: Union[bool, tp.List[bool]] = False,
     ) -> "LazyFrame":
         """

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -22,4 +22,4 @@ profile = "black"
 [tool.mypy]
 ignore_missing_imports = true
 disallow_untyped_defs = true
-files = "polars"
+files = ["polars", "mypy"]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -22,4 +22,4 @@ profile = "black"
 [tool.mypy]
 ignore_missing_imports = true
 disallow_untyped_defs = true
-files = ["polars", "mypy"]
+files = ["polars", "tests"]

--- a/py-polars/tests/db-benchmark/main.py
+++ b/py-polars/tests/db-benchmark/main.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import sys
 import time
 

--- a/py-polars/tests/files/test_functions.py
+++ b/py-polars/tests/files/test_functions.py
@@ -1,7 +1,7 @@
 import polars as pl
 
 
-def test_date_datetime():
+def test_date_datetime() -> None:
     df = pl.DataFrame(
         {
             "year": [2001, 2002, 2003],
@@ -13,9 +13,9 @@ def test_date_datetime():
 
     out = df.select(
         [
-            pl.all(),
-            pl.datetime("year", "month", "day", "hour").dt.hour().alias("h2"),
-            pl.date("year", "month", "day").dt.day().alias("date"),
+            pl.all(),  # type: ignore
+            pl.datetime("year", "month", "day", "hour").dt.hour().alias("h2"),  # type: ignore
+            pl.date("year", "month", "day").dt.day().alias("date"),  # type: ignore
         ]
     )
 

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 import polars as pl
 

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -1,7 +1,9 @@
+from typing import Optional, List
+
 import polars as pl
 
 
-def test_apply_none():
+def test_apply_none() -> None:
     df = pl.DataFrame(
         {
             "g": [1, 1, 1, 2, 2, 2, 5],
@@ -12,7 +14,7 @@ def test_apply_none():
 
     out = (
         df.groupby("g", maintain_order=True).agg(
-            pl.apply(
+            pl.apply(  # type: ignore
                 exprs=["a", pl.col("b") ** 4, pl.col("a") / 4],
                 f=lambda x: x[0] * x[1] + x[2].sum(),
             ).alias("multiple")
@@ -21,11 +23,11 @@ def test_apply_none():
     assert out[0].to_list() == [4.75, 326.75, 82.75]
     assert out[1].to_list() == [238.75, 3418849.75, 372.75]
 
-    out = df.select(pl.map(exprs=["a", "b"], f=lambda s: s[0] * s[1]))
+    out = df.select(pl.map(exprs=["a", "b"], f=lambda s: s[0] * s[1]))  # type: ignore
     assert out["a"].to_list() == (df["a"] * df["b"]).to_list()
 
     # check if we can return None
-    def func(s):
+    def func(s: List) -> Optional[int]:
         if s[0][0] == 190:
             return None
         else:
@@ -33,7 +35,7 @@ def test_apply_none():
 
     out = (
         df.groupby("g", maintain_order=True).agg(
-            pl.apply(exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], f=func).alias(
+            pl.apply(exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], f=func).alias(  # type: ignore
                 "multiple"
             )
         )

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -3,12 +3,12 @@ from datetime import date, datetime
 import polars as pl
 
 
-def test_fill_null():
+def test_fill_null() -> None:
     dt = datetime.strptime("2021-01-01", "%Y-%m-%d")
     s = pl.Series("A", [dt, None])
 
     for fill_val in (dt, pl.lit(dt)):
-        out = s.fill_null(fill_val)
+        out = s.fill_null(fill_val)  # type: ignore
 
         assert out.null_count() == 0
         assert out.dt[0] == dt
@@ -18,9 +18,9 @@ def test_fill_null():
     dt2 = date(2001, 1, 2)
     dt3 = date(2001, 1, 3)
     s = pl.Series("a", [dt1, dt2, dt3, None])
-    dt = date(2001, 1, 4)
-    for fill_val in (dt, pl.lit(dt)):
-        out = s.fill_null(fill_val)
+    dt_2 = date(2001, 1, 4)
+    for fill_val in (dt_2, pl.lit(dt_2)):  # type: ignore
+        out = s.fill_null(fill_val)  # type: ignore
 
         assert out.null_count() == 0
         assert out.dt[0] == dt1
@@ -28,7 +28,7 @@ def test_fill_null():
         assert out.dt[-1] == dt
 
 
-def test_downsample():
+def test_downsample() -> None:
     s = pl.Series(
         "datetime",
         [
@@ -70,7 +70,7 @@ def test_downsample():
     assert out["a"].dtype == "datetime64[ns]"
 
 
-def test_filter_date():
+def test_filter_date() -> None:
     dataset = pl.DataFrame(
         {"date": ["2020-01-02", "2020-01-03", "2020-01-04"], "index": [1, 2, 3]}
     )
@@ -83,7 +83,7 @@ def test_filter_date():
     assert df.filter(pl.col("date") < pl.lit(datetime(2020, 1, 5))).shape[0] == 3
 
 
-def test_diff_datetime():
+def test_diff_datetime() -> None:
 
     df = pl.DataFrame(
         {
@@ -104,7 +104,7 @@ def test_diff_datetime():
     assert out[0] == out[1]
 
 
-def test_timestamp():
+def test_timestamp() -> None:
     a = pl.Series("a", [10000, 20000, 30000], dtype=pl.Datetime)
     assert a.dt.timestamp() == [10000, 20000, 30000]
     out = a.dt.to_python_datetime()
@@ -117,7 +117,7 @@ def test_timestamp():
     assert isinstance(df.row(0)[0], datetime)
 
 
-def test_from_pydatetime():
+def test_from_pydatetime() -> None:
     dates = [
         datetime(2021, 1, 1),
         datetime(2021, 1, 2),
@@ -133,7 +133,7 @@ def test_from_pydatetime():
     # fmt dates and nulls
     print(s)
 
-    dates = [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3), None]
+    dates = [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3), None]  # type: ignore
     s = pl.Series("name", dates)
     assert s.dtype == pl.Date
     assert s.name == "name"
@@ -144,7 +144,7 @@ def test_from_pydatetime():
     print(s)
 
 
-def test_to_python_datetime():
+def test_to_python_datetime() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     assert (
         df.select(pl.col("a").cast(pl.Datetime).dt.to_python_datetime())["a"].dtype
@@ -155,7 +155,7 @@ def test_to_python_datetime():
     )
 
 
-def test_datetime_consistency():
+def test_datetime_consistency() -> None:
     dt = datetime(2021, 1, 1)
     df = pl.DataFrame({"date": [dt]})
     assert df["date"].dt[0] == dt

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -25,7 +25,7 @@ def test_fill_null() -> None:
         assert out.null_count() == 0
         assert out.dt[0] == dt1
         assert out.dt[1] == dt2
-        assert out.dt[-1] == dt
+        assert out.dt[-1] == dt_2
 
 
 def test_downsample() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -176,7 +176,7 @@ def test_init_pandas() -> None:
         assert df.frame_equal(truth)
 
     # pandas is not available
-    with patch("polars.eager.frame._PANDAS_AVAILABLE", False) :
+    with patch("polars.eager.frame._PANDAS_AVAILABLE", False):
         with pytest.raises(ValueError):
             pl.DataFrame(pandas_df)
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,4 +1,5 @@
 # flake8: noqa: W191,E101
+# type: ignore
 from builtins import range
 from datetime import datetime
 from io import BytesIO
@@ -12,24 +13,24 @@ import pytest
 import polars as pl
 
 
-def test_version():
+def test_version() -> None:
     pl.__version__
 
 
-def test_init_empty():
+def test_init_empty() -> None:
     # Empty initialization
     df1 = pl.DataFrame()
     assert df1.shape == (0, 0)
 
 
-def test_init_only_columns():
+def test_init_only_columns() -> None:
     df = pl.DataFrame(columns=["a", "b", "c"])
     truth = pl.DataFrame({"a": [], "b": [], "c": []})
     assert df.shape == (0, 3)
     assert df.frame_equal(truth, null_equal=True)
 
 
-def test_init_dict():
+def test_init_dict() -> None:
     # Empty dictionary
     df = pl.DataFrame({})
     assert df.shape == (0, 0)
@@ -48,7 +49,7 @@ def test_init_dict():
     assert df.columns == ["c", "d"]
 
 
-def test_init_ndarray():
+def test_init_ndarray() -> None:
     # Empty array
     df = pl.DataFrame(np.array([]))
     assert df.frame_equal(pl.DataFrame())
@@ -84,7 +85,7 @@ def test_init_ndarray():
 
 
 # TODO: Remove this test case when removing deprecated behaviour
-def test_init_ndarray_deprecated():
+def test_init_ndarray_deprecated() -> None:
     with pytest.deprecated_call():
         # 2D array - default to row orientation
         df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
@@ -92,7 +93,7 @@ def test_init_ndarray_deprecated():
         assert df.frame_equal(truth)
 
 
-def test_init_arrow():
+def test_init_arrow() -> None:
     # Handle unnamed column
     df = pl.DataFrame(pa.table({"a": [1, 2], None: [3, 4]}))
     truth = pl.DataFrame({"a": [1, 2], "column_1": [3, 4]})
@@ -110,7 +111,7 @@ def test_init_arrow():
         )
 
 
-def test_init_series():
+def test_init_series() -> None:
     # List of Series
     df = pl.DataFrame([pl.Series("a", [1, 2, 3]), pl.Series("b", [4, 5, 6])])
     truth = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -133,7 +134,7 @@ def test_init_series():
     assert df.frame_equal(truth)
 
 
-def test_init_seq_of_seq():
+def test_init_seq_of_seq() -> None:
     # List of lists
     df = pl.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
     truth = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
@@ -150,7 +151,7 @@ def test_init_seq_of_seq():
     assert df.frame_equal(truth)
 
 
-def test_init_1d_sequence():
+def test_init_1d_sequence() -> None:
     # Empty list
     df = pl.DataFrame([])
     assert df.frame_equal(pl.DataFrame())
@@ -165,7 +166,7 @@ def test_init_1d_sequence():
         pl.DataFrame("abc")
 
 
-def test_init_pandas():
+def test_init_pandas() -> None:
     pandas_df = pd.DataFrame([[1, 2], [3, 4]], columns=[1, 2])
 
     # pandas is available; integer column names
@@ -175,12 +176,12 @@ def test_init_pandas():
         assert df.frame_equal(truth)
 
     # pandas is not available
-    with patch("polars.eager.frame._PANDAS_AVAILABLE", False):
+    with patch("polars.eager.frame._PANDAS_AVAILABLE", False) :
         with pytest.raises(ValueError):
             pl.DataFrame(pandas_df)
 
 
-def test_init_errors():
+def test_init_errors() -> None:
     # Length mismatch
     with pytest.raises(RuntimeError):
         pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0, 4.0]})
@@ -194,7 +195,7 @@ def test_init_errors():
         pl.DataFrame(0)
 
 
-def test_init_records():
+def test_init_records() -> None:
     dicts = [
         {"a": 1, "b": 2},
         {"b": 1, "a": 2},
@@ -206,7 +207,7 @@ def test_init_records():
     assert df.to_dicts() == dicts
 
 
-def test_selection():
+def test_selection() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]})
 
     # get_column by name
@@ -277,7 +278,7 @@ def test_selection():
     assert df[::2].frame_equal(expect)
 
 
-def test_from_arrow():
+def test_from_arrow() -> None:
     tbl = pa.table(
         {
             "a": pa.array([1, 2], pa.timestamp("s")),
@@ -290,20 +291,20 @@ def test_from_arrow():
     assert pl.from_arrow(tbl).shape == (2, 5)
 
 
-def test_sort():
+def test_sort() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     df.sort("a", in_place=True)
     assert df.frame_equal(pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
 
 
-def test_replace():
+def test_replace() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     s = pl.Series("c", [True, False, True])
     df.replace("a", s)
     assert df.frame_equal(pl.DataFrame({"c": [True, False, True], "b": [1, 2, 3]}))
 
 
-def test_assignment():
+def test_assignment() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [2, 3, 4]})
     df["foo"] = df["foo"]
     # make sure that assignment does not change column order
@@ -312,18 +313,18 @@ def test_assignment():
     assert df["foo"].to_list() == [1, 9, 9]
 
 
-def test_slice():
+def test_slice() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"]})
     df = df.slice(1, 2)
     assert df.frame_equal(pl.DataFrame({"a": [1, 3], "b": ["b", "c"]}))
 
 
-def test_null_count():
+def test_null_count() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", None]})
     assert df.null_count().shape == (1, 2)
 
 
-def test_head_tail():
+def test_head_tail() -> None:
     df = pl.DataFrame({"a": range(10), "b": range(10)})
     assert df.head(5).height == 5
     assert df.tail(5).height == 5
@@ -334,14 +335,14 @@ def test_head_tail():
     assert df.tail(100).height == 10
 
 
-def test_explode():
+def test_explode() -> None:
     df = pl.DataFrame({"letters": ["c", "a"], "nrs": [[1, 2], [1, 3]]})
     out = df.explode("nrs")
     assert out["letters"].to_list() == ["c", "c", "a", "a"]
     assert out["nrs"].to_list() == [1, 2, 1, 3]
 
 
-def test_groupby():
+def test_groupby() -> None:
     df = pl.DataFrame(
         {
             "a": ["a", "b", "a", "b", "b", "c"],
@@ -390,7 +391,7 @@ def test_groupby():
     df.groupby("b").agg(pl.col("c").forward_fill()).explode("c")
 
 
-def test_join():
+def test_join() -> None:
     df_left = pl.DataFrame(
         {
             "a": ["a", "b", "a", "z"],
@@ -432,7 +433,7 @@ def test_join():
     assert lazy_join.shape == eager_join.shape
 
 
-def test_joins_dispatch():
+def test_joins_dispatch() -> None:
     # this just flexes the dispatch a bit
 
     # don't change the data of this dataframe, this triggered:
@@ -457,14 +458,14 @@ def test_joins_dispatch():
         dfa.join(dfa, on=["date"], how=how)
 
 
-def test_hstack():
+def test_hstack() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"]})
     df.hstack([pl.Series("stacked", [-1, -1, -1])], in_place=True)
     assert df.shape == (3, 3)
     assert df.columns == ["a", "b", "stacked"]
 
 
-def test_drop():
+def test_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
     df = df.drop("a")
     assert df.shape == (3, 2)
@@ -473,7 +474,7 @@ def test_drop():
     assert s.name == "a"
 
 
-def test_file_buffer():
+def test_file_buffer() -> None:
     f = BytesIO()
     f.write(b"1,2,3,4,5,6\n7,8,9,10,11,12")
     f.seek(0)
@@ -487,7 +488,7 @@ def test_file_buffer():
     assert "Invalid Parquet file" in str(e.value)
 
 
-def test_set():
+def test_set() -> None:
     np.random.seed(1)
     df = pl.DataFrame(
         {"foo": np.random.rand(10), "bar": np.arange(10), "ham": ["h"] * 10}
@@ -508,13 +509,13 @@ def test_set():
     assert df[0, "b"] == 2
 
 
-def test_melt():
+def test_melt() -> None:
     df = pl.DataFrame({"A": ["a", "b", "c"], "B": [1, 3, 5], "C": [2, 4, 6]})
     melted = df.melt(id_vars="A", value_vars=["B", "C"])
     assert melted["value"] == [1, 3, 4, 2, 4, 6]
 
 
-def test_shift():
+def test_shift() -> None:
     df = pl.DataFrame({"A": ["a", "b", "c"], "B": [1, 3, 5]})
     a = df.shift(1)
     b = pl.DataFrame(
@@ -523,7 +524,7 @@ def test_shift():
     assert a.frame_equal(b, null_equal=True)
 
 
-def test_to_dummies():
+def test_to_dummies() -> None:
     df = pl.DataFrame({"A": ["a", "b", "c"], "B": [1, 3, 5]})
     dummies = df.to_dummies()
     assert dummies["A_a"].to_list() == [1, 0, 0]
@@ -531,7 +532,7 @@ def test_to_dummies():
     assert dummies["A_c"].to_list() == [0, 0, 1]
 
 
-def test_from_pandas():
+def test_from_pandas() -> None:
     df = pd.DataFrame(
         {
             "bools": [False, True, False],
@@ -551,7 +552,7 @@ def test_from_pandas():
     assert out.shape == (3, 9)
 
 
-def test_from_pandas_nan_to_none():
+def test_from_pandas_nan_to_none() -> None:
     from pyarrow import ArrowInvalid
 
     df = pd.DataFrame(
@@ -572,7 +573,7 @@ def test_from_pandas_nan_to_none():
         pl.from_pandas(df, nan_to_none=False)
 
 
-def test_custom_groupby():
+def test_custom_groupby() -> None:
     df = pl.DataFrame({"a": [1, 2, 1, 1], "b": ["a", "b", "c", "c"]})
 
     out = (
@@ -584,13 +585,13 @@ def test_custom_groupby():
     assert out.shape == (3, 2)
 
 
-def test_multiple_columns_drop():
+def test_multiple_columns_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
     out = df.drop(["a", "b"])
     assert out.columns == ["c"]
 
 
-def test_concat():
+def test_concat() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
 
     df2 = pl.concat([df, df])
@@ -605,19 +606,19 @@ def test_concat():
     assert a.shape == (2, 2)
 
 
-def test_arg_where():
+def test_arg_where() -> None:
     s = pl.Series([True, False, True, False])
     assert pl.arg_where(s).series_equal(pl.Series([0, 2]))
 
 
-def test_get_dummies():
+def test_get_dummies() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     res = pl.get_dummies(df)
     expected = pl.DataFrame({"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]})
     assert res.frame_equal(expected)
 
 
-def test_to_pandas(df):
+def test_to_pandas(df) -> None:
     # pyarrow cannot deal with unsigned dictionary integer yet.
     # pyarrow cannot convert a time64 w/ non-zero nanoseconds
     df = df.drop(["cat", "time"])
@@ -629,7 +630,7 @@ def test_to_pandas(df):
     df.shift(2).to_pandas()
 
 
-def test_from_arrow_table():
+def test_from_arrow_table() -> None:
     data = {"a": [1, 2], "b": [1, 2]}
     tbl = pa.table(data)
 
@@ -637,7 +638,7 @@ def test_from_arrow_table():
     df.frame_equal(pl.DataFrame(data))
 
 
-def test_df_stats(df):
+def test_df_stats(df) -> None:
     df.var()
     df.std()
     df.min()
@@ -648,7 +649,7 @@ def test_df_stats(df):
     df.quantile(0.4)
 
 
-def test_df_fold():
+def test_df_fold() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
 
     assert df.fold(lambda s1, s2: s1 + s2).series_equal(pl.Series("a", [4.0, 5.0, 9.0]))
@@ -668,14 +669,14 @@ def test_df_fold():
     assert len(df.max(axis=1)) == 3
 
 
-def test_row_tuple():
+def test_row_tuple() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     assert df.row(0) == ("foo", 1, 1.0)
     assert df.row(1) == ("bar", 2, 2.0)
     assert df.row(-1) == ("2", 3, 3.0)
 
 
-def test_read_csv_categorical():
+def test_read_csv_categorical() -> None:
     f = BytesIO()
     f.write(b"col1,col2,col3,col4,col5,col6\n'foo',2,3,4,5,6\n'bar',8,9,10,11,12")
     f.seek(0)
@@ -683,13 +684,13 @@ def test_read_csv_categorical():
     assert df["col1"].dtype == pl.Categorical
 
 
-def test_df_apply():
+def test_df_apply() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.apply(lambda x: len(x), None)
     assert out.sum() == 9
 
 
-def test_column_names():
+def test_column_names() -> None:
     tbl = pa.table(
         {
             "a": pa.array([1, 2, 3, 4, 5], pa.decimal128(38, 2)),
@@ -700,7 +701,7 @@ def test_column_names():
     assert df.columns == ["a", "b"]
 
 
-def test_lazy_functions():
+def test_lazy_functions() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df[[pl.count("a")]]
     assert out["a"] == 3
@@ -754,7 +755,7 @@ def test_lazy_functions():
     assert np.isclose(pl.last(df["b"]), expected)
 
 
-def test_multiple_column_sort():
+def test_multiple_column_sort() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [2, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.sort([pl.col("b"), pl.col("c").reverse()])
     assert out["c"] == [2, 3, 1]
@@ -775,7 +776,7 @@ def test_multiple_column_sort():
     )
 
 
-def test_describe():
+def test_describe() -> None:
     df = pl.DataFrame(
         {
             "a": [1.0, 2.8, 3.0],
@@ -788,7 +789,7 @@ def test_describe():
     assert set(df.describe().select_at_idx(2)) == set([1.0, 4.0, 5.0, 6.0])
 
 
-def test_string_cache_eager_lazy():
+def test_string_cache_eager_lazy() -> None:
     # tests if the global string cache is really global and not interfered by the lazy execution.
     # first the global settings was thread-local and this breaks with the parallel execution of lazy
     with pl.StringCache():
@@ -811,7 +812,7 @@ def test_string_cache_eager_lazy():
     ).frame_equal(expected, null_equal=True)
 
 
-def test_assign():
+def test_assign() -> None:
     # check if can assign in case of a single column
     df = pl.DataFrame({"a": [1, 2, 3]})
     # test if we can assign in case of single column
@@ -819,17 +820,17 @@ def test_assign():
     assert df["a"] == [2, 4, 6]
 
 
-def test_to_numpy():
+def test_to_numpy() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     assert df.to_numpy().shape == (3, 2)
 
 
-def test_argsort_by(df):
+def test_argsort_by(df) -> None:
     a = df[pl.argsort_by(["int_nulls", "floats"], reverse=[False, True])]["int_nulls"]
     assert a == [1, 0, 3]
 
 
-def test_literal_series():
+def test_literal_series() -> None:
     df = pl.DataFrame(
         {
             "a": np.array([21.7, 21.8, 21], dtype=np.float32),
@@ -846,29 +847,29 @@ def test_literal_series():
     assert out["e"] == [2, 1, 3]
 
 
-def test_to_html(df):
+def test_to_html(df) -> None:
     # check if it does not panic/ error
     df._repr_html_()
 
 
-def test_rows():
+def test_rows() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [1, 2]})
     assert df.rows() == [(1, 1), (2, 2)]
 
 
-def test_rename(df):
+def test_rename(df) -> None:
     out = df.rename({"strings": "bars", "int": "foos"})
     # check if wel can select these new columns
     _ = out[["foos", "bars"]]
 
 
-def test_to_json(df):
+def test_to_json(df) -> None:
     s = df.to_json(to_string=True)
     out = pl.read_json(s)
     assert df.frame_equal(out, null_equal=True)
 
 
-def test_from_rows():
+def test_from_rows() -> None:
     df = pl.from_records([[1, 2, "foo"], [2, 3, "bar"]], orient="row")
     assert df.frame_equal(
         pl.DataFrame({"column_0": [1, 2], "foo": [2, 3], "column_2": ["foo", "bar"]})
@@ -881,7 +882,7 @@ def test_from_rows():
     assert df.dtypes == [pl.Int64, pl.Datetime]
 
 
-def test_repeat_by():
+def test_repeat_by() -> None:
     df = pl.DataFrame({"name": ["foo", "bar"], "n": [2, 3]})
 
     out = df[pl.col("n").repeat_by("n")]
@@ -890,7 +891,7 @@ def test_repeat_by():
     assert s[1] == [3, 3, 3]
 
 
-def test_join_dates():
+def test_join_dates() -> None:
     date_times = pd.date_range(
         "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", closed="left"
     )
@@ -911,7 +912,7 @@ def test_join_dates():
     df.join(df, on="datetime")
 
 
-def test_asof_cross_join():
+def test_asof_cross_join() -> None:
     left = pl.DataFrame({"a": [-10, 5, 10], "left_val": ["a", "b", "c"]})
     right = pl.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
 
@@ -930,7 +931,7 @@ def test_asof_cross_join():
     assert out.shape == (15, 4)
 
 
-def test_str_concat():
+def test_str_concat() -> None:
     df = pl.DataFrame(
         {
             "nrs": [1, 2, 3, 4],
@@ -942,30 +943,30 @@ def test_str_concat():
     assert out["graduated_name"][1] == "Dr. spam"
 
 
-def dot_product():
+def dot_product() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
 
     assert df["a"].dot(df["b"]) == 20
     assert df[[pl.col("a").dot("b")]][0, "a"] == 20
 
 
-def test_hash_rows():
+def test_hash_rows() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [2, 2, 2, 2]})
     assert df.hash_rows().dtype == pl.UInt64
     assert df["a"].hash().dtype == pl.UInt64
     assert df[[pl.col("a").hash().alias("foo")]]["foo"].dtype == pl.UInt64
 
 
-def test_create_df_from_object():
+def test_create_df_from_object() -> None:
     class Foo:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     df = pl.DataFrame({"a": [Foo(), Foo()]})
     assert df["a"].dtype == pl.Object
 
 
-def test_hashing_on_python_objects():
+def test_hashing_on_python_objects() -> None:
     # see if we can do a groupby, drop_duplicates on a DataFrame with objects.
     # this requires that the hashing and aggregations are done on python objects
 
@@ -975,12 +976,12 @@ def test_hashing_on_python_objects():
     assert df.drop_duplicates().shape == (3, 3)
 
 
-def test_drop_duplicates_unit_rows():
+def test_drop_duplicates_unit_rows() -> None:
     # simply test if we don't panic.
     pl.DataFrame({"a": [1], "b": [None]}).drop_duplicates(subset="a")
 
 
-def test_panic():
+def test_panic() -> None:
     # may contain some tests that yielded a panic in polars or arrow
     # https://github.com/pola-rs/polars/issues/1110
     a = pl.DataFrame(
@@ -991,7 +992,7 @@ def test_panic():
     a.filter(pl.col("col1") != "b")
 
 
-def test_h_agg():
+def test_h_agg() -> None:
     df = pl.DataFrame({"a": [1, None, 3], "b": [1, 2, 3]})
 
     assert df.sum(axis=1, null_strategy="ignore").to_list() == [2, 2, 6]
@@ -999,7 +1000,7 @@ def test_h_agg():
     assert df.mean(axis=1, null_strategy="propagate")[1] is None
 
 
-def test_slicing():
+def test_slicing() -> None:
     # https://github.com/pola-rs/polars/issues/1322
     n = 20
 
@@ -1016,13 +1017,13 @@ def test_slicing():
     )
 
 
-def test_apply_list_return():
+def test_apply_list_return() -> None:
     df = pl.DataFrame({"start": [1, 2], "end": [3, 5]})
     out = df.apply(lambda r: pl.Series(range(r[0], r[1] + 1)))
     assert out.to_list() == [[1, 2, 3], [2, 3, 4, 5]]
 
 
-def test_groupby_cat_list():  # noqa: W191,E101
+def test_groupby_cat_list() -> None:  # noqa: W191,E101
     grouped = (
         pl.DataFrame(
             [
@@ -1052,7 +1053,7 @@ Series: 'cat_column' [list]
     )
 
 
-def test_asof_join():
+def test_asof_join() -> None:
     fmt = "%F %T%.3f"
     dates = """2016-05-25 13:30:00.023
 2016-05-25 13:30:00.023
@@ -1134,7 +1135,7 @@ AAPL""".split(
     ]
 
 
-def test_groupby_agg_n_unique_floats():
+def test_groupby_agg_n_unique_floats() -> None:
     # tests proper dispatch
     df = pl.DataFrame({"a": [1, 1, 3], "b": [1.0, 2.0, 2.0]})
 
@@ -1145,14 +1146,14 @@ def test_groupby_agg_n_unique_floats():
         assert out["b_n_unique"].to_list() == [2, 1]
 
 
-def test_select_by_dtype(df):
+def test_select_by_dtype(df) -> None:
     out = df.select(pl.col(pl.Utf8))
     assert out.columns == ["strings", "strings_nulls"]
     out = df.select(pl.col([pl.Utf8, pl.Boolean]))
     assert out.columns == ["strings", "strings_nulls", "bools", "bools_nulls"]
 
 
-def test_with_row_count():
+def test_with_row_count() -> None:
     df = pl.DataFrame({"a": [1, 1, 3], "b": [1.0, 2.0, 2.0]})
 
     out = df.with_row_count()
@@ -1162,7 +1163,7 @@ def test_with_row_count():
     assert out["row_nr"].to_list() == [0, 1, 2]
 
 
-def test_filter_with_all_expansion():
+def test_filter_with_all_expansion() -> None:
     df = pl.DataFrame(
         {
             "b": [1, 2, None],
@@ -1174,7 +1175,7 @@ def test_filter_with_all_expansion():
     assert out.shape == (2, 3)
 
 
-def test_diag_concat():
+def test_diag_concat() -> None:
     a = pl.DataFrame({"a": [1, 2]})
     b = pl.DataFrame({"b": ["a", "b"], "c": [1, 2]})
     c = pl.DataFrame({"a": [5, 7], "c": [1, 2], "d": [1, 2]})
@@ -1192,7 +1193,7 @@ def test_diag_concat():
     assert out.frame_equal(expected, null_equal=True)
 
 
-def test_transpose():
+def test_transpose() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
     expected = pl.DataFrame(
         {

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -1,10 +1,10 @@
 import polars as pl
 
 
-def test_horizontal_agg(fruits_cars):
+def test_horizontal_agg(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
-    out = df.select(pl.max([pl.col("A"), pl.col("B")]))
+    out = df.select(pl.max([pl.col("A"), pl.col("B")]))  # type: ignore
     out[:, 0].to_list() == [5, 4, 3, 4, 5]
 
-    out = df.select(pl.min([pl.col("A"), pl.col("B")]))
+    out = df.select(pl.min([pl.col("A"), pl.col("B")]))  # type: ignore
     out[:, 0].to_list() == [1, 2, 3, 2, 1]

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -8,7 +8,7 @@ import pytest
 import polars as pl
 
 
-def test_from_pandas_datetime():
+def test_from_pandas_datetime() -> None:
     ts = datetime.datetime(2021, 1, 1, 20, 20, 20, 20)
     s = pd.Series([ts, ts])
     s = pl.from_pandas(s.to_frame("a"))["a"]
@@ -34,12 +34,12 @@ def test_from_pandas_datetime():
     pl.from_pandas(df)
 
 
-def test_arrow_list_roundtrip():
+def test_arrow_list_roundtrip() -> None:
     # https://github.com/pola-rs/polars/issues/1064
     pl.from_arrow(pa.table({"a": [1], "b": [[1, 2]]})).to_arrow()
 
 
-def test_arrow_dict_to_polars():
+def test_arrow_dict_to_polars() -> None:
     pa_dict = pa.DictionaryArray.from_arrays(
         indices=np.array([0, 1, 2, 3, 1, 0, 2, 3, 3, 2]),
         dictionary=np.array(["AAA", "BBB", "CCC", "DDD"]),
@@ -53,14 +53,14 @@ def test_arrow_dict_to_polars():
     assert s.series_equal(pl.Series("pa_dict", pa_dict))
 
 
-def test_arrow_list_chunked_array():
+def test_arrow_list_chunked_array() -> None:
     a = pa.array([[1, 2], [3, 4]])
     ca = pa.chunked_array([a, a, a])
     s = pl.from_arrow(ca)
     assert s.dtype == pl.List
 
 
-def test_from_pandas_null():
+def test_from_pandas_null() -> None:
     df = pd.DataFrame([{"a": None}, {"a": None}])
     out = pl.DataFrame(df)
     assert out.dtypes == [pl.Float64]
@@ -71,7 +71,7 @@ def test_from_pandas_null():
     assert out.dtypes == [pl.Float64, pl.Int64]
 
 
-def test_from_pandas_nested_list():
+def test_from_pandas_nested_list() -> None:
     # this panicked in https://github.com/pola-rs/polars/issues/1615
     pddf = pd.DataFrame(
         {"a": [1, 2, 3, 4], "b": [["x", "y"], ["x", "y", "z"], ["x"], ["x", "y"]]}
@@ -81,50 +81,50 @@ def test_from_pandas_nested_list():
     assert pldf.shape == (4, 2)
 
 
-def test_from_pandas_categorical_none():
+def test_from_pandas_categorical_none() -> None:
     s = pd.Series(["a", "b", "c", pd.NA], dtype="category")
     out = pl.from_pandas(s)
     assert out.dtype == pl.Categorical
     assert out.to_list() == ["a", "b", "c", None]
 
 
-def test_from_dict():
+def test_from_dict() -> None:
     data = {"a": [1, 2], "b": [3, 4]}
-    df = pl.from_dict(data)
+    df = pl.from_dict(data)  # type: ignore
     assert df.shape == (2, 2)
 
 
-def test_from_dicts():
+def test_from_dicts() -> None:
     data = [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
     df = pl.from_dicts(data)
     assert df.shape == (3, 2)
 
 
-def test_from_records():
+def test_from_records() -> None:
     data = [[1, 2, 3], [4, 5, 6]]
     df = pl.from_records(data, columns=["a", "b"])
     assert df.shape == (3, 2)
 
 
-def test_from_arrow():
+def test_from_arrow() -> None:
     data = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
     df = pl.from_arrow(data)
     assert df.shape == (3, 2)
 
 
-def test_from_pandas_dataframe():
+def test_from_pandas_dataframe() -> None:
     pd_df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
     df = pl.from_pandas(pd_df)
     assert df.shape == (2, 3)
 
 
-def test_from_pandas_series():
+def test_from_pandas_series() -> None:
     pd_series = pd.Series([1, 2, 3], name="pd")
     df = pl.from_pandas(pd_series)
     assert df.shape == (3,)
 
 
-def test_from_pandas_nan_to_none():
+def test_from_pandas_nan_to_none() -> None:
     from pyarrow import ArrowInvalid
 
     df = pd.Series([2, np.nan, None], name="pd")

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -5,14 +5,14 @@ import io
 import pickle
 import zlib
 from pathlib import Path
-from typing import List, Tuple, Callable, Dict, Type
+from typing import Callable, Dict, List, Tuple, Type
 
 import numpy as np
 import pandas as pd
 import pytest
-from polars import DataType
 
 import polars as pl
+from polars import DataType
 
 
 def test_to_from_buffer(df: pl.DataFrame) -> None:
@@ -26,7 +26,7 @@ def test_to_from_buffer(df: pl.DataFrame) -> None:
         to_fn(f)  # type: ignore
         f.seek(0)
 
-        df_1 = from_fn(f) # type: ignore
+        df_1 = from_fn(f)  # type: ignore
         assert df.frame_equal(df_1, null_equal=True)
 
 
@@ -381,7 +381,9 @@ def test_ignore_parse_dates() -> None:
 4,l,17290009""".encode()
 
     headers = ["a", "b", "c"]
-    dtypes: Dict[str, Type[DataType]] = {k: pl.Utf8 for k in headers}  # Forces Utf8 type for every column
+    dtypes: Dict[str, Type[DataType]] = {
+        k: pl.Utf8 for k in headers
+    }  # Forces Utf8 type for every column
     df = pl.read_csv(csv, columns=headers, dtype=dtypes)
     assert df.dtypes == [pl.Utf8, pl.Utf8, pl.Utf8]
 

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -5,15 +5,17 @@ import io
 import pickle
 import zlib
 from pathlib import Path
+from typing import List, Tuple, Callable, Dict, Type
 
 import numpy as np
 import pandas as pd
 import pytest
+from polars import DataType
 
 import polars as pl
 
 
-def test_to_from_buffer(df):
+def test_to_from_buffer(df: pl.DataFrame) -> None:
     df = df.drop("strings_nulls")
 
     for to_fn, from_fn in zip(
@@ -21,38 +23,38 @@ def test_to_from_buffer(df):
         [pl.read_parquet, pl.read_csv, pl.read_ipc, pl.read_json],
     ):
         f = io.BytesIO()
-        to_fn(f)
+        to_fn(f)  # type: ignore
         f.seek(0)
 
-        df_1 = from_fn(f)
+        df_1 = from_fn(f) # type: ignore
         assert df.frame_equal(df_1, null_equal=True)
 
 
-def test_select_columns_and_projection_from_buffer():
+def test_select_columns_and_projection_from_buffer() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [True, False, True], "c": ["a", "b", "c"]})
     expected = pl.DataFrame({"b": [True, False, True], "c": ["a", "b", "c"]})
     for to_fn, from_fn in zip(
         [df.to_parquet, df.to_ipc], [pl.read_parquet, pl.read_ipc]
     ):
         f = io.BytesIO()
-        to_fn(f)
+        to_fn(f)  # type: ignore
         f.seek(0)
 
-        df_1 = from_fn(f, columns=["b", "c"], use_pyarrow=False)
+        df_1 = from_fn(f, columns=["b", "c"], use_pyarrow=False)  # type: ignore
         assert df_1.frame_equal(expected)
 
     for to_fn, from_fn in zip(
         [df.to_parquet, df.to_ipc], [pl.read_parquet, pl.read_ipc]
     ):
         f = io.BytesIO()
-        to_fn(f)
+        to_fn(f)  # type: ignore
         f.seek(0)
 
-        df_2 = from_fn(f, projection=[1, 2], use_pyarrow=False)
+        df_2 = from_fn(f, projection=[1, 2], use_pyarrow=False)  # type: ignore
         assert df_2.frame_equal(expected)
 
 
-def test_compressed_to_ipc():
+def test_compressed_to_ipc() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [True, False, True], "c": ["a", "b", "c"]})
     compressions = ["uncompressed", "lz4", "zstd"]
 
@@ -65,13 +67,13 @@ def test_compressed_to_ipc():
         assert df_read.frame_equal(df)
 
 
-def test_read_web_file():
+def test_read_web_file() -> None:
     url = "https://raw.githubusercontent.com/pola-rs/polars/master/examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv"
     df = pl.read_csv(url)
     assert df.shape == (27, 4)
 
 
-def test_parquet_chunks():
+def test_parquet_chunks() -> None:
     """
     This failed in https://github.com/pola-rs/polars/issues/545
     """
@@ -100,7 +102,7 @@ def test_parquet_chunks():
         assert pl.DataFrame(df).frame_equal(polars_df)
 
 
-def test_parquet_datetime():
+def test_parquet_datetime() -> None:
     """
     This failed because parquet writers cast datetimeto Date
     """
@@ -125,7 +127,7 @@ def test_parquet_datetime():
     assert read.frame_equal(df)
 
 
-def test_csv_null_values():
+def test_csv_null_values() -> None:
     csv = """
 a,b,c
 na,b,c
@@ -155,7 +157,7 @@ a,n/a,c"""
     assert df[1, "b"] is None
 
 
-def test_datetime_parsing():
+def test_datetime_parsing() -> None:
     csv = """
 timestamp,open,high
 2021-01-01 00:00:00,0.00305500,0.00306000
@@ -169,7 +171,7 @@ timestamp,open,high
     assert df.dtypes == [pl.Datetime, pl.Float64, pl.Float64]
 
 
-def test_partial_dtype_overwrite():
+def test_partial_dtype_overwrite() -> None:
     csv = """
 a,b,c
 1,2,3
@@ -180,7 +182,7 @@ a,b,c
     assert df.dtypes == [pl.Utf8, pl.Int64, pl.Int64]
 
 
-def test_partial_column_rename():
+def test_partial_column_rename() -> None:
     csv = """
 a,b,c
 1,2,3
@@ -193,7 +195,7 @@ a,b,c
         assert df.columns == ["foo", "b", "c"]
 
 
-def test_column_rename_and_dtype_overwrite():
+def test_column_rename_and_dtype_overwrite() -> None:
     csv = """
 a,b,c
 1,2,3
@@ -230,7 +232,7 @@ a,b,c
     assert df.dtypes == [pl.Utf8, pl.Int64, pl.Float32]
 
 
-def test_compressed_csv():
+def test_compressed_csv() -> None:
     # gzip compression
     csv = """
 a,b,c
@@ -267,19 +269,19 @@ a,b,c
     assert out.frame_equal(expected)
 
     # no compression
-    f = io.BytesIO(b"a, b\n1,2\n")
-    out = pl.read_csv(f)
+    f2 = io.BytesIO(b"a, b\n1,2\n")
+    out2 = pl.read_csv(f2)
     expected = pl.DataFrame({"a": [1], "b": [2]})
-    assert out.frame_equal(expected)
+    assert out2.frame_equal(expected)
 
 
-def test_empty_bytes():
+def test_empty_bytes() -> None:
     b = b""
     with pytest.raises(ValueError):
         pl.read_csv(b)
 
 
-def test_pickle():
+def test_pickle() -> None:
     a = pl.Series("a", [1, 2])
     b = pickle.dumps(a)
     out = pickle.loads(b)
@@ -290,7 +292,7 @@ def test_pickle():
     assert df.frame_equal(out, null_equal=True)
 
 
-def test_copy():
+def test_copy() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
     assert copy.copy(df).frame_equal(df, True)
     assert copy.deepcopy(df).frame_equal(df, True)
@@ -300,7 +302,7 @@ def test_copy():
     assert copy.deepcopy(a).series_equal(a, True)
 
 
-def test_to_json():
+def test_to_json() -> None:
     # tests if it runs if no arg given
     df = pl.DataFrame({"a": [1, 2, 3]})
     assert (
@@ -308,7 +310,7 @@ def test_to_json():
     )
 
 
-def test_ipc_schema():
+def test_ipc_schema() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
     f = io.BytesIO()
     df.to_ipc(f)
@@ -317,18 +319,18 @@ def test_ipc_schema():
     assert pl.read_ipc_schema(f) == {"a": pl.Int64, "b": pl.Utf8, "c": pl.Boolean}
 
 
-def test_categorical_round_trip():
+def test_categorical_round_trip() -> None:
     df = pl.DataFrame({"ints": [1, 2, 3], "cat": ["a", "b", "c"]})
     df = df.with_column(pl.col("cat").cast(pl.Categorical))
 
     tbl = df.to_arrow()
     assert "dictionary" in str(tbl["cat"].type)
 
-    df = pl.from_arrow(tbl)
-    assert df.dtypes == [pl.Int64, pl.Categorical]
+    df2: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore
+    assert df2.dtypes == [pl.Int64, pl.Categorical]
 
 
-def test_csq_quote_char():
+def test_csq_quote_char() -> None:
     rolling_stones = """
     linenum,last_name,first_name
     1,Jagger,Mick
@@ -345,7 +347,7 @@ def test_csq_quote_char():
     assert pl.read_csv(rolling_stones.encode(), quote_char=None).shape == (9, 3)
 
 
-def test_date_list_fmt():
+def test_date_list_fmt() -> None:
     df = pl.DataFrame(
         {
             "mydate": ["2020-01-01", "2020-01-02", "2020-01-05", "2020-01-05"],
@@ -366,12 +368,12 @@ Series: 'mydate' [list]
     )
 
 
-def test_csv_empty_quotes_char():
+def test_csv_empty_quotes_char() -> None:
     # panicked in: https://github.com/pola-rs/polars/issues/1622
     pl.read_csv(b"a,b,c,d\nA1,B1,C1,1\nA2,B2,C2,2\n", quote_char="")
 
 
-def test_ignore_parse_dates():
+def test_ignore_parse_dates() -> None:
     csv = """a,b,c
 1,i,16200126
 2,j,16250130
@@ -379,16 +381,16 @@ def test_ignore_parse_dates():
 4,l,17290009""".encode()
 
     headers = ["a", "b", "c"]
-    dtypes = {k: pl.Utf8 for k in headers}  # Forces Utf8 type for every column
+    dtypes: Dict[str, Type[DataType]] = {k: pl.Utf8 for k in headers}  # Forces Utf8 type for every column
     df = pl.read_csv(csv, columns=headers, dtype=dtypes)
     assert df.dtypes == [pl.Utf8, pl.Utf8, pl.Utf8]
 
 
-def test_scan_csv():
+def test_scan_csv() -> None:
     df = pl.scan_csv(Path(__file__).parent / "files" / "small.csv")
     assert df.collect().shape == (4, 3)
 
 
-def test_scan_parquet():
+def test_scan_parquet() -> None:
     df = pl.scan_parquet(Path(__file__).parent / "files" / "small.parquet")
     assert df.collect().shape == (4, 3)

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1,3 +1,4 @@
+# type: ignore
 import numpy as np
 import pytest
 
@@ -5,7 +6,7 @@ import polars as pl
 from polars.lazy import col, lit, map_binary, when
 
 
-def test_lazy():
+def test_lazy() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     _ = df.lazy().with_column(lit(1).alias("foo")).select([col("a"), col("foo")])
 
@@ -22,7 +23,7 @@ def test_lazy():
     df.groupby("a").agg(pl.list("b"))
 
 
-def test_apply():
+def test_apply() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     new = df.lazy().with_column(col("a").map(lambda s: s * 2).alias("foo")).collect()
 
@@ -32,13 +33,13 @@ def test_apply():
     assert new.frame_equal(expected)
 
 
-def test_add_eager_column():
+def test_add_eager_column() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = df.lazy().with_column(pl.lit(pl.Series("c", [1, 2, 3]))).collect()
     assert out["c"].sum() == 6
 
 
-def test_set_null():
+def test_set_null() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = (
         df.lazy()
@@ -51,13 +52,13 @@ def test_set_null():
     assert s[2] is None
 
 
-def test_agg():
+def test_agg() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     ldf = df.lazy().min()
     assert ldf.collect().shape == (1, 2)
 
 
-def test_fold():
+def test_fold() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = df.select(
         [
@@ -76,19 +77,19 @@ def test_fold():
     assert out["foo"] == [2, 4, 6]
 
 
-def test_or():
+def test_or() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = df.lazy().filter((pl.col("a") == 1) | (pl.col("b") > 2)).collect()
     assert out.shape[0] == 2
 
 
-def test_groupby_apply():
+def test_groupby_apply() -> None:
     df = pl.DataFrame({"a": [1, 1, 3], "b": [1.0, 2.0, 3.0]})
     ldf = df.lazy().groupby("a").apply(lambda df: df)
     assert ldf.collect().sort("b").frame_equal(df)
 
 
-def test_binary_function():
+def test_binary_function() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = (
         df.lazy()
@@ -98,7 +99,7 @@ def test_binary_function():
     assert out["binary_function"] == (out.a + out.b)
 
 
-def test_filter_str():
+def test_filter_str() -> None:
     # use a str instead of a column expr
     df = pl.DataFrame(
         {
@@ -114,7 +115,7 @@ def test_filter_str():
     assert result.frame_equal(expected)
 
 
-def test_apply_custom_function():
+def test_apply_custom_function() -> None:
     df = pl.DataFrame(
         {
             "A": [1, 2, 3, 4, 5],
@@ -149,7 +150,7 @@ def test_apply_custom_function():
     assert a.frame_equal(expected)
 
 
-def test_groupby():
+def test_groupby() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
     out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
 
@@ -157,7 +158,7 @@ def test_groupby():
     assert out.sort(by="groups").frame_equal(expected)
 
 
-def test_shift_and_fill():
+def test_shift_and_fill() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
 
     # use exprs
@@ -169,19 +170,19 @@ def test_shift_and_fill():
     assert out["a"].null_count() == 0
 
 
-def test_arange():
+def test_arange() -> None:
     df = pl.DataFrame({"a": [1, 1, 1]}).lazy()
     result = df.filter(pl.lazy.col("a") >= pl.lazy.arange(0, 3)).collect()
     expected = pl.DataFrame({"a": [1, 1]})
     assert result.frame_equal(expected)
 
 
-def test_arg_sort():
+def test_arg_sort() -> None:
     df = pl.DataFrame({"a": [4, 1, 3]})
     assert df[col("a").arg_sort()]["a"] == [1, 2, 0]
 
 
-def test_window_function():
+def test_window_function() -> None:
     df = pl.DataFrame(
         {
             "A": [1, 2, 3, 4, 5],
@@ -205,7 +206,7 @@ def test_window_function():
     assert out["B_first"] == [5, 4, 3, 3, 5]
 
 
-def test_when_then_flatten():
+def test_when_then_flatten() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [3, 4, 5]})
 
     assert df[
@@ -217,11 +218,11 @@ def test_when_then_flatten():
     ]["bar"] == [30, 4, 5]
 
 
-def test_describe_plan():
+def test_describe_plan() -> None:
     pl.DataFrame({"a": [1]}).lazy().describe_optimized_plan()
 
 
-def test_window_deadlock():
+def test_window_deadlock() -> None:
     np.random.seed(12)
 
     df = pl.DataFrame(
@@ -242,7 +243,7 @@ def test_window_deadlock():
     ]
 
 
-def test_concat_str():
+def test_concat_str() -> None:
     df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 
     out = df[[pl.concat_str(["a", "b"], sep="-")]]
@@ -253,7 +254,7 @@ def test_concat_str():
     assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
 
 
-def test_fold_filter():
+def test_fold_filter() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
 
     out = df.filter(
@@ -277,7 +278,7 @@ def test_fold_filter():
     assert out.shape == (3, 2)
 
 
-def test_head_groupby():
+def test_head_groupby() -> None:
     commodity_prices = {
         "commodity": [
             "Wheat",
@@ -341,17 +342,17 @@ def test_head_groupby():
     )
 
 
-def test_drop_nulls():
+def test_drop_nulls() -> None:
     df = pl.DataFrame({"nrs": [1, 2, 3, 4, 5, None]})
     assert df.select(col("nrs").drop_nulls()).shape == (5, 1)
 
 
-def test_all_expr():
+def test_all_expr() -> None:
     df = pl.DataFrame({"nrs": [1, 2, 3, 4, 5, None]})
     assert df[[pl.all()]].frame_equal(df)
 
 
-def test_lazy_columns():
+def test_lazy_columns() -> None:
     df = pl.DataFrame(
         {
             "a": [1],
@@ -363,7 +364,7 @@ def test_lazy_columns():
     assert df.select(["a", "c"]).columns == ["a", "c"]
 
 
-def test_regex_selection():
+def test_regex_selection() -> None:
     df = pl.DataFrame(
         {
             "foo": [1],
@@ -376,27 +377,27 @@ def test_regex_selection():
     assert df.select([col("^foo.*$")]).columns == ["foo", "fooey", "foobar"]
 
 
-def test_exclude_selection():
+def test_exclude_selection() -> None:
     df = pl.DataFrame({"a": [1], "b": [1], "c": [1]}).lazy()
 
     assert df.select([pl.exclude("a")]).columns == ["b", "c"]
 
 
-def test_col_series_selection():
+def test_col_series_selection() -> None:
     df = pl.DataFrame({"a": [1], "b": [1], "c": [1]}).lazy()
     srs = pl.Series(["b", "c"])
 
     assert df.select(pl.col(srs)).columns == ["b", "c"]
 
 
-def test_literal_projection():
+def test_literal_projection() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     assert df.select([True]).dtypes == [pl.Boolean]
     assert df.select([1]).dtypes == [pl.Int32]
     assert df.select([2.0]).dtypes == [pl.Float64]
 
 
-def test_interpolate():
+def test_interpolate() -> None:
     df = pl.DataFrame({"a": [1, None, 3]})
     assert df.select(col("a").interpolate())["a"] == [1, 2, 3]
     assert df["a"].interpolate() == [1, 2, 3]
@@ -404,18 +405,18 @@ def test_interpolate():
     assert df.lazy().interpolate().collect()["a"] == [1, 2, 3]
 
 
-def test_fill_nan():
+def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1.0, np.nan, 3.0]})
     assert df.fill_nan(2.0)["a"] == [1.0, 2.0, 3.0]
     assert df.lazy().fill_nan(2.0).collect()["a"] == [1.0, 2.0, 3.0]
 
 
-def test_fill_null():
+def test_fill_null() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
     assert df.select([pl.col("a").fill_null("min")])["a"][1] == 1.0
 
 
-def test_take(fruits_cars):
+def test_take(fruits_cars) -> None:
     df = fruits_cars
 
     # out of bounds error
@@ -434,14 +435,14 @@ def test_take(fruits_cars):
     assert out[4, "B"] == [1, 4]
 
 
-def test_select_by_col_list(fruits_cars):
+def test_select_by_col_list(fruits_cars) -> None:
     df = fruits_cars
     out = df.select(col(["A", "B"]).sum())
     assert out.columns == ["A", "B"]
     assert out.shape == (1, 2)
 
 
-def test_rolling(fruits_cars):
+def test_rolling(fruits_cars) -> None:
     df = fruits_cars
     assert df.select(
         [
@@ -462,7 +463,7 @@ def test_rolling(fruits_cars):
     )
 
 
-def test_rolling_apply():
+def test_rolling_apply() -> None:
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0])
     out = s.rolling_apply(window_size=3, function=lambda s: s.std())
     assert out[0] is None
@@ -470,7 +471,7 @@ def test_rolling_apply():
     assert out[2] == 4.358898943540674
 
 
-def test_arr_namespace(fruits_cars):
+def test_arr_namespace(fruits_cars) -> None:
     df = fruits_cars
     out = df.select(
         [
@@ -513,7 +514,7 @@ def test_arr_namespace(fruits_cars):
     assert out.frame_equal(expected, null_equal=True)
 
 
-def test_arithmetic():
+def test_arithmetic() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 
     out = df.select(
@@ -549,19 +550,19 @@ def test_arithmetic():
     assert out.frame_equal(expected)
 
 
-def test_ufunc():
+def test_ufunc() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     out = df.select(np.log(col("a")))
     assert out["a"][1] == 0.6931471805599453
 
 
-def test_clip():
+def test_clip() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
     assert df.select(pl.col("a").clip(2, 4))["a"].to_list() == [2, 2, 3, 4, 4]
     assert pl.Series([1, 2, 3, 4, 5]).clip(2, 4).to_list() == [2, 2, 3, 4, 4]
 
 
-def test_argminmax():
+def test_argminmax() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
     out = df.select(
         [
@@ -573,7 +574,7 @@ def test_argminmax():
     assert out["min"][0] == 0
 
 
-def test_expr_bool_cmp():
+def test_expr_bool_cmp() -> None:
     # Since expressions are lazy they should not be evaluated as
     # bool(x), this has the nice side effect of throwing an error
     # if someone tries to chain them via the and|or operators
@@ -586,7 +587,7 @@ def test_expr_bool_cmp():
         df[[pl.col("a").gt(pl.col("b")) or pl.col("b").gt(pl.col("b"))]]
 
 
-def test_is_in():
+def test_is_in() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     assert df.select(pl.col("a").is_in([1, 2]))["a"].to_list() == [
         True,
@@ -595,19 +596,19 @@ def test_is_in():
     ]
 
 
-def test_rename():
+def test_rename() -> None:
     lf = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy()
     out = lf.rename({"a": "foo", "b": "bar"}).collect()
     # todo: preserve column order
     assert out.columns == ["c", "foo", "bar"]
 
 
-def test_drop_columns():
+def test_drop_columns() -> None:
     out = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy().drop(["a", "b"])
     assert out.columns == ["c"]
 
 
-def test_join_suffix():
+def test_join_suffix() -> None:
     df_left = pl.DataFrame(
         {
             "a": ["a", "b", "a", "z"],
@@ -628,13 +629,13 @@ def test_join_suffix():
     assert out.columns == ["a", "b", "c", "b_bar", "c_bar"]
 
 
-def test_str_concat():
+def test_str_concat() -> None:
     df = pl.DataFrame({"foo": [1, None, 2]})
     df = df.select(pl.col("foo").str_concat("-"))
     assert df[0, 0] == "1-null-2"
 
 
-def test_collect_all(df):
+def test_collect_all(df) -> None:
     lf1 = df.lazy().select(pl.col("int").sum())
     lf2 = df.lazy().select((pl.col("floats") * 2).sum())
     out = pl.collect_all([lf1, lf2])
@@ -642,7 +643,7 @@ def test_collect_all(df):
     assert out[1][0, 0] == 12.0
 
 
-def test_spearman_corr():
+def test_spearman_corr() -> None:
     df = pl.DataFrame(
         {
             "era": [1, 1, 1, 2, 2, 2],
@@ -660,7 +661,7 @@ def test_spearman_corr():
     assert np.isclose(out[1], -1.0)
 
 
-def test_lazy_concat(df):
+def test_lazy_concat(df) -> None:
     shape = df.shape
     shape = (shape[0] * 2, shape[1])
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -11,7 +11,7 @@ def create_series() -> pl.Series:
     return pl.Series("a", [1, 2])
 
 
-def test_cum_agg():
+def test_cum_agg() -> None:
     s = pl.Series("a", [1, 2, 3, 2])
     assert s.cumsum().series_equal(pl.Series([1, 3, 6, 8]))
     assert s.cummin().series_equal(pl.Series([1, 1, 1, 1]))
@@ -19,7 +19,7 @@ def test_cum_agg():
     assert s.cumprod().series_equal(pl.Series([1, 2, 6, 12]))
 
 
-def test_init_inputs():
+def test_init_inputs() -> None:
     # Good inputs
     pl.Series("a", [1, 2])
     pl.Series("a", values=[1, 2])
@@ -45,26 +45,26 @@ def test_init_inputs():
         pl.Series("bigint", [2 ** 64])
 
 
-def test_concat():
+def test_concat() -> None:
     s = pl.Series("a", [2, 1, 3])
 
-    assert pl.concat([s, s]).len() == 6
+    assert pl.concat([s, s]).len() == 6  # type: ignore
     # check if s remains unchanged
     assert s.len() == 3
 
 
-def test_to_frame():
+def test_to_frame() -> None:
     assert create_series().to_frame().shape == (2, 1)
 
 
-def test_bitwise_ops():
+def test_bitwise_ops() -> None:
     a = pl.Series([True, False, True])
     b = pl.Series([False, True, True])
     assert a & b == [False, False, True]
     assert a | b == [True, True, True]
 
 
-def test_equality():
+def test_equality() -> None:
     a = create_series()
     b = a
 
@@ -83,14 +83,14 @@ def test_equality():
     assert (a == "ham").to_list() == [True, False, False]
 
 
-def test_agg():
+def test_agg() -> None:
     a = create_series()
     assert a.mean() == 1.5
     assert a.min() == 1
     assert a.max() == 2
 
 
-def test_arithmetic():
+def test_arithmetic() -> None:
     a = create_series()
     b = a
 
@@ -122,7 +122,7 @@ def test_arithmetic():
     assert ((1.0 % a) == [0, 1]).sum() == 2
 
 
-def test_various():
+def test_various() -> None:
     a = create_series()
 
     assert a.is_null().sum() == 0
@@ -154,7 +154,7 @@ def test_various():
     assert not a.is_numeric()
 
 
-def test_filter_ops():
+def test_filter_ops() -> None:
     a = pl.Series("a", range(20))
     assert a[a > 1].len() == 18
     assert a[a < 1].len() == 1
@@ -164,7 +164,7 @@ def test_filter_ops():
     assert a[a != 1].len() == 19
 
 
-def test_cast():
+def test_cast() -> None:
     a = pl.Series("a", range(20))
 
     assert a.cast(pl.Float32).dtype == pl.Float32
@@ -175,7 +175,7 @@ def test_cast():
     assert a.cast(pl.Date).dtype == pl.Date
 
 
-def test_to_python():
+def test_to_python() -> None:
     a = pl.Series("a", range(20))
     b = a.to_list()
     assert isinstance(b, list)
@@ -190,23 +190,24 @@ def test_to_python():
     assert a.to_list() == [1, None, 2]
 
 
-def test_sort():
+def test_sort() -> None:
     a = pl.Series("a", [2, 1, 3])
-    assert a.sort().to_list() == [1, 2, 3]
+    a_sorted: pl.Series = a.sort()  # type: ignore
+    assert a_sorted.to_list() == [1, 2, 3]
     assert a.sort(reverse=True) == [3, 2, 1]
 
 
-def test_rechunk():
+def test_rechunk() -> None:
     a = pl.Series("a", [1, 2, 3])
     b = pl.Series("b", [4, 5, 6])
     a.append(b)
     assert a.n_chunks() == 2
-    assert a.rechunk(in_place=False).n_chunks() == 1
+    assert a.rechunk(in_place=False).n_chunks() == 1  # type: ignore
     a.rechunk(in_place=True)
     assert a.n_chunks() == 1
 
 
-def test_indexing():
+def test_indexing() -> None:
     a = pl.Series("a", [1, 2, None])
     assert a[1] == 2
     assert a[2] is None
@@ -221,7 +222,7 @@ def test_indexing():
     assert a[1] is None
 
 
-def test_arrow():
+def test_arrow() -> None:
     a = pl.Series("a", [1, 2, 3, None])
     out = a.to_arrow()
     assert out == pa.array([1, 2, 3, None])
@@ -235,13 +236,13 @@ def test_arrow():
     )
 
 
-def test_view():
+def test_view() -> None:
     a = pl.Series("a", [1.0, 2.0, 3.0])
     assert isinstance(a.view(), np.ndarray)
     assert np.all(a.view() == np.array([1, 2, 3]))
 
 
-def test_ufunc():
+def test_ufunc() -> None:
     a = pl.Series("a", [1.0, 2.0, 3.0, 4.0])
     b = np.multiply(a, 4)
     assert isinstance(b, pl.Series)
@@ -253,19 +254,19 @@ def test_ufunc():
     assert b.null_count() == 1
 
 
-def test_get():
+def test_get() -> None:
     a = pl.Series("a", [1, 2, 3])
     assert a[0] == 1
     assert a[:2] == [1, 2]
 
 
-def test_set():
+def test_set() -> None:
     a = pl.Series("a", [True, False, True])
     mask = pl.Series("msk", [True, False, True])
     a[mask] = False
 
 
-def test_fill_null():
+def test_fill_null() -> None:
     a = pl.Series("a", [1, 2, None])
     b = a.fill_null("forward")
     assert b == [1, 2, 2]
@@ -273,7 +274,7 @@ def test_fill_null():
     assert b.to_list() == [1, 2, 14]
 
 
-def test_apply():
+def test_apply() -> None:
     a = pl.Series("a", [1, 2, None])
     b = a.apply(lambda x: x ** 2)
     assert b == [1, 4, None]
@@ -295,7 +296,7 @@ def test_apply():
     a.apply(lambda x: x)
 
 
-def test_shift():
+def test_shift() -> None:
     a = pl.Series("a", [1, 2, 3])
     assert a.shift(1).to_list() == [None, 1, 2]
     assert a.shift(-1).to_list() == [2, 3, None]
@@ -303,20 +304,20 @@ def test_shift():
     assert a.shift_and_fill(-1, 10).to_list() == [2, 3, 10]
 
 
-def test_rolling():
-    a = pl.Series("a", [1, 2, 3, 2, 1])
+def test_rolling() -> None:
+    a = pl.Series("a", [1, 2, 3, 2, 1])  # type: ignore
     assert a.rolling_min(2).to_list() == [None, 1, 2, 2, 1]
     assert a.rolling_max(2).to_list() == [None, 2, 3, 3, 2]
     assert a.rolling_sum(2).to_list() == [None, 3, 5, 5, 3]
     assert a.rolling_mean(2).to_list() == [None, 1.5, 2.5, 2.5, 1.5]
-    assert np.isclose(a.rolling_std(2).to_list()[1], 0.7071067811865476)
-    assert np.isclose(a.rolling_var(2).to_list()[1], 0.5)
+    assert np.isclose(a.rolling_std(2).to_list()[1], 0.7071067811865476)  # type: ignore
+    assert np.isclose(a.rolling_var(2).to_list()[1], 0.5)  # type: ignore
     assert a.rolling_median(4).to_list() == [None, None, None, 2, 2]
     assert a.rolling_quantile(3, 0.5).to_list() == [None, None, 2, 2, 2]
     assert a.rolling_skew(4).null_count() == 3
 
 
-def test_object():
+def test_object() -> None:
     vals = [[12], "foo", 9]
     a = pl.Series("a", vals)
     assert a.dtype == pl.Object
@@ -324,7 +325,7 @@ def test_object():
     assert a[1] == "foo"
 
 
-def test_repeat():
+def test_repeat() -> None:
     s = pl.repeat(1, 10)
     assert s.dtype == pl.Int64
     assert s.len() == 10
@@ -340,22 +341,22 @@ def test_repeat():
     assert s.len() == 5
 
 
-def test_median():
+def test_median() -> None:
     s = pl.Series([1, 2, 3])
     assert s.median() == 2
 
 
-def test_quantile():
+def test_quantile() -> None:
     s = pl.Series([1, 2, 3])
     assert s.quantile(0.5) == 2
 
 
-def test_shape():
+def test_shape() -> None:
     s = pl.Series([1, 2, 3])
     assert s.shape == (3,)
 
 
-def test_create_list_series():
+def test_create_list_series() -> None:
     pass
     # may Segfault: see https://github.com/pola-rs/polars/issues/518
     # a = [[1, 2], None, [None, 3]]
@@ -363,7 +364,7 @@ def test_create_list_series():
     # assert s.to_list() == a
 
 
-def test_iter():
+def test_iter() -> None:
     s = pl.Series("", [1, 2, 3])
 
     iter = s.__iter__()
@@ -373,7 +374,7 @@ def test_iter():
     assert sum(s) == 6
 
 
-def test_empty():
+def test_empty() -> None:
     a = pl.Series(dtype=pl.Int8)
     assert a.dtype == pl.Int8
     a = pl.Series()
@@ -384,7 +385,7 @@ def test_empty():
     assert a.dtype == pl.Int8
 
 
-def test_describe():
+def test_describe() -> None:
     num_s = pl.Series([1, 2, 3])
     float_s = pl.Series([1.3, 4.6, 8.9])
     str_s = pl.Series(["abc", "pqr", "xyz"])
@@ -402,7 +403,7 @@ def test_describe():
         assert empty_s.describe()
 
 
-def test_is_in():
+def test_is_in() -> None:
     s = pl.Series([1, 2, 3])
 
     out = s.is_in([1, 2])
@@ -412,35 +413,35 @@ def test_is_in():
     assert df[pl.col("a").is_in(pl.col("b")).alias("mask")]["mask"] == [True, False]
 
 
-def test_str_slice():
+def test_str_slice() -> None:
     df = pl.DataFrame({"a": ["foobar", "barfoo"]})
     assert df["a"].str.slice(-3) == ["bar", "foo"]
 
     assert df[[pl.col("a").str.slice(2, 4)]]["a"] == ["obar", "rfoo"]
 
 
-def test_arange_expr():
+def test_arange_expr() -> None:
     df = pl.DataFrame({"a": ["foobar", "barfoo"]})
-    out = df[[pl.arange(0, pl.col("a").count() * 10)]]
+    out = df[[pl.arange(0, pl.col("a").count() * 10)]]  # type: ignore
     assert out.shape == (20, 1)
     assert out.select_at_idx(0)[-1] == 19
 
     # eager arange
-    out = pl.arange(0, 10, 2, eager=True)
+    out = pl.arange(0, 10, 2, eager=True)  # type: ignore
     assert out == [0, 2, 4, 8, 8]
 
-    out = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), step=2, eager=True)
+    out = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), step=2, eager=True)  # type: ignore
     assert out.dtype == pl.List
     assert out[0].to_list() == [0, 2]
 
 
-def test_round():
+def test_round() -> None:
     a = pl.Series("f", [1.003, 2.003])
     b = a.round(2)
     assert b == [1.00, 2.00]
 
 
-def test_apply_list_out():
+def test_apply_list_out() -> None:
     s = pl.Series("count", [3, 2, 2])
     out = s.apply(lambda val: pl.repeat(val, val))
     assert out[0] == [3, 3, 3]
@@ -448,26 +449,26 @@ def test_apply_list_out():
     assert out[2] == [2, 2]
 
 
-def test_is_first():
+def test_is_first() -> None:
     s = pl.Series("", [1, 1, 2])
     assert s.is_first() == [True, False, True]
 
 
-def test_reinterpret():
+def test_reinterpret() -> None:
     s = pl.Series("a", [1, 1, 2], dtype=pl.UInt64)
     assert s.reinterpret(signed=True).dtype == pl.Int64
     df = pl.DataFrame([s])
     assert df[[pl.col("a").reinterpret(signed=True)]]["a"].dtype == pl.Int64
 
 
-def test_mode():
+def test_mode() -> None:
     s = pl.Series("a", [1, 1, 2])
     assert s.mode() == [1]
     df = pl.DataFrame([s])
     assert df[[pl.col("a").mode()]]["a"] == [1]
 
 
-def test_jsonpath_single():
+def test_jsonpath_single() -> None:
     s = pl.Series(['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}'])
     print(s.str.json_path_match("$.a"))
     assert s.str.json_path_match("$.a").to_list() == [
@@ -479,7 +480,7 @@ def test_jsonpath_single():
     ]
 
 
-def test_extract_regex():
+def test_extract_regex() -> None:
     s = pl.Series(
         [
             "http://vote.com/ballon_dor?candidate=messi&ref=polars",
@@ -494,7 +495,7 @@ def test_extract_regex():
     ]
 
 
-def test_rank_dispatch():
+def test_rank_dispatch() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
 
     assert list(s.rank("dense")) == [2, 3, 4, 3, 3, 4, 1]
@@ -503,7 +504,7 @@ def test_rank_dispatch():
     df.select(pl.col("a").rank("dense"))["a"] == [2, 3, 4, 3, 3, 4, 1]
 
 
-def test_diff_dispatch():
+def test_diff_dispatch() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     expected = [1, 1, -1, 0, 1, -3]
 
@@ -513,54 +514,54 @@ def test_diff_dispatch():
     assert df.select(pl.col("a").diff())["a"].to_list() == [None, 1, 1, -1, 0, 1, -3]
 
 
-def test_skew_dispatch():
+def test_skew_dispatch() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
 
-    assert np.isclose(s.skew(True), -0.5953924651018018)
-    assert np.isclose(s.skew(False), -0.7717168360221258)
+    assert np.isclose(s.skew(True), -0.5953924651018018)  # type: ignore
+    assert np.isclose(s.skew(False), -0.7717168360221258)  # type: ignore
 
     df = pl.DataFrame([s])
     assert np.isclose(df.select(pl.col("a").skew(False))["a"][0], -0.7717168360221258)
 
 
-def test_kurtosis_dispatch():
+def test_kurtosis_dispatch() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     expected = -0.6406250000000004
 
-    assert np.isclose(s.kurtosis(), expected)
+    assert np.isclose(s.kurtosis(), expected)  # type: ignore
     df = pl.DataFrame([s])
     assert np.isclose(df.select(pl.col("a").kurtosis())["a"][0], expected)
 
 
-def test_arr_lengths_dispatch():
+def test_arr_lengths_dispatch() -> None:
     s = pl.Series("a", [[1, 2], [1, 2, 3]])
     assert s.arr.lengths().to_list() == [2, 3]
     df = pl.DataFrame([s])
     assert df.select(pl.col("a").arr.lengths())["a"].to_list() == [2, 3]
 
 
-def test_sqrt_dispatch():
+def test_sqrt_dispatch() -> None:
     s = pl.Series("a", [1, 2])
     assert s.sqrt().to_list() == [1, np.sqrt(2)]
     df = pl.DataFrame([s])
     assert df.select(pl.col("a").sqrt())["a"].to_list() == [1, np.sqrt(2)]
 
 
-def test_range():
+def test_range() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     assert s[2:5].series_equal(s[range(2, 5)])
     df = pl.DataFrame([s])
     assert df[2:5].frame_equal(df[range(2, 5)])
 
 
-def test_strict_cast():
+def test_strict_cast() -> None:
     with pytest.raises(RuntimeError):
         pl.Series("a", [2 ** 16]).cast(dtype=pl.Int16, strict=True)
     with pytest.raises(RuntimeError):
         pl.DataFrame({"a": [2 ** 16]}).select([pl.col("a").cast(pl.Int16, strict=True)])
 
 
-def test_list_concat_dispatch():
+def test_list_concat_dispatch() -> None:
     s0 = pl.Series("a", [[1, 2]])
     s1 = pl.Series("b", [[3, 4, 5]])
     expected = pl.Series("a", [[1, 2, 3, 4, 5]])
@@ -572,7 +573,7 @@ def test_list_concat_dispatch():
     assert out.series_equal(expected)
 
     df = pl.DataFrame([s0, s1])
-    assert df.select(pl.concat_list(["a", "b"]).alias("concat"))["concat"].series_equal(
+    assert df.select(pl.concat_list(["a", "b"]).alias("concat"))["concat"].series_equal(  # type: ignore
         expected
     )
     assert df.select(pl.col("a").arr.concat("b").alias("concat"))[
@@ -583,13 +584,13 @@ def test_list_concat_dispatch():
     ].series_equal(expected)
 
 
-def test_floor_divide():
+def test_floor_divide() -> None:
     s = pl.Series("a", [1, 2, 3])
     assert (s // 2).to_list() == [0, 1, 1]
     assert pl.DataFrame([s]).select(pl.col("a") // 2)["a"].to_list() == [0, 1, 1]
 
 
-def test_true_divide():
+def test_true_divide() -> None:
     s = pl.Series("a", [1, 2])
     assert (s / 2).to_list() == [0.5, 1.0]
     assert pl.DataFrame([s]).select(pl.col("a") / 2)["a"].to_list() == [0.5, 1.0]
@@ -601,7 +602,7 @@ def test_true_divide():
     assert pl.DataFrame({"a": vals}).select([pl.col("a") / 1])["a"].to_list() == vals
 
 
-def test_invalid_categorical():
+def test_invalid_categorical() -> None:
     s = pl.Series("cat_series", ["a", "b", "b", "c", "a"]).cast(pl.Categorical)
     assert s.std() is None
     assert s.var() is None
@@ -610,7 +611,7 @@ def test_invalid_categorical():
     assert s.mode().to_list() == [None]
 
 
-def test_bitwise():
+def test_bitwise() -> None:
     a = pl.Series("a", [1, 2, 3])
     b = pl.Series("b", [3, 4, 5])
     assert (a & b).to_list() == [1, 0, 1]
@@ -630,7 +631,7 @@ def test_bitwise():
     out["xor"].to_list() == [2, 6, 6]
 
 
-def test_to_numpy():
+def test_to_numpy() -> None:
     pl.eager.series._PYARROW_AVAILABLE = False
     a = pl.Series("a", [1, 2, 3])
     a.to_numpy() == np.array([1, 2, 3])
@@ -638,7 +639,7 @@ def test_to_numpy():
     a.to_numpy() == np.array([1.0, 2.0, np.nan])
 
 
-def test_from_sequences():
+def test_from_sequences() -> None:
     # test int, str, bool, flt
     values = [
         [[1], [None, 3]],
@@ -656,7 +657,7 @@ def test_from_sequences():
         assert a.to_list() == vals
 
 
-def test_comparisons_int_series_to_float():
+def test_comparisons_int_series_to_float() -> None:
     srs_int = pl.Series([1, 2, 3, 4])
     assert (srs_int - 1.0).to_list() == [0, 1, 2, 3]
     assert (srs_int + 1.0).to_list() == [2, 3, 4, 5]
@@ -675,7 +676,7 @@ def test_comparisons_int_series_to_float():
     assert (srs_int - True).to_list() == [0, 1, 2, 3]
 
 
-def test_comparisons_float_series_to_int():
+def test_comparisons_float_series_to_int() -> None:
     srs_float = pl.Series([1.0, 2.0, 3.0, 4.0])
     assert (srs_float - 1).to_list() == [0.0, 1.0, 2.0, 3.0]
     assert (srs_float + 1).to_list() == [2.0, 3.0, 4.0, 5.0]
@@ -693,7 +694,7 @@ def test_comparisons_float_series_to_int():
     assert (srs_float - True).to_list() == [0.0, 1.0, 2.0, 3.0]
 
 
-def test_comparisons_bool_series_to_int():
+def test_comparisons_bool_series_to_int() -> None:
     srs_bool = pl.Series([True, False])
     # todo: do we want this to work?
     assert (srs_bool / 1).to_list() == [True, False]
@@ -715,7 +716,7 @@ def test_comparisons_bool_series_to_int():
         srs_bool > 2
 
 
-def test_trigonometry_functions():
+def test_trigonometry_functions() -> None:
     srs_float = pl.Series("t", [0.0, np.pi])
     assert np.allclose(srs_float.sin(), np.array([0.0, 0.0]))
     assert np.allclose(srs_float.cos(), np.array([1.0, -1.0]))
@@ -727,7 +728,7 @@ def test_trigonometry_functions():
     assert np.allclose(srs_float.arctan(), np.array([0.785, 0.0, -0.785]), atol=0.01)
 
 
-def test_date_range():
+def test_date_range() -> None:
     result = pl.date_range(
         datetime(1985, 1, 1), datetime(2015, 7, 1), timedelta(days=1, hours=12)
     )
@@ -738,57 +739,58 @@ def test_date_range():
     assert result.dt[-1] == datetime(2015, 6, 30, 12, 0)
 
 
-def test_abs():
+def test_abs() -> None:
     # ints
     s = pl.Series([1, -2, 3, -4])
     assert s.abs().to_list() == [1, 2, 3, 4]
-    assert np.abs(s).to_list() == [1, 2, 3, 4]
+    assert np.abs(s).to_list() == [1, 2, 3, 4]  # type: ignore
 
     # floats
     s = pl.Series([1.0, -2.0, 3, -4.0])
     assert s.abs().to_list() == [1.0, 2.0, 3.0, 4.0]
-    assert np.abs(s).to_list() == [1.0, 2.0, 3.0, 4.0]
-    assert pl.select(pl.lit(s).abs()).to_series().to_list() == [1.0, 2.0, 3.0, 4.0]
+    assert np.abs(s).to_list() == [1.0, 2.0, 3.0, 4.0]  # type: ignore
+    assert pl.select(pl.lit(s).abs()).to_series().to_list() == [1.0, 2.0, 3.0, 4.0]  # type: ignore
 
 
-def test_to_dummies():
+def test_to_dummies() -> None:
     s = pl.Series("a", [1, 2, 3])
     result = s.to_dummies()
     expected = pl.DataFrame({"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]})
     assert result.frame_equal(expected)
 
 
-def test_value_counts():
+def test_value_counts() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     result = s.value_counts()
     expected = pl.DataFrame({"a": [1, 2, 3], "counts": [1, 2, 1]})
-    assert result.sort("a").frame_equal(expected)
+    result_sorted: pl.DataFrame = result.sort("a")  # type: ignore
+    assert result_sorted.frame_equal(expected)
 
 
-def test_chunk_lengths():
+def test_chunk_lengths() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     # this is a Series with one chunk, of length 4
     assert s.n_chunks() == 1
     assert s.chunk_lengths() == [4]
 
 
-def test_limit():
+def test_limit() -> None:
     s = pl.Series("a", [1, 2, 3])
     assert s.limit(2).series_equal(pl.Series("a", [1, 2]))
 
 
-def test_filter():
+def test_filter() -> None:
     s = pl.Series("a", [1, 2, 3])
     mask = pl.Series("", [True, False, True])
     assert s.filter(mask).series_equal(pl.Series("a", [1, 3]))
 
 
-def test_take_every():
+def test_take_every() -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     assert s.take_every(2).series_equal(pl.Series([1, 3]))
 
 
-def test_argsort():
+def test_argsort() -> None:
     s = pl.Series("a", [5, 3, 4, 1, 2])
     result = s.argsort()
     expected = pl.Series([3, 4, 1, 2, 0])
@@ -799,48 +801,48 @@ def test_argsort():
     assert result_reverse.series_equal(expected_reverse)
 
 
-def test_arg_min_and_arg_max():
+def test_arg_min_and_arg_max() -> None:
     s = pl.Series("a", [5, 3, 4, 1, 2])
     assert s.arg_min() == 3
     assert s.arg_max() == 0
 
 
-def test_is_null_is_not_null():
+def test_is_null_is_not_null() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, None])
     assert s.is_null().series_equal(pl.Series([False, False, False, True]))
     assert s.is_not_null().series_equal(pl.Series([True, True, True, False]))
 
 
-def test_is_finite_is_infinite():
+def test_is_finite_is_infinite() -> None:
     s = pl.Series("a", [1.0, 2.0, np.inf])
 
     s.is_finite().series_equal(pl.Series([True, True, False]))
     s.is_infinite().series_equal(pl.Series([False, False, True]))
 
 
-def test_is_nan_is_not_nan():
+def test_is_nan_is_not_nan() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, np.NaN])
     assert s.is_nan().series_equal(pl.Series([False, False, False, True]))
     assert s.is_not_nan().series_equal(pl.Series([True, True, True, False]))
 
 
-def test_is_unique():
+def test_is_unique() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     assert s.is_unique().series_equal(pl.Series([True, False, False, True]))
 
 
-def test_is_duplicated():
+def test_is_duplicated() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     assert s.is_duplicated().series_equal(pl.Series([False, True, True, False]))
 
 
-def test_dot():
+def test_dot() -> None:
     s = pl.Series("a", [1, 2, 3])
     s2 = pl.Series("b", [4.0, 5.0, 6.0])
     assert s.dot(s2) == 32
 
 
-def test_sample():
+def test_sample() -> None:
     s = pl.Series("a", [1, 2, 3, 4, 5])
     assert len(s.sample(n=2)) == 2
     assert len(s.sample(frac=0.4)) == 2
@@ -854,13 +856,13 @@ def test_sample():
     assert len(s.sample(n=10, with_replacement=True)) == 10
 
 
-def test_peak_max_peak_min():
+def test_peak_max_peak_min() -> None:
     s = pl.Series("a", [4, 1, 3, 2, 5])
     assert s.peak_min().series_equal(pl.Series([False, True, False, True, False]))
     assert s.peak_max().series_equal(pl.Series([True, False, True, False, True]))
 
 
-def test_shrink_to_fit():
+def test_shrink_to_fit() -> None:
     s = pl.Series("a", [4, 1, 3, 2, 5])
     assert s.shrink_to_fit(in_place=True) is None
 
@@ -868,22 +870,22 @@ def test_shrink_to_fit():
     assert isinstance(s.shrink_to_fit(in_place=False), pl.Series)
 
 
-def test_str_concat():
+def test_str_concat() -> None:
     s = pl.Series(["1", None, "2"])
     assert s.str_concat()[0] == "1-null-2"
 
 
-def test_str_lengths():
+def test_str_lengths() -> None:
     s = pl.Series(["messi", "ronaldo", None])
     assert s.str.lengths().to_list() == [5, 7, None]
 
 
-def test_str_contains():
+def test_str_contains() -> None:
     s = pl.Series(["messi", "ronaldo", "ibrahimovic"])
     assert s.str.contains("mes").to_list() == [True, False, False]
 
 
-def test_str_replace_str_replace_all():
+def test_str_replace_str_replace_all() -> None:
     s = pl.Series(["hello", "world", "test"])
     assert s.str.replace("o", "0").to_list() == ["hell0", "w0rld", "test"]
 
@@ -891,34 +893,34 @@ def test_str_replace_str_replace_all():
     assert s.str.replace_all("o", "0").to_list() == ["hell0", "w0rld", "test"]
 
 
-def test_str_to_lowercase():
+def test_str_to_lowercase() -> None:
     s = pl.Series(["Hello", "WORLD"])
     assert s.str.to_lowercase().to_list() == ["hello", "world"]
 
 
-def test_str_to_uppercase():
+def test_str_to_uppercase() -> None:
     s = pl.Series(["Hello", "WORLD"])
     assert s.str.to_uppercase().to_list() == ["HELLO", "WORLD"]
 
 
-def test_str_rstrip():
+def test_str_rstrip() -> None:
     s = pl.Series([" hello ", "world\t "])
     assert s.str.rstrip().to_list() == [" hello", "world"]
 
 
-def test_str_lstrip():
+def test_str_lstrip() -> None:
     s = pl.Series([" hello ", "\t world"])
     assert s.str.lstrip().to_list() == ["hello ", "world"]
 
 
-def test_dt_strftime():
+def test_dt_strftime() -> None:
     a = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
     assert a.dtype == pl.Date
     a = a.dt.strftime("%F")
     assert a[2] == "2052-02-20"
 
 
-def test_dt_year_month_week_day_ordinal_day():
+def test_dt_year_month_week_day_ordinal_day() -> None:
     a = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
     assert a.dt.year().to_list() == [1997, 2024, 2052]
     assert a.dt.month().to_list() == [5, 10, 2]

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -1,7 +1,7 @@
 import polars as pl
 
 
-def test_sort_dates_multiples():
+def test_sort_dates_multiples() -> None:
     df = pl.DataFrame(
         [
             pl.Series(
@@ -21,9 +21,9 @@ def test_sort_dates_multiples():
     expected = [4, 5, 2, 3, 1]
 
     # datetime
-    out = df.sort(["date", "values"])
+    out: pl.DataFrame = df.sort(["date", "values"])  # type: ignore
     assert out["values"].to_list() == expected
 
     # Date
-    out = df.with_column(pl.col("date").cast(pl.Date)).sort(["date", "values"])
+    out = df.with_column(pl.col("date").cast(pl.Date)).sort(["date", "values"])  # type: ignore
     assert out["values"].to_list() == expected

--- a/py-polars/tests/test_window.py
+++ b/py-polars/tests/test_window.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import numpy as np
 import pytest
 
@@ -5,17 +7,21 @@ import polars as pl
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64, pl.Int32])
-def test_std(dtype):
+def test_std(dtype: Type[pl.DataType]) -> None:
     if dtype == pl.Int32:
-        values = [1, 2, 3, 4]
+        df = pl.DataFrame(
+            [
+                pl.Series("groups", ["a", "a", "b", "b"]),
+                pl.Series("values", [1, 2, 3, 4], dtype=dtype),
+            ]
+        )
     else:
-        values = [1.0, 2.0, 3.0, 4.0]
-    df = pl.DataFrame(
-        [
-            pl.Series("groups", ["a", "a", "b", "b"]),
-            pl.Series("values", values, dtype=dtype),
-        ]
-    )
+        df = pl.DataFrame(
+            [
+                pl.Series("groups", ["a", "a", "b", "b"]),
+                pl.Series("values", [1.0, 2.0, 3.0, 4.0], dtype=dtype),
+            ]
+        )
 
     out = df.select(pl.col("values").std().over("groups"))
     assert np.isclose(out["values"][0], 0.7071067690849304)


### PR DESCRIPTION
This is a big change to ensure that our type annotations actually match usage of the library. As you can see, I have changed a number of type annotations here to match usage in unit tests.

Couple of common themes:
* add return type `None` to all unit tests
* for some reason, functions on the Polars module are not picked up. i.e. `pl.max` is something mypy complains about. As a result, for some test files, I have had to turn off the type checks, otherwise the code would be littered with `type: ignore`
* in-place ops pose a problem, as they return None or a Series/DataFrame. For instance DataFrame.sort. Can we fix this with overloads?
* the Series constructor does not always return a Series, but can also return None according to the types, which causes issues in a number of places. This is somewhat unintuitive to me, but Im not sure whether this is valid.
* sometimes I could not figure out what to do, and plugged in `#type: ignore`; we can gradually take those out.
