### PR TITLE
[Rust] Add `DataFrame::pop`

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -273,32 +273,6 @@ impl DataFrame {
         self.columns.pop()
     }
 
-    /// Appends the `Series` to the back of the `DataFrame` and return whether the operation is
-    /// successful or not.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let s1 = Series::new("Ocean", &["Atlantic", "Indian"]);
-    /// let s2 = Series::new("Area (km²)", &[106_460_000, 70_560_000]);
-    /// let s3 = Series::new("Average depth (m)", &[3_646]);
-    /// let mut df = DataFrame::default();
-    ///
-    /// assert!(df.push(s1));
-    /// assert!(df.push(s2));
-    /// assert!(!df.push(s3));
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn push(&mut self, value: Series) -> bool {
-        if self.is_empty() || (self.columns[0].len() == value.len()) {
-            self.columns.push(value);
-            true
-        } else {
-            false
-        }
-    }
-
     /// Add a new column at index 0 that counts the rows.
     ///
     /// # Example

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -253,6 +253,52 @@ impl DataFrame {
         Ok(df)
     }
 
+    /// Removes the last `Series` from the `DataFrame` and returns it, or [`None`] if it is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// let s1 = Series::new("Ocean", &["Atlantic", "Indian"]);
+    /// let s2 = Series::new("Area (km²)", &[106_460_000, 70_560_000]);
+    /// let mut df = DataFrame::new(vec![s1.clone(), s2.clone()])?;
+    ///
+    /// assert_eq!(df.pop(), Some(s2));
+    /// assert_eq!(df.pop(), Some(s1));
+    /// assert_eq!(df.pop(), None);
+    /// assert!(df.is_empty());
+    /// # Ok::<(), PolarsError>(())
+    /// ```
+    pub fn pop(&mut self) -> Option<Series> {
+        self.columns.pop()
+    }
+
+    /// Appends the `Series` to the back of the `DataFrame` and return whether the operation is
+    /// successful or not.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// let s1 = Series::new("Ocean", &["Atlantic", "Indian"]);
+    /// let s2 = Series::new("Area (km²)", &[106_460_000, 70_560_000]);
+    /// let s3 = Series::new("Average depth (m)", &[3_646]);
+    /// let mut df = DataFrame::default();
+    ///
+    /// assert!(df.push(s1));
+    /// assert!(df.push(s2));
+    /// assert!(!df.push(s3));
+    /// # Ok::<(), PolarsError>(())
+    /// ```
+    pub fn push(&mut self, value: Series) -> bool {
+        if self.is_empty() || (self.columns[0].len() == value.len()) {
+            self.columns.push(value);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Add a new column at index 0 that counts the rows.
     ///
     /// # Example


### PR DESCRIPTION
### New functions
- `DataFrame::push`
- `DataFrame::pop`

### Design
More globally, the `DataFrame` structure is based on a `Vec<Series>` that has other functionalities and guarantees than [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), which is a very familiar structure for the programmers. Hence, I think that we should exploit the [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html) features as much as possible, in order to rely on the [std](https://doc.rust-lang.org/std/index.html) work in addition to the work done in [arrow2](https://jorgecarleitao.github.io/arrow2/docs/arrow2/index.html) or in [polars](https://pola-rs.github.io/polars/polars/index.html) itself.

Don't hesitate to tell me if you disagree and/or if I have misunderstood the [polars](https://pola-rs.github.io/polars/polars/index.html) design.