### PR TITLE
correct logical type names in header in pivot operation

### DIFF
--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -797,6 +797,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "dtype-duration")]
     fn test_duration() -> Result<()> {
         let a = Int64Chunked::new("", &[1, 2, 3])
             .into_datetime(TimeUnit::Nanoseconds, None)
@@ -821,7 +822,6 @@ mod test {
                 .into_duration(TimeUnit::Nanoseconds)
                 .into_series()
         );
-        // assert_eq!(a.add_to(&c)?, b);
         Ok(())
     }
 }


### PR DESCRIPTION
fixes #2382

I see it as a temporary band aid. I need to redesign the pivot operations to better fit the current state of the library.