### PR TITLE
[Rust] `DataFrame::shape` improvement

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -477,7 +477,7 @@ impl DataFrame {
             .collect()
     }
 
-    /// Get (height, width)
+    /// Get (height, width) of the `DataFrame`.
     ///
     /// # Example
     ///

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -481,18 +481,27 @@ impl DataFrame {
     ///
     /// # Example
     ///
-    /// ```
-    /// use polars_core::prelude::*;
-    /// fn assert_shape(df: &DataFrame, shape: (usize, usize)) {
-    ///     assert_eq!(df.shape(), shape)
+    /// ```rust
+    /// use polars_core::df;         // or "use polars::df"
+    /// use polars_core::prelude::*; // or "use polars::prelude::*"
+    ///
+    /// fn example() -> Result<()> {
+    ///     let df0: DataFrame = DataFrame::default();
+    ///     let df1: DataFrame = df!("1" => &[1, 2, 3, 4, 5])?;
+    ///     let df2: DataFrame = df!("1" => &[1, 2, 3, 4, 5],
+    ///                              "2" => &[1, 2, 3, 4, 5])?;
+    ///
+    ///     assert_eq!(df0.shape(), (0 ,0));
+    ///     assert_eq!(df1.shape(), (5, 1));
+    ///     assert_eq!(df2.shape(), (5, 2));
+    ///
+    ///     Ok(())
     /// }
     /// ```
     pub fn shape(&self) -> (usize, usize) {
-        let columns = self.columns.len();
-        if columns > 0 {
-            (self.columns[0].len(), columns)
-        } else {
-            (0, 0)
+        match self.columns.as_slice() {
+            &[] => (0, 0),
+            v => (v[0].len(), v.len()),
         }
     }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -477,7 +477,7 @@ impl DataFrame {
             .collect()
     }
 
-    /// Get (height x width)
+    /// Get (height, width)
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Summary modification
### New summary
```rust
/// Get (height, width) of the `DataFrame`.
```
## Function modification
### New function
```rust
pub fn shape(&self) -> (usize, usize) {
    match self.columns.as_slice() {
        &[] => (0, 0),
        v => (v[0].len(), v.len()),
    }
}
```
### Benchmark
#### Results
- For an empty dataframe: a little more than 2 times faster.
- Otherwise: the slight improvement is too small to be considered significant.
### Code used
```rust
use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
use polars::df;
use polars::prelude::*;

fn old(df: &DataFrame) -> (usize, usize) {
    let columns = df.get_columns().len();
    if columns > 0 {
        (df.get_columns()[0].len(), columns)
    } else {
        (0, 0)
    }
}

fn new(df: &DataFrame) -> (usize, usize) {
    match df.get_columns().as_slice() {
        &[] => (0, 0),
        v => (v[0].len(), v.len()),
    }
}

fn bench_shape(c: &mut Criterion) {
    let df0 = DataFrame::default();
    let df1 = df!("a" => &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
                  "b" => &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
                  "c" => &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
    .unwrap();
    let df2 = CsvReader::from_path("games.csv")    // 7.7 MB 
        .unwrap()
        .has_header(true)
        .finish()
        .unwrap();
    let df3 = CsvReader::from_path("bitcoin.csv")  // 317.5 MB
        .unwrap()
        .has_header(true)
        .finish()
        .unwrap();

    let mut group = c.benchmark_group("shape");
    group.measurement_time(std::time::Duration::from_secs(60));
    for i in [df0, df1, df2, df3].iter() {
        group.bench_with_input(
            BenchmarkId::new("OLD", format!("{}-{}_old", i.shape().0, i.shape().1)),
            i,
            |b, i| b.iter(|| old(&i)),
        );
        group.bench_with_input(
            BenchmarkId::new("NEW", format!("{}-{}_new", i.shape().0, i.shape().1)),
            i,
            |b, i| b.iter(|| new(&i)),
        );
    }
    group.finish();
}

criterion_group!(benches, bench_shape);
criterion_main!(benches);
```

## Example modification
Modifying the example to make profit of the rustdoc features.
### New example
```rust
use polars_core::df;         // or "use polars::df"
use polars_core::prelude::*; // or "use polars::prelude::*"

fn example() -> Result<()> {
    let df0: DataFrame = DataFrame::default();
    let df1: DataFrame = df!("1" => &[1, 2, 3, 4, 5])?;
    let df2: DataFrame = df!("1" => &[1, 2, 3, 4, 5],
                             "2" => &[1, 2, 3, 4, 5])?;

    assert_eq!(df0.shape(), (0 ,0));
    assert_eq!(df1.shape(), (5, 1));
    assert_eq!(df2.shape(), (5, 2));

    Ok(())
}
```
### Features
- Provide real examples in the documentation.
- Provide a real test unit for the `shape` function.