### PR TITLE
Add "typing_extensions" as dependency for Python versions lower than …

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -5,12 +5,13 @@ build-backend = "maturin"
 [project]
 name = "polars"
 dependencies = [
-  "numpy",
+  "numpy >= 1.16.0",
+  "typing_extensions; python_version < '3.8'",
 ]
 requires-python = ">=3.6"
 
 [project.optional-dependencies]
-# the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS
+# the Arrow memory format is stable between 4.0, 5.0 and 6.0-SNAPSHOTS
 # (which the Rust libraries use to take advantage of Rust API changes).
 pyarrow = ["pyarrow>=4.0.*"]
 pandas = ["pyarrow>=4.0.*", "pandas"]


### PR DESCRIPTION
…3.8.