### PR TITLE
Fix Datetime NumPy Conversion + Test

### DIFF
--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1972,7 +1972,7 @@ class Series:
             if self.dtype == Date:
                 tp = "datetime64[D]"
             else:
-                tp = "datetime64[ms]"
+                tp = "datetime64[ns]"
             return arr.astype(tp)
 
         if _PYARROW_AVAILABLE and not self.is_datelike():

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -46,7 +46,6 @@ def test_filter_date() -> None:
 
 
 def test_diff_datetime() -> None:
-
     df = pl.DataFrame(
         {
             "timestamp": ["2021-02-01", "2021-03-1", "2021-04-1"],
@@ -172,11 +171,13 @@ def test_rows() -> None:
 
 def test_to_numpy() -> None:
     s0 = pl.Series("date", [123543, 283478, 1243]).cast(pl.Date)
-    s1 = pl.Series("datetime", [123543, 283478, 1243]).cast(pl.Datetime)
+    s1 = pl.Series(
+        "datetime", [datetime(2021, 1, 2, 3, 4, 5), datetime(2021, 2, 3, 4, 5, 6)]
+    )
     assert str(s0.to_numpy()) == "['2308-04-02' '2746-02-20' '1973-05-28']"
     assert (
         str(s1.to_numpy()[:2])
-        == "['1970-01-01T00:02:03.543' '1970-01-01T00:04:43.478']"
+        == "['2021-01-02T03:04:05.000000000' '2021-02-03T04:05:06.000000000']"
     )
 
 


### PR DESCRIPTION
I noticed this on Polars 0.12.5:
```python
from datetime import datetime

import polars as pl

dates = pl.date_range(low=datetime(2021, 1,1), high=datetime.now(), interval='1h')

dates.to_numpy()

array(['51003701-09-23T00:00:00.000', '51003815-10-22T16:00:00.000',
       '51003929-11-20T08:00:00.000', ..., '51990374-12-19T00:00:00.000',
       '51990489-01-15T16:00:00.000', '51990603-02-15T08:00:00.000'],
      dtype='datetime64[ms]')
```

It was a pretty simple fix, but I also updated the test to use `datetime64[ns]`.