### PR TITLE
[Rust] Implement `PartialEq` for `Series`

### DIFF
--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -4,7 +4,6 @@ use std::ops::Deref;
 
 impl Series {
     /// Check if series are equal. Note that `None == None` evaluates to `false`
-    #[deprecated]
     pub fn series_equal(&self, other: &Series) -> bool {
         if self.get_data_ptr() == other.get_data_ptr() {
             return true;
@@ -26,7 +25,6 @@ impl Series {
     }
 
     /// Check if all values in series are equal where `None == None` evaluates to `true`.
-    #[deprecated(note = "Use the binary operator '=='")]
     pub fn series_equal_missing(&self, other: &Series) -> bool {
         if self.get_data_ptr() == other.get_data_ptr() {
             return true;


### PR DESCRIPTION
## Rust standards
### Standard library
- None = None
```rust
assert_eq!(Option::<f64>::None, Option::<f64>::None);
```
- NAN ≠ NAN
```rust
assert_ne!(f64::NAN, f64::NAN);
```
Corollary: a pointer equality, despite being fast to check, does not fit the standards for the floats.
### Polars
Polars follows the previous rules.
```rust
use polars_core::prelude::*;

fn main() {
    let s1 = Series::new("", &[Some(1.0), None, Some(f64::NAN)]);
    let s2 = Series::new("", &[Some(1.0), None, Some(f64::NAN)]);
    println!("{:?}", s1.eq_missing(&s2));
}
```
Output:
```text
shape: (3,)
ChunkedArray: '' [bool]
[
        true
        true
        false
]
```

## New implementation
Despite not focusing on a deep and complete performance study, I tried to at least keep the previous tips to accelerate the check in some cases, so that the new implementation doesn't loose in speed.
```rust
impl PartialEq for Series {
    fn eq(&self, other: &Self) -> bool {
        self.len() == other.len()
            && self.field() == other.field()
            && self.null_count() == other.null_count()
            && self.eq_missing(other).sum().map(|s| s as usize) == Some(self.len())
    }
}
```
## Benchmark
Comparing the old `series_equal_missing` and the new implementation.
### Results
- Overall, the performance is the same on the classical cases (sometimes slightly better, sometimes slightly slower).
- The NAN case is now correct and 10 000 times faster.

### Dirty code used
```rust
use criterion::{criterion_group, criterion_main, Criterion};
use polars_core::prelude::*;
use rand::Rng;

fn series_equal_old(s1: &Series, s2: &Series) -> bool {
    if s1.get_data_ptr() == s2.get_data_ptr() {
        return true;
    }
    let null_count_left = s1.null_count();
    if s1.len() != s2.len() || null_count_left != s2.null_count() {
        return false;
    }
    if s1.dtype() != s2.dtype()
        && !(matches!(s1.dtype(), DataType::Utf8 | DataType::Categorical)
            || matches!(s2.dtype(), DataType::Utf8 | DataType::Categorical))
        && !(s1.is_numeric() && s2.is_numeric())
    {
        return false;
    }
    // if all null and previous check did not return (so other is also all null)
    if null_count_left == s1.len() {
        return true;
    }
    match s1.eq_missing(s2).sum() {
        None => false,
        Some(sum) => sum as usize == s1.len(),
    }
}

fn series_equal_new(s1: &Series, s2: &Series) -> bool {
    s1.len() == s2.len()
        && s1.field() == s2.field()
        && s1.null_count() == s2.null_count()
        && s1.eq_missing(s2).sum().map(|s| s as usize) == Some(s1.len()) 
}

fn bench_series_eq(c: &mut Criterion) {
    let mut rng = rand::thread_rng();

    let s1: Series = (1..10_000_000).map(|_| rng.gen::<f64>()).collect();
    let s2: Series = (1..10_000_000).map(|_| rng.gen::<f64>()).collect();
    let s3: Series = (1..10_000_000).map(|_| 1_i32).collect();
    let s4: Series = (1..10_000_000).map(|_| 1_i32).collect();
    let s5: Series = (1..10_000_000)
        .map(|x| if x % 2 == 0 { None } else { Some(1) })
        .collect();
    let s6: Series = (1..10_000_000)
        .map(|x| if x % 6 == 0 { None } else { Some(1) })
        .collect();
    let s7: Series = (1..10_000_000)
        .map(|x| if x % 6 == 0 { None } else { Some(1) })
        .collect();
    let s8: Series = (1..10_000_000)
        .map(|x| if x % 6 == 0 { None } else { Some(f64::NAN) })
        .collect();
    let s9: Series = (1..1_000_000).map(|_| rng.gen::<f64>()).collect();

    let mut group1 = c.benchmark_group("Series equality - Classic");
    group1.confidence_level(0.99);
    group1.bench_function("Neq Rand - OLD", |b| b.iter(|| series_equal_old(&s1, &s2)));
    group1.bench_function("Neq Rand - NEW", |b| b.iter(|| series_equal_new(&s1, &s2)));
    group1.bench_function("Eq - OLD", |b| b.iter(|| series_equal_old(&s3, &s4)));
    group1.bench_function("Eq - NEW", |b| b.iter(|| series_equal_new(&s3, &s4)));
    group1.finish();

    let mut group2 = c.benchmark_group("Series equality - Eq None");
    group2.confidence_level(0.99);
    group2.bench_function("Eq None - OLD", |b| b.iter(|| series_equal_old(&s6, &s7)));
    group2.bench_function("Eq None - NEW", |b| b.iter(|| series_equal_new(&s6, &s7)));
    group2.finish();

    let mut group3 = c.benchmark_group("Series equality - Neq None");
    group3.confidence_level(0.99);
    group3.bench_function("Neq None - OLD", |b| b.iter(|| series_equal_old(&s5, &s6)));
    group3.bench_function("Neq None - NEW", |b| b.iter(|| series_equal_new(&s5, &s6)));
    group3.finish();

    let mut group4 = c.benchmark_group("Series equality - Type, NAN, Size");
    group4.confidence_level(0.99);
    group4.bench_function("Neq Type - OLD", |b| b.iter(|| series_equal_old(&s1, &s3)));
    group4.bench_function("Neq Type - NEW", |b| b.iter(|| series_equal_new(&s1, &s3)));
    group4.bench_function("Neq NAN - OLD", |b| b.iter(|| series_equal_old(&s6, &s8)));
    group4.bench_function("Neq NAN - NEW", |b| b.iter(|| series_equal_new(&s6, &s8)));
    group4.bench_function("Neq Size - OLD", |b| b.iter(|| series_equal_old(&s1, &s9)));
    group4.bench_function("Neq Size - NEW", |b| b.iter(|| series_equal_new(&s1, &s9)));
    group4.finish();
}

criterion_group!(benches, bench_series_eq);
criterion_main!(benches);
```

## Change management
`series_equal` and `series_equal_missing` should be deprecated. I don't know how you want to make a clean change management.