### PR TITLE
Add description and min required Python version

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -3,12 +3,12 @@ name = "py-polars"
 version = "0.10.24"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars-book/"
-description = "Blazingly fast DataFrames in Rust & Python"
 edition = "2018"
 homepage = "https://github.com/pola-rs/polars"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/pola-rs/polars"
+description = "Blazingly fast DataFrames in Rust & Python"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -3,6 +3,7 @@ name = "py-polars"
 version = "0.10.24"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars-book/"
+description = "Blazingly fast DataFrames in Rust & Python"
 edition = "2018"
 homepage = "https://github.com/pola-rs/polars"
 license = "MIT"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/pola-rs/polars"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/pola-rs/polars"
-description = "Blazingly fast DataFrames in Rust & Python"
+description = "Blazingly fast DataFrames"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -7,6 +7,7 @@ name = "polars"
 dependencies = [
   "numpy",
 ]
+requires-python = ">=3.6"
 
 [project.optional-dependencies]
 # the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS


### PR DESCRIPTION
The description tag should fill this on PyPI:

![image](https://user-images.githubusercontent.com/11277667/143822661-fe59a5b0-df16-40d3-8459-6dea184e3145.png)

I have taken the header of the README, it is a bit odd maybe to advertise Rust on a Python package?

Also added minimum Python version in `pyproject.toml`.
