### PR TITLE
auto resize fmt, and min widths for column headers

### DIFF
--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -1853,7 +1853,7 @@ describe("meta", () => {
 │ --- │
 │ f64 │
 ╞═════╡
-│ 1   │
+│ 1.0 │
 └─────┘`;
     const actualInspect = df[Symbol.for("nodejs.util.inspect.custom")]();
     const dfString = df.toString();

--- a/nodejs-polars/__tests__/series.test.ts
+++ b/nodejs-polars/__tests__/series.test.ts
@@ -556,7 +556,7 @@ describe("series", () => {
   ${"concat"}        | ${pl.Series([1]).concat(pl.Series([2, 3]))}          | ${pl.Series([1, 2, 3])}
   ${"cumMax"}        | ${pl.Series([3, 2, 4]).cumMax()}                     | ${pl.Series([3, 3, 4])}
   ${"cumMin"}        | ${pl.Series([3, 2, 4]).cumMin()}                     | ${pl.Series([3, 2, 2])}
-  ${"cumProd"}       | ${pl.Series("", [1, 2, 3], pl.Int32).cumProd()}      | ${pl.Series("", [1, 2, 6], pl.Int32)}
+  ${"cumProd"}       | ${pl.Series("", [1, 2, 3], pl.Int32).cumProd()}      | ${pl.Series("", [1n, 2n, 6n], pl.Int64)}
   ${"cumSum"}        | ${pl.Series("", [1, 2, 3], pl.Int32).cumSum()}       | ${pl.Series("", [1, 3, 6], pl.Int32)}
   ${"diff"}          | ${pl.Series([1, 2, 12]).diff(1, "drop").toJS()}      | ${pl.Series([1, 10]).toJS()}
   ${"diff"}          | ${pl.Series([1, 11]).diff(1, "ignore")}              | ${pl.Series("", [null, 10], pl.Float64, false)}
@@ -631,7 +631,7 @@ describe("series", () => {
   ${"toFrame"}       | ${pl.Series("foo", [1, 2, 3]).toFrame().toJSON()}    | ${pl.DataFrame([pl.Series("foo", [1, 2, 3])]).toJSON()}
   ${"shiftAndFill"}  | ${pl.Series("foo", [1, 2, 3]).shiftAndFill(1, 99)}   | ${pl.Series("foo", [99, 1, 2])}
   `("$# $name: expected matches actual ", ({expected, actual}) => {
-    expect(expected).toStrictEqual(actual);
+    expect(actual).toStrictEqual(expected);
   });
   it("set: expected matches actual", () => {
     const expected = pl.Series([99, 2, 3]);
@@ -783,10 +783,10 @@ describe("comparators & math", () => {
 });
 describe("series proxy & metadata", () => {
   test("toString & inspect", () => {
-    const s = pl.Series("foo", [1, 2, 3]);
+    const s = pl.Series("foo", [1, 2, 3], pl.Int16);
     const sString = s.toString();
     const inspectString = s[Symbol.for("nodejs.util.inspect.custom")]();
-    const expected = "shape: (3,)\nSeries: 'foo' [f64]\n[\n\t1\n\t2\n\t3\n]";
+    const expected = "shape: (3,)\nSeries: 'foo' [i16]\n[\n\t1\n\t2\n\t3\n]";
     expect(sString).toStrictEqual(expected);
     expect(inspectString).toStrictEqual(expected);
   });

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -139,7 +139,7 @@ ahash = "0.7"
 anyhow = "1.0"
 
 base64 = { version = "0.13", optional = true }
-comfy-table = { version = "4.0", optional = true }
+comfy-table = { version = "5.0", optional = true }
 hashbrown = { version = "0.11", features = ["rayon"] }
 hex = { version = "0.4", optional = true }
 jsonpath_lib = { version = "0.3.0", optional = true, git = "https://github.com/ritchie46/jsonpath", branch = "improve_compiled" }

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -391,7 +391,7 @@ impl Display for DataFrame {
         }
         if reduce_columns {
             names.push("...".into());
-            
+
             #[cfg(feature = "pretty_fmt")]
             constraints.push(tbl_lb(5));
         }
@@ -414,8 +414,7 @@ impl Display for DataFrame {
             table
                 
                 .load_preset(preset)
-                .set_content_arrangement(ContentArrangement::Dynamic)
-                .force_no_tty();
+                .set_content_arrangement(ContentArrangement::Dynamic);
 
             let mut rows = Vec::with_capacity(max_n_rows);
             if self.height() > max_n_rows {

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -412,7 +412,6 @@ impl Display for DataFrame {
             };
 
             table
-                
                 .load_preset(preset)
                 .set_content_arrangement(ContentArrangement::Dynamic);
 

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -401,20 +401,15 @@ impl Display for DataFrame {
             for field in fields[0..n_first].iter() {
                 let (s, l) = field_to_str(field);
                 names.push(s);
-    
-                #[cfg(feature = "pretty_fmt")]
                 constraints.push(tbl_lower_bounds(l));
             }
             if reduce_columns {
                 names.push("...".into());
-    
-                #[cfg(feature = "pretty_fmt")]
                 constraints.push(tbl_lower_bounds(5));
             }
             for field in fields[self.width() - n_last..].iter() {
                 let (s, l) = field_to_str(field);
                 names.push(s);
-    
                 constraints.push(tbl_lower_bounds(l));
             }
             let mut table = Table::new();

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -370,6 +370,9 @@ impl Display for DataFrame {
             let s = format!("{}\n---\n{}", name, f.data_type());
             (s, lower_bounds)
         };
+        let tbl_lb = |l: usize| comfy_table::ColumnConstraint::LowerBoundary(
+            comfy_table::Width::Fixed(l as u16),
+        );
 
         let mut names = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
         let mut constraints = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
@@ -377,22 +380,16 @@ impl Display for DataFrame {
         let fields = schema.fields();
         for field in fields[0..n_first].iter() {
             let (s, l) = field_to_str(field);
-            constraints.push(comfy_table::ColumnConstraint::LowerBoundary(
-                comfy_table::Width::Fixed(l as u16),
-            ));
+            constraints.push(tbl_lb(l));
             names.push(s);
         }
         if reduce_columns {
             names.push("...".into());
-            constraints.push(comfy_table::ColumnConstraint::Absolute(
-                comfy_table::Width::Fixed(5u16),
-            ));
+            constraints.push(tbl_lb(5));
         }
         for field in fields[self.width() - n_last..].iter() {
             let (s, l) = field_to_str(field);
-            constraints.push(comfy_table::ColumnConstraint::LowerBoundary(
-                comfy_table::Width::Fixed(l as u16),
-            ));
+            constraints.push(tbl_lb(l));
             names.push(s);
         }
         #[cfg(feature = "pretty_fmt")]
@@ -461,12 +458,7 @@ impl Display for DataFrame {
         #[cfg(all(feature = "plain_fmt", not(feature = "pretty_fmt")))]
         {
             let mut table = Table::new();
-            table.set_titles(Row::new(
-                names
-                    .into_iter()
-                    .map(|s| Cell::new(&s).add_attribute(Attr::Bold))
-                    .collect(),
-            ));
+            table.set_titles(Row::new(names.into_iter().map(|s| Cell::new(&s)).collect()));
             let mut rows = Vec::with_capacity(max_n_rows);
             if self.height() > max_n_rows {
                 for i in 0..(max_n_rows / 2) {

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -365,33 +365,34 @@ impl Display for DataFrame {
             (self.width(), 0)
         };
         let reduce_columns = n_first + n_last < self.width();
-        let field_to_str = |f: &Field| {
-            let name = make_str_val(f.name());
-            let lower_bounds = std::cmp::max(5, std::cmp::min(12, name.len()));
-            let s = format!("{}\n---\n{}", name, f.data_type());
-            (s, lower_bounds)
-        };
+
         let mut names = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
 
         #[cfg(not(feature = "pretty_fmt"))]
+        let field_to_str = |f: &Field| format!("{}\n---\n{}", f.name(), f.data_type());
+
         {
             let schema = self.schema();
             let fields = schema.fields();
             for field in fields[0..n_first].iter() {
-                let (s, _) = field_to_str(field);
-                names.push(s);
+                names.push(field_to_str(field));
             }
             if reduce_columns {
                 names.push("...".into());
             }
             for field in fields[self.width() - n_last..].iter() {
-                let (s, _) = field_to_str(field);
-                names.push(s);
+                names.push(field_to_str(field));
             }
         }
 
         #[cfg(feature = "pretty_fmt")]
         {
+            let field_to_str = |f: &Field| {
+                let name = make_str_val(f.name());
+                let lower_bounds = std::cmp::max(5, std::cmp::min(12, name.len()));
+                let s = format!("{}\n---\n{}", name, f.data_type());
+                (s, lower_bounds)
+            };
             let tbl_lower_bounds = |l: usize| {
                 comfy_table::ColumnConstraint::LowerBoundary(comfy_table::Width::Fixed(l as u16))
             };

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -370,9 +370,9 @@ impl Display for DataFrame {
             let s = format!("{}\n---\n{}", name, f.data_type());
             (s, lower_bounds)
         };
-        let tbl_lb = |l: usize| comfy_table::ColumnConstraint::LowerBoundary(
-            comfy_table::Width::Fixed(l as u16),
-        );
+        let tbl_lb = |l: usize| {
+            comfy_table::ColumnConstraint::LowerBoundary(comfy_table::Width::Fixed(l as u16))
+        };
 
         let mut names = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
         let mut constraints = Vec::with_capacity(n_first + n_last + reduce_columns as usize);

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -369,9 +369,8 @@ impl Display for DataFrame {
         let mut names = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
 
         #[cfg(not(feature = "pretty_fmt"))]
-        let field_to_str = |f: &Field| format!("{}\n---\n{}", f.name(), f.data_type());
-
         {
+            let field_to_str = |f: &Field| format!("{}\n---\n{}", f.name(), f.data_type());
             let schema = self.schema();
             let fields = schema.fields();
             for field in fields[0..n_first].iter() {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e95a3e867422fd8d04049041f5671f94d53c32a9dcd82e2be268714942f3f3"
+checksum = "c42350b81f044f576ff88ac750419f914abb46a03831bb1747134344ee7a4e64"
 dependencies = [
  "crossterm",
  "strum",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
@@ -1615,15 +1615,15 @@ checksum = "a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -54,16 +54,23 @@ def test_tables(environ: None) -> None:
 
 
 def test_tbl_width_chars(environ: None) -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
-    pl.Config.set_tbl_width_chars(100)
-    assert max(len(line) for line in str(df).split("\n")) == 19
+    df = pl.DataFrame({
+        "a really long col": [1, 2, 3],
+        "b": ["", "this is a string value that will be truncated", None],
+        "this is 10": [4, 5, 6],
+    })
 
-    pl.Config.set_tbl_width_chars(15)
-    assert max(len(line) for line in str(df).split("\n")) == 15
+    assert max(len(line) for line in str(df).split("\n")) == 72
 
-    # this will not squeezed below 13 characters, so 10 yields 13
-    pl.Config.set_tbl_width_chars(10)
-    assert max(len(line) for line in str(df).split("\n")) == 13
+    pl.Config.set_tbl_width_chars(60)
+    assert max(len(line) for line in str(df).split("\n")) == 60
+
+    # formula for determining min width is
+    # sum(max(min(header.len, 12), 5)) + header.len + 1
+    # so we end up with 12+5+10+4 = 31
+
+    pl.Config.set_tbl_width_chars(0)
+    assert max(len(line) for line in str(df).split("\n")) == 31
 
 
 def test_set_tbl_cols(environ: None) -> None:

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -54,11 +54,13 @@ def test_tables(environ: None) -> None:
 
 
 def test_tbl_width_chars(environ: None) -> None:
-    df = pl.DataFrame({
-        "a really long col": [1, 2, 3],
-        "b": ["", "this is a string value that will be truncated", None],
-        "this is 10": [4, 5, 6],
-    })
+    df = pl.DataFrame(
+        {
+            "a really long col": [1, 2, 3],
+            "b": ["", "this is a string value that will be truncated", None],
+            "this is 10": [4, 5, 6],
+        }
+    )
 
     assert max(len(line) for line in str(df).split("\n")) == 72
 


### PR DESCRIPTION
## Description

this adds in some additional logic to prevent the columns from getting squished if the header is shorter than the value. as mentioned in #2288. 

comfy-table will auto detect the width if you do not specify one. Now the width is only set if the user explicitly sets one, allowing comfy-table to detect it. 

if the terminal width is too small, it will still wrap though. We would likely have to add some logic into the `max_n_cols` to set a default based off of the terminal width. 


## Before 

### Terminal width > table width

<img width="938" alt="image" src="https://user-images.githubusercontent.com/21327470/148514590-20063a46-72ad-4e3c-a95d-9e4d1c8c6c6a.png">

### Terminal width < table width

<img width="786" alt="image" src="https://user-images.githubusercontent.com/21327470/148514854-22fe9cf3-b261-48c2-af08-f3cc2b55ae3b.png">


## After

### Terminal width > table width

<img width="926" alt="image" src="https://user-images.githubusercontent.com/21327470/148514686-00a25aff-b87c-4d81-8959-bae2256f1292.png">

### Terminal width < table width

<img width="773" alt="image" src="https://user-images.githubusercontent.com/21327470/148514997-4f811fc4-9a50-47fc-82e4-262ce899bae0.png">


