### PR TITLE
Add support for compiling polars for PyPy.

### DIFF
--- a/.github/workflows/create-py-release-test.yaml
+++ b/.github/workflows/create-py-release-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin==0.11.0 pytest pandas pyarrow
+          pip install maturin==0.12.1 pytest pandas pyarrow
       - name: Run tests
         run: |
           cd py-polars

--- a/.github/workflows/create-py-universal2-release.yaml
+++ b/.github/workflows/create-py-universal2-release.yaml
@@ -41,6 +41,6 @@ jobs:
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
-          maturin-version: 0.11.3
+          maturin-version: 0.12.1
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist --universal2 -o wheels -i python -u ritchie46

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
+checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
 dependencies = [
  "ctor",
  "ghost",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "inventory-impl"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
+checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1293,8 +1293,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+source = "git+https://github.com/ghuls/pyo3?branch=polars_pypy_hasattr#5357442504126fcd61618bf809c737a8c702156b"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
@@ -1310,8 +1309,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+source = "git+https://github.com/ghuls/pyo3?branch=polars_pypy_hasattr#5357442504126fcd61618bf809c737a8c702156b"
 dependencies = [
  "once_cell",
 ]
@@ -1319,8 +1317,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+source = "git+https://github.com/ghuls/pyo3?branch=polars_pypy_hasattr#5357442504126fcd61618bf809c737a8c702156b"
 dependencies = [
  "pyo3-macros-backend",
  "quote",
@@ -1330,8 +1327,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+source = "git+https://github.com/ghuls/pyo3?branch=polars_pypy_hasattr#5357442504126fcd61618bf809c737a8c702156b"
 dependencies = [
  "proc-macro2",
  "pyo3-build-config",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -26,6 +26,9 @@ pyo3 = { version = "0.15", features = ["abi3-py36", "extension-module", "multipl
 serde_json = { version = "1", optional = true }
 thiserror = "1.0.20"
 
+[patch.crates-io]
+pyo3 = { git = "https://github.com/ghuls/pyo3", branch = "polars_pypy_hasattr" }
+
 # features are only there to enable building a slim binary for the benchmark in CI
 [features]
 parquet = ["polars/parquet"]

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -8,7 +8,7 @@ pyarrow
 pandas
 
 # Tooling
-maturin==0.11.0
+maturin==0.12.1
 pytest==6.2.5
 pytest-cov[toml]==3.0.0
 black==21.6b0

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Add support for compiling polars for PyPy:
  - requires newer version of maturin
  - requires pyo3 0.15.1 with the following patch:
       Map "PyPyObject_HasAttr" to "PyObject_HasAttr" so hasattr works with PyPy:
         - https://github.com/PyO3/pyo3/pull/2025
         - Available at: https://github.com/ghuls/pyo3/tree/pypy_hasattr
         - Patch against latest commits on https://github.com/PyO3/pyo3
           won't work for now, as rust-numpy 0.15 is not compatible with
           that version yet.