### PR TITLE
Remove wrap_ldf & wrap_expr

### DIFF
--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -3,10 +3,10 @@
 The modules within `polars.internals` are interdependent. To prevent cyclical imports, they all import from each other
 via this __init__ file using `import polars.internals as pli`. The imports below are being shared across this module.
 """
-from .expr import Expr, _selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_expr
+from .expr import Expr, _selection_to_pyexpr_list, expr_to_lit_or_expr
 from .frame import DataFrame, wrap_df
 from .functions import arg_where, concat, date_range, get_dummies, repeat
-from .lazy_frame import LazyFrame, wrap_ldf
+from .lazy_frame import LazyFrame
 from .lazy_functions import arange, argsort_by, col, concat_list, lit
 from .series import Series, wrap_s
 from .whenthen import when  # used in expr.clip()

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -176,6 +176,8 @@ class DataFrame:
     ╰─────┴─────┴─────╯
     """
 
+    _df: "PyDataFrame"
+
     def __init__(
         self,
         data: Optional[
@@ -2690,7 +2692,7 @@ class DataFrame:
 
         Lazy operations are advised because they allow for query optimization and more parallelization.
         """
-        return pli.wrap_ldf(self._df.lazy())
+        return pli.LazyFrame(self._df.lazy())
 
     def select(
         self,

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -84,7 +84,7 @@ def concat(
                 f"how should be one of {'vertical', 'diagonal'}, got {how}"
             )
     elif isinstance(items[0], pli.LazyFrame):
-        return pli.wrap_ldf(_concat_lf(items, rechunk))
+        return pli.LazyFrame(_concat_lf(items, rechunk))
     else:
         out = pli.wrap_s(_concat_series(items))
 

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -130,12 +130,12 @@ def col(
 
     if isinstance(name, list):
         if len(name) == 0 or isinstance(name[0], str):
-            return pli.wrap_expr(pycols(name))
+            return pli.Expr(pycols(name))
         elif isclass(name[0]) and issubclass(name[0], DataType):
-            return pli.wrap_expr(_dtype_cols(name))
+            return pli.Expr(_dtype_cols(name))
         else:
             raise ValueError("did expect argument of List[str] or List[DataType]")
-    return pli.wrap_expr(pycol(name))
+    return pli.Expr(pycol(name))
 
 
 @tp.overload
@@ -509,14 +509,14 @@ def lit(
     if isinstance(value, pli.Series):
         name = value.name
         value = value._s
-        return pli.wrap_expr(pylit(value)).alias(name)
+        return pli.Expr(pylit(value)).alias(name)
 
     if isinstance(value, np.ndarray):
         return lit(pli.Series("", value))
 
     if dtype:
-        return pli.wrap_expr(pylit(value)).cast(dtype)
-    return pli.wrap_expr(pylit(value))
+        return pli.Expr(pylit(value)).cast(dtype)
+    return pli.Expr(pylit(value))
 
 
 def spearman_rank_corr(
@@ -537,7 +537,7 @@ def spearman_rank_corr(
         a = col(a)
     if isinstance(b, str):
         b = col(b)
-    return pli.wrap_expr(pyspearman_rank_corr(a._pyexpr, b._pyexpr))
+    return pli.Expr(pyspearman_rank_corr(a._pyexpr, b._pyexpr))
 
 
 def pearson_corr(
@@ -558,7 +558,7 @@ def pearson_corr(
         a = col(a)
     if isinstance(b, str):
         b = col(b)
-    return pli.wrap_expr(pypearson_corr(a._pyexpr, b._pyexpr))
+    return pli.Expr(pypearson_corr(a._pyexpr, b._pyexpr))
 
 
 def cov(
@@ -579,7 +579,7 @@ def cov(
         a = col(a)
     if isinstance(b, str):
         b = col(b)
-    return pli.wrap_expr(pycov(a._pyexpr, b._pyexpr))
+    return pli.Expr(pycov(a._pyexpr, b._pyexpr))
 
 
 def map(
@@ -604,7 +604,7 @@ def map(
     Expr
     """
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(_map_mul(exprs, f, return_dtype, apply_groups=False))
+    return pli.Expr(_map_mul(exprs, f, return_dtype, apply_groups=False))
 
 
 def apply(
@@ -639,7 +639,7 @@ def apply(
     Expr
     """
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(_map_mul(exprs, f, return_dtype, apply_groups=True))
+    return pli.Expr(_map_mul(exprs, f, return_dtype, apply_groups=True))
 
 
 def map_binary(
@@ -668,7 +668,7 @@ def map_binary(
         a = col(a)
     if isinstance(b, str):
         b = col(b)
-    return pli.wrap_expr(pybinary_function(a._pyexpr, b._pyexpr, f, return_dtype))
+    return pli.Expr(pybinary_function(a._pyexpr, b._pyexpr, f, return_dtype))
 
 
 def fold(
@@ -697,7 +697,7 @@ def fold(
         exprs = [exprs]
 
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pyfold(acc._pyexpr, f, exprs))
+    return pli.Expr(pyfold(acc._pyexpr, f, exprs))
 
 
 def any(name: Union[str, tp.List["pli.Expr"]]) -> "pli.Expr":
@@ -840,7 +840,7 @@ def arange(
         df = pli.DataFrame({"a": [1]})
         return df.select(pli.arange(low, high, step).alias("arange"))["arange"]  # type: ignore
 
-    return pli.wrap_expr(pyarange(low._pyexpr, high._pyexpr, step))
+    return pli.Expr(pyarange(low._pyexpr, high._pyexpr, step))
 
 
 def argsort_by(
@@ -863,7 +863,7 @@ def argsort_by(
     if not isinstance(reverse, list):
         reverse = [reverse]
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pyargsort_by(exprs, reverse))
+    return pli.Expr(pyargsort_by(exprs, reverse))
 
 
 def _datetime(
@@ -912,7 +912,7 @@ def _datetime(
         second = pli.expr_to_lit_or_expr(second, str_to_lit=False)._pyexpr  # type: ignore
     if millisecond is not None:
         millisecond = pli.expr_to_lit_or_expr(millisecond, str_to_lit=False)._pyexpr  # type: ignore
-    return pli.wrap_expr(
+    return pli.Expr(
         py_datetime(
             year._pyexpr, month._pyexpr, day._pyexpr, hour, minute, second, millisecond
         )
@@ -951,7 +951,7 @@ def concat_str(exprs: tp.Sequence[Union["pli.Expr", str]], sep: str = "") -> "pl
         String value that will be used to separate the values.
     """
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(_concat_str(exprs, sep))
+    return pli.Expr(_concat_str(exprs, sep))
 
 
 def format(fstring: str, *args: Union["pli.Expr", str]) -> "pli.Expr":
@@ -1014,7 +1014,7 @@ def concat_list(exprs: tp.List["pli.Expr"]) -> "pli.Expr":
         Columns to concat into a List Series
     """
     exprs = pli._selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(_concat_lst(exprs))
+    return pli.Expr(_concat_lst(exprs))
 
 
 def collect_all(

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -182,6 +182,8 @@ class Series:
 
     """
 
+    _s: "PySeries"
+
     def __init__(
         self,
         name: Optional[Union[str, ArrayLike]] = None,

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -40,7 +40,7 @@ class WhenThenThen:
         See Also: the `when` function.
         """
         expr = pli.expr_to_lit_or_expr(expr)
-        return pli.wrap_expr(self.pywenthenthen.otherwise(expr._pyexpr))
+        return pli.Expr(self.pywenthenthen.otherwise(expr._pyexpr))
 
 
 class WhenThen:
@@ -64,7 +64,7 @@ class WhenThen:
         See Also: the `when` function.
         """
         expr = pli.expr_to_lit_or_expr(expr)
-        return pli.wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
+        return pli.Expr(self._pywhenthen.otherwise(expr._pyexpr))
 
 
 class When:


### PR DESCRIPTION
By using the __init__.py.

We could do the same with wrap_df and wrap_s, but there the initializers are also used to convert from other Python types, so that would become confusing?

This change does cause different behaviour for Expr and LazyFrame vs DataFrame and Series. Alternatively, we could make the "_from_pydf" class methods public (i.e. remove underscore)? That would also remove the separate wrap functions. But adds it to the public API..