### PR TITLE
panic on invalid when -> then -> otherwise state

### DIFF
--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -264,9 +264,10 @@ pub unsafe fn take_no_null_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &LargeStringArray,
     indices: I,
 ) -> Arc<LargeStringArray> {
-    let iter = indices
-        .into_iter()
-        .map(|idx| Some(arr.value_unchecked(idx)));
+    let iter = indices.into_iter().map(|idx| {
+        debug_assert!(idx < arr.len());
+        Some(arr.value_unchecked(idx))
+    });
 
     Arc::new(LargeStringArray::from_trusted_len_iter_unchecked(iter))
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -233,6 +233,7 @@ impl<'a> AggregationContext<'a> {
                     || !self.groups.as_ref().is_empty()
                     && self.groups[0].1.len() > 1)
                 {
+                    // todo! optimize this, we don't have to call agg_list, create the list directly.
                     Cow::Owned(s.expand_at_index(0, self.groups.iter().map(|g| g.1.len()).sum()))
                 } else {
                     Cow::Borrowed(s)

--- a/polars/polars-lazy/src/test.rs
+++ b/polars/polars-lazy/src/test.rs
@@ -2242,3 +2242,37 @@ fn test_literal_window_fn() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[should_panic]
+fn test_invalid_ternary_in_agg1() {
+    let df = df![
+        "groups" => [1, 1, 2, 2, 3, 3],
+        "vals" => [1, 2, 3, 4, 5, 6]
+    ]
+    .unwrap();
+
+    df.lazy()
+        .groupby([col("groups")])
+        .agg([when(col("vals").first().neq(lit(1)))
+            .then(lit("a"))
+            .otherwise(lit("b"))])
+        .collect();
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_ternary_in_agg2() {
+    let df = df![
+        "groups" => [1, 1, 2, 2, 3, 3],
+        "vals" => [1, 2, 3, 4, 5, 6]
+    ]
+    .unwrap();
+
+    df.lazy()
+        .groupby([col("groups")])
+        .agg([when(col("vals").neq(lit(1)))
+            .then(col("vals").first())
+            .otherwise(lit("b"))])
+        .collect();
+}


### PR DESCRIPTION
@ghuls 

This likely is a fix for what you showed in #1870 with regard to the memory allocation.
It is not a really satisfying fix, as we need to `panic` because an expression produces a result polars cannot handle.

The problem is the `first()` aggregations in this expression that is run in the `groupby` or  `agg` context:

```python
  [
      pl.when(
           pl.col("score").cast(pl.Utf8).first()
      ).then(
          (pl.col("score") * 2).cast(pl.Utf8) + pl.lit("_____") + pl.col("id").first() + pl.lit("_____") + pl.col("title")
      ).otherwise(
          "ne"
      ).alias("test_apply")
  ]
```

Note that we run the `when->then->otherwise` not in groups, but vectorized, e.g. as a whole column (the group by aggregation is done later), because its faster to work on the columns.

Because we run this in the `groupby` context, the `first` returns a `Series` of a length equal to the number of groups ( n_groups < df.height). If we then combine that with columns that produce the same length as the `DataFrame`s height we yield a Series that's too short when we start the aggregation and we out of bounds.

~I don't know a good solution for this yet. Maybe we must accept that we cannot run all expressions.~ At least we panic now and inform the user that he/she must rewrite their query.