### PR TITLE
Require typing-extensions >= 4.0.0

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "polars"
 dependencies = [
   "numpy >= 1.16.0",
-  "typing_extensions >= 4.0.0",
+  "typing_extensions >= 4.0.0; python_version < '3.10'",
 ]
 requires-python = ">=3.6"
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "polars"
 dependencies = [
   "numpy >= 1.16.0",
-  "typing_extensions",
+  "typing_extensions >= 4.0.0",
 ]
 requires-python = ">=3.6"
 


### PR DESCRIPTION
Closes #2185.

Im not 100% sure this has not been in before v4, i.e. the PR (https://github.com/python/typing/pull/803) was merged May 1, and the same day 3.10.0 of the package was released. However, I dont think it hurts to push to v4?