### PR TITLE
fix rank dtype consistency

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -19,7 +19,7 @@ pub enum RankMethod {
 pub(crate) fn rank(s: &Series, method: RankMethod) -> Series {
     if s.len() == 1 {
         return match method {
-            Average => Series::new(s.name(), &[1.0]),
+            Average => Series::new(s.name(), &[1.0f32]),
             _ => Series::new(s.name(), &[1u32]),
         };
     }

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -519,7 +519,7 @@ impl LazyFrame {
                 .iter()
                 .zip(new)
                 .map(|(old, new)| col(old).alias(new.as_ref()))
-                .collect(),
+                .collect::<Vec<_>>(),
         )
         .drop_columns_impl(&existing)
     }
@@ -959,7 +959,8 @@ impl LazyFrame {
     ///          )
     /// }
     /// ```
-    pub fn with_columns(self, exprs: Vec<Expr>) -> LazyFrame {
+    pub fn with_columns<E: AsRef<[Expr]>>(self, exprs: E) -> LazyFrame {
+        let exprs = exprs.as_ref().to_vec();
         let opt_state = self.get_opt_state();
         let lp = self.get_plan_builder().with_columns(exprs).build();
         Self::from_logical_plan(lp, opt_state)

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -2360,3 +2360,25 @@ fn test_binary_agg_context_2() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_single_ranked_group() -> Result<()> {
+    // tests type consistency of rank algorithm
+    let df = df!["group" => [1, 2, 2],
+        "value"=> [100, 50, 10]
+    ]?;
+
+    let out = df
+        .lazy()
+        .with_columns([col("value").rank(RankMethod::Average).over([col("group")])])
+        .collect()?;
+
+    let out = out.column("value")?.explode()?;
+    let out = out.f32()?;
+    assert_eq!(
+        Vec::from(out),
+        &[Some(1.0), Some(2.0), Some(1.0), Some(2.0), Some(1.0)]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
In case of a single group, avg rank return f64 instead of f32.

Fixes #1953