### PR TITLE
Clean doctest script

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3814,7 +3814,7 @@ class GroupBy:
         ...     {
         ...         "spam": ["sum", "min"],
         ...     }
-        ... )  # doctest: +IGNORE_RESULT
+        ... )  # doctest: +SKIP
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │


### PR DESCRIPTION
Main change: use unittest to show results, rather than rolling our own overview. +couple of smaller changes.