### PR TITLE
Fix test assertions to not assert list but check contents

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -746,8 +746,8 @@ def test_from_pandas_nan_to_none() -> None:
     out_true: pl.DataFrame = pl.from_pandas(df)  # type: ignore
     out_false: pl.DataFrame = pl.from_pandas(df, nan_to_none=False)  # type: ignore
     df.loc[2, "nulls"] = pd.NA
-    assert [val is None for val in out_true["nulls"]]
-    assert [np.isnan(val) for val in out_false["nulls"][1:]]
+    assert all(val is None for val in out_true["nulls"])
+    assert all(np.isnan(val) for val in out_false["nulls"][1:])
     with pytest.raises(ArrowInvalid, match="Could not convert"):
         pl.from_pandas(df, nan_to_none=False)
 


### PR DESCRIPTION
Using `assert <list> ` will pass any non-empty list, i.e.:

```python
assert [False]  # this passes
# because:
bool([False])
True
```