### PR TITLE
chore: update datetime logic in nodejs

### DIFF
--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -155,7 +155,6 @@ describe("dataframe", () => {
       ];
 
       const df = pl.DataFrame(rows);
-
       expect(df.row(0)).toEqual(Object.values(rows[0]));
       expect(df.row(1)).toEqual(Object.values(rows[1]));
       expect(df.columns).toEqual(Object.keys(rows[0]));

--- a/nodejs-polars/src/conversion/from.rs
+++ b/nodejs-polars/src/conversion/from.rs
@@ -56,8 +56,8 @@ impl FromJsUnknown for AnyValue<'_> {
                 if val.is_date()? {
                     let d: JsDate = unsafe { val.cast() };
                     let d = d.value_of()?;
-                    let d = d as i64 * 1000000;
-                    Ok(AnyValue::Datetime(d))
+                    let d = d as i64;
+                    Ok(AnyValue::Datetime(d, TimeUnit::Milliseconds, &None))
                 } else {
                     Err(JsPolarsEr::Other("Unsupported Data type".to_owned()).into())
                 }

--- a/nodejs-polars/src/conversion/into.rs
+++ b/nodejs-polars/src/conversion/into.rs
@@ -110,11 +110,11 @@ impl IntoJs<JsUnknown> for Wrap<AnyValue<'_>> {
             AnyValue::Float64(v) => cx.env.create_double(v).map(|v| v.into_unknown()),
             AnyValue::Date(v) => cx
                 .env
-                .create_date((v / 1000000) as f64)
+                .create_date(v as f64)
                 .map(|v| v.into_unknown()),
-            AnyValue::Datetime(v) => cx
+            AnyValue::Datetime(v, _, _) => cx
                 .env
-                .create_date((v / 1000000) as f64)
+                .create_date(v as f64)
                 .map(|v| v.into_unknown()),
             AnyValue::List(v) => cx.env.to_js_value(&v).map(|v| v.into_unknown()),
             _ => cx.env.get_null().map(|v| v.into_unknown()),

--- a/nodejs-polars/src/datatypes.rs
+++ b/nodejs-polars/src/datatypes.rs
@@ -91,12 +91,12 @@ impl From<&DataType> for JsDataType {
             DataType::Utf8 => Utf8,
             DataType::List(_) => List,
             DataType::Date => Date,
-            DataType::Datetime => Datetime,
+            DataType::Datetime(_, _) => Datetime,
             DataType::Time => Time,
             DataType::Object(_) => Object,
             DataType::Categorical => Categorical,
-            DataType::Null => {
-                panic!("null not expected here")
+            DataType::Null | DataType::Unknown => {
+                panic!("null or unknown not expected here")
             }
         }
     }
@@ -160,7 +160,7 @@ impl Into<DataType> for JsDataType {
             JsDataType::Utf8 => Utf8,
             JsDataType::List => List(DataType::Null.into()),
             JsDataType::Date => Date,
-            JsDataType::Datetime => Datetime,
+            JsDataType::Datetime => Datetime(TimeUnit::Milliseconds, None),
             JsDataType::Time => Time,
             JsDataType::Object => Object("object"),
             JsDataType::Categorical => Categorical,
@@ -206,7 +206,7 @@ pub fn num_to_polarstype(n: u32) -> DataType {
         11 => DataType::Utf8,
         12 => DataType::List(DataType::Null.into()),
         13 => DataType::Date,
-        14 => DataType::Datetime,
+        14 => DataType::Datetime(TimeUnit::Milliseconds, None),
         15 => DataType::Time,
         16 => DataType::Object("object"),
         17 => DataType::Categorical,

--- a/nodejs-polars/src/list_construction.rs
+++ b/nodejs-polars/src/list_construction.rs
@@ -354,7 +354,7 @@ pub fn js_arr_to_list(name: &str, obj: &JsObject, dtype: &DataType) -> JsResult<
             }
             builder.finish().into_series()
         }
-        DataType::Datetime => {
+        DataType::Datetime(_,_) => {
             let mut builder = ListPrimitiveChunkedBuilder::<i64>::new(
                 name,
                 len as usize,
@@ -384,7 +384,7 @@ pub fn js_arr_to_list(name: &str, obj: &JsObject, dtype: &DataType) -> JsResult<
                 let dt_series = inner_builder
                     .finish()
                     .into_series()
-                    .cast(&DataType::Datetime)
+                    .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
                     .map_err(JsPolarsEr::from)?;
                 builder.append_series(&dt_series);
             }


### PR DESCRIPTION
Right now, everything is just hard coded to Milliseconds on the rust side of things, as that is the precision used for Javascript `Date` object. Ill add the parameterized time units on the JS side of things in a follow up PR. 