### PR TITLE
feat(js): readstream and parquet

### DIFF
--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -73,6 +73,7 @@ features = [
   "horizontal_concat",
   "dataframe_arithmetic",
   "string_encoding",
+  "parquet"
 ]
 path = "../polars"
 

--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -73,7 +73,7 @@ features = [
   "horizontal_concat",
   "dataframe_arithmetic",
   "string_encoding",
-  "parquet"
+  "parquet",
 ]
 path = "../polars"
 

--- a/nodejs-polars/__tests__/expr.test.ts
+++ b/nodejs-polars/__tests__/expr.test.ts
@@ -1559,7 +1559,7 @@ describe("expr.str", () => {
     expect(actual).toFrameEqual(expected);
     expect(seriesActual).toFrameEqual(expected);
   });
-  test.only("base64 decode", () => {
+  test("base64 decode", () => {
     const _df = pl.DataFrame({"strings": ["666f6f", "626172", null]});
     console.log(_df.select(col("strings").str.decode("hex")));
     const df = pl.DataFrame({

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -1,5 +1,6 @@
 import pl from "@polars";
 import path from "path";
+import {Stream} from "stream";
 // eslint-disable-next-line no-undef
 const csvpath = path.resolve(__dirname, "../../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv");
 // eslint-disable-next-line no-undef
@@ -83,5 +84,24 @@ describe("scan", () => {
       expect(df.shape).toStrictEqual({height: 4, width: 4});
     });
     it.todo("can read from a stream");
+  });
+});
+
+describe("stream", () => {
+  test.only("readCSV", async () => {
+    const readStream = new Stream.Readable({read(){}});
+    readStream.push(`a,b\n`);
+    readStream.push(`1,2\n`);
+    readStream.push(`2,2\n`);
+    readStream.push(`3,2\n`);
+    readStream.push(`4,2\n`);
+    readStream.push(null);
+    const expected = pl.DataFrame({
+      a: pl.Series("a", [1n, 2n, 3n, 4n], pl.Int64),
+      b: pl.Series("b", [2n, 2n, 2n, 2n], pl.Int64)
+    });
+    const df = await pl.readCSVStream(readStream);
+    expect(df).toFrameEqual(expected);
+
   });
 });

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -1114,6 +1114,7 @@ export interface DataFrame {
    */
   toJSON(options?: WriteJsonOptions): string
   toJSON(destination: string | Writable, options?: WriteJsonOptions): void
+  toParquet(destination: string, compression: "uncompressed" | "snappy" | "gzip" | "lzo" | "brotli" | "lz4" | "zstd"): void
   toSeries(index: number): Series<any>
   toString(): string
   /**
@@ -1619,6 +1620,9 @@ export const dfWrapper = (_df: JsDataFrame): DataFrame => {
         // toJSON(writeStream, options)
         return writeToStreamOrString(arg0, "json", options);
       }
+    },
+    toParquet(path, compression) {
+      return unwrap("writeParquet", {path, compression});
     },
     toSeries: (index) => seriesWrapper(unwrap("select_at_idx", {index})),
     toString: () => noArgUnwrap<any>("as_str")().toString(),

--- a/nodejs-polars/polars/datatypes.ts
+++ b/nodejs-polars/polars/datatypes.ts
@@ -63,7 +63,7 @@ export type ReadCsvOptions = {
   commentChar?: string;
   encoding?: "utf8" | "utf8-lossy";
   endRows?: number;
-  hasHeader: boolean;
+  hasHeader?: boolean;
   ignoreErrors?: boolean;
   inferSchemaLength?: number;
   lowMemory?: boolean;
@@ -80,6 +80,14 @@ export type ReadJsonOptions = {
   inferSchemaLength?: number;
   batchSize?: number;
 };
+
+export type ReadParquetOptions = {
+  columns?: string[];
+  projection?: number[];
+  numRows?: number;
+  parallel?: boolean;
+  rechunk?: boolean;
+}
 export type JoinBaseOptions = {
   how?: "left" | "inner" | "outer" | "cross";
   suffix?: string;

--- a/nodejs-polars/polars/index.ts
+++ b/nodejs-polars/polars/index.ts
@@ -54,6 +54,9 @@ namespace pl {
   export import readParquet = io.readParquet;
   export import readJSON = io.readJSON;
 
+  export import readCSVStream = io.readCSVStream;
+  export import readJSONStream = io.readJSONStream;
+
   // lazy
   export import col = lazy.col
   export import cols = lazy.cols

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -1,4 +1,4 @@
-import { ReadCsvOptions, ReadJsonOptions } from "./datatypes";
+import { ReadCsvOptions, ReadJsonOptions, ReadParquetOptions } from "./datatypes";
 import pli from "./internals/polars_internal";
 import {DataFrame, dfWrapper} from "./dataframe";
 import { isPath } from "./utils";
@@ -154,7 +154,11 @@ export function scanCSV(arg: Partial<ReadCsvOptions> | string, options?: any): L
 
   return LazyDataFrame(pli.ldf.scanCSV(options));
 }
-export function readParquet() {}
+
+export function readParquet(path: string, options?: ReadParquetOptions): DataFrame {
+  return dfWrapper(pli.df.readParquet({path, ...options}));
+}
+
 export function scanParquet() {}
 export function readIPC() {}
 export function scanIPC() {}
@@ -204,9 +208,9 @@ class LineBatcher extends Stream.Transform {
 /**
  * __Read a stream into a Dataframe.__
  *
- * **Warning:** this is almost always slower than `scanCSV` or `readCSV`
+ * **Warning:** this is much slower than `scanCSV` or `readCSV`
  *
- * Only use it when you must consume from a stream, or when performance is not important
+ * Only use it when you must consume from a stream, or when performance is not a major consideration
  * ___
  * @param stream - readable stream containing csv data
  * @param options
@@ -294,9 +298,8 @@ export function readCSVStream(stream: Readable, options?: ReadCsvOptions): Promi
 }
 
 /**
- * __Read a JSON stream into a DataFrame.__
+ * __Read a newline delimited JSON stream into a DataFrame.__
  *
- * _Note: Currently only newline delimited JSON is supported_
  * @param stream - readable stream containing json data
  * @param options
  * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -210,7 +210,9 @@ class LineBatcher extends Stream.Transform {
  *
  * **Warning:** this is much slower than `scanCSV` or `readCSV`
  *
+ * This will consume the entire stream into a single buffer and then call `readCSV`
  * Only use it when you must consume from a stream, or when performance is not a major consideration
+ *
  * ___
  * @param stream - readable stream containing csv data
  * @param options

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -3,10 +3,12 @@ import pli from "./internals/polars_internal";
 import {DataFrame, dfWrapper} from "./dataframe";
 import { isPath } from "./utils";
 import {LazyDataFrame} from "./lazy/dataframe";
+import {Readable, Stream} from "stream";
+import {concat} from "./functions";
 
 const readCsvDefaultOptions: Partial<ReadCsvOptions> = {
-  inferSchemaLength: 10,
-  batchSize: 10,
+  inferSchemaLength: 50,
+  batchSize: 1000,
   ignoreErrors: true,
   hasHeader: true,
   sep: ",",
@@ -18,8 +20,8 @@ const readCsvDefaultOptions: Partial<ReadCsvOptions> = {
 };
 
 const readJsonDefaultOptions: Partial<ReadJsonOptions> = {
-  batchSize: 1000,
-  inferSchemaLength: 10
+  batchSize: 10000,
+  inferSchemaLength: 50
 };
 
 function readCSVBuffer(buff, options) {
@@ -157,3 +159,199 @@ export function scanParquet() {}
 export function readIPC() {}
 export function scanIPC() {}
 export function scanJSON() {}
+
+// utility to read streams as lines.
+class LineBatcher extends Stream.Transform {
+
+  #lines: Buffer[];
+  #accumulatedLines: number;
+  #batchSize: number;
+
+  constructor(options) {
+    super(options);
+    this.#lines = [];
+    this.#accumulatedLines = 0;
+    this.#batchSize = (options && options.batchSize) || 1000;
+  }
+
+  _transform(chunk, _encoding, done) {
+
+    var begin = 0;
+    for (var i = 0; i < chunk.length; i++) {
+      if (chunk[i] === 10) { // '\n'
+        this.#accumulatedLines++;
+        if (this.#accumulatedLines == this.#batchSize) {
+          this.#lines.push(chunk.slice(begin, i + 1));
+          this.push(Buffer.concat(this.#lines));
+          this.#lines = [];
+          this.#accumulatedLines = 0;
+          begin = i + 1;
+        }
+      }
+    }
+
+    this.#lines.push(chunk.slice(begin));
+
+    done();
+  }
+  _flush(done) {
+    this.push(Buffer.concat(this.#lines));
+
+    done();
+  }
+}
+
+/**
+ * __Read a stream into a Dataframe.__
+ *
+ * **Warning:** this is almost always slower than `scanCSV` or `readCSV`
+ *
+ * Only use it when you must consume from a stream, or when performance is not important
+ * ___
+ * @param stream - readable stream containing csv data
+ * @param options
+ * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+ *     If set to `null`, a full table scan will be done (slow).
+ * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+ * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
+ *     `x` being an enumeration over every column in the dataset.
+ * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
+ * @param options.endRows -After n rows are read from the CSV, it stops reading.
+ *     During multi-threaded parsing, an upper bound of `n` rows
+ *     cannot be guaranteed.
+ * @param options.startRows -Start reading after `startRows` position.
+ * @param options.projection -Indices of columns to select. Note that column indices start at zero.
+ * @param options.sep -Character to use as delimiter in the file.
+ * @param options.columns -Columns to select.
+ * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
+ * @param options.encoding -Allowed encodings: `utf8`, `utf8-lossy`. Lossy means that invalid utf8 values are replaced with `�` character.
+ * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
+ * @param options.dtype -Overwrite the dtypes during inference.
+ * @param options.lowMemory - Reduce memory usage in expense of performance.
+ * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+ * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
+ * @param options.nullValues - Values to interpret as null values. You can provide a
+ *     - `string` -> all values encountered equal to this string will be null
+ *     - `Array<string>` -> A null value per column.
+ *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
+ * @param options.parseDates -Whether to attempt to parse dates or not
+ * @returns Promise<DataFrame>
+ *
+ * @example
+ * ```
+ * >>> const readStream = new Stream.Readable({read(){}});
+ * >>> readStream.push(`a,b\n`);
+ * >>> readStream.push(`1,2\n`);
+ * >>> readStream.push(`2,2\n`);
+ * >>> readStream.push(`3,2\n`);
+ * >>> readStream.push(`4,2\n`);
+ * >>> readStream.push(null);
+ *
+ * >>> pl.readCSVStream(readStream).then(df => console.log(df));
+ * shape: (4, 2)
+ * ┌─────┬─────┐
+ * │ a   ┆ b   │
+ * │ --- ┆ --- │
+ * │ i64 ┆ i64 │
+ * ╞═════╪═════╡
+ * │ 1   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 2   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 3   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 4   ┆ 2   │
+ * └─────┴─────┘
+ * ```
+ */
+export function readCSVStream(stream: Readable, options?: ReadCsvOptions): Promise<DataFrame>  {
+  let batchSize = options?.batchSize ?? 100000;
+  let count = 0;
+  let end = options?.endRows ?? Number.POSITIVE_INFINITY;
+
+  return new Promise((resolve, reject) => {
+    const s = stream.pipe(new LineBatcher({batchSize}));
+    const chunks: any[] = [];
+
+    s.on("data", (chunk) => {
+      // early abort if 'end rows' is specified
+      if (count <= end) {
+        chunks.push(chunk);
+      } else {
+        s.end();
+      }
+      count += batchSize;
+    }).on("end", () => {
+      try {
+        let buff = Buffer.concat(chunks);
+        const df = readCSVBuffer(buff, options);
+        resolve(df);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+/**
+ * __Read a JSON stream into a DataFrame.__
+ *
+ * _Note: Currently only newline delimited JSON is supported_
+ * @param stream - readable stream containing json data
+ * @param options
+ * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+ *    If set to `null`, a full table scan will be done (slow).
+ *    Note: this is done per batch
+ * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+ * @example
+ * ```
+ * >>> const readStream = new Stream.Readable({read(){}});
+ * >>> readStream.push(`${JSON.stringify({a: 1, b: 2})} \n`);
+ * >>> readStream.push(`${JSON.stringify({a: 2, b: 2})} \n`);
+ * >>> readStream.push(`${JSON.stringify({a: 3, b: 2})} \n`);
+ * >>> readStream.push(`${JSON.stringify({a: 4, b: 2})} \n`);
+ * >>> readStream.push(null);
+ *
+ * >>> pl.readJSONStream(readStream).then(df => console.log(df));
+ * shape: (4, 2)
+ * ┌─────┬─────┐
+ * │ a   ┆ b   │
+ * │ --- ┆ --- │
+ * │ i64 ┆ i64 │
+ * ╞═════╪═════╡
+ * │ 1   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 2   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 3   ┆ 2   │
+ * ├╌╌╌╌╌┼╌╌╌╌╌┤
+ * │ 4   ┆ 2   │
+ * └─────┴─────┘
+ * ```
+ */
+export function readJSONStream(stream: Readable, options?: ReadJsonOptions): Promise<DataFrame>  {
+  let batchSize = options?.batchSize ?? 100000;
+
+  return new Promise((resolve, reject) => {
+    const chunks: any[] = [];
+
+    stream.pipe(new LineBatcher({batchSize}))
+      .on("data", (chunk) => {
+        try {
+          const df = readJSONBuffer(chunk, options);
+          chunks.push(df);
+        } catch(err) {
+          reject(err);
+        }
+      })
+      .on("end", () => {
+        try {
+          const df = concat(chunks);
+          resolve(df);
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+  });
+}

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -8,7 +8,7 @@ import {concat} from "./functions";
 
 const readCsvDefaultOptions: Partial<ReadCsvOptions> = {
   inferSchemaLength: 50,
-  batchSize: 1000,
+  batchSize: 10000,
   ignoreErrors: true,
   hasHeader: true,
   sep: ",",
@@ -175,7 +175,7 @@ class LineBatcher extends Stream.Transform {
     super(options);
     this.#lines = [];
     this.#accumulatedLines = 0;
-    this.#batchSize = (options && options.batchSize) || 1000;
+    this.#batchSize = options.batchSize;
   }
 
   _transform(chunk, _encoding, done) {
@@ -271,7 +271,7 @@ class LineBatcher extends Stream.Transform {
  * ```
  */
 export function readCSVStream(stream: Readable, options?: ReadCsvOptions): Promise<DataFrame>  {
-  let batchSize = options?.batchSize ?? 100000;
+  let batchSize = options?.batchSize ?? 10000;
   let count = 0;
   let end = options?.endRows ?? Number.POSITIVE_INFINITY;
 
@@ -335,12 +335,13 @@ export function readCSVStream(stream: Readable, options?: ReadCsvOptions): Promi
  * ```
  */
 export function readJSONStream(stream: Readable, options?: ReadJsonOptions): Promise<DataFrame>  {
-  let batchSize = options?.batchSize ?? 100000;
+  let batchSize = options?.batchSize ?? 10000;
 
   return new Promise((resolve, reject) => {
     const chunks: any[] = [];
 
-    stream.pipe(new LineBatcher({batchSize}))
+    stream
+      .pipe(new LineBatcher({batchSize}))
       .on("data", (chunk) => {
         try {
           const df = readJSONBuffer(chunk, options);

--- a/nodejs-polars/src/dataframe/mod.rs
+++ b/nodejs-polars/src/dataframe/mod.rs
@@ -97,7 +97,8 @@ impl JsDataFrame {
             napi::Property::new(env, "readCSVPath")?.with_method(io::read_csv_path),
             napi::Property::new(env, "readJSONBuffer")?.with_method(io::read_json_buffer),
             napi::Property::new(env, "readJSONPath")?.with_method(io::read_json_path),
-            napi::Property::new(env, "read_parquet")?.with_method(io::read_parquet),
+            napi::Property::new(env, "readParquet")?.with_method(io::read_parquet),
+            napi::Property::new(env, "writeParquet")?.with_method(io::write_parquet_path),
             napi::Property::new(env, "read_rows")?.with_method(io::read_rows),
         ])?;
         Ok(df_obj)


### PR DESCRIPTION
add a read option for reading from streams. While this can be slower, it is a useful utility when you do not have full control of the read source. It also opens up the possibilites for many more read sources, such as http, or any other read stream, which is a core component in node. 

```js
// using `readCSVStream` to read from a fetch response
const df = await fetch("https://some/csv/on/a/remote/server.csv")
  .then(res => res.body)
  .then(body => pl.readCSVStream(body));
```

since the functionality is so much different than the normal `read` implementations (one returns `DataFrame` the other `Promise<DataFrame>`, I thought it would make the most sense to have it as a separate method. 

I thought this would be confusing

```js
const df = pl.readCSV(buff)
const df = await pl.readCSV(stream)
```
this makes it more clear that `read<format>Stream`  is async while `read<format>` is sync
```js
const df = pl.readCSV(buff)
const df = await pl.readCSVStream(stream)
```

also adds limited read/write parquet functionality
