### PR TITLE
feat(nodejs): ipc & parquet support

### DIFF
--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -74,7 +74,7 @@ features = [
   "dataframe_arithmetic",
   "string_encoding",
   "parquet",
-  "ipc"
+  "ipc",
 ]
 path = "../polars"
 

--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -74,6 +74,7 @@ features = [
   "dataframe_arithmetic",
   "string_encoding",
   "parquet",
+  "ipc"
 ]
 path = "../polars"
 

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -60,6 +60,7 @@ describe("read:csv", () => {
   });
   it.todo("can read from a stream");
 });
+
 describe("read:json", () => {
   it("can read from a json file", () => {
     const df = pl.readJSON(jsonpath);
@@ -79,6 +80,7 @@ describe("read:json", () => {
     expect(df.toJSON({multiline:true})).toEqual(json.toString());
   });
 });
+
 describe("scan", () => {
   it("can lazy load (scan) from a csv file", () => {
     const df = pl.scanCSV(csvpath).collectSync();

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -5,7 +5,6 @@ import {Stream} from "stream";
 const csvpath = path.resolve(__dirname, "../../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv");
 // eslint-disable-next-line no-undef
 const jsonpath = path.resolve(__dirname, "./examples/foods.json");
-
 describe("read:csv", () => {
   it("can read from a csv file", () => {
     const df = pl.readCSV(csvpath);
@@ -78,6 +77,21 @@ describe("read:json", () => {
 describe("scan", () => {
   describe("csv", () => {
     it("can lazy load (scan) from a csv file", () => {
+      const df = pl.scanCSV(csvpath).collectSync();
+      expect(df.shape).toStrictEqual({height: 27, width: 4});
+    });
+    it("can lazy load (scan) from a csv file with options", () => {
+      const df = pl
+        .scanCSV(csvpath, {
+          hasHeader: false,
+          startRows: 1,
+          endRows: 4
+        })
+        .collectSync();
+
+      expect(df.shape).toStrictEqual({height: 4, width: 4});
+    });
+    it("can lazy load (scan) from a ipc file", () => {
       const df = pl.scanCSV(csvpath).collectSync();
       expect(df.shape).toStrictEqual({height: 27, width: 4});
     });

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -1,8 +1,13 @@
 import pl from "@polars";
 import path from "path";
 import {Stream} from "stream";
+import fs from "fs";
 // eslint-disable-next-line no-undef
 const csvpath = path.resolve(__dirname, "../../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv");
+// eslint-disable-next-line no-undef
+const parquetpath = path.resolve(__dirname, "./examples/foods.parquet");
+// eslint-disable-next-line no-undef
+const ipcpath = path.resolve(__dirname, "./examples/foods.ipc");
 // eslint-disable-next-line no-undef
 const jsonpath = path.resolve(__dirname, "./examples/foods.json");
 describe("read:csv", () => {
@@ -12,7 +17,7 @@ describe("read:csv", () => {
   });
 
   it("can read from a relative file", () => {
-    const df = pl.readCSV("../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv");
+    const df = pl.readCSV(csvpath);
     expect(df.shape).toStrictEqual({height: 27, width: 4});
   });
   it("can read from a csv file with options", () => {
@@ -75,39 +80,139 @@ describe("read:json", () => {
   });
 });
 describe("scan", () => {
-  describe("csv", () => {
-    it("can lazy load (scan) from a csv file", () => {
-      const df = pl.scanCSV(csvpath).collectSync();
-      expect(df.shape).toStrictEqual({height: 27, width: 4});
-    });
-    it("can lazy load (scan) from a csv file with options", () => {
-      const df = pl
-        .scanCSV(csvpath, {
-          hasHeader: false,
-          startRows: 1,
-          endRows: 4
-        })
-        .collectSync();
-
-      expect(df.shape).toStrictEqual({height: 4, width: 4});
-    });
-    it("can lazy load (scan) from a ipc file", () => {
-      const df = pl.scanCSV(csvpath).collectSync();
-      expect(df.shape).toStrictEqual({height: 27, width: 4});
-    });
-    it("can lazy load (scan) from a csv file with options", () => {
-      const df = pl
-        .scanCSV(csvpath, {
-          hasHeader: false,
-          startRows: 1,
-          endRows: 4
-        })
-        .collectSync();
-
-      expect(df.shape).toStrictEqual({height: 4, width: 4});
-    });
-    it.todo("can read from a stream");
+  it("can lazy load (scan) from a csv file", () => {
+    const df = pl.scanCSV(csvpath).collectSync();
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
   });
+  it("can lazy load (scan) from a csv file with options", () => {
+    const df = pl
+      .scanCSV(csvpath, {
+        hasHeader: false,
+        startRows: 1,
+        endRows: 4
+      })
+      .collectSync();
+
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+  it("can lazy load (scan) from a ipc file", () => {
+    const df = pl.scanCSV(csvpath).collectSync();
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+  it("can lazy load (scan) from a csv file with options", () => {
+    const df = pl
+      .scanCSV(csvpath, {
+        hasHeader: false,
+        startRows: 1,
+        endRows: 4
+      })
+      .collectSync();
+
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+
+  it("can lazy load (scan) from a parquet file with options", () => {
+    pl
+      .readCSV(csvpath, {
+        hasHeader: false,
+        startRows: 1,
+        endRows: 4
+      }).toParquet(parquetpath);
+
+    const df = pl.readParquet(parquetpath);
+
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+});
+
+describe("parquet", () => {
+  beforeEach(() => {
+    pl.readCSV(csvpath).toParquet(parquetpath);
+  });
+  afterEach(() => {
+    fs.rmSync(parquetpath);
+  });
+
+  test("read", () => {
+    const df = pl.readParquet(parquetpath);
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+  test("read:buffer", () => {
+    const buff = fs.readFileSync(parquetpath);
+    const df = pl.readParquet(buff);
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+
+  test("read:compressed", () => {
+    const csvDF = pl.readCSV(csvpath);
+    csvDF.toParquet(parquetpath, {compression: "lz4"});
+    const df = pl.readParquet(parquetpath);
+    expect(df).toFrameEqual(csvDF);
+  });
+
+  test("read:options", () => {
+    const df = pl.readParquet(parquetpath, {numRows: 4});
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+
+  test("scan", () => {
+    const df = pl.scanParquet(parquetpath).collectSync();
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+
+  test("scan:options", () => {
+    const df = pl.scanParquet(parquetpath, {numRows: 4}).collectSync();
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+});
+describe("ipc", () => {
+  beforeEach(() => {
+    pl.readCSV(csvpath).toIPC(ipcpath);
+  });
+  afterEach(() => {
+    fs.rmSync(ipcpath);
+  });
+
+  test("read", () => {
+    const df = pl.readIPC(ipcpath);
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+  test("read:buffer", () => {
+    const buff = fs.readFileSync(ipcpath);
+    const df = pl.readIPC(buff);
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+  test("read:compressed", () => {
+    const csvDF = pl.readCSV(csvpath);
+    csvDF.toIPC(ipcpath, {compression: "lz4"});
+    const ipcDF = pl.readIPC(ipcpath);
+    expect(ipcDF).toFrameEqual(csvDF);
+  });
+
+  // // https://github.com/pola-rs/polars/issues/2403
+  test.skip("read:options", () => {
+    const df = pl.readIPC(ipcpath, {numRows: 4});
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+
+  test("scan", () => {
+    const df = pl.scanIPC(ipcpath).collectSync();
+    expect(df.shape).toStrictEqual({height: 27, width: 4});
+  });
+
+  // https://github.com/pola-rs/polars/issues/2403
+  test.skip("scan:options", () => {
+    const df = pl.scanIPC(ipcpath, {numRows: 4}).collectSync();
+    expect(df.shape).toStrictEqual({height: 4, width: 4});
+  });
+
+  test("toIPC", () => {
+    const csvDF = pl.readCSV(csvpath);
+    csvDF.toIPC(ipcpath);
+    const ipcDF = pl.readIPC(ipcpath);
+    expect(ipcDF).toFrameEqual(csvDF);
+  });
+
 });
 
 describe("stream", () => {

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -1208,12 +1208,19 @@ export interface DataFrame extends Arithmetic<DataFrame> {
   toJSON(options?: WriteJsonOptions): string
   toJSON(destination: string | Writable, options?: WriteJsonOptions): void
 
-  /** write to IPC */
+  /**
+   * Write to Arrow IPC binary stream, or a feather file.
+   * @param file File path to which the file should be written.
+   * @param options.compression Compression method *defaults to "uncompressed"*
+   * */
   toIPC(path: string, options?: WriteIPCOptions): void
 
-  /** write to Parquet */
+  /**
+   * Write the DataFrame disk in parquet format.
+   * @param file File path to which the file should be written.
+   * @param options.compression Compression method *defaults to "uncompressed"*
+   * */
   toParquet(path: string, options?: WriteParquetOptions): void
-
   toSeries(index: number): Series<any>
   toString(): string
   /**

--- a/nodejs-polars/polars/datatypes.ts
+++ b/nodejs-polars/polars/datatypes.ts
@@ -86,6 +86,12 @@ export type ReadParquetOptions = {
   parallel?: boolean;
   rechunk?: boolean;
 }
+export type ReadIPCOptions = {
+  columns?: string[];
+  projection?: number[];
+  numRows?: number;
+}
+
 export type JoinBaseOptions = {
   how?: "left" | "inner" | "outer" | "cross";
   suffix?: string;

--- a/nodejs-polars/polars/datatypes.ts
+++ b/nodejs-polars/polars/datatypes.ts
@@ -55,42 +55,6 @@ export enum DataType {
 
 export type JsDataFrame = any;
 export type NullValues = string | Array<string> | Record<string, string>;
-export type ReadCsvOptions = {
-  batchSize?: number;
-  columns?: Array<string>;
-  commentChar?: string;
-  encoding?: "utf8" | "utf8-lossy";
-  endRows?: number;
-  hasHeader?: boolean;
-  ignoreErrors?: boolean;
-  inferSchemaLength?: number;
-  lowMemory?: boolean;
-  nullValues?: NullValues;
-  numThreads?: number;
-  parseDates?: boolean;
-  projection?: Array<number>;
-  quoteChar?: string;
-  rechunk?: boolean;
-  sep?: string;
-  startRows?: number;
-};
-export type ReadJsonOptions = {
-  inferSchemaLength?: number;
-  batchSize?: number;
-};
-
-export type ReadParquetOptions = {
-  columns?: string[];
-  projection?: number[];
-  numRows?: number;
-  parallel?: boolean;
-  rechunk?: boolean;
-}
-export type ReadIPCOptions = {
-  columns?: string[];
-  projection?: number[];
-  numRows?: number;
-}
 
 export type JoinBaseOptions = {
   how?: "left" | "inner" | "outer" | "cross";
@@ -102,14 +66,6 @@ export type JoinOptions = {
   on?: string | Array<string>;
   how?: "left" | "inner" | "outer" | "cross";
   suffix?: string;
-};
-export type WriteCsvOptions = {
-  hasHeader?: boolean;
-  sep?: string;
-};
-export type WriteJsonOptions = {
-  orient?: "row" | "col" | "dataframe";
-  multiline?: boolean;
 };
 
 

--- a/nodejs-polars/polars/index.ts
+++ b/nodejs-polars/polars/index.ts
@@ -47,13 +47,13 @@ namespace pl {
 
   // IO
   export import scanCSV = io.scanCSV;
-  export import scanJSON = io.scanJSON;
-  export import scanParquet = io.scanParquet;
-  export import readCSV = io.readCSV;
   export import scanIPC = io.scanIPC;
+  export import scanParquet = io.scanParquet;
+
+  export import readCSV = io.readCSV;
   export import readIPC = io.readIPC;
-  export import readParquet = io.readParquet;
   export import readJSON = io.readJSON;
+  export import readParquet = io.readParquet;
 
   export import readCSVStream = io.readCSVStream;
   export import readJSONStream = io.readJSONStream;

--- a/nodejs-polars/polars/index.ts
+++ b/nodejs-polars/polars/index.ts
@@ -2,7 +2,7 @@ import * as series from "./series";
 import * as df from "./dataframe";
 import { DataType } from "./datatypes";
 import * as func from "./functions";
-import * as io from "./io";
+import io from "./io";
 import * as cfg from "./cfg";
 import {version as _version} from "../package.json";
 
@@ -13,6 +13,7 @@ import  {
   GroupBy as lazyGroupBy,
   when as _when
 } from "./lazy";
+
 
 namespace pl {
   export import Expr = lazyExpr.Expr

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -78,224 +78,407 @@ const readJsonDefaultOptions: Partial<ReadJsonOptions> = {
   inferSchemaLength: 50
 };
 
-/**
- * __Read a CSV file or string into a Dataframe.__
- * ___
- * @param pathOrBody - path or buffer or string
- *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.csv`.
- *   - body: String or buffer to be read as a CSV
- * @param options
- * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
- *     If set to `null`, a full table scan will be done (slow).
- * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
- * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
- *     `x` being an enumeration over every column in the dataset.
- * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
- * @param options.endRows -After n rows are read from the CSV, it stops reading.
- *     During multi-threaded parsing, an upper bound of `n` rows
- *     cannot be guaranteed.
- * @param options.startRows -Start reading after `startRows` position.
- * @param options.projection -Indices of columns to select. Note that column indices start at zero.
- * @param options.sep -Character to use as delimiter in the file.
- * @param options.columns -Columns to select.
- * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
- * @param options.encoding -Allowed encodings: `utf8`, `utf8-lossy`. Lossy means that invalid utf8 values are replaced with `�` character.
- * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
- * @param options.dtype -Overwrite the dtypes during inference.
- * @param options.lowMemory - Reduce memory usage in expense of performance.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
- * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
- * @param options.nullValues - Values to interpret as null values. You can provide a
- *     - `string` -> all values encountered equal to this string will be null
- *     - `Array<string>` -> A null value per column.
- *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
- * @param options.parseDates -Whether to attempt to parse dates or not
- * @returns DataFrame
- */
-export function readCSV(pathOrBody: string | Buffer, options?: Partial<ReadCsvOptions>): DataFrame {
-  const extensions = [".tsv", ".csv"];
+// type definitions
+namespace io {
 
-  if (Buffer.isBuffer(pathOrBody)) {
-    return readCSVBuffer(pathOrBody, options);
-  }
+  /**
+   * __Read a CSV file or string into a Dataframe.__
+   * ___
+   * @param pathOrBody - path or buffer or string
+   *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.csv`.
+   *   - body: String or buffer to be read as a CSV
+   * @param options
+   * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+   *     If set to `null`, a full table scan will be done (slow).
+   * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+   * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
+   *     `x` being an enumeration over every column in the dataset.
+   * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
+   * @param options.endRows -After n rows are read from the CSV, it stops reading.
+   *     During multi-threaded parsing, an upper bound of `n` rows
+   *     cannot be guaranteed.
+   * @param options.startRows -Start reading after `startRows` position.
+   * @param options.projection -Indices of columns to select. Note that column indices start at zero.
+   * @param options.sep -Character to use as delimiter in the file.
+   * @param options.columns -Columns to select.
+   * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
+   * @param options.encoding -Allowed encodings: `utf8`, `utf8-lossy`. Lossy means that invalid utf8 values are replaced with `�` character.
+   * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
+   * @param options.dtype -Overwrite the dtypes during inference.
+   * @param options.lowMemory - Reduce memory usage in expense of performance.
+   * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+   * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
+   * @param options.nullValues - Values to interpret as null values. You can provide a
+   *     - `string` -> all values encountered equal to this string will be null
+   *     - `Array<string>` -> A null value per column.
+   *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
+   * @param options.parseDates -Whether to attempt to parse dates or not
+   * @returns DataFrame
+   */
+  export interface readCSV{(pathOrBody: string | Buffer, options?: Partial<ReadCsvOptions>): DataFrame;}
 
-  if (typeof pathOrBody === "string") {
-    const inline = !isPath(pathOrBody, extensions);
-    if (inline) {
-      return readCSVBuffer(Buffer.from(pathOrBody, "utf-8"), options);
-    } else {
-      return readCSVPath(pathOrBody, options);
+  /**
+   * __Lazily read from a CSV file or multiple files via glob patterns.__
+   *
+   * This allows the query optimizer to push down predicates and
+   * projections to the scan level, thereby potentially reducing
+   * memory overhead.
+   * ___
+   * @param path path to a file
+   * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
+   *     `x` being an enumeration over every column in the dataset.
+   * @param options.sep -Character to use as delimiter in the file.
+   * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+   * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
+   * @param options.startRows -Start reading after `startRows` position.
+   * @param options.nullValues - Values to interpret as null values. You can provide a
+   *     - `string` -> all values encountered equal to this string will be null
+   *     - `Array<string>` -> A null value per column.
+   *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
+   * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
+   * @param options.cache Cache the result after reading.
+   * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+   *     If set to `null`, a full table scan will be done (slow).
+   * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+   * @param options.endRows -After n rows are read from the CSV, it stops reading.
+   *     During multi-threaded parsing, an upper bound of `n` rows
+   *     cannot be guaranteed.
+   * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
+   * @param options.lowMemory - Reduce memory usage in expense of performance.
+   * ___
+   *
+   */
+  export interface scanCSV {(path: string, options?: Partial<ReadCsvOptions>): LazyDataFrame}
+
+  /**
+   * __Read a JSON file or string into a DataFrame.__
+   *
+   * _Note: Currently only newline delimited JSON is supported_
+   * @param pathOrBody - path or buffer or string
+   *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.csv`.
+   *   - body: String or buffer to be read as a CSV
+   * @param options
+   * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+   *    If set to `null`, a full table scan will be done (slow).
+   * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+   * @returns ({@link DataFrame})
+   * @example
+   * ```
+   * const jsonString = `
+   * {"a", 1, "b", "foo", "c": 3}
+   * {"a": 2, "b": "bar", "c": 6}
+   * `
+   * > const df = pl.readJSON(jsonString)
+   * > console.log(df)
+   *   shape: (2, 3)
+   * ╭─────┬─────┬─────╮
+   * │ a   ┆ b   ┆ c   │
+   * │ --- ┆ --- ┆ --- │
+   * │ i64 ┆ str ┆ i64 │
+   * ╞═════╪═════╪═════╡
+   * │ 1   ┆ foo ┆ 3   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 2   ┆ bar ┆ 6   │
+   * ╰─────┴─────┴─────╯
+   * ```
+   */
+  export interface readJSON {(pathOrBody: string | Buffer, options?: Partial<ReadJsonOptions>): DataFrame}
+
+  /**
+   * Read into a DataFrame from a parquet file.
+   * @param pathOrBuffer
+   * Path to a file, list of files, or a file like object. If the path is a directory, that directory will be used
+   * as partition aware scan.
+   * @param options.columns Columns to select. Accepts a list of column names.
+   * @param options.numRows  Stop reading from parquet file after reading ``n_rows``.
+   * @param options.parallel Read the parquet file in parallel. The single threaded reader consumes less memory.
+   */
+  export interface readParquet{(pathOrBody: string | Buffer, options?: ReadParquetOptions): DataFrame}
+
+  /**
+   * __Lazily read from a parquet file or multiple files via glob patterns.__
+   * ___
+   * This allows the query optimizer to push down predicates and projections to the scan level,
+   * thereby potentially reducing memory overhead.
+   * @param path Path to a file or or glob pattern
+   * @param options.numRows Stop reading from parquet file after reading ``n_rows``.
+   * @param options.cache Cache the result after reading.
+   * @param options.parallel Read the parquet file in parallel. The single threaded reader consumes less memory.
+   * @param options.rechunk In case of reading multiple files via a glob pattern rechunk the final DataFrame into contiguous memory chunks.
+   */
+  export interface scanParquet{(path: string, options?: ScanParquetOptions): LazyDataFrame}
+
+  /**
+   * __Read into a DataFrame from Arrow IPC (Feather v2) file.__
+   * ___
+   * @param pathOrBody - path or buffer or string
+   *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.ipc`.
+   *   - body: String or buffer to be read as Arrow IPC
+   * @param options.columns Columns to select. Accepts a list of column names.
+   * @param options.numRows Stop reading from parquet file after reading ``n_rows``.
+   */
+  export interface readIPC{(pathOrBody: string | Buffer, options?: ReadIPCOptions): DataFrame }
+
+  /**
+   * __Lazily read from an Arrow IPC (Feather v2) file or multiple files via glob patterns.__
+   * ___
+   * @param path Path to a IPC file.
+   * @param options.numRows Stop reading from IPC file after reading ``numRows``
+   * @param options.cache Cache the result after reading.
+   * @param options.rechunk Reallocate to contiguous memory when all chunks/ files are parsed.
+   */
+  export interface scanIPC{(path: string, options?: ScanIPCOptions): LazyDataFrame}
+
+  /**
+   * __Read a stream into a Dataframe.__
+   *
+   * **Warning:** this is much slower than `scanCSV` or `readCSV`
+   *
+   * This will consume the entire stream into a single buffer and then call `readCSV`
+   * Only use it when you must consume from a stream, or when performance is not a major consideration
+   *
+   * ___
+   * @param stream - readable stream containing csv data
+   * @param options
+   * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+   *     If set to `null`, a full table scan will be done (slow).
+   * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+   * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
+   *     `x` being an enumeration over every column in the dataset.
+   * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
+   * @param options.endRows -After n rows are read from the CSV, it stops reading.
+   *     During multi-threaded parsing, an upper bound of `n` rows
+   *     cannot be guaranteed.
+   * @param options.startRows -Start reading after `startRows` position.
+   * @param options.projection -Indices of columns to select. Note that column indices start at zero.
+   * @param options.sep -Character to use as delimiter in the file.
+   * @param options.columns -Columns to select.
+   * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
+   * @param options.encoding -Allowed encodings: `utf8`, `utf8-lossy`. Lossy means that invalid utf8 values are replaced with `�` character.
+   * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
+   * @param options.dtype -Overwrite the dtypes during inference.
+   * @param options.lowMemory - Reduce memory usage in expense of performance.
+   * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+   * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
+   * @param options.nullValues - Values to interpret as null values. You can provide a
+   *     - `string` -> all values encountered equal to this string will be null
+   *     - `Array<string>` -> A null value per column.
+   *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
+   * @param options.parseDates -Whether to attempt to parse dates or not
+   * @returns Promise<DataFrame>
+   *
+   * @example
+   * ```
+   * >>> const readStream = new Stream.Readable({read(){}});
+   * >>> readStream.push(`a,b\n`);
+   * >>> readStream.push(`1,2\n`);
+   * >>> readStream.push(`2,2\n`);
+   * >>> readStream.push(`3,2\n`);
+   * >>> readStream.push(`4,2\n`);
+   * >>> readStream.push(null);
+   *
+   * >>> pl.readCSVStream(readStream).then(df => console.log(df));
+   * shape: (4, 2)
+   * ┌─────┬─────┐
+   * │ a   ┆ b   │
+   * │ --- ┆ --- │
+   * │ i64 ┆ i64 │
+   * ╞═════╪═════╡
+   * │ 1   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 2   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 3   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 4   ┆ 2   │
+   * └─────┴─────┘
+   * ```
+   */
+  export interface readCSVStream{(stream: Readable, options?: ReadCsvOptions): Promise<DataFrame>}
+
+  /**
+   * __Read a newline delimited JSON stream into a DataFrame.__
+   *
+   * @param stream - readable stream containing json data
+   * @param options
+   * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
+   *    If set to `null`, a full table scan will be done (slow).
+   *    Note: this is done per batch
+   * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
+   * @example
+   * ```
+   * >>> const readStream = new Stream.Readable({read(){}});
+   * >>> readStream.push(`${JSON.stringify({a: 1, b: 2})} \n`);
+   * >>> readStream.push(`${JSON.stringify({a: 2, b: 2})} \n`);
+   * >>> readStream.push(`${JSON.stringify({a: 3, b: 2})} \n`);
+   * >>> readStream.push(`${JSON.stringify({a: 4, b: 2})} \n`);
+   * >>> readStream.push(null);
+   *
+   * >>> pl.readJSONStream(readStream).then(df => console.log(df));
+   * shape: (4, 2)
+   * ┌─────┬─────┐
+   * │ a   ┆ b   │
+   * │ --- ┆ --- │
+   * │ i64 ┆ i64 │
+   * ╞═════╪═════╡
+   * │ 1   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 2   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 3   ┆ 2   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 4   ┆ 2   │
+   * └─────┴─────┘
+   * ```
+   */
+  export interface readJSONStream{(stream: Readable, options?: ReadJsonOptions): Promise<DataFrame>}
+}
+
+
+// Implementation
+namespace io {
+
+  export function readCSV(pathOrBody, options?) {
+    const extensions = [".tsv", ".csv"];
+
+    if (Buffer.isBuffer(pathOrBody)) {
+      return readCSVBuffer(pathOrBody, options);
     }
-  } else {
-    throw new Error("must supply either a path or body");
-  }
-}
 
-/**
- * __Lazily read from a CSV file or multiple files via glob patterns.__
- *
- * This allows the query optimizer to push down predicates and
- * projections to the scan level, thereby potentially reducing
- * memory overhead.
- * ___
- * @param path path to a file
- * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
- *     `x` being an enumeration over every column in the dataset.
- * @param options.sep -Character to use as delimiter in the file.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
- * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
- * @param options.startRows -Start reading after `startRows` position.
- * @param options.nullValues - Values to interpret as null values. You can provide a
- *     - `string` -> all values encountered equal to this string will be null
- *     - `Array<string>` -> A null value per column.
- *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
- * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
- * @param options.cache Cache the result after reading.
- * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
- *     If set to `null`, a full table scan will be done (slow).
- * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
- * @param options.endRows -After n rows are read from the CSV, it stops reading.
- *     During multi-threaded parsing, an upper bound of `n` rows
- *     cannot be guaranteed.
- * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
- * @param options.lowMemory - Reduce memory usage in expense of performance.
- * ___
- *
- */
-export function scanCSV(path: string, options?: Partial<ReadCsvOptions>): LazyDataFrame {
-  options = {...readCsvDefaultOptions, ...options};
-
-  return LazyDataFrame(pli.ldf.scanCSV({path, ...options}));
-}
-
-/**
- * __Read a JSON file or string into a DataFrame.__
- *
- * _Note: Currently only newline delimited JSON is supported_
- * @param pathOrBody - path or buffer or string
- *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.csv`.
- *   - body: String or buffer to be read as a CSV
- * @param options
- * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
- *    If set to `null`, a full table scan will be done (slow).
- * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
- * @returns ({@link DataFrame})
- * @example
- * ```
- * const jsonString = `
- * {"a", 1, "b", "foo", "c": 3}
- * {"a": 2, "b": "bar", "c": 6}
- * `
- * > const df = pl.readJSON(jsonString)
- * > console.log(df)
- *   shape: (2, 3)
- * ╭─────┬─────┬─────╮
- * │ a   ┆ b   ┆ c   │
- * │ --- ┆ --- ┆ --- │
- * │ i64 ┆ str ┆ i64 │
- * ╞═════╪═════╪═════╡
- * │ 1   ┆ foo ┆ 3   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 2   ┆ bar ┆ 6   │
- * ╰─────┴─────┴─────╯
- * ```
- */
-export function readJSON(pathOrBody: string | Buffer, options?: Partial<ReadJsonOptions>): DataFrame {
-  const extensions = [".ndjson", ".json", ".jsonl"];
-  if (Buffer.isBuffer(pathOrBody)) {
-    return readJSONBuffer(pathOrBody, options);
-  }
-
-  if (typeof pathOrBody === "string") {
-    const inline = !isPath(pathOrBody, extensions);
-    if (inline) {
-      return readJSONBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+    if (typeof pathOrBody === "string") {
+      const inline = !isPath(pathOrBody, extensions);
+      if (inline) {
+        return readCSVBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+      } else {
+        return readCSVPath(pathOrBody, options);
+      }
     } else {
-      return readJSONPath(pathOrBody, options);
+      throw new Error("must supply either a path or body");
     }
-  } else {
-    throw new Error("must supply either a path or body");
-  }
-}
-
-
-/**
- * Read into a DataFrame from a parquet file.
- * @param pathOrBuffer
- * Path to a file, list of files, or a file like object. If the path is a directory, that directory will be used
- * as partition aware scan.
- * @param options.columns Columns to select. Accepts a list of column names.
- * @param options.numRows  Stop reading from parquet file after reading ``n_rows``.
- * @param options.parallel Read the parquet file in parallel. The single threaded reader consumes less memory.
- */
-export function readParquet(pathOrBody: string | Buffer, options?: ReadParquetOptions): DataFrame {
-  if (Buffer.isBuffer(pathOrBody)) {
-    return readParquetBuffer(pathOrBody, options);
   }
 
-  if (typeof pathOrBody === "string") {
-    const inline = !isPath(pathOrBody, [".parquet"]);
-    if (inline) {
-      return readParquetBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+  export function scanCSV(path, options?) {
+    options = {...readCsvDefaultOptions, ...options};
+
+    return LazyDataFrame(pli.ldf.scanCSV({path, ...options}));
+  }
+
+  export function readJSON(pathOrBody, options?) {
+    const extensions = [".ndjson", ".json", ".jsonl"];
+    if (Buffer.isBuffer(pathOrBody)) {
+      return readJSONBuffer(pathOrBody, options);
+    }
+
+    if (typeof pathOrBody === "string") {
+      const inline = !isPath(pathOrBody, extensions);
+      if (inline) {
+        return readJSONBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+      } else {
+        return readJSONPath(pathOrBody, options);
+      }
     } else {
-      return readParquetPath(pathOrBody, options);
+      throw new Error("must supply either a path or body");
     }
-  } else {
-    throw new Error("must supply either a path or body");
-  }
-}
-/**
- * __Lazily read from a parquet file or multiple files via glob patterns.__
- * ___
- * This allows the query optimizer to push down predicates and projections to the scan level,
- * thereby potentially reducing memory overhead.
- * @param path Path to a file or or glob pattern
- * @param options.numRows Stop reading from parquet file after reading ``n_rows``.
- * @param options.cache Cache the result after reading.
- * @param options.parallel Read the parquet file in parallel. The single threaded reader consumes less memory.
- * @param options.rechunk In case of reading multiple files via a glob pattern rechunk the final DataFrame into contiguous memory chunks.
- */
-export function scanParquet(path: string, options?: ScanParquetOptions): LazyDataFrame {
-  return LazyDataFrame(pli.ldf.scanParquet({path, ...options}));
-}
-
-
-/**
- * __Read into a DataFrame from Arrow IPC (Feather v2) file.__
- * ___
- * @param pathOrBody - path or buffer or string
- *   - path: Path to a file or a file like string. Any valid filepath can be used. Example: `file.ipc`.
- *   - body: String or buffer to be read as Arrow IPC
- * @param options.columns Columns to select. Accepts a list of column names.
- * @param options.numRows Stop reading from parquet file after reading ``n_rows``.
- */
-export function readIPC(pathOrBody: string | Buffer, options?: ReadIPCOptions): DataFrame {
-  if (Buffer.isBuffer(pathOrBody)) {
-    return readIPCBuffer(pathOrBody, options);
   }
 
-  if (typeof pathOrBody === "string") {
-    const inline = !isPath(pathOrBody, [".ipc"]);
-    if (inline) {
-      return readIPCBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+  export function readParquet(pathOrBody, options?) {
+    if (Buffer.isBuffer(pathOrBody)) {
+      return readParquetBuffer(pathOrBody, options);
+    }
+
+    if (typeof pathOrBody === "string") {
+      const inline = !isPath(pathOrBody, [".parquet"]);
+      if (inline) {
+        return readParquetBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+      } else {
+        return readParquetPath(pathOrBody, options);
+      }
     } else {
-      return readIPCPath(pathOrBody, options);
+      throw new Error("must supply either a path or body");
     }
-  } else {
-    throw new Error("must supply either a path or body");
   }
-}
 
-/**
- * __Lazily read from an Arrow IPC (Feather v2) file or multiple files via glob patterns.__
- * ___
- * @param path Path to a IPC file.
- * @param options.numRows Stop reading from IPC file after reading ``numRows``
- * @param options.cache Cache the result after reading.
- * @param options.rechunk Reallocate to contiguous memory when all chunks/ files are parsed.
- */
-export function scanIPC(path: string, options?: ScanIPCOptions): LazyDataFrame {
-  return LazyDataFrame(pli.ldf.scanIPC({path, ...options}));
+  export function scanParquet(path, options?) {
+    return LazyDataFrame(pli.ldf.scanParquet({path, ...options}));
+  }
+
+  export function readIPC(pathOrBody, options?) {
+    if (Buffer.isBuffer(pathOrBody)) {
+      return readIPCBuffer(pathOrBody, options);
+    }
+
+    if (typeof pathOrBody === "string") {
+      const inline = !isPath(pathOrBody, [".ipc"]);
+      if (inline) {
+        return readIPCBuffer(Buffer.from(pathOrBody, "utf-8"), options);
+      } else {
+        return readIPCPath(pathOrBody, options);
+      }
+    } else {
+      throw new Error("must supply either a path or body");
+    }
+  }
+
+  export function scanIPC(path, options?) {
+    return LazyDataFrame(pli.ldf.scanIPC({path, ...options}));
+  }
+
+  export function readCSVStream(stream, options?) {
+    let batchSize = options?.batchSize ?? 10000;
+    let count = 0;
+    let end = options?.endRows ?? Number.POSITIVE_INFINITY;
+
+    return new Promise((resolve, reject) => {
+      const s = stream.pipe(new LineBatcher({batchSize}));
+      const chunks: any[] = [];
+
+      s.on("data", (chunk) => {
+        // early abort if 'end rows' is specified
+        if (count <= end) {
+          chunks.push(chunk);
+        } else {
+          s.end();
+        }
+        count += batchSize;
+      }).on("end", () => {
+        try {
+          let buff = Buffer.concat(chunks);
+          const df = readCSVBuffer(buff, options);
+          resolve(df);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  export function readJSONStream(stream, options?) {
+    let batchSize = options?.batchSize ?? 10000;
+
+    return new Promise((resolve, reject) => {
+      const chunks: any[] = [];
+
+      stream
+        .pipe(new LineBatcher({batchSize}))
+        .on("data", (chunk) => {
+          try {
+            const df = readJSONBuffer(chunk, options);
+            chunks.push(df);
+          } catch (err) {
+            reject(err);
+          }
+        })
+        .on("end", () => {
+          try {
+            const df = concat(chunks);
+            resolve(df);
+          } catch (err) {
+            reject(err);
+          }
+        });
+
+    });
+  }
 }
 
 
@@ -344,164 +527,6 @@ class LineBatcher extends Stream.Transform {
   }
 }
 
-/**
- * __Read a stream into a Dataframe.__
- *
- * **Warning:** this is much slower than `scanCSV` or `readCSV`
- *
- * This will consume the entire stream into a single buffer and then call `readCSV`
- * Only use it when you must consume from a stream, or when performance is not a major consideration
- *
- * ___
- * @param stream - readable stream containing csv data
- * @param options
- * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
- *     If set to `null`, a full table scan will be done (slow).
- * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
- * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
- *     `x` being an enumeration over every column in the dataset.
- * @param options.ignoreErrors -Try to keep reading lines if some lines yield errors.
- * @param options.endRows -After n rows are read from the CSV, it stops reading.
- *     During multi-threaded parsing, an upper bound of `n` rows
- *     cannot be guaranteed.
- * @param options.startRows -Start reading after `startRows` position.
- * @param options.projection -Indices of columns to select. Note that column indices start at zero.
- * @param options.sep -Character to use as delimiter in the file.
- * @param options.columns -Columns to select.
- * @param options.rechunk -Make sure that all columns are contiguous in memory by aggregating the chunks into a single array.
- * @param options.encoding -Allowed encodings: `utf8`, `utf8-lossy`. Lossy means that invalid utf8 values are replaced with `�` character.
- * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
- * @param options.dtype -Overwrite the dtypes during inference.
- * @param options.lowMemory - Reduce memory usage in expense of performance.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
- * @param options.quotChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
- * @param options.nullValues - Values to interpret as null values. You can provide a
- *     - `string` -> all values encountered equal to this string will be null
- *     - `Array<string>` -> A null value per column.
- *     - `Record<string,string>` -> An object or map that maps column name to a null value string.Ex. {"column_1": 0}
- * @param options.parseDates -Whether to attempt to parse dates or not
- * @returns Promise<DataFrame>
- *
- * @example
- * ```
- * >>> const readStream = new Stream.Readable({read(){}});
- * >>> readStream.push(`a,b\n`);
- * >>> readStream.push(`1,2\n`);
- * >>> readStream.push(`2,2\n`);
- * >>> readStream.push(`3,2\n`);
- * >>> readStream.push(`4,2\n`);
- * >>> readStream.push(null);
- *
- * >>> pl.readCSVStream(readStream).then(df => console.log(df));
- * shape: (4, 2)
- * ┌─────┬─────┐
- * │ a   ┆ b   │
- * │ --- ┆ --- │
- * │ i64 ┆ i64 │
- * ╞═════╪═════╡
- * │ 1   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 2   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 3   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 4   ┆ 2   │
- * └─────┴─────┘
- * ```
- */
-export function readCSVStream(stream: Readable, options?: ReadCsvOptions): Promise<DataFrame> {
-  let batchSize = options?.batchSize ?? 10000;
-  let count = 0;
-  let end = options?.endRows ?? Number.POSITIVE_INFINITY;
-
-  return new Promise((resolve, reject) => {
-    const s = stream.pipe(new LineBatcher({batchSize}));
-    const chunks: any[] = [];
-
-    s.on("data", (chunk) => {
-      // early abort if 'end rows' is specified
-      if (count <= end) {
-        chunks.push(chunk);
-      } else {
-        s.end();
-      }
-      count += batchSize;
-    }).on("end", () => {
-      try {
-        let buff = Buffer.concat(chunks);
-        const df = readCSVBuffer(buff, options);
-        resolve(df);
-      } catch (err) {
-        reject(err);
-      }
-    });
-  });
-}
-
-/**
- * __Read a newline delimited JSON stream into a DataFrame.__
- *
- * @param stream - readable stream containing json data
- * @param options
- * @param options.inferSchemaLength -Maximum number of lines to read to infer schema. If set to 0, all columns will be read as pl.Utf8.
- *    If set to `null`, a full table scan will be done (slow).
- *    Note: this is done per batch
- * @param options.batchSize - Number of lines to read into the buffer at once. Modify this to change performance.
- * @example
- * ```
- * >>> const readStream = new Stream.Readable({read(){}});
- * >>> readStream.push(`${JSON.stringify({a: 1, b: 2})} \n`);
- * >>> readStream.push(`${JSON.stringify({a: 2, b: 2})} \n`);
- * >>> readStream.push(`${JSON.stringify({a: 3, b: 2})} \n`);
- * >>> readStream.push(`${JSON.stringify({a: 4, b: 2})} \n`);
- * >>> readStream.push(null);
- *
- * >>> pl.readJSONStream(readStream).then(df => console.log(df));
- * shape: (4, 2)
- * ┌─────┬─────┐
- * │ a   ┆ b   │
- * │ --- ┆ --- │
- * │ i64 ┆ i64 │
- * ╞═════╪═════╡
- * │ 1   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 2   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 3   ┆ 2   │
- * ├╌╌╌╌╌┼╌╌╌╌╌┤
- * │ 4   ┆ 2   │
- * └─────┴─────┘
- * ```
- */
-export function readJSONStream(stream: Readable, options?: ReadJsonOptions): Promise<DataFrame> {
-  let batchSize = options?.batchSize ?? 10000;
-
-  return new Promise((resolve, reject) => {
-    const chunks: any[] = [];
-
-    stream
-      .pipe(new LineBatcher({batchSize}))
-      .on("data", (chunk) => {
-        try {
-          const df = readJSONBuffer(chunk, options);
-          chunks.push(df);
-        } catch (err) {
-          reject(err);
-        }
-      })
-      .on("end", () => {
-        try {
-          const df = concat(chunks);
-          resolve(df);
-        } catch (err) {
-          reject(err);
-        }
-      });
-
-  });
-}
-
-
 // helper functions
 
 function readCSVBuffer(buff, options) {
@@ -528,3 +553,6 @@ function readIPCBuffer(buff, options) {
 function readIPCPath(path, options) {
   return dfWrapper(pli.df.readIPCPath({...options, path}));
 }
+
+
+export = io;

--- a/nodejs-polars/polars/io.ts
+++ b/nodejs-polars/polars/io.ts
@@ -1,10 +1,63 @@
-import { ReadCsvOptions, ReadIPCOptions, ReadJsonOptions, ReadParquetOptions } from "./datatypes";
+import { NullValues } from "./datatypes";
 import pli from "./internals/polars_internal";
 import {DataFrame, dfWrapper} from "./dataframe";
 import { isPath } from "./utils";
 import {LazyDataFrame} from "./lazy/dataframe";
 import {Readable, Stream} from "stream";
 import {concat} from "./functions";
+
+
+type ScanIPCOptions = {
+  numRows?: number;
+  cache?: boolean;
+  rechunk?: boolean;
+}
+
+type ScanParquetOptions = {
+  numRows?: number;
+  parallel?: boolean;
+  cache?: boolean;
+  rechunk?: boolean;
+}
+
+type ReadCsvOptions = {
+  batchSize?: number;
+  columns?: Array<string>;
+  commentChar?: string;
+  encoding?: "utf8" | "utf8-lossy";
+  endRows?: number;
+  hasHeader?: boolean;
+  ignoreErrors?: boolean;
+  inferSchemaLength?: number;
+  lowMemory?: boolean;
+  nullValues?: NullValues;
+  numThreads?: number;
+  parseDates?: boolean;
+  projection?: Array<number>;
+  quoteChar?: string;
+  rechunk?: boolean;
+  sep?: string;
+  startRows?: number;
+};
+type ReadJsonOptions = {
+  inferSchemaLength?: number;
+  batchSize?: number;
+};
+
+type ReadParquetOptions = {
+  columns?: string[];
+  projection?: number[];
+  numRows?: number;
+  parallel?: boolean;
+  rechunk?: boolean;
+}
+
+type ReadIPCOptions = {
+  columns?: string[];
+  projection?: number[];
+  numRows?: number;
+}
+
 
 const readCsvDefaultOptions: Partial<ReadCsvOptions> = {
   inferSchemaLength: 50,
@@ -200,10 +253,18 @@ export function readIPC(pathOrBody: string | Buffer, options?: ReadIPCOptions): 
   } else {
     throw new Error("must supply either a path or body");
   }
-}export function scanIPC() {}
+}
 
 
-export function scanParquet() {}
+export function scanIPC(path: string, options?: ScanIPCOptions): LazyDataFrame {
+  return LazyDataFrame(pli.ldf.scanIPC({path, ...options}));
+}
+
+
+export function scanParquet(path: string, options?: ScanParquetOptions): LazyDataFrame {
+  return LazyDataFrame(pli.ldf.scanParquet({path, ...options}));
+}
+
 export function scanJSON() {}
 
 // utility to read streams as lines.
@@ -407,4 +468,3 @@ export function readJSONStream(stream: Readable, options?: ReadJsonOptions): Pro
 
   });
 }
-

--- a/nodejs-polars/src/dataframe/io.rs
+++ b/nodejs-polars/src/dataframe/io.rs
@@ -211,9 +211,8 @@ pub(crate) fn write_csv_path(cx: CallContext) -> JsResult<JsUndefined> {
 // ------
 // PARQUET
 // ------
-
 #[js_function(1)]
-pub(crate) fn read_parquet(cx: CallContext) -> JsResult<JsExternal> {
+pub(crate) fn read_parquet_path(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let path = params.get_as::<String>("path")?;
     let columns: Option<Vec<String>> = params.get_as("columns")?;
@@ -225,6 +224,30 @@ pub(crate) fn read_parquet(cx: CallContext) -> JsResult<JsExternal> {
     let f = File::open(&path)?;
 
     ParquetReader::new(f)
+        .with_projection(projection)
+        .with_columns(columns)
+        .read_parallel(parallel)
+        .with_n_rows(n_rows)
+        .set_rechunk(rechunk)
+        .finish()
+        .map_err(JsPolarsEr::from)?
+        .try_into_js(&cx)
+}
+
+#[js_function(1)]
+pub(crate) fn read_parquet_buffer(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let columns: Option<Vec<String>> = params.get_as("columns")?;
+    let projection: Option<Vec<usize>> = params.get_as("projection")?;
+    let n_rows: Option<usize> = params.get_as("numRows")?;
+    let parallel: bool = params.get_or("parallel", true)?;
+    let rechunk: bool = params.get_or("rechunk", true)?;
+    let buff = params.get::<napi::JsBuffer>("buff")?;
+    let buffer_value = buff.into_value()?;
+
+    let cursor = Cursor::new(buffer_value.as_ref());
+
+    ParquetReader::new(cursor)
         .with_projection(projection)
         .with_columns(columns)
         .read_parallel(parallel)
@@ -271,10 +294,67 @@ pub(crate) fn write_parquet_stream(_cx: CallContext) -> JsResult<JsUndefined> {
 // ------
 
 #[js_function(1)]
-#[cfg(feature = "ipc")]
-pub(crate) fn read_ipc(_cx: CallContext) -> JsResult<JsExternal> {
-    todo!()
+pub(crate) fn read_ipc_path(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let path = params.get_as::<String>("path")?;
+    let columns: Option<Vec<String>> = params.get_as("columns")?;
+    let projection: Option<Vec<usize>> = params.get_as("projection")?;
+    let n_rows: Option<usize> = params.get_as("numRows")?;
+
+    let f = File::open(&path)?;
+
+    IpcReader::new(f)
+        .with_projection(projection)
+        .with_columns(columns)
+        .with_n_rows(n_rows)
+        .finish()
+        .map_err(JsPolarsEr::from)?
+        .try_into_js(&cx)
 }
+
+#[js_function(1)]
+pub(crate) fn read_ipc_buffer(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let columns: Option<Vec<String>> = params.get_as("columns")?;
+    let projection: Option<Vec<usize>> = params.get_as("projection")?;
+    let n_rows: Option<usize> = params.get_as("numRows")?;
+    let buff = params.get::<napi::JsBuffer>("buff")?;
+    let buffer_value = buff.into_value()?;
+
+    let cursor = Cursor::new(buffer_value.as_ref());
+
+    IpcReader::new(cursor)
+        .with_projection(projection)
+        .with_columns(columns)
+        .with_n_rows(n_rows)
+        .finish()
+        .map_err(JsPolarsEr::from)?
+        .try_into_js(&cx)
+}
+
+#[js_function(1)]
+pub(crate) fn write_ipc_path(cx: CallContext) -> JsResult<JsUndefined> {
+    let params = get_params(&cx)?;
+    let compression = params.get_as::<String>("compression")?;
+    let df = params.get_external::<DataFrame>(&cx, "_df")?;
+    let path = params.get_as::<String>("path")?;
+
+    let compression = match compression.as_str() {
+        "uncompressed" => None,
+        "lz4" => Some(IpcCompression::LZ4),
+        "zstd" => Some(IpcCompression::ZSTD),
+        s => return Err(JsPolarsEr::Other(format!("compression {} not supported", s)).into()),
+    };
+    let f = File::create(&path)?;
+
+    IpcWriter::new(f)
+        .with_compression(compression)
+        .finish(df)
+        .map_err(JsPolarsEr::from)?;
+
+    cx.env.get_undefined()
+}
+
 
 // ------
 // JSON

--- a/nodejs-polars/src/dataframe/io.rs
+++ b/nodejs-polars/src/dataframe/io.rs
@@ -355,7 +355,6 @@ pub(crate) fn write_ipc_path(cx: CallContext) -> JsResult<JsUndefined> {
     cx.env.get_undefined()
 }
 
-
 // ------
 // JSON
 // ------

--- a/nodejs-polars/src/dataframe/mod.rs
+++ b/nodejs-polars/src/dataframe/mod.rs
@@ -81,25 +81,36 @@ impl JsDataFrame {
             napi::Property::new(env, "width")?.with_method(df::width),
             napi::Property::new(env, "with_column")?.with_method(df::with_column),
             napi::Property::new(env, "with_row_count")?.with_method(df::with_row_count),
+            // IO
             napi::Property::new(env, "to_js")?.with_method(io::to_js),
-            napi::Property::new(env, "to_json")?.with_method(io::to_json),
+            // row
             napi::Property::new(env, "to_row")?.with_method(io::to_row),
-            napi::Property::new(env, "to_rows")?.with_method(io::to_rows),
             napi::Property::new(env, "to_row_object")?.with_method(io::to_row_object),
-            napi::Property::new(env, "to_row_objects")?.with_method(io::to_row_objects),
-            napi::Property::new(env, "write_csv_path")?.with_method(io::write_csv_path),
-            napi::Property::new(env, "write_csv_stream")?.with_method(io::write_csv_stream),
-            napi::Property::new(env, "write_json_path")?.with_method(io::write_json_path),
-            napi::Property::new(env, "write_json_stream")?.with_method(io::write_json_stream),
+            // rows
+            napi::Property::new(env, "to_rows")?.with_method(io::to_rows),
+            napi::Property::new(env, "read_rows")?.with_method(io::read_rows),
             napi::Property::new(env, "read_array_rows")?.with_method(io::read_array_rows),
+            napi::Property::new(env, "to_row_objects")?.with_method(io::to_row_objects),
             napi::Property::new(env, "read_columns")?.with_method(io::read_columns),
+            //csv
             napi::Property::new(env, "readCSVBuffer")?.with_method(io::read_csv_buffer),
             napi::Property::new(env, "readCSVPath")?.with_method(io::read_csv_path),
+            napi::Property::new(env, "write_csv_path")?.with_method(io::write_csv_path),
+            napi::Property::new(env, "write_csv_stream")?.with_method(io::write_csv_stream),
+            // json
+            napi::Property::new(env, "to_json")?.with_method(io::to_json),
             napi::Property::new(env, "readJSONBuffer")?.with_method(io::read_json_buffer),
             napi::Property::new(env, "readJSONPath")?.with_method(io::read_json_path),
-            napi::Property::new(env, "readParquet")?.with_method(io::read_parquet),
+            napi::Property::new(env, "write_json_path")?.with_method(io::write_json_path),
+            napi::Property::new(env, "write_json_stream")?.with_method(io::write_json_stream),
+            // parquet
+            napi::Property::new(env, "readParquetPath")?.with_method(io::read_parquet_path),
+            napi::Property::new(env, "readParquetBuffer")?.with_method(io::read_parquet_buffer),
             napi::Property::new(env, "writeParquet")?.with_method(io::write_parquet_path),
-            napi::Property::new(env, "read_rows")?.with_method(io::read_rows),
+            // ipc
+            napi::Property::new(env, "readIPCPath")?.with_method(io::read_ipc_path),
+            napi::Property::new(env, "readIPCBuffer")?.with_method(io::read_ipc_buffer),
+            napi::Property::new(env, "writeIPC")?.with_method(io::write_ipc_path),
         ])?;
         Ok(df_obj)
     }

--- a/nodejs-polars/src/lazy/lazyframe.rs
+++ b/nodejs-polars/src/lazy/lazyframe.rs
@@ -97,7 +97,6 @@ pub fn scan_ipc(cx: CallContext) -> JsResult<JsExternal> {
         .try_into_js(&cx)
 }
 
-
 #[js_function(1)]
 pub fn describe_plan(cx: CallContext) -> JsResult<JsString> {
     get_params(&cx)?

--- a/nodejs-polars/src/lazy/lazyframe.rs
+++ b/nodejs-polars/src/lazy/lazyframe.rs
@@ -19,9 +19,8 @@ impl IntoJs<JsExternal> for LazyGroupBy {
 }
 
 #[js_function(1)]
-pub fn new_from_csv(cx: CallContext) -> JsResult<JsExternal> {
+pub fn scan_csv(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
-
     let cache: bool = params.get_or("cache", true)?;
     let comment_char: Option<&str> = params.get_as("commentChar")?;
     let has_header: bool = params.get_or("hasHeader", true)?;
@@ -56,6 +55,48 @@ pub fn new_from_csv(cx: CallContext) -> JsResult<JsExternal> {
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }
+#[js_function(1)]
+pub fn scan_parquet(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+
+    let path: String = params.get_as("path")?;
+    let n_rows: Option<usize> = params.get_as("numRows")?;
+    let parallel: bool = params.get_or("parallel", true)?;
+    let cache: bool = params.get_or("cache", true)?;
+    let rechunk: bool = params.get_or("rechunk", true)?;
+
+    let args = ScanArgsParquet {
+        n_rows,
+        cache,
+        parallel,
+        rechunk,
+    };
+
+    LazyFrame::scan_parquet(path, args)
+        .map_err(JsPolarsEr::from)?
+        .try_into_js(&cx)
+}
+
+#[js_function(1)]
+pub fn scan_ipc(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+
+    let path: String = params.get_as("path")?;
+    let n_rows: Option<usize> = params.get_as("numRows")?;
+    let cache: bool = params.get_or("cache", true)?;
+    let rechunk: bool = params.get_or("rechunk", true)?;
+
+    let args = ScanArgsIpc {
+        n_rows,
+        cache,
+        rechunk,
+    };
+
+    LazyFrame::scan_ipc(path, args)
+        .map_err(JsPolarsEr::from)?
+        .try_into_js(&cx)
+}
+
 
 #[js_function(1)]
 pub fn describe_plan(cx: CallContext) -> JsResult<JsString> {

--- a/nodejs-polars/src/lazy/lazyframe_object.rs
+++ b/nodejs-polars/src/lazy/lazyframe_object.rs
@@ -9,7 +9,7 @@ impl JsLazyFrame {
         let mut ldf = env.create_object()?;
         ldf.define_properties(&[
             napi::Property::new(env, "scanCSV")?.with_method(lazyframe::scan_csv),
-            napi::Property::new(env, "scanParquet")?.with_method(lazyframe::scan_csv),
+            napi::Property::new(env, "scanParquet")?.with_method(lazyframe::scan_parquet),
             napi::Property::new(env, "scanIPC")?.with_method(lazyframe::scan_ipc),
             napi::Property::new(env, "describePlan")?.with_method(lazyframe::describe_plan),
             napi::Property::new(env, "describeOptimizedPlan")?

--- a/nodejs-polars/src/lazy/lazyframe_object.rs
+++ b/nodejs-polars/src/lazy/lazyframe_object.rs
@@ -8,7 +8,9 @@ impl JsLazyFrame {
     pub fn to_object(env: &napi::Env) -> JsResult<JsObject> {
         let mut ldf = env.create_object()?;
         ldf.define_properties(&[
-            napi::Property::new(env, "scanCSV")?.with_method(lazyframe::new_from_csv),
+            napi::Property::new(env, "scanCSV")?.with_method(lazyframe::scan_csv),
+            napi::Property::new(env, "scanParquet")?.with_method(lazyframe::scan_csv),
+            napi::Property::new(env, "scanIPC")?.with_method(lazyframe::scan_ipc),
             napi::Property::new(env, "describePlan")?.with_method(lazyframe::describe_plan),
             napi::Property::new(env, "describeOptimizedPlan")?
                 .with_method(lazyframe::describe_optimized_plan),


### PR DESCRIPTION
Right now, this only supports writing to a file path for both IPC & parquet. Unlike CSV & JSON,  the underlying writers require `Seek` to be implemented, which can't be done for a node stream. 

closes #2400