### PR TITLE
Extra sort options part 1

### DIFF
--- a/js-polars/src/series.rs
+++ b/js-polars/src/series.rs
@@ -185,11 +185,6 @@ impl Series {
         (self.series.tail(length)).into()
     }
 
-    #[wasm_bindgen(js_name = SortInPlace)]
-    pub fn sort_in_place(&mut self, reverse: bool) {
-        self.series.sort_in_place(reverse);
-    }
-
     pub fn sort(&mut self, reverse: bool) -> Self {
         (self.series.sort(reverse)).into()
     }

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -496,10 +496,10 @@ pub trait ToDummies<T>: ChunkUnique<T> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 pub struct SortOptions {
-    descending: bool,
-    nulls_last: bool,
+    pub descending: bool,
+    pub nulls_last: bool,
 }
 
 /// Sort operations on `ChunkedArray`.

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -505,9 +505,7 @@ pub struct SortOptions {
 /// Sort operations on `ChunkedArray`.
 pub trait ChunkSort<T> {
     #[allow(unused_variables)]
-    fn sort_with(&self, options: SortOptions) -> ChunkedArray<T> {
-        unimplemented!()
-    }
+    fn sort_with(&self, options: SortOptions) -> ChunkedArray<T>;
 
     /// Returned a sorted `ChunkedArray`.
     fn sort(&self, reverse: bool) -> ChunkedArray<T>;

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -510,9 +510,6 @@ pub trait ChunkSort<T> {
     /// Returned a sorted `ChunkedArray`.
     fn sort(&self, reverse: bool) -> ChunkedArray<T>;
 
-    /// Sort this array in place.
-    fn sort_in_place(&mut self, reverse: bool);
-
     /// Retrieve the indexes needed to sort this array.
     fn argsort(&self, reverse: bool) -> UInt32Chunked;
 

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 #[cfg(feature = "dtype-categorical")]
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 /// # Safety
 /// only may produce true, for f32/f64::NaN
@@ -297,11 +297,6 @@ where
         })
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        let mut sorted = self.sort(reverse);
-        self.chunks = std::mem::take(&mut sorted.chunks);
-    }
-
     fn argsort(&self, reverse: bool) -> UInt32Chunked {
         if !self.has_validity() {
             let mut vals = Vec::with_capacity(self.len());
@@ -508,11 +503,6 @@ impl ChunkSort<Utf8Type> for Utf8Chunked {
         })
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        let mut sorted = self.sort(reverse);
-        self.chunks = std::mem::take(&mut sorted.chunks);
-    }
-
     fn argsort(&self, reverse: bool) -> UInt32Chunked {
         argsort!(self, reverse)
     }
@@ -580,10 +570,6 @@ impl ChunkSort<CategoricalType> for CategoricalChunked {
         self.deref().sort(reverse).into()
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        self.deref_mut().sort_in_place(reverse)
-    }
-
     fn argsort(&self, reverse: bool) -> UInt32Chunked {
         self.deref().argsort(reverse)
     }
@@ -604,11 +590,6 @@ impl ChunkSort<BooleanType> for BooleanChunked {
             descending: reverse,
             nulls_last: false,
         })
-    }
-
-    fn sort_in_place(&mut self, reverse: bool) {
-        let mut sorted = self.sort(reverse);
-        self.chunks = std::mem::take(&mut sorted.chunks);
     }
 
     fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -306,8 +306,8 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort(&self, reverse: bool) -> Series {
-        ChunkSort::sort(&self.0, reverse).into_series()
+    fn sort_with(&self, options: SortOptions) -> Series {
+        ChunkSort::sort_with(&self.0, options).into_series()
     }
 
     fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -306,10 +306,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        ChunkSort::sort_in_place(&mut self.0, reverse);
-    }
-
     fn sort(&self, reverse: bool) -> Series {
         ChunkSort::sort(&self.0, reverse).into_series()
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -286,8 +286,8 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort(&self, reverse: bool) -> Series {
-        ChunkSort::sort(&self.0, reverse).into_series()
+    fn sort_with(&self, options: SortOptions) -> Series {
+        ChunkSort::sort_with(&self.0, options).into_series()
     }
 
     fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -286,10 +286,6 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        ChunkSort::sort_in_place(&mut self.0, reverse);
-    }
-
     fn sort(&self, reverse: bool) -> Series {
         ChunkSort::sort(&self.0, reverse).into_series()
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -467,11 +467,6 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index).$into_logical()
             }
 
-            fn sort_in_place(&mut self, reverse: bool) {
-                let ca = self.0.deref().sort(reverse);
-                self.0 = ca.$into_logical();
-            }
-
             fn sort(&self, reverse: bool) -> Series {
                 self.0.sort(reverse).$into_logical().into_series()
             }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -467,8 +467,8 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index).$into_logical()
             }
 
-            fn sort(&self, reverse: bool) -> Series {
-                self.0.sort(reverse).$into_logical().into_series()
+            fn sort_with(&self, options: SortOptions) -> Series {
+                self.0.sort_with(options).$into_logical().into_series()
             }
 
             fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -451,8 +451,8 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort(&self, reverse: bool) -> Series {
-                ChunkSort::sort(&self.0, reverse).into_series()
+            fn sort_with(&self, options: SortOptions) -> Series {
+                ChunkSort::sort_with(&self.0, options).into_series()
             }
 
             fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -451,10 +451,6 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort_in_place(&mut self, reverse: bool) {
-                ChunkSort::sort_in_place(&mut self.0, reverse);
-            }
-
             fn sort(&self, reverse: bool) -> Series {
                 ChunkSort::sort(&self.0, reverse).into_series()
             }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -616,8 +616,8 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort(&self, reverse: bool) -> Series {
-                ChunkSort::sort(&self.0, reverse).into_series()
+            fn sort_with(&self, options: SortOptions) -> Series {
+                ChunkSort::sort_with(&self.0, options).into_series()
             }
 
             fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -616,10 +616,6 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort_in_place(&mut self, reverse: bool) {
-                ChunkSort::sort_in_place(&mut self.0, reverse);
-            }
-
             fn sort(&self, reverse: bool) -> Series {
                 ChunkSort::sort(&self.0, reverse).into_series()
             }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -298,10 +298,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_in_place(&mut self, reverse: bool) {
-        ChunkSort::sort_in_place(&mut self.0, reverse);
-    }
-
     fn sort(&self, reverse: bool) -> Series {
         ChunkSort::sort(&self.0, reverse).into_series()
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -298,8 +298,8 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort(&self, reverse: bool) -> Series {
-        ChunkSort::sort(&self.0, reverse).into_series()
+    fn sort_with(&self, options: SortOptions) -> Series {
+        ChunkSort::sort_with(&self.0, options).into_series()
     }
 
     fn argsort(&self, reverse: bool) -> UInt32Chunked {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -182,6 +182,13 @@ impl Series {
         Ok(self)
     }
 
+    pub fn sort(&self, reverse: bool) -> Self {
+        self.sort_with(SortOptions {
+            descending: reverse,
+            ..Default::default()
+        })
+    }
+
     /// Only implemented for numeric types
     pub fn as_single_ptr(&mut self) -> Result<usize> {
         self.get_inner_mut().as_single_ptr()

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -182,13 +182,6 @@ impl Series {
         Ok(self)
     }
 
-    /// Sort in place.
-    pub fn sort_in_place(&mut self, reverse: bool) -> &mut Self {
-        self.get_inner_mut().sort_in_place(reverse);
-        self
-    }
-
-    /// Rechunk and return a pointer to the start of the Series.
     /// Only implemented for numeric types
     pub fn as_single_ptr(&mut self) -> Result<usize> {
         self.get_inner_mut().as_single_ptr()

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -661,11 +661,6 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
-    /// Sort in place.
-    fn sort_in_place(&mut self, _reverse: bool) {
-        invalid_operation_panic!(self)
-    }
-
     fn sort(&self, _reverse: bool) -> Series {
         invalid_operation_panic!(self)
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -661,7 +661,7 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
-    fn sort(&self, _reverse: bool) -> Series {
+    fn sort_with(&self, _options: SortOptions) -> Series {
         invalid_operation_panic!(self)
     }
 

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -269,7 +269,7 @@ pub enum Expr {
     },
     Sort {
         expr: Box<Expr>,
-        reverse: bool,
+        options: SortOptions,
     },
     Take {
         expr: Box<Expr>,
@@ -387,7 +387,7 @@ impl fmt::Debug for Expr {
             Not(expr) => write!(f, "NOT {:?}", expr),
             IsNull(expr) => write!(f, "{:?} IS NULL", expr),
             IsNotNull(expr) => write!(f, "{:?} IS NOT NULL", expr),
-            Sort { expr, reverse } => match reverse {
+            Sort { expr, options } => match options.descending {
                 true => write!(f, "{:?} DESC", expr),
                 false => write!(f, "{:?} ASC", expr),
             },
@@ -840,12 +840,21 @@ impl Expr {
     }
 
     /// Sort in increasing order. See [the eager implementation](polars_core::series::SeriesTrait::sort).
-    ///
-    /// Can be used in `default` and `aggregation` context.
     pub fn sort(self, reverse: bool) -> Self {
         Expr::Sort {
             expr: Box::new(self),
-            reverse,
+            options: SortOptions {
+                descending: reverse,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Sort with given options.
+    pub fn sort_with(self, options: SortOptions) -> Self {
+        Expr::Sort {
+            expr: Box::new(self),
+            options,
         }
     }
 

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -49,7 +49,7 @@ pub enum AExpr {
     },
     Sort {
         expr: Node,
-        reverse: bool,
+        options: SortOptions,
     },
     Take {
         expr: Node,
@@ -368,7 +368,7 @@ impl AExpr {
                 (Literal(left), Literal(right)) => left == right,
                 (BinaryExpr { op: l, .. }, BinaryExpr { op: r, .. }) => l == r,
                 (Cast { data_type: l, .. }, Cast { data_type: r, .. }) => l == r,
-                (Sort { reverse: l, .. }, Sort { reverse: r, .. }) => l == r,
+                (Sort { options: l, .. }, Sort { options: r, .. }) => l == r,
                 (SortBy { reverse: l, .. }, SortBy { reverse: r, .. }) => l == r,
                 (Shift { periods: l, .. }, Shift { periods: r, .. }) => l == r,
                 (

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -41,9 +41,9 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             expr: to_aexpr(*expr, arena),
             idx: to_aexpr(*idx, arena),
         },
-        Expr::Sort { expr, reverse } => AExpr::Sort {
+        Expr::Sort { expr, options } => AExpr::Sort {
             expr: to_aexpr(*expr, arena),
-            reverse,
+            options,
         },
         Expr::SortBy { expr, by, reverse } => AExpr::SortBy {
             expr: to_aexpr(*expr, arena),
@@ -450,11 +450,11 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 strict,
             }
         }
-        AExpr::Sort { expr, reverse } => {
+        AExpr::Sort { expr, options } => {
             let exp = node_to_exp(expr, expr_arena);
             Expr::Sort {
                 expr: Box::new(exp),
-                reverse,
+                options,
             }
         }
         AExpr::Take { expr, idx } => {

--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -345,10 +345,14 @@ impl OptimizationRule for SimplifyExprRule {
             AExpr::Reverse(expr) => {
                 let input = expr_arena.get(*expr);
                 match input {
-                    AExpr::Sort { expr, reverse } => Some(AExpr::Sort {
-                        expr: *expr,
-                        reverse: !*reverse,
-                    }),
+                    AExpr::Sort { expr, options } => {
+                        let mut options = *options;
+                        options.descending = !options.descending;
+                        Some(AExpr::Sort {
+                            expr: *expr,
+                            options,
+                        })
+                    }
                     AExpr::SortBy { expr, by, reverse } => Some(AExpr::SortBy {
                         expr: *expr,
                         by: by.clone(),

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -531,11 +531,11 @@ impl DefaultPlanner {
                 column,
                 node_to_exp(expression, expr_arena),
             ))),
-            Sort { expr, reverse } => {
+            Sort { expr, options } => {
                 let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
                 Ok(Arc::new(SortExpr::new(
                     phys_expr,
-                    reverse,
+                    options,
                     node_to_exp(expression, expr_arena),
                 )))
             }

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -594,6 +594,11 @@ class Expr:
         ----------
         reverse
             Reverse the operation.
+
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Int64 before summing to prevent overflow issues.
         """
         return wrap_expr(self._pyexpr.cumsum(reverse))
 
@@ -605,6 +610,11 @@ class Expr:
         ----------
         reverse
             Reverse the operation.
+
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Int64 before summing to prevent overflow issues.
         """
         return wrap_expr(self._pyexpr.cumprod(reverse))
 
@@ -693,7 +703,7 @@ class Expr:
         dtype = py_type_to_dtype(dtype)
         return wrap_expr(self._pyexpr.cast(dtype, strict))
 
-    def sort(self, reverse: bool = False) -> "Expr":
+    def sort(self, reverse: bool = False, nulls_last: bool = False) -> "Expr":
         """
         Sort this column. In projection/ selection context the whole column is sorted.
         If used in a groupby context, the groups are sorted.
@@ -703,8 +713,10 @@ class Expr:
         reverse
             False -> order from small to large.
             True -> order from large to small.
+        nulls_last
+            If True nulls are considered to be larger than any valid value
         """
-        return wrap_expr(self._pyexpr.sort(reverse))
+        return wrap_expr(self._pyexpr.sort_with(reverse, nulls_last))
 
     def arg_sort(self, reverse: bool = False) -> "Expr":
         """
@@ -894,7 +906,9 @@ class Expr:
         """
         Get sum value.
 
-        Note that dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
         Int64 before summing to prevent overflow issues.
         """
         return wrap_expr(self._pyexpr.sum())

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -700,7 +700,9 @@ class Series:
         """
         Reduce this Series to the sum value.
 
-        Note that dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
         Int64 before summing to prevent overflow issues.
 
         Examples
@@ -944,6 +946,11 @@ class Series:
         reverse
             reverse the operation.
 
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Int64 before summing to prevent overflow issues.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
@@ -1015,6 +1022,11 @@ class Series:
         ----------
         reverse
             reverse the operation.
+
+        Notes
+        -----
+        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+        Int64 before summing to prevent overflow issues.
 
         Examples
         --------

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1232,7 +1232,7 @@ class Series:
 
         """
         if in_place:
-            self._s.sort_in_place(reverse)
+            self._s = self._s.sort(reverse)
             return self
         else:
             return wrap_s(self._s.sort(reverse))

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -157,8 +157,14 @@ impl PyExpr {
         };
         expr.into()
     }
-    pub fn sort(&self, reverse: bool) -> PyExpr {
-        self.clone().inner.sort(reverse).into()
+    pub fn sort_with(&self, descending: bool, nulls_last: bool) -> PyExpr {
+        self.clone()
+            .inner
+            .sort_with(SortOptions {
+                descending,
+                nulls_last,
+            })
+            .into()
     }
 
     pub fn arg_sort(&self, reverse: bool) -> PyExpr {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -464,10 +464,6 @@ impl PySeries {
         (self.series.tail(length)).into()
     }
 
-    pub fn sort_in_place(&mut self, reverse: bool) {
-        self.series.sort_in_place(reverse);
-    }
-
     pub fn sort(&mut self, reverse: bool) -> Self {
         PySeries::new(self.series.sort(reverse))
     }


### PR DESCRIPTION
This adds dispatch of extra sort options, (where to place null values)

Currently this is only correctly implemented for numeric values.

TODO:

- utf8
- boolean
- argsort (all types)

Also removed `sort_in_place` in Rust. Not really useful, we can just do `*s = s.sort()`