### PR TITLE
Preserve Series types when constructing a list-series

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -132,7 +132,7 @@ def sequence_to_pyseries(
                 )
             return arrow_to_pyseries(name, pa.array(values))
 
-        elif dtype_ == list or dtype_ == tuple or dtype_ == pli.Series:
+        elif dtype_ == list or dtype_ == tuple:
             nested_value = _get_first_non_none(value)
             nested_dtype = type(nested_value) if value is not None else float
 
@@ -168,6 +168,10 @@ def sequence_to_pyseries(
 
             # Convert mixed sequences like `[[12], "foo", 9]`
             return PySeries.new_object(name, values, strict)
+
+        elif dtype_ == pli.Series:
+            return PySeries.new_series_list(name, [v.inner() for v in values], strict)
+
         else:
             constructor = py_type_to_constructor(dtype_)
             return constructor(name, values, strict)

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -196,6 +196,12 @@ impl PySeries {
     }
 
     #[staticmethod]
+    pub fn new_series_list(name: &str, val: Vec<Self>, _strict: bool) -> Self {
+        let series_vec = to_series_collection(val);
+        Series::new(name, &series_vec).into()
+    }
+
+    #[staticmethod]
     pub fn repeat(name: &str, val: &PyAny, n: usize, dtype: &PyAny) -> Self {
         let str_repr = dtype.str().unwrap().to_str().unwrap();
         let dtype = str_to_polarstype(str_repr);

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1064,3 +1064,10 @@ def test_init_categorical() -> None:
         expected = pl.Series("a", values, dtype=pl.Utf8).cast(pl.Categorical)
         a = pl.Series("a", values, dtype=pl.Categorical)
         testing.assert_series_equal(a, expected)
+
+
+def test_nested_list_types_preserved() -> None:
+    expected_dtype = pl.UInt32
+    srs1 = pl.Series([pl.Series([3, 4, 5, 6], dtype=expected_dtype) for _ in range(5)])
+    for srs2 in srs1:
+        assert srs2.dtype == expected_dtype


### PR DESCRIPTION
This is a fix for the type-change observed in https://github.com/pola-rs/polars/issues/1866#issuecomment-979712457 - this PR does not include the fix for the serde-issue discussed there.

The reason was that the construction of the list-series involved checking the python-type of the series and constructing a series based on that type. Looking at `_PY_TYPE_TO_DTYPE` [here](https://github.com/pola-rs/polars/blob/2d475d84e119fd039f185ce329a6ab5addf97760/py-polars/polars/datatypes.py#L150) everything getting converted to a python `int` corresponded to an arrow `Int64` - which is exactly what was observed in the issue. This change avoids the comparison of the contents based on python types when the values are a `Series`-type.