### PR TITLE
Fix typing errors on master

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1736,10 +1736,10 @@ class DataFrame:
 
         summary = pli.concat(
             [
-                describe_cast(self.mean()),  # type: ignore
+                describe_cast(self.mean()),
                 describe_cast(self.std()),
-                describe_cast(self.min()),  # type: ignore
-                describe_cast(self.max()),  # type: ignore
+                describe_cast(self.min()),
+                describe_cast(self.max()),
                 describe_cast(self.median()),
             ]
         )

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -420,7 +420,7 @@ def test_groupby() -> None:
     # df.groupby(by="a", select="b", agg="count").frame_equal(
     #     pl.DataFrame({"a": ["a", "b", "c"], "": [2, 3, 1]})
     # )
-    assert df.groupby("a").apply(lambda df: df[["c"]].sum()).sort("c")["c"][0] == 1  # type: ignore
+    assert df.groupby("a").apply(lambda df: df[["c"]].sum()).sort("c")["c"][0] == 1
 
     assert (
         df.groupby("a")


### PR DESCRIPTION
Not sure why this was not picked up before, does not seem like two merges were incompatible as the ignores had been around for some time.