### PR TITLE
chore: remove unused seek traits from parquet & ipc

### DIFF
--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -237,7 +237,7 @@ pub use write::Compression as IpcCompression;
 
 impl<W> IpcWriter<W>
 where
-    W: Write + Seek,
+    W: Write,
 {
     /// Set the compression used. Defaults to None.
     pub fn with_compression(mut self, compression: Option<write::Compression>) -> Self {

--- a/polars/polars-io/src/parquet/write.rs
+++ b/polars/polars-io/src/parquet/write.rs
@@ -6,7 +6,7 @@ use arrow::io::parquet::write::{array_to_pages, DynIter, DynStreamingIterator, E
 use polars_core::prelude::*;
 use rayon::prelude::*;
 use std::collections::VecDeque;
-use std::io::{Seek, Write};
+use std::io::Write;
 
 struct Bla {
     columns: VecDeque<CompressedPage>,
@@ -52,12 +52,12 @@ pub use write::Compression as ParquetCompression;
 
 impl<W> ParquetWriter<W>
 where
-    W: Write + Seek,
+    W: Write,
 {
     /// Create a new writer
     pub fn new(writer: W) -> Self
     where
-        W: Write + Seek,
+        W: Write,
     {
         ParquetWriter {
             writer,


### PR DESCRIPTION
parquet & ipc are not using the `seek`. trait. Removing them for nodejs compatibility. 