### PR TITLE
Rank reverse

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -19,14 +19,14 @@ pub enum RankMethod {
 #[derive(Copy, Clone)]
 pub struct RankOptions {
     pub method: RankMethod,
-    pub reverse: bool,
+    pub descending: bool,
 }
 
 impl Default for RankOptions {
     fn default() -> Self {
         Self {
             method: RankMethod::Dense,
-            reverse: false,
+            descending: false,
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -73,7 +73,7 @@ pub(crate) fn rank(s: &Series, options: RankOptions) -> Series {
 
     let len = s.len();
     let null_count = s.null_count();
-    let sort_idx_ca = s.argsort(false);
+    let sort_idx_ca = s.argsort(options.descending);
     let sort_idx = sort_idx_ca.downcast_iter().next().unwrap().values();
 
     let mut inv: AlignedVec<u32> = AlignedVec::with_capacity(len);

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -364,13 +364,13 @@ mod test {
         assert_eq!(
             out,
             &[
-                Some(2.0f32),
-                Some(3.5),
-                Some(5.0),
-                Some(3.5),
-                Some(6.5),
-                Some(6.5),
-                Some(1.0)
+                Some(4.0f32),
+                Some(5.5),
+                Some(7.0),
+                Some(5.5),
+                Some(1.5),
+                Some(1.5),
+                Some(3.0)
             ]
         );
         let s = Series::new(
@@ -396,7 +396,7 @@ mod test {
         .u32()?
         .into_no_null_iter()
         .collect::<Vec<_>>();
-        assert_eq!(out, &[4, 5, 3, 8, 7, 3, 1, 6]);
+        assert_eq!(out, &[5, 6, 4, 1, 8, 4, 2, 7]);
 
         Ok(())
     }

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -443,4 +443,22 @@ mod test {
         );
         assert_eq!(out.dtype(), &DataType::UInt32);
     }
+
+    #[test]
+    fn test_rank_reverse() -> Result<()> {
+        let s = Series::new("", &[None, Some(1), Some(1), Some(5), None]);
+        let out = rank(
+            &s,
+            RankOptions {
+                method: RankMethod::Dense,
+                descending: true,
+            },
+        )
+        .u32()?
+        .into_no_null_iter()
+        .collect::<Vec<_>>();
+        assert_eq!(out, &[1, 3, 3, 2, 1]);
+
+        Ok(())
+    }
 }

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -42,7 +42,7 @@ pub use crate::chunked_array::temporal::conversion::*;
 pub use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 
 #[cfg(feature = "rank")]
-pub use crate::chunked_array::ops::unique::rank::RankMethod;
+pub use crate::chunked_array::ops::unique::rank::{RankMethod, RankOptions};
 
 #[cfg(feature = "rolling_window")]
 pub use crate::chunked_array::ops::rolling_window::RollingOptions;

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -651,7 +651,7 @@ impl Series {
     #[cfg(feature = "rank")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
     pub fn rank(&self, options: RankOptions) -> Series {
-        rank(self, options)
+        rank(self, options.method, options.descending)
     }
 
     /// Cast throws an error if conversion had overflows

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -2,6 +2,7 @@
 pub use crate::prelude::ChunkCompare;
 use crate::prelude::*;
 use arrow::array::ArrayRef;
+
 pub(crate) mod arithmetic;
 mod comparison;
 mod from;
@@ -15,7 +16,7 @@ pub mod unstable;
 
 use crate::chunked_array::ops::rolling_window::RollingOptions;
 #[cfg(feature = "rank")]
-use crate::prelude::unique::rank::{rank, RankMethod};
+use crate::prelude::unique::rank::{rank};
 #[cfg(feature = "groupby_list")]
 use crate::utils::Wrap;
 use crate::utils::{split_ca, split_series};
@@ -649,8 +650,8 @@ impl Series {
 
     #[cfg(feature = "rank")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
-    pub fn rank(&self, method: RankMethod) -> Series {
-        rank(self, method)
+    pub fn rank(&self, options: RankOptions) -> Series {
+        rank(self, options)
     }
 
     /// Cast throws an error if conversion had overflows
@@ -664,7 +665,7 @@ impl Series {
                     self.dtype(),
                     data_type
                 )
-                .into(),
+                    .into(),
             ))
         } else {
             Ok(s)
@@ -746,7 +747,7 @@ impl Series {
             dt => {
                 return Err(PolarsError::InvalidOperation(
                     format!("abs not supportedd for series of type {:?}", dt).into(),
-                ))
+                ));
             }
         };
         Ok(out)
@@ -780,7 +781,7 @@ where
     fn as_ref(&self) -> &ChunkedArray<T> {
         if &T::get_dtype() == self.dtype() ||
             // needed because we want to get ref of List no matter what the inner type is.
-            (matches!(T::get_dtype(), DataType::List(_)) && matches!(self.dtype(), DataType::List(_)) )
+            (matches!(T::get_dtype(), DataType::List(_)) && matches!(self.dtype(), DataType::List(_)))
         {
             unsafe { &*(self as *const dyn SeriesTrait as *const ChunkedArray<T>) }
         } else {
@@ -800,7 +801,7 @@ where
     fn as_mut(&mut self) -> &mut ChunkedArray<T> {
         if &T::get_dtype() == self.dtype() ||
             // needed because we want to get ref of List no matter what the inner type is.
-            (matches!(T::get_dtype(), DataType::List(_)) && matches!(self.dtype(), DataType::List(_)) )
+            (matches!(T::get_dtype(), DataType::List(_)) && matches!(self.dtype(), DataType::List(_)))
         {
             unsafe { &mut *(self as *mut dyn SeriesTrait as *mut ChunkedArray<T>) }
         } else {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -16,7 +16,7 @@ pub mod unstable;
 
 use crate::chunked_array::ops::rolling_window::RollingOptions;
 #[cfg(feature = "rank")]
-use crate::prelude::unique::rank::{rank};
+use crate::prelude::unique::rank::rank;
 #[cfg(feature = "groupby_list")]
 use crate::utils::Wrap;
 use crate::utils::{split_ca, split_series};

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1632,10 +1632,10 @@ impl Expr {
 
     #[cfg(feature = "rank")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
-    pub fn rank(self, method: RankMethod) -> Expr {
+    pub fn rank(self, options: RankOptions) -> Expr {
         self.apply(
-            move |s| Ok(s.rank(method)),
-            GetOutput::map_field(move |fld| match method {
+            move |s| Ok(s.rank(options)),
+            GetOutput::map_field(move |fld| match options.method {
                 RankMethod::Average => Field::new(fld.name(), DataType::Float32),
                 _ => Field::new(fld.name(), DataType::UInt32),
             }),

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -65,7 +65,17 @@ pub fn pearson_corr(a: Expr, b: Expr) -> Expr {
 #[cfg(feature = "rank")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
 pub fn spearman_rank_corr(a: Expr, b: Expr) -> Expr {
-    pearson_corr(a.rank(RankMethod::Min), b.rank(RankMethod::Min)).alias("spearman_rank_corr")
+    pearson_corr(
+        a.rank(RankOptions {
+            method: RankMethod::Min,
+            ..Default::default()
+        }),
+        b.rank(RankOptions {
+            method: RankMethod::Min,
+            ..Default::default()
+        }),
+    )
+    .alias("spearman_rank_corr")
 }
 
 /// Find the indexes that would sort these series in order of appearance.

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1567,6 +1567,7 @@ fn test_reverse_in_groups() -> Result<()> {
     );
     Ok(())
 }
+
 #[test]
 fn test_take_in_groups() -> Result<()> {
     let df = fruits_cars();
@@ -1975,7 +1976,10 @@ fn test_groupby_rank() -> Result<()> {
     let out = df
         .lazy()
         .stable_groupby([col("cars")])
-        .agg([col("B").rank(RankMethod::Dense)])
+        .agg([col("B").rank(RankOptions {
+            method: RankMethod::Dense,
+            ..Default::default()
+        })])
         .collect()?;
 
     let out = out.column("B")?;
@@ -2371,7 +2375,12 @@ fn test_single_ranked_group() -> Result<()> {
 
     let out = df
         .lazy()
-        .with_columns([col("value").rank(RankMethod::Average).over([col("group")])])
+        .with_columns([col("value")
+            .rank(RankOptions {
+                method: RankMethod::Average,
+                ..Default::default()
+            })
+            .over([col("group")])])
         .collect()?;
 
     let out = out.column("value")?.explode()?;

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1725,7 +1725,7 @@ class Expr:
         """
         return pli.argsort_by([self], [reverse])
 
-    def rank(self, method: str = "average") -> "Expr":
+    def rank(self, method: str = "average", reverse: bool = False) -> "Expr":
         """
         Assign ranks to data, dealing with ties appropriately.
 
@@ -1749,8 +1749,10 @@ class Expr:
                 the order that the values occur in `a`.
               * 'random': Like 'ordinal', but the rank for ties is not dependent
                 on the order that the values occur in `a`.
+        reverse
+            reverse the operation
         """
-        return wrap_expr(self._pyexpr.rank(method))
+        return wrap_expr(self._pyexpr.rank(method, reverse))
 
     def diff(self, n: int = 1, null_behavior: str = "ignore") -> "Expr":
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2967,7 +2967,7 @@ class Series:
         """
         return wrap_s(self._s.abs())
 
-    def rank(self, method: str = "average") -> "Series":
+    def rank(self, method: str = "average", reverse: bool = False) -> "Series":
         """
         Assign ranks to data, dealing with ties appropriately.
 
@@ -2991,9 +2991,11 @@ class Series:
                 the order that the values occur in `a`.
               * 'random': Like 'ordinal', but the rank for ties is not dependent
                 on the order that the values occur in `a`.
+        reverse
+            reverse the operation
 
         """
-        return wrap_s(self._s.rank(method))
+        return wrap_s(self._s.rank(method, reverse))
 
     def diff(self, n: int = 1, null_behavior: str = "ignore") -> "Series":
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -931,9 +931,13 @@ impl PyExpr {
             .into()
     }
 
-    fn rank(&self, method: &str) -> Self {
+    fn rank(&self, method: &str, reverse: bool) -> Self {
         let method = str_to_rankmethod(method).unwrap();
-        self.inner.clone().rank(method).into()
+        let options = RankOptions {
+            method,
+            reverse,
+        };
+        self.inner.clone().rank(options).into()
     }
 
     fn diff(&self, n: usize, null_behavior: &str) -> Self {
@@ -1042,7 +1046,7 @@ impl WhenThen {
             self.then.inner.clone(),
             expr.inner,
         )
-        .into()
+            .into()
     }
 }
 
@@ -1131,7 +1135,7 @@ pub fn lit(value: &PyAny) -> PyExpr {
                 .to_str()
                 .expect("could not transform Python string to Rust Unicode"),
         )
-        .into()
+            .into()
     } else if let Ok(series) = value.extract::<PySeries>() {
         dsl::lit(series.series).into()
     } else if value.is_none() {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -933,7 +933,10 @@ impl PyExpr {
 
     fn rank(&self, method: &str, reverse: bool) -> Self {
         let method = str_to_rankmethod(method).unwrap();
-        let options = RankOptions { method, descending: reverse };
+        let options = RankOptions {
+            method,
+            descending: reverse,
+        };
         self.inner.clone().rank(options).into()
     }
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -933,10 +933,7 @@ impl PyExpr {
 
     fn rank(&self, method: &str, reverse: bool) -> Self {
         let method = str_to_rankmethod(method).unwrap();
-        let options = RankOptions {
-            method,
-            reverse,
-        };
+        let options = RankOptions { method, descending: reverse };
         self.inner.clone().rank(options).into()
     }
 
@@ -1046,7 +1043,7 @@ impl WhenThen {
             self.then.inner.clone(),
             expr.inner,
         )
-            .into()
+        .into()
     }
 }
 
@@ -1135,7 +1132,7 @@ pub fn lit(value: &PyAny) -> PyExpr {
                 .to_str()
                 .expect("could not transform Python string to Rust Unicode"),
         )
-            .into()
+        .into()
     } else if let Ok(series) = value.extract::<PySeries>() {
         dsl::lit(series.series).into()
     } else if value.is_none() {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1329,9 +1329,13 @@ impl PySeries {
         }
     }
 
-    pub fn rank(&self, method: &str) -> PyResult<Self> {
-        let method = str_to_rankmethod(method)?;
-        Ok(self.series.rank(method).into())
+    pub fn rank(&self, method: &str, reverse: bool) -> PyResult<Self> {
+        let method = str_to_rankmethod(method).unwrap();
+        let options = RankOptions {
+            method,
+            reverse,
+        };
+        Ok(self.series.rank(options).into())
     }
 
     pub fn diff(&self, n: usize, null_behavior: &str) -> PyResult<Self> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1331,7 +1331,10 @@ impl PySeries {
 
     pub fn rank(&self, method: &str, reverse: bool) -> PyResult<Self> {
         let method = str_to_rankmethod(method).unwrap();
-        let options = RankOptions { method, descending: reverse };
+        let options = RankOptions {
+            method,
+            descending: reverse,
+        };
         Ok(self.series.rank(options).into())
     }
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1331,10 +1331,7 @@ impl PySeries {
 
     pub fn rank(&self, method: &str, reverse: bool) -> PyResult<Self> {
         let method = str_to_rankmethod(method).unwrap();
-        let options = RankOptions {
-            method,
-            reverse,
-        };
+        let options = RankOptions { method, descending: reverse };
         Ok(self.series.rank(options).into())
     }
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -536,7 +536,7 @@ def test_rank_dispatch() -> None:
 
     testing.assert_series_equal(
         s.rank("dense", reverse=True),
-        pl.Series("a", [3, 2, 1, 4, 4, 1, 2], dtype=UInt32),
+        pl.Series("a", [3, 2, 1, 2, 2, 1, 4], dtype=UInt32),
     )
 
 
@@ -799,7 +799,9 @@ def test_abs() -> None:
     # floats
     s = pl.Series([1.0, -2.0, 3, -4.0])
     testing.assert_series_equal(s.abs(), pl.Series([1.0, 2.0, 3.0, 4.0]))
-    testing.assert_series_equal(np.abs(s), pl.Series([1.0, 2.0, 3.0, 4.0]))  # type: ignore
+    testing.assert_series_equal(
+        np.abs(s), pl.Series([1.0, 2.0, 3.0, 4.0])  # type: ignore
+    )
     testing.assert_series_equal(
         pl.select(pl.lit(s).abs()).to_series(), pl.Series([1.0, 2.0, 3.0, 4.0])
     )  # type: ignore

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -534,6 +534,11 @@ def test_rank_dispatch() -> None:
     df = pl.DataFrame([s])
     assert df.select(pl.col("a").rank("dense"))["a"] == [2, 3, 4, 3, 3, 4, 1]
 
+    testing.assert_series_equal(
+        s.rank("dense", reverse=True),
+        pl.Series("a", [3, 2, 1, 4, 4, 1, 2], dtype=UInt32),
+    )
+
 
 def test_diff_dispatch() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
@@ -795,7 +800,9 @@ def test_abs() -> None:
     s = pl.Series([1.0, -2.0, 3, -4.0])
     testing.assert_series_equal(s.abs(), pl.Series([1.0, 2.0, 3.0, 4.0]))
     testing.assert_series_equal(np.abs(s), pl.Series([1.0, 2.0, 3.0, 4.0]))  # type: ignore
-    testing.assert_series_equal(pl.select(pl.lit(s).abs()).to_series(), pl.Series([1.0, 2.0, 3.0, 4.0]))  # type: ignore
+    testing.assert_series_equal(
+        pl.select(pl.lit(s).abs()).to_series(), pl.Series([1.0, 2.0, 3.0, 4.0])
+    )  # type: ignore
 
 
 def test_to_dummies() -> None:


### PR DESCRIPTION
Added reverse option to rank functions. In addition, made a couple breaking changes to the rank algorithm with the goal of resolving some inconsistencies:

1. `Expr.rank` and `Series.rank` have an `options` parameter, similar to `rolling_*`. In the future, a `nulls_last` or `null_behavior` field could be added to this type.
2. Changed null behavior to make nulls ranked highest, this is consistent with the default behavior of sort.
3. When all elements are null, rank returns numerical rankings instead of an all null array. In the future, `rank` could support an option that determines whether nulls are always ranked highest, lowest, or have ranks set to null. If the last option is supported, it would make sense for null values to have null ranks if and only if that option is set.

Future work: The ranks of null values can be tied with non-null values. It would be best to add support for `nulls_last` in `argsort` and pass in the null values instead of filling them.