### PR TITLE
Remove typing as tp import

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1,7 +1,6 @@
 import copy
-import typing as tp
 from datetime import date, datetime, timedelta
-from typing import Any, Callable, Optional, Sequence, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 
@@ -29,8 +28,8 @@ from polars.datatypes import (
 
 def _selection_to_pyexpr_list(
     exprs: Union[str, "Expr", Sequence[Union[str, "Expr"]], "pli.Series"]
-) -> tp.List["PyExpr"]:
-    pyexpr_list: tp.List[PyExpr]
+) -> List["PyExpr"]:
+    pyexpr_list: List[PyExpr]
     if isinstance(exprs, Sequence) and not isinstance(exprs, str):
         pyexpr_list = []
         for expr in exprs:
@@ -287,7 +286,7 @@ class Expr:
 
     def exclude(
         self,
-        columns: Union[str, tp.List[str], Type[DataType], Sequence[Type[DataType]]],
+        columns: Union[str, List[str], Type[DataType], Sequence[Type[DataType]]],
     ) -> "Expr":
         """
         Exclude certain columns from a wildcard/regex selection.
@@ -806,8 +805,8 @@ class Expr:
 
     def sort_by(
         self,
-        by: Union["Expr", str, tp.List[Union["Expr", str]]],
-        reverse: Union[bool, tp.List[bool]] = False,
+        by: Union["Expr", str, List[Union["Expr", str]]],
+        reverse: Union[bool, List[bool]] = False,
     ) -> "Expr":
         """
         Sort this column by the ordering of another column, or multiple other columns.
@@ -830,9 +829,7 @@ class Expr:
 
         return wrap_expr(self._pyexpr.sort_by(by, reverse))
 
-    def take(
-        self, index: Union[tp.List[int], "Expr", "pli.Series", np.ndarray]
-    ) -> "Expr":
+    def take(self, index: Union[List[int], "Expr", "pli.Series", np.ndarray]) -> "Expr":
         """
         Take values by index.
 
@@ -1014,7 +1011,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.list())
 
-    def over(self, expr: Union[str, "Expr", tp.List[Union["Expr", str]]]) -> "Expr":
+    def over(self, expr: Union[str, "Expr", List[Union["Expr", str]]]) -> "Expr":
         """
         Apply window function over a subgroup.
         This is similar to a groupby + aggregation + self join.
@@ -1274,7 +1271,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.pow(exponent))
 
-    def is_in(self, other: Union["Expr", tp.List[Any]]) -> "Expr":
+    def is_in(self, other: Union["Expr", List[Any]]) -> "Expr":
         """
         Check if elements of this Series are in the right Series, or List values of the right Series.
 
@@ -1426,7 +1423,7 @@ class Expr:
     def rolling_min(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -1458,7 +1455,7 @@ class Expr:
     def rolling_max(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -1490,7 +1487,7 @@ class Expr:
     def rolling_mean(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -1551,7 +1548,7 @@ class Expr:
     def rolling_sum(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -1583,7 +1580,7 @@ class Expr:
     def rolling_std(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -1616,7 +1613,7 @@ class Expr:
     def rolling_var(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Expr":
@@ -2068,7 +2065,7 @@ class Expr:
         """
         return np.arctan(self)  # type: ignore
 
-    def reshape(self, dims: tp.Tuple[int, ...]) -> "Expr":
+    def reshape(self, dims: Tuple[int, ...]) -> "Expr":
         """
         Reshape this Expr to a flat series, shape: (len,)
         or a List series, shape: (rows, cols)
@@ -2178,7 +2175,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.lst_unique())
 
-    def concat(self, other: Union[tp.List[Union[Expr, str]], Expr, str]) -> "Expr":
+    def concat(self, other: Union[List[Union[Expr, str]], Expr, str]) -> "Expr":
         """
         Concat the arrays in a Series dtype List in linear time.
 
@@ -2187,7 +2184,7 @@ class ExprListNameSpace:
         other
             Columns to concat into a List Series
         """
-        other_list: tp.List[Union[Expr, str]]
+        other_list: List[Union[Expr, str]]
         if not isinstance(other, list):
             other_list = [other]
         else:
@@ -2748,7 +2745,7 @@ class ExprDateTimeNameSpace:
 
 
 def expr_to_lit_or_expr(
-    expr: Union[Expr, bool, int, float, str, tp.List[Expr], tp.List[str], "pli.Series"],
+    expr: Union[Expr, bool, int, float, str, List[Expr], List[str], "pli.Series"],
     str_to_lit: bool = True,
 ) -> Expr:
     """

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3,7 +3,6 @@ Module containing logic related to eager DataFrames
 """
 import os
 import sys
-import typing as tp
 from datetime import timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -14,12 +13,14 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Optional,
     Sequence,
     TextIO,
     Tuple,
     Type,
     Union,
+    overload,
 )
 
 if sys.version_info >= (3, 8):
@@ -359,15 +360,13 @@ class DataFrame:
     def read_csv(
         file: Union[str, BinaryIO, bytes],
         has_header: bool = True,
-        columns: Optional[Union[tp.List[int], tp.List[str]]] = None,
+        columns: Optional[Union[List[int], List[str]]] = None,
         sep: str = ",",
         comment_char: Optional[str] = None,
         quote_char: Optional[str] = r'"',
         skip_rows: int = 0,
-        dtypes: Optional[
-            Union[Dict[str, Type[DataType]], tp.List[Type[DataType]]]
-        ] = None,
-        null_values: Optional[Union[str, tp.List[str], Dict[str, str]]] = None,
+        dtypes: Optional[Union[Dict[str, Type[DataType]], List[Type[DataType]]]] = None,
+        null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
         ignore_errors: bool = False,
         parse_dates: bool = False,
         n_threads: Optional[int] = None,
@@ -464,7 +463,7 @@ class DataFrame:
             if isinstance(file, StringIO):
                 file = file.getvalue().encode()
 
-        projection: Optional[tp.List[int]] = None
+        projection: Optional[List[int]] = None
         if columns:
             if isinstance(columns, list):
                 if all(isinstance(i, int) for i in columns):
@@ -475,8 +474,8 @@ class DataFrame:
                         "columns arg should contain a list of all integers or all strings values."
                     )
 
-        dtype_list: Optional[tp.List[Tuple[str, Type[DataType]]]] = None
-        dtype_slice: Optional[tp.List[Type[DataType]]] = None
+        dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
+        dtype_slice: Optional[List[Type[DataType]]] = None
         if dtypes is not None:
             if isinstance(dtypes, dict):
                 dtype_list = []
@@ -517,7 +516,7 @@ class DataFrame:
     @staticmethod
     def read_parquet(
         file: Union[str, BinaryIO],
-        columns: Optional[Union[tp.List[int], tp.List[str]]] = None,
+        columns: Optional[Union[List[int], List[str]]] = None,
         n_rows: Optional[int] = None,
     ) -> "DataFrame":
         """
@@ -532,7 +531,7 @@ class DataFrame:
         n_rows
             Stop reading from parquet file after reading ``n_rows``.
         """
-        projection: Optional[tp.List[int]] = None
+        projection: Optional[List[int]] = None
         if columns:
             if isinstance(columns, list):
                 if all(isinstance(i, int) for i in columns):
@@ -550,7 +549,7 @@ class DataFrame:
     @staticmethod
     def read_ipc(
         file: Union[str, BinaryIO],
-        columns: Optional[Union[tp.List[int], tp.List[str]]] = None,
+        columns: Optional[Union[List[int], List[str]]] = None,
         n_rows: Optional[int] = None,
     ) -> "DataFrame":
         """
@@ -569,7 +568,7 @@ class DataFrame:
         -------
         DataFrame
         """
-        projection: Optional[tp.List[int]] = None
+        projection: Optional[List[int]] = None
         if columns:
             if isinstance(columns, list):
                 if all(isinstance(i, int) for i in columns):
@@ -617,7 +616,7 @@ class DataFrame:
 
     def to_dict(
         self, as_series: bool = True
-    ) -> Union[Dict[str, "pli.Series"], Dict[str, tp.List[Any]]]:
+    ) -> Union[Dict[str, "pli.Series"], Dict[str, List[Any]]]:
         """
         Convert DataFrame to a dictionary mapping column name to values.
 
@@ -711,7 +710,7 @@ class DataFrame:
         else:
             return {s.name: s.to_list() for s in self}
 
-    @tp.overload
+    @overload
     def to_json(
         self,
         file: Optional[Union[BytesIO, str, Path]] = ...,
@@ -721,7 +720,7 @@ class DataFrame:
     ) -> str:
         ...
 
-    @tp.overload
+    @overload
     def to_json(
         self,
         file: Optional[Union[BytesIO, str, Path]] = ...,
@@ -731,7 +730,7 @@ class DataFrame:
     ) -> None:
         ...
 
-    @tp.overload
+    @overload
     def to_json(
         self,
         file: Optional[Union[BytesIO, str, Path]] = ...,
@@ -870,7 +869,7 @@ class DataFrame:
 
         self._df.to_ipc(file, compression)
 
-    def to_dicts(self) -> tp.List[Dict[str, Any]]:
+    def to_dicts(self) -> List[Dict[str, Any]]:
         pydf = self._df
         names = self.columns
 
@@ -883,7 +882,7 @@ class DataFrame:
         self,
         include_header: bool = False,
         header_name: str = "column",
-        column_names: Optional[Union[tp.Iterator[str], tp.Sequence[str]]] = None,
+        column_names: Optional[Union[Iterator[str], Sequence[str]]] = None,
     ) -> "pli.DataFrame":
         """
         Transpose a DataFrame over the diagonal.
@@ -1542,7 +1541,7 @@ class DataFrame:
         return self._df.width()
 
     @property
-    def columns(self) -> tp.List[str]:
+    def columns(self) -> List[str]:
         """
         Get or set column names.
 
@@ -1593,7 +1592,7 @@ class DataFrame:
         self._df.set_column_names(columns)
 
     @property
-    def dtypes(self) -> tp.List[Type[DataType]]:
+    def dtypes(self) -> List[Type[DataType]]:
         """
         Get dtypes of columns in DataFrame. Dtypes can also be found in column headers when printing the DataFrame.
 
@@ -1743,31 +1742,31 @@ class DataFrame:
         """
         self._df.replace_at_idx(index, series._s)
 
-    @tp.overload
+    @overload
     def sort(
         self,
-        by: Union[str, "pli.Expr", tp.List[str], tp.List["pli.Expr"]],
-        reverse: Union[bool, tp.List[bool]] = ...,
+        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
+        reverse: Union[bool, List[bool]] = ...,
         *,
         in_place: Literal[False] = ...,
     ) -> "DataFrame":
         ...
 
-    @tp.overload
+    @overload
     def sort(
         self,
-        by: Union[str, "pli.Expr", tp.List[str], tp.List["pli.Expr"]],
-        reverse: Union[bool, tp.List[bool]] = ...,
+        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
+        reverse: Union[bool, List[bool]] = ...,
         *,
         in_place: Literal[True],
     ) -> None:
         ...
 
-    @tp.overload
+    @overload
     def sort(
         self,
-        by: Union[str, "pli.Expr", tp.List[str], tp.List["pli.Expr"]],
-        reverse: Union[bool, tp.List[bool]] = ...,
+        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
+        reverse: Union[bool, List[bool]] = ...,
         *,
         in_place: bool,
     ) -> Optional["DataFrame"]:
@@ -1775,8 +1774,8 @@ class DataFrame:
 
     def sort(
         self,
-        by: Union[str, "pli.Expr", tp.List[str], tp.List["pli.Expr"]],
-        reverse: Union[bool, tp.List[bool]] = False,
+        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
+        reverse: Union[bool, List[bool]] = False,
         *,
         in_place: bool = False,
     ) -> Optional["DataFrame"]:
@@ -2044,7 +2043,7 @@ class DataFrame:
         """
         return wrap_df(self._df.tail(length))
 
-    def drop_nulls(self, subset: Optional[tp.List[str]] = None) -> "DataFrame":
+    def drop_nulls(self, subset: Optional[List[str]] = None) -> "DataFrame":
         """
         Return a new DataFrame where the null values are dropped.
 
@@ -2259,7 +2258,7 @@ class DataFrame:
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: str = "right",
-        by: Optional[Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]] = None,
+        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
     ) -> "DynamicGroupBy":
         """
         Groups based on a time value. Time windows are calculated and rows are assigned to windows.
@@ -2532,18 +2531,14 @@ class DataFrame:
     def join(
         self,
         df: "DataFrame",
-        left_on: Optional[
-            Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]
-        ] = None,
-        right_on: Optional[
-            Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]
-        ] = None,
-        on: Optional[Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]] = None,
+        left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         how: str = "inner",
         suffix: str = "_right",
-        asof_by: Optional[Union[str, tp.List[str]]] = None,
-        asof_by_left: Optional[Union[str, tp.List[str]]] = None,
-        asof_by_right: Optional[Union[str, tp.List[str]]] = None,
+        asof_by: Optional[Union[str, List[str]]] = None,
+        asof_by_left: Optional[Union[str, List[str]]] = None,
+        asof_by_right: Optional[Union[str, List[str]]] = None,
     ) -> "DataFrame":
         """
         SQL like joins.
@@ -2629,13 +2624,13 @@ class DataFrame:
         if how == "cross":
             return wrap_df(self._df.join(df._df, [], [], how, suffix))
 
-        left_on_: Optional[tp.List[Union[str, pli.Expr]]]
+        left_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(left_on, (str, pli.Expr)):
             left_on_ = [left_on]
         else:
             left_on_ = left_on
 
-        right_on_: Optional[tp.List[Union[str, pli.Expr]]]
+        right_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(right_on, (str, pli.Expr)):
             right_on_ = [right_on]
         else:
@@ -2725,7 +2720,7 @@ class DataFrame:
         )
 
     def hstack(
-        self, columns: Union[tp.List["pli.Series"], "DataFrame"], in_place: bool = False
+        self, columns: Union[List["pli.Series"], "DataFrame"], in_place: bool = False
     ) -> Optional["DataFrame"]:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
@@ -2770,15 +2765,15 @@ class DataFrame:
         else:
             return wrap_df(self._df.hstack([s.inner() for s in columns]))
 
-    @tp.overload
+    @overload
     def vstack(self, df: "DataFrame", in_place: Literal[True]) -> None:
         ...
 
-    @tp.overload
+    @overload
     def vstack(self, df: "DataFrame", in_place: Literal[False] = ...) -> "DataFrame":
         ...
 
-    @tp.overload
+    @overload
     def vstack(self, df: "DataFrame", in_place: bool) -> Optional["DataFrame"]:
         ...
 
@@ -2833,7 +2828,7 @@ class DataFrame:
         else:
             return wrap_df(self._df.vstack(df._df))
 
-    def drop(self, name: Union[str, tp.List[str]]) -> "DataFrame":
+    def drop(self, name: Union[str, List[str]]) -> "DataFrame":
         """
         Remove column from DataFrame and return as new.
 
@@ -2950,7 +2945,7 @@ class DataFrame:
     def __deepcopy__(self, memodict={}) -> "DataFrame":  # type: ignore
         return self.clone()
 
-    def get_columns(self) -> tp.List["pli.Series"]:
+    def get_columns(self) -> List["pli.Series"]:
         """
         Get the DataFrame as a List of Series.
         """
@@ -3010,7 +3005,7 @@ class DataFrame:
         return self.lazy().fill_nan(fill_value).collect(no_optimization=True)
 
     def explode(
-        self, columns: Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]
+        self, columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]]
     ) -> "DataFrame":
         """
         Explode `DataFrame` to long format by exploding a column with Lists.
@@ -3083,7 +3078,7 @@ class DataFrame:
         return self.lazy().explode(columns).collect(no_optimization=True)
 
     def melt(
-        self, id_vars: Union[tp.List[str], str], value_vars: Union[tp.List[str], str]
+        self, id_vars: Union[List[str], str], value_vars: Union[List[str], str]
     ) -> "DataFrame":
         """
         Unpivot DataFrame to long format.
@@ -3275,9 +3270,7 @@ class DataFrame:
             self.lazy().select(exprs).collect(no_optimization=True, string_cache=False)  # type: ignore
         )
 
-    def with_columns(
-        self, exprs: Union["pli.Expr", tp.List["pli.Expr"]]
-    ) -> "DataFrame":
+    def with_columns(self, exprs: Union["pli.Expr", List["pli.Expr"]]) -> "DataFrame":
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -3585,7 +3578,7 @@ class DataFrame:
     def drop_duplicates(
         self,
         maintain_order: bool = True,
-        subset: Optional[Union[str, tp.List[str]]] = None,
+        subset: Optional[Union[str, List[str]]] = None,
     ) -> "DataFrame":
         """
         Drop duplicate rows from this DataFrame.
@@ -3779,7 +3772,7 @@ class DataFrame:
         """
         return self._df.row_tuple(index)
 
-    def rows(self) -> tp.List[Tuple]:
+    def rows(self) -> List[Tuple]:
         """
         Convert columnar data to rows as python tuples.
         """
@@ -3865,7 +3858,7 @@ class DynamicGroupBy:
         truncate: bool = True,
         include_boundaries: bool = True,
         closed: str = "none",
-        by: Optional[Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]] = None,
+        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
     ):
         self.df = df
         self.time_column = time_column
@@ -3880,9 +3873,9 @@ class DynamicGroupBy:
     def agg(
         self,
         column_to_agg: Union[
-            tp.List[Tuple[str, tp.List[str]]],
-            Dict[str, Union[str, tp.List[str]]],
-            tp.List["pli.Expr"],
+            List[Tuple[str, List[str]]],
+            Dict[str, Union[str, List[str]]],
+            List["pli.Expr"],
             "pli.Expr",
         ],
     ) -> DataFrame:
@@ -3941,7 +3934,7 @@ class GroupBy:
     def __init__(
         self,
         df: "PyDataFrame",
-        by: Union[str, tp.List[str]],
+        by: Union[str, List[str]],
         maintain_order: bool = False,
     ):
         self._df = df
@@ -3951,7 +3944,7 @@ class GroupBy:
     def __getitem__(self, item: Any) -> "GBSelection":
         return self._select(item)
 
-    def _select(self, columns: Union[str, tp.List[str]]) -> "GBSelection":
+    def _select(self, columns: Union[str, List[str]]) -> "GBSelection":
         """
         Select the columns that will be aggregated.
 
@@ -4036,9 +4029,9 @@ class GroupBy:
     def agg(
         self,
         column_to_agg: Union[
-            tp.List[Tuple[str, tp.List[str]]],
-            Dict[str, Union[str, tp.List[str]]],
-            tp.List["pli.Expr"],
+            List[Tuple[str, List[str]]],
+            Dict[str, Union[str, List[str]]],
+            List["pli.Expr"],
             "pli.Expr",
         ],
     ) -> DataFrame:
@@ -4376,7 +4369,7 @@ class PivotOps:
     def __init__(
         self,
         df: DataFrame,
-        by: Union[str, tp.List[str]],
+        by: Union[str, List[str]],
         pivot_column: str,
         values_column: str,
     ):
@@ -4450,8 +4443,8 @@ class GBSelection:
     def __init__(
         self,
         df: "PyDataFrame",
-        by: Union[str, tp.List[str]],
-        selection: Optional[tp.List[str]],
+        by: Union[str, List[str]],
+        selection: Optional[List[str]],
     ):
         self._df = df
         self.by = by

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -5,8 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-import typing as tp
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 try:
     from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
@@ -25,8 +24,8 @@ def wrap_ldf(ldf: "PyLazyFrame") -> "LazyFrame":
 
 
 def _prepare_groupby_inputs(
-    by: Optional[Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]],
-) -> tp.List["PyExpr"]:
+    by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]],
+) -> List["PyExpr"]:
     if isinstance(by, list):
         new_by = []
         for e in by:
@@ -65,10 +64,10 @@ class LazyFrame:
         quote_char: Optional[str] = r'"',
         skip_rows: int = 0,
         dtypes: Optional[Dict[str, Type[DataType]]] = None,
-        null_values: Optional[Union[str, tp.List[str], Dict[str, str]]] = None,
+        null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
         ignore_errors: bool = False,
         cache: bool = True,
-        with_column_names: Optional[Callable[[tp.List[str]], tp.List[str]]] = None,
+        with_column_names: Optional[Callable[[List[str]], List[str]]] = None,
         infer_schema_length: Optional[int] = 100,
         n_rows: Optional[int] = None,
         low_memory: bool = False,
@@ -76,7 +75,7 @@ class LazyFrame:
         """
         See Also: `pl.scan_csv`
         """
-        dtype_list: Optional[tp.List[Tuple[str, Type[DataType]]]] = None
+        dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
         if dtypes is not None:
             dtype_list = []
             for k, v in dtypes.items():
@@ -246,8 +245,8 @@ class LazyFrame:
 
     def sort(
         self,
-        by: Union[str, "pli.Expr", tp.List[str], tp.List["pli.Expr"]],
-        reverse: Union[bool, tp.List[bool]] = False,
+        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
+        reverse: Union[bool, List[bool]] = False,
     ) -> "LazyFrame":
         """
         Sort the DataFrame by:
@@ -378,7 +377,7 @@ class LazyFrame:
         return pli.wrap_df(ldf.fetch(n_rows))
 
     @property
-    def columns(self) -> tp.List[str]:
+    def columns(self) -> List[str]:
         """
         Get or set column names.
 
@@ -481,7 +480,7 @@ class LazyFrame:
 
     def groupby(
         self,
-        by: Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]],
+        by: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
         maintain_order: bool = False,
     ) -> "LazyGroupBy":
         """
@@ -507,7 +506,7 @@ class LazyFrame:
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: str = "right",
-        by: Optional[Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]] = None,
+        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
     ) -> "LazyGroupBy":
         """
         Groups based on a time value. Time windows are calculated and rows are assigned to windows.
@@ -577,20 +576,16 @@ class LazyFrame:
     def join(
         self,
         ldf: "LazyFrame",
-        left_on: Optional[
-            Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]
-        ] = None,
-        right_on: Optional[
-            Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]
-        ] = None,
-        on: Optional[Union[str, "pli.Expr", tp.List[Union[str, "pli.Expr"]]]] = None,
+        left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         how: str = "inner",
         suffix: str = "_right",
         allow_parallel: bool = True,
         force_parallel: bool = False,
-        asof_by: Optional[Union[str, tp.List[str]]] = None,
-        asof_by_left: Optional[Union[str, tp.List[str]]] = None,
-        asof_by_right: Optional[Union[str, tp.List[str]]] = None,
+        asof_by: Optional[Union[str, List[str]]] = None,
+        asof_by_left: Optional[Union[str, List[str]]] = None,
+        asof_by_right: Optional[Union[str, List[str]]] = None,
     ) -> "LazyFrame":
         """
         Add a join operation to the Logical Plan.
@@ -645,13 +640,13 @@ class LazyFrame:
                 )
             )
 
-        left_on_: Optional[tp.List[Union[str, pli.Expr]]]
+        left_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(left_on, (str, pli.Expr)):
             left_on_ = [left_on]
         else:
             left_on_ = left_on
 
-        right_on_: Optional[tp.List[Union[str, pli.Expr]]]
+        right_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(right_on, (str, pli.Expr)):
             right_on_ = [right_on]
         else:
@@ -680,13 +675,13 @@ class LazyFrame:
 
         # set asof_by
 
-        left_asof_by_: Union[tp.List[str], None]
+        left_asof_by_: Union[List[str], None]
         if isinstance(asof_by_left, str):
             left_asof_by_ = [asof_by_left]
         else:
             left_asof_by_ = asof_by_left
 
-        right_asof_by_: Union[tp.List[str], None]
+        right_asof_by_: Union[List[str], None]
         if isinstance(asof_by_right, (str, pli.Expr)):
             right_asof_by_ = [asof_by_right]
         else:
@@ -718,9 +713,7 @@ class LazyFrame:
             )
         )
 
-    def with_columns(
-        self, exprs: Union[tp.List["pli.Expr"], "pli.Expr"]
-    ) -> "LazyFrame":
+    def with_columns(self, exprs: Union[List["pli.Expr"], "pli.Expr"]) -> "LazyFrame":
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -753,7 +746,7 @@ class LazyFrame:
         """
         return self.with_columns([expr])
 
-    def drop(self, columns: Union[str, tp.List[str]]) -> "LazyFrame":
+    def drop(self, columns: Union[str, List[str]]) -> "LazyFrame":
         """
         Remove one or multiple columns from a DataFrame.
 
@@ -979,7 +972,7 @@ class LazyFrame:
         return wrap_ldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(
-        self, columns: Union[str, tp.List[str], "pli.Expr", tp.List["pli.Expr"]]
+        self, columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]]
     ) -> "LazyFrame":
         """
         Explode lists to long format.
@@ -1047,7 +1040,7 @@ class LazyFrame:
     def drop_duplicates(
         self,
         maintain_order: bool = False,
-        subset: Optional[Union[tp.List[str], str]] = None,
+        subset: Optional[Union[List[str], str]] = None,
     ) -> "LazyFrame":
         """
         Drop duplicate rows from this DataFrame.
@@ -1057,9 +1050,7 @@ class LazyFrame:
             subset = [subset]
         return wrap_ldf(self._ldf.drop_duplicates(maintain_order, subset))
 
-    def drop_nulls(
-        self, subset: Optional[Union[tp.List[str], str]] = None
-    ) -> "LazyFrame":
+    def drop_nulls(self, subset: Optional[Union[List[str], str]] = None) -> "LazyFrame":
         """
         Drop rows with null values from this DataFrame.
 
@@ -1140,7 +1131,7 @@ class LazyFrame:
         return wrap_ldf(self._ldf.drop_nulls(subset))
 
     def melt(
-        self, id_vars: Union[str, tp.List[str]], value_vars: Union[str, tp.List[str]]
+        self, id_vars: Union[str, List[str]], value_vars: Union[str, List[str]]
     ) -> "LazyFrame":
         """
         Unpivot DataFrame to long format.
@@ -1199,7 +1190,7 @@ class LazyGroupBy:
     def __init__(self, lgb: "PyLazyGroupBy"):
         self.lgb = lgb
 
-    def agg(self, aggs: Union[tp.List["pli.Expr"], "pli.Expr"]) -> "LazyFrame":
+    def agg(self, aggs: Union[List["pli.Expr"], "pli.Expr"]) -> "LazyFrame":
         """
         Describe the aggregation that need to be done on a group.
 

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,7 +1,6 @@
-import typing as tp
 from datetime import date, datetime, timezone
 from inspect import isclass
-from typing import Any, Callable, Optional, Sequence, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Type, Union, overload
 
 import numpy as np
 
@@ -32,9 +31,7 @@ except ImportError:  # pragma: no cover
 
 
 def col(
-    name: Union[
-        str, tp.List[str], tp.List[Type[DataType]], "pli.Series", Type[DataType]
-    ]
+    name: Union[str, List[str], List[Type[DataType]], "pli.Series", Type[DataType]]
 ) -> "pli.Expr":
     """
     A column in a DataFrame.
@@ -142,12 +139,12 @@ def col(
     return pli.wrap_expr(pycol(name))
 
 
-@tp.overload
+@overload
 def count(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def count(column: "pli.Series") -> int:
     ...
 
@@ -170,12 +167,12 @@ def to_list(name: str) -> "pli.Expr":
     return col(name).list()
 
 
-@tp.overload
+@overload
 def std(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def std(column: "pli.Series") -> Optional[float]:
     ...
 
@@ -189,12 +186,12 @@ def std(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
     return col(column).std()
 
 
-@tp.overload
+@overload
 def var(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def var(column: "pli.Series") -> Optional[float]:
     ...
 
@@ -208,18 +205,18 @@ def var(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
     return col(column).var()
 
 
-@tp.overload
-def max(column: Union[str, tp.List[Union["pli.Expr", str]]]) -> "pli.Expr":
+@overload
+def max(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def max(column: "pli.Series") -> Union[int, float]:
     ...
 
 
 def max(
-    column: Union[str, tp.List[Union["pli.Expr", str]], "pli.Series"]
+    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
 ) -> Union["pli.Expr", Any]:
     """
     Get the maximum value. Can be used horizontally or vertically.
@@ -230,7 +227,7 @@ def max(
         Column(s) to be used in aggregation. Will lead to different behavior based on the input.
         input:
         - Union[str, Series] -> aggregate the maximum value of that column.
-        - tp.List[Expr] -> aggregate the maximum value horizontally.
+        - List[Expr] -> aggregate the maximum value horizontally.
     """
     if isinstance(column, pli.Series):
         return column.max()
@@ -248,18 +245,18 @@ def max(
         return col(column).max()
 
 
-@tp.overload
-def min(column: Union[str, tp.List[Union["pli.Expr", str]]]) -> "pli.Expr":
+@overload
+def min(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def min(column: "pli.Series") -> Union[int, float]:
     ...
 
 
 def min(
-    column: Union[str, tp.List[Union["pli.Expr", str]], "pli.Series"]
+    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
 ) -> Union["pli.Expr", Any]:
     """
     Get the minimum value.
@@ -268,7 +265,7 @@ def min(
         Column(s) to be used in aggregation. Will lead to different behavior based on the input.
         input:
         - Union[str, Series] -> aggregate the sum value of that column.
-        - tp.List[Expr] -> aggregate the sum value horizontally.
+        - List[Expr] -> aggregate the sum value horizontally.
     """
     if isinstance(column, pli.Series):
         return column.min()
@@ -286,18 +283,18 @@ def min(
         return col(column).min()
 
 
-@tp.overload
-def sum(column: Union[str, tp.List[Union["pli.Expr", str]]]) -> "pli.Expr":
+@overload
+def sum(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def sum(column: "pli.Series") -> Union[int, float]:
     ...
 
 
 def sum(
-    column: Union[str, tp.List[Union["pli.Expr", str]], "pli.Series"]
+    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
 ) -> Union["pli.Expr", Any]:
     """
     Get the sum value.
@@ -306,7 +303,7 @@ def sum(
         Column(s) to be used in aggregation. Will lead to different behavior based on the input.
         input:
         - Union[str, Series] -> aggregate the sum value of that column.
-        - tp.List[Expr] -> aggregate the sum value horizontally.
+        - List[Expr] -> aggregate the sum value horizontally.
     """
     if isinstance(column, pli.Series):
         return column.sum()
@@ -319,12 +316,12 @@ def sum(
         return col(column).sum()
 
 
-@tp.overload
+@overload
 def mean(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def mean(column: "pli.Series") -> float:
     ...
 
@@ -338,12 +335,12 @@ def mean(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
     return col(column).mean()
 
 
-@tp.overload
+@overload
 def avg(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def avg(column: "pli.Series") -> float:
     ...
 
@@ -355,12 +352,12 @@ def avg(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
     return mean(column)
 
 
-@tp.overload
+@overload
 def median(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def median(column: "pli.Series") -> Union[float, int]:
     ...
 
@@ -374,12 +371,12 @@ def median(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float, int]:
     return col(column).median()
 
 
-@tp.overload
+@overload
 def n_unique(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def n_unique(column: "pli.Series") -> int:
     ...
 
@@ -391,12 +388,12 @@ def n_unique(column: Union[str, "pli.Series"]) -> Union["pli.Expr", int]:
     return col(column).n_unique()
 
 
-@tp.overload
+@overload
 def first(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def first(column: "pli.Series") -> Any:
     ...
 
@@ -413,12 +410,12 @@ def first(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Any]:
     return col(column).first()
 
 
-@tp.overload
+@overload
 def last(column: str) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def last(column: "pli.Series") -> Any:
     ...
 
@@ -435,12 +432,12 @@ def last(column: Union[str, "pli.Series"]) -> "pli.Expr":
     return col(column).last()
 
 
-@tp.overload
+@overload
 def head(column: str, n: Optional[int]) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def head(column: "pli.Series", n: Optional[int]) -> "pli.Series":
     ...
 
@@ -463,12 +460,12 @@ def head(
     return col(column).head(n)
 
 
-@tp.overload
+@overload
 def tail(column: str, n: Optional[int]) -> "pli.Expr":
     ...
 
 
-@tp.overload
+@overload
 def tail(column: "pli.Series", n: Optional[int]) -> "pli.Series":
     ...
 
@@ -614,8 +611,8 @@ def cov(
 
 
 def map(
-    exprs: Union[tp.List[str], tp.List["pli.Expr"]],
-    f: Callable[[tp.List["pli.Series"]], "pli.Series"],
+    exprs: Union[List[str], List["pli.Expr"]],
+    f: Callable[[List["pli.Series"]], "pli.Series"],
     return_dtype: Optional[Type[DataType]] = None,
 ) -> "pli.Expr":
     """
@@ -639,8 +636,8 @@ def map(
 
 
 def apply(
-    exprs: tp.List[Union[str, "pli.Expr"]],
-    f: Callable[[tp.List["pli.Series"]], "pli.Series"],
+    exprs: List[Union[str, "pli.Expr"]],
+    f: Callable[[List["pli.Series"]], "pli.Series"],
     return_dtype: Optional[Type[DataType]] = None,
 ) -> "pli.Expr":
     """
@@ -705,7 +702,7 @@ def map_binary(
 def fold(
     acc: "pli.Expr",
     f: Callable[["pli.Series", "pli.Series"], "pli.Series"],
-    exprs: Union[tp.Sequence[Union["pli.Expr", str]], "pli.Expr"],
+    exprs: Union[Sequence[Union["pli.Expr", str]], "pli.Expr"],
 ) -> "pli.Expr":
     """
     Accumulate over multiple columns horizontally/ row wise with a left fold.
@@ -731,7 +728,7 @@ def fold(
     return pli.wrap_expr(pyfold(acc._pyexpr, f, exprs))
 
 
-def any(name: Union[str, tp.List["pli.Expr"]]) -> "pli.Expr":
+def any(name: Union[str, List["pli.Expr"]]) -> "pli.Expr":
     """
     Evaluate columnwise or elementwise with a bitwise OR operation.
     """
@@ -740,7 +737,7 @@ def any(name: Union[str, tp.List["pli.Expr"]]) -> "pli.Expr":
     return col(name).sum() > 0
 
 
-def exclude(columns: Union[str, tp.List[str]]) -> "pli.Expr":
+def exclude(columns: Union[str, List[str]]) -> "pli.Expr":
     """
     Exclude certain columns from a wildcard expression.
 
@@ -796,7 +793,7 @@ def exclude(columns: Union[str, tp.List[str]]) -> "pli.Expr":
     return col("*").exclude(columns)
 
 
-def all(name: Optional[Union[str, tp.List["pli.Expr"]]] = None) -> "pli.Expr":
+def all(name: Optional[Union[str, List["pli.Expr"]]] = None) -> "pli.Expr":
     """
     This function is two things
 
@@ -887,7 +884,7 @@ def arange(
 
 
 def argsort_by(
-    exprs: tp.List[Union["pli.Expr", str]], reverse: Union[tp.List[bool], bool] = False
+    exprs: List[Union["pli.Expr", str]], reverse: Union[List[bool], bool] = False
 ) -> "pli.Expr":
     """
     Find the indexes that would sort the columns.
@@ -992,7 +989,7 @@ def _date(
     return _datetime(year, month, day).cast(Date).alias("date")
 
 
-def concat_str(exprs: tp.Sequence[Union["pli.Expr", str]], sep: str = "") -> "pli.Expr":
+def concat_str(exprs: Sequence[Union["pli.Expr", str]], sep: str = "") -> "pli.Expr":
     """
     Concat Utf8 Series in linear time. Non utf8 columns are cast to utf8.
 
@@ -1117,14 +1114,14 @@ def concat_list(exprs: Sequence[Union[str, "pli.Expr"]]) -> "pli.Expr":
 
 
 def collect_all(
-    lazy_frames: "tp.List[pli.LazyFrame]",
+    lazy_frames: "List[pli.LazyFrame]",
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
     string_cache: bool = False,
     no_optimization: bool = False,
-) -> "tp.List[pli.DataFrame]":
+) -> "List[pli.DataFrame]":
     """
     Collect multiple LazyFrames at the same time. This runs all the computation graphs in parallel on
     Polars threadpool.

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1,8 +1,18 @@
 import sys
-import typing as tp
 from datetime import date, datetime, timedelta
 from numbers import Number
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 import numpy as np
 
@@ -40,7 +50,9 @@ from polars.datatypes import (
     Int16,
     Int32,
     Int64,
-    List,
+)
+from polars.datatypes import List as PlList
+from polars.datatypes import (
     Object,
     UInt8,
     UInt16,
@@ -549,12 +561,12 @@ class Series:
         if isinstance(item, int):
             if item < 0:
                 item = self.len() + item
-            if self.dtype in (List, Date, Datetime, Object):
+            if self.dtype in (PlList, Date, Datetime, Object):
                 f = get_ffi_func("get_<>", self.dtype, self._s)
                 if f is None:
                     return NotImplemented
                 out = f(item)
-                if self.dtype == List:
+                if self.dtype == PlList:
                     if out is None:
                         return None
                     return wrap_s(out)
@@ -587,7 +599,7 @@ class Series:
         if f is None:
             return NotImplemented
         out = f(item)
-        if self.dtype == List:
+        if self.dtype == PlList:
             return wrap_s(out)
         return out
 
@@ -1003,15 +1015,15 @@ class Series:
         s._s.rename(name)
         return s
 
-    @tp.overload
+    @overload
     def rename(self, name: str, in_place: Literal[False] = ...) -> "Series":
         ...
 
-    @tp.overload
+    @overload
     def rename(self, name: str, in_place: Literal[True]) -> None:
         ...
 
-    @tp.overload
+    @overload
     def rename(self, name: str, in_place: bool) -> Optional["Series"]:
         ...
 
@@ -1045,7 +1057,7 @@ class Series:
         else:
             return self.alias(name)
 
-    def chunk_lengths(self) -> tp.List[int]:
+    def chunk_lengths(self) -> List[int]:
         """
         Get the length of each individual chunk.
         """
@@ -1433,7 +1445,7 @@ class Series:
         """
         return wrap_s(self._s.unique())
 
-    def take(self, indices: Union[np.ndarray, tp.List[int]]) -> "Series":
+    def take(self, indices: Union[np.ndarray, List[int]]) -> "Series":
         """
         Take values by index.
 
@@ -1617,7 +1629,7 @@ class Series:
         """
         return Series._from_pyseries(self._s.is_not_nan())
 
-    def is_in(self, other: Union["Series", tp.List]) -> "Series":
+    def is_in(self, other: Union["Series", List]) -> "Series":
         """
         Check if elements of this Series are in the right Series, or List values of the right Series.
 
@@ -1864,7 +1876,7 @@ class Series:
         """
         return wrap_s(self._s.to_physical)
 
-    def to_list(self, use_pyarrow: bool = False) -> tp.List[Optional[Any]]:
+    def to_list(self, use_pyarrow: bool = False) -> List[Optional[Any]]:
         """
         Convert this Series to a Python List. This operation clones data.
 
@@ -2021,7 +2033,7 @@ class Series:
             self._s.rechunk(in_place=True)
 
         if method == "__call__":
-            args: tp.List[Union[Number, np.ndarray]] = []
+            args: List[Union[Number, np.ndarray]] = []
             for arg in inputs:
                 if isinstance(arg, Number):
                     args.append(arg)
@@ -2532,7 +2544,7 @@ class Series:
     def rolling_min(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -2577,7 +2589,7 @@ class Series:
     def rolling_max(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -2622,7 +2634,7 @@ class Series:
     def rolling_mean(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -2667,7 +2679,7 @@ class Series:
     def rolling_sum(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -2712,7 +2724,7 @@ class Series:
     def rolling_std(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -2744,7 +2756,7 @@ class Series:
     def rolling_var(
         self,
         window_size: int,
-        weights: Optional[tp.List[float]] = None,
+        weights: Optional[List[float]] = None,
         min_periods: Optional[int] = None,
         center: bool = False,
     ) -> "Series":
@@ -3166,7 +3178,7 @@ class Series:
             self.name
         ]
 
-    def reshape(self, dims: tp.Tuple[int, ...]) -> "Series":
+    def reshape(self, dims: Tuple[int, ...]) -> "Series":
         """
         Reshape this Series to a flat series, shape: (len,)
         or a List series, shape: (rows, cols)
@@ -3480,7 +3492,7 @@ class ListNameSpace:
         """
         return pli.select(pli.lit(wrap_s(self._s)).arr.unique()).to_series()
 
-    def concat(self, other: Union[tp.List[Series], Series]) -> "Series":
+    def concat(self, other: Union[List[Series], Series]) -> "Series":
         """
         Concat the arrays in a Series dtype List in linear time.
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,14 +1,13 @@
 import ctypes
-import typing as tp
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
 
 def _process_null_values(
-    null_values: Union[None, str, tp.List[str], Dict[str, str]] = None,
-) -> Union[None, str, tp.List[str], tp.List[Tuple[str, str]]]:
+    null_values: Union[None, str, List[str], Dict[str, str]] = None,
+) -> Union[None, str, List[str], List[Tuple[str, str]]]:
     if isinstance(null_values, dict):
         return list(null_values.items())
     else:


### PR DESCRIPTION
This was done to resolve conflicts between `typing.List` and `polars.datatypes.List`. Given that we rarely use the latter in the code, but mostly `typing.List` for type annotations, making this change. Makes the code more pythonic, especially as in newer python versions we could even do `list[int]` rather than `List[int]`.