### PR TITLE
Fix overflow warning test_log_exp

### DIFF
--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -38,14 +38,14 @@ def test_cumcount() -> None:
 
 def test_log_exp() -> None:
     a = pl.Series("a", [1, 100, 1000])
+    b = pl.Series("a", [0.0, 2.0, 3.0])
     out = pl.select(a.log10()).to_series()
-    expected = pl.Series("a", [0.0, 2.0, 3.0])
-    testing.assert_series_equal(out, expected)
+    testing.assert_series_equal(out, b)
 
     out = pl.select(a.log()).to_series()
     expected = pl.Series("a", np.log(a.to_numpy()))
     testing.assert_series_equal(out, expected)
 
-    out = pl.select(a.exp()).to_series()
-    expected = pl.Series("a", np.exp(a.to_numpy()))
+    out = pl.select(b.exp()).to_series()
+    expected = pl.Series("a", np.exp(b.to_numpy()))
     testing.assert_series_equal(out, expected)

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1176,18 +1176,18 @@ def test_nested_list_types_preserved() -> None:
 
 def test_log_exp() -> None:
     a = pl.Series("a", [1, 100, 1000])
+    b = pl.Series("a", [0.0, 2.0, 3.0])
 
     out = a.log10()
-    expected = pl.Series("a", [0.0, 2.0, 3.0])
-    testing.assert_series_equal(out, expected)
+    testing.assert_series_equal(out, b)
     a = pl.Series("a", [1, 100, 1000])
 
     out = a.log()
     expected = pl.Series("a", np.log(a.to_numpy()))
     testing.assert_series_equal(out, expected)
 
-    out = a.exp()
-    expected = pl.Series("a", np.exp(a.to_numpy()))
+    out = b.exp()
+    expected = pl.Series("a", np.exp(b.to_numpy()))
     testing.assert_series_equal(out, expected)
 
 


### PR DESCRIPTION
Taking exp(1000) leads to a numpy overflow and Python runtime warning. Switched around the test on exp to take exp([0, 2, 3)) instead.