### PR TITLE
Print each argument on new line in Python docs

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -1,0 +1,18 @@
+/* source: https://github.com/sphinx-doc/sphinx/issues/1514#issuecomment-742703082 */
+
+/* Newlines (\a) and spaces (\20) before each parameter */
+.sig-param::before {
+    content: "\a\20\20\20\20";
+    white-space: pre;
+}
+
+/* Newline after the last parameter (so the closing bracket is on a new line) */
+dt em.sig-param:last-of-type::after {
+    content: "\a";
+    white-space: pre;
+}
+
+/* To have blue background of width of the block (instead of width of content) */
+dl.class > dt:first-of-type {
+    display: block !important;
+}

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -63,7 +63,7 @@ html_theme = "pydata_sphinx_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = ['css/custom.css']  # relative to html_static_path
+html_css_files = ["css/custom.css"]  # relative to html_static_path
 
 html_logo = "../img/polars_logo.png"
 autosummary_generate = True

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -62,7 +62,8 @@ html_theme = "pydata_sphinx_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
+html_static_path = ["_static"]
+html_css_files = ['css/custom.css']  # relative to html_static_path
 
 html_logo = "../img/polars_logo.png"
 autosummary_generate = True


### PR DESCRIPTION
When there are multiple arguments, they were just added onto the same line. Given type annotations and such, this lead to a very cluttered view. I have added a bit of custom css (see commit for source, modified slightly) to list each new param on a new line.

