### PR TITLE
lazy: sort_by multiple expressions

### DIFF
--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -57,8 +57,8 @@ pub enum AExpr {
     },
     SortBy {
         expr: Node,
-        by: Node,
-        reverse: bool,
+        by: Vec<Node>,
+        reverse: Vec<bool>,
     },
     Filter {
         input: Node,

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -47,7 +47,7 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         },
         Expr::SortBy { expr, by, reverse } => AExpr::SortBy {
             expr: to_aexpr(*expr, arena),
-            by: to_aexpr(*by, arena),
+            by: by.into_iter().map(|e| to_aexpr(e, arena)).collect(),
             reverse,
         },
         Expr::Filter { input, by } => AExpr::Filter {
@@ -467,10 +467,13 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
         }
         AExpr::SortBy { expr, by, reverse } => {
             let expr = node_to_exp(expr, expr_arena);
-            let by = node_to_exp(by, expr_arena);
+            let by = by
+                .iter()
+                .map(|node| node_to_exp(*node, expr_arena))
+                .collect();
             Expr::SortBy {
                 expr: Box::new(expr),
-                by: Box::new(by),
+                by,
                 reverse,
             }
         }

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -25,7 +25,9 @@ macro_rules! push_expr {
             }
             SortBy { expr, by, .. } => {
                 $push(expr);
-                $push(by)
+                for e in by {
+                    $push(e)
+                }
             }
             Agg(agg_e) => {
                 use AggExpr::*;
@@ -176,7 +178,9 @@ impl AExpr {
             }
             SortBy { expr, by, .. } => {
                 push(expr);
-                push(by);
+                for node in by {
+                    push(node)
+                }
             }
             Filter { input, by } => {
                 push(input);

--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -351,8 +351,8 @@ impl OptimizationRule for SimplifyExprRule {
                     }),
                     AExpr::SortBy { expr, by, reverse } => Some(AExpr::SortBy {
                         expr: *expr,
-                        by: *by,
-                        reverse: !*reverse,
+                        by: by.clone(),
+                        reverse: reverse.iter().map(|r| !*r).collect(),
                     }),
                     // TODO: add support for cumsum and other operation that allow reversing.
                     _ => None,

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -540,7 +540,7 @@ impl DefaultPlanner {
             }
             SortBy { expr, by, reverse } => {
                 let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                let phys_by = self.create_physical_expr(by, ctxt, expr_arena)?;
+                let phys_by = self.create_physical_expressions(&by, ctxt, expr_arena)?;
                 Ok(Arc::new(SortByExpr::new(
                     phys_expr,
                     phys_by,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -185,8 +185,9 @@ impl PyExpr {
         self.clone().inner.take(idx.inner).into()
     }
 
-    pub fn sort_by(&self, by: PyExpr, reverse: bool) -> PyExpr {
-        self.clone().inner.sort_by(by.inner, reverse).into()
+    pub fn sort_by(&self, by: Vec<PyExpr>, reverse: Vec<bool>) -> PyExpr {
+        let by = by.into_iter().map(|e| e.inner).collect::<Vec<_>>();
+        self.clone().inner.sort_by(by, reverse).into()
     }
 
     pub fn backward_fill(&self) -> PyExpr {

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -1,3 +1,5 @@
+from typing import List, Union
+
 import polars as pl
 
 
@@ -27,3 +29,23 @@ def test_sort_dates_multiples() -> None:
     # Date
     out = df.with_column(pl.col("date").cast(pl.Date)).sort(["date", "values"])  # type: ignore
     assert out["values"].to_list() == expected
+
+
+def test_sort_by() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 2, 3, 4, 5], "b": [1, 1, 1, 2, 2], "c": [2, 3, 1, 2, 1]}
+    )
+
+    by: List[Union[pl.Expr, str]]
+    for by in [["b", "c"], [pl.col("b"), "c"]]:  # type: ignore
+        out = df.select([pl.col("a").sort_by(by)])
+        assert out["a"].to_list() == [3, 1, 2, 5, 4]
+
+    out = df.select([pl.col("a").sort_by(by, reverse=[False])])
+    assert out["a"].to_list() == [3, 1, 2, 5, 4]
+
+    out = df.select([pl.col("a").sort_by(by, reverse=[True])])
+    assert out["a"].to_list() == [4, 5, 2, 1, 3]
+
+    out = df.select([pl.col("a").sort_by(by, reverse=[True, False])])
+    assert out["a"].to_list() == [5, 4, 3, 1, 2]


### PR DESCRIPTION
closes #1797 

Also use `par_iter` on `evaluate_on_groups`, so that's likey faster.