### PR TITLE
[Rust][Documentation] `DataFrame` cleaning, enabling run check

### DIFF
--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -18,19 +18,20 @@ impl DataFrame {
     /// # Example
     ///
     /// ```ignore
-    ///  use polars_core::prelude::*;
-    ///  let s0 = Series::new("a", &[1i64, 2, 3]);
-    ///  let s1 = Series::new("b", &[1i64, 1, 1]);
-    ///  let s2 = Series::new("c", &[2i64, 2, 2]);
-    ///  let list = Series::new("foo", &[s0, s1, s2]);
+    /// # use polars_core::prelude::*;
+    /// let s0 = Series::new("a", &[1i64, 2, 3]);
+    /// let s1 = Series::new("b", &[1i64, 1, 1]);
+    /// let s2 = Series::new("c", &[2i64, 2, 2]);
+    /// let list = Series::new("foo", &[s0, s1, s2]);
     ///
-    ///  let s0 = Series::new("B", [1, 2, 3]);
-    ///  let s1 = Series::new("C", [1, 1, 1]);
-    ///  let df = DataFrame::new(vec![list, s0, s1]).unwrap();
-    ///  let exploded = df.explode("foo").unwrap();
+    /// let s0 = Series::new("B", [1, 2, 3]);
+    /// let s1 = Series::new("C", [1, 1, 1]);
+    /// let df = DataFrame::new(vec![list, s0, s1])?;
+    /// let exploded = df.explode("foo")?;
     ///
-    ///  println!("{:?}", df);
-    ///  println!("{:?}", exploded);
+    /// println!("{:?}", df);
+    /// println!("{:?}", exploded);
+    /// # Ok::<(), PolarsError>(())
     /// ```
     /// Outputs:
     ///
@@ -129,19 +130,17 @@ impl DataFrame {
     /// * `value_vars` - String slice that represent the columns to use as value variables.
     ///
     /// ```ignore
-    ///
-    ///  # #[macro_use] extern crate polars_core;
-    /// use polars_core::prelude::*;
+    /// # use polars_core::prelude::*;
     /// let df = df!("A" => &["a", "b", "a"],
     ///              "B" => &[1, 3, 5],
     ///              "C" => &[10, 11, 12],
     ///              "D" => &[2, 4, 6]
-    ///     )
-    /// .unwrap();
+    ///     )?;
     ///
-    /// let melted = df.melt(&["A", "B"], &["C", "D"]).unwrap();
+    /// let melted = df.melt(&["A", "B"], &["C", "D"])?;
     /// println!("{:?}", df);
     /// println!("{:?}", melted);
+    /// # Ok::<(), PolarsError>(())
     /// ```
     /// Outputs:
     /// ```text

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1046,22 +1046,17 @@ impl DataFrame {
     ///
     /// # Example
     ///
-    /// ```rust
-    /// use polars_core::df;
-    /// use polars_core::prelude::*;
+    /// ```no_run
+    /// # use polars_core::prelude::*;
+    /// let df1: DataFrame = df!("Fruit" => &["Apple", "Banana", "Pear"],
+    ///                          "Phosphorus (mg/100g)" => &[11, 22, 12])?;
+    /// let df2: DataFrame = df!("Name" => &["Apple", "Banana", "Pear"],
+    ///                          "Potassium (mg/100g)" => &[107, 358, 115])?;
     ///
-    /// fn example() -> Result<()> {
-    ///     let df1: DataFrame = df!("Fruit" => &["Apple", "Banana", "Pear"],
-    ///                              "Phosphorus (mg/100g)" => &[11, 22, 12])?;
-    ///     let df2: DataFrame = df!("Name" => &["Apple", "Banana", "Pear"],
-    ///                              "Potassium (mg/100g)" => &[107, 358, 115])?;
-    ///
-    ///     let df3: DataFrame = df1.join(&df2, "Fruit", "Name", JoinType::Inner, None)?;
-    ///     assert_eq!(df3.shape(), (3, 3));
-    ///     println!("{}", df3);
-    ///
-    ///     Ok(())
-    /// }
+    /// let df3: DataFrame = df1.join(&df2, "Fruit", "Name", JoinType::Inner, None)?;
+    /// assert_eq!(df3.shape(), (3, 3));
+    /// println!("{}", df3);
+    /// # Ok::<(), PolarsError>(())
     /// ```
     ///
     /// Output:
@@ -1240,7 +1235,7 @@ impl DataFrame {
     /// # Example
     ///
     /// ```
-    /// use polars_core::prelude::*;
+    /// # use polars_core::prelude::*;
     /// fn join_dfs(left: &DataFrame, right: &DataFrame) -> Result<DataFrame> {
     ///     left.inner_join(right, "join_column_left", "join_column_right")
     /// }
@@ -1281,7 +1276,7 @@ impl DataFrame {
     /// # Example
     ///
     /// ```
-    /// use polars_core::prelude::*;
+    /// # use polars_core::prelude::*;
     /// fn join_dfs(left: &DataFrame, right: &DataFrame) -> Result<DataFrame> {
     ///     left.left_join(right, "join_column_left", "join_column_right")
     /// }
@@ -1323,7 +1318,7 @@ impl DataFrame {
     /// # Example
     ///
     /// ```
-    /// use polars_core::prelude::*;
+    /// # use polars_core::prelude::*;
     /// fn join_dfs(left: &DataFrame, right: &DataFrame) -> Result<DataFrame> {
     ///     left.outer_join(right, "join_column_left", "join_column_right")
     /// }


### PR DESCRIPTION
### Documentation
- The `use polars[...]` issue is explained once, so that the others are removed from the visible documentation.
- We assume now that the reader is familiar with the [std::result](https://doc.rust-lang.org/std/result/) module.

### Testing
- The `fn example()` are not used anymore, because they were preventing from run checks.

### To be solved later
- Some tests don't pass the `cargo miri` check. They're stated `ignore` (no check) or `no_run` (only compile check).
- Not all the functions are yet carefully documented.

This PR improves the documentation as well as the robustness of the crate, despite putting on hold some issues for the moment.