### PR TITLE
Add tests on Config

### DIFF
--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -14,7 +14,10 @@ class Config:
         """
         Use utf8 characters to print tables
         """
-        os.environ.unsetenv("POLARS_FMT_NO_UTF8")  # type: ignore
+        # os.unsetenv is automatically called if we remove a key from os.environ,
+        # see https://docs.python.org/3/library/os.html#os.environ. However, we cannot call
+        # os.unsetenv directly, as that fails on Windows
+        os.environ.pop("POLARS_FMT_NO_UTF8", None)
         return cls
 
     @classmethod

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -1,0 +1,50 @@
+import os
+from typing import Generator
+
+import pytest
+
+import polars as pl
+
+
+@pytest.fixture()
+def environ() -> Generator:
+    """Fixture to restore the environment variables after the test"""
+    old_environ = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(old_environ)
+
+
+def test_tables(environ: None) -> None:
+    os.environ.pop("POLARS_FMT_NO_UTF8", None)
+
+    assert "POLARS_FMT_NO_UTF8" not in os.environ
+    pl.Config.set_ascii_tables()
+    assert os.environ["POLARS_FMT_NO_UTF8"] == "1"
+
+    pl.Config.set_utf8_tables()
+    assert "POLARS_FMT_NO_UTF8" not in os.environ
+
+
+def test_tbl_width_chars(environ: None) -> None:
+    pl.Config.set_tbl_width_chars(100)
+    assert os.environ["POLARS_TABLE_WIDTH"] == "100"
+    pl.Config.set_tbl_width_chars(200)
+    assert os.environ["POLARS_TABLE_WIDTH"] == "200"
+
+
+def test_tbl_cols_rows(environ: None) -> None:
+    pl.Config.set_tbl_cols(50)
+    assert os.environ["POLARS_FMT_MAX_COLS"] == "50"
+    pl.Config.set_tbl_cols(60)
+    assert os.environ["POLARS_FMT_MAX_COLS"] == "60"
+
+    pl.Config.set_tbl_rows(50)
+    assert os.environ["POLARS_FMT_MAX_ROWS"] == "50"
+    pl.Config.set_tbl_rows(60)
+    assert os.environ["POLARS_FMT_MAX_ROWS"] == "60"
+
+
+@pytest.mark.skip("how to test this")
+def test_string_cache(environ: None) -> None:
+    pl.Config.set_global_string_cache()


### PR DESCRIPTION
The tests only check the value of th environment variables, not whether those are actually used correctly by relevant (Rust) code.

As discussed before, I have updated the implementation to no longer use unsetenv; it does not work on Windows + Python 3.9/3.10 for me. Popping the key does.

For the string cache, how can it be tested? I dont see any environment variable being set.