### PR TITLE
improve numerical sort (nulls only): `~1.5-2x`

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -205,6 +205,10 @@ harness = false
 name = "take"
 harness = false
 
+[[bench]]
+name = "sort"
+harness = false
+
 [package.metadata.docs.rs]
 # not all because arrow 4.3 does not compile with simd
 # all-features = true

--- a/polars/benches/collect.rs
+++ b/polars/benches/collect.rs
@@ -22,7 +22,7 @@ fn bench_collect_optional_str(v: &[Option<String>]) {
     criterion::black_box(f());
 }
 
-fn create_array(size: i32, null_percentage: f32) -> Vec<Option<i32>> {
+pub fn create_array(size: i32, null_percentage: f32) -> Vec<Option<i32>> {
     let mut rng = StdRng::seed_from_u64(0);
     (0..size)
         .map(|i| {

--- a/polars/benches/sort.rs
+++ b/polars/benches/sort.rs
@@ -1,0 +1,29 @@
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use polars::prelude::*;
+
+fn bench_sort(s: &Int32Chunked) {
+    criterion::black_box(s.sort(false));
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let ca = Int32Chunked::init_rand(size, 0.0, 10);
+
+        c.bench_function(&format!("sort 2^{} i32", log2_size), |b| {
+            b.iter(|| bench_sort(&ca))
+        });
+
+        let ca = Int32Chunked::init_rand(size, 0.1, 10);
+        c.bench_function(&format!("sort null 2^{} i32", log2_size), |b| {
+            b.iter(|| bench_sort(&ca))
+        });
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -496,8 +496,19 @@ pub trait ToDummies<T>: ChunkUnique<T> {
     }
 }
 
+#[derive(Default)]
+pub struct SortOptions {
+    descending: bool,
+    nulls_last: bool,
+}
+
 /// Sort operations on `ChunkedArray`.
 pub trait ChunkSort<T> {
+    #[allow(unused_variables)]
+    fn sort_with(&self, options: SortOptions) -> ChunkedArray<T> {
+        unimplemented!()
+    }
+
     /// Returned a sorted `ChunkedArray`.
     fn sort(&self, reverse: bool) -> ChunkedArray<T>;
 


### PR DESCRIPTION
Also sets up for more control over sorting, e.g. null handling. 

This doesn't improve sorting a `DataFrame` as in that algorithm we also store the indexes and need to know the indexes of the null values.

```
Gnuplot not found, using plotters backend
sort 2^10 i32           time:   [8.3604 us 8.3902 us 8.4344 us]                           
                        change: [+4.3972% +4.7180% +5.1695%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

sort null 2^10 i32      time:   [8.7783 us 8.7808 us 8.7834 us]                                
                        change: [-49.084% -48.883% -48.726%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

sort 2^12 i32           time:   [66.708 us 67.331 us 68.036 us]                          
                        change: [-3.5240% -1.8990% -0.3466%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

sort null 2^12 i32      time:   [45.821 us 47.340 us 48.820 us]                                
                        change: [-62.299% -61.168% -60.044%] (p = 0.00 < 0.05)
                        Performance has improved.

sort 2^14 i32           time:   [152.50 us 153.66 us 154.89 us]                          
                        change: [+3.5869% +4.7691% +5.9280%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

sort null 2^14 i32      time:   [179.57 us 180.46 us 181.43 us]                               
                        change: [-33.481% -32.048% -30.669%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

sort 2^16 i32           time:   [398.64 us 400.97 us 403.41 us]                          
                        change: [-2.8009% -0.6869% +1.3031%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

sort null 2^16 i32      time:   [480.25 us 481.69 us 483.22 us]                               
                        change: [-43.284% -42.818% -42.327%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking sort 2^18 i32: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
sort 2^18 i32           time:   [1.5215 ms 1.5307 ms 1.5409 ms]                           
                        change: [-0.6383% +0.8262% +2.5583%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

sort null 2^18 i32      time:   [2.2712 ms 2.2826 ms 2.2948 ms]                                
                        change: [-33.561% -33.148% -32.627%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

sort 2^20 i32           time:   [6.4847 ms 6.5140 ms 6.5448 ms]                          
                        change: [-2.5346% -1.5822% -0.6890%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

sort null 2^20 i32      time:   [9.9493 ms 9.9924 ms 10.037 ms]                               
                        change: [-27.738% -27.286% -26.836%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

```