### PR TITLE
python patch: 0.12.4 always install typing extensions

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2018"

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "polars"
 dependencies = [
   "numpy >= 1.16.0",
-  "typing_extensions; python_version < '3.8'",
+  "typing_extensions",
 ]
 requires-python = ">=3.6"
 


### PR DESCRIPTION
Importing a clean install of polars `0.12.3` failed with:

```
Traceback (most recent call last):
  File "generate_data.py", line 6, in <module>
    import polars as pl
  File "/home/runner/work/polars-book/polars-book/.venv/lib/python3.8/site-packages/polars/__init__.py", line 18, in <module>
    from polars.convert import from_arrow, from_dict, from_dicts, from_pandas, from_records
  File "/home/runner/work/polars-book/polars-book/.venv/lib/python3.8/site-packages/polars/convert.py", line 5, in <module>
    from polars.internals import DataFrame, Series
  File "/home/runner/work/polars-book/polars-book/.venv/lib/python3.8/site-packages/polars/internals/__init__.py", line 6, in <module>
    from .expr import Expr, _selection_to_pyexpr_list, expr_to_lit_or_expr, wrap_expr
  File "/home/runner/work/polars-book/polars-book/.venv/lib/python3.8/site-packages/polars/internals/expr.py", line 7, in <module>
    from polars.utils import _timedelta_to_pl_duration
  File "/home/runner/work/polars-book/polars-book/.venv/lib/python3.8/site-packages/polars/utils.py", line 11, in <module>
    from typing_extensions import TypeGuard
ModuleNotFoundError: No module named 'typing_extensions'
```

This PR patches that and makes sure we always install `typing_extensions` it is only 22kb in size.