### PR TITLE
fix unique/n_unique for Categorical

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -10,8 +10,8 @@ description = "Arrow interfaces for Polars DataFrame library"
 
 [dependencies]
 # arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "e9a6c3ef7e1a328c298bd45e36ac2abf8ae44ebb", default-features = false }
-# arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "fn_to" }
-arrow = { package = "arrow2", version = "0.8", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "offset_pub" }
+# arrow = { package = "arrow2", version = "0.8", default-features = false }
 num = "^0.4"
 thiserror = "^1.0"
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -158,7 +158,9 @@ unsafe_unwrap = "^0.1.0"
 
 [dependencies.arrow]
 package = "arrow2"
-version = "0.8"
+git = "https://github.com/ritchie46/arrow2"
+branch = "offset_pub"
+# version = "0.8"
 default-features = false
 features = [
   "compute_aggregate",

--- a/polars/polars-core/src/chunked_array/builder/from.rs
+++ b/polars/polars-core/src/chunked_array/builder/from.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{BooleanChunked, ChunkedArray, PolarsNumericType};
+use crate::prelude::*;
 use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
 use std::sync::Arc;
 
@@ -8,6 +8,12 @@ impl<T: PolarsNumericType> From<(&str, PrimitiveArray<T::Native>)> for ChunkedAr
         let arr = tpl.1;
 
         ChunkedArray::new_from_chunks(name, vec![Arc::new(arr)])
+    }
+}
+
+impl<T: PolarsNumericType> From<&[T::Native]> for ChunkedArray<T> {
+    fn from(slice: &[T::Native]) -> Self {
+        ChunkedArray::new_from_slice("", slice)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/categorical/builder.rs
@@ -174,12 +174,15 @@ impl CategoricalChunkedBuilder {
     }
 
     pub fn finish(self) -> ChunkedArray<CategoricalType> {
+        // both for the local and the global map, we own a map that has all unique keys
+        let bit_settings = 1u8 << 4;
+
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![self.array_builder.into_arc()],
             phantom: PhantomData,
             categorical_map: Some(Arc::new(self.reverse_mapping.finish())),
-            ..Default::default()
+            bit_settings,
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/categorical/mod.rs
@@ -69,6 +69,13 @@ impl CategoricalChunked {
         self
     }
 
+    pub(crate) fn can_fast_unique(&self) -> bool {
+        self.bit_settings & 1 << 4 != 0 && self.chunks.len() == 1 && {
+            let arr = self.downcast_iter().next().unwrap();
+            arr.values().offset() == 0
+        }
+    }
+
     /// Create an `[Iterator]` that iterates over the `&str` values of the `[CategoricalChunked]`.
     pub fn iter_str(&self) -> CatIter<'_> {
         let iter = self.deref().into_iter();
@@ -177,5 +184,19 @@ mod test {
         assert_eq!(appended.str_value(1), "\"b\"");
         assert_eq!(appended.str_value(4), "\"x\"");
         assert_eq!(appended.str_value(5), "\"y\"");
+    }
+
+    #[test]
+    fn test_fast_unique() {
+        let mut s = Series::new("1", vec!["a", "b", "c"])
+            .cast(&DataType::Categorical)
+            .unwrap();
+
+        assert_eq!(s.n_unique().unwrap(), 3);
+        // make sure that it does not take the fast path after take/ slice
+        let out = s.take(&([1, 2].as_ref()).into()).unwrap();
+        assert_eq!(out.n_unique().unwrap(), 2);
+        let out = s.slice(1, 2);
+        assert_eq!(out.n_unique().unwrap(), 2);
     }
 }

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -155,6 +155,8 @@ pub struct ChunkedArray<T> {
     /// third bit dtype list: fast_explode
     ///     - unset: unknown or not all arrays have at least one value
     ///     - set: all list arrays are filled (this allows for cheap explode)
+    /// fourth bit: original local categorical
+    ///             meaning that n_unique is the same as the cat map length
     pub(crate) bit_settings: u8,
 }
 

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -32,8 +32,8 @@ private = []
 ahash = "0.7"
 anyhow = "1.0"
 # arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "e9a6c3ef7e1a328c298bd45e36ac2abf8ae44ebb", default-features = false }
-# arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "fn_to" }
-arrow = { package = "arrow2", version = "0.8", default-features = false }
+arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "offset_pub" }
+# arrow = { package = "arrow2", version = "0.8", default-features = false }
 csv-core = { version = "0.1.10", optional = true }
 dirs = "4.0"
 flate2 = { version = "1", optional = true, default-features = false }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -60,22 +60,24 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b39f376298030a620034a2965a480fada646830d18a4eacb2e49715416eff1"
+version = "0.8.1"
+source = "git+https://github.com/ritchie46/arrow2?branch=offset_pub#46a80f0fa84023207452b8625f9be27135a898ca"
 dependencies = [
+ "ahash",
  "arrow-format",
  "base64",
  "chrono",
  "csv",
  "futures",
  "hash_hasher",
+ "itertools",
  "lexical-core",
  "lz4",
  "multiversion",
  "num-traits",
  "packed_simd_2",
  "parquet2",
+ "regex",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",


### PR DESCRIPTION
Fixes #1936. There was a fast path for categorical types that should not always be taken.