### PR TITLE
ensure we always work on groups in the groupby context

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -15,7 +15,6 @@ mod series_trait;
 pub mod unstable;
 
 use crate::chunked_array::ops::rolling_window::RollingOptions;
-use crate::frame::groupby::GroupTuples;
 #[cfg(feature = "rank")]
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "groupby_list")]
@@ -761,21 +760,6 @@ impl Series {
             }
         };
         Ok(out)
-    }
-
-    /// Take the group tuples.
-    ///
-    /// # Safety
-    /// - Group tuples have to be in bounds.
-    pub unsafe fn take_group_values(&self, groups: &GroupTuples) -> Series {
-        let len = groups.iter().map(|g| g.1.len()).sum::<usize>();
-        self.take_iter_unchecked(
-            &mut groups
-                .iter()
-                .map(|g| g.1.iter().map(|idx| *idx as usize))
-                .flatten()
-                .trust_my_length(len),
-        )
     }
 }
 


### PR DESCRIPTION
Consistency crisis averted. 