### PR TITLE
Refactor DataFrame.__getitem__

### DIFF
--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -14,7 +14,7 @@ pytest-cov[toml]==3.0.0
 black==21.6b0
 blackdoc==0.3.4
 isort~=5.9.2
-mypy==0.910
+mypy==0.920
 ghp-import==2.0.1
 flake8==4.0.1
 sphinx==4.2.0

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -14,7 +14,7 @@ pytest-cov[toml]==3.0.0
 black==21.6b0
 blackdoc==0.3.4
 isort~=5.9.2
-mypy==0.920
+mypy==0.910
 ghp-import==2.0.1
 flake8==4.0.1
 sphinx==4.2.0

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3,7 +3,7 @@ Module containing logic related to eager DataFrames
 """
 import os
 import sys
-from datetime import timedelta
+from datetime import datetime, timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
@@ -1140,17 +1140,30 @@ class DataFrame:
         else:
             return self.shape[dim] + idx
 
-    def __getitem__(self, item: Any) -> Any:
+    # __getitem__() mostly returns a dataframe. The major exception is when a string is passed in. Note that there are
+    # more subtle cases possible where a non-string value leads to a Series.
+    @overload
+    def __getitem__(self, item: str) -> "pli.Series":
+        ...
+
+    @overload
+    def __getitem__(
+        self,
+        item: Union[
+            int, range, slice, np.ndarray, "pli.Expr", "pli.Series", List, tuple
+        ],
+    ) -> "DataFrame":
+        ...
+
+    def __getitem__(self, item: Any) -> Union["DataFrame", "pli.Series"]:
         """
         Does quite a lot. Read the comments.
         """
         if hasattr(item, "_pyexpr"):
             return self.select(item)
-        if isinstance(item, np.ndarray):
-            item = pli.Series("", item)
         # select rows and columns at once
         # every 2d selection, i.e. tuple is row column order, just like numpy
-        if isinstance(item, tuple):
+        if isinstance(item, tuple) and len(item) == 2:
             row_selection, col_selection = item
 
             # df[:, unknown]
@@ -1220,10 +1233,10 @@ class DataFrame:
                 # df[:, [1, 2]]
                 # select by column indexes
                 if isinstance(col_selection[0], int):
-                    series = [self.to_series(i) for i in col_selection]
-                    df = DataFrame(series)
+                    series_list = [self.to_series(i) for i in col_selection]
+                    df = DataFrame(series_list)
                     return df[row_selection]
-            df = self.__getitem__(col_selection)
+            df = self.__getitem__(col_selection)  # type: ignore
             return df.__getitem__(row_selection)
 
         # select single column
@@ -1273,14 +1286,6 @@ class DataFrame:
                     pli.col("*").slice(start, length).take_every(item.step)  # type: ignore
                 )
 
-        # select multiple columns
-        # df["foo", "bar"]
-        if isinstance(item, Sequence):
-            if isinstance(item[0], str):
-                return wrap_df(self._df.select(item))
-            elif isinstance(item[0], pli.Expr):
-                return self.select(item)
-
         # select rows by mask or index
         # df[[1, 2, 3]]
         # df[true, false, true]
@@ -1289,20 +1294,29 @@ class DataFrame:
                 return wrap_df(self._df.take(item))
             if isinstance(item[0], str):
                 return wrap_df(self._df.select(item))
-        if isinstance(item, (pli.Series, Sequence)):
-            if isinstance(item, Sequence):
-                # only bool or integers allowed
-                if type(item[0]) == bool:
-                    item = pli.Series("", item)
-                else:
-                    return wrap_df(
-                        self._df.take([self._pos_idx(i, dim=0) for i in item])
-                    )
+            if item.dtype == bool:
+                return wrap_df(self._df.filter(pli.Series("", item).inner()))
+            raise IndexError
+
+        if isinstance(item, Sequence):
+            if isinstance(item[0], str):
+                # select multiple columns
+                # df[["foo", "bar"]]
+                return wrap_df(self._df.select(item))
+            elif isinstance(item[0], pli.Expr):
+                return self.select(item)
+            elif type(item[0]) == bool:
+                item = pli.Series("", item)
+            else:
+                return wrap_df(self._df.take([self._pos_idx(i, dim=0) for i in item]))
+
+        if isinstance(item, pli.Series):
             dtype = item.dtype
             if dtype == Boolean:
                 return wrap_df(self._df.filter(item.inner()))
             if dtype == UInt32:
                 return wrap_df(self._df.take_with_series(item.inner()))
+            raise IndexError
 
     def __setitem__(self, key: Union[str, int, Tuple[Any, Any]], value: Any) -> None:
         # df["foo"] = series
@@ -1335,7 +1349,7 @@ class DataFrame:
             if isinstance(col_selection, str):
                 s = self.__getitem__(col_selection)
             elif isinstance(col_selection, int):
-                s = self[:, col_selection]
+                s = self[:, col_selection]  # type: ignore
             else:
                 raise ValueError(f"column selection not understood: {col_selection}")
 
@@ -2526,8 +2540,8 @@ class DataFrame:
         bounds = self.select(
             [pli.col(by).min().alias("low"), pli.col(by).max().alias("high")]
         )
-        low = bounds["low"].dt[0]
-        high = bounds["high"].dt[0]
+        low: datetime = bounds["low"].dt[0]  # type: ignore
+        high: datetime = bounds["high"].dt[0]  # type: ignore
         upsampled = pli.date_range(low, high, interval, name=by)
         return DataFrame(upsampled).join(self, on=by, how="left")
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1143,7 +1143,7 @@ class DataFrame:
     # __getitem__() mostly returns a dataframe. The major exception is when a string is passed in. Note that there are
     # more subtle cases possible where a non-string value leads to a Series.
     @overload
-    def __getitem__(self, item: str) -> "pli.Series":
+    def __getitem__(self, item: str) -> "pli.Series":  # type: ignore
         ...
 
     @overload

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -24,8 +24,8 @@ def test_apply_none() -> None:
     assert out[0].to_list() == [4.75, 326.75, 82.75]
     assert out[1].to_list() == [238.75, 3418849.75, 372.75]
 
-    out = df.select(pl.map(exprs=["a", "b"], f=lambda s: s[0] * s[1]))
-    assert out["a"].to_list() == (df["a"] * df["b"]).to_list()
+    out_df = df.select(pl.map(exprs=["a", "b"], f=lambda s: s[0] * s[1]))
+    assert out_df["a"].to_list() == (df["a"] * df["b"]).to_list()
 
     # check if we can return None
     def func(s: List) -> Optional[int]:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -486,12 +486,12 @@ def test_arange_expr() -> None:
     assert out.select_at_idx(0)[-1] == 19
 
     # eager arange
-    out = pl.arange(0, 10, 2, eager=True)
-    assert out == [0, 2, 4, 8, 8]
+    out2 = pl.arange(0, 10, 2, eager=True)
+    assert out2 == [0, 2, 4, 8, 8]
 
-    out = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), step=2, eager=True)
-    assert out.dtype == pl.List
-    assert out[0].to_list() == [0, 2]
+    out3 = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), step=2, eager=True)
+    assert out3.dtype == pl.List  # type: ignore
+    assert out3[0].to_list() == [0, 2]  # type: ignore
 
 
 def test_round() -> None:


### PR DESCRIPTION
* added a test covering all one-dimensional uses. Most were hit already by other tests, but good to have this in a single place. The tuple input (2D) is to be tested in a future PR.
* moved around some logic for numpy ndarray, it was confusing as some code path could not be hit at all.
* added type overloads so a user no longer loses typing the moment this method is used. This has led in various places in the tests for type warnings to pop up, some I could not fix/didnt fully understand, added ignores in those cases.