### PR TITLE
throw error when scanning compressed csv

### DIFF
--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -127,6 +127,11 @@ impl<'a> CoreReader<'a> {
         #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
         let mut reader_bytes = reader_bytes;
 
+        #[cfg(not(any(feature = "decompress", feature = "decompress-fast")))]
+        if is_compressed(&reader_bytes) {
+            return Err(PolarsError::ComputeError("cannot read compressed csv file; compile with feature 'decompress' or 'decompress-fast'".into()));
+        }
+
         // check if schema should be inferred
         let delimiter = delimiter.unwrap_or(b',');
 

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -149,7 +149,7 @@ impl<'a> LazyCsvReader<'a> {
         self
     }
 
-    pub fn finish(self) -> LazyFrame {
+    pub fn finish(self) -> Result<LazyFrame> {
         let mut lf: LazyFrame = LogicalPlanBuilder::scan_csv(
             self.path,
             self.delimiter,
@@ -165,11 +165,11 @@ impl<'a> LazyCsvReader<'a> {
             self.quote_char,
             self.null_values,
             self.infer_schema_length,
-        )
+        )?
         .build()
         .into();
         lf.opt_state.agg_scan_projection = true;
-        lf
+        Ok(lf)
     }
 }
 

--- a/polars/polars-lazy/src/test.rs
+++ b/polars/polars-lazy/src/test.rs
@@ -13,7 +13,7 @@ use std::iter::FromIterator;
 
 fn scan_foods_csv() -> LazyFrame {
     let path = "../../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv";
-    LazyCsvReader::new(path.to_string()).finish()
+    LazyCsvReader::new(path.to_string()).finish().unwrap()
 }
 
 pub(crate) fn fruits_cars() -> DataFrame {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -1,5 +1,6 @@
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsEr;
+use crate::lazy::dataframe::PyLazyFrame;
 use crate::prelude::*;
 use crate::series::PySeries;
 use polars::chunked_array::object::PolarsObjectSafe;
@@ -16,7 +17,6 @@ use pyo3::types::{PyDict, PySequence};
 use pyo3::{PyAny, PyResult};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use crate::lazy::dataframe::PyLazyFrame;
 
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude;
 pub mod series;
 pub mod utils;
 
-use crate::conversion::{get_df, get_pyseq, get_series, Wrap, get_lf};
+use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
 use crate::error::PyPolarsEr;
 use crate::file::get_either_file;
 use crate::prelude::{DataType, PyDataType};
@@ -196,7 +196,6 @@ fn concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 fn concat_lf(lfs: &PyAny, rechunk: bool) -> PyResult<PyLazyFrame> {
     let (seq, len) = get_pyseq(lfs)?;
     let mut lfs = Vec::with_capacity(len);
-
 
     for res in seq.iter()? {
         let item = res?;


### PR DESCRIPTION
Decompression requires all data read, so suggest `read_csv` if data is compressed.