### PR TITLE
Remove @tp.overload from coverage exclusion list

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -30,4 +30,4 @@ module = ["pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx"
 ignore_missing_imports = true
 
 [tool.coverage.report]
-exclude_lines = ["pragma: no cover", "@overload", "@tp.overload"]
+exclude_lines = ["pragma: no cover", "@overload"]


### PR DESCRIPTION
Imports from the `Typing` module are now always done without the rename (i.e. `import Typing as tp`), so this coverage exclusion entry can be dropped.