### PR TITLE
window function cache

### DIFF
--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -186,8 +186,6 @@
 //! }
 //! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#[cfg(all(feature = "datafusion", feature = "compile"))]
-mod datafusion;
 #[cfg(all(feature = "dot_diagram", feature = "compile"))]
 mod dot;
 #[cfg(feature = "compile")]

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -30,23 +30,108 @@ fn set_n_rows(n_rows: Option<usize>) -> Option<usize> {
     }
 }
 
+fn execute_projection_cached_window_fns(
+    df: &DataFrame,
+    exprs: &[Arc<dyn PhysicalExpr>],
+    state: &ExecutionState,
+) -> Result<Vec<Series>> {
+    // We partition by normal expression and window expression
+    // - the normal expressions can run in parallel
+    // - the window expression take more memory and often use the same groupby keys and join tuples
+    //   so they are cached and run sequential
+
+    // the partitioning messes with column order, so we also store the idx
+    // and use those to restore the original projection order
+    #[allow(clippy::type_complexity)]
+    let mut windows: Vec<(String, Vec<(u32, Arc<dyn PhysicalExpr>)>)> = vec![];
+    let mut other = Vec::with_capacity(exprs.len());
+
+    // first we partition the window function by the values they group over.
+    // the groupby values should be cached
+    let mut index = 0u32;
+    exprs.iter().for_each(|phys| {
+        index += 1;
+        let e = phys.as_expression();
+
+        let mut is_window = false;
+        for e in e.into_iter() {
+            if let Expr::Window { partition_by, .. } = e {
+                let groupby = format!("{:?}", partition_by.as_slice());
+                // *windows.entry(groupby).or_insert(0) += 1;
+                if let Some(tpl) = windows.iter_mut().find(|tpl| tpl.0 == groupby) {
+                    tpl.1.push((index, phys.clone()))
+                } else {
+                    windows.push((groupby, vec![(index, phys.clone())]))
+                }
+                is_window = true;
+                break;
+            }
+        }
+        if !is_window {
+            other.push((index, phys))
+        }
+    });
+
+    let mut selected_columns = POOL.install(|| {
+        other
+            .par_iter()
+            .map(|(idx, expr)| expr.evaluate(df, state).map(|s| (*idx, s)))
+            .collect::<Result<Vec<_>>>()
+    })?;
+
+    for partition in windows {
+        // clear the cache for every partitioned group
+        let mut state = state.clone();
+        state.clear_expr_cache();
+
+        // don't bother caching if we only have a single window function in this partition
+        if partition.1.len() == 1 {
+            state.cache_window = false;
+        } else {
+            state.cache_window = true;
+        }
+
+        for (index, e) in partition.1 {
+            let s = e.evaluate(df, &state)?;
+            selected_columns.push((index, s));
+        }
+    }
+
+    selected_columns.sort_unstable_by_key(|tpl| tpl.0);
+    let selected_columns = selected_columns.into_iter().map(|tpl| tpl.1).collect();
+    Ok(selected_columns)
+}
+
 pub(crate) fn evaluate_physical_expressions(
     df: &DataFrame,
     exprs: &[Arc<dyn PhysicalExpr>],
     state: &ExecutionState,
+    has_windows: bool,
 ) -> Result<DataFrame> {
     let zero_length = df.height() == 0;
-    let mut selected_columns = POOL.install(|| {
-        exprs
-            .par_iter()
-            .map(|expr| expr.evaluate(df, state))
-            .collect::<Result<Vec<Series>>>()
-    })?;
+    let selected_columns = if has_windows {
+        execute_projection_cached_window_fns(df, exprs, state)?
+    } else {
+        POOL.install(|| {
+            exprs
+                .par_iter()
+                .map(|expr| expr.evaluate(df, state))
+                .collect::<Result<_>>()
+        })?
+    };
+
+    check_expand_literals(selected_columns, zero_length)
+}
+
+fn check_expand_literals(
+    mut selected_columns: Vec<Series>,
+    zero_length: bool,
+) -> Result<DataFrame> {
     let first_len = selected_columns[0].len();
     let mut df_height = 0;
     let mut all_equal_len = true;
     {
-        let mut names = PlHashSet::with_capacity(exprs.len());
+        let mut names = PlHashSet::with_capacity(selected_columns.len());
         for s in &selected_columns {
             let len = s.len();
             df_height = std::cmp::max(df_height, len);

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -8,6 +8,7 @@ use polars_core::prelude::*;
 pub struct ProjectionExec {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) expr: Vec<Arc<dyn PhysicalExpr>>,
+    pub(crate) has_windows: bool,
     #[cfg(test)]
     pub(crate) schema: SchemaRef,
 }
@@ -16,7 +17,7 @@ impl Executor for ProjectionExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let df = self.input.execute(state)?;
 
-        let df = evaluate_physical_expressions(&df, &self.expr, state);
+        let df = evaluate_physical_expressions(&df, &self.expr, state, self.has_windows);
 
         // this only runs during testing and check if the runtime type matches the predicted schema
         #[cfg(test)]

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -249,23 +249,10 @@ impl Executor for CsvExec {
 
 /// Producer of an in memory DataFrame
 pub struct DataFrameExec {
-    df: Arc<DataFrame>,
-    projection: Option<Vec<Arc<dyn PhysicalExpr>>>,
-    selection: Option<Arc<dyn PhysicalExpr>>,
-}
-
-impl DataFrameExec {
-    pub(crate) fn new(
-        df: Arc<DataFrame>,
-        projection: Option<Vec<Arc<dyn PhysicalExpr>>>,
-        selection: Option<Arc<dyn PhysicalExpr>>,
-    ) -> Self {
-        DataFrameExec {
-            df,
-            projection,
-            selection,
-        }
-    }
+    pub(crate) df: Arc<DataFrame>,
+    pub(crate) projection: Option<Vec<Arc<dyn PhysicalExpr>>>,
+    pub(crate) selection: Option<Arc<dyn PhysicalExpr>>,
+    pub(crate) has_windows: bool,
 }
 
 impl Executor for DataFrameExec {
@@ -276,7 +263,7 @@ impl Executor for DataFrameExec {
         // projection should be before selection as those are free
         // TODO: this is only the case if we don't create new columns
         if let Some(projection) = &self.projection {
-            df = evaluate_physical_expressions(&df, projection, state)?;
+            df = evaluate_physical_expressions(&df, projection, state, self.has_windows)?;
         }
 
         if let Some(selection) = &self.selection {

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -1,17 +1,13 @@
+use crate::physical_plan::executors::execute_projection_cached_window_fns;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
 use polars_core::{prelude::*, POOL};
 use rayon::prelude::*;
 
 pub struct StackExec {
-    input: Box<dyn Executor>,
-    expr: Vec<Arc<dyn PhysicalExpr>>,
-}
-
-impl StackExec {
-    pub(crate) fn new(input: Box<dyn Executor>, expr: Vec<Arc<dyn PhysicalExpr>>) -> Self {
-        Self { input, expr }
-    }
+    pub(crate) input: Box<dyn Executor>,
+    pub(crate) has_windows: bool,
+    pub(crate) expr: Vec<Arc<dyn PhysicalExpr>>,
 }
 
 impl Executor for StackExec {
@@ -19,21 +15,25 @@ impl Executor for StackExec {
         let mut df = self.input.execute(state)?;
         let height = df.height();
 
-        let res = POOL.install(|| {
-            self.expr
-                .par_iter()
-                .map(|expr| {
-                    expr.evaluate(&df, state).map(|series| {
-                        // literal series. Should be whole column size
-                        if series.len() == 1 && height > 1 {
-                            series.expand_at_index(0, height)
-                        } else {
-                            series
-                        }
+        let res = if self.has_windows {
+            execute_projection_cached_window_fns(&df, &self.expr, state)?
+        } else {
+            POOL.install(|| {
+                self.expr
+                    .par_iter()
+                    .map(|expr| {
+                        expr.evaluate(&df, state).map(|series| {
+                            // literal series. Should be whole column size
+                            if series.len() == 1 && height > 1 {
+                                series.expand_at_index(0, height)
+                            } else {
+                                series
+                            }
+                        })
                     })
-                })
-                .collect::<Result<Vec<_>>>()
-        })?;
+                    .collect::<Result<Vec<_>>>()
+            })?
+        };
 
         for s in res {
             df.with_column(s)?;

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -16,6 +16,7 @@ pub struct ExecutionState {
     /// Used by Window Expression to prevent redundant joins
     pub(crate) join_tuples: JoinTuplesCache,
     pub(crate) verbose: bool,
+    pub(crate) cache_window: bool,
 }
 
 impl ExecutionState {
@@ -25,6 +26,7 @@ impl ExecutionState {
             group_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
             join_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
             verbose: std::env::var("POLARS_VERBOSE").is_ok(),
+            cache_window: true,
         }
     }
 

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -731,7 +731,6 @@ fn test_lazy_window_functions() {
         Vec::from(out.select_at_idx(1).unwrap().i32().unwrap()),
         correct
     );
-    dbg!(out);
 }
 
 #[test]

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -64,6 +64,10 @@ where
     arena.iter(current_node).any(|(_node, e)| matches(e))
 }
 
+pub(crate) fn has_window_aexpr(current_node: Node, arena: &Arena<AExpr>) -> bool {
+    has_aexpr(current_node, arena, |e| matches!(e, AExpr::Window { .. }))
+}
+
 /// Can check if an expression tree has a matching_expr. This
 /// requires a dummy expression to be created that will be used to patter match against.
 pub(crate) fn has_expr<F>(current_expr: &Expr, matches: F) -> bool
@@ -87,6 +91,8 @@ pub(crate) fn has_wildcard(current_expr: &Expr) -> bool {
 pub(crate) fn output_name(expr: &Expr) -> Result<Arc<str>> {
     for e in expr {
         match e {
+            // don't follow the partition by branch
+            Expr::Window { function, .. } => return output_name(function),
             Expr::Column(name) => return Ok(name.clone()),
             Expr::Alias(_, name) => return Ok(name.clone()),
             _ => {}


### PR DESCRIPTION
Window functions are magic for a `groupby` operation followed by a `join` operation.

These intermediate data structure can be quite large. This PR make sure that we run the window functions sequential so that we don't have multiple data structures in RAM at once. I expect this to not be much slower as the `groupby` and the `join` both already use all available threads.

Besides running sequential, the window functions are now being partitioned on the the `over` columns. The needed data structures with a partition are cached and reused.

We could still decide to parallelize over partitions instead of over window functions themselves.

@universalmind303 this might solve the memory issues you encountered lately when dealing with multiple window functions.