### PR TITLE
[Rust] `DataFrame::find_idx_by_name` improvement

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -899,13 +899,29 @@ impl DataFrame {
     }
 
     /// Get column index of a series by name.
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::df;         // or "use polars::df"
+    /// use polars_core::prelude::*; // or "use polars::prelude::*"
+    ///
+    /// fn example() -> Result<()> {
+    ///     let df: DataFrame = df!("Name" => &["Player 1", "Player 2", "Player 3"],
+    ///                             "Health" => &[100, 200, 500],
+    ///                             "Mana" => &[250, 100, 0],
+    ///                             "Strength" => &[30, 150, 300])?;
+    ///
+    ///     assert_eq!(df.find_idx_by_name("Name"), Some(0));
+    ///     assert_eq!(df.find_idx_by_name("Health"), Some(1));
+    ///     assert_eq!(df.find_idx_by_name("Mana"), Some(2));
+    ///     assert_eq!(df.find_idx_by_name("Strength"), Some(3));
+    ///     assert_eq!(df.find_idx_by_name("Haste"), None);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn find_idx_by_name(&self, name: &str) -> Option<usize> {
-        self.columns
-            .iter()
-            .enumerate()
-            .filter(|(_idx, series)| series.name() == name)
-            .map(|(idx, _)| idx)
-            .next()
+        self.columns.iter().position(|s| s.name() == name)
     }
 
     /// Select a single column by name.


### PR DESCRIPTION
## New implementation
### Function
```rust
pub fn find_idx_by_name(&self, name: &str) -> Option<usize> {
    self.columns.iter().position(|s| s.name() == name)
}
```

### Benchmark
#### Results
- The new function is overall 15% faster.
#### Code used
```rust
use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
use polars_core::df;
use polars_core::prelude::*;

fn old(df: &DataFrame, name: &str) -> Option<usize> {
    df.get_columns()
        .iter()
        .enumerate()
        .filter(|(_idx, series)| series.name() == name)
        .map(|(idx, _)| idx)
        .next()
}

fn new(df: &DataFrame, name: &str) -> Option<usize> {
    df.get_columns().iter().position(|s| s.name() == name)
}

fn bench_idx_by_name(c: &mut Criterion) {
    let mut group = c.benchmark_group("find_idx_by_name");
    let df = df!("a" => &[1, 2, 3, 4, 5],
                 "b" => &[1, 2, 3, 4, 5],
                 "c" => &[1, 2, 3, 4, 5],
                 "d" => &[1, 2, 3, 4, 5],
                 "e" => &[1, 2, 3, 4, 5],
                 "f" => &[1, 2, 3, 4, 5],
                 "g" => &[1, 2, 3, 4, 5],
                 "h" => &[1, 2, 3, 4, 5],
                 "i" => &[1, 2, 3, 4, 5],
                 "j" => &[1, 2, 3, 4, 5],
                 "k" => &[1, 2, 3, 4, 5],
                 "l" => &[1, 2, 3, 4, 5],
                 "m" => &[1, 2, 3, 4, 5],
                 "n" => &[1, 2, 3, 4, 5],
                 "o" => &[1, 2, 3, 4, 5],
                 "p" => &[1, 2, 3, 4, 5],
                 "q" => &[1, 2, 3, 4, 5],
                 "r" => &[1, 2, 3, 4, 5],
                 "s" => &[1, 2, 3, 4, 5],
                 "t" => &[1, 2, 3, 4, 5],
                 "u" => &[1, 2, 3, 4, 5],
                 "v" => &[1, 2, 3, 4, 5],
                 "w" => &[1, 2, 3, 4, 5],
                 "x" => &[1, 2, 3, 4, 5],
                 "y" => &[1, 2, 3, 4, 5],
                 "z" => &[1, 2, 3, 4, 5])
    .unwrap();
    for i in [
        "0", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
        "r", "s", "t", "u", "v", "w", "x", "y", "z",
    ]
    .iter()
    {
        group.bench_with_input(BenchmarkId::new("OLD", i), i, |b, i| b.iter(|| old(&df, i)));
        group.bench_with_input(BenchmarkId::new("NEW", i), i, |b, i| b.iter(|| new(&df, i)));
    }
    group.finish();
}

criterion_group!(benches, bench_idx_by_name);
criterion_main!(benches);
```

## New documentation
New example using the rustdoc features.
```rust
use polars_core::df;         // or "use polars::df"
use polars_core::prelude::*; // or "use polars::prelude::*"

fn example() -> Result<()> {
    let df: DataFrame = df!("Name" => &["Player 1", "Player 2", "Player 3"],
                            "Health" => &[100, 200, 500],
                            "Mana" => &[250, 100, 0],
                            "Strength" => &[30, 150, 300])?;

    assert_eq!(df.find_idx_by_name("Name"), Some(0));
    assert_eq!(df.find_idx_by_name("Health"), Some(1));
    assert_eq!(df.find_idx_by_name("Mana"), Some(2));
    assert_eq!(df.find_idx_by_name("Strength"), Some(3));
    assert_eq!(df.find_idx_by_name("Haste"), None);

    Ok(())
}
```