### PR TITLE
Improve lazy apply with filtered arguments and correctly tag `trust_my_length` as unsafe.

### DIFF
--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -5,6 +5,7 @@ use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, PhysicalType};
 use arrow::types::NativeType;
+use std::iter::FromIterator;
 use std::sync::Arc;
 
 /// # Safety
@@ -290,7 +291,6 @@ pub unsafe fn take_no_null_bool_opt_iter_unchecked<I: IntoIterator<Item = Option
 
 /// # Safety
 /// - no bounds checks
-/// - iterator must be TrustedLen
 #[inline]
 pub unsafe fn take_no_null_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &LargeStringArray,
@@ -300,12 +300,11 @@ pub unsafe fn take_no_null_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
         debug_assert!(idx < arr.len());
         arr.value_unchecked(idx)
     });
-    Arc::new(MutableUtf8Array::<i64>::from_trusted_len_values_iter_unchecked(iter).into())
+    Arc::new(MutableUtf8Array::<i64>::from_iter_values(iter).into())
 }
 
 /// # Safety
 /// - no bounds checks
-/// - iterator must be TrustedLen
 #[inline]
 pub unsafe fn take_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &LargeStringArray,
@@ -321,7 +320,7 @@ pub unsafe fn take_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
         }
     });
 
-    Arc::new(LargeStringArray::from_trusted_len_iter_unchecked(iter))
+    Arc::new(LargeStringArray::from_iter(iter))
 }
 
 /// # Safety

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -5,7 +5,6 @@ use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, PhysicalType};
 use arrow::types::NativeType;
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 /// # Safety
@@ -291,6 +290,7 @@ pub unsafe fn take_no_null_bool_opt_iter_unchecked<I: IntoIterator<Item = Option
 
 /// # Safety
 /// - no bounds checks
+/// - iterator must be TrustedLen
 #[inline]
 pub unsafe fn take_no_null_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &LargeStringArray,
@@ -300,11 +300,12 @@ pub unsafe fn take_no_null_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
         debug_assert!(idx < arr.len());
         arr.value_unchecked(idx)
     });
-    Arc::new(MutableUtf8Array::<i64>::from_iter_values(iter).into())
+    Arc::new(MutableUtf8Array::<i64>::from_trusted_len_values_iter_unchecked(iter).into())
 }
 
 /// # Safety
 /// - no bounds checks
+/// - iterator must be TrustedLen
 #[inline]
 pub unsafe fn take_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
     arr: &LargeStringArray,
@@ -320,7 +321,7 @@ pub unsafe fn take_utf8_iter_unchecked<I: IntoIterator<Item = usize>>(
         }
     });
 
-    Arc::new(LargeStringArray::from_iter(iter))
+    Arc::new(LargeStringArray::from_trusted_len_iter_unchecked(iter))
 }
 
 /// # Safety

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -4,6 +4,7 @@ use arrow::bitmap::Bitmap;
 use arrow::types::NativeType;
 use std::ops::BitAnd;
 
+#[derive(Clone)]
 pub struct TrustMyLength<I: Iterator<Item = J>, J> {
     iter: I,
     len: usize,

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -68,7 +68,11 @@ pub trait CustomIterTools: Iterator {
         Some(self.fold(first, f))
     }
 
-    fn trust_my_length(self, length: usize) -> TrustMyLength<Self, Self::Item>
+    /// Turn any iterator in a trusted length iterator
+    ///
+    /// # Safety
+    /// The given length must be correct.
+    unsafe fn trust_my_length(self, length: usize) -> TrustMyLength<Self, Self::Item>
     where
         Self: Sized,
     {

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -37,10 +37,13 @@ where
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
     fn into_iter(self) -> Self::IntoIter {
         Box::new(
-            self.downcast_iter()
-                .flatten()
-                .map(|x| x.copied())
-                .trust_my_length(self.len()),
+            // we know that we only iterate over length == self.len()
+            unsafe {
+                self.downcast_iter()
+                    .flatten()
+                    .map(|x| x.copied())
+                    .trust_my_length(self.len())
+            },
         )
     }
 }
@@ -59,7 +62,8 @@ impl<'a> IntoIterator for &'a BooleanChunked {
     type Item = Option<bool>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
     fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.downcast_iter().flatten().trust_my_length(self.len()))
+        // we know that we only iterate over length == self.len()
+        unsafe { Box::new(self.downcast_iter().flatten().trust_my_length(self.len())) }
     }
 }
 
@@ -127,10 +131,13 @@ impl BooleanChunked {
            + ExactSizeIterator
            + DoubleEndedIterator
            + TrustedLen {
-        self.downcast_iter()
-            .map(BoolIterNoNull::new)
-            .flatten()
-            .trust_my_length(self.len())
+        // we know that we only iterate over length == self.len()
+        unsafe {
+            self.downcast_iter()
+                .map(BoolIterNoNull::new)
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 }
 
@@ -138,7 +145,8 @@ impl<'a> IntoIterator for &'a Utf8Chunked {
     type Item = Option<&'a str>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
     fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.downcast_iter().flatten().trust_my_length(self.len()))
+        // we know that we only iterate over length == self.len()
+        unsafe { Box::new(self.downcast_iter().flatten().trust_my_length(self.len())) }
     }
 }
 
@@ -205,10 +213,13 @@ impl Utf8Chunked {
            + ExactSizeIterator
            + DoubleEndedIterator
            + TrustedLen {
-        self.downcast_iter()
-            .map(Utf8IterNoNull::new)
-            .flatten()
-            .trust_my_length(self.len())
+        // we know that we only iterate over length == self.len()
+        unsafe {
+            self.downcast_iter()
+                .map(Utf8IterNoNull::new)
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 }
 
@@ -216,13 +227,16 @@ impl<'a> IntoIterator for &'a ListChunked {
     type Item = Option<Series>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
     fn into_iter(self) -> Self::IntoIter {
-        Box::new(
-            self.downcast_iter()
-                .map(|arr| arr.iter())
-                .flatten()
-                .trust_my_length(self.len())
-                .map(|arr| arr.map(|arr| Series::try_from(("", arr)).unwrap())),
-        )
+        // we know that we only iterate over length == self.len()
+        unsafe {
+            Box::new(
+                self.downcast_iter()
+                    .map(|arr| arr.iter())
+                    .flatten()
+                    .trust_my_length(self.len())
+                    .map(|arr| arr.map(|arr| Series::try_from(("", arr)).unwrap())),
+            )
+        }
     }
 }
 
@@ -291,10 +305,13 @@ impl ListChunked {
            + ExactSizeIterator
            + DoubleEndedIterator
            + TrustedLen {
-        self.downcast_iter()
-            .map(ListIterNoNull::new)
-            .flatten()
-            .trust_my_length(self.len())
+        // we know that we only iterate over length == self.len()
+        unsafe {
+            self.downcast_iter()
+                .map(ListIterNoNull::new)
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 }
 
@@ -306,7 +323,8 @@ where
     type Item = Option<&'a T>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
     fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.downcast_iter().flatten().trust_my_length(self.len()))
+        // we know that we only iterate over length == self.len()
+        unsafe { Box::new(self.downcast_iter().flatten().trust_my_length(self.len())) }
     }
 }
 
@@ -317,10 +335,13 @@ impl<T: PolarsObject> ObjectChunked<T> {
         &self,
     ) -> impl Iterator<Item = &T> + '_ + Send + Sync + ExactSizeIterator + DoubleEndedIterator + TrustedLen
     {
-        self.downcast_iter()
-            .map(|arr| arr.values().iter())
-            .flatten()
-            .trust_my_length(self.len())
+        // we know that we only iterate over length == self.len()
+        unsafe {
+            self.downcast_iter()
+                .map(|arr| arr.values().iter())
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 }
 

--- a/polars/polars-core/src/chunked_array/list/iterator.rs
+++ b/polars/polars-core/src/chunked_array/list/iterator.rs
@@ -69,11 +69,13 @@ impl ListChunked {
             series_container,
             inner: NonNull::new(ptr).unwrap(),
             lifetime: PhantomData,
-            iter: self
-                .downcast_iter()
-                .map(|arr| arr.iter())
-                .flatten()
-                .trust_my_length(self.len()),
+            // safety: we know the iterators len
+            iter: unsafe {
+                self.downcast_iter()
+                    .map(|arr| arr.iter())
+                    .flatten()
+                    .trust_my_length(self.len())
+            },
         }
     }
 

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -542,10 +542,13 @@ where
            + TrustedLen {
         // .copied was significantly slower in benchmark, next call did not inline?
         #[allow(clippy::map_clone)]
-        self.data_views()
-            .flatten()
-            .map(|v| *v)
-            .trust_my_length(self.len())
+        // we know the iterators len
+        unsafe {
+            self.data_views()
+                .flatten()
+                .map(|v| *v)
+                .trust_my_length(self.len())
+        }
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -75,18 +75,22 @@ where
 {
     fn cummax(&self, reverse: bool) -> ChunkedArray<T> {
         let init = Bounded::min_value();
-        let mut ca: Self = match reverse {
-            false => self
-                .into_iter()
-                .scan(init, det_max)
-                .trust_my_length(self.len())
-                .collect_trusted(),
-            true => self
-                .into_iter()
-                .rev()
-                .scan(init, det_max)
-                .trust_my_length(self.len())
-                .collect_reversed(),
+
+        // safety: we know the iterators len
+        let mut ca: Self = unsafe {
+            match reverse {
+                false => self
+                    .into_iter()
+                    .scan(init, det_max)
+                    .trust_my_length(self.len())
+                    .collect_trusted(),
+                true => self
+                    .into_iter()
+                    .rev()
+                    .scan(init, det_max)
+                    .trust_my_length(self.len())
+                    .collect_reversed(),
+            }
         };
 
         ca.rename(self.name());
@@ -95,18 +99,21 @@ where
 
     fn cummin(&self, reverse: bool) -> ChunkedArray<T> {
         let init = Bounded::max_value();
-        let mut ca: Self = match reverse {
-            false => self
-                .into_iter()
-                .scan(init, det_min)
-                .trust_my_length(self.len())
-                .collect_trusted(),
-            true => self
-                .into_iter()
-                .rev()
-                .scan(init, det_min)
-                .trust_my_length(self.len())
-                .collect_reversed(),
+        // safety: we know the iterators len
+        let mut ca: Self = unsafe {
+            match reverse {
+                false => self
+                    .into_iter()
+                    .scan(init, det_min)
+                    .trust_my_length(self.len())
+                    .collect_trusted(),
+                true => self
+                    .into_iter()
+                    .rev()
+                    .scan(init, det_min)
+                    .trust_my_length(self.len())
+                    .collect_reversed(),
+            }
         };
 
         ca.rename(self.name());
@@ -115,18 +122,21 @@ where
 
     fn cumsum(&self, reverse: bool) -> ChunkedArray<T> {
         let init = None;
-        let mut ca: Self = match reverse {
-            false => self
-                .into_iter()
-                .scan(init, det_sum)
-                .trust_my_length(self.len())
-                .collect_trusted(),
-            true => self
-                .into_iter()
-                .rev()
-                .scan(init, det_sum)
-                .trust_my_length(self.len())
-                .collect_reversed(),
+        // safety: we know the iterators len
+        let mut ca: Self = unsafe {
+            match reverse {
+                false => self
+                    .into_iter()
+                    .scan(init, det_sum)
+                    .trust_my_length(self.len())
+                    .collect_trusted(),
+                true => self
+                    .into_iter()
+                    .rev()
+                    .scan(init, det_sum)
+                    .trust_my_length(self.len())
+                    .collect_reversed(),
+            }
         };
 
         ca.rename(self.name());
@@ -135,18 +145,21 @@ where
 
     fn cumprod(&self, reverse: bool) -> ChunkedArray<T> {
         let init = None;
-        let mut ca: Self = match reverse {
-            false => self
-                .into_iter()
-                .scan(init, det_prod)
-                .trust_my_length(self.len())
-                .collect_trusted(),
-            true => self
-                .into_iter()
-                .rev()
-                .scan(init, det_prod)
-                .trust_my_length(self.len())
-                .collect_reversed(),
+        // safety: we know the iterators len
+        let mut ca: Self = unsafe {
+            match reverse {
+                false => self
+                    .into_iter()
+                    .scan(init, det_prod)
+                    .trust_my_length(self.len())
+                    .collect_trusted(),
+                true => self
+                    .into_iter()
+                    .rev()
+                    .scan(init, det_prod)
+                    .trust_my_length(self.len())
+                    .collect_reversed(),
+            }
         };
 
         ca.rename(self.name());

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -54,17 +54,21 @@ where
 
                 let mut ca: BooleanChunked = if self.len() == 1 && other.len() != 1 {
                     let value = self.get(0);
-                    other
-                        .list()?
-                        .amortized_iter()
-                        .map(|opt_s| {
-                            opt_s.map(|s| {
-                                let ca = s.as_ref().unpack::<T>().unwrap();
-                                ca.into_iter().any(|a| a == value)
-                            }) == Some(true)
-                        })
-                        .trust_my_length(other.len())
-                        .collect_trusted()
+
+                    // we know the iterators len
+                    unsafe {
+                        other
+                            .list()?
+                            .amortized_iter()
+                            .map(|opt_s| {
+                                opt_s.map(|s| {
+                                    let ca = s.as_ref().unpack::<T>().unwrap();
+                                    ca.into_iter().any(|a| a == value)
+                                }) == Some(true)
+                            })
+                            .trust_my_length(other.len())
+                            .collect_trusted()
+                    }
                 } else {
                     self.into_iter()
                         .zip(other.list()?.amortized_iter())
@@ -126,17 +130,20 @@ impl IsIn for Utf8Chunked {
             DataType::List(dt) if self.dtype() == &**dt => {
                 let mut ca: BooleanChunked = if self.len() == 1 && other.len() != 1 {
                     let value = self.get(0);
-                    other
-                        .list()?
-                        .amortized_iter()
-                        .map(|opt_s| {
-                            opt_s.map(|s| {
-                                let ca = s.as_ref().unpack::<Utf8Type>().unwrap();
-                                ca.into_iter().any(|a| a == value)
-                            }) == Some(true)
-                        })
-                        .trust_my_length(other.len())
-                        .collect_trusted()
+                    // safety: we know the iterators len
+                    unsafe {
+                        other
+                            .list()?
+                            .amortized_iter()
+                            .map(|opt_s| {
+                                opt_s.map(|s| {
+                                    let ca = s.as_ref().unpack::<Utf8Type>().unwrap();
+                                    ca.into_iter().any(|a| a == value)
+                                }) == Some(true)
+                            })
+                            .trust_my_length(other.len())
+                            .collect_trusted()
+                    }
                 } else {
                     self.into_iter()
                         .zip(other.list()?.amortized_iter())
@@ -190,17 +197,20 @@ impl IsIn for BooleanChunked {
             DataType::List(dt) if self.dtype() == &**dt => {
                 let mut ca: BooleanChunked = if self.len() == 1 && other.len() != 1 {
                     let value = self.get(0);
-                    other
-                        .list()?
-                        .amortized_iter()
-                        .map(|opt_s| {
-                            opt_s.map(|s| {
-                                let ca = s.as_ref().unpack::<BooleanType>().unwrap();
-                                ca.into_iter().any(|a| a == value)
-                            }) == Some(true)
-                        })
-                        .trust_my_length(other.len())
-                        .collect_trusted()
+                    // safety: we know the iterators len
+                    unsafe {
+                        other
+                            .list()?
+                            .amortized_iter()
+                            .map(|opt_s| {
+                                opt_s.map(|s| {
+                                    let ca = s.as_ref().unpack::<BooleanType>().unwrap();
+                                    ca.into_iter().any(|a| a == value)
+                                }) == Some(true)
+                            })
+                            .trust_my_length(other.len())
+                            .collect_trusted()
+                    }
                 } else {
                     self.into_iter()
                         .zip(other.list()?.amortized_iter())

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -10,13 +10,16 @@ pub(crate) fn naive_date_to_date(nd: NaiveDate) -> i32 {
 
 impl DateChunked {
     pub fn as_date_iter(&self) -> impl Iterator<Item = Option<NaiveDate>> + TrustedLen + '_ {
-        self.downcast_iter()
-            .map(|iter| {
-                iter.into_iter()
-                    .map(|opt_v| opt_v.copied().map(date32_to_date))
-            })
-            .flatten()
-            .trust_my_length(self.len())
+        // safety: we know the iterators len
+        unsafe {
+            self.downcast_iter()
+                .map(|iter| {
+                    iter.into_iter()
+                        .map(|opt_v| opt_v.copied().map(date32_to_date))
+                })
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 
     /// Extract month from underlying NaiveDate representation.

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -12,10 +12,13 @@ impl DatetimeChunked {
             TimeUnit::Nanoseconds => timestamp_ns_to_datetime,
             TimeUnit::Milliseconds => timestamp_ms_to_datetime,
         };
-        self.downcast_iter()
-            .map(move |iter| iter.into_iter().map(move |opt_v| opt_v.copied().map(func)))
-            .flatten()
-            .trust_my_length(self.len())
+        // we know the iterators len
+        unsafe {
+            self.downcast_iter()
+                .map(move |iter| iter.into_iter().map(move |opt_v| opt_v.copied().map(func)))
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 
     pub fn time_unit(&self) -> TimeUnit {

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -13,13 +13,16 @@ pub(crate) fn time_to_time64ns(time: &NaiveTime) -> i64 {
 
 impl TimeChunked {
     pub fn as_time_iter(&self) -> impl Iterator<Item = Option<NaiveTime>> + TrustedLen + '_ {
-        self.downcast_iter()
-            .map(|iter| {
-                iter.into_iter()
-                    .map(|opt_v| opt_v.copied().map(time64ns_to_time))
-            })
-            .flatten()
-            .trust_my_length(self.len())
+        // we know the iterators len
+        unsafe {
+            self.downcast_iter()
+                .map(|iter| {
+                    iter.into_iter()
+                        .map(|opt_v| opt_v.copied().map(time64ns_to_time))
+                })
+                .flatten()
+                .trust_my_length(self.len())
+        }
     }
 
     /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -325,14 +325,11 @@ impl FromParallelIterator<bool> for BooleanChunked {
 
         let capacity: usize = get_capacity_from_par_results(&vectors);
 
-        // 2021-02-07: this was ~70% faster than with the builder, even with the extra Option<T> added.
-        let arr = BooleanArray::from_iter(
-            vectors
-                .into_iter()
-                .flatten()
-                .trust_my_length(capacity)
-                .map(Some),
-        );
+        let arr = unsafe {
+            BooleanArray::from_trusted_len_values_iter(
+                vectors.into_iter().flatten().trust_my_length(capacity),
+            )
+        };
         Self::new_from_chunks("", vec![Arc::new(arr)])
     }
 }

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -71,9 +71,12 @@ where
                             // so we join with the last: the biggest
                             let item = tuples.last().map(|_| rhs_idx - 1);
 
-                            let iter = std::iter::repeat(item)
-                                .take(remaining)
-                                .trust_my_length(remaining);
+                            // we know the iterators len
+                            let iter = unsafe {
+                                std::iter::repeat(item)
+                                    .take(remaining)
+                                    .trust_my_length(remaining)
+                            };
                             tuples.extend_trusted_len(iter);
 
                             return Ok(tuples);

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -39,11 +39,15 @@ where
     });
 
     let len = hash_tbl.len();
-    hash_tbl
-        .into_iter()
-        .map(|(_k, tpl)| tpl)
-        .trust_my_length(len)
-        .collect_trusted()
+
+    //  we know that iterators length
+    unsafe {
+        hash_tbl
+            .into_iter()
+            .map(|(_k, tpl)| tpl)
+            .trust_my_length(len)
+            .collect_trusted()
+    }
 }
 
 /// Determine group tuples over different threads. The hash of the key is used to determine the partitions.
@@ -105,11 +109,14 @@ where
                 offset += len;
             }
             let len = hash_tbl.len();
-            hash_tbl
-                .into_iter()
-                .map(|(_k, v)| v)
-                .trust_my_length(len)
-                .collect_trusted::<Vec<_>>()
+            //  we know that iterators length
+            unsafe {
+                hash_tbl
+                    .into_iter()
+                    .map(|(_k, v)| v)
+                    .trust_my_length(len)
+                    .collect_trusted::<Vec<_>>()
+            }
         })
     })
     .flatten()

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -611,22 +611,28 @@ where
             let keys_a = splitted_a
                 .iter()
                 .map(|ca| {
-                    ca.downcast_iter()
-                        .map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                        .flatten()
-                        .trust_my_length(ca.len())
-                        .collect_trusted::<Vec<_>>()
+                    // we know that we only iterate over length == self.len()
+                    unsafe {
+                        ca.downcast_iter()
+                            .map(|v| v.into_iter().map(|v| v.copied().as_u64()))
+                            .flatten()
+                            .trust_my_length(ca.len())
+                            .collect_trusted::<Vec<_>>()
+                    }
                 })
                 .collect::<Vec<_>>();
 
             let keys_b = splitted_b
                 .iter()
                 .map(|ca| {
-                    ca.downcast_iter()
-                        .map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                        .flatten()
-                        .trust_my_length(ca.len())
-                        .collect_trusted::<Vec<_>>()
+                    // we know that we only iterate over length == self.len()
+                    unsafe {
+                        ca.downcast_iter()
+                            .map(|v| v.into_iter().map(|v| v.copied().as_u64()))
+                            .flatten()
+                            .trust_my_length(ca.len())
+                            .collect_trusted::<Vec<_>>()
+                    }
                 })
                 .collect::<Vec<_>>();
             hash_join_tuples_left(keys_a, keys_b)

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1337,7 +1337,7 @@ impl DataFrame {
     /// ```
     pub fn take_iter<I>(&self, iter: I) -> Result<Self>
     where
-        I: Iterator<Item = usize> + Clone + Sync,
+        I: Iterator<Item = usize> + Clone + Sync + TrustedLen,
     {
         let new_col = POOL.install(|| {
             self.columns
@@ -1358,7 +1358,7 @@ impl DataFrame {
     /// This doesn't do any bound checking but checks null validity.
     pub unsafe fn take_iter_unchecked<I>(&self, mut iter: I) -> Self
     where
-        I: Iterator<Item = usize> + Clone + Sync,
+        I: Iterator<Item = usize> + Clone + Sync + TrustedLen,
     {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
             let idx_ca: NoNull<UInt32Chunked> = iter.into_iter().map(|idx| idx as u32).collect();
@@ -1407,7 +1407,7 @@ impl DataFrame {
     /// Null validity is checked
     pub unsafe fn take_opt_iter_unchecked<I>(&self, mut iter: I) -> Self
     where
-        I: Iterator<Item = Option<usize>> + Clone + Sync,
+        I: Iterator<Item = Option<usize>> + Clone + Sync + TrustedLen,
     {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
             let idx_ca: UInt32Chunked = iter.into_iter().map(|opt| opt.map(|v| v as u32)).collect();

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -15,6 +15,7 @@ mod series_trait;
 pub mod unstable;
 
 use crate::chunked_array::ops::rolling_window::RollingOptions;
+use crate::frame::groupby::GroupTuples;
 #[cfg(feature = "rank")]
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "groupby_list")]
@@ -760,6 +761,19 @@ impl Series {
             }
         };
         Ok(out)
+    }
+
+    /// Take the group tuples.
+    ///
+    /// # Safety
+    /// Group tuples have to be in bounds.
+    pub unsafe fn take_group_values(&self, groups: &GroupTuples) -> Series {
+        self.take_iter_unchecked(
+            &mut groups
+                .iter()
+                .map(|g| g.1.iter().map(|idx| *idx as usize))
+                .flatten(),
+        )
     }
 }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -766,13 +766,15 @@ impl Series {
     /// Take the group tuples.
     ///
     /// # Safety
-    /// Group tuples have to be in bounds.
+    /// - Group tuples have to be in bounds.
     pub unsafe fn take_group_values(&self, groups: &GroupTuples) -> Series {
+        let len = groups.iter().map(|g| g.1.len()).sum::<usize>();
         self.take_iter_unchecked(
             &mut groups
                 .iter()
                 .map(|g| g.1.iter().map(|idx| *idx as usize))
-                .flatten(),
+                .flatten()
+                .trust_my_length(len),
         )
     }
 }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -509,7 +509,8 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// This doesn't check any bounds.
+    /// - This doesn't check any bounds.
+    /// - Iterator must be TrustedLen
     unsafe fn take_iter_unchecked(&self, _iter: &mut dyn TakeIterator) -> Series {
         invalid_operation_panic!(self)
     }
@@ -526,7 +527,8 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     ///
-    /// This doesn't check any bounds.
+    /// - This doesn't check any bounds.
+    /// - Iterator must be TrustedLen
     unsafe fn take_opt_iter_unchecked(&self, _iter: &mut dyn TakeIteratorNulls) -> Series {
         invalid_operation_panic!(self)
     }

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -264,29 +264,31 @@ pub fn datetime(
         }
         let millisecond = millisecond.u32()?;
 
-        let ca: Int64Chunked = year
-            .into_iter()
-            .zip(month.into_iter())
-            .zip(day.into_iter())
-            .zip(hour.into_iter())
-            .zip(minute.into_iter())
-            .zip(second.into_iter())
-            .zip(millisecond.into_iter())
-            .map(|((((((y, m), d), h), mnt), s), ms)| {
-                if let (Some(y), Some(m), Some(d), Some(h), Some(mnt), Some(s), Some(ms)) =
-                    (y, m, d, h, mnt, s, ms)
-                {
-                    Some(
-                        NaiveDate::from_ymd(y, m, d)
-                            .and_hms_milli(h, mnt, s, ms)
-                            .timestamp_millis(),
-                    )
-                } else {
-                    None
-                }
-            })
-            .trust_my_length(max_len)
-            .collect_trusted();
+        // safety: we know the iterators len
+        let ca: Int64Chunked = unsafe {
+            year.into_iter()
+                .zip(month.into_iter())
+                .zip(day.into_iter())
+                .zip(hour.into_iter())
+                .zip(minute.into_iter())
+                .zip(second.into_iter())
+                .zip(millisecond.into_iter())
+                .map(|((((((y, m), d), h), mnt), s), ms)| {
+                    if let (Some(y), Some(m), Some(d), Some(h), Some(mnt), Some(s), Some(ms)) =
+                        (y, m, d, h, mnt, s, ms)
+                    {
+                        Some(
+                            NaiveDate::from_ymd(y, m, d)
+                                .and_hms_milli(h, mnt, s, ms)
+                                .timestamp_millis(),
+                        )
+                    } else {
+                        None
+                    }
+                })
+                .trust_my_length(max_len)
+                .collect_trusted()
+        };
 
         Ok(ca.into_datetime(TimeUnit::Milliseconds, None).into_series())
     }) as Arc<dyn SeriesUdf>);

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -70,23 +70,23 @@ impl PhysicalAggregation for AggregationExpr {
 
         match self.agg_type {
             GroupByMethod::Min => {
-                let agg_s = ac.flat().into_owned().agg_min(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_min(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Max => {
-                let agg_s = ac.flat().into_owned().agg_max(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_max(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Median => {
-                let agg_s = ac.flat().into_owned().agg_median(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_median(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Mean => {
-                let agg_s = ac.flat().into_owned().agg_mean(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_mean(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Sum => {
-                let agg_s = ac.flat().into_owned().agg_sum(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_sum(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Count => {
@@ -96,17 +96,17 @@ impl PhysicalAggregation for AggregationExpr {
                 Ok(Some(ca.into_inner().into_series()))
             }
             GroupByMethod::First => {
-                let mut agg_s = ac.flat().into_owned().agg_first(ac.groups());
+                let mut agg_s = ac.flat_naive().into_owned().agg_first(ac.groups());
                 agg_s.rename(&new_name);
                 Ok(Some(agg_s))
             }
             GroupByMethod::Last => {
-                let mut agg_s = ac.flat().into_owned().agg_last(ac.groups());
+                let mut agg_s = ac.flat_naive().into_owned().agg_last(ac.groups());
                 agg_s.rename(&new_name);
                 Ok(Some(agg_s))
             }
             GroupByMethod::NUnique => {
-                let opt_agg = ac.flat().into_owned().agg_n_unique(ac.groups());
+                let opt_agg = ac.flat_naive().into_owned().agg_n_unique(ac.groups());
                 let opt_agg = opt_agg.map(|mut agg| {
                     agg.rename(&new_name);
                     agg.into_series()
@@ -131,11 +131,11 @@ impl PhysicalAggregation for AggregationExpr {
                 Ok(Some(column.into_series()))
             }
             GroupByMethod::Std => {
-                let agg_s = ac.flat().into_owned().agg_std(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_std(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Var => {
-                let agg_s = ac.flat().into_owned().agg_var(ac.groups());
+                let agg_s = ac.flat_naive().into_owned().agg_var(ac.groups());
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Quantile(_, _) => {

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -188,7 +188,11 @@ impl PhysicalExpr for BinaryExpr {
             // Both are or a flat series or aggregated into a list
             // so we can flatten the Series and apply the operators
             _ => {
-                let out = apply_operator(ac_l.flat().as_ref(), ac_r.flat().as_ref(), self.op)?;
+                let out = apply_operator(
+                    ac_l.flat_naive().as_ref(),
+                    ac_r.flat_naive().as_ref(),
+                    self.op,
+                )?;
                 ac_l.combine_groups(ac_r).with_series(out, false);
                 Ok(ac_l)
             }

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -65,7 +65,7 @@ impl PhysicalExpr for CastExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
-        let s = ac.flat();
+        let s = ac.flat_naive();
         let s = self.finish(s.as_ref())?;
         ac.with_series(s, false);
         Ok(ac)

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -37,7 +37,7 @@ impl PhysicalExpr for FilterExpr {
         let mut ac_s = self.input.evaluate_on_groups(df, groups, state)?;
         let ac_predicate = self.by.evaluate_on_groups(df, groups, state)?;
         let groups = ac_s.groups();
-        let predicate_s = ac_predicate.flat();
+        let predicate_s = ac_predicate.flat_naive();
         let predicate = predicate_s.bool()?;
 
         let groups = POOL.install(|| {

--- a/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
@@ -35,7 +35,7 @@ impl PhysicalExpr for IsNotNullExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
-        let s = ac.flat();
+        let s = ac.flat_naive();
         let s = s.is_not_null().into_series();
         ac.with_series(s, false);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
@@ -35,7 +35,7 @@ impl PhysicalExpr for IsNullExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
-        let s = ac.flat();
+        let s = ac.flat_naive();
         let s = s.is_null().into_series();
         ac.with_series(s, false);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/not.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/not.rs
@@ -38,7 +38,7 @@ impl PhysicalExpr for NotExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.0.evaluate_on_groups(df, groups, state)?;
-        let s = ac.flat().into_owned();
+        let s = ac.flat_naive().into_owned();
         ac.with_series(self.finish(s)?, false);
 
         Ok(ac)

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -38,7 +38,7 @@ impl PhysicalExpr for SortExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
-        let series = ac.flat().into_owned();
+        let series = ac.flat_naive().into_owned();
 
         let groups = ac
             .groups()

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -78,7 +78,7 @@ impl PhysicalExpr for SortByExpr {
 
         let groups = if self.by.len() == 1 {
             let mut ac_sort_by = self.by[0].evaluate_on_groups(df, groups, state)?;
-            let sort_by_s = ac_sort_by.flat().into_owned();
+            let sort_by_s = ac_sort_by.flat_naive().into_owned();
             let groups = ac_sort_by.groups();
 
             groups
@@ -112,7 +112,7 @@ impl PhysicalExpr for SortByExpr {
                 .collect::<Result<Vec<_>>>()?;
             let sort_by_s = ac_sort_by
                 .iter()
-                .map(|s| s.flat().into_owned())
+                .map(|s| s.flat_naive().into_owned())
                 .collect::<Vec<_>>();
             let groups = ac_sort_by[0].groups();
 

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -48,7 +48,7 @@ impl PhysicalExpr for TernaryExpr {
         let mut ac_truthy = ac_truthy?;
         let mut ac_falsy = ac_falsy?;
 
-        let mask_s = ac_mask.flat();
+        let mask_s = ac_mask.flat_naive();
 
         assert!(
             !(mask_s.len() != required_height),
@@ -182,7 +182,9 @@ The predicate produced {} values. Where the original DataFrame has {} values",
             // so we can flatten the Series an apply the operators
             _ => {
                 let mask = mask_s.bool()?;
-                let out = ac_truthy.flat().zip_with(mask, ac_falsy.flat().as_ref())?;
+                let out = ac_truthy
+                    .flat_naive()
+                    .zip_with(mask, ac_falsy.flat_naive().as_ref())?;
 
                 assert!(!(out.len() != required_height), "The output of the `when -> then -> otherwise-expr` is of a different length than the groups.\
 The expr produced {} values. Where the original DataFrame has {} values",

--- a/polars/polars-lazy/src/physical_plan/expressions/unique.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/unique.rs
@@ -27,7 +27,7 @@ impl PhysicalExpr for UniqueExpr {
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
-        let series = ac.flat().into_owned();
+        let series = ac.flat_naive().into_owned();
 
         let groups = ac
             .groups

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -2507,13 +2507,20 @@ fn test_parquet_exec() -> Result<()> {
 fn test_is_in() -> Result<()> {
     let df = fruits_cars();
 
-    // TODO! fix this
-    // // this will be executed by apply (still incorrect)
-    // let out = df
-    //     .lazy()
-    //     .groupby_stable([col("fruits")])
-    //     .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))))])
-    //     .collect()?;
+    // // this will be executed by apply
+    let out = df
+        .clone()
+        .lazy()
+        .groupby_stable([col("fruits")])
+        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))))])
+        .collect()?;
+    let out = out.column("cars").unwrap();
+    let out = out.explode()?;
+    let out = out.bool().unwrap();
+    assert_eq!(
+        Vec::from(out),
+        &[Some(true), Some(false), Some(true), Some(true), Some(true)]
+    );
 
     // this will be executed by map
     let out = df

--- a/py-polars/src/apply/mod.rs
+++ b/py-polars/src/apply/mod.rs
@@ -28,20 +28,23 @@ fn iterator_to_primitive<T>(
 where
     T: PyArrowPrimitiveType,
 {
-    let mut ca: ChunkedArray<T> = if init_null_count > 0 {
-        (0..init_null_count)
-            .map(|_| None)
-            .chain(std::iter::once(first_value))
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else if first_value.is_some() {
-        std::iter::once(first_value)
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else {
-        it.collect()
+    // safety: we know the iterators len
+    let mut ca: ChunkedArray<T> = unsafe {
+        if init_null_count > 0 {
+            (0..init_null_count)
+                .map(|_| None)
+                .chain(std::iter::once(first_value))
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else if first_value.is_some() {
+            std::iter::once(first_value)
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else {
+            it.collect()
+        }
     };
     debug_assert_eq!(ca.len(), capacity);
     ca.rename(name);
@@ -55,20 +58,23 @@ fn iterator_to_bool(
     name: &str,
     capacity: usize,
 ) -> ChunkedArray<BooleanType> {
-    let mut ca: BooleanChunked = if init_null_count > 0 {
-        (0..init_null_count)
-            .map(|_| None)
-            .chain(std::iter::once(first_value))
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else if first_value.is_some() {
-        std::iter::once(first_value)
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else {
-        it.collect()
+    // safety: we know the iterators len
+    let mut ca: BooleanChunked = unsafe {
+        if init_null_count > 0 {
+            (0..init_null_count)
+                .map(|_| None)
+                .chain(std::iter::once(first_value))
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else if first_value.is_some() {
+            std::iter::once(first_value)
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else {
+            it.collect()
+        }
     };
     debug_assert_eq!(ca.len(), capacity);
     ca.rename(name);
@@ -82,20 +88,23 @@ fn iterator_to_object(
     name: &str,
     capacity: usize,
 ) -> ObjectChunked<ObjectValue> {
-    let mut ca: ObjectChunked<ObjectValue> = if init_null_count > 0 {
-        (0..init_null_count)
-            .map(|_| None)
-            .chain(std::iter::once(first_value))
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else if first_value.is_some() {
-        std::iter::once(first_value)
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else {
-        it.collect()
+    // safety: we know the iterators len
+    let mut ca: ObjectChunked<ObjectValue> = unsafe {
+        if init_null_count > 0 {
+            (0..init_null_count)
+                .map(|_| None)
+                .chain(std::iter::once(first_value))
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else if first_value.is_some() {
+            std::iter::once(first_value)
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else {
+            it.collect()
+        }
     };
     debug_assert_eq!(ca.len(), capacity);
     ca.rename(name);
@@ -109,20 +118,23 @@ fn iterator_to_utf8<'a>(
     name: &str,
     capacity: usize,
 ) -> Utf8Chunked {
-    let mut ca: Utf8Chunked = if init_null_count > 0 {
-        (0..init_null_count)
-            .map(|_| None)
-            .chain(std::iter::once(first_value))
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else if first_value.is_some() {
-        std::iter::once(first_value)
-            .chain(it)
-            .trust_my_length(capacity)
-            .collect()
-    } else {
-        it.collect()
+    // safety: we know the iterators len
+    let mut ca: Utf8Chunked = unsafe {
+        if init_null_count > 0 {
+            (0..init_null_count)
+                .map(|_| None)
+                .chain(std::iter::once(first_value))
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else if first_value.is_some() {
+            std::iter::once(first_value)
+                .chain(it)
+                .trust_my_length(capacity)
+                .collect_trusted()
+        } else {
+            it.collect()
+        }
     };
     debug_assert_eq!(ca.len(), capacity);
     ca.rename(name);

--- a/py-polars/src/list_construction.rs
+++ b/py-polars/src/list_construction.rs
@@ -16,17 +16,21 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &PyAny) -> PyResult<Series
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
                 let (sub_seq, len) = get_pyseq(sub_seq)?;
-                let iter = sub_seq
-                    .iter()?
-                    .map(|v| {
-                        let v = v.unwrap();
-                        if v.is_none() {
-                            None
-                        } else {
-                            Some(v.extract::<i64>().unwrap())
-                        }
-                    })
-                    .trust_my_length(len);
+
+                // safety: we know the iterators len
+                let iter = unsafe {
+                    sub_seq
+                        .iter()?
+                        .map(|v| {
+                            let v = v.unwrap();
+                            if v.is_none() {
+                                None
+                            } else {
+                                Some(v.extract::<i64>().unwrap())
+                            }
+                        })
+                        .trust_my_length(len)
+                };
                 builder.append_iter(iter)
             }
             builder.finish().into_series()
@@ -37,17 +41,20 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &PyAny) -> PyResult<Series
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
                 let (sub_seq, len) = get_pyseq(sub_seq)?;
-                let iter = sub_seq
-                    .iter()?
-                    .map(|v| {
-                        let v = v.unwrap();
-                        if v.is_none() {
-                            None
-                        } else {
-                            Some(v.extract::<f64>().unwrap())
-                        }
-                    })
-                    .trust_my_length(len);
+                // safety: we know the iterators len
+                let iter = unsafe {
+                    sub_seq
+                        .iter()?
+                        .map(|v| {
+                            let v = v.unwrap();
+                            if v.is_none() {
+                                None
+                            } else {
+                                Some(v.extract::<f64>().unwrap())
+                            }
+                        })
+                        .trust_my_length(len)
+                };
                 builder.append_iter(iter)
             }
             builder.finish().into_series()
@@ -57,17 +64,20 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &PyAny) -> PyResult<Series
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
                 let (sub_seq, len) = get_pyseq(sub_seq)?;
-                let iter = sub_seq
-                    .iter()?
-                    .map(|v| {
-                        let v = v.unwrap();
-                        if v.is_none() {
-                            None
-                        } else {
-                            Some(v.extract::<bool>().unwrap())
-                        }
-                    })
-                    .trust_my_length(len);
+                // safety: we know the iterators len
+                let iter = unsafe {
+                    sub_seq
+                        .iter()?
+                        .map(|v| {
+                            let v = v.unwrap();
+                            if v.is_none() {
+                                None
+                            } else {
+                                Some(v.extract::<bool>().unwrap())
+                            }
+                        })
+                        .trust_my_length(len)
+                };
                 builder.append_iter(iter)
             }
             builder.finish().into_series()
@@ -77,17 +87,20 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &PyAny) -> PyResult<Series
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
                 let (sub_seq, len) = get_pyseq(sub_seq)?;
-                let iter = sub_seq
-                    .iter()?
-                    .map(|v| {
-                        let v = v.unwrap();
-                        if v.is_none() {
-                            None
-                        } else {
-                            Some(v.extract::<&str>().unwrap())
-                        }
-                    })
-                    .trust_my_length(len);
+                // safety: we know the iterators len
+                let iter = unsafe {
+                    sub_seq
+                        .iter()?
+                        .map(|v| {
+                            let v = v.unwrap();
+                            if v.is_none() {
+                                None
+                            } else {
+                                Some(v.extract::<&str>().unwrap())
+                            }
+                        })
+                        .trust_my_length(len)
+                };
                 builder.append_iter(iter)
             }
             builder.finish().into_series()


### PR DESCRIPTION
This adds a lot of `unsafe` code. We can remove a lot of them by implementing `TrustedLen` for those iterators.