### PR TITLE
allow collection object types into a list

### DIFF
--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -2,7 +2,12 @@ use super::*;
 use polars_arrow::{array::list::AnonymousBuilder, prelude::*};
 
 pub trait ListBuilderTrait {
-    fn append_opt_series(&mut self, opt_s: Option<&Series>);
+    fn append_opt_series(&mut self, opt_s: Option<&Series>) {
+        match opt_s {
+            Some(s) => self.append_series(s),
+            None => self.append_null(),
+        }
+    }
     fn append_series(&mut self, s: &Series);
     fn append_null(&mut self);
     fn finish(&mut self) -> ListChunked;

--- a/polars/polars-core/src/chunked_array/object/extension/list.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/list.rs
@@ -1,0 +1,90 @@
+use crate::chunked_array::object::builder::ObjectChunkedBuilder;
+use crate::chunked_array::object::extension::create_extension;
+use crate::prelude::*;
+
+impl<T: PolarsObject> ObjectChunked<T> {
+    pub(crate) fn get_list_builder(
+        name: &str,
+        values_capacity: usize,
+        list_capacity: usize,
+    ) -> Box<dyn ListBuilderTrait> {
+        Box::new(ExtensionListBuilder::<T>::new(
+            name,
+            values_capacity,
+            list_capacity,
+        ))
+    }
+}
+
+struct ExtensionListBuilder<T: PolarsObject> {
+    values_builder: ObjectChunkedBuilder<T>,
+    offsets: Vec<i64>,
+    fast_explode: bool,
+}
+
+impl<T: PolarsObject> ExtensionListBuilder<T> {
+    pub(crate) fn new(name: &str, values_capacity: usize, list_capacity: usize) -> Self {
+        let mut offsets = Vec::with_capacity(list_capacity + 1);
+        offsets.push(0);
+        Self {
+            values_builder: ObjectChunkedBuilder::new(name, values_capacity),
+            offsets,
+            fast_explode: true,
+        }
+    }
+}
+
+impl<T: PolarsObject> ListBuilderTrait for ExtensionListBuilder<T> {
+    fn append_series(&mut self, s: &Series) {
+        let arr = s
+            .as_any()
+            .downcast_ref::<ObjectChunked<T>>()
+            .expect("series of type object");
+
+        for v in arr.into_iter() {
+            self.values_builder.append_option(v.cloned())
+        }
+        if arr.is_empty() {
+            self.fast_explode = false;
+        }
+        let len_so_far = self.offsets[self.offsets.len() - 1];
+        self.offsets.push(len_so_far + arr.len() as i64);
+    }
+
+    fn append_null(&mut self) {
+        self.values_builder.append_null();
+        let len_so_far = self.offsets[self.offsets.len() - 1];
+        self.offsets.push(len_so_far + 1);
+    }
+
+    fn finish(&mut self) -> ListChunked {
+        let values_builder = std::mem::take(&mut self.values_builder);
+        let offsets = std::mem::take(&mut self.offsets);
+        let ca = values_builder.finish();
+        let obj_arr = ca.downcast_chunks().get(0).unwrap().clone();
+
+        let mut pe = create_extension(obj_arr.into_iter_cloned());
+
+        // Safety:
+        // this is safe because we just created the PolarsExtension
+        // meaning that the sentinel is heap allocated and the dereference of the
+        // pointer does not fail
+        unsafe { pe.set_to_series_fn::<T>() };
+        let extension_array = Arc::new(pe.take_and_forget()) as ArrayRef;
+        let extension_dtype = extension_array.data_type();
+
+        let data_type = ListArray::<i64>::default_datatype(extension_dtype.clone());
+        let arr = Arc::new(ListArray::<i64>::from_data(
+            data_type,
+            offsets.into(),
+            extension_array,
+            None,
+        )) as ArrayRef;
+
+        let mut listarr = ListChunked::new_from_chunks(ca.name(), vec![arr]);
+        if self.fast_explode {
+            listarr.set_fast_explode()
+        }
+        listarr
+    }
+}

--- a/polars/polars-core/src/chunked_array/object/iterator.rs
+++ b/polars/polars-core/src/chunked_array/object/iterator.rs
@@ -1,5 +1,6 @@
 use crate::chunked_array::object::{ObjectArray, PolarsObject};
 use arrow::array::Array;
+use polars_arrow::trusted_len::TrustedLen;
 
 /// An iterator that returns Some(T) or None, that can be used on any ObjectArray
 // Note: This implementation is based on std's [Vec]s' [IntoIter].
@@ -101,6 +102,8 @@ impl<T: PolarsObject> OwnedObjectIter<T> {
         }
     }
 }
+
+unsafe impl<T: PolarsObject> TrustedLen for OwnedObjectIter<T> {}
 
 impl<T: PolarsObject> ObjectArray<T> {
     pub(crate) fn into_iter_cloned(self) -> OwnedObjectIter<T> {

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -283,6 +283,12 @@ where
                     s.dtype().clone(),
                 ),
             ),
+            #[cfg(feature = "object")]
+            DataType::Object(_) => {
+                let mut builder =
+                    s.get_list_builder("collected", capacity * estimated_s_size, capacity);
+                primitive_series_collect(nulls_so_far, it, s, &mut builder)
+            }
             _ => {
                 let mut builder = get_list_builder(
                     s.dtype(),

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -601,7 +601,7 @@ impl Display for AnyValue<'_> {
             }
             AnyValue::List(s) => write!(f, "{}", s.fmt_list()),
             #[cfg(feature = "object")]
-            AnyValue::Object(_) => write!(f, "object"),
+            AnyValue::Object(v) => write!(f, "{}", v),
         }
     }
 }

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -659,7 +659,7 @@ impl<T: PolarsObject> AggList for ObjectChunked<T> {
         // this is safe because we just created the PolarsExtension
         // meaning that the sentinel is heap allocated and the dereference of the
         // pointer does not fail
-        unsafe { pe.set_to_series_fn::<T>(self.name()) };
+        unsafe { pe.set_to_series_fn::<T>() };
         let extension_array = Arc::new(pe.take_and_forget()) as ArrayRef;
         let extension_dtype = extension_array.data_type();
 

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -307,7 +307,7 @@ impl Series {
                 // (the pid is checked before dereference)
                 let s = {
                     let pe = PolarsExtension::new(arr.clone());
-                    let s = pe.get_series();
+                    let s = pe.get_series(name);
                     pe.take_and_forget();
                     s
                 };

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -31,6 +31,15 @@ impl<T> PrivateSeries for SeriesWrap<ObjectChunked<T>>
 where
     T: PolarsObject,
 {
+    fn get_list_builder(
+        &self,
+        _name: &str,
+        _values_capacity: usize,
+        _list_capacity: usize,
+    ) -> Box<dyn ListBuilderTrait> {
+        ObjectChunked::<T>::get_list_builder(_name, _values_capacity, _list_capacity)
+    }
+
     fn _field(&self) -> Cow<Field> {
         Cow::Borrowed(self.0.ref_field())
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -54,6 +54,16 @@ pub(crate) mod private {
     }
 
     pub trait PrivateSeries {
+        #[cfg(feature = "object")]
+        fn get_list_builder(
+            &self,
+            _name: &str,
+            _values_capacity: usize,
+            _list_capacity: usize,
+        ) -> Box<dyn ListBuilderTrait> {
+            invalid_operation_panic!(self)
+        }
+
         /// Get field (used in schema)
         fn _field(&self) -> Cow<Field> {
             invalid_operation_panic!(self)

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -95,6 +95,7 @@ pub fn argsort_by<E: AsRef<[Expr]>>(by: E, reverse: &[bool]) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: false,
+            auto_explode: true,
         },
     }
 }
@@ -114,6 +115,7 @@ pub fn concat_str(s: Vec<Expr>, sep: &str) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
+            auto_explode: false,
         },
     }
 }
@@ -142,6 +144,7 @@ pub fn concat_lst(s: Vec<Expr>) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
+            auto_explode: true,
         },
     }
 }
@@ -304,6 +307,7 @@ pub fn datetime(
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
+            auto_explode: false,
         },
     }
     .alias("datetime")

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -77,9 +77,18 @@ pub struct AggregationContext<'a> {
     /// This is true when the Series and GroupTuples still have all
     /// their original values. Not the case when filtered
     original_len: bool,
+    all_unit_len: bool,
 }
 
 impl<'a> AggregationContext<'a> {
+    pub(crate) fn with_all_unit_len(&mut self, toggle: bool) {
+        self.all_unit_len = toggle
+    }
+
+    pub(crate) fn is_all_unit_len(&self) -> bool {
+        self.all_unit_len
+    }
+
     pub(crate) fn groups(&mut self) -> &Cow<'a, GroupTuples> {
         match self.update_groups {
             UpdateGroups::No => {}
@@ -202,6 +211,7 @@ impl<'a> AggregationContext<'a> {
             sorted: false,
             update_groups: UpdateGroups::No,
             original_len: true,
+            all_unit_len: false,
         }
     }
 
@@ -228,6 +238,7 @@ impl<'a> AggregationContext<'a> {
                 assert_eq!(series.len(), self.groups.len());
                 AggState::AggregatedList(series)
             }
+            (true, _) => AggState::AggregatedFlat(series),
             _ => {
                 // already aggregated to sum, min even this series was flattened it never could
                 // retrieve the length before grouping, so it stays  in this state.

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -639,6 +639,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -660,6 +661,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -681,6 +683,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -702,6 +705,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -723,6 +727,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -746,6 +751,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -767,6 +773,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -788,6 +795,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -809,6 +817,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -830,6 +839,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -855,6 +865,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -881,6 +892,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -914,6 +926,7 @@ impl DefaultPlanner {
                                     function,
                                     expr: node_to_exp(expression, expr_arena),
                                     collect_groups: ApplyOptions::ApplyFlat,
+                                    auto_explode: false,
                                 }))
                             }
                         }
@@ -961,6 +974,7 @@ impl DefaultPlanner {
                     function,
                     expr: node_to_exp(expression, expr_arena),
                     collect_groups: options.collect_groups,
+                    auto_explode: options.auto_explode,
                 }))
             }
             BinaryFunction {
@@ -1011,6 +1025,7 @@ impl DefaultPlanner {
                     function,
                     expr: node_to_exp(expression, expr_arena),
                     collect_groups: ApplyOptions::ApplyGroups,
+                    auto_explode: false,
                 }))
             }
             Duplicated(expr) => {
@@ -1024,6 +1039,7 @@ impl DefaultPlanner {
                     function,
                     expr: node_to_exp(expression, expr_arena),
                     collect_groups: ApplyOptions::ApplyGroups,
+                    auto_explode: false,
                 }))
             }
             IsUnique(expr) => {
@@ -1037,6 +1053,7 @@ impl DefaultPlanner {
                     function,
                     expr: node_to_exp(expression, expr_arena),
                     collect_groups: ApplyOptions::ApplyGroups,
+                    auto_explode: false,
                 }))
             }
             Explode(expr) => {
@@ -1050,6 +1067,7 @@ impl DefaultPlanner {
                     function,
                     expr: node_to_exp(expression, expr_arena),
                     collect_groups: ApplyOptions::ApplyFlat,
+                    auto_explode: false,
                 }))
             }
             Wildcard => panic!("should be no wildcard at this point"),

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -667,7 +667,7 @@ def map(
 
 def apply(
     exprs: List[Union[str, "pli.Expr"]],
-    f: Callable[[List["pli.Series"]], "pli.Series"],
+    f: Callable[[List["pli.Series"]], Union["pli.Series", Any]],
     return_dtype: Optional[Type[DataType]] = None,
 ) -> "pli.Expr":
     """

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -36,7 +36,7 @@ def test_apply_none() -> None:
 
     out = (
         df.groupby("g", maintain_order=True).agg(
-            pl.apply(exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], f=func).alias(  # type: ignore
+            pl.apply(exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], f=func).alias(
                 "multiple"
             )
         )
@@ -50,3 +50,18 @@ def test_apply_return_py_object() -> None:
     out = df.select([pl.all().map(lambda s: reduce(lambda a, b: a + b, s))])
 
     assert out.shape == (1, 2)
+
+
+def test_agg_objects() -> None:
+    df = pl.DataFrame(
+        {
+            "names": ["foo", "ham", "spam", "cheese", "egg", "foo"],
+            "dates": ["1", "1", "2", "3", "3", "4"],
+            "groups": ["A", "A", "B", "B", "B", "C"],
+        }
+    )
+
+    out = df.groupby("groups").agg(
+        [pl.apply([pl.col("dates"), pl.col("names")], lambda s: dict(zip(s[0], s[1])))]
+    )
+    assert out.dtypes == [pl.Utf8, pl.Object]


### PR DESCRIPTION
Inspired by https://stackoverflow.com/questions/70626081/groupby-aggregate-two-columns-into-a-dictionary-in-polars

Which is not really idiomatic polars, but is something we need to support. I made it possible to collect any object dtype in a list. This is needed to be able to use them in the aggregation context. To be able to do this we copy the python pointers into a `FixedSizeBinary` array and later copied again to a `Vec<PythonObject>`.

This is all quite slow, has redundant copies, but it works. And the slowness might nudge people in better directions. ;)

```python
data = pl.DataFrame(
    {
        "names": ["foo", "ham", "spam", "cheese", "egg", "foo"],
        "dates": ["1", "1", "2", "3", "3", "4"],
        "groups": ["A", "A", "B", "B", "B", "C"],
    }
)


(data
    .groupby("groups")
    .agg([
        pl.apply([pl.col("dates"), pl.col("names")], lambda s: dict(zip(s[0], s[1])))
    ])
)
```

```
shape: (3, 2)
┌────────┬───────────────────────────┐
│ groups ┆ dates                     │
│ ---    ┆ ---                       │
│ str    ┆ object                    │
╞════════╪═══════════════════════════╡
│ A      ┆ {'1': 'ham'}              │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ B      ┆ {'2': 'spam', '3': 'egg'} │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ C      ┆ {'4': 'foo'}              │
└────────┴───────────────────────────┘
```