### PR TITLE
polars 0.19.0

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "polars"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2018"
+edition = "2021"
 keywords = ["dataframe", "query-engine", "arrow"]
 license = "MIT"
 readme = "../README.md"
@@ -185,9 +185,9 @@ bench = [
 ]
 
 [dependencies]
-polars-core = { version = "0.18.0", path = "./polars-core", features = ["docs", "private"], default-features = false }
-polars-io = { version = "0.18.0", path = "./polars-io", features = ["private"], default-features = false, optional = true }
-polars-lazy = { version = "0.18.0", path = "./polars-lazy", features = ["private"], default-features = false, optional = true }
+polars-core = { version = "0.19.0", path = "./polars-core", features = ["docs", "private"], default-features = false }
+polars-io = { version = "0.19.0", path = "./polars-io", features = ["private"], default-features = false, optional = true }
+polars-lazy = { version = "0.19.0", path = "./polars-lazy", features = ["private"], default-features = false, optional = true }
 
 [dev-dependencies]
 ahash = "0.7"

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-arrow"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -9,13 +9,13 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "a4383b18955b35bef1237be05e0a747d9dca1171", default-features = false }
-hashbrown = "0.11"
+# arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "a4383b18955b35bef1237be05e0a747d9dca1171", default-features = false }
 # arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "offset_pub" }
-# arrow = { package = "arrow2", version = "0.8", default-features = false }
+arrow = { package = "arrow2", version = "0.9", default-features = false, features = ["compute_concatenate"] }
+hashbrown = "0.11"
 num = "^0.4"
 thiserror = "^1.0"
 
 [features]
 strings = []
-compute = ["arrow/compute_cast", "arrow/compute_concatenate"]
+compute = ["arrow/compute_cast"]

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-core"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -145,8 +145,8 @@ lazy_static = "1.4"
 ndarray = { version = "0.15", optional = true, default_features = false }
 num = "^0.4"
 num_cpus = "1.1"
-polars-arrow = { version = "0.18.0", path = "../polars-arrow", features = ["compute"] }
-polars-time = { version = "0.18.0", path = "../polars-time", optional = true }
+polars-arrow = { version = "0.19.0", path = "../polars-arrow", features = ["compute"] }
+polars-time = { version = "0.1.0", path = "../polars-time", optional = true }
 polars-utils = { version = "0.1.0", path = "../polars-utils", optional = true }
 prettytable-rs = { version = "0.8.0", optional = true }
 rand = { version = "0.8", optional = true }
@@ -161,11 +161,11 @@ unsafe_unwrap = "^0.1.0"
 
 [dependencies.arrow]
 package = "arrow2"
-git = "https://github.com/jorgecarleitao/arrow2"
+# git = "https://github.com/jorgecarleitao/arrow2"
 # git = "https://github.com/ritchie46/arrow2"
-rev = "a4383b18955b35bef1237be05e0a747d9dca1171"
+# rev = "a4383b18955b35bef1237be05e0a747d9dca1171"
 # branch = "offset_pub"
-# version = "0.8"
+version = "0.9"
 default-features = false
 features = [
   "compute_aggregate",

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-io"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -31,9 +31,9 @@ private = []
 [dependencies]
 ahash = "0.7"
 anyhow = "1.0"
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "a4383b18955b35bef1237be05e0a747d9dca1171", default-features = false }
+# arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "a4383b18955b35bef1237be05e0a747d9dca1171", default-features = false }
 # arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", default-features = false, features = ["compute"], branch = "offset_pub" }
-# arrow = { package = "arrow2", version = "0.8", default-features = false }
+arrow = { package = "arrow2", version = "0.9", default-features = false }
 csv-core = { version = "0.1.10", optional = true }
 dirs = "4.0"
 flate2 = { version = "1", optional = true, default-features = false }
@@ -43,8 +43,8 @@ memchr = "2.4"
 memmap = { package = "memmap2", version = "0.5.0", optional = true }
 num = "^0.4.0"
 num_cpus = "1.13.0"
-polars-arrow = { version = "0.18.0", path = "../polars-arrow" }
-polars-core = { version = "0.18.0", path = "../polars-core", features = ["private"], default-features = false }
+polars-arrow = { version = "0.19.0", path = "../polars-arrow" }
+polars-core = { version = "0.19.0", path = "../polars-core", features = ["private"], default-features = false }
 polars-utils = { version = "0.1.0", path = "../polars-utils", optional = true }
 rayon = "1.5"
 regex = "1.4"

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-lazy"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -85,9 +85,9 @@ glob = "0.3"
 rayon = "1.5"
 regex = { version = "1.4", optional = true }
 
-polars-arrow = { version = "0.18.0", path = "../polars-arrow" }
-polars-core = { version = "0.18.0", path = "../polars-core", features = ["lazy", "private", "zip_with"], default-features = false }
-polars-io = { version = "0.18.0", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
+polars-arrow = { version = "0.19.0", path = "../polars-arrow" }
+polars-core = { version = "0.19.0", path = "../polars-core", features = ["lazy", "private", "zip_with"], default-features = false }
+polars-io = { version = "0.19.0", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
 polars-utils = { version = "0.1.0", path = "../polars-utils" }
 # uncomment to have datafusion integration
 # when uncommenting we both need to point to the same arrow version

--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "polars-time"
-version = "0.18.0"
+version = "0.1.0"
+authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
+license = "MIT"
+description = "Time related code for the polars dataframe library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 chrono = "0.4"
-polars-arrow = { version = "0.18.0", path = "../polars-arrow", features = ["compute"] }
+polars-arrow = { version = "0.19.0", path = "../polars-arrow", features = ["compute"] }

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "polars-utils"
 version = "0.1.0"
+authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2021"
+license = "MIT"
+description = "private utils for the polars dataframe library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -50,21 +50,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
-name = "arrow-format"
-version = "0.3.0"
+name = "array-init-cursor"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7da2d9660bfaebbdb0a44a33b3bd1dcb5a952fafa02c0dfc6a51ea471fef2a"
+checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
+
+[[package]]
+name = "arrow-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2333f8ccf0d597ba779863c57a0b61f635721187fb2fdeabae92691d7d582fe5"
 dependencies = [
- "flatbuffers",
+ "planus",
+ "serde",
 ]
 
 [[package]]
 name = "arrow2"
-version = "0.8.1"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=a4383b18955b35bef1237be05e0a747d9dca1171#a4383b18955b35bef1237be05e0a747d9dca1171"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b578c7e6b6325e735dc919abc4d92e6f10a2f09dabac177526320ac9fa3457ec"
 dependencies = [
  "arrow-format",
  "base64",
+ "bytemuck",
  "chrono",
  "csv",
  "fallible-streaming-iterator",
@@ -184,6 +193,26 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -394,17 +423,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "flatbuffers"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4c5738bcd7fad10315029c50026f83c9da5e4a21f8ed66826f43e0e2bde5f6"
-dependencies = [
- "bitflags",
- "smallvec",
- "thiserror",
-]
 
 [[package]]
 name = "flate2"
@@ -1120,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "parquet2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e98d7da0076cead49c49580cc5771dfe0ba8a93cadff9b47c1681a4a78e1f9"
+checksum = "c7ee9d21df8de64b98e08ad59bf3106c27e00e556c0843e81a3271f7470c65dc"
 dependencies = [
  "async-stream",
  "bitpacking",
@@ -1174,8 +1192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "planus"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffebaf174d6cad46a5f0f1bb1c45c6eb509571688bcb18dfab217f3c9f9b151"
+dependencies = [
+ "array-init-cursor",
+]
+
+[[package]]
 name = "polars"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -1184,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arrow2",
  "hashbrown",
@@ -1194,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1223,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1247,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "glob",
@@ -1261,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.18.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "polars-arrow",


### PR DESCRIPTION
# New rust polars release! :rocket: 

This release is here thanks to the contributions of: (in no specific order):

- @ibENPC 
- @nmandery 
- @zundertj 
- @ghuls
- @alexander-beedie 
- @MarcoGorelli 
- @mhconradt 
- @marcvanheerden 
- @illumination-k 
- @jay-johnson 
- @universalmind303 
- @dbr 
- @Brooooooklyn 

*did I forget your contribution, please ping me, I do this manually :see_no_evil:*


[Full changelog](https://github.com/pola-rs/polars/compare/031b5e970...b02bb21970762a443790a167e2699688fdfa21d2)

Most notable changes are:

* Many bug fixes

## features
* `Duration` data type added
* `DataType::Datetime` backed by nanoseconds or milliseconds
* `groupby_dynamic` added to group by time windows are value based windows and having the complete expression API at your disposal for aggregations.
* pivot on multiple groups and columns
* Improve ergonomics of `ChunkedArray` and `Series` creation with `NamedFrom::new`
* interpolation options for quantile aggregation
* Union node in lazy
* add rolling options for rolling median and quantile
* slice pushdown optimization
* globbing scans. e.g. `LazyFrame::scan_csv("**/*.csv").filter(..)..`
* **new expressions**
   - shuffle
   - exlude_dtype
   - emwa (exponential moving average)
   - emw_std
   - emw_var
   - pct_change
   - any
   - all
   - truncate
   - product
   - arg_min
   - arg_max

## performance improvements
* csv-parser performance improved ([among/ or faster than] the fastest I could find, e.g. pyarrow and R data.table)
* parallel parquet reader
* ndarray conversion
* redesign pivot algorithm
* dropped chunk alignment requirement of `DataFrame`
* use parquet statistics in predicate pushdown optimization. This may prevent polars for parsing a parquet file and then dropping al data afterwards, doing that work in vain.

## Arrow2 0.9.0
Not included in this list, but also available in this release are all the new improvements upstream in arrow2 thanks to @jorgecarleitao and the other devs upstream:

https://github.com/jorgecarleitao/arrow2/releases/tag/v0.9.0
