### PR TITLE
Split slice

### DIFF
--- a/polars/polars-core/src/chunked_array/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/categorical/mod.rs
@@ -70,9 +70,14 @@ impl CategoricalChunked {
     }
 
     pub(crate) fn can_fast_unique(&self) -> bool {
-        self.bit_settings & 1 << 4 != 0 && self.chunks.len() == 1 && {
-            let arr = self.downcast_iter().next().unwrap();
-            arr.values().offset() == 0
+        self.bit_settings & 1 << 3 != 0 && self.chunks.len() == 1
+    }
+
+    pub(crate) fn set_fast_unique(&mut self, can: bool) {
+        if can {
+            self.bit_settings |= 1u8 << 3;
+        } else {
+            self.bit_settings &= !(1u8 << 3);
         }
     }
 

--- a/polars/polars-core/src/chunked_array/ops/len.rs
+++ b/polars/polars-core/src/chunked_array/ops/len.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+impl<T> ChunkLen for ChunkedArray<T> {
+    /// Combined length of all the chunks.
+    #[inline]
+    fn len(&self) -> usize {
+        match self.chunks.len() {
+            // fast path
+            1 => self.chunks[0].len(),
+            _ => self.chunks.iter().fold(0, |acc, arr| acc + arr.len()),
+        }
+    }
+}

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::{
             PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
         },
         iterator::{IntoNoNullIterator, PolarsIterator},
-        ops::{aggregate::*, chunkops::ChunkOps, *},
+        ops::{aggregate::*, *},
         ChunkedArray,
     },
     datatypes,

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -117,7 +117,10 @@ macro_rules! split_array {
 }
 
 #[cfg(feature = "private")]
-pub fn split_ca<T>(ca: &ChunkedArray<T>, n: usize) -> Result<Vec<ChunkedArray<T>>> {
+pub fn split_ca<T>(ca: &ChunkedArray<T>, n: usize) -> Result<Vec<ChunkedArray<T>>>
+where
+    ChunkedArray<T>: ChunkOps,
+{
     split_array!(ca, n, i64)
 }
 


### PR DESCRIPTION
This allows for specialized impls.

Also fixes a bug in Categorical -> unique fast path.
When offset == 0 in slice operation, the fast path
was a false positive.