### PR TITLE
add callback to lazy csv scanner so that column names can be modified

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -575,6 +575,10 @@ impl Field {
         self.data_type = dtype;
     }
 
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+
     pub fn to_arrow(&self) -> ArrowField {
         ArrowField::new(&self.name, self.data_type.to_arrow(), true)
     }

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -53,6 +53,7 @@ class LazyFrame:
         comment_char: Optional[str] = None,
         quote_char: Optional[str] = r'"',
         null_values: Optional[Union[str, tp.List[str], Dict[str, str]]] = None,
+        with_column_names: Optional[Callable[[tp.List[str]], tp.List[str]]] = None,
     ) -> "LazyFrame":
         """
         See Also: `pl.scan_csv`
@@ -79,6 +80,7 @@ class LazyFrame:
             quote_char,
             processed_null_values,
             infer_schema_length,
+            with_column_names,
         )
         return self
 


### PR DESCRIPTION
This will reduce the need of first loading a csv file eagerly before using the Lazy API.

```python
# we can use `with_column_names` to modify the header before scanning
df = pl.DataFrame({
    "BrEeZaH": [1, 2, 3, 4],
    "LaNgUaGe": ["is", "terrible", "to", "read"]
})
df.to_csv("mydf.csv")
(pl.scan_csv("mydf.csv",
    with_column_names=lambda cols: [col.lower() for col in cols])
.fetch()
)
```
```
    shape: (4, 2)
    ┌─────────┬──────────┐
    │ breezah ┆ language │
    │ ---     ┆ ---      │
    │ i64     ┆ str      │
    ╞═════════╪══════════╡
    │ 1       ┆ is       │
    ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
    │ 2       ┆ terrible │
    ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
    │ 3       ┆ to       │
    ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
    │ 4       ┆ read     │
    └─────────┴──────────┘
```

@koaning, this will make your WoW pipeline truly lazy start to end. :)