### PR TITLE
Ignore Miri leaks

### DIFF
--- a/polars/Makefile
+++ b/polars/Makefile
@@ -34,7 +34,7 @@ miri:
 	# not tested on all features because miri does not support SIMD
 	# some tests are also filtered, because miri cannot deal with the rayon threadpool
 	# Miri also reports UB in prettytable.rs, so we must toggle that feature off.
-	MIRIFLAGS="-Zmiri-disable-isolation" \
+	MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
 	POLARS_ALLOW_EXTENSION=1 \
 	cargo miri test \
 	    --no-default-features \

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -199,4 +199,18 @@ mod test {
         assert_eq!(df3, df3);
         assert_ne!(df4, df4);
     }
+
+    //-----RAYON LEAK PROOF-----
+    #[test]
+    fn test_miri_rayonthread_leak1() {
+        crate::POOL.install(|| ());
+    }
+
+    #[test]
+    fn test_miri_rayonthread_leak2() {
+        use rayon::prelude::*;
+        let tmp: Vec<i32> = [1, 2].par_iter().map(|x| x * x).collect();
+        assert_eq!(tmp, &[1, 4]);
+    }
+    //--------------
 }


### PR DESCRIPTION
## Issue
As discussed in #1927, [Miri](https://github.com/rust-lang/miri) considers by default that a global [ThreadPool](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html) is an error.
### Polars ThreadPool
The following simple function gives an error according to [Miri](https://github.com/rust-lang/miri):
```rust
fn test_miri_rayonthread_leak1() {
    crate::POOL.install(|| ());
}
```
### Rayon ThreadPool
The following simple function gives an error according to [Miri](https://github.com/rust-lang/miri):
```rust
fn test_miri_rayonthread_leak2() {
    use rayon::prelude::*;
    let tmp: Vec<i32> = [1, 2].par_iter().map(|x| x * x).collect();
    assert_eq!(tmp, &[1, 4]);
}
```
## Solution
Adding `-Zmiri-ignore-leaks` to the `MIRIFLAGS`, as it seems to be the standard solution with [Rayon](https://docs.rs/rayon/latest/rayon/).

### What we loose
- [Miri](https://github.com/rust-lang/miri) doesn't check any memory or thread leak.

The serious memory leaks in Rust are not impossible but quite rare.

### What we gain
#### - Performance

We can continue to use [Rayon](https://docs.rs/rayon/latest/rayon/) as much as possible without being annoyed by [Miri](https://github.com/rust-lang/miri). Indeed, many functions can still be improved in speed.

#### - Robustness

Making tests on functions using [Rayon](https://docs.rs/rayon/latest/rayon/) (namely thanks to our `POOL` [ThreadPool](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html)) is possible in order to monitor the bugs.

### Synthesis

In my opinion, the loss is tiny compared to the improvement on speed and robustness that can be done after this PR.

If we fear for memory leak in some cases, we can still use the default `cargo miri` manually. All the other [Miri](https://github.com/rust-lang/miri) features are kept.