### PR TITLE
[LAZY] slice pushdown 

### DIFF
--- a/polars/polars-lazy/src/tests/optimization_checks.rs
+++ b/polars/polars-lazy/src/tests/optimization_checks.rs
@@ -92,5 +92,12 @@ pub fn test_simple_slice() -> Result<()> {
     let out = q.collect()?;
     assert_eq!(out.height(), 3);
 
+    let q = scan_foods_parquet(false)
+        .select([col("category"), col("calories").alias("bar")])
+        .limit(3);
+    assert!(slice_at_scan(&lp_arena, root));
+    let out = q.collect()?;
+    assert_eq!(out.height(), 3);
+
     Ok(())
 }

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -57,6 +57,13 @@ impl PushNode for &mut [Option<Node>] {
     }
 }
 
+/// A projection that only takes a column or a column + alias.
+pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr>) -> bool {
+    arena
+        .iter(current_node)
+        .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
+}
+
 pub(crate) fn has_aexpr<F>(current_node: Node, arena: &Arena<AExpr>, matches: F) -> bool
 where
     F: Fn(&AExpr) -> bool,

--- a/polars/polars-utils/src/arena.rs
+++ b/polars/polars-utils/src/arena.rs
@@ -73,14 +73,12 @@ impl<T> Arena<T> {
 
     #[inline]
     pub fn get(&self, idx: Node) -> &T {
-        debug_assert!(idx.0 < self.items.len());
-        unsafe { self.items.get_unchecked(idx.0) }
+        self.items.get(idx.0).unwrap()
     }
 
     #[inline]
     pub fn get_mut(&mut self, idx: Node) -> &mut T {
-        debug_assert!(idx.0 < self.items.len());
-        unsafe { self.items.get_unchecked_mut(idx.0) }
+        self.items.get_mut(idx.0).unwrap()
     }
 
     #[inline]


### PR DESCRIPTION
Make slice pushdown optimization also work for simple projectons
like 'col("foo"), 'col("bar").alias("spam").
These projections will not block the pusdhown.