### PR TITLE
Fix panics on series deserialization

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -153,6 +153,7 @@ regex = { version = "1.4", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+bincode = { version = "1", optional = true}
 thiserror = "1.0"
 unsafe_unwrap = "^0.1.0"
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -153,7 +153,6 @@ regex = { version = "1.4", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-bincode = { version = "1", optional = true}
 thiserror = "1.0"
 unsafe_unwrap = "^0.1.0"
 
@@ -175,6 +174,9 @@ features = [
   "compute_if_then_else",
   "compute_take",
 ]
+
+[dev-dependencies]
+bincode = "1"
 
 [package.metadata.docs.rs]
 # not all because arrow 4.3 does not compile with simd

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -72,6 +72,12 @@ impl<'de> Deserialize<'de> for Series {
             where
                 A: MapAccess<'de>,
             {
+                debug_assert!(
+                    map.size_hint() == Some(FIELDS.len()) || map.size_hint() == None,
+                    "unexpected map size. size_hint == {:?}",
+                    map.size_hint(),
+                );
+
                 let mut name: Option<Cow<'de, str>> = None;
                 let mut dtype = None;
                 let mut values_set = false;

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -72,12 +72,6 @@ impl<'de> Deserialize<'de> for Series {
             where
                 A: MapAccess<'de>,
             {
-                debug_assert!(
-                    map.size_hint() == Some(FIELDS.len()) || map.size_hint() == None,
-                    "unexpected map size. size_hint == {:?}",
-                    map.size_hint(),
-                );
-
                 let mut name: Option<Cow<'de, str>> = None;
                 let mut dtype = None;
                 let mut values_set = false;
@@ -169,7 +163,7 @@ impl<'de> Deserialize<'de> for Series {
                         Ok(Series::new(&name, values))
                     }
                     DeDataType::List => {
-                        let values: Vec<Series> = map.next_value()?;
+                        let values: Vec<Option<Series>> = map.next_value()?;
                         Ok(Series::new(&name, values))
                     }
                     dt => {

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -159,7 +159,7 @@ impl<'de> Deserialize<'de> for Series {
                         Ok(Series::new(&name, values))
                     }
                     DeDataType::Utf8 => {
-                        let values: Vec<Option<&str>> = map.next_value()?;
+                        let values: Vec<Option<Cow<str>>> = map.next_value()?;
                         Ok(Series::new(&name, values))
                     }
                     DeDataType::List => {

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -5,6 +5,7 @@ use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
 use crate::prelude::*;
 use arrow::compute::cast::utf8_to_large_utf8;
 use polars_arrow::compute::cast::cast;
+use std::borrow::Cow;
 use std::convert::TryFrom;
 
 pub trait NamedFrom<T, Phantom: ?Sized> {
@@ -30,6 +31,24 @@ impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Series {
 impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Series {
     fn new(name: &str, v: T) -> Self {
         Utf8Chunked::new_from_opt_slice(name, v.as_ref()).into_series()
+    }
+}
+
+impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
+            .into_series()
+    }
+}
+impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_iter(
+            name,
+            v.as_ref()
+                .iter()
+                .map(|opt| opt.as_ref().map(|value| value.as_ref())),
+        )
+        .into_series()
     }
 }
 


### PR DESCRIPTION
This PR aims to fix #1866, but I am currently somewhat stuck in resolving this issue and would appreciate any hints.

So far the changes are:
* 105bf2e extends the (de-)serialization tests and adds tests using `bincode`. As the result these test fail for the `List` type and interestingly for the `Utf8` type as well
* c5f0739 fixes the issue with the `Utf8` type, which was caused by `String` vs `str` when using `DeserializeOwned`.
* 7424b12 just adds a debug assertion to point out the still present issue with the `List` type.

The output of the debug assertion of the last commit when running the unittests of the first commit is:

```
---- serde::test::test_serde_df_owned_bincode stdout ----
thread 'serde::test::test_serde_df_owned_bincode' panicked at 'unexpected map size. size_hint == Some(769)', polars/polars-core/src/serde/series.rs:75:17
stack backtrace:
   0: rust_begin_unwind
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:460:5
   2: <polars_core::serde::series::<impl serde::de::Deserialize for polars_core::series::Series>::deserialize::SeriesVisitor as serde::de::Visitor>::visit_map
             at ./src/serde/series.rs:75:17
   3: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_map
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/bincode-1.3.3/src/de/mod.rs:396:9
   4: polars_core::serde::series::<impl serde::de::Deserialize for polars_core::series::Series>::deserialize
             at ./src/serde/series.rs:182:9
   5: <core::marker::PhantomData<T> as serde::de::DeserializeSeed>::deserialize
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.130/src/de/mod.rs:785:9
   6: <<&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_tuple::Access<R,O> as serde::de::SeqAccess>::next_element_seed
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/bincode-1.3.3/src/de/mod.rs:314:25
   7: serde::de::SeqAccess::next_element
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.130/src/de/mod.rs:1707:9
   8: <serde::de::impls::<impl serde::de::Deserialize for alloc::vec::Vec<T>>::deserialize::VecVisitor<T> as serde::de::Visitor>::visit_seq
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.130/src/de/impls.rs:928:46
   9: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_tuple
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/bincode-1.3.3/src/de/mod.rs:326:9
  10: <&mut bincode::de::Deserializer<R,O> as serde::de::Deserializer>::deserialize_seq
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/bincode-1.3.3/src/de/mod.rs:350:9
  11: serde::de::impls::<impl serde::de::Deserialize for alloc::vec::Vec<T>>::deserialize
             at /home/nico/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.130/src/de/impls.rs:939:9
```

The value of the size_hint should be `Some(4)`, so serde attempts to read that many elements from the buffer, which causes the `UnexpectedEof` error. I am currently stuck here in find the cause for this. Anybody got any pointers? The error occurs only when using `bincode` format, which is not self-describing.  

I did run the tests using

```
RUST_BACKTRACE=1 cargo test --features="serde,serde_json,bincode"
```