### PR TITLE
Implement `NamedFrom` for `ChunkedArrays`

### DIFF
--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -440,9 +440,9 @@ pub(crate) mod test {
     use crate::prelude::*;
 
     pub(crate) fn create_two_chunked() -> (Int32Chunked, Int32Chunked) {
-        let mut a1 = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-        let a2 = Int32Chunked::new_from_slice("a", &[4, 5, 6]);
-        let a3 = Int32Chunked::new_from_slice("a", &[1, 2, 3, 4, 5, 6]);
+        let mut a1 = Int32Chunked::new("a", &[1, 2, 3]);
+        let a2 = Int32Chunked::new("a", &[4, 5, 6]);
+        let a3 = Int32Chunked::new("a", &[1, 2, 3, 4, 5, 6]);
         a1.append(&a2);
         (a1, a3)
     }
@@ -466,7 +466,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_power() {
-        let a = UInt32Chunked::new_from_slice("", &[1, 2, 3]);
+        let a = UInt32Chunked::new("", &[1, 2, 3]);
         let b = a.pow_f64(2.);
         println!("{:?}", b);
     }

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -167,7 +167,7 @@ mod test {
     #[cfg(feature = "dtype-categorical")]
     fn test_cast_noop() {
         // check if we can cast categorical twice without panic
-        let ca = Utf8Chunked::new_from_slice("foo", &["bar", "ham"]);
+        let ca = Utf8Chunked::new("foo", &["bar", "ham"]);
         let out = ca.cast(&DataType::Categorical).unwrap();
         let out = out.cast(&DataType::Categorical).unwrap();
         assert_eq!(out.dtype(), &DataType::Categorical)

--- a/polars/polars-core/src/chunked_array/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/categorical/builder.rs
@@ -205,7 +205,7 @@ mod test {
             Some("foo"),
             Some("bar"),
         ];
-        let ca = Utf8Chunked::new_from_opt_slice("a", slice);
+        let ca = Utf8Chunked::new("a", slice);
         let out = ca.cast(&DataType::Categorical)?;
         let mut out = out.categorical().unwrap().clone();
         assert_eq!(out.categorical_map.take().unwrap().len(), 2);
@@ -224,9 +224,9 @@ mod test {
         // Check that we don't panic if we append two categorical arrays
         // build under the same string cache
         // https://github.com/pola-rs/polars/issues/1115
-        let ca1 = Utf8Chunked::new_from_opt_slice("a", slice).cast(&DataType::Categorical)?;
+        let ca1 = Utf8Chunked::new("a", slice).cast(&DataType::Categorical)?;
         let mut ca1 = ca1.categorical().unwrap().clone();
-        let ca2 = Utf8Chunked::new_from_opt_slice("a", slice).cast(&DataType::Categorical)?;
+        let ca2 = Utf8Chunked::new("a", slice).cast(&DataType::Categorical)?;
         let ca2 = ca2.categorical().unwrap();
         ca1.append(ca2);
 

--- a/polars/polars-core/src/chunked_array/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/categorical/mod.rs
@@ -159,7 +159,7 @@ mod test {
             Some("foo"),
             Some("bar"),
         ];
-        let ca = Utf8Chunked::new_from_opt_slice("a", slice);
+        let ca = Utf8Chunked::new("a", slice);
         let ca = ca.cast(&DataType::Categorical)?;
         let ca = ca.categorical().unwrap();
 

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -849,7 +849,7 @@ mod test {
 
     #[test]
     fn test_bitwise_ops() {
-        let a = BooleanChunked::new_from_slice("a", &[true, false, false]);
+        let a = BooleanChunked::new("a", &[true, false, false]);
         let b = BooleanChunked::new("b", &[Some(true), Some(true), None]);
         assert_eq!(Vec::from(&a | &b), &[Some(true), Some(true), None]);
         assert_eq!(Vec::from(&a & &b), &[Some(true), Some(false), Some(false)]);

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -850,7 +850,7 @@ mod test {
     #[test]
     fn test_bitwise_ops() {
         let a = BooleanChunked::new_from_slice("a", &[true, false, false]);
-        let b = BooleanChunked::new_from_opt_slice("b", &[Some(true), Some(true), None]);
+        let b = BooleanChunked::new("b", &[Some(true), Some(true), None]);
         assert_eq!(Vec::from(&a | &b), &[Some(true), Some(true), None]);
         assert_eq!(Vec::from(&a & &b), &[Some(true), Some(false), Some(false)]);
         assert_eq!(Vec::from(!b), &[Some(false), Some(false), None]);
@@ -1056,7 +1056,7 @@ mod test {
 
     #[test]
     fn test_kleene() {
-        let a = BooleanChunked::new_from_opt_slice("", &[Some(true), Some(false), None]);
+        let a = BooleanChunked::new("", &[Some(true), Some(false), None]);
         let trues = BooleanChunked::new_from_slice("", &[true, true, true]);
         let falses = BooleanChunked::new_from_slice("", &[false, false, false]);
 

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -474,8 +474,7 @@ mod test {
         ($test_name:ident, $ca_type:ty, $first_val:expr, $second_val:expr, $third_val:expr) => {
             #[test]
             fn $test_name() {
-                let a =
-                    <$ca_type>::new_from_opt_slice("test", &[$first_val, $second_val, $third_val]);
+                let a = <$ca_type>::new("test", &[$first_val, $second_val, $third_val]);
 
                 // normal iterator
                 let mut it = a.into_iter();
@@ -617,8 +616,8 @@ mod test {
         ($test_name:ident, $ca_type:ty, $first_val:expr, $second_val:expr, $third_val:expr) => {
             #[test]
             fn $test_name() {
-                let mut a = <$ca_type>::new_from_opt_slice("test", &[$first_val, $second_val]);
-                let a_b = <$ca_type>::new_from_opt_slice("", &[$third_val]);
+                let mut a = <$ca_type>::new("test", &[$first_val, $second_val]);
+                let a_b = <$ca_type>::new("", &[$third_val]);
                 a.append(&a_b);
 
                 // normal iterator
@@ -886,7 +885,7 @@ mod test {
         8,
         Some("0"),
         None,
-        { Utf8Chunked::new_from_opt_slice("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE)) }
+        { Utf8Chunked::new("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE)) }
     );
 
     impl_test_iter_skip!(utf8_iter_many_chunk_skip, 18, Some("0"), Some("9"), {
@@ -897,10 +896,8 @@ mod test {
     });
 
     impl_test_iter_skip!(utf8_iter_many_chunk_null_check_skip, 18, Some("0"), None, {
-        let mut a =
-            Utf8Chunked::new_from_opt_slice("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE));
-        let a_b =
-            Utf8Chunked::new_from_opt_slice("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE));
+        let mut a = Utf8Chunked::new("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE));
+        let a_b = Utf8Chunked::new("test", &generate_opt_utf8_vec(SKIP_ITERATOR_SIZE));
         a.append(&a_b);
         a
     });
@@ -925,7 +922,7 @@ mod test {
     });
 
     impl_test_iter_skip!(bool_iter_single_chunk_null_check_skip, 8, None, None, {
-        BooleanChunked::new_from_opt_slice("test", &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE))
+        BooleanChunked::new("test", &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE))
     });
 
     impl_test_iter_skip!(bool_iter_many_chunk_skip, 18, Some(true), Some(false), {
@@ -937,14 +934,8 @@ mod test {
     });
 
     impl_test_iter_skip!(bool_iter_many_chunk_null_check_skip, 18, None, None, {
-        let mut a = BooleanChunked::new_from_opt_slice(
-            "test",
-            &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE),
-        );
-        let a_b = BooleanChunked::new_from_opt_slice(
-            "test",
-            &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE),
-        );
+        let mut a = BooleanChunked::new("test", &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE));
+        let a_b = BooleanChunked::new("test", &generate_opt_boolean_vec(SKIP_ITERATOR_SIZE));
         a.append(&a_b);
         a
     });

--- a/polars/polars-core/src/chunked_array/iterator/par/boolean.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/boolean.rs
@@ -194,32 +194,17 @@ mod test {
     // Single Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(
         boolean_par_iter_single_chunk_null_check_return_option_map,
-        {
-            BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),) }
     );
 
     impl_par_iter_return_option_filter_test!(
         boolean_par_iter_single_chunk_null_check_return_option_filter,
-        {
-            BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),) }
     );
 
     impl_par_iter_return_option_fold_test!(
         boolean_par_iter_single_chunk_null_check_return_option_fold,
-        {
-            BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),) }
     );
 
     // Many Chunk Parallel Iterator Tests.
@@ -254,14 +239,10 @@ mod test {
     impl_par_iter_return_option_map_test!(
         boolean_par_iter_many_chunk_null_check_return_option_map,
         {
-            let mut a = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            let a_b =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
@@ -270,14 +251,10 @@ mod test {
     impl_par_iter_return_option_filter_test!(
         boolean_par_iter_many_chunk_null_check_return_option_filter,
         {
-            let mut a = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            let a_b =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
@@ -286,14 +263,10 @@ mod test {
     impl_par_iter_return_option_fold_test!(
         boolean_par_iter_many_chunk_null_check_return_option_fold,
         {
-            let mut a = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = BooleanChunked::new_from_opt_slice(
-                "a",
-                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            let a_b =
+                BooleanChunked::new("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }

--- a/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
@@ -966,32 +966,17 @@ mod test {
     // Single Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(
         uint32_par_iter_single_chunk_null_check_return_option_map,
-        {
-            UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),) }
     );
 
     impl_par_iter_return_option_filter_test!(
         uint32_par_iter_single_chunk_null_check_return_option_filter,
-        {
-            UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),) }
     );
 
     impl_par_iter_return_option_fold_test!(
         uint32_par_iter_single_chunk_null_check_return_option_fold,
-        {
-            UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            )
-        }
+        { UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),) }
     );
 
     // Many Chunk Parallel Iterator Tests.
@@ -1026,14 +1011,9 @@ mod test {
     impl_par_iter_return_option_map_test!(
         uint32_par_iter_many_chunk_null_check_return_option_map,
         {
-            let mut a = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+            let a_b = UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
@@ -1042,14 +1022,9 @@ mod test {
     impl_par_iter_return_option_filter_test!(
         uint32_par_iter_many_chunk_null_check_return_option_filter,
         {
-            let mut a = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+            let a_b = UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
@@ -1058,14 +1033,9 @@ mod test {
     impl_par_iter_return_option_fold_test!(
         uint32_par_iter_many_chunk_null_check_return_option_fold,
         {
-            let mut a = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = UInt32Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a =
+                UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+            let a_b = UInt32Chunked::new("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }

--- a/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
@@ -205,17 +205,17 @@ mod test {
     // Single Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(
         utf8_par_iter_single_chunk_null_check_return_option_map,
-        { Utf8Chunked::new_from_opt_slice("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
+        { Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
     );
 
     impl_par_iter_return_option_filter_test!(
         utf8_par_iter_single_chunk_null_check_return_option_filter,
-        { Utf8Chunked::new_from_opt_slice("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
+        { Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
     );
 
     impl_par_iter_return_option_fold_test!(
         utf8_par_iter_single_chunk_null_check_return_option_fold,
-        { Utf8Chunked::new_from_opt_slice("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
+        { Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE)) }
     );
 
     // Many Chunk Parallel Iterator Tests.
@@ -242,10 +242,8 @@ mod test {
 
     // Many Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(utf8_par_iter_many_chunk_null_check_return_option_map, {
-        let mut a =
-            Utf8Chunked::new_from_opt_slice("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
-        let a_b =
-            Utf8Chunked::new_from_opt_slice("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
+        let mut a = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
+        let a_b = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
@@ -253,14 +251,8 @@ mod test {
     impl_par_iter_return_option_filter_test!(
         utf8_par_iter_many_chunk_null_check_return_option_filter,
         {
-            let mut a = Utf8Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = Utf8Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
+            let a_b = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
@@ -269,14 +261,8 @@ mod test {
     impl_par_iter_return_option_fold_test!(
         utf8_par_iter_many_chunk_null_check_return_option_fold,
         {
-            let mut a = Utf8Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE),
-            );
-            let a_b = Utf8Chunked::new_from_opt_slice(
-                "a",
-                &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE),
-            );
+            let mut a = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
+            let a_b = Utf8Chunked::new("a", &generate_opt_utf8_vec(UTF8_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -289,8 +289,8 @@ impl<T> ChunkedArray<T> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let mut array = Int32Chunked::new_from_slice("array", &[1, 2]);
-    /// let array_2 = Int32Chunked::new_from_slice("2nd", &[3]);
+    /// let mut array = Int32Chunked::new("array", &[1, 2]);
+    /// let array_2 = Int32Chunked::new("2nd", &[3]);
     ///
     /// array.append(&array_2);
     /// assert_eq!(Vec::from(&array), [Some(1), Some(2), Some(3)])
@@ -615,19 +615,19 @@ pub(crate) mod test {
     use crate::prelude::*;
 
     pub(crate) fn get_chunked_array() -> Int32Chunked {
-        ChunkedArray::new_from_slice("a", &[1, 2, 3])
+        ChunkedArray::new("a", &[1, 2, 3])
     }
 
     #[test]
     fn test_sort() {
-        let a = Int32Chunked::new_from_slice("a", &[1, 9, 3, 2]);
+        let a = Int32Chunked::new("a", &[1, 9, 3, 2]);
         let b = a
             .sort(false)
             .into_iter()
             .map(|opt| opt.unwrap())
             .collect::<Vec<_>>();
         assert_eq!(b, [1, 2, 3, 9]);
-        let a = Utf8Chunked::new_from_slice("a", &["b", "a", "c"]);
+        let a = Utf8Chunked::new("a", &["b", "a", "c"]);
         let a = a.sort(false);
         let b = a.into_iter().collect::<Vec<_>>();
         assert_eq!(b, [Some("a"), Some("b"), Some("c")]);
@@ -663,10 +663,7 @@ pub(crate) mod test {
     fn filter() {
         let a = get_chunked_array();
         let b = a
-            .filter(&BooleanChunked::new_from_slice(
-                "filter",
-                &[true, false, false],
-            ))
+            .filter(&BooleanChunked::new("filter", &[true, false, false]))
             .unwrap();
         assert_eq!(b.len(), 1);
         assert_eq!(b.into_iter().next(), Some(Some(1)));
@@ -716,8 +713,8 @@ pub(crate) mod test {
 
     #[test]
     fn slice() {
-        let mut first = UInt32Chunked::new_from_slice("first", &[0, 1, 2]);
-        let second = UInt32Chunked::new_from_slice("second", &[3, 4, 5]);
+        let mut first = UInt32Chunked::new("first", &[0, 1, 2]);
+        let second = UInt32Chunked::new("second", &[3, 4, 5]);
         first.append(&second);
         assert_slice_equal(&first.slice(0, 3), &[0, 1, 2]);
         assert_slice_equal(&first.slice(0, 4), &[0, 1, 2, 3]);
@@ -735,7 +732,7 @@ pub(crate) mod test {
 
     #[test]
     fn sorting() {
-        let s = UInt32Chunked::new_from_slice("", &[9, 2, 4]);
+        let s = UInt32Chunked::new("", &[9, 2, 4]);
         let sorted = s.sort(false);
         assert_slice_equal(&sorted, &[2, 4, 9]);
         let sorted = s.sort(true);
@@ -762,16 +759,16 @@ pub(crate) mod test {
 
     #[test]
     fn reverse() {
-        let s = UInt32Chunked::new_from_slice("", &[1, 2, 3]);
+        let s = UInt32Chunked::new("", &[1, 2, 3]);
         // path with continuous slice
         assert_slice_equal(&s.reverse(), &[3, 2, 1]);
         // path with options
         let s = UInt32Chunked::new("", &[Some(1), None, Some(3)]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(3), None, Some(1)]);
-        let s = BooleanChunked::new_from_slice("", &[true, false]);
+        let s = BooleanChunked::new("", &[true, false]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(false), Some(true)]);
 
-        let s = Utf8Chunked::new_from_slice("", &["a", "b", "c"]);
+        let s = Utf8Chunked::new("", &["a", "b", "c"]);
         assert_eq!(Vec::from(&s.reverse()), &[Some("c"), Some("b"), Some("a")]);
 
         let s = Utf8Chunked::new("", &[Some("a"), None, Some("c")]);
@@ -780,11 +777,11 @@ pub(crate) mod test {
 
     #[test]
     fn test_null_sized_chunks() {
-        let mut s = Float64Chunked::new_from_slice("s", &Vec::<f64>::new());
-        s.append(&Float64Chunked::new_from_slice("s2", &[1., 2., 3.]));
+        let mut s = Float64Chunked::new("s", &Vec::<f64>::new());
+        s.append(&Float64Chunked::new("s2", &[1., 2., 3.]));
         dbg!(&s);
 
-        let s = Float64Chunked::new_from_slice("s", &Vec::<f64>::new());
+        let s = Float64Chunked::new("s", &Vec::<f64>::new());
         dbg!(&s.into_iter().next());
     }
 

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -766,7 +766,7 @@ pub(crate) mod test {
         // path with continuous slice
         assert_slice_equal(&s.reverse(), &[3, 2, 1]);
         // path with options
-        let s = UInt32Chunked::new_from_opt_slice("", &[Some(1), None, Some(3)]);
+        let s = UInt32Chunked::new("", &[Some(1), None, Some(3)]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(3), None, Some(1)]);
         let s = BooleanChunked::new_from_slice("", &[true, false]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(false), Some(true)]);
@@ -774,7 +774,7 @@ pub(crate) mod test {
         let s = Utf8Chunked::new_from_slice("", &["a", "b", "c"]);
         assert_eq!(Vec::from(&s.reverse()), &[Some("c"), Some("b"), Some("a")]);
 
-        let s = Utf8Chunked::new_from_opt_slice("", &[Some("a"), None, Some("c")]);
+        let s = Utf8Chunked::new("", &[Some("a"), None, Some("c")]);
         assert_eq!(Vec::from(&s.reverse()), &[Some("c"), None, Some("a")]);
     }
 
@@ -795,8 +795,7 @@ pub(crate) mod test {
         use crate::SINGLE_LOCK;
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        let ca =
-            Utf8Chunked::new_from_opt_slice("", &[Some("foo"), None, Some("bar"), Some("ham")]);
+        let ca = Utf8Chunked::new("", &[Some("foo"), None, Some("bar"), Some("ham")]);
         let ca = ca.cast(&DataType::Categorical).unwrap();
         let ca = ca.categorical().unwrap();
         let v: Vec<_> = ca.into_iter().collect();

--- a/polars/polars-core/src/chunked_array/ndarray.rs
+++ b/polars/polars-core/src/chunked_array/ndarray.rs
@@ -79,8 +79,8 @@ impl DataFrame {
     ///
     /// ```rust
     /// use polars_core::prelude::*;
-    /// let a = UInt32Chunked::new_from_slice("a", &[1, 2, 3]).into_series();
-    /// let b = Float64Chunked::new_from_slice("b", &[10., 8., 6.]).into_series();
+    /// let a = UInt32Chunked::new("a", &[1, 2, 3]).into_series();
+    /// let b = Float64Chunked::new("b", &[10., 8., 6.]).into_series();
     ///
     /// let df = DataFrame::new(vec![a, b]).unwrap();
     /// let ndarray = df.to_ndarray::<Float64Type>().unwrap();
@@ -124,7 +124,7 @@ mod test {
 
     #[test]
     fn test_ndarray_from_ca() -> Result<()> {
-        let ca = Float64Chunked::new_from_slice("", &[1.0, 2.0, 3.0]);
+        let ca = Float64Chunked::new("", &[1.0, 2.0, 3.0]);
         let ndarr = ca.to_ndarray()?;
         assert_eq!(ndarr, ArrayView1::from(&[1.0, 2.0, 3.0]));
 

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -185,7 +185,7 @@ mod test {
         };
 
         let values = &[Some(foo1), None, Some(foo2), None];
-        let ca = ObjectChunked::new_from_opt_slice("", values);
+        let ca = ObjectChunked::new("", values);
 
         let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])];
         let out = ca.agg_list(&groups).unwrap();
@@ -208,7 +208,7 @@ mod test {
         };
 
         let values = &[Some(foo1.clone()), None, Some(foo2.clone()), None];
-        let ca = ObjectChunked::new_from_opt_slice("", values);
+        let ca = ObjectChunked::new("", values);
 
         let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])];
         let out = ca.agg_list(&groups).unwrap();

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -588,7 +588,7 @@ mod test {
 
     #[test]
     fn test_mean() {
-        let ca = Float32Chunked::new_from_opt_slice("", &[Some(1.0), Some(2.0), None]);
+        let ca = Float32Chunked::new("", &[Some(1.0), Some(2.0), None]);
         assert_eq!(ca.mean().unwrap(), 1.5);
         // all mean_as_series are cast to f64.
         assert_eq!(ca.mean_as_series().f64().unwrap().get(0).unwrap(), 1.5);
@@ -600,7 +600,7 @@ mod test {
 
     #[test]
     fn test_quantile_all_null() {
-        let ca = Float32Chunked::new_from_opt_slice("", &[None, None, None]);
+        let ca = Float32Chunked::new("", &[None, None, None]);
         let out = ca.quantile(0.9).unwrap();
         assert_eq!(out, None)
     }

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -493,7 +493,7 @@ mod test {
         // validated with numpy
         // Note that numpy as an argument ddof wich influences results. The default is ddof=0
         // we chose ddof=1, which is standard in statistics
-        let ca1 = Int32Chunked::new_from_slice("", &[5, 8, 9, 5, 0]);
+        let ca1 = Int32Chunked::new("", &[5, 8, 9, 5, 0]);
         let ca2 = Int32Chunked::new(
             "",
             &[
@@ -517,10 +517,10 @@ mod test {
 
     #[test]
     fn test_agg_float() {
-        let ca1 = Float32Chunked::new_from_slice("a", &[1.0, f32::NAN]);
-        let ca2 = Float32Chunked::new_from_slice("b", &[f32::NAN, 1.0]);
+        let ca1 = Float32Chunked::new("a", &[1.0, f32::NAN]);
+        let ca2 = Float32Chunked::new("b", &[f32::NAN, 1.0]);
         assert_eq!(ca1.min(), ca2.min());
-        let ca1 = Float64Chunked::new_from_slice("a", &[1.0, f64::NAN]);
+        let ca1 = Float64Chunked::new("a", &[1.0, f64::NAN]);
         let ca2 = Float64Chunked::new_from_slice("b", &[f64::NAN, 1.0]);
         assert_eq!(ca1.min(), ca2.min());
         println!("{:?}", (ca1.min(), ca2.min()))

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -494,7 +494,7 @@ mod test {
         // Note that numpy as an argument ddof wich influences results. The default is ddof=0
         // we chose ddof=1, which is standard in statistics
         let ca1 = Int32Chunked::new_from_slice("", &[5, 8, 9, 5, 0]);
-        let ca2 = Int32Chunked::new_from_opt_slice(
+        let ca2 = Int32Chunked::new(
             "",
             &[
                 Some(5),
@@ -528,12 +528,12 @@ mod test {
 
     #[test]
     fn test_median() {
-        let ca = UInt32Chunked::new_from_opt_slice(
+        let ca = UInt32Chunked::new(
             "a",
             &[Some(2), Some(1), None, Some(3), Some(5), None, Some(4)],
         );
         assert_eq!(ca.median(), Some(3.0));
-        let ca = UInt32Chunked::new_from_opt_slice(
+        let ca = UInt32Chunked::new(
             "a",
             &[
                 None,

--- a/polars/polars-core/src/chunked_array/ops/concat_str.rs
+++ b/polars/polars-core/src/chunked_array/ops/concat_str.rs
@@ -61,7 +61,7 @@ mod test {
 
     #[test]
     fn test_str_concat() {
-        let ca = Int32Chunked::new_from_opt_slice("foo", &[Some(1), None, Some(3)]);
+        let ca = Int32Chunked::new("foo", &[Some(1), None, Some(3)]);
         let out = ca.str_concat("-");
 
         let out = out.get(0);

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -160,7 +160,7 @@ mod test {
 
     #[test]
     fn test_cummax() {
-        let ca = UInt8Chunked::new_from_opt_slice("foo", &[None, Some(1), Some(3), None, Some(1)]);
+        let ca = UInt8Chunked::new("foo", &[None, Some(1), Some(3), None, Some(1)]);
         let out = ca.cummax(true);
         assert_eq!(Vec::from(&out), &[None, Some(3), Some(3), None, Some(1)]);
         let out = ca.cummax(false);
@@ -169,7 +169,7 @@ mod test {
 
     #[test]
     fn test_cummin() {
-        let ca = UInt8Chunked::new_from_opt_slice("foo", &[None, Some(1), Some(3), None, Some(2)]);
+        let ca = UInt8Chunked::new("foo", &[None, Some(1), Some(3), None, Some(2)]);
         let out = ca.cummin(true);
         assert_eq!(Vec::from(&out), &[None, Some(1), Some(2), None, Some(2)]);
         let out = ca.cummin(false);
@@ -178,17 +178,14 @@ mod test {
 
     #[test]
     fn test_cumsum() {
-        let ca = Int32Chunked::new_from_opt_slice("foo", &[None, Some(1), Some(3), None, Some(1)]);
+        let ca = Int32Chunked::new("foo", &[None, Some(1), Some(3), None, Some(1)]);
         let out = ca.cumsum(true);
         assert_eq!(Vec::from(&out), &[None, Some(5), Some(4), None, Some(1)]);
         let out = ca.cumsum(false);
         assert_eq!(Vec::from(&out), &[None, Some(1), Some(4), None, Some(5)]);
 
         // just check if the trait bounds allow for floats
-        let ca = Float32Chunked::new_from_opt_slice(
-            "foo",
-            &[None, Some(1.0), Some(3.0), None, Some(1.0)],
-        );
+        let ca = Float32Chunked::new("foo", &[None, Some(1.0), Some(3.0), None, Some(1.0)]);
         let _out = ca.cumsum(false);
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -246,8 +246,7 @@ mod test {
 
     #[test]
     fn test_fill_null() {
-        let ca =
-            Int32Chunked::new_from_opt_slice("a", &[None, Some(2), Some(3), None, Some(4), None]);
+        let ca = Int32Chunked::new("a", &[None, Some(2), Some(3), None, Some(4), None]);
         let filled = ca.fill_null(FillNullStrategy::Forward).unwrap();
         assert_eq!(filled.name(), "a");
 
@@ -279,7 +278,7 @@ mod test {
             Vec::from(&filled),
             &[Some(3), Some(2), Some(3), Some(3), Some(4), Some(3)]
         );
-        let ca = Int32Chunked::new_from_opt_slice("a", &[None, None, None, None, Some(4), None]);
+        let ca = Int32Chunked::new("a", &[None, None, None, None, Some(4), None]);
         let filled = ca.fill_null(FillNullStrategy::Backward).unwrap();
         assert_eq!(filled.name(), "a");
         assert_eq!(

--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -122,25 +122,21 @@ mod test {
 
     #[test]
     fn test_interpolate() {
-        let ca = UInt32Chunked::new_from_opt_slice("", &[Some(1), None, None, Some(4), Some(5)]);
+        let ca = UInt32Chunked::new("", &[Some(1), None, None, Some(4), Some(5)]);
         let out = ca.interpolate();
         assert_eq!(
             Vec::from(&out),
             &[Some(1), Some(2), Some(3), Some(4), Some(5)]
         );
 
-        let ca =
-            UInt32Chunked::new_from_opt_slice("", &[None, Some(1), None, None, Some(4), Some(5)]);
+        let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5)]);
         let out = ca.interpolate();
         assert_eq!(
             Vec::from(&out),
             &[None, Some(1), Some(2), Some(3), Some(4), Some(5)]
         );
 
-        let ca = UInt32Chunked::new_from_opt_slice(
-            "",
-            &[None, Some(1), None, None, Some(4), Some(5), None],
-        );
+        let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5), None]);
         let out = ca.interpolate();
         assert_eq!(
             Vec::from(&out),

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -188,8 +188,8 @@ mod test {
 
     #[test]
     fn test_is_in() -> Result<()> {
-        let a = Int32Chunked::new_from_slice("a", &[1, 2, 3, 4]);
-        let b = Int64Chunked::new_from_slice("b", &[4, 5, 1]);
+        let a = Int32Chunked::new("a", &[1, 2, 3, 4]);
+        let b = Int64Chunked::new("b", &[4, 5, 1]);
 
         let out = a.is_in(&b.into_series())?;
         assert_eq!(
@@ -197,8 +197,8 @@ mod test {
             [Some(true), Some(false), Some(false), Some(true)]
         );
 
-        let a = Utf8Chunked::new_from_slice("a", &["a", "b", "c", "d"]);
-        let b = Utf8Chunked::new_from_slice("b", &["d", "e", "c"]);
+        let a = Utf8Chunked::new("a", &["a", "b", "c", "d"]);
+        let b = Utf8Chunked::new("b", &["d", "e", "c"]);
 
         let out = a.is_in(&b.into_series())?;
         assert_eq!(

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -225,7 +225,7 @@ pub trait ChunkSet<'a, A, B> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let ca = UInt32Chunked::new_from_slice("a", &[1, 2, 3]);
+    /// let ca = UInt32Chunked::new("a", &[1, 2, 3]);
     /// let new = ca.set_at_idx(vec![0, 1], Some(10)).unwrap();
     ///
     /// assert_eq!(Vec::from(&new), &[Some(10), Some(10), Some(3)]);
@@ -244,7 +244,7 @@ pub trait ChunkSet<'a, A, B> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
+    /// let ca = Int32Chunked::new("a", &[1, 2, 3]);
     /// let new = ca.set_at_idx_with(vec![0, 1], |opt_v| opt_v.map(|v| v - 5)).unwrap();
     ///
     /// assert_eq!(Vec::from(&new), &[Some(-4), Some(-3), Some(3)]);
@@ -259,8 +259,8 @@ pub trait ChunkSet<'a, A, B> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-    /// let mask = BooleanChunked::new_from_slice("mask", &[false, true, false]);
+    /// let ca = Int32Chunked::new("a", &[1, 2, 3]);
+    /// let mask = BooleanChunked::new("mask", &[false, true, false]);
     /// let new = ca.set(&mask, Some(5)).unwrap();
     /// assert_eq!(Vec::from(&new), &[Some(1), Some(5), Some(3)]);
     /// ```
@@ -274,8 +274,8 @@ pub trait ChunkSet<'a, A, B> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let ca = UInt32Chunked::new_from_slice("a", &[1, 2, 3]);
-    /// let mask = BooleanChunked::new_from_slice("mask", &[false, true, false]);
+    /// let ca = UInt32Chunked::new("a", &[1, 2, 3]);
+    /// let mask = BooleanChunked::new("mask", &[false, true, false]);
     /// let new = ca.set_with(&mask, |opt_v| opt_v.map(
     ///     |v| v * 2
     /// )).unwrap();
@@ -590,8 +590,8 @@ pub trait ChunkFilter<T> {
     ///
     /// ```rust
     /// # use polars_core::prelude::*;
-    /// let array = Int32Chunked::new_from_slice("array", &[1, 2, 3]);
-    /// let mask = BooleanChunked::new_from_slice("mask", &[true, false, true]);
+    /// let array = Int32Chunked::new("array", &[1, 2, 3]);
+    /// let mask = BooleanChunked::new("mask", &[true, false, true]);
     ///
     /// let filtered = array.filter(&mask).unwrap();
     /// assert_eq!(Vec::from(&filtered), [Some(1), Some(3)])

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -418,7 +418,7 @@ mod test {
 
     #[test]
     fn test_rolling_mean() {
-        let ca = Float64Chunked::new_from_opt_slice(
+        let ca = Float64Chunked::new(
             "foo",
             &[
                 Some(0.0),
@@ -484,7 +484,7 @@ mod test {
 
     #[test]
     fn test_rolling_apply() {
-        let ca = Float64Chunked::new_from_opt_slice(
+        let ca = Float64Chunked::new(
             "foo",
             &[
                 Some(0.0),
@@ -514,7 +514,7 @@ mod test {
 
     #[test]
     fn test_rolling_var() {
-        let ca = Float64Chunked::new_from_opt_slice(
+        let ca = Float64Chunked::new(
             "foo",
             &[
                 Some(0.0),

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -349,7 +349,7 @@ mod test {
 
     #[test]
     fn test_rolling() {
-        let ca = Int32Chunked::new_from_slice("foo", &[1, 2, 3, 2, 1]);
+        let ca = Int32Chunked::new("foo", &[1, 2, 3, 2, 1]);
         let a = ca
             .rolling_sum(RollingOptions {
                 window_size: 2,

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -294,17 +294,17 @@ mod test {
         assert_eq!(Vec::from(&ca), &[Some(1), Some(5), Some(3)]);
 
         let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-        let mask = BooleanChunked::new_from_opt_slice("mask", &[None, Some(true), None]);
+        let mask = BooleanChunked::new("mask", &[None, Some(true), None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(5), Some(3)]);
 
         let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-        let mask = BooleanChunked::new_from_opt_slice("mask", &[None, None, None]);
+        let mask = BooleanChunked::new("mask", &[None, None, None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(2), Some(3)]);
 
         let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-        let mask = BooleanChunked::new_from_opt_slice("mask", &[Some(true), Some(false), None]);
+        let mask = BooleanChunked::new("mask", &[Some(true), Some(false), None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(5), Some(2), Some(3)]);
 
@@ -328,16 +328,16 @@ mod test {
 
     #[test]
     fn test_set_null_values() {
-        let ca = Int32Chunked::new_from_opt_slice("a", &[Some(1), None, Some(3)]);
-        let mask = BooleanChunked::new_from_opt_slice("mask", &[Some(false), Some(true), None]);
+        let ca = Int32Chunked::new("a", &[Some(1), None, Some(3)]);
+        let mask = BooleanChunked::new("mask", &[Some(false), Some(true), None]);
         let ca = ca.set(&mask, Some(2)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(2), Some(3)]);
 
-        let ca = Utf8Chunked::new_from_opt_slice("a", &[Some("foo"), None, Some("bar")]);
+        let ca = Utf8Chunked::new("a", &[Some("foo"), None, Some("bar")]);
         let ca = ca.set(&mask, Some("foo")).unwrap();
         assert_eq!(Vec::from(&ca), &[Some("foo"), Some("foo"), Some("bar")]);
 
-        let ca = BooleanChunked::new_from_opt_slice("a", &[Some(false), None, Some(true)]);
+        let ca = BooleanChunked::new("a", &[Some(false), None, Some(true)]);
         let ca = ca.set(&mask, Some(true)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(false), Some(true), Some(true)]);
     }

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -288,22 +288,22 @@ mod test {
 
     #[test]
     fn test_set() {
-        let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
-        let mask = BooleanChunked::new_from_slice("mask", &[false, true, false]);
+        let ca = Int32Chunked::new("a", &[1, 2, 3]);
+        let mask = BooleanChunked::new("mask", &[false, true, false]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(5), Some(3)]);
 
-        let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
+        let ca = Int32Chunked::new("a", &[1, 2, 3]);
         let mask = BooleanChunked::new("mask", &[None, Some(true), None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(5), Some(3)]);
 
-        let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
+        let ca = Int32Chunked::new("a", &[1, 2, 3]);
         let mask = BooleanChunked::new("mask", &[None, None, None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(1), Some(2), Some(3)]);
 
-        let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
+        let ca = Int32Chunked::new("a", &[1, 2, 3]);
         let mask = BooleanChunked::new("mask", &[Some(true), Some(false), None]);
         let ca = ca.set(&mask, Some(5)).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(5), Some(2), Some(3)]);
@@ -314,14 +314,14 @@ mod test {
         assert!(ca.set_at_idx(vec![0, 10], Some(0)).is_err());
 
         // test booleans
-        let ca = BooleanChunked::new_from_slice("a", &[true, true, true]);
-        let mask = BooleanChunked::new_from_slice("mask", &[false, true, false]);
+        let ca = BooleanChunked::new("a", &[true, true, true]);
+        let mask = BooleanChunked::new("mask", &[false, true, false]);
         let ca = ca.set(&mask, None).unwrap();
         assert_eq!(Vec::from(&ca), &[Some(true), None, Some(true)]);
 
         // test utf8
-        let ca = Utf8Chunked::new_from_slice("a", &["foo", "foo", "foo"]);
-        let mask = BooleanChunked::new_from_slice("mask", &[false, true, false]);
+        let ca = Utf8Chunked::new("a", &["foo", "foo", "foo"]);
+        let mask = BooleanChunked::new("mask", &[false, true, false]);
         let ca = ca.set(&mask, Some("bar")).unwrap();
         assert_eq!(Vec::from(&ca), &[Some("foo"), Some("bar"), Some("foo")]);
     }

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -131,7 +131,7 @@ mod test {
 
     #[test]
     fn test_shift() {
-        let ca = Int32Chunked::new_from_slice("", &[1, 2, 3]);
+        let ca = Int32Chunked::new("", &[1, 2, 3]);
 
         // shift by 0, 1, 2, 3, 4
         let shifted = ca.shift_and_fill(0, Some(5));

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -706,7 +706,7 @@ mod test {
 
     #[test]
     fn test_argsort() {
-        let a = Int32Chunked::new_from_opt_slice(
+        let a = Int32Chunked::new(
             "a",
             &[
                 Some(1), // 0
@@ -734,7 +734,7 @@ mod test {
 
     #[test]
     fn test_sort() {
-        let a = Int32Chunked::new_from_opt_slice(
+        let a = Int32Chunked::new(
             "a",
             &[
                 Some(1),
@@ -843,8 +843,7 @@ mod test {
 
     #[test]
     fn test_sort_utf8() {
-        let ca =
-            Utf8Chunked::new_from_opt_slice("a", &[Some("a"), None, Some("c"), None, Some("b")]);
+        let ca = Utf8Chunked::new("a", &[Some("a"), None, Some("c"), None, Some("b")]);
         let out = ca.sort_with(SortOptions {
             descending: false,
             nulls_last: false,
@@ -875,7 +874,7 @@ mod test {
         assert_eq!(Vec::from(&out), expected);
 
         // no nulls
-        let ca = Utf8Chunked::new_from_opt_slice("a", &[Some("a"), Some("c"), Some("b")]);
+        let ca = Utf8Chunked::new("a", &[Some("a"), Some("c"), Some("b")]);
         let out = ca.sort(false);
         let expected = &[Some("a"), Some("b"), Some("c")];
         assert_eq!(Vec::from(&out), expected);

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -787,9 +787,9 @@ mod test {
     #[cfg(feature = "sort_multiple")]
     #[cfg_attr(miri, ignore)]
     fn test_argsort_multiple() -> Result<()> {
-        let a = Int32Chunked::new_from_slice("a", &[1, 2, 1, 1, 3, 4, 3, 3]);
-        let b = Int64Chunked::new_from_slice("b", &[0, 1, 2, 3, 4, 5, 6, 1]);
-        let c = Utf8Chunked::new_from_slice("c", &["a", "b", "c", "d", "e", "f", "g", "h"]);
+        let a = Int32Chunked::new("a", &[1, 2, 1, 1, 3, 4, 3, 3]);
+        let b = Int64Chunked::new("b", &[0, 1, 2, 3, 4, 5, 6, 1]);
+        let c = Utf8Chunked::new("c", &["a", "b", "c", "d", "e", "f", "g", "h"]);
         let df = DataFrame::new(vec![a.into_series(), b.into_series(), c.into_series()])?;
 
         let out = df.sort(&["a", "b", "c"], false)?;
@@ -808,8 +808,8 @@ mod test {
         );
 
         // now let the first sort be a string
-        let a = Utf8Chunked::new_from_slice("a", &["a", "b", "c", "a", "b", "c"]).into_series();
-        let b = Int32Chunked::new_from_slice("b", &[5, 4, 2, 3, 4, 5]).into_series();
+        let a = Utf8Chunked::new("a", &["a", "b", "c", "a", "b", "c"]).into_series();
+        let b = Int32Chunked::new("b", &[5, 4, 2, 3, 4, 5]).into_series();
         let df = DataFrame::new(vec![a, b])?;
 
         let out = df.sort(&["a", "b"], false)?;

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -407,7 +407,7 @@ impl ChunkUnique<BooleanType> for BooleanChunked {
                 unique.push(v)
             }
         }
-        Ok(ChunkedArray::new_from_opt_slice(self.name(), &unique))
+        Ok(ChunkedArray::new(self.name(), &unique))
     }
 
     fn arg_unique(&self) -> Result<UInt32Chunked> {
@@ -570,8 +570,7 @@ mod test {
             vec![Some(true), Some(false)]
         );
 
-        let ca =
-            Utf8Chunked::new_from_opt_slice("", &[Some("a"), None, Some("a"), Some("b"), None]);
+        let ca = Utf8Chunked::new("", &[Some("a"), None, Some("a"), Some("b"), None]);
         assert_eq!(
             Vec::from(&ca.unique().unwrap().sort(false)),
             &[None, Some("a"), Some("b")]
@@ -605,7 +604,7 @@ mod test {
     #[test]
     #[cfg(feature = "is_first")]
     fn is_first() {
-        let ca = UInt32Chunked::new_from_opt_slice(
+        let ca = UInt32Chunked::new(
             "a",
             &[Some(1), Some(2), Some(1), Some(1), None, Some(3), None],
         );

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -330,7 +330,7 @@ mod test {
 
     #[test]
     fn test_rank_all_null() {
-        let s = UInt32Chunked::new_from_opt_slice("", &[None, None, None]).into_series();
+        let s = UInt32Chunked::new("", &[None, None, None]).into_series();
         let out = rank(&s, RankMethod::Average);
         assert_eq!(out.null_count(), 3);
         assert_eq!(out.dtype(), &DataType::Float32);

--- a/polars/polars-core/src/doc/time.rs
+++ b/polars/polars-core/src/doc/time.rs
@@ -38,7 +38,7 @@
 //! // Parsing fmt
 //! let fmt = "%Y-%m%-d %H:%M:%S";
 //! // Create the ChunkedArray
-//! let ca = Utf8Chunked::new_from_slice("datetime", datetime_values);
+//! let ca = Utf8Chunked::new("datetime", datetime_values);
 //! // Parse strings as DateTime objects
 //! let date_ca = ca.as_datetime(Some(fmt));
 //! ```

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -642,7 +642,7 @@ Series: 'a' [list]
 
     #[test]
     fn test_fmt_temporal() {
-        let s = Int32Chunked::new_from_opt_slice("Date", &[Some(1), None, Some(3)]).into_date();
+        let s = Int32Chunked::new("Date", &[Some(1), None, Some(3)]).into_date();
         assert_eq!(
             r#"shape: (3,)
 Series: 'Date' [date]
@@ -654,8 +654,7 @@ Series: 'Date' [date]
             format!("{:?}", s.into_series())
         );
 
-        let s = Int64Chunked::new_from_opt_slice("", &[Some(1), None, Some(1_000_000_000_000)])
-            .into_date();
+        let s = Int64Chunked::new("", &[Some(1), None, Some(1_000_000_000_000)]).into_date();
         assert_eq!(
             r#"shape: (3,)
 Series: '' [datetime]
@@ -670,7 +669,7 @@ Series: '' [datetime]
 
     #[test]
     fn test_fmt_chunkedarray() {
-        let ca = Int32Chunked::new_from_opt_slice("Date", &[Some(1), None, Some(3)]);
+        let ca = Int32Chunked::new("Date", &[Some(1), None, Some(3)]);
         println!("{:?}", ca);
         assert_eq!(
             r#"shape: (3,)

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -681,7 +681,7 @@ ChunkedArray: 'Date' [Int32]
 ]"#,
             format!("{:?}", ca)
         );
-        let ca = Utf8Chunked::new_from_slice("name", &["a", "b"]);
+        let ca = Utf8Chunked::new("name", &["a", "b"]);
         println!("{:?}", ca);
         assert_eq!(
             r#"shape: (2,)

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1512,7 +1512,7 @@ mod test {
             vec![1, 2, 3, 4, 4, 4, 2, 1, 1],
             vec![1, 2, 3, 4, 4, 4],
         ] {
-            let ca = UInt32Chunked::new_from_slice("", slice);
+            let ca = UInt32Chunked::new("", slice);
             let split = split_ca(&ca, 4).unwrap();
 
             let a = groupby(ca.into_iter()).into_iter().sorted().collect_vec();

--- a/polars/polars-core/src/frame/groupby/resample.rs
+++ b/polars/polars-core/src/frame/groupby/resample.rs
@@ -421,7 +421,7 @@ mod test {
 
     #[test]
     fn test_downsample() -> Result<()> {
-        let ts = Int64Chunked::new_from_slice(
+        let ts = Int64Chunked::new(
             "ms",
             &[
                 946684800000,
@@ -487,7 +487,7 @@ mod test {
 20210319 23:59:01";
         let data: Vec<_> = data.split('\n').collect();
 
-        let date = Utf8Chunked::new_from_slice("date", &data);
+        let date = Utf8Chunked::new("date", &data);
         let date = date.as_datetime(None)?.into_series();
         let values =
             UInt32Chunked::new_from_iter("values", (0..date.len()).map(|v| v as u32)).into_series();

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1383,7 +1383,7 @@ impl DataFrame {
     /// ```
     /// # use polars_core::prelude::*;
     /// fn example(df: &DataFrame) -> Result<DataFrame> {
-    ///     let idx = UInt32Chunked::new_from_slice("idx", &[0, 1, 9]);
+    ///     let idx = UInt32Chunked::new("idx", &[0, 1, 9]);
     ///     df.take(&idx)
     /// }
     /// ```

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod export;
 mod fmt;
 pub mod frame;
 pub mod functions;
+mod named_from;
 pub mod prelude;
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -22,35 +22,6 @@ macro_rules! impl_named_from {
     };
 }
 
-impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_slice(name, v.as_ref()).into_series()
-    }
-}
-impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_opt_slice(name, v.as_ref()).into_series()
-    }
-}
-
-impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
-            .into_series()
-    }
-}
-impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_opt_iter(
-            name,
-            v.as_ref()
-                .iter()
-                .map(|opt| opt.as_ref().map(|value| value.as_ref())),
-        )
-        .into_series()
-    }
-}
-
 impl_named_from!([String], Utf8Type, new_from_slice);
 impl_named_from!([bool], BooleanType, new_from_slice);
 #[cfg(feature = "dtype-u8")]
@@ -117,5 +88,72 @@ impl<T: AsRef<[Option<Series>]>> NamedFrom<T, [Option<Series>]> for Series {
             builder.append_opt_series(series.as_ref())
         }
         builder.finish().into_series()
+    }
+}
+impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_slice(name, v.as_ref()).into_series()
+    }
+}
+
+impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Utf8Chunked {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_slice(name, v.as_ref())
+    }
+}
+
+impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_slice(name, v.as_ref()).into_series()
+    }
+}
+
+impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Utf8Chunked {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_slice(name, v.as_ref())
+    }
+}
+
+impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
+            .into_series()
+    }
+}
+
+impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Utf8Chunked {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
+    }
+}
+
+impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new(name, v).into_series()
+    }
+}
+
+impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Utf8Chunked {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_iter(
+            name,
+            v.as_ref()
+                .iter()
+                .map(|opt| opt.as_ref().map(|value| value.as_ref())),
+        )
+    }
+}
+
+#[cfg(feature = "object")]
+impl<T: PolarsObject> NamedFrom<&[T], &[T]> for ObjectChunked<T> {
+    fn new(name: &str, v: &[T]) -> Self {
+        ObjectChunked::new_from_slice(name, v)
+    }
+}
+
+#[cfg(feature = "object")]
+impl<T: PolarsObject, S: AsRef<[Option<T>]>> NamedFrom<S, [Option<T>]> for ObjectChunked<T> {
+    fn new(name: &str, v: S) -> Self {
+        ObjectChunked::new_from_opt_slice(name, v.as_ref())
     }
 }

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -1,0 +1,121 @@
+use crate::chunked_array::builder::get_list_builder;
+use crate::prelude::*;
+use std::borrow::Cow;
+
+pub trait NamedFrom<T, Phantom: ?Sized> {
+    /// Initialize by name and values.
+    fn new(name: &str, _: T) -> Self;
+}
+//
+macro_rules! impl_named_from {
+    ($type:ty, $polars_type:ident, $method:ident) => {
+        impl<T: AsRef<$type>> NamedFrom<T, $type> for Series {
+            fn new(name: &str, v: T) -> Self {
+                ChunkedArray::<$polars_type>::$method(name, v.as_ref()).into_series()
+            }
+        }
+        impl<T: AsRef<$type>> NamedFrom<T, $type> for ChunkedArray<$polars_type> {
+            fn new(name: &str, v: T) -> Self {
+                ChunkedArray::<$polars_type>::$method(name, v.as_ref())
+            }
+        }
+    };
+}
+
+impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_slice(name, v.as_ref()).into_series()
+    }
+}
+impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_slice(name, v.as_ref()).into_series()
+    }
+}
+
+impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
+            .into_series()
+    }
+}
+impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        Utf8Chunked::new_from_opt_iter(
+            name,
+            v.as_ref()
+                .iter()
+                .map(|opt| opt.as_ref().map(|value| value.as_ref())),
+        )
+        .into_series()
+    }
+}
+
+impl_named_from!([String], Utf8Type, new_from_slice);
+impl_named_from!([bool], BooleanType, new_from_slice);
+#[cfg(feature = "dtype-u8")]
+impl_named_from!([u8], UInt8Type, new_from_slice);
+#[cfg(feature = "dtype-u16")]
+impl_named_from!([u16], UInt16Type, new_from_slice);
+impl_named_from!([u32], UInt32Type, new_from_slice);
+impl_named_from!([u64], UInt64Type, new_from_slice);
+#[cfg(feature = "dtype-i8")]
+impl_named_from!([i8], Int8Type, new_from_slice);
+#[cfg(feature = "dtype-i16")]
+impl_named_from!([i16], Int16Type, new_from_slice);
+impl_named_from!([i32], Int32Type, new_from_slice);
+impl_named_from!([i64], Int64Type, new_from_slice);
+impl_named_from!([f32], Float32Type, new_from_slice);
+impl_named_from!([f64], Float64Type, new_from_slice);
+impl_named_from!([Option<String>], Utf8Type, new_from_opt_slice);
+impl_named_from!([Option<bool>], BooleanType, new_from_opt_slice);
+#[cfg(feature = "dtype-u8")]
+impl_named_from!([Option<u8>], UInt8Type, new_from_opt_slice);
+#[cfg(feature = "dtype-u16")]
+impl_named_from!([Option<u16>], UInt16Type, new_from_opt_slice);
+impl_named_from!([Option<u32>], UInt32Type, new_from_opt_slice);
+impl_named_from!([Option<u64>], UInt64Type, new_from_opt_slice);
+#[cfg(feature = "dtype-i8")]
+impl_named_from!([Option<i8>], Int8Type, new_from_opt_slice);
+#[cfg(feature = "dtype-i16")]
+impl_named_from!([Option<i16>], Int16Type, new_from_opt_slice);
+impl_named_from!([Option<i32>], Int32Type, new_from_opt_slice);
+impl_named_from!([Option<i64>], Int64Type, new_from_opt_slice);
+impl_named_from!([Option<f32>], Float32Type, new_from_opt_slice);
+impl_named_from!([Option<f64>], Float64Type, new_from_opt_slice);
+
+impl<T: AsRef<[Series]>> NamedFrom<T, ListType> for Series {
+    fn new(name: &str, s: T) -> Self {
+        let series_slice = s.as_ref();
+        let values_cap = series_slice.iter().fold(0, |acc, s| acc + s.len());
+
+        let dt = series_slice[0].dtype();
+        let mut builder = get_list_builder(dt, values_cap, series_slice.len(), name);
+        for series in series_slice {
+            builder.append_series(series)
+        }
+        builder.finish().into_series()
+    }
+}
+
+impl<T: AsRef<[Option<Series>]>> NamedFrom<T, [Option<Series>]> for Series {
+    fn new(name: &str, s: T) -> Self {
+        let series_slice = s.as_ref();
+        let values_cap = series_slice.iter().fold(0, |acc, opt_s| {
+            acc + opt_s.as_ref().map(|s| s.len()).unwrap_or(0)
+        });
+
+        let dt = series_slice
+            .iter()
+            .filter_map(|opt| opt.as_ref())
+            .next()
+            .expect("cannot create List Series from a slice of nulls")
+            .dtype();
+
+        let mut builder = get_list_builder(dt, values_cap, series_slice.len(), name);
+        for series in series_slice {
+            builder.append_opt_series(series.as_ref())
+        }
+        builder.finish().into_series()
+    }
+}

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -19,9 +19,10 @@ pub use crate::{
     df,
     error::{PolarsError, Result},
     frame::{hash_join::JoinType, DataFrame},
+    named_from::NamedFrom,
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},
-        IntoSeries, NamedFrom, Series, SeriesTrait,
+        IntoSeries, Series, SeriesTrait,
     },
     testing::*,
     utils::IntoVec,

--- a/polars/polars-core/src/serde/mod.rs
+++ b/polars/polars-core/src/serde/mod.rs
@@ -75,7 +75,7 @@ mod test {
 
     #[test]
     fn test_serde() -> Result<()> {
-        let ca = UInt32Chunked::new_from_opt_slice("foo", &[Some(1), None, Some(2)]);
+        let ca = UInt32Chunked::new("foo", &[Some(1), None, Some(2)]);
 
         let json = serde_json::to_string(&ca).unwrap();
         dbg!(&json);
@@ -83,7 +83,7 @@ mod test {
         let out = serde_json::from_str::<Series>(&json).unwrap();
         assert!(ca.into_series().series_equal_missing(&out));
 
-        let ca = Utf8Chunked::new_from_opt_slice("foo", &[Some("foo"), None, Some("bar")]);
+        let ca = Utf8Chunked::new("foo", &[Some("foo"), None, Some("bar")]);
 
         let json = serde_json::to_string(&ca).unwrap();
         dbg!(&json);
@@ -97,7 +97,7 @@ mod test {
     /// test using the `DeserializedOwned` trait
     #[test]
     fn test_serde_owned() {
-        let ca = UInt32Chunked::new_from_opt_slice("foo", &[Some(1), None, Some(2)]);
+        let ca = UInt32Chunked::new("foo", &[Some(1), None, Some(2)]);
 
         let json = serde_json::to_string(&ca).unwrap();
         dbg!(&json);

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -1,125 +1,10 @@
-use crate::chunked_array::builder::get_list_builder;
 use crate::chunked_array::cast::cast_chunks;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
 use crate::prelude::*;
 use arrow::compute::cast::utf8_to_large_utf8;
 use polars_arrow::compute::cast::cast;
-use std::borrow::Cow;
 use std::convert::TryFrom;
-
-pub trait NamedFrom<T, Phantom: ?Sized> {
-    /// Initialize by name and values.
-    fn new(name: &str, _: T) -> Self;
-}
-//
-macro_rules! impl_named_from {
-    ($type:ty, $series_var:ident, $method:ident) => {
-        impl<T: AsRef<$type>> NamedFrom<T, $type> for Series {
-            fn new(name: &str, v: T) -> Self {
-                ChunkedArray::<$series_var>::$method(name, v.as_ref()).into_series()
-            }
-        }
-    };
-}
-
-impl<'a, T: AsRef<[&'a str]>> NamedFrom<T, [&'a str]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_slice(name, v.as_ref()).into_series()
-    }
-}
-impl<'a, T: AsRef<[Option<&'a str>]>> NamedFrom<T, [Option<&'a str>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_opt_slice(name, v.as_ref()).into_series()
-    }
-}
-
-impl<'a, T: AsRef<[Cow<'a, str>]>> NamedFrom<T, [Cow<'a, str>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_iter(name, v.as_ref().iter().map(|value| value.as_ref()))
-            .into_series()
-    }
-}
-impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> for Series {
-    fn new(name: &str, v: T) -> Self {
-        Utf8Chunked::new_from_opt_iter(
-            name,
-            v.as_ref()
-                .iter()
-                .map(|opt| opt.as_ref().map(|value| value.as_ref())),
-        )
-        .into_series()
-    }
-}
-
-impl_named_from!([String], Utf8Type, new_from_slice);
-impl_named_from!([bool], BooleanType, new_from_slice);
-#[cfg(feature = "dtype-u8")]
-impl_named_from!([u8], UInt8Type, new_from_slice);
-#[cfg(feature = "dtype-u16")]
-impl_named_from!([u16], UInt16Type, new_from_slice);
-impl_named_from!([u32], UInt32Type, new_from_slice);
-impl_named_from!([u64], UInt64Type, new_from_slice);
-#[cfg(feature = "dtype-i8")]
-impl_named_from!([i8], Int8Type, new_from_slice);
-#[cfg(feature = "dtype-i16")]
-impl_named_from!([i16], Int16Type, new_from_slice);
-impl_named_from!([i32], Int32Type, new_from_slice);
-impl_named_from!([i64], Int64Type, new_from_slice);
-impl_named_from!([f32], Float32Type, new_from_slice);
-impl_named_from!([f64], Float64Type, new_from_slice);
-impl_named_from!([Option<String>], Utf8Type, new_from_opt_slice);
-impl_named_from!([Option<bool>], BooleanType, new_from_opt_slice);
-#[cfg(feature = "dtype-u8")]
-impl_named_from!([Option<u8>], UInt8Type, new_from_opt_slice);
-#[cfg(feature = "dtype-u16")]
-impl_named_from!([Option<u16>], UInt16Type, new_from_opt_slice);
-impl_named_from!([Option<u32>], UInt32Type, new_from_opt_slice);
-impl_named_from!([Option<u64>], UInt64Type, new_from_opt_slice);
-#[cfg(feature = "dtype-i8")]
-impl_named_from!([Option<i8>], Int8Type, new_from_opt_slice);
-#[cfg(feature = "dtype-i16")]
-impl_named_from!([Option<i16>], Int16Type, new_from_opt_slice);
-impl_named_from!([Option<i32>], Int32Type, new_from_opt_slice);
-impl_named_from!([Option<i64>], Int64Type, new_from_opt_slice);
-impl_named_from!([Option<f32>], Float32Type, new_from_opt_slice);
-impl_named_from!([Option<f64>], Float64Type, new_from_opt_slice);
-
-impl<T: AsRef<[Series]>> NamedFrom<T, ListType> for Series {
-    fn new(name: &str, s: T) -> Self {
-        let series_slice = s.as_ref();
-        let values_cap = series_slice.iter().fold(0, |acc, s| acc + s.len());
-
-        let dt = series_slice[0].dtype();
-        let mut builder = get_list_builder(dt, values_cap, series_slice.len(), name);
-        for series in series_slice {
-            builder.append_series(series)
-        }
-        builder.finish().into_series()
-    }
-}
-
-impl<T: AsRef<[Option<Series>]>> NamedFrom<T, [Option<Series>]> for Series {
-    fn new(name: &str, s: T) -> Self {
-        let series_slice = s.as_ref();
-        let values_cap = series_slice.iter().fold(0, |acc, opt_s| {
-            acc + opt_s.as_ref().map(|s| s.len()).unwrap_or(0)
-        });
-
-        let dt = series_slice
-            .iter()
-            .filter_map(|opt| opt.as_ref())
-            .next()
-            .expect("cannot create List Series from a slice of nulls")
-            .dtype();
-
-        let mut builder = get_list_builder(dt, values_cap, series_slice.len(), name);
-        for series in series_slice {
-            builder.append_opt_series(series.as_ref())
-        }
-        builder.finish().into_series()
-    }
-}
 
 fn convert_list_inner(arr: &ArrayRef, fld: &ArrowField) -> ArrayRef {
     // if inner type is Utf8, we need to convert that to large utf8
@@ -145,7 +30,7 @@ fn convert_list_inner(arr: &ArrayRef, fld: &ArrowField) -> ArrayRef {
 }
 
 // TODO: add types
-impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
+impl TryFrom<(&str, Vec<ArrayRef>)> for Series {
     type Error = PolarsError;
 
     fn try_from(name_arr: (&str, Vec<ArrayRef>)) -> Result<Self> {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -756,9 +756,7 @@ mod test {
 
     #[test]
     fn test_arithmetic_dispatch() {
-        let s = Int64Chunked::new_from_slice("", &[1, 2, 3])
-            .into_date()
-            .into_series();
+        let s = Int64Chunked::new("", &[1, 2, 3]).into_date().into_series();
 
         // check if we don't panic.
         let out = &s * 100;

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -783,7 +783,7 @@ mod test {
 
     #[test]
     fn cast() {
-        let ar = UInt32Chunked::new_from_slice("a", &[1, 2]);
+        let ar = UInt32Chunked::new("a", &[1, 2]);
         let s = ar.into_series();
         let s2 = s.cast(&DataType::Int64).unwrap();
 
@@ -796,7 +796,7 @@ mod test {
     fn new_series() {
         Series::new("boolean series", &vec![true, false, true]);
         Series::new("int series", &[1, 2, 3]);
-        let ca = Int32Chunked::new_from_slice("a", &[1, 2, 3]);
+        let ca = Int32Chunked::new("a", &[1, 2, 3]);
         ca.into_series();
     }
 

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -891,9 +891,9 @@ mod test {
 
     #[test]
     fn test_align_chunks() {
-        let a = Int32Chunked::new_from_slice("", &[1, 2, 3, 4]);
-        let mut b = Int32Chunked::new_from_slice("", &[1]);
-        let b2 = Int32Chunked::new_from_slice("", &[2, 3, 4]);
+        let a = Int32Chunked::new("", &[1, 2, 3, 4]);
+        let mut b = Int32Chunked::new("", &[1]);
+        let b2 = Int32Chunked::new("", &[2, 3, 4]);
 
         b.append(&b2);
         let (a, b) = align_chunks_binary(&a, &b);
@@ -902,8 +902,8 @@ mod test {
             b.chunk_id().collect::<Vec<_>>()
         );
 
-        let a = Int32Chunked::new_from_slice("", &[1, 2, 3, 4]);
-        let mut b = Int32Chunked::new_from_slice("", &[1]);
+        let a = Int32Chunked::new("", &[1, 2, 3, 4]);
+        let mut b = Int32Chunked::new("", &[1]);
         let b1 = b.clone();
         b.append(&b1);
         b.append(&b1);

--- a/polars/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -37,7 +37,7 @@ impl PhysicalExpr for LiteralExpr {
             Float32(v) => Float32Chunked::full("literal", *v, 1).into_series(),
             Float64(v) => Float64Chunked::full("literal", *v, 1).into_series(),
             Boolean(v) => BooleanChunked::full("literal", *v, 1).into_series(),
-            Null => BooleanChunked::new_from_opt_slice("literal", &[None]).into_series(),
+            Null => BooleanChunked::new("literal", &[None]).into_series(),
             Range {
                 low,
                 high,

--- a/polars/src/docs/eager.rs
+++ b/polars/src/docs/eager.rs
@@ -67,7 +67,7 @@
 //! let s = Series::new("foo", &[1, 2, 3]);
 //!
 //! // from a chunked-array
-//! let ca = UInt32Chunked::new_from_opt_slice("foo", &[Some(1), None, Some(3)]);
+//! let ca = UInt32Chunked::new("foo", &[Some(1), None, Some(3)]);
 //! let s = ca.into_series();
 //! ```
 //!
@@ -161,7 +161,7 @@
 //! # fn example() -> Result<()> {
 //!
 //! let s = Series::new("a", &[1, 2, 3]);
-//! let ca = UInt32Chunked::new_from_opt_slice("b", &[Some(3), None, Some(1)]);
+//! let ca = UInt32Chunked::new("b", &[Some(3), None, Some(1)]);
 //!
 //! // compare Series with numeric values
 //! // ==

--- a/polars/src/docs/eager.rs
+++ b/polars/src/docs/eager.rs
@@ -45,7 +45,7 @@
 //! let ca: UInt32Chunked = (0..10).map(Some).collect();
 //!
 //! // from slices
-//! let ca = UInt32Chunked::new_from_slice("foo", &[1, 2, 3]);
+//! let ca = UInt32Chunked::new("foo", &[1, 2, 3]);
 //!
 //! // use builders
 //! let mut builder = PrimitiveChunkedBuilder::<UInt32Type>::new("foo", 10);
@@ -146,7 +146,7 @@
 //!
 //! ```rust
 //! # use polars::prelude::*;
-//! let ca = UInt32Chunked::new_from_slice("foo", &[1, 2, 3]);
+//! let ca = UInt32Chunked::new("foo", &[1, 2, 3]);
 //!
 //! // 1 / ca
 //! let divide_one_by_ca = ca.apply(|rhs| 1 / rhs);


### PR DESCRIPTION
Most of the time you can now create a new ca by calling `ChunkedArray::new("name"m &1, 2])`.

Instead of specifying the specific dispatched method for `&[T], &[Option<T>], Iterator<Item=T>, Iterator<Item=Option<T>>`