### PR TITLE
Remove date_like_to_physical

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -179,17 +179,6 @@ if _PYARROW_AVAILABLE:
     }
 
 
-def date_like_to_physical(dtype: Type[DataType]) -> Type[DataType]:
-    #  TODO: add more
-    if dtype == Date:
-        return Int32
-    if dtype == Datetime:
-        return Int64
-    if dtype == Time:
-        return Int64
-    return dtype
-
-
 def dtype_to_ctype(dtype: Type[DataType]) -> Type[_SimpleCData]:
     try:
         return _DTYPE_TO_CTYPE[dtype]


### PR DESCRIPTION
This function was only used in arithmetic methods in pl.Series. Not sure what we would expect, what should the answer be when we subtract two dates, or a date and a time, given we do not have a timedelta data type. No tests are hitting this logic either. So I propose to remove it, but I may be missing something here..