### PR TITLE
improve conversion to ndarray/numpy `~3/4x`

### DIFF
--- a/polars/polars-arrow/src/kernels/set.rs
+++ b/polars/polars-arrow/src/kernels/set.rs
@@ -1,7 +1,6 @@
 use crate::array::default_arrays::FromData;
 use crate::error::{PolarsError, Result};
 use crate::kernels::BinaryMaskedSliceIterator;
-use crate::prelude::PolarsArray;
 use crate::trusted_len::PushUnchecked;
 use arrow::array::*;
 use arrow::{datatypes::DataType, types::NativeType};
@@ -14,7 +13,7 @@ where
     T: NativeType,
 {
     let values = array.values();
-    if !array.has_validity() {
+    if array.null_count() == 0 {
         return array.clone();
     }
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "hex",
  "jsonpath_lib",
  "lazy_static",
+ "ndarray",
  "num",
  "num_cpus",
  "polars-arrow",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -89,6 +89,7 @@ features = [
   "json",
   "string_encoding",
   "product",
+  "ndarray",
 ]
 
 # [patch.crates-io]

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1152,7 +1152,13 @@ class DataFrame:
         <class 'numpy.ndarray'>
 
         """
-        return np.vstack([self.to_series(i).to_numpy() for i in range(self.width)]).T
+        out = self._df.to_numpy()
+        if out is None:
+            return np.vstack(
+                [self.to_series(i).to_numpy() for i in range(self.width)]
+            ).T
+        else:
+            return out
 
     def __getstate__(self):  # type: ignore
         return self.get_columns()


### PR DESCRIPTION
Improves conversion to numpy. Series to numpy conversion can be zero copy. For `DataFrames` this is not the case as for numpy all data needs to be contiguous and row-oriented.

We `memcpy` parallel to the correct offsets and then we transpose the array. The transposed array is only a strides adjustment.

![image](https://user-images.githubusercontent.com/3023000/150133962-5851b90f-40d8-44ef-9593-d275d9abe633.png)
