### PR TITLE
WIP: Fix pygroupby dispatch

### DIFF
--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -816,7 +816,7 @@ impl From<LogicalPlan> for LogicalPlanBuilder {
 }
 
 pub(crate) fn prepare_projection(exprs: Vec<Expr>, schema: &Schema) -> (Vec<Expr>, Schema) {
-    let exprs = rewrite_projections(exprs, schema);
+    let exprs = rewrite_projections(exprs, schema, &[]);
     let schema = utils::expressions_to_schema(&exprs, schema, Context::Default);
     (exprs, schema)
 }
@@ -1037,7 +1037,7 @@ impl LogicalPlanBuilder {
     /// Apply a filter
     pub fn filter(self, predicate: Expr) -> Self {
         let predicate = if has_expr(&predicate, |e| matches!(e, Expr::Wildcard)) {
-            let rewritten = rewrite_projections(vec![predicate], self.0.schema());
+            let rewritten = rewrite_projections(vec![predicate], self.0.schema(), &[]);
             combine_predicates_expr(rewritten.into_iter())
         } else {
             predicate
@@ -1059,7 +1059,7 @@ impl LogicalPlanBuilder {
     ) -> Self {
         debug_assert!(!(keys.is_empty() && dynamic_options.is_none()));
         let current_schema = self.0.schema();
-        let aggs = rewrite_projections(aggs.as_ref().to_vec(), current_schema);
+        let aggs = rewrite_projections(aggs.as_ref().to_vec(), current_schema, keys.as_ref());
 
         let schema1 = utils::expressions_to_schema(&keys, current_schema, Context::Default);
         let schema2 = utils::expressions_to_schema(&aggs, current_schema, Context::Aggregation);
@@ -1102,7 +1102,7 @@ impl LogicalPlanBuilder {
     }
 
     pub fn explode(self, columns: Vec<Expr>) -> Self {
-        let columns = rewrite_projections(columns, self.0.schema());
+        let columns = rewrite_projections(columns, self.0.schema(), &[]);
         // columns to string
         let columns = columns
             .iter()

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -22,7 +22,6 @@ use polars_io::parquet::ParquetReader;
 use crate::logical_plan::LogicalPlan::DataFrameScan;
 use crate::utils::{
     combine_predicates_expr, expr_to_root_column_names, get_single_root, has_expr, has_wildcard,
-    rename_expr_root_name,
 };
 use crate::{prelude::*, utils};
 use polars_io::csv::NullValues;

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -230,21 +230,6 @@ pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema) -> Vec<Expr
         if has_wildcard(&expr) {
             // keep track of column excluded from the wildcard
             let exclude = prepare_excluded(&expr, schema);
-
-            // if count wildcard. count one column
-            if has_expr(&expr, |e| matches!(e, Expr::Agg(AggExpr::Count(_)))) {
-                let new_name = Arc::from(schema.field(0).unwrap().name().as_str());
-                let expr = rename_expr_root_name(&expr, new_name).unwrap();
-
-                let expr = if let Expr::Alias(_, _) = &expr {
-                    expr
-                } else {
-                    Expr::Alias(Box::new(expr), Arc::from("count"))
-                };
-                result.push(expr);
-
-                continue;
-            }
             // this path prepares the wildcard as input for the Function Expr
             if has_expr(
                 &expr,

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -155,7 +155,7 @@ fn expand_dtypes(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema, dtypes: &
 
 // schema is not used if regex not activated
 #[allow(unused_variables)]
-fn prepare_excluded(expr: &Expr, schema: &Schema) -> Vec<Arc<str>> {
+fn prepare_excluded(expr: &Expr, schema: &Schema, keys: &[Expr]) -> Vec<Arc<str>> {
     let mut exclude = vec![];
     expr.into_iter().for_each(|e| {
         if let Expr::Exclude(_, to_exclude) = e {
@@ -205,12 +205,29 @@ fn prepare_excluded(expr: &Expr, schema: &Schema) -> Vec<Arc<str>> {
             }
         }
     });
+    for mut expr in keys.iter() {
+        // Allow a number of aliases of a column expression, still exclude column from aggregation
+        loop {
+            match expr {
+                Expr::Column(name) => {
+                    exclude.push(name.clone());
+                    break;
+                }
+                Expr::Alias(e, _) => {
+                    expr = e;
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+    }
     exclude
 }
 
 /// In case of single col(*) -> do nothing, no selection is the same as select all
 /// In other cases replace the wildcard with an expression with all columns
-pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema) -> Vec<Expr> {
+pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema, keys: &[Expr]) -> Vec<Expr> {
     let mut result = Vec::with_capacity(exprs.len() + schema.fields().len());
 
     for mut expr in exprs {
@@ -229,7 +246,7 @@ pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema) -> Vec<Expr
 
         if has_wildcard(&expr) {
             // keep track of column excluded from the wildcard
-            let exclude = prepare_excluded(&expr, schema);
+            let exclude = prepare_excluded(&expr, schema, keys);
             // this path prepares the wildcard as input for the Function Expr
             if has_expr(
                 &expr,

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -577,7 +577,7 @@ fn test_lazy_wildcard() {
         .agg([col("*").sum(), col("*").first()])
         .collect()
         .unwrap();
-    assert_eq!(new.shape(), (3, 6));
+    assert_eq!(new.shape(), (3, 5)); // Should exclude b from wildcard aggregations.
 }
 
 #[test]

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -216,13 +216,6 @@ pub(crate) fn expr_to_root_column_exprs(expr: &Expr) -> Vec<Expr> {
     out
 }
 
-pub(crate) fn rename_expr_root_name(expr: &Expr, new_name: Arc<str>) -> Result<Expr> {
-    let mut arena = Arena::with_capacity(32);
-    let root = to_aexpr(expr.clone(), &mut arena);
-    rename_aexpr_root_name(root, &mut arena, new_name)?;
-    Ok(node_to_exp(root, &arena))
-}
-
 /// Take a list of expressions and a schema and determine the output schema.
 pub(crate) fn expressions_to_schema(expr: &[Expr], schema: &Schema, ctxt: Context) -> Schema {
     let fields = expr

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -7,6 +7,6 @@ from .expr import Expr, _selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_exp
 from .frame import DataFrame, wrap_df
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
 from .lazy_frame import LazyFrame, wrap_ldf
-from .lazy_functions import argsort_by, col, concat_list, lit, select
+from .lazy_functions import all, argsort_by, col, concat_list, lit, select
 from .series import Series, wrap_s
 from .whenthen import when  # used in expr.clip()

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4316,7 +4316,7 @@ class GroupBy:
         """
         Count the number of values in each group.
         """
-        return self._select_all().count()
+        return self.agg(pyall().count())
 
     def mean(self) -> DataFrame:
         """

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -49,7 +49,6 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-from polars.internals.lazy_functions import all as pyall
 
 try:
     from polars.polars import PyDataFrame, PySeries

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -49,6 +49,7 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
+from polars.internals.lazy_functions import all as pyall
 
 try:
     from polars.polars import PyDataFrame, PySeries
@@ -4285,49 +4286,97 @@ class GroupBy:
         """
         Aggregate the first values in the group.
         """
-        return self._select_all().first()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().first())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def last(self) -> DataFrame:
         """
         Aggregate the last values in the group.
         """
-        return self._select_all().last()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().last())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def sum(self) -> DataFrame:
         """
         Reduce the groups to the sum.
         """
-        return self._select_all().sum()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().sum())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def min(self) -> DataFrame:
         """
         Reduce the groups to the minimal value.
         """
-        return self._select_all().min()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().min())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def max(self) -> DataFrame:
         """
         Reduce the groups to the maximal value.
         """
-        return self._select_all().max()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().max())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def count(self) -> DataFrame:
         """
         Count the number of values in each group.
         """
-        return self._select_all().count()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().count())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def mean(self) -> DataFrame:
         """
         Reduce the groups to the mean values.
         """
-        return self._select_all().mean()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().mean())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def n_unique(self) -> DataFrame:
         """
         Count the unique values per group.
         """
-        return self._select_all().n_unique()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().n_unique())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def quantile(self, quantile: float, interpolation: str = "nearest") -> DataFrame:
         """
@@ -4342,19 +4391,37 @@ class GroupBy:
             interpolation type, options: ['nearest', 'higher', 'lower', 'midpoint', 'linear']
 
         """
-        return self._select_all().quantile(quantile, interpolation)
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().quantile(quantile, interpolation))
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def median(self) -> DataFrame:
         """
         Return the median per group.
         """
-        return self._select_all().median()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().median())
+            .collect(no_optimization=True, string_cache=False)
+        )
 
     def agg_list(self) -> DataFrame:
         """
         Aggregate the groups into Series.
         """
-        return self._select_all().agg_list()
+        return (
+            wrap_df(self._df)
+            .lazy()
+            .groupby(self.by, self.maintain_order)
+            .agg(pyall().list())  # agg_list is internally called list.
+            .collect(no_optimization=True, string_cache=False)
+        )
 
 
 class PivotOps:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4316,13 +4316,7 @@ class GroupBy:
         """
         Count the number of values in each group.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().count())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self._select_all().count()
 
     def mean(self) -> DataFrame:
         """

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4286,49 +4286,49 @@ class GroupBy:
         """
         Aggregate the first values in the group.
         """
-        return self.agg(pyall().first())
+        return self.agg(pli.all().first())
 
     def last(self) -> DataFrame:
         """
         Aggregate the last values in the group.
         """
-        return self.agg(pyall().last())
+        return self.agg(pli.all().last())
 
     def sum(self) -> DataFrame:
         """
         Reduce the groups to the sum.
         """
-        return self.agg(pyall().sum())
+        return self.agg(pli.all().sum())
 
     def min(self) -> DataFrame:
         """
         Reduce the groups to the minimal value.
         """
-        return self.agg(pyall().min())
+        return self.agg(pli.all().min())
 
     def max(self) -> DataFrame:
         """
         Reduce the groups to the maximal value.
         """
-        return self.agg(pyall().max())
+        return self.agg(pli.all().max())
 
     def count(self) -> DataFrame:
         """
         Count the number of values in each group.
         """
-        return self.agg(pyall().count())
+        return self.agg(pli.all().count())
 
     def mean(self) -> DataFrame:
         """
         Reduce the groups to the mean values.
         """
-        return self.agg(pyall().mean())
+        return self.agg(pli.all().mean())
 
     def n_unique(self) -> DataFrame:
         """
         Count the unique values per group.
         """
-        return self.agg(pyall().n_unique())
+        return self.agg(pli.all().n_unique())
 
     def quantile(self, quantile: float, interpolation: str = "nearest") -> DataFrame:
         """
@@ -4343,19 +4343,19 @@ class GroupBy:
             interpolation type, options: ['nearest', 'higher', 'lower', 'midpoint', 'linear']
 
         """
-        return self.agg(pyall().quantile(quantile, interpolation))
+        return self.agg(pli.all().quantile(quantile, interpolation))
 
     def median(self) -> DataFrame:
         """
         Return the median per group.
         """
-        return self.agg(pyall().median())
+        return self.agg(pli.all().median())
 
     def agg_list(self) -> DataFrame:
         """
         Aggregate the groups into Series.
         """
-        return self.agg(pyall().list())
+        return self.agg(pli.all().list())
 
 
 class PivotOps:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4286,61 +4286,31 @@ class GroupBy:
         """
         Aggregate the first values in the group.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().first())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().first())
 
     def last(self) -> DataFrame:
         """
         Aggregate the last values in the group.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().last())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().last())
 
     def sum(self) -> DataFrame:
         """
         Reduce the groups to the sum.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().sum())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().sum())
 
     def min(self) -> DataFrame:
         """
         Reduce the groups to the minimal value.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().min())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().min())
 
     def max(self) -> DataFrame:
         """
         Reduce the groups to the maximal value.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().max())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().max())
 
     def count(self) -> DataFrame:
         """
@@ -4358,25 +4328,13 @@ class GroupBy:
         """
         Reduce the groups to the mean values.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().mean())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().mean())
 
     def n_unique(self) -> DataFrame:
         """
         Count the unique values per group.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().n_unique())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().n_unique())
 
     def quantile(self, quantile: float, interpolation: str = "nearest") -> DataFrame:
         """
@@ -4391,37 +4349,19 @@ class GroupBy:
             interpolation type, options: ['nearest', 'higher', 'lower', 'midpoint', 'linear']
 
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().quantile(quantile, interpolation))
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().quantile(quantile, interpolation))
 
     def median(self) -> DataFrame:
         """
         Return the median per group.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().median())
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().median())
 
     def agg_list(self) -> DataFrame:
         """
         Aggregate the groups into Series.
         """
-        return (
-            wrap_df(self._df)
-            .lazy()
-            .groupby(self.by, self.maintain_order)
-            .agg(pyall().list())  # agg_list is internally called list.
-            .collect(no_optimization=True, string_cache=False)
-        )
+        return self.agg(pyall().list())
 
 
 class PivotOps:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1310,6 +1310,14 @@ def test_extension() -> None:
     assert sys.getrefcount(foos[0]) == base_count
 
 
+def test_groupby_order_dispatch() -> None:
+    df = pl.DataFrame({"x": list("bab"), "y": range(3)})
+    expected = pl.DataFrame({"x": ["b", "a"], "y_count": [2, 1]})
+    assert df.groupby("x", maintain_order=True).count().frame_equal(expected)
+    expected = pl.DataFrame({"x": ["b", "a"], "y_agg_list": [[0, 2], [1]]})
+    assert df.groupby("x", maintain_order=True).agg_list().frame_equal(expected)
+
+
 def test_schema() -> None:
     df = pl.DataFrame(
         {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}


### PR DESCRIPTION
I switched all aggregations to use the expressions API, except for `count` because `pl.all().count()` is not supported by the expressions API:
```
thread '<unnamed>' panicked at 'should be only a column', /Users/maxwellconradt/polars/polars/polars-lazy/src/utils.rs:197:22
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/48a5999fceeea84a8971634355287faa349909d4/library/std/src/panicking.rs:525:12
   1: polars_lazy::utils::rename_aexpr_root_name::{{closure}}
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/utils.rs:197:22
   2: polars_core::utils::Arena<T>::replace_with
             at /Users/maxwellconradt/polars/polars/polars-core/src/utils/mod.rs:252:27
   3: polars_lazy::utils::rename_aexpr_root_name
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/utils.rs:195:13
   4: polars_lazy::utils::rename_expr_root_name
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/utils.rs:222:5
   5: polars_lazy::logical_plan::projection::rewrite_projections
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/logical_plan/projection.rs:237:28
   6: polars_lazy::logical_plan::LogicalPlanBuilder::groupby
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/logical_plan/mod.rs:1063:20
   7: polars_lazy::frame::LazyGroupBy::agg
             at /Users/maxwellconradt/polars/polars/polars-lazy/src/frame.rs:1179:18
   8: polars::lazy::dataframe::PyLazyGroupBy::agg
             at ./src/lazy/dataframe.rs:27:9
   9: polars::lazy::dataframe::__init15321774910097321675::__wrap::{{closure}}
             at ./src/lazy/dataframe.rs:22:1
  10: pyo3::callback::handle_panic::{{closure}}
             at /Users/maxwellconradt/.cargo/git/checkouts/pyo3-d009474511846c5e/5357442/src/callback.rs:247:9
  11: std::panicking::try::do_call
             at /rustc/48a5999fceeea84a8971634355287faa349909d4/library/std/src/panicking.rs:406:40
  12: <unknown>
             at /rustc/48a5999fceeea84a8971634355287faa349909d4/library/std/src/panicking.rs:434:6
  13: std::panicking::try
             at /rustc/48a5999fceeea84a8971634355287faa349909d4/library/std/src/panicking.rs:370:19
  14: std::panic::catch_unwind
             at /rustc/48a5999fceeea84a8971634355287faa349909d4/library/std/src/panic.rs:133:14
  15: pyo3::callback::handle_panic
             at /Users/maxwellconradt/.cargo/git/checkouts/pyo3-d009474511846c5e/5357442/src/callback.rs:245:24
  16: polars::lazy::dataframe::__init15321774910097321675::__wrap
             at ./src/lazy/dataframe.rs:22:1
  17: _method_vectorcall_VARARGS_KEYWORDS
  18: __PyEval_EvalFrameDefault
  19: __PyFunction_Vectorcall
  20: __PyEval_EvalFrameDefault
  21: __PyEval_EvalCodeWithName
  22: _PyRun_InteractiveOneObjectEx
  23: _PyRun_InteractiveLoopFlags
  24: _PyRun_AnyFileExFlags
  25: _pymain_run_stdin
  26: _pymain_run_python
  27: _Py_RunMain
  28: _pymain_main
  29: _main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/maxwellconradt/polars/py-polars/polars/internals/lazy_frame.py", line 1221, in agg
    return wrap_ldf(self.lgb.agg(aggs))
pyo3_runtime.PanicException: should be only a column
```

Any ideas?