### PR TITLE
Allow non-list to be concat into list and optimization of unit lists

### DIFF
--- a/polars/polars-core/src/chunked_array/list/namespace.rs
+++ b/polars/polars-core/src/chunked_array/list/namespace.rs
@@ -107,16 +107,25 @@ impl ListChunked {
                 Some(s) => s,
                 None => {
                     builder.append_null();
+                    // make sure that the iterators advance before we continue
+                    for it in &mut iters {
+                        it.next().unwrap();
+                    }
                     continue;
                 }
             };
+            let mut already_null = false;
             for it in &mut iters {
                 match it.next().unwrap() {
                     Some(s) => {
                         acc.append(s.as_ref())?;
                     }
                     None => {
-                        builder.append_null();
+                        if !already_null {
+                            builder.append_null();
+                            already_null = true;
+                        }
+
                         continue;
                     }
                 }

--- a/polars/polars-core/src/chunked_array/ops/full.rs
+++ b/polars/polars-core/src/chunked_array/ops/full.rs
@@ -94,7 +94,7 @@ impl ListChunked {
         inner_dtype: &DataType,
     ) -> ListChunked {
         let arr = new_null_array(
-            ArrowDataType::List(Box::new(ArrowField::new(
+            ArrowDataType::LargeList(Box::new(ArrowField::new(
                 "item",
                 inner_dtype.to_arrow(),
                 true,

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -237,11 +237,9 @@ impl DataFrame {
             series_cols
         };
 
-        let mut df = DataFrame {
+        Ok(DataFrame {
             columns: series_cols,
-        };
-        df.rechunk();
-        Ok(df)
+        })
     }
 
     /// Removes the last `Series` from the `DataFrame` and returns it, or [`None`] if it is empty.
@@ -639,7 +637,6 @@ impl DataFrame {
         for col in columns {
             self.columns.push(col.clone());
         }
-        self.rechunk();
         self
     }
 
@@ -952,7 +949,6 @@ impl DataFrame {
     fn insert_at_idx_no_name_check(&mut self, index: usize, series: Series) -> Result<&mut Self> {
         if series.len() == self.height() {
             self.columns.insert(index, series);
-            self.rechunk();
             Ok(self)
         } else {
             Err(PolarsError::ShapeMisMatch(
@@ -981,7 +977,6 @@ impl DataFrame {
                 self.replace_at_idx(idx, series)?;
             } else {
                 self.columns.push(series);
-                self.rechunk();
             }
             Ok(self)
         } else {
@@ -1806,7 +1801,6 @@ impl DataFrame {
             let col = self.columns.get_unchecked_mut(idx);
             col.rename(&name);
         }
-        self.rechunk();
         Ok(self)
     }
 
@@ -1874,7 +1868,6 @@ impl DataFrame {
             let col = self.columns.get_unchecked_mut(idx);
             col.rename(&name);
         }
-        self.rechunk();
         Ok(self)
     }
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -907,6 +907,7 @@ class DataFrame:
 
         Examples
         --------
+
         >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
         >>> df.transpose(include_header=True)
         shape: (2, 4)
@@ -921,6 +922,7 @@ class DataFrame:
         └────────┴──────────┴──────────┴──────────┘
 
         # replace the auto generated column names with a list
+
         >>> df.transpose(include_header=False, column_names=["a", "b", "c"])
         shape: (2, 3)
         ┌─────┬─────┬─────┐

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1094,7 +1094,6 @@ def concat_list(exprs: Sequence[Union[str, "pli.Expr"]]) -> "pli.Expr":
     ...         ]
     ...     )
     ... )
-
     shape: (5, 1)
     ┌─────────────────┐
     │ A_rolling       │


### PR DESCRIPTION
This allows for concattenation without calling `reshape(-1, 1)` first. Also implements a fast path for converting any array with `reshape(-1, 1)` to a list array.

```python
pl.DataFrame(
        {
            "A": [1.0, 2.0, 9.0, 2.0, 13.0],
        }
    )
    .with_columns([pl.col("A").shift(i).alias(f"A_lag_{i}") for i in range(3)])
    .select(
        [pl.concat_list([f"A_lag_{i}" for i in range(3)][::-1]).alias("A_rolling")]
    )
)
```

```
shape: (5, 1)
┌─────────────────┐
│ A_rolling       │
│ ---             │
│ list [f64]      │
╞═════════════════╡
│ [null, null, 1] │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [null, 1, 2]    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [1, 2, 9]       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [2, 9, 2]       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [9, 2, 13]      │
└─────────────────
```