### PR TITLE
Tidy Arrow timestamp handling

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -142,7 +142,6 @@ __all__ = [
     "scan_ipc",
     "scan_parquet",
     "read_ipc_schema",
-    "testing",
     # polars.stringcache
     "StringCache",
     # polars.config

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -142,6 +142,7 @@ __all__ = [
     "scan_ipc",
     "scan_parquet",
     "read_ipc_schema",
+    "testing",
     # polars.stringcache
     "StringCache",
     # polars.config

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -421,10 +421,11 @@ def pandas_to_pydf(
 def coerce_arrow(array: "pa.Array") -> "pa.Array":
     # also coerces timezone to naive representation
     # units are accounted for by pyarrow
-    if "timestamp" in str(array.type):
-        warnings.warn(
-            "Conversion of (potentially) timezone aware to naive datetimes. TZ information may be lost",
-        )
+    if isinstance(array, pa.TimestampArray):
+        if array.type.tz is not None:
+            warnings.warn(
+                "Conversion of timezone aware to naive datetimes. TZ information may be lost",
+            )
         ts_ms = pa.compute.cast(array, pa.timestamp("ms"), safe=False)
         ms = pa.compute.cast(ts_ms, pa.int64())
         del ts_ms


### PR DESCRIPTION
* Use isinstance to check for timestamp type
* Only raise timezone warning in case a timezone aware array is passed in
* Add test to guarantee the previous point; cleans up all TZ warnings in test output