### PR TITLE
Fix date_range w/ nominal (i.e. monthly) interval

### DIFF
--- a/polars/polars-time/src/calendar.rs
+++ b/polars/polars-time/src/calendar.rs
@@ -48,34 +48,34 @@ pub fn date_range(
 
     let mut t = start;
     let f = match tu {
-        TimeUnit::Nanoseconds => <Duration>::duration_ns,
-        TimeUnit::Milliseconds => <Duration>::duration_ms,
+        TimeUnit::Nanoseconds => <Duration>::add_ns,
+        TimeUnit::Milliseconds => <Duration>::add_ms,
     };
     match closed {
         ClosedWindow::Both => {
             while t <= stop {
                 ts.push(t);
-                t += f(&every)
+                t = f(&every, t)
             }
         }
         ClosedWindow::Left => {
             while t < stop {
                 ts.push(t);
-                t += f(&every)
+                t = f(&every, t)
             }
         }
         ClosedWindow::Right => {
-            t += f(&every);
+            t = f(&every, t);
             while t <= stop {
                 ts.push(t);
-                t += f(&every)
+                t = f(&every, t)
             }
         }
         ClosedWindow::None => {
-            t += f(&every);
+            t = f(&every, t);
             while t < stop {
                 ts.push(t);
-                t += f(&every)
+                t = f(&every, t)
             }
         }
     }

--- a/polars/polars-time/src/duration.rs
+++ b/polars/polars-time/src/duration.rs
@@ -170,12 +170,12 @@ impl Duration {
     /// Estimated duration of the window duration. Not a very good one if months != 0.
     #[inline]
     pub const fn duration_ns(&self) -> i64 {
-        self.months * 30 * 24 * 3600 * NS_SECOND + self.nsecs
+        self.months * 28 * 24 * 3600 * NS_SECOND + self.nsecs
     }
 
     #[inline]
     pub const fn duration_ms(&self) -> i64 {
-        self.months * 30 * 24 * 3600 * MILLISECONDS + self.nsecs / 1_000_000
+        self.months * 28 * 24 * 3600 * MILLISECONDS + self.nsecs / 1_000_000
     }
 
     #[inline]

--- a/polars/polars-time/src/test.rs
+++ b/polars/polars-time/src/test.rs
@@ -29,6 +29,27 @@ fn test_date_range() {
     assert_eq!(dates, expected);
 }
 
+#[test]
+fn test_feb_date_range() {
+    let start = NaiveDate::from_ymd(2022, 2, 1).and_hms(0, 0, 0);
+    let end = NaiveDate::from_ymd(2022, 3, 1).and_hms(0, 0, 0);
+    let dates = date_range(
+        start.timestamp_nanos(),
+        end.timestamp_nanos(),
+        Duration::parse("1mo"),
+        ClosedWindow::Both,
+        TimeUnit::Nanoseconds,
+    );
+    let expected = [
+        NaiveDate::from_ymd(2022, 2, 1),
+        NaiveDate::from_ymd(2022, 3, 1),
+    ]
+    .iter()
+    .map(|d| d.and_hms(0, 0, 0).timestamp_nanos())
+    .collect::<Vec<_>>();
+    assert_eq!(dates, expected);
+}
+
 fn print_ns(ts: &[i64]) {
     for ts in ts {
         println!("{}", timestamp_ns_to_datetime(*ts));

--- a/polars/polars-time/src/test.rs
+++ b/polars/polars-time/src/test.rs
@@ -5,6 +5,30 @@ use crate::window::Window;
 use chrono::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::timestamp_ns_to_datetime;
 
+#[test]
+fn test_date_range() {
+    // Test month as interval in date range
+    let start = NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0);
+    let end = NaiveDate::from_ymd(2022, 4, 1).and_hms(0, 0, 0);
+    let dates = date_range(
+        start.timestamp_nanos(),
+        end.timestamp_nanos(),
+        Duration::parse("1mo"),
+        ClosedWindow::Both,
+        TimeUnit::Nanoseconds,
+    );
+    let expected = [
+        NaiveDate::from_ymd(2022, 1, 1),
+        NaiveDate::from_ymd(2022, 2, 1),
+        NaiveDate::from_ymd(2022, 3, 1),
+        NaiveDate::from_ymd(2022, 4, 1),
+    ]
+    .iter()
+    .map(|d| d.and_hms(0, 0, 0).timestamp_nanos())
+    .collect::<Vec<_>>();
+    assert_eq!(dates, expected);
+}
+
 fn print_ns(ts: &[i64]) {
     for ts in ts {
         println!("{}", timestamp_ns_to_datetime(*ts));


### PR DESCRIPTION
Fixes #2331 by using some already implemented functionality that takes the current element of the date range into account when finding the next element, instead of adding a fixed amount.
I also made `duration_ns` and `duration_ms` a lower bound instead of just an "estimate". I thought that was more useful and it fixed one case of `date_range`: a monthly interval between February 1st and March 1st. This is a sneaky change, but I think it could be useful since it provides an additional guarantee about the estimate (and the tests still pass).