### PR TITLE
Nodejs interop

### DIFF
--- a/nodejs-polars/.eslintrc.json
+++ b/nodejs-polars/.eslintrc.json
@@ -77,7 +77,6 @@
         "@typescript-eslint/func-call-spacing": "error",
         "@typescript-eslint/no-duplicate-imports": "error",
         "@typescript-eslint/comma-spacing": "error",
-        "@typescript-eslint/member-ordering": "error",
         "@typescript-eslint/type-annotation-spacing": "error"
     }
 }

--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -1268,7 +1268,7 @@ describe("io", () => {
         },
       ]
     };
-    const actual = df.toJS({orient:"dataframe"});
+    const actual = df.toObject({orient:"dataframe"});
     expect(actual).toEqual(expected);
   });
   test("toJS:row", () => {
@@ -1279,19 +1279,29 @@ describe("io", () => {
     const expected = [
       {foo: 1.0, bar: "a"}
     ];
-    const actual = df.toJS({orient:"row"});
+    const actual = df.toObject({orient:"row"});
     expect(actual).toEqual(expected);
   });
-  test("toJS", () => {
+  test("toObject", () => {
     const df = pl.DataFrame({
       foo: [1],
       bar: ["a"]
     });
     const expected = {
-      foo: [1],
-      bar: ["a"]
+      columns: [
+        {
+          name: "foo",
+          datatype: "Float64",
+          values: [1]
+        },
+        {
+          name: "bar",
+          datatype: "Utf8",
+          values: ["a"]
+        }
+      ]
     };
-    const actual = df.toJS();
+    const actual = df.toObject();
     expect(actual).toEqual(expected);
   });
   test("toJSON:multiline", () => {
@@ -1355,7 +1365,7 @@ describe("io", () => {
     const actual = pl.DataFrame(rows).toJSON({orient:"row"});
     expect(actual).toEqual(expected);
   });
-  test("toJSON:cols", () => {
+  test("toJSON:col", () => {
     const cols = {
       foo: [1, 2, 3],
       bar: ["a", "b", "c"]
@@ -1543,7 +1553,7 @@ describe("create", () => {
     expected.int8_list = int8List.map(i => [...i]);
     const df = pl.DataFrame(expected);
 
-    expect(df.toJS()).toEqual(expected);
+    expect(df.toObject({orient: "col"})).toEqual(expected);
   });
 });
 describe("arithmetic", () => {

--- a/nodejs-polars/__tests__/expr.test.ts
+++ b/nodejs-polars/__tests__/expr.test.ts
@@ -550,7 +550,6 @@ describe("expr", () => {
     const df = pl.DataFrame([
       pl.Series("int16", [1, 2, 3], pl.Int16),
       pl.Series("int32", [1, 2, 3], pl.Int32),
-      pl.Series("int64", [1n, 2n, 3n], pl.Int64),
       pl.Series("uint16", [1, 2, 3], pl.UInt16),
       pl.Series("uint32", [1, 2, 3], pl.UInt32),
       pl.Series("uint64", [1n, 2n, 3n], pl.UInt64),
@@ -559,7 +558,6 @@ describe("expr", () => {
     const expected = pl.DataFrame([
       pl.Series("int16", [-32768], pl.Int16),
       pl.Series("int32", [-2147483648], pl.Int32),
-      pl.Series("int64", [-9223372036854775808n], pl.Int64),
       pl.Series("uint16", [0], pl.UInt16),
       pl.Series("uint32", [0], pl.UInt32),
       pl.Series("uint64", [0n], pl.UInt64),
@@ -772,7 +770,7 @@ describe("expr", () => {
     const df = pl.DataFrame([
       pl.Series("a", [1n, 2n, 3n], pl.UInt64)
     ]);
-    const expected = pl.Series("a", [1n, 2n, 3n], pl.Int64);
+    const expected = pl.Series("a", [1, 2, 3], pl.Int64);
     const actual = df.select(col("a").reinterpret()).getColumn("a");
     expect(actual).toSeriesStrictEqual(expected);
   });
@@ -1015,7 +1013,6 @@ describe("expr", () => {
     const df = pl.DataFrame([
       pl.Series("int16", [1, 2, 3], pl.Int16),
       pl.Series("int32", [1, 2, 3], pl.Int32),
-      pl.Series("int64", [1n, 2n, 3n], pl.Int64),
       pl.Series("uint16", [1, 2, 3], pl.UInt16),
       pl.Series("uint32", [1, 2, 3], pl.UInt32),
       pl.Series("uint64", [1n, 2n, 3n], pl.UInt64),
@@ -1023,7 +1020,6 @@ describe("expr", () => {
     const expected = pl.DataFrame([
       pl.Series("int16", [32767],  pl.Int16),
       pl.Series("int32", [2147483647],  pl.Int32),
-      pl.Series("int64", [9223372036854775807n],  pl.Int64),
       pl.Series("uint16", [65535],  pl.UInt16),
       pl.Series("uint32", [4294967295],  pl.UInt32),
       pl.Series("uint64", [18446744073709551615n], pl.UInt64),

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -106,8 +106,8 @@ describe("stream", () => {
     readStream.push(`4,2\n`);
     readStream.push(null);
     const expected = pl.DataFrame({
-      a: pl.Series("a", [1n, 2n, 3n, 4n], pl.Int64),
-      b: pl.Series("b", [2n, 2n, 2n, 2n], pl.Int64)
+      a: pl.Series("a", [1, 2, 3, 4], pl.Int64),
+      b: pl.Series("b", [2, 2, 2, 2], pl.Int64)
     });
     const df = await pl.readCSVStream(readStream, {batchSize: 2});
     expect(df).toFrameEqual(expected);
@@ -136,8 +136,8 @@ describe("stream", () => {
     readStream.push(null);
 
     const expected = pl.DataFrame({
-      a: pl.Series("a", [1n, 2n, 3n, 4n], pl.Int64),
-      b: pl.Series("b", [2n, 2n, 2n, 2n], pl.Int64)
+      a: pl.Series("a", [1, 2, 3, 4], pl.Int64),
+      b: pl.Series("b", [2, 2, 2, 2], pl.Int64)
     });
     const df = await pl.readJSONStream(readStream);
     expect(df).toFrameEqual(expected);

--- a/nodejs-polars/__tests__/lazyframe.test.ts
+++ b/nodejs-polars/__tests__/lazyframe.test.ts
@@ -30,20 +30,21 @@ describe("lazyframe", () => {
       "foo": [1, 2],
       "bar": ["a", "b"]
     }).lazy();
-    const actual = df.describePlan();
-    expect(actual).toEqual(
-      `TABLE: ["foo", "bar"]; PROJECT */2 COLUMNS; SELECTION: None\\n
-                    PROJECTION: None`);
+    const actual = df.describePlan().replace(/\s+/g, " ");
+    expect(actual).toEqual(`MEMTABLE: ["foo", "bar"];
+project */2 columns	|	details: None;
+selection: "None" `.replace(/\s+/g, " "));
   });
   test("describeOptimiziedPlan", () => {
     const df = pl.DataFrame({
       "foo": [1, 2],
       "bar": ["a", "b"]
     }).lazy();
-    const actual = df.describeOptimizedPlan();
+    const actual = df.describeOptimizedPlan().replace(/\s+/g, " ");
     expect(actual).toEqual(
-      `TABLE: ["foo", "bar"]; PROJECT */2 COLUMNS; SELECTION: None\\n
-                    PROJECTION: None`);
+      `MEMTABLE: ["foo", "bar"];
+      project */2 columns	|	details: None;
+      selection: "None" `.replace(/\s+/g, " "));
   });
   test("drop", () => {
     const df = pl.DataFrame({

--- a/nodejs-polars/polars/datatypes.ts
+++ b/nodejs-polars/polars/datatypes.ts
@@ -1,5 +1,4 @@
 import pli from "./internals/polars_internal";
-import {Stream} from "stream";
 
 export type DtypeToPrimitive<T> = T extends DataType.Bool ? boolean :
  T extends DataType.Utf8 ? string :

--- a/nodejs-polars/polars/datatypes.ts
+++ b/nodejs-polars/polars/datatypes.ts
@@ -5,8 +5,7 @@ export type DtypeToPrimitive<T> = T extends DataType.Bool ? boolean :
  T extends DataType.Categorical ? string :
  T extends DataType.Datetime ? number | Date :
  T extends DataType.Date ? Date :
- T extends DataType.UInt64 ? bigint :
- T extends DataType.Int64 ? bigint : number
+ T extends DataType.UInt64 ? bigint : number
 
 export type PrimitiveToDtype<T> = T extends boolean ? DataType.Bool :
  T extends string ? DataType.Utf8 :
@@ -127,33 +126,6 @@ export const DTYPE_TO_FFINAME: Record<DataType, string> = {
   [DataType.Time]: "time",
   [DataType.Object]: "object",
   [DataType.Categorical]: "categorical",
-};
-
-export const iterToTypedArray = (dtype: DataType, iterator: any): Iterable<any>  => {
-  switch (dtype) {
-  case DataType.Int8:
-    return Int8Array.from(iterator);
-  case DataType.Int16:
-    return Int16Array.from(iterator);
-  case DataType.Int32:
-    return Int32Array.from(iterator);
-  case DataType.Int64:
-    return BigInt64Array.from(iterator);
-  case DataType.UInt8:
-    return Uint8Array.from(iterator);
-  case DataType.UInt16:
-    return Uint16Array.from(iterator);
-  case DataType.UInt32:
-    return Uint32Array.from(iterator);
-  case DataType.UInt64:
-    return BigUint64Array.from(iterator);
-  case DataType.Float32:
-    return Float32Array.from(iterator);
-  case DataType.Float64:
-    return Float64Array.from(iterator);
-  default:
-    return iterator;
-  }
 };
 
 const POLARS_TYPE_TO_CONSTRUCTOR: Record<string, string> = {

--- a/nodejs-polars/polars/groupby.ts
+++ b/nodejs-polars/polars/groupby.ts
@@ -1,7 +1,6 @@
 import {DataFrame, dfWrapper} from "./dataframe";
 import * as utils from "./utils";
 import util from "util";
-import {InvalidOperationError} from "./error";
 import {Expr} from "./lazy/expr";
 import {col, exclude} from "./lazy/functions";
 import pli from "./internals/polars_internal";

--- a/nodejs-polars/polars/internals/construction.ts
+++ b/nodejs-polars/polars/internals/construction.ts
@@ -3,6 +3,7 @@ import { DataType, polarsTypeToConstructor } from "../datatypes";
 import { isTypedArray } from "util/types";
 import {Series} from "../series";
 
+
 export const jsTypeToPolarsType = (value: unknown): DataType => {
   if(value === null) {
     return DataType.Float64;
@@ -123,7 +124,7 @@ export function arrayToJsSeries(name: string, values: any[], dtype?: any, strict
   return series;
 }
 
-export function arrayToJsDataFrame(data: any[], columns?: string[], orient?: "col"| "row"): any {
+export function arrayToJsDataFrame(data: any[], columns?: string[], orient?: "col"| "row", typedArrays?: boolean): any {
   let dataSeries;
 
   if(!data.length) {
@@ -159,7 +160,17 @@ export function arrayToJsDataFrame(data: any[], columns?: string[], orient?: "co
 
       return df;
     } else {
-      dataSeries = data.map((s, idx) => Series(`column_${idx}`, s).inner());
+      if(typedArrays) {
+
+        dataSeries = data.map((s, idx) => Series.from(s)
+          .as(`column_${idx}`)
+          .inner()
+        );
+
+      } else {
+
+        dataSeries = data.map((s, idx) => Series(`column_${idx}`, s).inner());
+      }
     }
 
   }

--- a/nodejs-polars/polars/series.ts
+++ b/nodejs-polars/polars/series.ts
@@ -1,6 +1,6 @@
 import pli from "./internals/polars_internal";
-import { arrayToJsSeries } from "./internals/construction";
-import { DataType, DtypeToPrimitive, DTYPE_TO_FFINAME, iterToTypedArray, Optional } from "./datatypes";
+import {arrayToJsSeries} from "./internals/construction";
+import {DataType, DtypeToPrimitive, DTYPE_TO_FFINAME, iterToTypedArray, Optional, TypedArray} from "./datatypes";
 import {DataFrame, dfWrapper} from "./dataframe";
 import {StringFunctions} from "./series/string";
 import {ListFunctions} from "./series/list";
@@ -8,7 +8,7 @@ import {DateTimeFunctions} from "./series/datetime";
 import {InvalidOperationError, todo} from "./error";
 import {RankMethod} from "./utils";
 import {col} from "./lazy/functions";
-import {isExternal} from "util/types";
+import {isExternal, isTypedArray} from "util/types";
 import {Arithmetic, Comparison, Cumulative, Rolling} from "./shared_traits";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
@@ -100,9 +100,9 @@ export interface Series<T> extends
    * Get the index of the maximal value.
    */
   argMax(): Optional<number>
-    /**
-   * Get the index of the minimal value.
-   */
+  /**
+ * Get the index of the minimal value.
+ */
   argMin(): Optional<number>
   /**
    * Get index values where Boolean Series evaluate True.
@@ -200,17 +200,17 @@ export interface Series<T> extends
    */
   diff(n: number, nullBehavior: "ignore" | "drop"): Series<T>
   diff({n, nullBehavior}: {n: number, nullBehavior: "ignore" | "drop"}): Series<T>
-   /**
-   * Compute the dot/inner product between two Series
-   * ___
-   * @example
-   * ```
-   * > const s = pl.Series("a", [1, 2, 3])
-   * > const s2 = pl.Series("b", [4.0, 5.0, 6.0])
-   * > s.dot(s2)
-   * 32.0
-   * ```
-   */
+  /**
+  * Compute the dot/inner product between two Series
+  * ___
+  * @example
+  * ```
+  * > const s = pl.Series("a", [1, 2, 3])
+  * > const s2 = pl.Series("b", [4.0, 5.0, 6.0])
+  * > s.dot(s2)
+  * 32.0
+  * ```
+  */
   dot(other: Series<any>): Optional<number>
   /**
    * Create a new Series that copies data from this Series without null values.
@@ -238,11 +238,11 @@ export interface Series<T> extends
    * ```
    */
   explode(): any
-    /**
-   * Extend the Series with given number of values.
-   * @param value The value to extend the Series with. This value may be null to fill with nulls.
-   * @param n The number of values to extend.
-   */
+  /**
+ * Extend the Series with given number of values.
+ * @param value The value to extend the Series with. This value may be null to fill with nulls.
+ * @param n The number of values to extend.
+ */
   extend(value: any, n: number): Series<T>
   extend(opt: {value: any, n: number}): Series<T>
   /**
@@ -757,7 +757,7 @@ export interface Series<T> extends
    * @param value value to replace masked values with
    */
   set(filter: Series<boolean>, value: T): Series<T>
-  setAtIdx(indices: number[] | Series<number>,  value: T): Series<T>
+  setAtIdx(indices: number[] | Series<number>, value: T): Series<T>
   /**
    * __Shift the values by a given period__
    *
@@ -995,6 +995,7 @@ export interface Series<T> extends
    * ```
    */
   toJS(): {name: string, datatype: string, values: any[]}
+  toBinary(): Buffer
   toFrame(): DataFrame
 }
 
@@ -1002,7 +1003,7 @@ export interface Series<T> extends
 export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
   const unwrap = <U>(method: string, args?: object, _series = _s): U => {
 
-    return pli.series[method]({_series, ...args });
+    return pli.series[method]({_series, ...args});
   };
   const wrap = <U>(method, args?, _series = _s): Series<U> => {
     return seriesWrapper(unwrap(method, args, _series));
@@ -1012,35 +1013,35 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
   const dtypeAccessor = (fn) => (method, args: {field, key}, _series = _s) => {
     const dtype = unwrap<string>("dtype");
     if (args.field?._series) {
-      return fn(method, { [args.key]: args.field._series }, _series);
+      return fn(method, {[args.key]: args.field._series}, _series);
     } else {
       const dt = (DTYPE_TO_FFINAME as any)[DataType[dtype]];
       const internalMethod = `${method}_${dt}`;
-      if(DataType[dtype] === DataType.List) {
-        return seriesWrapper(fn(internalMethod, { [args.key]: args.field }, _series));
+      if (DataType[dtype] === DataType.List) {
+        return seriesWrapper(fn(internalMethod, {[args.key]: args.field}, _series));
       }
 
-      return fn(internalMethod, { [args.key]: args.field }, _series);
+      return fn(internalMethod, {[args.key]: args.field}, _series);
     }
   };
-  const inPlaceOptional = (method: string) =>  (obj?: {inPlace: boolean} | boolean): any  => {
-    if(obj === true || obj?.["inPlace"] === true) {
+  const inPlaceOptional = (method: string) => (obj?: {inPlace: boolean} | boolean): any => {
+    if (obj === true || obj?.["inPlace"] === true) {
       unwrap(method, {inPlace: true});
     } else {
       return wrap(method);
     }
   };
 
-  const rolling = (method: string) =>  (opts, weights?, minPeriods?, center?): Series<T> => {
+  const rolling = (method: string) => (opts, weights?, minPeriods?, center?): Series<T> => {
     const windowSize = opts?.["windowSize"] ?? (typeof opts === "number" ? opts : null);
-    if(windowSize === null) {
+    if (windowSize === null) {
       throw new Error("window size is required");
     }
     const callOpts = {
-      window_size: opts?.["windowSize"] ?? (typeof opts === "number"? opts : null),
+      window_size: opts?.["windowSize"] ?? (typeof opts === "number" ? opts : null),
       weights: opts?.["weights"] ?? weights,
       min_periods: opts?.["minPeriods"] ?? minPeriods ?? windowSize,
-      center : opts?.["center"] ?? center ?? false,
+      center: opts?.["center"] ?? center ?? false,
     };
 
     return wrap(method, callOpts);
@@ -1075,7 +1076,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     get length() {
       return unwrap("len");
     },
-    get str(){
+    get str() {
       return StringFunctions(_s);
     },
     get lst() {
@@ -1090,12 +1091,12 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     },
     alias(name) {
       const s = this.clone();
-      unwrap("rename", { name }, s._series);
+      unwrap("rename", {name}, s._series);
 
       return s;
     },
     append(other) {
-      return wrap("append", { other: other._series });
+      return wrap("append", {other: other._series});
     },
     argMax: noArgUnwrap("arg_max"),
     argMin: noArgUnwrap("arg_min"),
@@ -1110,13 +1111,13 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
       return this.alias(name);
     },
     bitand(other) {
-      return wrap("bitand", { other: other._series });
+      return wrap("bitand", {other: other._series});
     },
     bitor(other) {
-      return wrap("bitor", { other: other._series });
+      return wrap("bitor", {other: other._series});
     },
     bitxor(other) {
-      return wrap("bitxor", { other: other._series });
+      return wrap("bitxor", {other: other._series});
     },
     cast(dtype, strict: any = false) {
       return typeof strict === "boolean" ?
@@ -1129,7 +1130,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     },
     concat(other) {
       const s = this.clone();
-      unwrap("append", { other: other._series }, s._series);
+      unwrap("append", {other: other._series}, s._series);
 
       return s;
     },
@@ -1162,10 +1163,10 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     describe() {
       let s = seriesWrapper(_s);
       let stats = {};
-      if(!this.length) {
+      if (!this.length) {
         throw new RangeError("Series must contain at least one value");
       }
-      if(this.isNumeric()) {
+      if (this.isNumeric()) {
         s = s.cast(DataType.Float64);
         stats = {
           "min": s.min(),
@@ -1198,7 +1199,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
         "value": Object.values(stats)
       });
     },
-    diff(n: any = 1, null_behavior="ignore") {
+    diff(n: any = 1, null_behavior = "ignore") {
       return typeof n === "number" ?
         wrap("diff", {n, null_behavior}) :
         wrap("diff", {
@@ -1213,7 +1214,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
       return this.div(field);
     },
     dot(other) {
-      return unwrap("dot", { other: other._series });
+      return unwrap("dot", {other: other._series});
     },
     dropNulls: noArgWrap("drop_nulls"),
     eq(field) {
@@ -1224,7 +1225,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     },
     explode: noArgWrap("explode"),
     extend(o, n?) {
-      if(n !== null && typeof n === "number") {
+      if (n !== null && typeof n === "number") {
         return wrap("extend", {value: o, n});
       }
 
@@ -1259,15 +1260,15 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     greaterThanEquals(field) {
       return this.gtEq(field);
     },
-    hash(obj: any = 0, k1=1, k2=2, k3=3) {
-      if(typeof obj === "number" || typeof obj === "bigint") {
-        return wrap<bigint>("hash", { k0: obj, k1: k1, k2: k2, k3: k3 });
+    hash(obj: any = 0, k1 = 1, k2 = 2, k3 = 3) {
+      if (typeof obj === "number" || typeof obj === "bigint") {
+        return wrap<bigint>("hash", {k0: obj, k1: k1, k2: k2, k3: k3});
       }
 
-      return wrap("hash", { k0: 0, k1, k2, k3, ...obj });
+      return wrap("hash", {k0: 0, k1, k2, k3, ...obj});
     },
     hasValidity: noArgUnwrap("has_validity"),
-    head(length=5) {
+    head(length = 5) {
       return wrap("head", {length});
     },
     inner() {
@@ -1336,13 +1337,13 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
 
     },
     isUnique: noArgWrap("is_unique"),
-    isUtf8()  {
+    isUtf8() {
       const dtype = unwrap<keyof DataType>("dtype");
 
       return DataType[dtype] === DataType.Utf8;
     },
-    kurtosis(fisher: any = true, bias=true) {
-      if(typeof fisher === "boolean") {
+    kurtosis(fisher: any = true, bias = true) {
+      if (typeof fisher === "boolean") {
         return unwrap("kurtosis", {fisher, bias});
       }
 
@@ -1355,7 +1356,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     len: noArgUnwrap("len"),
     lessThan: (field) => dtypeAccessor(wrap)("lt", {field, key: "rhs"}),
     lessThanEquals: (field) => dtypeAccessor(wrap)("lt_eq", {field, key: "rhs"}),
-    limit: (n=10) => wrap("limit", { num_elements: n }),
+    limit: (n = 10) => wrap("limit", {num_elements: n}),
     ltEq: (field) => dtypeAccessor(wrap)("lt_eq", {field, key: "rhs"}),
     lt: (field) => dtypeAccessor(wrap)("lt", {field, key: "rhs"}),
     max: noArgUnwrap("max"),
@@ -1374,12 +1375,12 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     peakMin: noArgWrap("peak_min"),
     plus: (field) => dtypeAccessor(wrap)("add", {field, key: "other"}),
     quantile: (quantile) => unwrap<number>("quantile", {quantile}),
-    rank: (method="average") => wrap("rank", { method}),
+    rank: (method = "average") => wrap("rank", {method}),
     rechunk: inPlaceOptional("rechunk"),
-    reinterpret(signed=true)  {
+    reinterpret(signed = true) {
       const dtype = unwrap<string>("dtype");
       if ([DataType.UInt64, DataType.Int64].includes(DataType[dtype])) {
-        return wrap("reinterpret", { signed }) as any;
+        return wrap("reinterpret", {signed}) as any;
       } else {
         throw new InvalidOperationError("reinterpret", dtype);
       }
@@ -1388,7 +1389,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     modulo: (field) => dtypeAccessor(wrap)("rem", {field, key: "other"}),
     rename(obj: any, inPlace = false) {
       if (obj?.inPlace ?? inPlace) {
-        unwrap("rename", { name: obj?.name ?? obj });
+        unwrap("rename", {name: obj?.name ?? obj});
       } else {
         return this.alias(obj?.name ?? obj);
       }
@@ -1413,8 +1414,8 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
         .getColumn(this.name);
     },
     round(opt): any {
-      if(this.isNumeric()) {
-        if(typeof opt === "number") {
+      if (this.isNumeric()) {
+        if (typeof opt === "number") {
           return wrap("round", {decimals: opt});
         } else {
           return wrap("round", opt);
@@ -1425,7 +1426,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
       }
     },
     sample(opts?, frac?, withReplacement = false) {
-      if(opts?.n  !== undefined || opts?.frac  !== undefined) {
+      if (opts?.n !== undefined || opts?.frac !== undefined) {
         return this.sample(opts.n, opts.frac, opts.withReplacement);
       }
       if (typeof opts === "number") {
@@ -1434,7 +1435,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
           withReplacement
         });
       }
-      if(typeof frac === "number") {
+      if (typeof frac === "number") {
         return wrap("sample_frac", {
           frac,
           withReplacement,
@@ -1468,7 +1469,7 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
 
     },
     shift(opt: any = 1) {
-      if(typeof opt === "number") {
+      if (typeof opt === "number") {
         return wrap<T>("shift", {periods: opt});
       }
 
@@ -1484,21 +1485,21 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     },
     shrinkToFit: inPlaceOptional("shrink_to_fit"),
     skew(opt: any = true) {
-      if(typeof opt === "boolean") {
+      if (typeof opt === "boolean") {
         return unwrap("skew", {bias: opt});
       }
 
       return unwrap("skew", opt);
     },
     slice(opts, length?) {
-      if(typeof opts === "number") {
+      if (typeof opts === "number") {
         return wrap("slice", {offset: opts, length});
       }
 
       return wrap("slice", opts);
     },
-    sort(opt: any = false)  {
-      if(typeof opt === "boolean") {
+    sort(opt: any = false) {
+      if (typeof opt === "boolean") {
         return wrap("sort", {reverse: opt});
       }
 
@@ -1506,24 +1507,24 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     },
     sub: (field) => dtypeAccessor(wrap)("sub", {field, key: "other"}),
     sum: noArgUnwrap("sum"),
-    tail: (length=5) => wrap("tail", {length}),
+    tail: (length = 5) => wrap("tail", {length}),
     take: (indices) => wrap("take", {indices}),
     takeEvery: (n) => wrap("take_every", {n}),
     multiplyBy: (field) => dtypeAccessor(wrap)("mul", {field, key: "other"}),
     toArray() {
-      const series = seriesWrapper<any>(_s);
+      const arr = unwrap<any>("to_array").values as any[];
+      const dtype = this.dtype as any as string;
+      if (DataType[dtype] === DataType.List) {
+        console.log(arr);
 
-      const dtype = series.dtype as any as string;
-      if(DataType[dtype] === DataType.List) {
-        return [...series].map(s => s.toArray());
+        return arr.map(s => s.values);
       }
-
-      return Array.from(series);
     },
-    toFrame()  {
+    toFrame() {
       return dfWrapper(pli.df.read_columns({columns: [_s]}));
     },
     toJS: noArgUnwrap("to_js"),
+    toBinary: noArgUnwrap("to_binary"),
     unique: noArgWrap("unique"),
     valueCounts() {
       return dfWrapper(unwrap("value_counts"));
@@ -1534,15 +1535,15 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
   } as Series<T>;
 
   return new Proxy(seriesObject, {
-    get: function(target, prop, receiver) {
-      if(typeof prop !== "symbol" && !Number.isNaN(Number(prop))) {
+    get: function (target, prop, receiver) {
+      if (typeof prop !== "symbol" && !Number.isNaN(Number(prop))) {
         return target.get(Number(prop));
       } else {
         return Reflect.get(target, prop, receiver);
       }
     },
-    set: function(series, prop, input): any {
-      if(typeof prop !== "symbol" && !Number.isNaN(Number(prop))) {
+    set: function (series, prop, input): any {
+      if (typeof prop !== "symbol" && !Number.isNaN(Number(prop))) {
         series.setAtIdx([Number(prop)], input);
 
         return true;
@@ -1556,11 +1557,19 @@ export interface SeriesConstructor {
   <V extends ArrayLike<any>>(name: string, values: V): ValueOrNever<V>
   <T extends DataType, U extends ArrayLikeDataType<T>>(name: string, values: U, dtype: T): Series<DtypeToPrimitive<T>>
   <T extends DataType, U extends boolean, V extends ArrayLikeOrDataType<T, U>>(name: string, values: V, dtype?: T, strict?: U): Series<DataTypeOrValue<T, U>>
+  /**
+   * Creates a series from a `TypedArray` type.
+   * This is **MUCH** faster than using `pl.Series`.
+   * If working with non null numeric data, this is the preferred method for creating `Series`.
+   */
+  from(values: TypedArray): Series<number | bigint>
+  /** converts any iterable into a series */
+  from<T>(values: Iterable<T>): Series<T>
   isSeries(arg: any): arg is Series<any>;
 }
 
-const SeriesConstructor = (arg0: any, arg1?: any, dtype?: any, strict?: any)  => {
-  if(typeof arg0 === "string") {
+const SeriesConstructor = (arg0: any, arg1?: any, dtype?: any, strict?: any) => {
+  if (typeof arg0 === "string") {
     const _s = arrayToJsSeries(arg0, arg1, dtype, strict);
 
     return seriesWrapper(_s);
@@ -1572,11 +1581,11 @@ const SeriesConstructor = (arg0: any, arg1?: any, dtype?: any, strict?: any)  =>
 
 const isSeries = <T>(anyVal: any): anyVal is Series<T> => isExternal(anyVal?._series);
 
-const fromNonNull = <T>(name: string, iterable: Iterable<T>, dtype: DataType): Series<T> => {
-  const typedarray = iterToTypedArray(dtype, iterable);
-
-  return pli.series.new_from_typed_array({ name, values:typedarray});
-
+const from = <T>(values: Iterable<T>): Series<T> => {
+  if(isTypedArray(values)) {
+    return seriesWrapper(pli.series.new_from_typed_array({name: "", values}));
+  } else {
+    return SeriesConstructor("", Array.from(values));
+  }
 };
-
-export const Series: SeriesConstructor = Object.assign(SeriesConstructor, {isSeries, fromNonNull});
+export const Series: SeriesConstructor = Object.assign(SeriesConstructor, {isSeries, from});

--- a/nodejs-polars/polars/series.ts
+++ b/nodejs-polars/polars/series.ts
@@ -1,6 +1,6 @@
 import pli from "./internals/polars_internal";
 import {arrayToJsSeries} from "./internals/construction";
-import {DataType, DtypeToPrimitive, DTYPE_TO_FFINAME, iterToTypedArray, Optional, TypedArray} from "./datatypes";
+import {DataType, DtypeToPrimitive, DTYPE_TO_FFINAME, Optional} from "./datatypes";
 import {DataFrame, dfWrapper} from "./dataframe";
 import {StringFunctions} from "./series/string";
 import {ListFunctions} from "./series/list";
@@ -697,7 +697,7 @@ export interface Series<T> extends
    * @see {@link cast}
    *
    */
-  reinterpret(signed?: boolean): T extends bigint ? Series<bigint> : never
+  reinterpret(signed?: boolean): T extends bigint ? Series<number> : T extends number ? Series<bigint> : never
   /**
    * __Rename this Series.__
    *
@@ -916,21 +916,7 @@ export interface Series<T> extends
    * ```
    */
   take(indices: Array<number>): Series<T>
-  /**
-   * __Convert this Series to a Javascript Array.__
-   *
-   * This operation clones data.
-   * ___
-   * @example
-   * ```
-   * const s = pl.Series("a", [1, 2, 3])
-   * const arr = s.toArray()
-   * [1, 2, 3]
-   * Array.isArray(arr)
-   * true
-   * ```
-   */
-  toArray(): Array<T>
+
   /**
    * __Get unique elements in series.__
    * ___
@@ -980,8 +966,27 @@ export interface Series<T> extends
    *
    */
   zipWith<U>(mask: Series<boolean>, other: Series<T>): Series<U>
+
   /**
-   * _Returns a Javascript representation of Series
+   * __Convert this Series to a Javascript Array.__
+   *
+   * This operation clones data, and is very slow, but maintains greater precision for all dtypes.
+   * Often times `series.toObject().values` is faster, but less precise
+   * ___
+   * @example
+   * ```
+   * const s = pl.Series("a", [1, 2, 3])
+   * const arr = s.toArray()
+   * [1, 2, 3]
+   * Array.isArray(arr)
+   * true
+   * ```
+   */
+  toArray(): Array<T>
+
+  /**
+   * _Returns a Javascript object representation of Series_
+   * Often this is much faster than the iterator, or `values` method
    *
    * @example
    * ```
@@ -994,9 +999,12 @@ export interface Series<T> extends
    * }
    * ```
    */
-  toJS(): {name: string, datatype: string, values: any[]}
-  toBinary(): Buffer
+  toObject(): {name: string, datatype: string, values: any[]}
   toFrame(): DataFrame
+
+  toJSON(): string
+  /** Returns an iterator over the values */
+  values(): IterableIterator<T>
 }
 
 /** @ignore */
@@ -1512,22 +1520,33 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
     takeEvery: (n) => wrap("take_every", {n}),
     multiplyBy: (field) => dtypeAccessor(wrap)("mul", {field, key: "other"}),
     toArray() {
-      const arr = unwrap<any>("to_array").values as any[];
+
+      const arr = unwrap<any>("to_js").values;
       const dtype = this.dtype as any as string;
       if (DataType[dtype] === DataType.List) {
-        console.log(arr);
-
-        return arr.map(s => s.values);
+        return arr.map((s: any) => s.values);
       }
+
+      return arr;
     },
     toFrame() {
       return dfWrapper(pli.df.read_columns({columns: [_s]}));
     },
-    toJS: noArgUnwrap("to_js"),
-    toBinary: noArgUnwrap("to_binary"),
+    toJSON(arg0?) {
+      // JSON.stringify passes `""` by default then stringifies the JS output
+      if(arg0 === "") {
+        return unwrap("to_js");
+      }
+
+      return unwrap<Buffer>("to_json").toString();
+    },
+    toObject: noArgUnwrap("to_js"),
     unique: noArgWrap("unique"),
     valueCounts() {
       return dfWrapper(unwrap("value_counts"));
+    },
+    values() {
+      return this[Symbol.iterator]();
     },
     zipWith(mask, other) {
       return wrap("zip_with", {mask: mask._series, other: other._series});
@@ -1552,23 +1571,28 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
   });
 };
 
+
 export interface SeriesConstructor {
   <V extends ArrayLike<any>>(values: V): ValueOrNever<V>
   <V extends ArrayLike<any>>(name: string, values: V): ValueOrNever<V>
   <T extends DataType, U extends ArrayLikeDataType<T>>(name: string, values: U, dtype: T): Series<DtypeToPrimitive<T>>
   <T extends DataType, U extends boolean, V extends ArrayLikeOrDataType<T, U>>(name: string, values: V, dtype?: T, strict?: U): Series<DataTypeOrValue<T, U>>
+
   /**
-   * Creates a series from a `TypedArray` type.
-   * This is **MUCH** faster than using `pl.Series`.
-   * If working with non null numeric data, this is the preferred method for creating `Series`.
+   * Creates an array from an array-like object.
+   * @param arrayLike — An array-like object to convert to an array.
    */
-  from(values: TypedArray): Series<number | bigint>
-  /** converts any iterable into a series */
-  from<T>(values: Iterable<T>): Series<T>
+  from<T>(arrayLike: ArrayLike<T>): Series<T>
+  /**
+   * Returns a new Series from a set of elements.
+   * @param items — A set of elements to include in the new series object.
+   */
+  of<T>(...items: T[]): Series<T>
   isSeries(arg: any): arg is Series<any>;
+
 }
 
-const SeriesConstructor = (arg0: any, arg1?: any, dtype?: any, strict?: any) => {
+function SeriesConstructor (arg0: any, arg1?: any, dtype?: any, strict?: any) {
   if (typeof arg0 === "string") {
     const _s = arrayToJsSeries(arg0, arg1, dtype, strict);
 
@@ -1576,16 +1600,24 @@ const SeriesConstructor = (arg0: any, arg1?: any, dtype?: any, strict?: any) => 
   }
 
   return SeriesConstructor("", arg0);
-
-};
+}
 
 const isSeries = <T>(anyVal: any): anyVal is Series<T> => isExternal(anyVal?._series);
 
-const from = <T>(values: Iterable<T>): Series<T> => {
+const from = <T>(values: ArrayLike<T>): Series<T> => {
   if(isTypedArray(values)) {
     return seriesWrapper(pli.series.new_from_typed_array({name: "", values}));
-  } else {
-    return SeriesConstructor("", Array.from(values));
   }
+
+  return SeriesConstructor("", values);
 };
-export const Series: SeriesConstructor = Object.assign(SeriesConstructor, {isSeries, from});
+
+const of = <T>(...values: T[]): Series<T> => {
+  return from(values);
+};
+
+export const Series: SeriesConstructor = Object.assign(SeriesConstructor, {
+  isSeries,
+  from,
+  of
+});

--- a/nodejs-polars/src/lazy/dsl.rs
+++ b/nodejs-polars/src/lazy/dsl.rs
@@ -29,7 +29,6 @@ pub(crate) fn add(cx: CallContext) -> JsResult<JsExternal> {
     let expr = params.get_external::<Expr>(&cx, "_expr")?.clone();
     let other = params.get_external::<Expr>(&cx, "other")?.clone();
     dsl::binary_expr(expr, Operator::Plus, other).try_into_js(&cx)
-
 }
 
 #[js_function(1)]

--- a/nodejs-polars/src/lazy/lazyframe.rs
+++ b/nodejs-polars/src/lazy/lazyframe.rs
@@ -187,10 +187,7 @@ pub fn fetch(cx: CallContext) -> JsResult<JsObject> {
     let ldf: LazyFrame = params.get_external::<LazyFrame>(&cx, "_ldf")?.clone();
     let n_rows: usize = params.get_or("numRows", 500 as usize)?;
 
-    let fetch_task = Fetch {
-        ldf,
-        n_rows
-    };
+    let fetch_task = Fetch { ldf, n_rows };
     cx.env.spawn(fetch_task).map(|task| task.promise_object())
 }
 

--- a/nodejs-polars/src/series.rs
+++ b/nodejs-polars/src/series.rs
@@ -636,6 +636,31 @@ pub fn shrink_to_fit(_: CallContext) -> JsResult<JsUnknown> {
 }
 
 #[js_function(1)]
+pub fn to_array(cx: CallContext) -> JsResult<JsUnknown> {
+    let params = get_params(&cx)?;
+    let series: &Series = params.get_external::<Series>(&cx, "_series")?;
+
+    match *series.dtype() {
+        DataType::UInt8 => cx.env.to_js_value(series.u8().unwrap()),
+        DataType::UInt16 => cx.env.to_js_value(series.u16().unwrap()),
+        DataType::UInt32 => cx.env.to_js_value(series.u32().unwrap()),
+        DataType::UInt64 => cx.env.to_js_value(series.u64().unwrap()),
+        DataType::Int8 => cx.env.to_js_value(series.i8().unwrap()),
+        DataType::Int16 => cx.env.to_js_value(series.i16().unwrap()),
+        DataType::Int32 => cx.env.to_js_value(series.i32().unwrap()),
+        DataType::Int64 => cx.env.to_js_value(series.i64().unwrap()),
+        DataType::Float32 => cx.env.to_js_value(series.f32().unwrap()),
+        DataType::Float64 => cx.env.to_js_value(series.f64().unwrap()),
+        DataType::Utf8 => cx.env.to_js_value(series.utf8().unwrap()),
+        DataType::Date => cx.env.to_js_value(series.date().unwrap()),
+        DataType::Datetime(_, _) => cx.env.to_js_value(series.datetime().unwrap()),
+        DataType::List(_) => cx.env.to_js_value(series.list().unwrap()),
+        DataType::Categorical => cx.env.to_js_value(series.categorical().unwrap()),
+        _ => todo!(),
+    }
+}
+
+#[js_function(1)]
 pub fn is_in(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let series = params.get_external::<Series>(&cx, "_series")?;

--- a/nodejs-polars/src/series.rs
+++ b/nodejs-polars/src/series.rs
@@ -866,17 +866,11 @@ pub fn get_datetime(cx: CallContext) -> JsResult<JsUnknown> {
                 index as usize
             };
             match ca.get(index) {
-                Some(v) => {
-                    cx.env.create_date(v as f64).map(|v| v.into_unknown())
-                }
-                None => {
-                    cx.env.get_null().map(|v| v.into_unknown())
-                }
+                Some(v) => cx.env.create_date(v as f64).map(|v| v.into_unknown()),
+                None => cx.env.get_null().map(|v| v.into_unknown()),
             }
         }
-        Err(_) => {
-            cx.env.get_null().map(|v| v.into_unknown())
-        }
+        Err(_) => cx.env.get_null().map(|v| v.into_unknown()),
     }
 }
 
@@ -886,6 +880,17 @@ pub fn to_js(cx: CallContext) -> JsResult<JsUnknown> {
     let series = params.get_external::<Series>(&cx, "_series")?;
     let obj: JsUnknown = cx.env.to_js_value(series)?;
     Ok(obj)
+}
+
+#[js_function(1)]
+pub fn to_json(cx: CallContext) -> JsResult<napi::JsBuffer> {
+    let params = get_params(&cx)?;
+    let series = params.get_external::<Series>(&cx, "_series")?;
+    let buf = serde_json::to_vec(series).unwrap();
+
+    let bytes = cx.env.create_buffer_with_data(buf).unwrap();
+    let js_buff = bytes.into_raw();
+    Ok(js_buff)
 }
 
 #[js_function(1)]

--- a/nodejs-polars/src/series_object.rs
+++ b/nodejs-polars/src/series_object.rs
@@ -390,6 +390,7 @@ impl JsSeries {
             napi::Property::new(env, "weekday")?.with_method(weekday),
             napi::Property::new(env, "year")?.with_method(year),
             napi::Property::new(env, "zip_with")?.with_method(zip_with),
+            napi::Property::new(env, "to_array")?.with_method(to_array),
         ])?;
 
         Ok(series)

--- a/nodejs-polars/src/series_object.rs
+++ b/nodejs-polars/src/series_object.rs
@@ -391,6 +391,7 @@ impl JsSeries {
             napi::Property::new(env, "year")?.with_method(year),
             napi::Property::new(env, "zip_with")?.with_method(zip_with),
             napi::Property::new(env, "to_array")?.with_method(to_array),
+            napi::Property::new(env, "to_json")?.with_method(to_json),
         ])?;
 
         Ok(series)


### PR DESCRIPTION
adds better interop with native nodejs methods for series & to a lesser extend DataFrame. 


### Features 
To better align with native nodejs objects,  Series now implements the following

```ts
Series.from(arrayLike: ArrayLike<T>)
Series.of(...values: T[])
JSON.stringify(series)  
series.toJSON() 
series.values() // returns the iterator similar to `array.values()` 
```

### Refactors
- `series.toArray` now uses the serde implementation instead of the iterator.  Which changes `Int64` from bigint to number, and does not preserve dates for `Date` & `Datetime`. The Serde implementation is much faster than using the iterator, but can cause some downcasting. 
- `Array.from(series.values())` can still be used if you want to minimize any downcasting from serde. 
- `toJS` was renamed to `toObject` as it is already technically `js` so it makes more sense to convert it `toObject` instead of  `toJS`

