### PR TITLE
[Rust] `PartialEq` for `DataFrame`

### DIFF
--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -1,5 +1,6 @@
 //! Testing utilities.
 use crate::prelude::*;
+use rayon::iter::*;
 use std::ops::Deref;
 
 impl Series {
@@ -110,6 +111,17 @@ impl DataFrame {
     }
 }
 
+impl PartialEq for DataFrame {
+    fn eq(&self, other: &Self) -> bool {
+        self.shape() == other.shape()
+            && self
+                .columns
+                .par_iter()
+                .zip_eq(other.columns.par_iter())
+                .all(|(x, y)| x == y)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
@@ -149,5 +161,24 @@ mod test {
         assert_eq!(s2, s2);
         assert_ne!(s2, s3);
         assert_ne!(s4, s4);
+    }
+
+    #[test]
+    fn test_df_partialeq() {
+        let df1 = df!("a" => &[1, 2, 3],
+                      "b" => &[4, 5, 6])
+        .unwrap();
+        let df2 = df!("b" => &[4, 5, 6],
+                      "a" => &[1, 2, 3])
+        .unwrap();
+        let df3 = df!("" => &[Some(1), None]).unwrap();
+        let df4 = df!("" => &[f32::NAN]).unwrap();
+
+        assert_eq!(df1, df1);
+        assert_ne!(df1, df2);
+        assert_eq!(df2, df2);
+        assert_ne!(df2, df3);
+        assert_eq!(df3, df3);
+        assert_ne!(df4, df4);
     }
 }

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -1,6 +1,5 @@
 //! Testing utilities.
 use crate::prelude::*;
-use rayon::iter::*;
 use std::ops::Deref;
 
 impl Series {
@@ -116,9 +115,9 @@ impl PartialEq for DataFrame {
         self.shape() == other.shape()
             && self
                 .columns
-                .par_iter()
-                .zip_eq(other.columns.par_iter())
-                .all(|(x, y)| x == y)
+                .iter()
+                .zip(other.columns.iter())
+                .all(|(s1, s2)| s1 == s2)
     }
 }
 


### PR DESCRIPTION
### New implementation

Following #1833

```Rust
impl PartialEq for DataFrame {
    fn eq(&self, other: &Self) -> bool {
        self.shape() == other.shape()
            && self
                .columns
                .par_iter()
                .zip_eq(other.columns.par_iter())
                .all(|(x, y)| x == y)
    }
}
```

### Miri issue
Miri is giving me these warning and error:
```text
test testing::test::test_df_partialeq ... warning: thread support is experimental and incomplete: weak memory effects are not emulated.

[...]

error: the main thread terminated without waiting for all remaining threads
```

I assume that the problem is because the `eq` function is parallel and is tested at the end of the Miri check, but I don't know why it doesn't wait for all the threads to finish 😅