### PR TITLE
List builder for arbitrary nested types

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -18,5 +18,5 @@ thiserror = "^1.0"
 
 [features]
 strings = []
-compute = ["arrow/compute_cast"]
+compute = ["arrow/compute_cast", "arrow/compute_concatenate"]
 parquet = ["arrow/io_parquet", "arrow/io_parquet_compression"]

--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -1,0 +1,67 @@
+use arrow::array::{Array, ListArray};
+use arrow::bitmap::MutableBitmap;
+use arrow::compute::concatenate;
+use arrow::error::Result;
+
+pub struct AnonymousBuilder<'a> {
+    arrays: Vec<&'a dyn Array>,
+    offsets: Vec<i64>,
+    validity: Option<MutableBitmap>,
+    size: i64,
+}
+
+impl<'a> AnonymousBuilder<'a> {
+    pub fn new(size: usize) -> Self {
+        let mut offsets = Vec::with_capacity(size + 1);
+        offsets.push(0i64);
+        Self {
+            arrays: Vec::with_capacity(size),
+            offsets,
+            validity: None,
+            size: 0,
+        }
+    }
+    #[inline]
+    fn last_offset(&self) -> i64 {
+        *self.offsets.last().unwrap()
+    }
+
+    pub fn push(&mut self, arr: &'a dyn Array) {
+        self.size += arr.len() as i64;
+        self.offsets.push(self.size);
+        self.arrays.push(arr);
+
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
+        }
+    }
+    pub fn push_null(&mut self) {
+        self.offsets.push(self.last_offset());
+        match &mut self.validity {
+            Some(validity) => validity.push(false),
+            None => self.init_validity(),
+        }
+    }
+
+    fn init_validity(&mut self) {
+        let len = self.offsets.len() - 1;
+
+        let mut validity = MutableBitmap::with_capacity(self.offsets.capacity());
+        validity.extend_constant(len, true);
+        validity.set(len - 1, false);
+        self.validity = Some(validity)
+    }
+
+    pub fn finish(self) -> Result<ListArray<i64>> {
+        let inner_dtype = self.arrays[0].data_type();
+        let values = concatenate::concatenate(&self.arrays)?;
+
+        let dtype = ListArray::<i64>::default_datatype(inner_dtype.clone());
+        Ok(ListArray::<i64>::from_data(
+            dtype,
+            self.offsets.into(),
+            values.into(),
+            self.validity.map(|validity| validity.into()),
+        ))
+    }
+}

--- a/polars/polars-arrow/src/array/mod.rs
+++ b/polars/polars-arrow/src/array/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use crate::utils::CustomIterTools;
 
 pub mod default_arrays;
+pub mod list;
 
 pub trait ValueSize {
     /// Useful for a Utf8 or a List to get underlying value size.

--- a/polars/polars-core/src/chunked_array/builder/mod.rs
+++ b/polars/polars-core/src/chunked_array/builder/mod.rs
@@ -1,6 +1,6 @@
 mod boolean;
 mod from;
-mod list;
+pub mod list;
 mod primitive;
 mod utf8;
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -149,6 +149,18 @@ def sequence_to_pyseries(
             nested_value = _get_first_non_none(value)
             nested_dtype = type(nested_value) if value is not None else float
 
+            # recursively call Series constructor
+            if nested_dtype == list:
+                return sequence_to_pyseries(
+                    name=name,
+                    values=[
+                        sequence_to_pyseries(name, seq, dtype=None, strict=strict)
+                        for seq in values
+                    ],
+                    dtype=None,
+                    strict=strict,
+                )
+
             # logs will show a panic if we infer wrong dtype
             # and its hard to error from rust side
             # to reduce the likelihood of this happening
@@ -184,6 +196,8 @@ def sequence_to_pyseries(
 
         elif dtype_ == pli.Series:
             return PySeries.new_series_list(name, [v.inner() for v in values], strict)
+        elif dtype_ == PySeries:
+            return PySeries.new_series_list(name, values, strict)
 
         else:
             constructor = py_type_to_constructor(dtype_)


### PR DESCRIPTION
This allows arbitrarily deep nested list construction:

```python
pl.Series("a", [[[[1, 2, 3]]], [[[1, 2]]]])
```

```
shape: (2,)
Series: 'a' [list]
[
	[[[1, 2, 3]]]
	[[[1, 2]]]
]
```


@jorgecarleitao the changes in `polars-arrow` show that its now done by storing the `dyn Array` in a `Vec` and later concatenating them. 

I have been thinking about a solution that has an untyped `MutableArray` trait that accepts pushing `dyn Array` from the same dtype. Or maybe one that's typed `u8`, similar to how an allocator only needs to know how many bytes + alignment. Any thoughts?