### PR TITLE
partial fix for python datetime conversions (fractional seconds currently get dropped)

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -425,11 +425,11 @@ def coerce_arrow(array: "pa.Array") -> "pa.Array":
         warnings.warn(
             "Conversion of (potentially) timezone aware to naive datetimes. TZ information may be lost",
         )
-        ts_ms = pa.compute.cast(array, pa.timestamp("ms"), safe=False)
-        ms = pa.compute.cast(ts_ms, pa.int64())
-        del ts_ms
-        array = pa.compute.cast(ms, pa.timestamp("ms"))
-        del ms
+        ts_us = pa.compute.cast(array, pa.timestamp("us"), safe=False)
+        us = pa.compute.cast(ts_us, pa.int64())
+        del ts_us
+        array = pa.compute.cast(us, pa.timestamp("us"))
+        del us
     # note: Decimal256 could not be cast to float
     elif isinstance(array.type, pa.Decimal128Type):
         array = pa.compute.cast(array, pa.float64())

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -425,11 +425,11 @@ def coerce_arrow(array: "pa.Array") -> "pa.Array":
         warnings.warn(
             "Conversion of (potentially) timezone aware to naive datetimes. TZ information may be lost",
         )
-        ts_us = pa.compute.cast(array, pa.timestamp("us"), safe=False)
-        us = pa.compute.cast(ts_us, pa.int64())
-        del ts_us
-        array = pa.compute.cast(us, pa.timestamp("us"))
-        del us
+        ts_ms = pa.compute.cast(array, pa.timestamp("ms"), safe=False)
+        ms = pa.compute.cast(ts_ms, pa.int64())
+        del ts_ms
+        array = pa.compute.cast(ms, pa.timestamp("ms"))
+        del ms
     # note: Decimal256 could not be cast to float
     elif isinstance(array.type, pa.Decimal128Type):
         array = pa.compute.cast(array, pa.float64())

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3440,8 +3440,7 @@ class DateTimeNameSpace:
         """
         Go from Date/Datetime to python DateTime objects
         """
-
-        return (self.timestamp() // 1000).apply(
+        return (self.timestamp() / 1000).apply(
             lambda ts: datetime.utcfromtimestamp(ts), Object
         )
 
@@ -3510,7 +3509,7 @@ def _to_python_datetime(
         return datetime.utcfromtimestamp(value * 3600 * 24).date()
     elif dtype == Datetime:
         # ms to seconds
-        return datetime.utcfromtimestamp(value // 1000)
+        return datetime.utcfromtimestamp(value / 1000)
     else:
         raise NotImplementedError
 

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -151,7 +151,8 @@ def test_to_python_datetime() -> None:
 
 
 def test_datetime_consistency() -> None:
-    dt = datetime(2021, 1, 1)
+   #dt = datetime(2021, 1, 1, 10, 30, 45, 123456)
+    dt = datetime(2021, 1, 1, 10, 30, 45, 123000)
     df = pl.DataFrame({"date": [dt]})
     assert df["date"].dt[0] == dt
     assert df.select(pl.lit(dt))["literal"].dt[0] == dt

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -151,7 +151,7 @@ def test_to_python_datetime() -> None:
 
 
 def test_datetime_consistency() -> None:
-   #dt = datetime(2021, 1, 1, 10, 30, 45, 123456)
+    # dt = datetime(2021, 1, 1, 10, 30, 45, 123456)
     dt = datetime(2021, 1, 1, 10, 30, 45, 123000)
     df = pl.DataFrame({"date": [dt]})
     assert df["date"].dt[0] == dt

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -101,7 +101,7 @@ def test_parquet_chunks() -> None:
 
 def test_parquet_datetime() -> None:
     """
-    This failed because parquet writers cast datetimeto Date
+    This failed because parquet writers cast datetime to Date
     """
     f = io.BytesIO()
     data = {


### PR DESCRIPTION
Polars was dropping fractional seconds during datetime conversions due to (unnecessary ;) use of integer division in `datetime.utcfromtimestamp( ... )` conversions. The patch below restores millisecond accuracy (see updated unit test: `test_datetime_consistency`), but getting the full microsecond accuracy for python datetimes looks like it needs a small Rust-side update to the Datetime type default unit. 

int64 (the underlying Datetime type) can readily handle microsecond accuracy, but it seems to have been set to _milliseconds_ instead, which means that all python datetime conversions where microseconds are involved -tick data series and the like- are currently getting incorrectly rounded/truncated (I commented out a line in `test_datetime_consistency` that shows this).

I'm not currently able to build the Rust code, or I'd happily take a look and see if I could patch that too, but I can equally imagine that changing the default unit may need a bit of care.