### PR TITLE
Add DataFrame.schema

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1561,8 +1561,31 @@ class DataFrame:
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
+        See Also
+        --------
+        schema : Return a dict of [column name, dtype]
         """
         return [DTYPES[idx] for idx in self._df.dtypes()]
+
+    @property
+    def schema(self) -> Dict[str, Type[DataType]]:
+        """
+        Get a dict[column name, DataType]]
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [6.0, 7.0, 8.0],
+        ...         "ham": ["a", "b", "c"],
+        ...     }
+        ... )
+        >>> df.schema
+        {'foo': <class 'polars.datatypes.Int64'>, 'bar': <class 'polars.datatypes.Float64'>, 'ham': <class 'polars.datatypes.Utf8'>}
+
+        """
+        return {c: self[c].dtype for c in self.columns}
 
     def describe(self) -> "DataFrame":
         """

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1570,7 +1570,7 @@ class DataFrame:
     @property
     def schema(self) -> Dict[str, Type[DataType]]:
         """
-        Get a dict[column name, DataType]]
+        Get a dict[column name, DataType]
 
         Examples
         --------

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1308,3 +1308,11 @@ def test_extension() -> None:
     assert sys.getrefcount(foos[0]) == base_count + 1
     del df
     assert sys.getrefcount(foos[0]) == base_count
+
+
+def test_schema() -> None:
+    df = pl.DataFrame(
+        {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
+    )
+    expected = {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.Utf8}
+    assert df.schema == expected


### PR DESCRIPTION
Closes #1988

Have implemented this as a property, like `dtypes`. `describe` is a method. Not sure whether we should pick method or property here.