### PR TITLE
Add test for Series neq date

### DIFF
--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -224,7 +224,7 @@ def test_date_comp() -> None:
     two = date(2001, 1, 2)  # type: ignore
     a = pl.Series("a", [one, two])
     assert (a == one).to_list() == [True, False]
-    assert (a == two).to_list() == [False, True]
+    assert (a != one).to_list() == [False, True]
     assert (a > one).to_list() == [False, True]
     assert (a >= one).to_list() == [True, True]
     assert (a < one).to_list() == [False, False]


### PR DESCRIPTION
The specific code path for not-equals date was not covered; made the test suite the same as for datetime.