### PR TITLE
fix(nodejs-polars): jest failing

### DIFF
--- a/nodejs-polars/jest.config.ts
+++ b/nodejs-polars/jest.config.ts
@@ -15,7 +15,7 @@ export default {
   coveragePathIgnorePatterns: ["/node_modules/"],
   coverageProvider: "v8",
   moduleDirectories: ["node_modules", "./polars"],
-  moduleFileExtensions: ["js", "ts", "node"],
+  moduleFileExtensions: ["js", "ts"],
   setupFilesAfterEnv : ["<rootDir>/__tests__/setup.ts"],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/polars" }),
   testPathIgnorePatterns: ["<rootDir>/__tests__/setup.ts"]


### PR DESCRIPTION
so jest was trying to read the debug binary in as a regular file, and string buffers have a 512mb limit. So i guess the unoptimized bundle got pushed just over 512 which was causing the issue. 

I excluded the `.node` binary from jest, and everything works fine now. 