### PR TITLE
Enforce minimum Python test coverage

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -28,7 +28,7 @@ test: venv
 	$(PYTHON) -m pytest tests
 
 test-with-cov: venv
-	@cd tests && ../$(PYTHON) -m pytest --cov=polars --import-mode=importlib
+	@cd tests && ../$(PYTHON) -m pytest --cov=polars --cov-fail-under=92 --import-mode=importlib
 
 doctest:
 	cd tests && ../$(PYTHON) run_doc_examples.py


### PR DESCRIPTION
Test coverage has increased steadily over the last month. To make sure we are not going back, adding a minimum level of (currently) 92%. If the coverage drops below this level, pytest will fail.