### PR TITLE
Fix previously ignored flake8 W605 errors

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 # just stop shouting as black decides line lengths.
 max-line-length = 180
-# E203, W504: due to black fmt
-ignore = E203,W503,W605
+# E203, W503: due to black fmt
+ignore = E203,W503
 exclude = legacy, docs
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1662,7 +1662,7 @@ class Expr:
         return wrap_expr(self._pyexpr.diff(n, null_behavior))
 
     def skew(self, bias: bool = True) -> "Expr":
-        """Compute the sample skewness of a data set.
+        r"""Compute the sample skewness of a data set.
         For normally distributed data, the skewness should be about zero. For
         unimodal continuous distributions, a skewness value greater than zero means
         that there is more weight in the right tail of the distribution. The
@@ -2073,7 +2073,7 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_json_path_match(json_path))
 
     def extract(self, pattern: str, group_index: int = 1) -> Expr:
-        """
+        r"""
         Extract the target capture group from provided patterns.
 
         Parameters
@@ -2099,7 +2099,7 @@ class ExprStringNameSpace:
         ...             'http://vote.com/ballon_dor?candidate=ronaldo&ref=polars'
         ...         ]})
         >>> df.select([
-        ...             pl.col('a').str.extract('candidate=(\w+)', 1)
+        ...             pl.col('a').str.extract(r'candidate=(\w+)', 1)
         ...         ])
         shape: (3, 1)
         ┌─────────┐

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2907,7 +2907,7 @@ class Series:
         return wrap_s(self._s.diff(n, null_behavior))
 
     def skew(self, bias: bool = True) -> Optional[float]:
-        """Compute the sample skewness of a data set.
+        r"""Compute the sample skewness of a data set.
         For normally distributed data, the skewness should be about zero. For
         unimodal continuous distributions, a skewness value greater than zero means
         that there is more weight in the right tail of the distribution. The
@@ -3083,7 +3083,7 @@ class StringNameSpace:
         return wrap_s(self._s.str_json_path_match(json_path))
 
     def extract(self, pattern: str, group_index: int = 1) -> Series:
-        """
+        r"""
         Extract the target capture group from provided patterns.
 
         Parameters
@@ -3109,7 +3109,7 @@ class StringNameSpace:
         ...             'http://vote.com/ballon_dor?candidate=ronaldo&ref=polars'
         ...         ]})
         >>> df.select([
-        ...             pl.col('a').str.extract('candidate=(\w+)', 1)
+        ...             pl.col('a').str.extract(r'candidate=(\w+)', 1)
         ...         ])
         shape: (3, 1)
         ┌─────────┐


### PR DESCRIPTION
By using raw (doc) strings in the appropriate places.
