### PR TITLE
Remove print statements from Python tests

### DIFF
--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -130,8 +130,6 @@ def test_from_pydatetime() -> None:
     assert s.name == "name"
     assert s.null_count() == 1
     assert s.dt[0] == dates[0]
-    # fmt dates and nulls
-    print(s)
 
     dates = [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3), None]  # type: ignore
     s = pl.Series("name", dates)
@@ -139,9 +137,6 @@ def test_from_pydatetime() -> None:
     assert s.name == "name"
     assert s.null_count() == 1
     assert s.dt[0] == dates[0]
-
-    # fmt dates and nulls
-    print(s)
 
 
 def test_to_python_datetime() -> None:

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -77,7 +77,6 @@ def test_from_pandas_nested_list() -> None:
         {"a": [1, 2, 3, 4], "b": [["x", "y"], ["x", "y", "z"], ["x"], ["x", "y"]]}
     )
     pldf = pl.from_pandas(pddf)
-    print(pldf)
     assert pldf.shape == (4, 2)
 
 

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -89,12 +89,9 @@ def test_parquet_chunks() -> None:
             np.tile([1.0, pd.to_datetime("2010-10-10")], [case, 1]),
             columns=["floats", "dates"],
         )
-        print(df)
 
         # write as parquet
         df.to_parquet(f)
-
-        print(f"reading {case} dates with polars...", end="")
         f.seek(0)
 
         # read it with polars

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -471,7 +471,6 @@ def test_mode() -> None:
 
 def test_jsonpath_single() -> None:
     s = pl.Series(['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}'])
-    print(s.str.json_path_match("$.a"))
     assert s.str.json_path_match("$.a").to_list() == [
         "1",
         None,


### PR DESCRIPTION
To unclutter  test output.