### PR TITLE
AnyValue::to_static

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -356,6 +356,39 @@ impl<'a> AnyValue<'a> {
             _ => todo!(),
         }
     }
+
+    /// Try to coerce to an AnyValue with static lifetime.
+    /// This can be done if it does not borrow any values.
+    pub fn to_static(&self) -> Result<AnyValue<'static>> {
+        use AnyValue::*;
+        let av = match self {
+            Null => AnyValue::Null,
+            Int8(v) => AnyValue::Int8(*v),
+            Int16(v) => AnyValue::Int16(*v),
+            Int32(v) => AnyValue::Int32(*v),
+            Int64(v) => AnyValue::Int64(*v),
+            UInt8(v) => AnyValue::UInt8(*v),
+            UInt16(v) => AnyValue::UInt16(*v),
+            UInt32(v) => AnyValue::UInt32(*v),
+            UInt64(v) => AnyValue::UInt64(*v),
+            Boolean(v) => AnyValue::Boolean(*v),
+            Float32(v) => AnyValue::Float32(*v),
+            Float64(v) => AnyValue::Float64(*v),
+            #[cfg(feature = "dtype-date")]
+            Date(v) => AnyValue::Date(*v),
+            #[cfg(feature = "dtype-datetime")]
+            Datetime(v) => AnyValue::Datetime(*v),
+            #[cfg(feature = "dtype-time")]
+            Time(v) => AnyValue::Time(*v),
+            List(v) => AnyValue::List(v.clone()),
+            dt => {
+                return Err(PolarsError::ComputeError(
+                    format!("cannot get static AnyValue from {}", dt).into(),
+                ))
+            }
+        };
+        Ok(av)
+    }
 }
 
 impl<'a> From<AnyValue<'a>> for Option<i64> {


### PR DESCRIPTION
@universalmind303 this may reduce the number of patterns matched needed in #2177. 

Numbers, booleans and dates can be turned into an `AnyValue` with static lifetime.