### PR TITLE
[Rust] Rename `ChunkCompare::eq` to `ChunkCompare::equal`

### DIFF
--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -86,19 +86,19 @@ where
         }
     }
 
-    fn neq(&self, rhs: &ChunkedArray<T>) -> BooleanChunked {
+    fn not_equal(&self, rhs: &ChunkedArray<T>) -> BooleanChunked {
         // broadcast
         match (self.len(), rhs.len()) {
             (_, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.neq(value)
+                    self.not_equal(value)
                 } else {
                     BooleanChunked::full("", false, self.len())
                 }
             }
             (1, _) => {
                 if let Some(value) = self.get(0) {
-                    rhs.neq(value)
+                    rhs.not_equal(value)
                 } else {
                     BooleanChunked::full("", false, rhs.len())
                 }
@@ -262,7 +262,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
         }
     }
 
-    fn neq(&self, rhs: &BooleanChunked) -> BooleanChunked {
+    fn not_equal(&self, rhs: &BooleanChunked) -> BooleanChunked {
         // broadcast
         match (self.len(), rhs.len()) {
             (_, 1) => {
@@ -474,17 +474,17 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
         }
     }
 
-    fn neq(&self, rhs: &Utf8Chunked) -> BooleanChunked {
+    fn not_equal(&self, rhs: &Utf8Chunked) -> BooleanChunked {
         // broadcast
         if rhs.len() == 1 {
             if let Some(value) = rhs.get(0) {
-                self.neq(value)
+                self.not_equal(value)
             } else {
                 BooleanChunked::full("", false, self.len())
             }
         } else if self.len() == 1 {
             if let Some(value) = self.get(0) {
-                rhs.neq(value)
+                rhs.not_equal(value)
             } else {
                 BooleanChunked::full("", false, self.len())
             }
@@ -619,7 +619,7 @@ where
         self.primitive_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
     }
 
-    fn neq(&self, rhs: Rhs) -> BooleanChunked {
+    fn not_equal(&self, rhs: Rhs) -> BooleanChunked {
         self.primitive_compare_scalar(rhs, |l, rhs| comparison::neq_scalar(l, rhs))
     }
 
@@ -659,7 +659,7 @@ impl ChunkCompare<&str> for Utf8Chunked {
     fn equal(&self, rhs: &str) -> BooleanChunked {
         self.utf8_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
     }
-    fn neq(&self, rhs: &str) -> BooleanChunked {
+    fn not_equal(&self, rhs: &str) -> BooleanChunked {
         self.utf8_compare_scalar(rhs, |l, rhs| comparison::neq_scalar(l, rhs))
     }
 
@@ -721,7 +721,7 @@ impl ChunkCompare<&ListChunked> for ListChunked {
         impl_cmp_list!(self, rhs, series_equal)
     }
 
-    fn neq(&self, rhs: &ListChunked) -> BooleanChunked {
+    fn not_equal(&self, rhs: &ListChunked) -> BooleanChunked {
         self.equal(rhs).not()
     }
 
@@ -869,11 +869,11 @@ mod test {
             repeat(Some(true)).take(6).collect_vec()
         );
         assert_eq!(
-            a1.neq(&a2).into_iter().collect_vec(),
+            a1.not_equal(&a2).into_iter().collect_vec(),
             repeat(Some(false)).take(6).collect_vec()
         );
         assert_eq!(
-            a2.neq(&a1).into_iter().collect_vec(),
+            a2.not_equal(&a1).into_iter().collect_vec(),
             repeat(Some(false)).take(6).collect_vec()
         );
         assert_eq!(
@@ -924,11 +924,11 @@ mod test {
             repeat(Some(true)).take(3).collect_vec()
         );
         assert_eq!(
-            a1.neq(&a2).into_iter().collect_vec(),
+            a1.not_equal(&a2).into_iter().collect_vec(),
             repeat(Some(false)).take(3).collect_vec()
         );
         assert_eq!(
-            a2.neq(&a1).into_iter().collect_vec(),
+            a2.not_equal(&a1).into_iter().collect_vec(),
             repeat(Some(false)).take(3).collect_vec()
         );
         assert_eq!(
@@ -984,12 +984,12 @@ mod test {
         );
 
         assert_eq!(
-            a1.neq(&a2).into_iter().collect_vec(),
-            a1.neq(&a2_2chunks).into_iter().collect_vec()
+            a1.not_equal(&a2).into_iter().collect_vec(),
+            a1.not_equal(&a2_2chunks).into_iter().collect_vec()
         );
         assert_eq!(
-            a1.neq(&a2).into_iter().collect_vec(),
-            a2_2chunks.neq(&a1).into_iter().collect_vec()
+            a1.not_equal(&a2).into_iter().collect_vec(),
+            a2_2chunks.not_equal(&a1).into_iter().collect_vec()
         );
 
         assert_eq!(
@@ -1037,7 +1037,7 @@ mod test {
         let a1 = a1.slice(1, 1);
         let a2: Int32Chunked = (&[Some(2)]).iter().copied().collect();
         assert_eq!(a1.equal(&a2).sum(), a2.equal(&a1).sum());
-        assert_eq!(a1.neq(&a2).sum(), a2.neq(&a1).sum());
+        assert_eq!(a1.not_equal(&a2).sum(), a2.not_equal(&a1).sum());
         assert_eq!(a1.gt(&a2).sum(), a2.gt(&a1).sum());
         assert_eq!(a1.lt(&a2).sum(), a2.lt(&a1).sum());
         assert_eq!(a1.lt_eq(&a2).sum(), a2.lt_eq(&a1).sum());
@@ -1047,7 +1047,7 @@ mod test {
         let a1 = a1.slice(1, 1);
         let a2: Utf8Chunked = (&["b"]).iter().copied().collect();
         assert_eq!(a1.equal(&a2).sum(), a2.equal(&a1).sum());
-        assert_eq!(a1.neq(&a2).sum(), a2.neq(&a1).sum());
+        assert_eq!(a1.not_equal(&a2).sum(), a2.not_equal(&a1).sum());
         assert_eq!(a1.gt(&a2).sum(), a2.gt(&a1).sum());
         assert_eq!(a1.lt(&a2).sum(), a2.lt(&a1).sum());
         assert_eq!(a1.lt_eq(&a2).sum(), a2.lt_eq(&a1).sum());
@@ -1082,13 +1082,13 @@ mod test {
         let out = false_.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
 
-        let out = a.neq(&true_);
+        let out = a.not_equal(&true_);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
-        let out = true_.neq(&a);
+        let out = true_.not_equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
-        let out = a.neq(&false_);
+        let out = a.not_equal(&false_);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
-        let out = false_.neq(&a);
+        let out = false_.not_equal(&a);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
 
         let out = a.gt(&true_);
@@ -1143,13 +1143,13 @@ mod test {
         let out = three.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(false), Some(true)]);
 
-        let out = a.neq(&one);
+        let out = a.not_equal(&one);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(true)]);
-        let out = one.neq(&a);
+        let out = one.not_equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(true)]);
-        let out = a.neq(&three);
+        let out = a.not_equal(&three);
         assert_eq!(Vec::from(&out), &[Some(true), Some(true), Some(false)]);
-        let out = three.neq(&a);
+        let out = three.not_equal(&a);
         assert_eq!(Vec::from(&out), &[Some(true), Some(true), Some(false)]);
 
         let out = a.gt(&one);

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -61,19 +61,19 @@ where
         impl_eq_missing!(self, rhs)
     }
 
-    fn eq(&self, rhs: &ChunkedArray<T>) -> BooleanChunked {
+    fn equal(&self, rhs: &ChunkedArray<T>) -> BooleanChunked {
         // broadcast
         match (self.len(), rhs.len()) {
             (_, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.eq(value)
+                    self.equal(value)
                 } else {
                     BooleanChunked::full("", false, self.len())
                 }
             }
             (1, _) => {
                 if let Some(value) = self.get(0) {
-                    rhs.eq(value)
+                    rhs.equal(value)
                 } else {
                     BooleanChunked::full("", false, rhs.len())
                 }
@@ -231,7 +231,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
         impl_eq_missing!(self, rhs)
     }
 
-    fn eq(&self, rhs: &BooleanChunked) -> BooleanChunked {
+    fn equal(&self, rhs: &BooleanChunked) -> BooleanChunked {
         // broadcast
         match (self.len(), rhs.len()) {
             (_, 1) => {
@@ -451,17 +451,17 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
         impl_eq_missing!(self, rhs)
     }
 
-    fn eq(&self, rhs: &Utf8Chunked) -> BooleanChunked {
+    fn equal(&self, rhs: &Utf8Chunked) -> BooleanChunked {
         // broadcast
         if rhs.len() == 1 {
             if let Some(value) = rhs.get(0) {
-                self.eq(value)
+                self.equal(value)
             } else {
                 BooleanChunked::full("", false, self.len())
             }
         } else if self.len() == 1 {
             if let Some(value) = self.get(0) {
-                rhs.eq(value)
+                rhs.equal(value)
             } else {
                 BooleanChunked::full("", false, self.len())
             }
@@ -612,10 +612,10 @@ where
     Rhs: ToPrimitive,
 {
     fn eq_missing(&self, rhs: Rhs) -> BooleanChunked {
-        self.eq(rhs)
+        self.equal(rhs)
     }
 
-    fn eq(&self, rhs: Rhs) -> BooleanChunked {
+    fn equal(&self, rhs: Rhs) -> BooleanChunked {
         self.primitive_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
     }
 
@@ -653,10 +653,10 @@ impl Utf8Chunked {
 
 impl ChunkCompare<&str> for Utf8Chunked {
     fn eq_missing(&self, rhs: &str) -> BooleanChunked {
-        self.eq(rhs)
+        self.equal(rhs)
     }
 
-    fn eq(&self, rhs: &str) -> BooleanChunked {
+    fn equal(&self, rhs: &str) -> BooleanChunked {
         self.utf8_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
     }
     fn neq(&self, rhs: &str) -> BooleanChunked {
@@ -717,12 +717,12 @@ impl ChunkCompare<&ListChunked> for ListChunked {
         impl_cmp_list!(self, rhs, series_equal_missing)
     }
 
-    fn eq(&self, rhs: &ListChunked) -> BooleanChunked {
+    fn equal(&self, rhs: &ListChunked) -> BooleanChunked {
         impl_cmp_list!(self, rhs, series_equal)
     }
 
     fn neq(&self, rhs: &ListChunked) -> BooleanChunked {
-        self.eq(rhs).not()
+        self.equal(rhs).not()
     }
 
     // following are not implemented because gt, lt comparison of series don't make sense
@@ -861,11 +861,11 @@ mod test {
         let (a1, a2) = create_two_chunked();
 
         assert_eq!(
-            a1.eq(&a2).into_iter().collect_vec(),
+            a1.equal(&a2).into_iter().collect_vec(),
             repeat(Some(true)).take(6).collect_vec()
         );
         assert_eq!(
-            a2.eq(&a1).into_iter().collect_vec(),
+            a2.equal(&a1).into_iter().collect_vec(),
             repeat(Some(true)).take(6).collect_vec()
         );
         assert_eq!(
@@ -916,11 +916,11 @@ mod test {
         let a2 = get_chunked_array();
 
         assert_eq!(
-            a1.eq(&a2).into_iter().collect_vec(),
+            a1.equal(&a2).into_iter().collect_vec(),
             repeat(Some(true)).take(3).collect_vec()
         );
         assert_eq!(
-            a2.eq(&a1).into_iter().collect_vec(),
+            a2.equal(&a1).into_iter().collect_vec(),
             repeat(Some(true)).take(3).collect_vec()
         );
         assert_eq!(
@@ -979,8 +979,8 @@ mod test {
         a2_2chunks.append(&(&[Some(3)]).iter().copied().collect());
 
         assert_eq!(
-            a1.eq(&a2).into_iter().collect_vec(),
-            a1.eq(&a2_2chunks).into_iter().collect_vec()
+            a1.equal(&a2).into_iter().collect_vec(),
+            a1.equal(&a2_2chunks).into_iter().collect_vec()
         );
 
         assert_eq!(
@@ -1036,7 +1036,7 @@ mod test {
         let a1: Int32Chunked = (&[Some(1), Some(2)]).iter().copied().collect();
         let a1 = a1.slice(1, 1);
         let a2: Int32Chunked = (&[Some(2)]).iter().copied().collect();
-        assert_eq!(a1.eq(&a2).sum(), a2.eq(&a1).sum());
+        assert_eq!(a1.equal(&a2).sum(), a2.equal(&a1).sum());
         assert_eq!(a1.neq(&a2).sum(), a2.neq(&a1).sum());
         assert_eq!(a1.gt(&a2).sum(), a2.gt(&a1).sum());
         assert_eq!(a1.lt(&a2).sum(), a2.lt(&a1).sum());
@@ -1046,7 +1046,7 @@ mod test {
         let a1: Utf8Chunked = (&["a", "b"]).iter().copied().collect();
         let a1 = a1.slice(1, 1);
         let a2: Utf8Chunked = (&["b"]).iter().copied().collect();
-        assert_eq!(a1.eq(&a2).sum(), a2.eq(&a1).sum());
+        assert_eq!(a1.equal(&a2).sum(), a2.equal(&a1).sum());
         assert_eq!(a1.neq(&a2).sum(), a2.neq(&a1).sum());
         assert_eq!(a1.gt(&a2).sum(), a2.gt(&a1).sum());
         assert_eq!(a1.lt(&a2).sum(), a2.lt(&a1).sum());
@@ -1073,13 +1073,13 @@ mod test {
         let true_ = BooleanChunked::new_from_slice("", &[true]);
         let false_ = BooleanChunked::new_from_slice("", &[false]);
 
-        let out = a.eq(&true_);
+        let out = a.equal(&true_);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
-        let out = true_.eq(&a);
+        let out = true_.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
-        let out = a.eq(&false_);
+        let out = a.equal(&false_);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
-        let out = false_.eq(&a);
+        let out = false_.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
 
         let out = a.neq(&true_);
@@ -1134,13 +1134,13 @@ mod test {
         let one = Int32Chunked::new_from_slice("", &[1]);
         let three = Int32Chunked::new_from_slice("", &[3]);
 
-        let out = a.eq(&one);
+        let out = a.equal(&one);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(false)]);
-        let out = one.eq(&a);
+        let out = one.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(false)]);
-        let out = a.eq(&three);
+        let out = a.equal(&three);
         assert_eq!(Vec::from(&out), &[Some(false), Some(false), Some(true)]);
-        let out = three.eq(&a);
+        let out = three.equal(&a);
         assert_eq!(Vec::from(&out), &[Some(false), Some(false), Some(true)]);
 
         let out = a.neq(&one);

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -414,7 +414,7 @@ pub trait ChunkVar<T> {
 /// fn filter_all_ones(df: &DataFrame) -> Result<DataFrame> {
 ///     let mask = df
 ///     .column("column_a")?
-///     .eq(1);
+///     .equal(1);
 ///
 ///     df.filter(&mask)
 /// }
@@ -424,7 +424,7 @@ pub trait ChunkCompare<Rhs> {
     fn eq_missing(&self, rhs: Rhs) -> BooleanChunked;
 
     /// Check for equality.
-    fn eq(&self, rhs: Rhs) -> BooleanChunked;
+    fn equal(&self, rhs: Rhs) -> BooleanChunked;
 
     /// Check for inequality.
     fn neq(&self, rhs: Rhs) -> BooleanChunked;

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -427,7 +427,7 @@ pub trait ChunkCompare<Rhs> {
     fn equal(&self, rhs: Rhs) -> BooleanChunked;
 
     /// Check for inequality.
-    fn neq(&self, rhs: Rhs) -> BooleanChunked;
+    fn not_equal(&self, rhs: Rhs) -> BooleanChunked;
 
     /// Greater than comparison.
     fn gt(&self, rhs: Rhs) -> BooleanChunked;

--- a/polars/polars-core/src/chunked_array/ops/take/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_single.rs
@@ -188,7 +188,7 @@ mod test {
     fn test_oob() {
         let data: Series = [1.0, 2.0, 3.0].iter().collect();
         let data = data.f64().unwrap();
-        let matches = data.eq(5.0);
+        let matches = data.equal(5.0);
         let matches_indexes = matches.arg_true();
         matches_indexes.get(0);
     }

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -80,7 +80,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod) -> Series {
             // in bounds
             let arr = unsafe { s.take_unchecked(&sort_idx_ca).unwrap() };
             let not_consecutive_same = (&arr.slice(1, len - 1))
-                .neq(&arr.slice(0, len - 1))
+                .not_equal(&arr.slice(0, len - 1))
                 .rechunk();
             let obs = not_consecutive_same.downcast_iter().next().unwrap();
 
@@ -132,7 +132,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod) -> Series {
             let arr = unsafe { s.take_unchecked(&sort_idx_ca).unwrap() };
             let validity = arr.chunks()[0].validity().cloned();
             let not_consecutive_same = (&arr.slice(1, len - 1))
-                .neq(&arr.slice(0, len - 1))
+                .not_equal(&arr.slice(0, len - 1))
                 .rechunk();
             // this obs is shorter than that of scipy stats, because we can just start the cumsum by 1
             // instead of 0

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2156,7 +2156,7 @@ impl DataFrame {
                 // make sure that we do not divide by zero
                 // by replacing with None
                 let value_length = value_length
-                    .set(&value_length.eq(0), None)?
+                    .set(&value_length.equal(0), None)?
                     .into_series()
                     .cast(&DataType::Float64)?;
 
@@ -2508,7 +2508,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn test_select() {
         let df = create_frame();
-        assert_eq!(df.column("days").unwrap().eq(1).sum(), Some(1));
+        assert_eq!(df.column("days").unwrap().equal(1).sum(), Some(1));
     }
 
     #[test]
@@ -2517,7 +2517,7 @@ mod test {
         let df = create_frame();
         println!("{}", df.column("days").unwrap());
         println!("{:?}", df);
-        println!("{:?}", df.filter(&df.column("days").unwrap().eq(0)))
+        println!("{:?}", df.filter(&df.column("days").unwrap().equal(0)))
     }
 
     #[test]
@@ -2530,7 +2530,7 @@ mod test {
         println!("{}", df.column(col_name).unwrap());
         println!("{:?}", df);
 
-        df = df.filter(&df.column(col_name).unwrap().eq("")).unwrap();
+        df = df.filter(&df.column(col_name).unwrap().equal("")).unwrap();
         assert_eq!(df.column(col_name).unwrap().n_chunks(), 1);
         println!("{:?}", df);
     }

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -147,7 +147,7 @@ impl ChunkCompare<&Series> for Series {
     }
 
     /// Create a boolean mask by checking for inequality.
-    fn neq(&self, rhs: &Series) -> BooleanChunked {
+    fn not_equal(&self, rhs: &Series) -> BooleanChunked {
         #[cfg(feature = "dtype-categorical")]
         use DataType::*;
         match (self.dtype(), rhs.dtype(), self.len(), rhs.len()) {
@@ -157,7 +157,7 @@ impl ChunkCompare<&Series> for Series {
                     self,
                     rhs,
                     self.name(),
-                    |s, idx| s.neq(idx),
+                    |s, idx| s.not_equal(idx),
                     true,
                 );
             }
@@ -167,12 +167,12 @@ impl ChunkCompare<&Series> for Series {
                     rhs,
                     self,
                     self.name(),
-                    |s, idx| s.neq(idx),
+                    |s, idx| s.not_equal(idx),
                     true,
                 );
             }
             _ => {
-                impl_compare!(self, rhs, neq)
+                impl_compare!(self, rhs, not_equal)
             }
         }
     }
@@ -210,8 +210,8 @@ where
         apply_method_numeric_series!(self, equal, rhs)
     }
 
-    fn neq(&self, rhs: Rhs) -> BooleanChunked {
-        apply_method_numeric_series!(self, neq, rhs)
+    fn not_equal(&self, rhs: Rhs) -> BooleanChunked {
+        apply_method_numeric_series!(self, not_equal, rhs)
     }
 
     fn gt(&self, rhs: Rhs) -> BooleanChunked {
@@ -248,14 +248,18 @@ impl ChunkCompare<&str> for Series {
         }
     }
 
-    fn neq(&self, rhs: &str) -> BooleanChunked {
+    fn not_equal(&self, rhs: &str) -> BooleanChunked {
         use DataType::*;
         match self.dtype() {
-            Utf8 => self.utf8().unwrap().neq(rhs),
+            Utf8 => self.utf8().unwrap().not_equal(rhs),
             #[cfg(feature = "dtype-categorical")]
-            Categorical => {
-                compare_cat_to_str_value(self, rhs, self.name(), |lhs, idx| lhs.neq(idx), true)
-            }
+            Categorical => compare_cat_to_str_value(
+                self,
+                rhs,
+                self.name(),
+                |lhs, idx| lhs.not_equal(idx),
+                true,
+            ),
             _ => BooleanChunked::full(self.name(), false, self.len()),
         }
     }

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -116,7 +116,7 @@ impl ChunkCompare<&Series> for Series {
     }
 
     /// Create a boolean mask by checking for equality.
-    fn eq(&self, rhs: &Series) -> BooleanChunked {
+    fn equal(&self, rhs: &Series) -> BooleanChunked {
         #[cfg(feature = "dtype-categorical")]
         use DataType::*;
         match (self.dtype(), rhs.dtype(), self.len(), rhs.len()) {
@@ -126,7 +126,7 @@ impl ChunkCompare<&Series> for Series {
                     self,
                     rhs,
                     self.name(),
-                    |s, idx| s.eq(idx),
+                    |s, idx| s.equal(idx),
                     false,
                 );
             }
@@ -136,12 +136,12 @@ impl ChunkCompare<&Series> for Series {
                     rhs,
                     self,
                     self.name(),
-                    |s, idx| s.eq(idx),
+                    |s, idx| s.equal(idx),
                     false,
                 );
             }
             _ => {
-                impl_compare!(self, rhs, eq)
+                impl_compare!(self, rhs, equal)
             }
         }
     }
@@ -203,11 +203,11 @@ where
     Rhs: NumericNative,
 {
     fn eq_missing(&self, rhs: Rhs) -> BooleanChunked {
-        self.eq(rhs)
+        self.equal(rhs)
     }
 
-    fn eq(&self, rhs: Rhs) -> BooleanChunked {
-        apply_method_numeric_series!(self, eq, rhs)
+    fn equal(&self, rhs: Rhs) -> BooleanChunked {
+        apply_method_numeric_series!(self, equal, rhs)
     }
 
     fn neq(&self, rhs: Rhs) -> BooleanChunked {
@@ -233,16 +233,16 @@ where
 
 impl ChunkCompare<&str> for Series {
     fn eq_missing(&self, rhs: &str) -> BooleanChunked {
-        self.eq(rhs)
+        self.equal(rhs)
     }
 
-    fn eq(&self, rhs: &str) -> BooleanChunked {
+    fn equal(&self, rhs: &str) -> BooleanChunked {
         use DataType::*;
         match self.dtype() {
-            Utf8 => self.utf8().unwrap().eq(rhs),
+            Utf8 => self.utf8().unwrap().equal(rhs),
             #[cfg(feature = "dtype-categorical")]
             Categorical => {
-                compare_cat_to_str_value(self, rhs, self.name(), |lhs, idx| lhs.eq(idx), false)
+                compare_cat_to_str_value(self, rhs, self.name(), |lhs, idx| lhs.equal(idx), false)
             }
             _ => BooleanChunked::full(self.name(), false, self.len()),
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -80,7 +80,7 @@ use std::sync::Arc;
 /// # use polars_core::prelude::*;
 /// use itertools::Itertools;
 /// let s = Series::new("dollars", &[1, 2, 3]);
-/// let mask = s.eq(1);
+/// let mask = s.equal(1);
 /// let valid = [true, false, false].iter();
 /// assert!(mask
 ///     .into_iter()

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -18,7 +18,7 @@ impl Series {
         {
             return false;
         }
-        match self.eq(other).sum() {
+        match self.equal(other).sum() {
             None => false,
             Some(sum) => sum as usize == self.len(),
         }

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -35,7 +35,7 @@ pub(crate) fn apply_operator(left: &Series, right: &Series, op: Operator) -> Res
         Operator::Lt => Ok(ChunkCompare::<&Series>::lt(left, right).into_series()),
         Operator::LtEq => Ok(ChunkCompare::<&Series>::lt_eq(left, right).into_series()),
         Operator::Eq => Ok(ChunkCompare::<&Series>::equal(left, right).into_series()),
-        Operator::NotEq => Ok(ChunkCompare::<&Series>::neq(left, right).into_series()),
+        Operator::NotEq => Ok(ChunkCompare::<&Series>::not_equal(left, right).into_series()),
         Operator::Plus => Ok(left + right),
         Operator::Minus => Ok(left - right),
         Operator::Multiply => Ok(left * right),

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -34,7 +34,7 @@ pub(crate) fn apply_operator(left: &Series, right: &Series, op: Operator) -> Res
         Operator::GtEq => Ok(ChunkCompare::<&Series>::gt_eq(left, right).into_series()),
         Operator::Lt => Ok(ChunkCompare::<&Series>::lt(left, right).into_series()),
         Operator::LtEq => Ok(ChunkCompare::<&Series>::lt_eq(left, right).into_series()),
-        Operator::Eq => Ok(ChunkCompare::<&Series>::eq(left, right).into_series()),
+        Operator::Eq => Ok(ChunkCompare::<&Series>::equal(left, right).into_series()),
         Operator::NotEq => Ok(ChunkCompare::<&Series>::neq(left, right).into_series()),
         Operator::Plus => Ok(left + right),
         Operator::Minus => Ok(left - right),

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -588,7 +588,7 @@ impl PySeries {
         }
     }
     pub fn eq(&self, rhs: &PySeries) -> PyResult<Self> {
-        Ok(Self::new(self.series.eq(&rhs.series).into_series()))
+        Ok(Self::new(self.series.equal(&rhs.series).into_series()))
     }
 
     pub fn neq(&self, rhs: &PySeries) -> PyResult<Self> {
@@ -1634,7 +1634,7 @@ macro_rules! impl_eq_num {
         #[pymethods]
         impl PySeries {
             pub fn $name(&self, rhs: $type) -> PyResult<PySeries> {
-                Ok(PySeries::new(self.series.eq(rhs).into_series()))
+                Ok(PySeries::new(self.series.equal(rhs).into_series()))
             }
         }
     };

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -592,7 +592,7 @@ impl PySeries {
     }
 
     pub fn neq(&self, rhs: &PySeries) -> PyResult<Self> {
-        Ok(Self::new(self.series.neq(&rhs.series).into_series()))
+        Ok(Self::new(self.series.not_equal(&rhs.series).into_series()))
     }
 
     pub fn gt(&self, rhs: &PySeries) -> PyResult<Self> {
@@ -1658,7 +1658,7 @@ macro_rules! impl_neq_num {
         #[pymethods]
         impl PySeries {
             pub fn $name(&self, rhs: $type) -> PyResult<PySeries> {
-                Ok(PySeries::new(self.series.neq(rhs).into_series()))
+                Ok(PySeries::new(self.series.not_equal(rhs).into_series()))
             }
         }
     };


### PR DESCRIPTION
See #1816

I know that it might be a big change, but I think it is worth it with what will follow. It is only a name changing while all the powerful mechanics are still there.