### PR TITLE
Redesign pivot `[~2.5x improvement]`

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -57,9 +57,6 @@ performant = ["polars-core/performant"]
 plain_fmt = ["polars-core/plain_fmt"]
 pretty_fmt = ["polars-core/pretty_fmt"]
 
-# features
-# resample operation on DataFrame
-pivot = ["polars-core/pivot"]
 # sort by multiple columns
 sort_multiple = ["polars-core/sort_multiple"]
 
@@ -144,7 +141,6 @@ docs-selection = [
   "parquet",
   "ipc",
   "dtype-full",
-  "pivot",
   "is_in",
   "sort_multiple",
   "rows",

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -32,11 +32,10 @@ pretty_fmt = ["comfy-table"]
 plain_fmt = ["prettytable-rs"]
 
 # opt-in features
-# pivot operation on DataFrame
-pivot = []
 # sort by multiple columns
 sort_multiple = []
 # create from row values
+# and include pivot operation
 rows = []
 # dont use this
 private = []
@@ -95,7 +94,6 @@ parquet = ["arrow/io_parquet"]
 
 docs-selection = [
   "ndarray",
-  "pivot",
   "is_in",
   "sort_multiple",
   "rows",

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -25,6 +25,8 @@ mod dynamic;
 pub(crate) mod hashing;
 #[cfg(feature = "pivot")]
 pub(crate) mod pivot;
+#[cfg(feature = "pivot")]
+pub use pivot::PivotAgg;
 #[cfg(not(feature = "dynamic_groupby"))]
 #[derive(Clone, Debug)]
 pub struct DynamicGroupOptions {

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -23,9 +23,9 @@ pub mod aggregations;
 #[cfg(feature = "dynamic_groupby")]
 mod dynamic;
 pub(crate) mod hashing;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 pub(crate) mod pivot;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 pub use pivot::PivotAgg;
 #[cfg(not(feature = "dynamic_groupby"))]
 #[derive(Clone, Debug)]

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -398,7 +398,7 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
     /// | "C" | 2    | null | null | null | null |
     /// +-----+------+------+------+------+------+
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "pivot")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     #[deprecated(note = "use DataFrame::pivot")]
     #[allow(deprecated)]
     pub fn pivot(
@@ -419,7 +419,7 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
 
 /// Intermediate structure when a `pivot` operation is applied.
 /// See [the pivot method for more information.](../group_by/struct.GroupBy.html#method.pivot)
-#[cfg_attr(docsrs, doc(cfg(feature = "pivot")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
 #[deprecated(note = "use DataFrame::pivot")]
 #[allow(deprecated)]
 pub struct Pivot<'df, 'selection_str> {

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1493,6 +1493,11 @@ impl DataFrame {
         Ok(DataFrame::new_no_checks(new_col))
     }
 
+    #[cfg(feature = "pivot")]
+    pub(crate) unsafe fn take_unchecked_slice(&self, idx: &[u32]) -> Self {
+        self.take_iter_unchecked(idx.iter().map(|i| *i as usize))
+    }
+
     pub(crate) unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Self {
         let cols = POOL.install(|| {
             self.columns
@@ -2593,7 +2598,7 @@ impl DataFrame {
         let df = if maintain_order {
             let mut groups = groups.collect::<Vec<_>>();
             groups.sort_unstable();
-            unsafe { self.take_iter_unchecked(groups.into_iter().map(|i| i as usize)) }
+            unsafe { self.take_iter_unchecked(groups.iter().map(|i| *i as usize)) }
         } else {
             unsafe { self.take_iter_unchecked(groups.into_iter().map(|i| i as usize)) }
         };

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1493,7 +1493,7 @@ impl DataFrame {
         Ok(DataFrame::new_no_checks(new_col))
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     pub(crate) unsafe fn take_unchecked_slice(&self, idx: &[u32]) -> Self {
         self.take_iter_unchecked(idx.iter().map(|i| *i as usize))
     }

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -10,7 +10,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
@@ -114,7 +114,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -125,7 +125,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -11,7 +11,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
@@ -93,7 +93,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -104,7 +104,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -16,7 +16,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
@@ -168,7 +168,7 @@ macro_rules! impl_dyn_series {
                 self.0.agg_valid_count(groups)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot<'a>(
                 &self,
                 pivot_series: &'a Series,
@@ -179,7 +179,7 @@ macro_rules! impl_dyn_series {
                 self.0.pivot(pivot_series, keys, groups, agg_type)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot_count<'a>(
                 &self,
                 pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -6,7 +6,7 @@ use crate::chunked_array::{
     comparison::*, ops::explode::ExplodeByOffsets, AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
@@ -176,7 +176,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -187,7 +187,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -6,7 +6,7 @@ use crate::chunked_array::{
     comparison::*, ops::explode::ExplodeByOffsets, AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
@@ -171,7 +171,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -182,7 +182,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -17,7 +17,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
@@ -194,7 +194,7 @@ macro_rules! impl_dyn_series {
                 self.0.agg_valid_count(groups)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot<'a>(
                 &self,
                 pivot_series: &'a Series,
@@ -205,7 +205,7 @@ macro_rules! impl_dyn_series {
                 self.0.pivot(pivot_series, keys, groups, agg_type)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot_count<'a>(
                 &self,
                 pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -10,7 +10,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::prelude::*;
@@ -87,7 +87,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -98,7 +98,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -35,7 +35,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
@@ -237,7 +237,7 @@ macro_rules! impl_dyn_series {
                 self.0.agg_valid_count(groups)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot<'a>(
                 &self,
                 pivot_series: &'a Series,
@@ -248,7 +248,7 @@ macro_rules! impl_dyn_series {
                 self.0.pivot(pivot_series, keys, groups, agg_type)
             }
 
-            #[cfg(feature = "pivot")]
+            #[cfg(feature = "rows")]
             fn pivot_count<'a>(
                 &self,
                 pivot_series: &'a Series,

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -10,7 +10,7 @@ use crate::chunked_array::{
     AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
-#[cfg(feature = "pivot")]
+#[cfg(feature = "rows")]
 use crate::frame::groupby::pivot::*;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
@@ -88,7 +88,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.agg_valid_count(groups)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot<'a>(
         &self,
         pivot_series: &'a Series,
@@ -99,7 +99,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.pivot(pivot_series, keys, groups, agg_type)
     }
 
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     fn pivot_count<'a>(
         &self,
         pivot_series: &'a Series,

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -34,7 +34,7 @@ macro_rules! invalid_operation_panic {
 
 pub(crate) mod private {
     use super::*;
-    #[cfg(feature = "pivot")]
+    #[cfg(feature = "rows")]
     use crate::frame::groupby::pivot::PivotAgg;
     use crate::frame::groupby::GroupTuples;
 
@@ -217,7 +217,7 @@ pub(crate) mod private {
         fn agg_valid_count(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
             None
         }
-        #[cfg(feature = "pivot")]
+        #[cfg(feature = "rows")]
         fn pivot<'a>(
             &self,
             _pivot_series: &'a Series,
@@ -228,7 +228,7 @@ pub(crate) mod private {
             invalid_operation_panic!(self)
         }
 
-        #[cfg(feature = "pivot")]
+        #[cfg(feature = "rows")]
         fn pivot_count<'a>(
             &self,
             _pivot_series: &'a Series,

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -118,6 +118,7 @@
 //!     - `pivot` - [pivot operation](crate::frame::groupby::GroupBy::pivot) on `DataFrame`s
 //!     - `sort_multiple` - Allow sorting a `DataFrame` on multiple columns
 //!     - `rows` - Create `DataFrame` from rows and extract rows from `DataFrames`.
+//!                And activates `pivot` and `transpose` operations
 //!     - `asof_join` - Join as of, to join on nearest keys instead of exact equality match.
 //!     - `cross_join` - Create the cartesian product of two DataFrames.
 //!     - `groupby_list` - Allow groupby operation on keys of type List.

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.12.11"
+version = "0.12.12"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -33,12 +33,11 @@ pyo3 = { git = "https://github.com/ghuls/pyo3", branch = "polars_pypy_hasattr" }
 # features are only there to enable building a slim binary for the benchmark in CI
 [features]
 parquet = ["polars/parquet"]
-pivot = ["polars/pivot"]
 ipc = ["polars/ipc"]
 is_in = ["polars/is_in"]
 json = ["polars/serde", "serde_json"]
 
-default = ["pivot", "json", "parquet", "ipc", "is_in", "json", "polars/repeat_by"]
+default = ["json", "parquet", "ipc", "is_in", "json", "polars/repeat_by"]
 
 [dependencies.polars]
 path = "../polars"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.12.11"
+version = "0.12.12"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -100,6 +100,7 @@ Manipulation/ selection
     DataFrame.fill_null
     DataFrame.fill_nan
     DataFrame.explode
+    DataFrame.pivot
     DataFrame.melt
     DataFrame.shift
     DataFrame.shift_and_fill

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3258,6 +3258,54 @@ class DataFrame:
         """
         return self.lazy().explode(columns).collect(no_optimization=True)
 
+    def pivot(
+        self,
+        values: Union[List[str], str],
+        index: Union[List[str], str],
+        columns: Union[List[str], str],
+        aggregate_fn: str = "first",
+        maintain_order: bool = False,
+    ) -> "DataFrame":
+        """
+        Create a spreadsheet-style pivot table as a DataFrame.
+
+        Parameters
+        ----------
+        values
+            Column values to aggregate. Can be multiple columns if the *columns* arguments contains multiple columns as well
+        index
+            One or multiple keys to group by
+        columns
+            Columns whose values will be used as the header of the output DataFrame
+        aggregate_fn
+            Any of:
+
+            - "sum"
+            - "max"
+            - "min"
+            - "mean"
+            - "median"
+            - "first"
+            - "last"
+            - "count"
+
+        maintain_order
+            Sort the grouped keys so that the output order is predictable.
+
+        Returns
+        -------
+
+        """
+        if isinstance(values, str):
+            values = [values]
+        if isinstance(index, str):
+            index = [index]
+        if isinstance(columns, str):
+            columns = [columns]
+        return wrap_df(
+            self._df.pivot2(values, index, columns, aggregate_fn, maintain_order)
+        )
+
     def melt(
         self, id_vars: Union[List[str], str], value_vars: Union[List[str], str]
     ) -> "DataFrame":
@@ -4493,6 +4541,9 @@ class GroupBy:
     def pivot(self, pivot_column: str, values_column: str) -> "PivotOps":
         """
         Do a pivot operation based on the group key, a pivot column and an aggregation function on the values column.
+
+        .. deprecated::
+            Use DataFrame.pivot directly
 
         Parameters
         ----------

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::series::PySeries;
 use polars::chunked_array::object::PolarsObjectSafe;
 use polars::frame::row::Row;
-use polars::frame::NullStrategy;
+use polars::frame::{groupby::PivotAgg, NullStrategy};
 use polars::prelude::AnyValue;
 use polars::series::ops::NullBehavior;
 use polars_core::prelude::QuantileInterpolOptions;
@@ -56,6 +56,22 @@ pub(crate) fn get_lf(obj: &PyAny) -> PyResult<LazyFrame> {
 pub(crate) fn get_series(obj: &PyAny) -> PyResult<Series> {
     let pydf = obj.getattr("_s")?;
     Ok(pydf.extract::<PySeries>()?.series)
+}
+
+impl<'a> FromPyObject<'a> for Wrap<PivotAgg> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        match ob.extract::<&str>()? {
+            "sum" => Ok(Wrap(PivotAgg::Sum)),
+            "min" => Ok(Wrap(PivotAgg::Min)),
+            "max" => Ok(Wrap(PivotAgg::Max)),
+            "first" => Ok(Wrap(PivotAgg::First)),
+            "mean" => Ok(Wrap(PivotAgg::Mean)),
+            "median" => Ok(Wrap(PivotAgg::Median)),
+            "count" => Ok(Wrap(PivotAgg::Count)),
+            "last" => Ok(Wrap(PivotAgg::Last)),
+            s => panic!("aggregation {} is not supported", s),
+        }
+    }
 }
 
 impl<'a, T> FromPyObject<'a> for Wrap<ChunkedArray<T>>

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -790,7 +790,6 @@ impl PyDataFrame {
         Ok(PyDataFrame::new(df))
     }
 
-    #[cfg(feature = "pivot")]
     pub fn pivot(
         &self,
         by: Vec<String>,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -20,6 +20,7 @@ use crate::{
     series::{to_pyseries_collection, to_series_collection, PySeries},
 };
 use polars::frame::row::{rows_to_schema, Row};
+use polars_core::frame::groupby::PivotAgg;
 use polars_core::prelude::QuantileInterpolOptions;
 
 #[pyclass]
@@ -824,6 +825,22 @@ impl PyDataFrame {
             .df
             .melt(id_vars, value_vars)
             .map_err(PyPolarsEr::from)?;
+        Ok(PyDataFrame::new(df))
+    }
+
+    pub fn pivot2(
+        &self,
+        values: Vec<String>,
+        index: Vec<String>,
+        columns: Vec<String>,
+        aggregate_fn: Wrap<PivotAgg>,
+        maintain_order: bool,
+    ) -> PyResult<Self> {
+        let fun = match maintain_order {
+            true => DataFrame::pivot,
+            false => DataFrame::pivot_stable,
+        };
+        let df = fun(&self.df, values, index, columns, aggregate_fn.0).map_err(PyPolarsEr::from)?;
         Ok(PyDataFrame::new(df))
     }
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -489,6 +489,10 @@ def test_pivot() -> None:
     assert gb.count().shape == (2, 6)
     assert gb.median().shape == (2, 6)
 
+    for agg_fn in ["sum", "min", "max", "mean", "count", "median", "mean"]:
+        out = df.pivot(values="c", index="b", columns="a", aggregate_fn=agg_fn)
+        assert out.shape == (2, 6)
+
 
 def test_join() -> None:
     df_left = pl.DataFrame(

--- a/py-polars/tests/test_queries.py
+++ b/py-polars/tests/test_queries.py
@@ -10,7 +10,7 @@ def test_sort_by_bools() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-    out = df.with_column((pl.col("foo") % 2 == 1).alias("foo_uneven")).sort(
-        by=["foo", "foo_uneven"]
+    out = df.with_column((pl.col("foo") % 2 == 1).alias("foo_odd")).sort(
+        by=["foo", "foo_odd"]
     )
     assert out.shape == (3, 4)


### PR DESCRIPTION
This PR redesigns the pivot algorithm. There is a lot of compiler bloat in the current implementation and it is hard to extend/ improve upon.

This replaces it with a single implementation that is able to work on multiple columns, indexes and values. Still have to benchmark.