### PR TITLE
improve equality checks & column generation of transpose

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -389,7 +389,7 @@ impl<T> ChunkedArray<T> {
                 Arc::new(BooleanArray::from_data_default(bitmap, None)) as ArrayRef
             })
             .collect_vec();
-        BooleanChunked::new_from_chunks("is_null", chunks)
+        BooleanChunked::new_from_chunks(self.name(), chunks)
     }
 
     /// Get a mask of the valid values.
@@ -408,7 +408,7 @@ impl<T> ChunkedArray<T> {
                 Arc::new(BooleanArray::from_data_default(bitmap, None)) as ArrayRef
             })
             .collect_vec();
-        BooleanChunked::new_from_chunks("is_not_null", chunks)
+        BooleanChunked::new_from_chunks(self.name(), chunks)
     }
 
     /// Get data type of ChunkedArray.

--- a/polars/polars-core/src/chunked_array/ops/reverse.rs
+++ b/polars/polars-core/src/chunked_array/ops/reverse.rs
@@ -32,7 +32,9 @@ macro_rules! impl_reverse {
     ($arrow_type:ident, $ca_type:ident) => {
         impl ChunkReverse<$arrow_type> for $ca_type {
             fn reverse(&self) -> Self {
-                self.into_iter().rev().collect_trusted()
+                let mut ca: Self = self.into_iter().rev().collect_trusted();
+                ca.rename(self.name());
+                ca
             }
         }
     };

--- a/polars/polars-core/src/chunked_array/ops/take/take_every.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_every.rs
@@ -8,42 +8,50 @@ where
     T: PolarsNumericType,
 {
     fn take_every(&self, n: usize) -> ChunkedArray<T> {
-        if !self.has_validity() {
+        let mut ca = if !self.has_validity() {
             let a: NoNull<_> = self.into_no_null_iter().step_by(n).collect();
             a.into_inner()
         } else {
             self.into_iter().step_by(n).collect()
-        }
+        };
+        ca.rename(self.name());
+        ca
     }
 }
 
 impl ChunkTakeEvery<BooleanType> for BooleanChunked {
     fn take_every(&self, n: usize) -> BooleanChunked {
-        if !self.has_validity() {
+        let mut ca: Self = if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()
-        }
+        };
+        ca.rename(self.name());
+        ca
     }
 }
 
 impl ChunkTakeEvery<Utf8Type> for Utf8Chunked {
     fn take_every(&self, n: usize) -> Utf8Chunked {
-        if !self.has_validity() {
+        let mut ca: Self = if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()
-        }
+        };
+        ca.rename(self.name());
+        ca
     }
 }
 
 impl ChunkTakeEvery<ListType> for ListChunked {
     fn take_every(&self, n: usize) -> ListChunked {
-        if !self.has_validity() {
+        let mut ca: Self = if !self.has_validity() {
             self.into_no_null_iter().step_by(n).collect()
         } else {
             self.into_iter().step_by(n).collect()
-        }
+        };
+        ca.rename(self.name());
+        ca
     }
 }
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -859,7 +859,7 @@ hello,","," ",world,"!"
             assert!(df
                 .column(col)
                 .unwrap()
-                .series_equal(&Series::new("", &[&**val; 4])));
+                .series_equal(&Series::new(col, &[&**val; 4])));
         }
     }
 

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -49,7 +49,7 @@
 //! assert!(new.column("new_column")
 //!     .unwrap()
 //!     .series_equal(
-//!         &Series::new("valid", &[50, 40, 30, 20, 10])
+//!         &Series::new("new_column", &[50, 40, 30, 20, 10])
 //!     )
 //! );
 //! ```
@@ -82,7 +82,7 @@
 //! assert!(new.column("new_column")
 //!     .unwrap()
 //!     .series_equal(
-//!         &Series::new("valid", &[100, 100, 3, 4, 5])
+//!         &Series::new("new_column", &[100, 100, 3, 4, 5])
 //!     )
 //! );
 //! ```

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -843,9 +843,8 @@ class DataFrame:
         │ b   ┆ 1   ┆ 2   ┆ 3   │
         └─────┴─────┴─────┴─────┘
 
-        >>> import typing as tp
         >>> # replace the auto generated column with column names from a generator function
-        >>> def name_generator() -> tp.Iterator[str]:
+        >>> def name_generator():
         >>>     base_name = "my_column_"
         >>>     count = 0
         >>>     while True:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -777,7 +777,10 @@ class DataFrame:
         ]
 
     def transpose(
-        self, include_header: bool = False, header_name: str = "column"
+        self,
+        include_header: bool = False,
+        header_name: str = "column",
+        column_names: Optional[Union[tp.Iterator[str], tp.Sequence[str]]] = None,
     ) -> "pli.DataFrame":
         """
         Transpose a DataFrame over the diagonal.
@@ -788,6 +791,8 @@ class DataFrame:
             If set, the column names will be added as first column.
         header_name:
             If `include_header` is set, this determines the name of the column that will be inserted
+        column_names:
+            Optional generator/iterator that yields column names. Will be used to replace the columns in the DataFrame.
 
         Notes
         -----
@@ -797,8 +802,81 @@ class DataFrame:
         -------
         DataFrame
 
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+        >>> df.transpose(include_header=True)
+        shape: (2, 4)
+        ┌────────┬──────────┬──────────┬──────────┐
+        │ column ┆ column_0 ┆ column_1 ┆ column_2 │
+        │ ---    ┆ ---      ┆ ---      ┆ ---      │
+        │ str    ┆ i64      ┆ i64      ┆ i64      │
+        ╞════════╪══════════╪══════════╪══════════╡
+        │ a      ┆ 1        ┆ 2        ┆ 3        │
+        ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ b      ┆ 1        ┆ 2        ┆ 3        │
+        └────────┴──────────┴──────────┴──────────┘
+
+        # replace the auto generated column names with a list
+        >>> df.transpose(include_header=False, column_names=["a", "b", "c"])
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 2   ┆ 3   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 1   ┆ 2   ┆ 3   │
+        └─────┴─────┴─────┘
+
+        >>> # include the header as a separate column
+        >>> df.transpose(include_header=True, header_name="foo", column_names=["a", "b", "c"])
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ foo ┆ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ a   ┆ 1   ┆ 2   ┆ 3   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
+        │ b   ┆ 1   ┆ 2   ┆ 3   │
+        └─────┴─────┴─────┴─────┘
+
+        >>> import typing as tp
+        >>> # replace the auto generated column with column names from a generator function
+        >>> def name_generator() -> tp.Iterator[str]:
+        >>>     base_name = "my_column_"
+        >>>     count = 0
+        >>>     while True:
+        >>>         yield f"{base_name}{count}"
+        >>>         count += 1
+        >>> df.transpose(include_header=False, column_names=name_generator())
+        shape: (2, 3)
+        ┌─────────────┬─────────────┬─────────────┐
+        │ my_column_0 ┆ my_column_1 ┆ my_column_2 │
+        │ ---         ┆ ---         ┆ ---         │
+        │ i64         ┆ i64         ┆ i64         │
+        ╞═════════════╪═════════════╪═════════════╡
+        │ 1           ┆ 2           ┆ 3           │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 1           ┆ 2           ┆ 3           │
+        └─────────────┴─────────────┴─────────────┘
+
         """
-        return wrap_df(self._df.transpose(include_header, header_name))
+        df = wrap_df(self._df.transpose(include_header, header_name))
+        if column_names is not None:
+            names = []
+            n = df.width
+            if include_header:
+                names.append(header_name)
+                n -= 1
+
+            column_names = iter(column_names)
+            for _ in range(n):
+                names.append(next(column_names))
+            df.columns = names
+        return df
 
     def to_parquet(
         self,
@@ -1573,7 +1651,7 @@ class DataFrame:
         else:
             return wrap_df(self._df.sort(by, reverse))
 
-    def frame_equal(self, other: "DataFrame", null_equal: bool = False) -> bool:
+    def frame_equal(self, other: "DataFrame", null_equal: bool = True) -> bool:
         """
         Check if DataFrame is equal to other.
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1628,7 +1628,9 @@ class Series:
         """
         return wrap_s(self._s.explode())
 
-    def series_equal(self, other: "Series", null_equal: bool = False) -> bool:
+    def series_equal(
+        self, other: "Series", null_equal: bool = False, strict: bool = False
+    ) -> bool:
         """
         Check if series is equal with another Series.
 
@@ -1638,6 +1640,8 @@ class Series:
             Series to compare with.
         null_equal
             Consider null values as equal.
+        strict
+            Don't allow different numerical dtypes, e.g. comparing `pl.UInt32` with a `pl.Int64` will return `False`.
 
         Examples
         --------
@@ -1649,7 +1653,7 @@ class Series:
         False
 
         """
-        return self._s.series_equal(other._s, null_equal)
+        return self._s.series_equal(other._s, null_equal, strict)
 
     def len(self) -> int:
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1674,7 +1674,11 @@ class Series:
     def __len__(self) -> int:
         return self.len()
 
-    def cast(self, dtype: Type[DataType], strict: bool = True) -> "Series":
+    def cast(
+        self,
+        dtype: Union[Type[DataType], Type[int], Type[float], Type[str], Type[bool]],
+        strict: bool = True,
+    ) -> "Series":
         """
         Cast between data types.
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -580,8 +580,10 @@ impl PySeries {
         s.into()
     }
 
-    pub fn series_equal(&self, other: &PySeries, null_equal: bool) -> bool {
-        if null_equal {
+    pub fn series_equal(&self, other: &PySeries, null_equal: bool, strict: bool) -> bool {
+        if strict {
+            self.series.eq(&other.series)
+        } else if null_equal {
             self.series.series_equal_missing(&other.series)
         } else {
             self.series.series_equal(&other.series)

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,4 +1,5 @@
 # flake8: noqa: W191,E101
+import typing as tp
 from builtins import range
 from datetime import datetime
 from io import BytesIO
@@ -95,7 +96,7 @@ def test_init_ndarray_deprecated() -> None:
 def test_init_arrow() -> None:
     # Handle unnamed column
     df = pl.DataFrame(pa.table({"a": [1, 2], None: [3, 4]}))
-    truth = pl.DataFrame({"a": [1, 2], "column_1": [3, 4]})
+    truth = pl.DataFrame({"a": [1, 2], "None": [3, 4]})
     assert df.frame_equal(truth)
 
     # Rename columns
@@ -304,7 +305,7 @@ def test_replace() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     s = pl.Series("c", [True, False, True])
     df.replace("a", s)
-    assert df.frame_equal(pl.DataFrame({"c": [True, False, True], "b": [1, 2, 3]}))
+    assert df.frame_equal(pl.DataFrame({"a": [True, False, True], "b": [1, 2, 3]}))
 
 
 def test_assignment() -> None:
@@ -366,7 +367,10 @@ def test_groupby() -> None:
     assert df.groupby("a").apply(lambda df: df[["c"]].sum()).sort("c")["c"][0] == 1
 
     assert (
-        df.groupby("a").groups().sort("a")["a"].series_equal(pl.Series(["a", "b", "c"]))
+        df.groupby("a")
+        .groups()
+        .sort("a")["a"]
+        .series_equal(pl.Series("a", ["a", "b", "c"]))
     )
 
     for subdf in df.groupby("a"):  # type: ignore
@@ -412,10 +416,10 @@ def test_join() -> None:
     )
 
     joined = df_left.join(df_right, left_on="a", right_on="a").sort("a")
-    assert joined["b"].series_equal(pl.Series("", [1, 3, 2, 2]))
+    assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2]))
     joined = df_left.join(df_right, left_on="a", right_on="a", how="left").sort("a")
     assert joined["c_right"].is_null().sum() == 1
-    assert joined["b"].series_equal(pl.Series("", [1, 3, 2, 2, 4]))
+    assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2, 4]))
     joined = df_left.join(df_right, left_on="a", right_on="a", how="outer").sort("a")
     assert joined["c_right"].null_count() == 1
     assert joined["c"].null_count() == 1
@@ -612,13 +616,15 @@ def test_concat() -> None:
 
 def test_arg_where() -> None:
     s = pl.Series([True, False, True, False])
-    assert pl.arg_where(s).series_equal(pl.Series([0, 2]))
+    assert pl.arg_where(s).cast(int).series_equal(pl.Series([0, 2]))
 
 
 def test_get_dummies() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     res = pl.get_dummies(df)
-    expected = pl.DataFrame({"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]})
+    expected = pl.DataFrame(
+        {"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]}
+    ).with_columns(pl.all().cast(pl.UInt8))
     assert res.frame_equal(expected)
 
 
@@ -809,7 +815,7 @@ def test_string_cache_eager_lazy() -> None:
             "region_ids": ["reg1", "reg2", "reg3", "reg4", "reg5"],
             "score": [2.0, 1.0, None, 3.0, None],
         }
-    )
+    ).with_column(pl.col("region_ids").cast(pl.Categorical))
 
     assert df1.join(
         df2, left_on="region_ids", right_on="seq_name", how="left"
@@ -871,6 +877,8 @@ def test_rename(df: pl.DataFrame) -> None:
 
 
 def test_to_json(df: pl.DataFrame) -> None:
+    # text based conversion loses time info
+    df = df.select(pl.all().exclude(["cat", "time"]))
     s: str = df.to_json(to_string=True)  # type: ignore
     # TODO add overload on to_json()
     out = pl.read_json(s)
@@ -880,7 +888,9 @@ def test_to_json(df: pl.DataFrame) -> None:
 def test_from_rows() -> None:
     df = pl.from_records([[1, 2, "foo"], [2, 3, "bar"]], orient="row")
     assert df.frame_equal(
-        pl.DataFrame({"column_0": [1, 2], "foo": [2, 3], "column_2": ["foo", "bar"]})
+        pl.DataFrame(
+            {"column_0": [1, 2], "column_1": [2, 3], "column_2": ["foo", "bar"]}
+        )
     )
 
     df = pl.from_records(
@@ -1204,11 +1214,51 @@ def test_transpose() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
     expected = pl.DataFrame(
         {
-            "columns": ["a", "b"],
+            "column": ["a", "b"],
             "column_0": [1, 1],
             "column_1": [2, 2],
             "column_2": [3, 3],
         }
     )
     out = df.transpose(include_header=True)
+    assert expected.frame_equal(out)
+
+    out = df.transpose(include_header=False, column_names=["a", "b", "c"])
+    expected = pl.DataFrame(
+        {
+            "a": [1, 1],
+            "b": [2, 2],
+            "c": [3, 3],
+        }
+    )
+    assert expected.frame_equal(out)
+
+    out = df.transpose(
+        include_header=True, header_name="foo", column_names=["a", "b", "c"]
+    )
+    expected = pl.DataFrame(
+        {
+            "foo": ["a", "b"],
+            "a": [1, 1],
+            "b": [2, 2],
+            "c": [3, 3],
+        }
+    )
+    assert expected.frame_equal(out)
+
+    def name_generator() -> tp.Iterator[str]:
+        base_name = "my_column_"
+        count = 0
+        while True:
+            yield f"{base_name}{count}"
+            count += 1
+
+    out = df.transpose(include_header=False, column_names=name_generator())
+    expected = pl.DataFrame(
+        {
+            "my_column_0": [1, 1],
+            "my_column_1": [2, 2],
+            "my_column_2": [3, 3],
+        }
+    )
     assert expected.frame_equal(out)

--- a/py-polars/tests/test_functions.py
+++ b/py-polars/tests/test_functions.py
@@ -14,10 +14,10 @@ def test_date_datetime() -> None:
     out = df.select(
         [
             pl.all(),
-            pl.datetime("year", "month", "day", "hour").dt.hour().alias("h2"),
-            pl.date("year", "month", "day").dt.day().alias("date"),
+            pl.datetime("year", "month", "day", "hour").dt.hour().cast(int).alias("h2"),
+            pl.date("year", "month", "day").dt.day().cast(int).alias("date"),
         ]
     )
 
-    assert out["date"].series_equal(df["day"])
-    assert out["h2"].series_equal(df["hour"])
+    assert out["date"].series_equal(df["day"].rename("date"))
+    assert out["h2"].series_equal(df["hour"].rename("h2"))

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -47,7 +47,7 @@ def test_arrow_dict_to_polars() -> None:
     ).cast(pa.large_utf8())
 
     s = pl.Series(
-        name="s",
+        name="pa_dict",
         values=["AAA", "BBB", "CCC", "DDD", "BBB", "AAA", "CCC", "DDD", "DDD", "CCC"],
     )
 

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -18,16 +18,22 @@ from polars import DataType
 def test_to_from_buffer(df: pl.DataFrame) -> None:
     df = df.drop("strings_nulls")
 
-    for to_fn, from_fn in zip(
+    for to_fn, from_fn, text_based in zip(
         [df.to_parquet, df.to_csv, df.to_ipc, df.to_json],
         [pl.read_parquet, pl.read_csv, pl.read_ipc, pl.read_json],
+        [False, True, False, True],
     ):
         f = io.BytesIO()
         to_fn(f)  # type: ignore
         f.seek(0)
 
         df_1 = from_fn(f)  # type: ignore
-        assert df.frame_equal(df_1, null_equal=True)
+        # some type information is lost due to text conversion
+        if text_based:
+            df_1 = df_1.with_columns(
+                [pl.col("cat").cast(pl.Categorical), pl.col("time").cast(pl.Time)]
+            )
+        assert df.frame_equal(df_1)
 
 
 def test_select_columns_and_projection_from_buffer() -> None:
@@ -267,7 +273,7 @@ a,b,c
     assert out.frame_equal(expected)
 
     # no compression
-    f2 = io.BytesIO(b"a, b\n1,2\n")
+    f2 = io.BytesIO(b"a,b\n1,2\n")
     out2 = pl.read_csv(f2)
     expected = pl.DataFrame({"a": [1], "b": [2]})
     assert out2.frame_equal(expected)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -14,10 +14,10 @@ def create_series() -> pl.Series:
 
 def test_cum_agg() -> None:
     s = pl.Series("a", [1, 2, 3, 2])
-    assert s.cumsum().series_equal(pl.Series([1, 3, 6, 8]))
-    assert s.cummin().series_equal(pl.Series([1, 1, 1, 1]))
-    assert s.cummax().series_equal(pl.Series([1, 2, 3, 3]))
-    assert s.cumprod().series_equal(pl.Series([1, 2, 6, 12]))
+    assert s.cumsum().series_equal(pl.Series("a", [1, 3, 6, 8]))
+    assert s.cummin().series_equal(pl.Series("a", [1, 1, 1, 1]))
+    assert s.cummax().series_equal(pl.Series("a", [1, 2, 3, 3]))
+    assert s.cumprod().series_equal(pl.Series("a", [1, 2, 6, 12]))
 
 
 def test_init_inputs() -> None:
@@ -140,9 +140,9 @@ def test_various() -> None:
     assert len(a) == 2
     b = a.slice(1, 1)
     assert b.len() == 1
-    assert b.series_equal(pl.Series("", [2]))
+    assert b.series_equal(pl.Series("b", [2]))
     a.append(b)
-    assert a.series_equal(pl.Series("", [1, 2, 2]))
+    assert a.series_equal(pl.Series("b", [1, 2, 2]))
 
     a = pl.Series("a", range(20))
     assert a.head(5).len() == 5
@@ -151,11 +151,11 @@ def test_various() -> None:
 
     a = pl.Series("a", [2, 1, 4])
     a.sort(in_place=True)
-    assert a.series_equal(pl.Series("", [1, 2, 4]))
+    assert a.series_equal(pl.Series("a", [1, 2, 4]))
     a = pl.Series("a", [2, 1, 1, 4, 4, 4])
     assert a.arg_unique().to_list() == [0, 1, 3]
 
-    assert a.take([2, 3]).series_equal(pl.Series("", [1, 4]))
+    assert a.take([2, 3]).series_equal(pl.Series("a", [1, 4]))
     assert a.is_numeric()
     a = pl.Series("bool", [True, False])
     assert not a.is_numeric()
@@ -580,15 +580,11 @@ def test_list_concat_dispatch() -> None:
     assert out.series_equal(expected)
 
     df = pl.DataFrame([s0, s1])
-    assert df.select(pl.concat_list(["a", "b"]).alias("concat"))["concat"].series_equal(
+    assert df.select(pl.concat_list(["a", "b"]).alias("a"))["a"].series_equal(expected)
+    assert df.select(pl.col("a").arr.concat("b").alias("a"))["a"].series_equal(expected)
+    assert df.select(pl.col("a").arr.concat(["b"]).alias("a"))["a"].series_equal(
         expected
     )
-    assert df.select(pl.col("a").arr.concat("b").alias("concat"))[
-        "concat"
-    ].series_equal(expected)
-    assert df.select(pl.col("a").arr.concat(["b"]).alias("concat"))[
-        "concat"
-    ].series_equal(expected)
 
 
 def test_floor_divide() -> None:
@@ -796,17 +792,17 @@ def test_filter() -> None:
 
 def test_take_every() -> None:
     s = pl.Series("a", [1, 2, 3, 4])
-    assert s.take_every(2).series_equal(pl.Series([1, 3]))
+    assert s.take_every(2).series_equal(pl.Series("a", [1, 3]))
 
 
 def test_argsort() -> None:
     s = pl.Series("a", [5, 3, 4, 1, 2])
     result = s.argsort()
-    expected = pl.Series([3, 4, 1, 2, 0])
+    expected = pl.Series("a", [3, 4, 1, 2, 0])
     assert result.series_equal(expected)
 
     result_reverse = s.argsort(True)
-    expected_reverse = pl.Series([0, 2, 1, 4, 3])
+    expected_reverse = pl.Series("a", [0, 2, 1, 4, 3])
     assert result_reverse.series_equal(expected_reverse)
 
 
@@ -818,31 +814,31 @@ def test_arg_min_and_arg_max() -> None:
 
 def test_is_null_is_not_null() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, None])
-    assert s.is_null().series_equal(pl.Series([False, False, False, True]))
-    assert s.is_not_null().series_equal(pl.Series([True, True, True, False]))
+    assert s.is_null().series_equal(pl.Series("a", [False, False, False, True]))
+    assert s.is_not_null().series_equal(pl.Series("a", [True, True, True, False]))
 
 
 def test_is_finite_is_infinite() -> None:
     s = pl.Series("a", [1.0, 2.0, np.inf])
 
-    s.is_finite().series_equal(pl.Series([True, True, False]))
-    s.is_infinite().series_equal(pl.Series([False, False, True]))
+    s.is_finite().series_equal(pl.Series("a", [True, True, False]))
+    s.is_infinite().series_equal(pl.Series("a", [False, False, True]))
 
 
 def test_is_nan_is_not_nan() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, np.NaN])
-    assert s.is_nan().series_equal(pl.Series([False, False, False, True]))
-    assert s.is_not_nan().series_equal(pl.Series([True, True, True, False]))
+    assert s.is_nan().series_equal(pl.Series("a", [False, False, False, True]))
+    assert s.is_not_nan().series_equal(pl.Series("a", [True, True, True, False]))
 
 
 def test_is_unique() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
-    assert s.is_unique().series_equal(pl.Series([True, False, False, True]))
+    assert s.is_unique().series_equal(pl.Series("a", [True, False, False, True]))
 
 
 def test_is_duplicated() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
-    assert s.is_duplicated().series_equal(pl.Series([False, True, True, False]))
+    assert s.is_duplicated().series_equal(pl.Series("a", [False, True, True, False]))
 
 
 def test_dot() -> None:


### PR DESCRIPTION
Equality of Series and DataFrames now also checks
the column name. This also uncovered some inconsistencies
wich are now fixed.

For python transpose a generator option is
added so that a use can define column names