### PR TITLE
Fix invalid csv scanning

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,6 +35,8 @@ jobs:
           cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0
+          echo "LAZY vs EAGER tests"
+          python lazy_vs_eager.py
           echo "ON STRINGS"
           python main.py on_strings
           echo "ON CATEGORICALS"

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -317,6 +317,7 @@ where
 }
 
 impl<'a> AnyValue<'a> {
+    #[cfg(any(feature = "dtype-date", feature = "dtype-datetime"))]
     pub(crate) fn into_date(self) -> Self {
         match self {
             #[cfg(feature = "dtype-date")]

--- a/polars/polars-core/src/series/into.rs
+++ b/polars/polars-core/src/series/into.rs
@@ -1,4 +1,9 @@
 use crate::prelude::*;
+#[cfg(any(
+    feature = "dtype-datetime",
+    feature = "dtype-date",
+    feature = "dtype-time"
+))]
 use polars_arrow::compute::cast::cast;
 
 impl Series {

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -8,6 +8,7 @@ use crate::chunked_array::ChunkIdIter;
 #[cfg(feature = "object")]
 use std::any::Any;
 use std::borrow::Cow;
+#[cfg(feature = "temporal")]
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -48,6 +48,7 @@ use crate::utils::resolve_homedir;
 use crate::{PhysicalIoExpr, ScanAggregation, SerReader, SerWriter};
 pub use arrow::io::csv::write;
 use polars_core::prelude::*;
+#[cfg(feature = "temporal")]
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Write;

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -429,7 +429,7 @@ where
             schema_overwrite: None,
             dtype_overwrite: None,
             sample_size: 1024,
-            chunk_size: 8192,
+            chunk_size: 1 << 16,
             low_memory: false,
             comment_char: None,
             null_values: None,
@@ -1263,6 +1263,7 @@ linenum,last_name,first_name
         Ok(())
     }
 
+    #[test]
     fn test_projection_and_quoting() -> Result<()> {
         let csv = "a,b,c,d
 A1,'B1',C1,1

--- a/polars/polars-io/src/csv_core/buffer.rs
+++ b/polars/polars-io/src/csv_core/buffer.rs
@@ -77,7 +77,6 @@ trait ParsedBuffer<T> {
         &mut self,
         bytes: &[u8],
         ignore_errors: bool,
-        start_pos: usize,
         _needs_escaping: bool,
     ) -> Result<()>;
 }
@@ -91,7 +90,6 @@ where
         &mut self,
         bytes: &[u8],
         ignore_errors: bool,
-        _start_pos: usize,
         _needs_escaping: bool,
     ) -> Result<()> {
         if bytes.is_empty() {
@@ -159,7 +157,6 @@ impl ParsedBuffer<Utf8Type> for Utf8Field {
         &mut self,
         bytes: &[u8],
         ignore_errors: bool,
-        _start_pos: usize,
         needs_escaping: bool,
     ) -> Result<()> {
         // Only for lossy utf8 we check utf8 now. Otherwise we check all utf8 at the end.
@@ -224,7 +221,6 @@ impl ParsedBuffer<BooleanType> for BooleanChunkedBuilder {
         &mut self,
         bytes: &[u8],
         ignore_errors: bool,
-        start_pos: usize,
         _needs_escaping: bool,
     ) -> Result<()> {
         if bytes.eq_ignore_ascii_case(b"false") {
@@ -236,8 +232,7 @@ impl ParsedBuffer<BooleanType> for BooleanChunkedBuilder {
         } else {
             return Err(PolarsError::ComputeError(
                 format!(
-                    "Error while parsing value {} at byte position {} as boolean",
-                    start_pos,
+                    "Error while parsing value {} as boolean",
                     String::from_utf8_lossy(bytes)
                 )
                 .into(),
@@ -400,7 +395,6 @@ impl Buffer {
         &mut self,
         bytes: &[u8],
         ignore_errors: bool,
-        start_pos: usize,
         needs_escaping: bool,
     ) -> Result<()> {
         use Buffer::*;
@@ -409,7 +403,6 @@ impl Buffer {
                 buf,
                 bytes,
                 ignore_errors,
-                start_pos,
                 needs_escaping,
             ),
             Int32(buf) => {
@@ -417,7 +410,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -426,7 +418,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -435,7 +426,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -444,7 +434,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -453,7 +442,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -462,7 +450,6 @@ impl Buffer {
                     buf,
                     bytes,
                     ignore_errors,
-                    start_pos,
                     needs_escaping,
                 )
             }
@@ -470,7 +457,6 @@ impl Buffer {
                 buf,
                 bytes,
                 ignore_errors,
-                start_pos,
                 needs_escaping,
             ),
         }

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -418,7 +418,7 @@ impl<'a> CoreReader<'a> {
                             let local_bytes = &bytes[read..stop_at_nbytes];
 
                             last_read = read;
-                            read = parse_lines(
+                            read += parse_lines(
                                 local_bytes,
                                 read,
                                 delimiter,
@@ -530,7 +530,7 @@ impl<'a> CoreReader<'a> {
                             let local_bytes = &bytes[read..stop_at_nbytes];
 
                             last_read = read;
-                            read = parse_lines(
+                            read += parse_lines(
                                 local_bytes,
                                 read,
                                 delimiter,
@@ -542,7 +542,7 @@ impl<'a> CoreReader<'a> {
                                 ignore_parser_errors,
                                 // chunk size doesn't really matter anymore,
                                 // less calls if we increase the size
-                                chunk_size * 320000,
+                                usize::MAX,
                             )?;
                         }
                         Ok(DataFrame::new_no_checks(

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -5,6 +5,7 @@ use crate::logical_plan::IpcOptions;
 use crate::utils::try_path_to_str;
 use polars_io::prelude::*;
 use polars_io::{csv::CsvEncoding, ScanAggregation};
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 use std::fs::File;
 use std::mem;
 use std::path::Path;
@@ -23,11 +24,16 @@ fn cache_hit(
     (cache_key, cached)
 }
 
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 type Projection = Option<Vec<usize>>;
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 type StopNRows = Option<usize>;
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 type Aggregation<'a> = Option<&'a [ScanAggregation]>;
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 type Predicate = Option<Arc<dyn PhysicalIoExpr>>;
 
+#[cfg(any(feature = "ipc", feature = "parquet"))]
 fn prepare_scan_args<'a>(
     path: &Path,
     predicate: &Option<Arc<dyn PhysicalExpr>>,

--- a/py-polars/tests/db-benchmark/lazy_vs_eager.py
+++ b/py-polars/tests/db-benchmark/lazy_vs_eager.py
@@ -1,0 +1,9 @@
+import polars as pl
+
+path = "G1_1e7_1e2_5_0.csv"
+predicate = pl.col("v2") < 5
+
+shape_eager = pl.read_csv(path).filter(predicate).shape
+
+shape_lazy = (pl.scan_csv(path).filter(predicate)).collect().shape
+assert shape_lazy == shape_eager


### PR DESCRIPTION
Fixes #1808.

Also adds a test in CI where we compare eager vs lazy outputs. We can extend this and run agains the db-benchmark csv, which is quite large.