### PR TITLE
Test Python 3.10 instead of 3.9 

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.9" ]
+        python-version: [ "3.6", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest Rust nightly


### PR DESCRIPTION
Given 3.10 is the latest stable release.

Closes #1921