### PR TITLE
Fix README.md code example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ To learn more, read the [User Guide](https://pola-rs.github.io/polars-book/).
     "fruits",
     "cars",
     pl.lit("fruits").alias("literal_string_fruits"),
-    pl.col("B").filter(col("cars") == "beetle").sum(),
-    pl.col("A").filter(col("B") > 2).sum().over("cars").alias("sum_A_by_cars"),       # groups by "cars"
+    pl.col("B").filter(pl.col("cars") == "beetle").sum(),
+    pl.col("A").filter(pl.col("B") > 2).sum().over("cars").alias("sum_A_by_cars"),    # groups by "cars"
     pl.col("A").sum().over("fruits").alias("sum_A_by_fruits"),                        # groups by "fruits"
     pl.col("A").reverse().over("fruits").flatten().alias("rev_A_by_fruits"),          # groups by "fruits
     pl.col("A").sort_by("B").over("fruits").flatten().alias("sort_A_by_B_by_fruits")  # groups by "fruits"


### PR DESCRIPTION
`Readme.md` code example has some error.
It need to use `pl.col` insteads of `col`