### PR TITLE
Use full path for test file in test

### DIFF
--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -252,7 +252,8 @@ a,b,c
     assert out.frame_equal(expected)
 
     # now from disk
-    out = pl.read_csv("tests/files/gzipped.csv")
+    csv_file = Path(__file__).parent / "files" / "gzipped.csv"
+    out = pl.read_csv(str(csv_file))
     assert out.frame_equal(expected)
 
     # now with column projection


### PR DESCRIPTION
The relative path causes issues when running from a different working dir (it does for me), fixed by using a full path.