### PR TITLE
Add more tests

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1213,7 +1213,7 @@ class Expr:
         """
 
         # input x: Series of type list containing the group values
-        def wrap_f(x: "pli.Series") -> "pli.Series":
+        def wrap_f(x: "pli.Series") -> "pli.Series":  # pragma: no cover
             return x.apply(f, return_dtype=return_dtype)
 
         return self.map(wrap_f, agg_list=True)
@@ -1402,7 +1402,7 @@ class Expr:
 
         """
 
-        def inspect(s: "pli.Series") -> "pli.Series":
+        def inspect(s: "pli.Series") -> "pli.Series":  # pragma: no cover
             print(fmt.format(s))
             return s
 
@@ -2295,13 +2295,17 @@ class ExprStringNameSpace:
             "yyyy-mm-dd".
         """
         if not issubclass(datatype, DataType):
-            raise ValueError(f"expected: {DataType} got: {datatype}")
+            raise ValueError(
+                f"expected: {DataType} got: {datatype}"
+            )  # pragma: no cover
         if datatype == Date:
             return wrap_expr(self._pyexpr.str_parse_date(fmt))
         elif datatype == Datetime:
             return wrap_expr(self._pyexpr.str_parse_datetime(fmt))
         else:
-            raise ValueError("dtype should be of type {Date, Datetime}")
+            raise ValueError(
+                "dtype should be of type {Date, Datetime}"
+            )  # pragma: no cover
 
     def lengths(self) -> Expr:
         """

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3392,6 +3392,20 @@ class DataFrame:
             return pli.wrap_s(self._df.hmin())
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
+    @overload
+    def sum(self, axis: Literal[0], null_strategy: str = "ignore") -> "DataFrame":
+        ...
+
+    @overload
+    def sum(self, axis: Literal[1], null_strategy: str = "ignore") -> "pli.Series":
+        ...
+
+    @overload
+    def sum(
+        self, axis: int = 0, null_strategy: str = "ignore"
+    ) -> Union["DataFrame", "pli.Series"]:
+        ...
+
     def sum(
         self, axis: int = 0, null_strategy: str = "ignore"
     ) -> Union["DataFrame", "pli.Series"]:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3392,20 +3392,6 @@ class DataFrame:
             return pli.wrap_s(self._df.hmin())
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
-    @overload
-    def sum(self, axis: Literal[0], null_strategy: str = "ignore") -> "DataFrame":
-        ...
-
-    @overload
-    def sum(self, axis: Literal[1], null_strategy: str = "ignore") -> "pli.Series":
-        ...
-
-    @overload
-    def sum(
-        self, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union["DataFrame", "pli.Series"]:
-        ...
-
     def sum(
         self, axis: int = 0, null_strategy: str = "ignore"
     ) -> Union["DataFrame", "pli.Series"]:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -233,7 +233,9 @@ def max(
         return column.max()
     elif isinstance(column, list):
 
-        def max_(acc: "pli.Series", val: "pli.Series") -> "pli.Series":
+        def max_(
+            acc: "pli.Series", val: "pli.Series"
+        ) -> "pli.Series":  # pragma: no cover
             mask = acc > val
             return acc.zip_with(mask, val)
 
@@ -271,7 +273,9 @@ def min(
         return column.min()
     elif isinstance(column, list):
 
-        def min_(acc: "pli.Series", val: "pli.Series") -> "pli.Series":
+        def min_(
+            acc: "pli.Series", val: "pli.Series"
+        ) -> "pli.Series":  # pragma: no cover
             mask = acc < val
             return acc.zip_with(mask, val)
 
@@ -1169,10 +1173,7 @@ def collect_all(
     out = _collect_all(prepared)
 
     # wrap the pydataframes into dataframe
-
-    result = []
-    for pydf in out:
-        result.append(pli.wrap_df(pydf))
+    result = [pli.wrap_df(pydf) for pydf in out]
 
     return result
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -81,7 +81,7 @@ except ImportError:  # pragma: no cover
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # pragma: no cover
 
 
 def get_ffi_func(
@@ -460,7 +460,7 @@ class Series:
         elif isinstance(key, (np.ndarray, list, tuple)):
             s = wrap_s(PySeries.new_u32("", np.array(key, np.uint32), True))
             self.__setitem__(s, value)
-        elif isinstance(key, int):
+        elif isinstance(key, int) and not isinstance(key, bool):
             self.__setitem__([key], value)
         else:
             raise ValueError(f'cannot use "{key}" for indexing')
@@ -1995,7 +1995,9 @@ class Series:
         return wrap_s(f(filter._s, value))
 
     def set_at_idx(
-        self, idx: Union["Series", np.ndarray], value: Union[int, float]
+        self,
+        idx: Union["Series", np.ndarray, List[int], Tuple[int]],
+        value: Union[int, float, str, bool],
     ) -> "Series":
         """
         Set values at the index locations.

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -1,6 +1,10 @@
+from functools import reduce
+from typing import Any
+
 import pytest
 
 import polars as pl
+from polars import testing
 
 
 @pytest.fixture
@@ -42,6 +46,29 @@ def fruits_cars() -> pl.DataFrame:
     )
 
 
-@pytest.fixture
-def series() -> pl.Series:
-    return pl.Series("a", [1, 2])
+def _getattr_multi(obj: object, op: str) -> Any:
+    """ "
+    Allows `op` to be multiple layers deep, i.e. op="str.lengths" will mean we first
+    get the attribute "str", and then the attribute "lengths"
+    """
+    op_list = op.split(".")
+    return reduce(lambda o, m: getattr(o, m), op_list, obj)
+
+
+def verify_series_and_expr_api(
+    input: pl.Series, expected: pl.Series, op: str, *args: Any
+) -> None:
+    """
+    Small helper function to test element-wise functions for both the series and expressions api.
+
+    Examples
+    --------
+    >>> s = pl.Series([1, 3, 2])
+    >>> expected = pl.Series([1, 2, 3])
+    >>> verify_series_and_expr_api(s, expected, "sort")
+    """
+    expr = _getattr_multi(pl.col("*"), op)(*args)
+    result_expr: pl.Series = input.to_frame().select(expr)[:, 0]  # type: ignore
+    result_series = _getattr_multi(input, op)(*args)
+    testing.assert_series_equal(result_expr, expected)
+    testing.assert_series_equal(result_series, expected)

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -1,10 +1,6 @@
-from functools import reduce
-from typing import Any
-
 import pytest
 
 import polars as pl
-from polars import testing
 
 
 @pytest.fixture
@@ -44,31 +40,3 @@ def fruits_cars() -> pl.DataFrame:
             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
         }
     )
-
-
-def _getattr_multi(obj: object, op: str) -> Any:
-    """ "
-    Allows `op` to be multiple layers deep, i.e. op="str.lengths" will mean we first
-    get the attribute "str", and then the attribute "lengths"
-    """
-    op_list = op.split(".")
-    return reduce(lambda o, m: getattr(o, m), op_list, obj)
-
-
-def verify_series_and_expr_api(
-    input: pl.Series, expected: pl.Series, op: str, *args: Any
-) -> None:
-    """
-    Small helper function to test element-wise functions for both the series and expressions api.
-
-    Examples
-    --------
-    >>> s = pl.Series([1, 3, 2])
-    >>> expected = pl.Series([1, 2, 3])
-    >>> verify_series_and_expr_api(s, expected, "sort")
-    """
-    expr = _getattr_multi(pl.col("*"), op)(*args)
-    result_expr: pl.Series = input.to_frame().select(expr)[:, 0]  # type: ignore
-    result_series = _getattr_multi(input, op)(*args)
-    testing.assert_series_equal(result_expr, expected)
-    testing.assert_series_equal(result_series, expected)

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -595,7 +595,7 @@ def test_take(fruits_cars: pl.DataFrame) -> None:
             )
         )
 
-    for index in [[0, 1], pl.Series([0, 1]), np.array([0, 1])]:
+    for index in [[0, 1], pl.Series([0, 1]), np.array([0, 1]), pl.lit(1)]:
         out = df.sort("fruits").select(
             [col("B").reverse().take(index).list().over("fruits"), "fruits"]  # type: ignore
         )
@@ -866,10 +866,11 @@ def test_str_concat() -> None:
     assert df[0, 0] == "1-null-2"
 
 
-def test_collect_all(df: pl.DataFrame) -> None:
+@pytest.mark.parametrize("no_optimization", [False, True])
+def test_collect_all(df: pl.DataFrame, no_optimization: bool) -> None:
     lf1 = df.lazy().select(pl.col("int").sum())
     lf2 = df.lazy().select((pl.col("floats") * 2).sum())
-    out = pl.collect_all([lf1, lf2])
+    out = pl.collect_all([lf1, lf2], no_optimization=no_optimization)
     assert out[0][0, 0] == 6
     assert out[1][0, 0] == 12.0
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -8,15 +8,16 @@ import pytest
 
 import polars as pl
 from polars import testing
-from polars.datatypes import Float64, Int32, Int64, UInt32
+from polars.datatypes import Float64, Int32, Int64, UInt32, UInt64
+from tests.conftest import verify_series_and_expr_api
 
 
 def test_cum_agg() -> None:
     s = pl.Series("a", [1, 2, 3, 2])
-    assert s.cumsum().series_equal(pl.Series("a", [1, 3, 6, 8]))
-    assert s.cummin().series_equal(pl.Series("a", [1, 1, 1, 1]))
-    assert s.cummax().series_equal(pl.Series("a", [1, 2, 3, 3]))
-    assert s.cumprod().series_equal(pl.Series("a", [1, 2, 6, 12]))
+    verify_series_and_expr_api(s, pl.Series("a", [1, 3, 6, 8]), "cumsum")
+    verify_series_and_expr_api(s, pl.Series("a", [1, 1, 1, 1]), "cummin")
+    verify_series_and_expr_api(s, pl.Series("a", [1, 2, 3, 3]), "cummax")
+    verify_series_and_expr_api(s, pl.Series("a", [1, 2, 6, 12]), "cumprod")
 
 
 def test_init_inputs() -> None:
@@ -63,8 +64,9 @@ def test_concat() -> None:
     assert s.len() == 3
 
 
-def test_to_frame(series: pl.Series) -> None:
-    assert series.to_frame().shape == (2, 1)
+def test_to_frame() -> None:
+    s = pl.Series([1, 2])
+    assert s.to_frame().shape == (2, 1)
 
 
 def test_bitwise_ops() -> None:
@@ -83,8 +85,13 @@ def test_bitwise_ops() -> None:
     assert (True ^ a).series_equal(pl.Series([False, True, False]))  # type: ignore
 
 
-def test_equality(series: pl.Series) -> None:
-    a = series
+def test_bitwise_floats_invert() -> None:
+    a = pl.Series([2.0, 3.0, 0.0])
+    assert ~a == NotImplemented
+
+
+def test_equality() -> None:
+    a = pl.Series("a", [1, 2])
     b = a
 
     cmp = a == b
@@ -102,15 +109,19 @@ def test_equality(series: pl.Series) -> None:
     testing.assert_series_equal((a == "ham"), pl.Series("name", [True, False, False]))
 
 
-def test_agg(series: pl.Series) -> None:
+def test_agg() -> None:
+    series = pl.Series("a", [1, 2])
     assert series.mean() == 1.5
     assert series.min() == 1
     assert series.max() == 2
 
 
-def test_arithmetic(series: pl.Series) -> None:
-    a = series
-    b = a
+@pytest.mark.parametrize(
+    "s", [pl.Series([1, 2], dtype=Int64), pl.Series([1, 2], dtype=Float64)]
+)
+def test_arithmetic(s: pl.Series) -> None:
+    a = s
+    b = s
 
     assert ((a * b) == [1, 4]).sum() == 2
     assert ((a / b) == [1.0, 1.0]).sum() == 2
@@ -125,8 +136,12 @@ def test_arithmetic(series: pl.Series) -> None:
     assert ((1 - a) == [0, -1]).sum() == 2
     assert ((1 * a) == [1, 2]).sum() == 2
     # integer division
-    assert ((1 / a) == [1.0, 0.5]).sum() == 2
-    assert ((1 // a) == [1, 0]).sum() == 2
+    testing.assert_series_equal(1 / a, pl.Series([1.0, 0.5]))  # type: ignore
+    if s.dtype == Int64:
+        expected = pl.Series([1, 0])
+    else:
+        expected = pl.Series([1.0, 0.5])
+    testing.assert_series_equal(1 // a, expected)
     # modulo
     assert ((1 % a) == [0, 1]).sum() == 2
     assert ((a % 1) == [0, 0]).sum() == 2
@@ -140,8 +155,14 @@ def test_arithmetic(series: pl.Series) -> None:
     assert ((1.0 % a) == [0, 1]).sum() == 2
 
 
-def test_various(series: pl.Series) -> None:
-    a = series
+def test_add_string() -> None:
+    s = pl.Series(["hello", "weird"])
+    result = s + " world"
+    testing.assert_series_equal(result, pl.Series(["hello world", "weird world"]))
+
+
+def test_various() -> None:
+    a = pl.Series("a", [1, 2])
 
     assert a.is_null().sum() == 0
     assert a.name == "a"
@@ -286,6 +307,35 @@ def test_set() -> None:
     testing.assert_series_equal(a, pl.Series("", [False] * 3))
 
 
+def test_set_value_as_list_fail() -> None:
+    """ " it is not allowed to use a list to set values"""
+    s = pl.Series("a", [1, 2, 3])
+    with pytest.raises(ValueError):
+        s[[0, 1]] = [4, 5]
+
+
+@pytest.mark.parametrize("key", [True, False, 1.0])
+def test_set_invalid_key(key: Any) -> None:
+    s = pl.Series("a", [1, 2, 3])
+    with pytest.raises(ValueError):
+        s[key] = 1
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pl.Series([False, True, True]),
+        pl.Series([1, 2], dtype=UInt32),
+        pl.Series([1, 2], dtype=UInt64),
+    ],
+)
+def test_set_key_series(key: pl.Series) -> None:
+    """only UInt32/UInt64/bool are allowed"""
+    s = pl.Series("a", [1, 2, 3])
+    s[key] = 4
+    testing.assert_series_equal(s, pl.Series("a", [1, 4, 4]))
+
+
 def test_set_np_array_boolean_mask() -> None:
     a = pl.Series("a", [1, 2, 3])
     mask = np.array([True, False, True])
@@ -310,10 +360,11 @@ def test_set_list_and_tuple(idx: Union[list, tuple]) -> None:
 
 def test_fill_null() -> None:
     a = pl.Series("a", [1, 2, None])
-    b = a.fill_null("forward")
-    assert b == [1, 2, 2]
-    b = a.fill_null(14)
-    testing.assert_series_equal(b, pl.Series("a", [1, 2, 14], dtype=Int64))
+    verify_series_and_expr_api(a, pl.Series("a", [1, 2, 2]), "fill_null", "forward")
+
+    verify_series_and_expr_api(
+        a, pl.Series("a", [1, 2, 14], dtype=Int64), "fill_null", 14
+    )
 
 
 def test_apply() -> None:
@@ -415,12 +466,12 @@ def test_shape() -> None:
     assert s.shape == (3,)
 
 
-def test_create_list_series() -> None:
-    for b in [True, False]:
-        pl.internals.series._PYARROW_AVAILABLE = b
-        a = [[1, 2], None, [None, 3]]
-        s = pl.Series("", a)
-        assert s.to_list() == a
+@pytest.mark.parametrize("arrow_available", [True, False])
+def test_create_list_series(arrow_available: bool) -> None:
+    pl.internals.series._PYARROW_AVAILABLE = arrow_available
+    a = [[1, 2], None, [None, 3]]
+    s = pl.Series("", a)
+    assert s.to_list() == a
 
 
 def test_iter() -> None:
@@ -529,18 +580,16 @@ def test_mode() -> None:
 
 def test_jsonpath_single() -> None:
     s = pl.Series(['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}'])
-    testing.assert_series_equal(
-        s.str.json_path_match("$.a"),
-        pl.Series(
-            [
-                "1",
-                None,
-                "2",
-                "2.1",
-                "true",
-            ]
-        ),
+    expected = pl.Series(
+        [
+            "1",
+            None,
+            "2",
+            "2.1",
+            "true",
+        ]
     )
+    verify_series_and_expr_api(s, expected, "str.json_path_match", "$.a")
 
 
 def test_extract_regex() -> None:
@@ -551,16 +600,14 @@ def test_extract_regex() -> None:
             "http://vote.com/ballon_dor?candidate=ronaldo&ref=polars",
         ]
     )
-    testing.assert_series_equal(
-        s.str.extract(r"candidate=(\w+)", 1),
-        pl.Series(
-            [
-                "messi",
-                None,
-                "ronaldo",
-            ]
-        ),
+    expected = pl.Series(
+        [
+            "messi",
+            None,
+            "ronaldo",
+        ]
     )
+    verify_series_and_expr_api(s, expected, "str.extract", r"candidate=(\w+)", 1)
 
 
 def test_rank_dispatch() -> None:
@@ -899,13 +946,12 @@ def test_take_every() -> None:
 
 def test_argsort() -> None:
     s = pl.Series("a", [5, 3, 4, 1, 2])
-    result = s.argsort()
-    expected = pl.Series("a", [3, 4, 1, 2, 0])
-    assert result.series_equal(expected)
+    expected = pl.Series("a", [3, 4, 1, 2, 0], dtype=UInt32)
 
-    result_reverse = s.argsort(True)
-    expected_reverse = pl.Series("a", [0, 2, 1, 4, 3])
-    assert result_reverse.series_equal(expected_reverse)
+    verify_series_and_expr_api(s, expected, "argsort")
+
+    expected_reverse = pl.Series("a", [0, 2, 1, 4, 3], dtype=UInt32)
+    verify_series_and_expr_api(s, expected_reverse, "argsort", True)
 
 
 def test_arg_min_and_arg_max() -> None:
@@ -991,90 +1037,83 @@ def test_str_concat() -> None:
 
 def test_str_lengths() -> None:
     s = pl.Series(["messi", "ronaldo", None])
-    result = s.str.lengths()
     expected = pl.Series([5, 7, None], dtype=UInt32)
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.lengths")
 
 
 def test_str_contains() -> None:
     s = pl.Series(["messi", "ronaldo", "ibrahimovic"])
-    result = s.str.contains("mes")
     expected = pl.Series([True, False, False])
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.contains", "mes")
 
 
 def test_str_replace_str_replace_all() -> None:
     s = pl.Series(["hello", "world", "test"])
-    result = s.str.replace("o", "0")
     expected = pl.Series(["hell0", "w0rld", "test"])
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.replace", "o", "0")
 
     s = pl.Series(["hello", "world", "test"])
-    result = s.str.replace_all("o", "0")
     expected = pl.Series(["hell0", "w0rld", "test"])
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.replace_all", "o", "0")
 
 
 def test_str_to_lowercase() -> None:
     s = pl.Series(["Hello", "WORLD"])
-    result = s.str.to_lowercase()
     expected = pl.Series(["hello", "world"])
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.to_lowercase")
 
 
 def test_str_to_uppercase() -> None:
     s = pl.Series(["Hello", "WORLD"])
-    result = s.str.to_uppercase()
     expected = pl.Series(["HELLO", "WORLD"])
-    testing.assert_series_equal(result, expected)
+    verify_series_and_expr_api(s, expected, "str.to_uppercase")
 
 
 def test_str_rstrip() -> None:
     s = pl.Series([" hello ", "world\t "])
-    result = s.str.rstrip()
     expected = pl.Series([" hello", "world"])
-    testing.assert_series_equal(result, expected)
+    testing.assert_series_equal(s.str.rstrip(), expected)
 
 
 def test_str_lstrip() -> None:
     s = pl.Series([" hello ", "\t world"])
-    result = s.str.lstrip()
     expected = pl.Series(["hello ", "world"])
-    testing.assert_series_equal(result, expected)
+    testing.assert_series_equal(s.str.lstrip(), expected)
 
 
 def test_str_strptime() -> None:
     s = pl.Series(["2020-01-01", "2020-02-02"])
-    out = s.str.strptime(pl.Date, fmt="%Y-%m-%d")
     expected = pl.Series([date(2020, 1, 1), date(2020, 2, 2)])
-    testing.assert_series_equal(out, expected)
+    verify_series_and_expr_api(s, expected, "str.strptime", pl.Date, "%Y-%m-%d")
 
     s = pl.Series(["2020-01-01 00:00:00", "2020-02-02 03:20:10"])
-    out = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S")
     expected = pl.Series(
         [datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 2, 2, 3, 20, 10)]
     )
-    testing.assert_series_equal(out, expected)
+    verify_series_and_expr_api(
+        s, expected, "str.strptime", pl.Datetime, "%Y-%m-%d %H:%M:%S"
+    )
 
 
 def test_dt_strftime() -> None:
     a = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
     assert a.dtype == pl.Date
-    a = a.dt.strftime("%F")
-    assert a[2] == "2052-02-20"
+    expected = pl.Series("a", ["1997-05-19", "2024-10-04", "2052-02-20"])
+    verify_series_and_expr_api(a, expected, "dt.strftime", "%F")
 
 
 def test_dt_year_month_week_day_ordinal_day() -> None:
     a = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
-    testing.assert_series_equal(
-        a.dt.year(), pl.Series("a", [1997, 2024, 2052], dtype=Int32)
-    )
-    testing.assert_series_equal(a.dt.month(), pl.Series("a", [5, 10, 2], dtype=UInt32))
-    testing.assert_series_equal(a.dt.weekday(), pl.Series("a", [0, 4, 1], dtype=UInt32))
-    testing.assert_series_equal(a.dt.week(), pl.Series("a", [21, 40, 8], dtype=UInt32))
-    testing.assert_series_equal(a.dt.day(), pl.Series("a", [19, 4, 20], dtype=UInt32))
-    testing.assert_series_equal(
-        a.dt.ordinal_day(), pl.Series("a", [139, 278, 51], dtype=UInt32)
+
+    exp = pl.Series("a", [1997, 2024, 2052], dtype=Int32)
+    verify_series_and_expr_api(a, exp, "dt.year")
+
+    verify_series_and_expr_api(a, pl.Series("a", [5, 10, 2], dtype=UInt32), "dt.month")
+    verify_series_and_expr_api(a, pl.Series("a", [0, 4, 1], dtype=UInt32), "dt.weekday")
+    verify_series_and_expr_api(a, pl.Series("a", [21, 40, 8], dtype=UInt32), "dt.week")
+    verify_series_and_expr_api(a, pl.Series("a", [19, 4, 20], dtype=UInt32), "dt.day")
+    verify_series_and_expr_api(
+        a, pl.Series("a", [139, 278, 51], dtype=UInt32), "dt.ordinal_day"
     )
 
     assert a.dt.median() == date(2024, 10, 4)
@@ -1086,21 +1125,24 @@ def test_dt_datetimes() -> None:
     s = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S")
 
     # hours, minutes, seconds and nanoseconds
-    testing.assert_series_equal(s.dt.hour(), pl.Series("", [0, 3], dtype=UInt32))
-    testing.assert_series_equal(s.dt.minute(), pl.Series("", [0, 20], dtype=UInt32))
-    testing.assert_series_equal(s.dt.second(), pl.Series("", [0, 10], dtype=UInt32))
-    testing.assert_series_equal(s.dt.nanosecond(), pl.Series("", [0, 0], dtype=UInt32))
+    verify_series_and_expr_api(s, pl.Series("", [0, 3], dtype=UInt32), "dt.hour")
+    verify_series_and_expr_api(s, pl.Series("", [0, 20], dtype=UInt32), "dt.minute")
+    verify_series_and_expr_api(s, pl.Series("", [0, 10], dtype=UInt32), "dt.second")
+    verify_series_and_expr_api(s, pl.Series("", [0, 0], dtype=UInt32), "dt.nanosecond")
 
     # epoch methods
-    testing.assert_series_equal(
-        s.dt.epoch_days(), pl.Series("", [18262, 18294], dtype=Int32)
+    verify_series_and_expr_api(
+        s, pl.Series("", [18262, 18294], dtype=Int32), "dt.epoch_days"
     )
-    testing.assert_series_equal(
-        s.dt.epoch_seconds(), pl.Series("", [1_577_836_800, 1_580_613_610], dtype=Int64)
+    verify_series_and_expr_api(
+        s,
+        pl.Series("", [1_577_836_800, 1_580_613_610], dtype=Int64),
+        "dt.epoch_seconds",
     )
-    testing.assert_series_equal(
-        s.dt.epoch_milliseconds(),
+    verify_series_and_expr_api(
+        s,
         pl.Series("", [1_577_836_800_000, 1_580_613_610_000], dtype=Int64),
+        "dt.epoch_milliseconds",
     )
 
 
@@ -1181,18 +1223,13 @@ def test_nested_list_types_preserved() -> None:
 def test_log_exp() -> None:
     a = pl.Series("a", [1, 100, 1000])
     b = pl.Series("a", [0.0, 2.0, 3.0])
+    verify_series_and_expr_api(a, b, "log10")
 
-    out = a.log10()
-    testing.assert_series_equal(out, b)
-    a = pl.Series("a", [1, 100, 1000])
-
-    out = a.log()
     expected = pl.Series("a", np.log(a.to_numpy()))
-    testing.assert_series_equal(out, expected)
+    verify_series_and_expr_api(a, expected, "log")
 
-    out = b.exp()
     expected = pl.Series("a", np.exp(b.to_numpy()))
-    testing.assert_series_equal(out, expected)
+    verify_series_and_expr_api(b, expected, "exp")
 
 
 def test_shuffle() -> None:
@@ -1208,12 +1245,30 @@ def test_shuffle() -> None:
 def test_to_physical() -> None:
     # casting an int result in an int
     a = pl.Series("a", [1, 2, 3])
-    testing.assert_series_equal(a.to_physical(), a)
+    verify_series_and_expr_api(a, a, "to_physical")
 
     # casting a date results in an Int32
     a = pl.Series("a", [date(2020, 1, 1)] * 3)
     expected = pl.Series("a", [18262] * 3, dtype=Int32)
-    testing.assert_series_equal(a.to_physical(), expected)
+    verify_series_and_expr_api(a, expected, "to_physical")
+
+
+def test_is_between_datetime() -> None:
+    s = pl.Series("a", [datetime(2020, 1, 1, 10, 0, 0), datetime(2020, 1, 1, 20, 0, 0)])
+    start = datetime(2020, 1, 1, 12, 0, 0)
+    end = datetime(2020, 1, 1, 23, 0, 0)
+    expected = pl.Series("a", [False, True])
+
+    # only on the expression api
+    result = s.to_frame().with_column(pl.col("*").is_between(start, end))["is_between"]
+    testing.assert_series_equal(result.rename("a"), expected)
+
+
+@pytest.mark.parametrize("f", ["sin", "cos", "tan", "arcsin", "arccos", "arctan"])
+def test_trigonometric(f: str) -> None:
+    s = pl.Series("a", [0.0])
+    expected = pl.Series("a", getattr(np, f)(s.to_numpy()))
+    verify_series_and_expr_api(s, expected, f)
 
 
 def test_ew() -> None:


### PR DESCRIPTION
I have introduced the helper method `verify_series_and_expr_api`, as many operations that preserve the Series shape (i.e. non reducing) are available on both the Series api directly, and via the Expression api. For example `log`, `sin`, `cumsum`, etc. This helper allows one to test both at the same time.