### PR TITLE
csv: fix bug in projection of quoted field

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -1407,4 +1407,19 @@ A3,\"B4_\"\"with_embedded_double_quotes\"\"\",C4,4";
         assert_eq!(df.dtypes(), &[DataType::Int64, DataType::Utf8]);
         Ok(())
     }
+
+    #[test]
+    fn test_quoted_projection() -> Result<()> {
+        let csv = r#"c1,c2,c3,c4,c5
+a,"b",c,d,1
+a,"b",c,d,1
+a,b,c,d,1"#;
+        let file = Cursor::new(csv);
+        let df = CsvReader::new(file)
+            .with_projection(Some(vec![1, 4]))
+            .finish()?;
+        assert_eq!(df.shape(), (3, 2));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #2362

Also very likely improves csv parsing performance. We now don't update the bytes every parsed field, but now only once we have depleted a line or all the projected columns, therefore amortizing this code path.