### PR TITLE
Small refactor of expr_to_lit et al

### DIFF
--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -3,7 +3,7 @@
 The modules within `polars.internals` are interdependent. To prevent cyclical imports, they all import from each other
 via this __init__ file using `import polars.internals as pli`. The imports below are being shared across this module.
 """
-from .expr import Expr, _selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_expr
+from .expr import Expr, selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_expr
 from .frame import DataFrame, wrap_df
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
 from .lazy_frame import LazyFrame, wrap_ldf

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -3,7 +3,7 @@
 The modules within `polars.internals` are interdependent. To prevent cyclical imports, they all import from each other
 via this __init__ file using `import polars.internals as pli`. The imports below are being shared across this module.
 """
-from .expr import Expr, selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_expr
+from .expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
 from .frame import DataFrame, wrap_df
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
 from .lazy_frame import LazyFrame, wrap_ldf

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -29,7 +29,9 @@ from polars.datatypes import (
 def selection_to_pyexpr_list(
     exprs: Union[str, "Expr", Sequence[Union[str, "Expr"]], "pli.Series"]
 ) -> List["PyExpr"]:
-    is_non_string_sequence = isinstance(exprs, Sequence) and (not isinstance(exprs, str))
+    is_non_string_sequence = isinstance(exprs, Sequence) and (
+        not isinstance(exprs, str)
+    )
     if not is_non_string_sequence:
         # this is a single item, wrap it in a list as we always return a list in this function
         exprs = [exprs]

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1,6 +1,6 @@
 import copy
 from datetime import date, datetime, timedelta
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union, overload
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -27,13 +27,9 @@ from polars.datatypes import (
 
 
 def selection_to_pyexpr_list(
-    exprs: Union[str, "Expr", Sequence[Union[str, "Expr"]], "pli.Series"]
+    exprs: Union[str, "Expr", Sequence[Union[str, "Expr", "pli.Series"]], "pli.Series"]
 ) -> List["PyExpr"]:
-    is_non_string_sequence = isinstance(exprs, Sequence) and (
-        not isinstance(exprs, str)
-    )
-    if not is_non_string_sequence:
-        # this is a single item, wrap it in a list as we always return a list in this function
+    if isinstance(exprs, (str, Expr, pli.Series)):
         exprs = [exprs]
 
     return [expr_to_lit_or_expr(e, str_to_lit=False)._pyexpr for e in exprs]

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -270,8 +270,7 @@ class LazyFrame:
         if type(reverse) is bool:
             reverse = [reverse]
 
-        by = pli.expr_to_lit_or_expr(by, str_to_lit=False)
-        by = pli._selection_to_pyexpr_list(by)
+        by = pli.selection_to_pyexpr_list(by)
         return wrap_ldf(self._ldf.sort_by_exprs(by, reverse))
 
     def collect(
@@ -478,7 +477,7 @@ class LazyFrame:
         exprs
             Column or columns to select.
         """
-        exprs = pli._selection_to_pyexpr_list(exprs)
+        exprs = pli.selection_to_pyexpr_list(exprs)
         return wrap_ldf(self._ldf.select(exprs))
 
     def groupby(
@@ -1037,7 +1036,7 @@ class LazyFrame:
         └─────────┴─────┘
 
         """
-        columns = pli._selection_to_pyexpr_list(columns)
+        columns = pli.selection_to_pyexpr_list(columns)
         return wrap_ldf(self._ldf.explode(columns))
 
     def drop_duplicates(
@@ -1217,7 +1216,7 @@ class LazyGroupBy:
         ... )  # doctest: +SKIP
 
         """
-        aggs = pli._selection_to_pyexpr_list(aggs)
+        aggs = pli.selection_to_pyexpr_list(aggs)
         return wrap_ldf(self.lgb.agg(aggs))
 
     def head(self, n: int = 5) -> "LazyFrame":

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -631,7 +631,7 @@ def map(
     -------
     Expr
     """
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_map_mul(exprs, f, return_dtype, apply_groups=False))
 
 
@@ -666,7 +666,7 @@ def apply(
     -------
     Expr
     """
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_map_mul(exprs, f, return_dtype, apply_groups=True))
 
 
@@ -724,7 +724,7 @@ def fold(
     if isinstance(exprs, pli.Expr):
         exprs = [exprs]
 
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(pyfold(acc._pyexpr, f, exprs))
 
 
@@ -902,7 +902,7 @@ def argsort_by(
     """
     if not isinstance(reverse, list):
         reverse = [reverse] * len(exprs)
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(pyargsort_by(exprs, reverse))
 
 
@@ -1000,7 +1000,7 @@ def concat_str(exprs: Sequence[Union["pli.Expr", str]], sep: str = "") -> "pli.E
     sep
         String value that will be used to separate the values.
     """
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_concat_str(exprs, sep))
 
 
@@ -1109,7 +1109,7 @@ def concat_list(exprs: Sequence[Union[str, "pli.Expr"]]) -> "pli.Expr":
     └─────────────────┘
 
     """
-    exprs = pli._selection_to_pyexpr_list(exprs)
+    exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_concat_lst(exprs))
 
 


### PR DESCRIPTION
* removed underscore from `_selection_to_pyexpr_list`, as it was used in multiple modules in the code base
* make flow easier to follow in `_selection_to_pyexpr_list`
* remove support for `List[str]` and `List[Expr]` inputs to `expr_to_lit_or_expr`, so that this always returns a single expression. Only minor changes in the code base were needed for this.