### PR TITLE
[Rust][Documentation] New example for `DataFrame::iter`

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -345,7 +345,7 @@ impl DataFrame {
     ///
     /// fn example() -> Result<()> {
     ///     let s1: Series = Series::new("Name", &["Pythagoras theorem", "Shannon entropy"]);
-    ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=-Σ[P(x)log|P[x]|"]);
+    ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=-Σ[P(x)log|P(x)|]"]);
     ///     let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;
     ///
     ///     let mut iterator = df.iter();

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -337,6 +337,25 @@ impl DataFrame {
     }
 
     /// Iterator over the columns as Series.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::prelude::*;  // or "use polars::prelude::*"
+    ///
+    /// fn example() -> Result<()> {
+    ///     let s1: Series = Series::new("Name", &["Pythagoras theorem", "Shannon entropy"]);
+    ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=Σ[P(x)log|P[x]|"]);
+    ///     let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;
+    ///
+    ///     let mut iterator = df.iter();
+    ///     assert_eq!(iterator.next(), Some(&s1));
+    ///     assert_eq!(iterator.next(), Some(&s2));
+    ///     assert_eq!(iterator.next(), None);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn iter(&self) -> std::slice::Iter<'_, Series> {
         self.columns.iter()
     }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -345,7 +345,7 @@ impl DataFrame {
     ///
     /// fn example() -> Result<()> {
     ///     let s1: Series = Series::new("Name", &["Pythagoras theorem", "Shannon entropy"]);
-    ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=Σ[P(x)log|P[x]|"]);
+    ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=-Σ[P(x)log|P[x]|"]);
     ///     let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;
     ///
     ///     let mut iterator = df.iter();

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -344,7 +344,7 @@ impl DataFrame {
     /// use polars_core::prelude::*;  // or "use polars::prelude::*"
     ///
     /// fn example() -> Result<()> {
-    ///     let s1: Series = Series::new("Name", &["Pythagoras theorem", "Shannon entropy"]);
+    ///     let s1: Series = Series::new("Name", &["Pythagoras' theorem", "Shannon entropy"]);
     ///     let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=-Σ[P(x)log|P(x)|]"]);
     ///     let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;
     ///


### PR DESCRIPTION
New example for `DataFrame::iter` using the rustdoc features.

```rust
use polars_core::prelude::*;  // or "use polars::prelude::*"

fn example() -> Result<()> {
    let s1: Series = Series::new("Name", &["Pythagoras' theorem", "Shannon entropy"]);
    let s2: Series = Series::new("Formula", &["a²+b²=c²", "H=-Σ[P(x)log|P(x)|]"]);
    let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;

    let mut iterator = df.iter();
    assert_eq!(iterator.next(), Some(&s1));
    assert_eq!(iterator.next(), Some(&s2));
    assert_eq!(iterator.next(), None);

    Ok(())
}
```