### PR TITLE
Enable mypy on tests (part 2)

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -13,6 +13,44 @@ from polars.eager.frame import DataFrame, wrap_df
 from polars.eager.series import Series, wrap_s
 from polars.lazy.expr import Expr, wrap_expr
 from polars.lazy.frame import LazyFrame, wrap_ldf
+from polars.lazy.functions import (
+    all,
+    any,
+    apply,
+    arange,
+    argsort_by,
+    avg,
+    col,
+    collect_all,
+    concat_list,
+    concat_str,
+    count,
+    cov,
+    exclude,
+    first,
+    fold,
+    format,
+    groups,
+    head,
+    last,
+    lit,
+    map,
+    map_binary,
+    max,
+    mean,
+    median,
+    min,
+    n_unique,
+    pearson_corr,
+    quantile,
+    select,
+    spearman_rank_corr,
+    std,
+    sum,
+    tail,
+    to_list,
+    var,
+)
 
 from . import cfg, convert, datatypes, eager, functions, io, lazy, string_cache
 from .cfg import *

--- a/py-polars/polars/eager/frame.py
+++ b/py-polars/polars/eager/frame.py
@@ -1511,7 +1511,7 @@ class DataFrame:
         by: Union[str, "pl.Expr", tp.List[str], tp.List["pl.Expr"]],
         reverse: Union[bool, tp.List[bool]] = False,
         in_place: bool = False,
-    ) -> Optional["DataFrame"]:
+    ) -> "DataFrame":
         """
         Sort the DataFrame by column.
 
@@ -1560,11 +1560,11 @@ class DataFrame:
             )
             if in_place:
                 self._df = df._df
-                return None
+                return self
             return df
         if in_place:
             self._df.sort_in_place(by, reverse)
-            return None
+            return self
         else:
             return wrap_df(self._df.sort(by, reverse))
 
@@ -2457,7 +2457,7 @@ class DataFrame:
             return self.fill_null(pl.lit(strategy))
         return wrap_df(self._df.fill_null(strategy))
 
-    def fill_nan(self, fill_value: "pl.Expr") -> "DataFrame":
+    def fill_nan(self, fill_value: Union["pl.Expr", int, float]) -> "DataFrame":
         """
         Fill None/missing values by a an Expression evaluation.
 
@@ -2690,7 +2690,15 @@ class DataFrame:
         return pl.lazy.frame.wrap_ldf(self._df.lazy())
 
     def select(
-        self, exprs: Union[str, "pl.Expr", Sequence[str], Sequence["pl.Expr"]]
+        self,
+        exprs: Union[
+            str,
+            "pl.Expr",
+            Sequence[Union[str, "pl.Expr"]],
+            Sequence[bool],
+            Sequence[int],
+            Sequence[float],
+        ],
     ) -> "DataFrame":
         """
         Select columns from this DataFrame.
@@ -2723,7 +2731,7 @@ class DataFrame:
 
         """
         return (
-            self.lazy().select(exprs).collect(no_optimization=True, string_cache=False)
+            self.lazy().select(exprs).collect(no_optimization=True, string_cache=False)  # type: ignore
         )
 
     def with_columns(self, exprs: Union["pl.Expr", tp.List["pl.Expr"]]) -> "DataFrame":
@@ -3412,7 +3420,7 @@ class GroupBy:
         >>> .agg([pl.sum("ham"), col("spam").tail(4).sum()])
 
         >>> # use a dict
-        >>> (df.groupby(["foo", "bar])
+        >>> (df.groupby(["foo", "bar"])
         >>> .agg({"spam": ["sum", "min"})
 
         """

--- a/py-polars/polars/lazy/expr.py
+++ b/py-polars/polars/lazy/expr.py
@@ -642,7 +642,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.round(decimals))
 
-    def dot(self, other: "Expr") -> "Expr":
+    def dot(self, other: Union["Expr", str]) -> "Expr":
         """
         Compute the dot/inner product between two Expressions
 
@@ -924,7 +924,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.list())
 
-    def over(self, expr: Union[str, "Expr", tp.List["Expr"]]) -> "Expr":
+    def over(self, expr: Union[str, "Expr", tp.List[Union["Expr", str]]]) -> "Expr":
         """
         Apply window function over a subgroup.
         This is similar to a groupby + aggregation + self join.
@@ -1176,7 +1176,7 @@ class Expr:
             other = expr_to_lit_or_expr(other, str_to_lit=False)
         return wrap_expr(self._pyexpr.is_in(other._pyexpr))
 
-    def repeat_by(self, by: "Expr") -> "Expr":
+    def repeat_by(self, by: Union["Expr", str]) -> "Expr":
         """
         Repeat the elements in this Series `n` times by dictated by the number given by `by`.
         The elements are expanded into a `List`
@@ -2336,7 +2336,7 @@ class ExprDateTimeNameSpace:
 
 
 def expr_to_lit_or_expr(
-    expr: Union[Expr, int, float, str, tp.List[Expr], tp.List[str], "pl.Series"],
+    expr: Union[Expr, bool, int, float, str, tp.List[Expr], tp.List[str], "pl.Series"],
     str_to_lit: bool = True,
 ) -> Expr:
     """

--- a/py-polars/polars/lazy/frame.py
+++ b/py-polars/polars/lazy/frame.py
@@ -797,7 +797,7 @@ class LazyFrame:
             fill_value = lit(fill_value)
         return wrap_ldf(self._ldf.fill_null(fill_value._pyexpr))
 
-    def fill_nan(self, fill_value: Union[int, str, "Expr"]) -> "LazyFrame":
+    def fill_nan(self, fill_value: Union[int, str, float, "Expr"]) -> "LazyFrame":
         """
         Fill floating point NaN values.
 

--- a/py-polars/polars/lazy/functions.py
+++ b/py-polars/polars/lazy/functions.py
@@ -74,7 +74,7 @@ __all__ = [
 
 
 def col(
-    name: Union[str, tp.List[str], tp.List[Type[DataType]], Type[DataType]]
+    name: Union[str, tp.List[str], tp.List[Type[DataType]], "pl.Series", Type[DataType]]
 ) -> "pl.Expr":
     """
     A column in a DataFrame.
@@ -163,7 +163,7 @@ def col(
 
     """
     if isinstance(name, pl.Series):
-        name = name.to_list()
+        name = name.to_list()  # type: ignore
 
     if isclass(name) and issubclass(name, DataType):  # type: ignore
         name = [name]  # type: ignore
@@ -176,6 +176,16 @@ def col(
         else:
             raise ValueError("did expect argument of List[str] or List[DataType]")
     return pl.lazy.expr.wrap_expr(pycol(name))
+
+
+@tp.overload
+def count(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def count(column: "pl.Series") -> int:
+    ...
 
 
 def count(column: Union[str, "pl.Series"] = "") -> Union["pl.Expr", int]:
@@ -196,6 +206,16 @@ def to_list(name: str) -> "pl.Expr":
     return col(name).list()
 
 
+@tp.overload
+def std(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def std(column: "pl.Series") -> Optional[float]:
+    ...
+
+
 def std(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Optional[float]]:
     """
     Get the standard deviation.
@@ -203,6 +223,16 @@ def std(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Optional[float]]:
     if isinstance(column, pl.Series):
         return column.std()
     return col(column).std()
+
+
+@tp.overload
+def var(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def var(column: "pl.Series") -> Optional[float]:
+    ...
 
 
 def var(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Optional[float]]:
@@ -214,7 +244,19 @@ def var(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Optional[float]]:
     return col(column).var()
 
 
-def max(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr", Any]:
+@tp.overload
+def max(column: Union[str, tp.List[Union["pl.Expr", str]]]) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def max(column: "pl.Series") -> Union[int, float]:
+    ...
+
+
+def max(
+    column: Union[str, tp.List[Union["pl.Expr", str]], "pl.Series"]
+) -> Union["pl.Expr", Any]:
     """
     Get the maximum value. Can be used horizontally or vertically.
 
@@ -242,7 +284,19 @@ def max(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr",
         return col(column).max()
 
 
-def min(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr", Any]:
+@tp.overload
+def min(column: Union[str, tp.List[Union["pl.Expr", str]]]) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def min(column: "pl.Series") -> Union[int, float]:
+    ...
+
+
+def min(
+    column: Union[str, tp.List[Union["pl.Expr", str]], "pl.Series"]
+) -> Union["pl.Expr", Any]:
     """
     Get the minimum value.
 
@@ -268,7 +322,19 @@ def min(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr",
         return col(column).min()
 
 
-def sum(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr", Any]:
+@tp.overload
+def sum(column: Union[str, tp.List[Union["pl.Expr", str]]]) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def sum(column: "pl.Series") -> Union[int, float]:
+    ...
+
+
+def sum(
+    column: Union[str, tp.List[Union["pl.Expr", str]], "pl.Series"]
+) -> Union["pl.Expr", Any]:
     """
     Get the sum value.
 
@@ -289,6 +355,16 @@ def sum(column: Union[str, tp.List["pl.Expr"], "pl.Series"]) -> Union["pl.Expr",
         return col(column).sum()
 
 
+@tp.overload
+def mean(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def mean(column: "pl.Series") -> float:
+    ...
+
+
 def mean(column: Union[str, "pl.Series"]) -> Union["pl.Expr", float]:
     """
     Get the mean value.
@@ -298,11 +374,31 @@ def mean(column: Union[str, "pl.Series"]) -> Union["pl.Expr", float]:
     return col(column).mean()
 
 
+@tp.overload
+def avg(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def avg(column: "pl.Series") -> float:
+    ...
+
+
 def avg(column: Union[str, "pl.Series"]) -> Union["pl.Expr", float]:
     """
     Alias for mean.
     """
     return mean(column)
+
+
+@tp.overload
+def median(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def median(column: "pl.Series") -> Union[float, int]:
+    ...
 
 
 def median(column: Union[str, "pl.Series"]) -> Union["pl.Expr", float, int]:
@@ -314,11 +410,31 @@ def median(column: Union[str, "pl.Series"]) -> Union["pl.Expr", float, int]:
     return col(column).median()
 
 
+@tp.overload
+def n_unique(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def n_unique(column: "pl.Series") -> int:
+    ...
+
+
 def n_unique(column: Union[str, "pl.Series"]) -> Union["pl.Expr", int]:
     """Count unique values."""
     if isinstance(column, pl.Series):
         return column.n_unique()
     return col(column).n_unique()
+
+
+@tp.overload
+def first(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def first(column: "pl.Series") -> Any:
+    ...
 
 
 def first(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Any]:
@@ -331,6 +447,16 @@ def first(column: Union[str, "pl.Series"]) -> Union["pl.Expr", Any]:
         else:
             raise IndexError("The series is empty, so no first value can be returned.")
     return col(column).first()
+
+
+@tp.overload
+def last(column: str) -> "pl.Expr":
+    ...
+
+
+@tp.overload
+def last(column: "pl.Series") -> Any:
+    ...
 
 
 def last(column: Union[str, "pl.Series"]) -> "pl.Expr":
@@ -590,7 +716,7 @@ def map_binary(
 def fold(
     acc: "pl.Expr",
     f: Callable[["pl.Series", "pl.Series"], "pl.Series"],
-    exprs: Union[tp.List["pl.Expr"], "pl.Expr"],
+    exprs: Union[tp.Sequence[Union["pl.Expr", str]], "pl.Expr"],
 ) -> "pl.Expr":
     """
     Accumulate over multiple columns horizontally/ row wise with a left fold.
@@ -760,7 +886,7 @@ def arange(
 
 
 def argsort_by(
-    exprs: tp.List["pl.Expr"], reverse: Union[tp.List[bool], bool] = False
+    exprs: tp.List[Union["pl.Expr", str]], reverse: Union[tp.List[bool], bool] = False
 ) -> "pl.Expr":
     """
     Find the indexes that would sort the columns.
@@ -855,7 +981,7 @@ def _date(year: "pl.Expr", month: "pl.Expr", day: "pl.Expr") -> "pl.Expr":
     return _datetime(year, month, day).cast(pl.Date).alias("date")
 
 
-def concat_str(exprs: tp.List["pl.Expr"], sep: str = "") -> "pl.Expr":
+def concat_str(exprs: tp.Sequence[Union["pl.Expr", str]], sep: str = "") -> "pl.Expr":
     """
     Concat Utf8 Series in linear time. Non utf8 columns are cast to utf8.
 

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -15,7 +15,7 @@ def test_apply_none() -> None:
     out = (
         df.groupby("g", maintain_order=True).agg(
             pl.apply(  # type: ignore
-                exprs=["a", pl.col("b") ** 4, pl.col("a") / 4],
+                exprs=["a", pl.col("b") ** 4, pl.col("a") / 4],  # type: ignore
                 f=lambda x: x[0] * x[1] + x[2].sum(),
             ).alias("multiple")
         )

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -840,7 +840,7 @@ def test_literal_series() -> None:
     )
     out = (
         df.lazy()
-        .with_column(pl.Series("e", [2, 1, 3]))  # type: ignore  # TODO: is this allowed?
+        .with_column(pl.Series("e", [2, 1, 3]))  # type: ignore
         .with_column(pl.col("e").cast(pl.Float32))
         .collect()
     )

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1,4 +1,3 @@
-# type: ignore
 import numpy as np
 import pytest
 
@@ -416,33 +415,33 @@ def test_fill_null() -> None:
     assert df.select([pl.col("a").fill_null("min")])["a"][1] == 1.0
 
 
-def test_take(fruits_cars) -> None:
+def test_take(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
 
     # out of bounds error
     with pytest.raises(RuntimeError):
         (
             df.sort("fruits").select(
-                [col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]
+                [col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]  # type: ignore
             )
         )
 
     out = df.sort("fruits").select(
-        [col("B").reverse().take([0, 1]).list().over("fruits"), "fruits"]
+        [col("B").reverse().take([0, 1]).list().over("fruits"), "fruits"]  # type: ignore
     )
 
     assert out[0, "B"] == [2, 3]
     assert out[4, "B"] == [1, 4]
 
 
-def test_select_by_col_list(fruits_cars) -> None:
+def test_select_by_col_list(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
     out = df.select(col(["A", "B"]).sum())
     assert out.columns == ["A", "B"]
     assert out.shape == (1, 2)
 
 
-def test_rolling(fruits_cars) -> None:
+def test_rolling(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
     assert df.select(
         [
@@ -471,10 +470,10 @@ def test_rolling_apply() -> None:
     assert out[2] == 4.358898943540674
 
 
-def test_arr_namespace(fruits_cars) -> None:
+def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
     out = df.select(
-        [
+        [  # type: ignore
             "fruits",
             col("B").over("fruits").arr.min().alias("B_by_fruits_min1"),
             col("B").min().over("fruits").alias("B_by_fruits_min2"),
@@ -552,7 +551,7 @@ def test_arithmetic() -> None:
 
 def test_ufunc() -> None:
     df = pl.DataFrame({"a": [1, 2]})
-    out = df.select(np.log(col("a")))
+    out = df.select(np.log(col("a")))  # type: ignore
     assert out["a"][1] == 0.6931471805599453
 
 
@@ -635,7 +634,7 @@ def test_str_concat() -> None:
     assert df[0, 0] == "1-null-2"
 
 
-def test_collect_all(df) -> None:
+def test_collect_all(df: pl.DataFrame) -> None:
     lf1 = df.lazy().select(pl.col("int").sum())
     lf2 = df.lazy().select((pl.col("floats") * 2).sum())
     out = pl.collect_all([lf1, lf2])
@@ -661,10 +660,10 @@ def test_spearman_corr() -> None:
     assert np.isclose(out[1], -1.0)
 
 
-def test_lazy_concat(df) -> None:
+def test_lazy_concat(df: pl.DataFrame) -> None:
     shape = df.shape
     shape = (shape[0] * 2, shape[1])
 
-    out = pl.concat([df.lazy(), df.lazy()]).collect()
+    out = pl.concat([df.lazy(), df.lazy()]).collect()  # type: ignore
     assert out.shape == shape
     assert out.frame_equal(df.vstack(df.clone()), null_equal=True)


### PR DESCRIPTION
* All test files are now being checked, so going forward all new unit tests will be type checked.
* Have used some more `#type: ignore` where I could not fix individual cases.

As in the first PR, I think best to merge and iterate. The problems are now more focused.