### PR TITLE
Groups slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
   "polars/polars-utils",
 ]
 
-# [patch.crates-io]
+[patch.crates-io]
+packed_simd_2 = { git = "https://github.com/hkratz/packed_simd", branch = "remove_llvm_asm" }
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -209,6 +209,13 @@ impl ListUtf8ChunkedBuilder {
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();
     }
+
+    #[inline]
+    pub(crate) fn append(&mut self, ca: &Utf8Chunked) {
+        let value_builder = self.builder.mut_values();
+        value_builder.try_extend(ca).unwrap();
+        self.builder.try_push_valid().unwrap();
+    }
 }
 
 impl ListBuilderTrait for ListUtf8ChunkedBuilder {
@@ -233,9 +240,7 @@ impl ListBuilderTrait for ListUtf8ChunkedBuilder {
             self.fast_explode = false;
         }
         let ca = s.utf8().unwrap();
-        let value_builder = self.builder.mut_values();
-        value_builder.try_extend(ca).unwrap();
-        self.builder.try_push_valid().unwrap();
+        self.append(ca)
     }
 
     fn finish(&mut self) -> ListChunked {
@@ -274,6 +279,16 @@ impl ListBooleanChunkedBuilder {
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();
     }
+
+    #[inline]
+    pub(crate) fn append(&mut self, ca: &BooleanChunked) {
+        if ca.is_empty() {
+            self.fast_explode = false;
+        }
+        let value_builder = self.builder.mut_values();
+        value_builder.extend(ca);
+        self.builder.try_push_valid().unwrap();
+    }
 }
 
 impl ListBuilderTrait for ListBooleanChunkedBuilder {
@@ -295,12 +310,7 @@ impl ListBuilderTrait for ListBooleanChunkedBuilder {
     #[inline]
     fn append_series(&mut self, s: &Series) {
         let ca = s.bool().unwrap();
-        if ca.is_empty() {
-            self.fast_explode = false;
-        }
-        let value_builder = self.builder.mut_values();
-        value_builder.extend(ca);
-        self.builder.try_push_valid().unwrap();
+        self.append(ca)
     }
 
     fn finish(&mut self) -> ListChunked {

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -89,7 +89,7 @@ impl ChunkCast for Utf8Chunked {
             DataType::Categorical => {
                 let iter = self.into_iter();
                 let mut builder = CategoricalChunkedBuilder::new(self.name(), self.len());
-                builder.from_iter(iter);
+                builder.drain_iter(iter);
                 let ca = builder.finish();
                 Ok(ca.into_series())
             }

--- a/polars/polars-core/src/chunked_array/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/categorical/builder.rs
@@ -133,7 +133,7 @@ impl CategoricalChunkedBuilder {
 }
 impl CategoricalChunkedBuilder {
     /// Appends all the values in a single lock of the global string cache.
-    pub fn from_iter<'a, I>(&mut self, i: I)
+    pub fn drain_iter<'a, I>(&mut self, i: I)
     where
         I: IntoIterator<Item = Option<&'a str>>,
     {
@@ -260,8 +260,8 @@ mod test {
             // does not interfere with the index mapping
             let mut builder1 = CategoricalChunkedBuilder::new("foo", 10);
             let mut builder2 = CategoricalChunkedBuilder::new("foo", 10);
-            builder1.from_iter(vec![None, Some("hello"), Some("vietnam")]);
-            builder2.from_iter(vec![Some("hello"), None, Some("world")].into_iter());
+            builder1.drain_iter(vec![None, Some("hello"), Some("vietnam")]);
+            builder2.drain_iter(vec![Some("hello"), None, Some("world")].into_iter());
 
             let s = builder1.finish().into_series();
             assert_eq!(s.str_value(0), "null");

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -190,7 +190,7 @@ mod test {
         let values = &[Some(foo1), None, Some(foo2), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])];
+        let groups = GroupsProxy::Idx(vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])]);
         let out = ca.agg_list(&groups).unwrap();
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());
@@ -214,7 +214,7 @@ mod test {
         let ca = ObjectChunked::new("", values);
 
         let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])];
-        let out = ca.agg_list(&groups).unwrap();
+        let out = ca.agg_list(&GroupsProxy::Idx(groups)).unwrap();
         let a = out.explode().unwrap();
 
         let ca_foo = a.as_any().downcast_ref::<ObjectChunked<Foo>>().unwrap();

--- a/polars/polars-core/src/chunked_array/ops/full.rs
+++ b/polars/polars-core/src/chunked_array/ops/full.rs
@@ -82,7 +82,7 @@ impl ChunkFullNull for CategoricalChunked {
         use crate::chunked_array::categorical::CategoricalChunkedBuilder;
         let mut builder = CategoricalChunkedBuilder::new(name, length);
         let iter = (0..length).map(|_| None);
-        builder.from_iter(iter);
+        builder.drain_iter(iter);
         builder.finish()
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -134,7 +134,7 @@ where
     if ca.is_empty() {
         return ca.clone();
     }
-    let mut groups = ca.group_tuples(true);
+    let mut groups = ca.group_tuples(true).into_idx();
     groups.sort_unstable_by_key(|k| k.1.len());
     let first = &groups[0];
 

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -6,7 +6,7 @@ use crate::chunked_array::categorical::RevMapping;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectType;
 use crate::datatypes::PlHashSet;
-use crate::frame::groupby::{GroupTuples, IntoGroupTuples};
+use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::utils::NoNull;
 use rayon::prelude::*;
@@ -50,7 +50,7 @@ pub(crate) fn is_unique_helper2(
 }
 
 pub(crate) fn is_unique_helper(
-    groups: GroupTuples,
+    groups: GroupsProxy,
     len: u32,
     unique_val: bool,
     duplicated_val: bool,
@@ -128,7 +128,7 @@ where
 #[allow(clippy::needless_collect)]
 fn mode<T>(ca: &ChunkedArray<T>) -> ChunkedArray<T>
 where
-    ChunkedArray<T>: IntoGroupTuples + ChunkTake,
+    ChunkedArray<T>: IntoGroupsProxy + ChunkTake,
 {
     if ca.is_empty() {
         return ca.clone();

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -57,6 +57,7 @@ pub(crate) fn is_unique_helper(
 ) -> BooleanChunked {
     debug_assert_ne!(unique_val, duplicated_val);
     let idx = groups
+        .into_idx()
         .into_iter()
         .filter_map(|(first, g)| if g.len() == 1 { Some(first) } else { None })
         .collect::<Vec<_>>();
@@ -168,7 +169,7 @@ macro_rules! arg_unique_ca {
 
 macro_rules! impl_value_counts {
     ($self:expr) => {{
-        let group_tuples = $self.group_tuples(true);
+        let group_tuples = $self.group_tuples(true).into_idx();
         let values =
             unsafe { $self.take_unchecked(group_tuples.iter().map(|t| t.0 as usize).into()) };
         let mut counts: NoNull<UInt32Chunked> = group_tuples
@@ -208,6 +209,7 @@ where
         is_unique_duplicated!(self, true)
     }
 
+    // TODO! implement on series. Not worth the compile times here.
     fn value_counts(&self) -> Result<DataFrame> {
         impl_value_counts!(self)
     }
@@ -350,7 +352,7 @@ fn sort_columns(mut columns: Vec<Series>) -> Vec<Series> {
 
 impl ToDummies<Utf8Type> for Utf8Chunked {
     fn to_dummies(&self) -> Result<DataFrame> {
-        let groups = self.group_tuples(true);
+        let groups = self.group_tuples(true).into_idx();
         let col_name = self.name();
         let taker = self.take_rand();
 
@@ -376,7 +378,7 @@ where
     ChunkedArray<T>: ChunkOps + ChunkCompare<T::Native> + ChunkUnique<T>,
 {
     fn to_dummies(&self) -> Result<DataFrame> {
-        let groups = self.group_tuples(true);
+        let groups = self.group_tuples(true).into_idx();
         let col_name = self.name();
         let taker = self.take_rand();
 

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -17,7 +17,14 @@ use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_arrow::trusted_len::PushUnchecked;
 use std::ops::Deref;
 
-fn agg_helper<T, F>(groups: &[(u32, Vec<u32>)], f: F) -> Option<Series>
+fn slice_from_offsets<T>(ca: &ChunkedArray<T>, first: u32, len: u32) -> ChunkedArray<T>
+where
+    ChunkedArray<T>: ChunkOps,
+{
+    ca.slice(first as i64, len as usize)
+}
+
+fn agg_helper_idx<T, F>(groups: &[(u32, Vec<u32>)], f: F) -> Option<Series>
 where
     F: Fn(&(u32, Vec<u32>)) -> Option<T::Native> + Send + Sync,
     T: PolarsNumericType,
@@ -27,36 +34,148 @@ where
     Some(ca.into_series())
 }
 
+fn agg_helper_slice<T, F>(groups: &[[u32; 2]], f: F) -> Option<Series>
+where
+    F: Fn([u32; 2]) -> Option<T::Native> + Send + Sync,
+    T: PolarsNumericType,
+    ChunkedArray<T>: IntoSeries,
+{
+    let ca: ChunkedArray<T> = POOL.install(|| groups.par_iter().copied().map(f).collect());
+    Some(ca.into_series())
+}
+
 impl BooleanChunked {
-    pub(crate) fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    pub(crate) fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
         self.cast(&DataType::UInt32).unwrap().agg_min(groups)
     }
-    pub(crate) fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    pub(crate) fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
         self.cast(&DataType::UInt32).unwrap().agg_max(groups)
     }
-    pub(crate) fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    pub(crate) fn agg_sum(&self, groups: &GroupsProxy) -> Option<Series> {
         self.cast(&DataType::UInt32).unwrap().agg_sum(groups)
     }
 }
 
-impl<T> ChunkedArray<T>
-where
-    ChunkedArray<T>: ChunkTake,
-    T: PolarsDataType + Sync,
-{
-    #[cfg(feature = "lazy")]
-    pub(crate) fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<UInt32Type, _>(groups, |(_first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                None
-            } else if !self.has_validity() {
-                Some(idx.len() as u32)
-            } else {
-                let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                Some((take.len() - take.null_count()) as u32)
+impl Series {
+    fn slice_from_offsets(&self, first: u32, len: u32) -> Self {
+        self.slice(first as i64, len as usize)
+    }
+
+    // implemented on the series because we don't need types
+    pub(crate) fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<UInt32Type, _>(groups, |(_first, idx)| {
+                debug_assert!(idx.len() <= self.len());
+                if idx.is_empty() {
+                    None
+                } else if !self.has_validity() {
+                    Some(idx.len() as u32)
+                } else {
+                    let take =
+                        unsafe { self.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize)) };
+                    Some((take.len() - take.null_count()) as u32)
+                }
+            }),
+            GroupsProxy::Slice(groups) => {
+                agg_helper_slice::<UInt32Type, _>(groups, |[first, len]| {
+                    debug_assert!(len <= self.len() as u32);
+                    if len == 0 {
+                        None
+                    } else if !self.has_validity() {
+                        Some(len)
+                    } else {
+                        let take = self.slice_from_offsets(first, len);
+                        Some((take.len() - take.null_count()) as u32)
+                    }
+                })
             }
-        })
+        }
+    }
+
+    pub(crate) fn agg_first(&self, groups: &GroupsProxy) -> Series {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let mut iter = groups.iter().map(|(first, idx)| {
+                    if idx.is_empty() {
+                        None
+                    } else {
+                        Some(*first as usize)
+                    }
+                });
+                // Safety:
+                // groups are always in bounds
+                unsafe { self.take_opt_iter_unchecked(&mut iter) }
+            }
+            GroupsProxy::Slice(groups) => {
+                let mut iter =
+                    groups.iter().map(
+                        |&[first, len]| {
+                            if len == 0 {
+                                None
+                            } else {
+                                Some(first as usize)
+                            }
+                        },
+                    );
+                // Safety:
+                // groups are always in bounds
+                unsafe { self.take_opt_iter_unchecked(&mut iter) }
+            }
+        }
+    }
+
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<UInt32Type, _>(groups, |(_first, idx)| {
+                debug_assert!(idx.len() <= self.len());
+                if idx.is_empty() {
+                    None
+                } else {
+                    let take =
+                        unsafe { self.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize)) };
+                    take.n_unique().ok().map(|v| v as u32)
+                }
+            }),
+            GroupsProxy::Slice(groups) => {
+                agg_helper_slice::<UInt32Type, _>(groups, |[first, len]| {
+                    debug_assert!(len <= self.len() as u32);
+                    if len == 0 {
+                        None
+                    } else {
+                        let take = self.slice_from_offsets(first, len);
+                        take.n_unique().ok().map(|v| v as u32)
+                    }
+                })
+            }
+        }
+    }
+
+    pub(crate) fn agg_last(&self, groups: &GroupsProxy) -> Series {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let mut iter = groups.iter().map(|(_, idx)| {
+                    if idx.is_empty() {
+                        None
+                    } else {
+                        Some(idx[idx.len() - 1] as usize)
+                    }
+                });
+                unsafe { self.take_opt_iter_unchecked(&mut iter) }
+            }
+            GroupsProxy::Slice(groups) => {
+                let mut iter =
+                    groups.iter().map(
+                        |&[first, len]| {
+                            if len == 0 {
+                                None
+                            } else {
+                                Some(first as usize)
+                            }
+                        },
+                    );
+                unsafe { self.take_opt_iter_unchecked(&mut iter) }
+            }
+        }
     }
 }
 
@@ -70,199 +189,283 @@ where
         + arrow::compute::aggregate::SimdOrd<T::Native>,
     ChunkedArray<T>: IntoSeries,
 {
-    pub(crate) fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<T, _>(groups, |(first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                None
-            } else if idx.len() == 1 {
-                self.get(*first as usize)
-            } else {
-                match (self.has_validity(), self.chunks.len()) {
-                    (false, 1) => Some(unsafe {
-                        take_agg_no_null_primitive_iter_unchecked(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| if a < b { a } else { b },
-                            T::Native::max_value(),
-                        )
-                    }),
-                    (_, 1) => unsafe {
-                        take_agg_primitive_iter_unchecked::<T::Native, _, _>(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| if a < b { a } else { b },
-                            T::Native::max_value(),
-                        )
-                    },
-                    _ => {
-                        let take =
-                            unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                        take.min()
+    pub(crate) fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<T, _>(groups, |(first, idx)| {
+                debug_assert!(idx.len() <= self.len());
+                if idx.is_empty() {
+                    None
+                } else if idx.len() == 1 {
+                    self.get(*first as usize)
+                } else {
+                    match (self.has_validity(), self.chunks.len()) {
+                        (false, 1) => Some(unsafe {
+                            take_agg_no_null_primitive_iter_unchecked(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| if a < b { a } else { b },
+                                T::Native::max_value(),
+                            )
+                        }),
+                        (_, 1) => unsafe {
+                            take_agg_primitive_iter_unchecked::<T::Native, _, _>(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| if a < b { a } else { b },
+                                T::Native::max_value(),
+                            )
+                        },
+                        _ => {
+                            let take = unsafe {
+                                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                            };
+                            take.min()
+                        }
                     }
                 }
-            }
-        })
+            }),
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize),
+                    _ => {
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.min()
+                    }
+                }
+            }),
+        }
     }
 
-    pub(crate) fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<T, _>(groups, |(first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                None
-            } else if idx.len() == 1 {
-                self.get(*first as usize)
-            } else {
-                match (self.has_validity(), self.chunks.len()) {
-                    (false, 1) => Some(unsafe {
-                        take_agg_no_null_primitive_iter_unchecked(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| if a > b { a } else { b },
-                            T::Native::min_value(),
-                        )
-                    }),
-                    (_, 1) => unsafe {
-                        take_agg_primitive_iter_unchecked::<T::Native, _, _>(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| if a > b { a } else { b },
-                            T::Native::min_value(),
-                        )
-                    },
-                    _ => {
-                        let take =
-                            unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                        take.max()
+    pub(crate) fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<T, _>(groups, |(first, idx)| {
+                debug_assert!(idx.len() <= self.len());
+                if idx.is_empty() {
+                    None
+                } else if idx.len() == 1 {
+                    self.get(*first as usize)
+                } else {
+                    match (self.has_validity(), self.chunks.len()) {
+                        (false, 1) => Some(unsafe {
+                            take_agg_no_null_primitive_iter_unchecked(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| if a > b { a } else { b },
+                                T::Native::min_value(),
+                            )
+                        }),
+                        (_, 1) => unsafe {
+                            take_agg_primitive_iter_unchecked::<T::Native, _, _>(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| if a > b { a } else { b },
+                                T::Native::min_value(),
+                            )
+                        },
+                        _ => {
+                            let take = unsafe {
+                                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                            };
+                            take.max()
+                        }
                     }
                 }
-            }
-        })
+            }),
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize),
+                    _ => {
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.max()
+                    }
+                }
+            }),
+        }
     }
 
-    pub(crate) fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<T, _>(groups, |(first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                None
-            } else if idx.len() == 1 {
-                self.get(*first as usize)
-            } else {
-                match (self.has_validity(), self.chunks.len()) {
-                    (false, 1) => Some(unsafe {
-                        take_agg_no_null_primitive_iter_unchecked(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
-                    }),
-                    (_, 1) => unsafe {
-                        take_agg_primitive_iter_unchecked::<T::Native, _, _>(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
-                    },
-                    _ => {
-                        let take =
-                            unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                        take.sum()
+    pub(crate) fn agg_sum(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<T, _>(groups, |(first, idx)| {
+                debug_assert!(idx.len() <= self.len());
+                if idx.is_empty() {
+                    None
+                } else if idx.len() == 1 {
+                    self.get(*first as usize)
+                } else {
+                    match (self.has_validity(), self.chunks.len()) {
+                        (false, 1) => Some(unsafe {
+                            take_agg_no_null_primitive_iter_unchecked(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| a + b,
+                                T::Native::zero(),
+                            )
+                        }),
+                        (_, 1) => unsafe {
+                            take_agg_primitive_iter_unchecked::<T::Native, _, _>(
+                                self.downcast_iter().next().unwrap(),
+                                idx.iter().map(|i| *i as usize),
+                                |a, b| a + b,
+                                T::Native::zero(),
+                            )
+                        },
+                        _ => {
+                            let take = unsafe {
+                                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                            };
+                            take.sum()
+                        }
                     }
                 }
-            }
-        })
+            }),
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize),
+                    _ => {
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.sum()
+                    }
+                }
+            }),
+        }
     }
 }
 
 impl<T> SeriesWrap<ChunkedArray<T>>
 where
     T: PolarsFloatType,
-    ChunkedArray<T>: IntoSeries,
+    ChunkedArray<T>: IntoSeries + ChunkVar<T::Native>,
     T::Native: NativeType + PartialOrd + Num + NumCast + Simd + std::iter::Sum<T::Native>,
     <T::Native as Simd>::Simd: std::ops::Add<Output = <T::Native as Simd>::Simd>
         + arrow::compute::aggregate::Sum<T::Native>
         + arrow::compute::aggregate::SimdOrd<T::Native>,
 {
-    pub(crate) fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<T, _>(groups, |(first, idx)| {
-            // this can fail due to a bug in lazy code.
-            // here users can create filters in aggregations
-            // and thereby creating shorter columns than the original group tuples.
-            // the group tuples are modified, but if that's done incorrect there can be out of bounds
-            // access
-            debug_assert!(idx.len() <= self.len());
-            let out = if idx.is_empty() {
-                None
-            } else if idx.len() == 1 {
-                self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
-            } else {
-                match (self.has_validity(), self.chunks.len()) {
-                    (false, 1) => unsafe {
-                        take_agg_no_null_primitive_iter_unchecked(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
-                    }
-                    .to_f64()
-                    .map(|sum| sum / idx.len() as f64),
-                    (_, 1) => unsafe {
-                        take_agg_primitive_iter_unchecked_count_nulls::<T::Native, _, _>(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
-                    }
-                    .map(|(sum, null_count)| {
-                        sum.to_f64()
-                            .map(|sum| sum / (idx.len() as f64 - null_count as f64))
-                            .unwrap()
-                    }),
+    pub(crate) fn agg_mean(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                agg_helper_idx::<T, _>(groups, |(first, idx)| {
+                    // this can fail due to a bug in lazy code.
+                    // here users can create filters in aggregations
+                    // and thereby creating shorter columns than the original group tuples.
+                    // the group tuples are modified, but if that's done incorrect there can be out of bounds
+                    // access
+                    debug_assert!(idx.len() <= self.len());
+                    let out = if idx.is_empty() {
+                        None
+                    } else if idx.len() == 1 {
+                        self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
+                    } else {
+                        match (self.has_validity(), self.chunks.len()) {
+                            (false, 1) => unsafe {
+                                take_agg_no_null_primitive_iter_unchecked(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                            .to_f64()
+                            .map(|sum| sum / idx.len() as f64),
+                            (_, 1) => unsafe {
+                                take_agg_primitive_iter_unchecked_count_nulls::<T::Native, _, _>(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                            .map(|(sum, null_count)| {
+                                sum.to_f64()
+                                    .map(|sum| sum / (idx.len() as f64 - null_count as f64))
+                                    .unwrap()
+                            }),
+                            _ => {
+                                let take = unsafe {
+                                    self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                                };
+                                let opt_sum: Option<T::Native> = take.sum();
+                                opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                            }
+                        }
+                    };
+                    out.map(|flt| NumCast::from(flt).unwrap())
+                })
+            }
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize),
                     _ => {
-                        let take =
-                            unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                        let opt_sum: Option<T::Native> = take.sum();
-                        opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.mean().map(|flt| NumCast::from(flt).unwrap())
                     }
                 }
-            };
-            out.map(|flt| NumCast::from(flt).unwrap())
-        })
+            }),
+        }
     }
 
-    pub(crate) fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    pub(crate) fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
         let ca = &self.0;
-        agg_helper::<T, _>(groups, |(_first, idx)| {
-            debug_assert!(idx.len() <= ca.len());
-            if idx.is_empty() {
-                return None;
-            }
-            let take = unsafe { ca.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-            take.into_series()
-                .var_as_series()
-                .unpack::<T>()
-                .unwrap()
-                .get(0)
-        })
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<T, _>(groups, |(_first, idx)| {
+                debug_assert!(idx.len() <= ca.len());
+                if idx.is_empty() {
+                    return None;
+                }
+                let take = unsafe { ca.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                take.into_series()
+                    .var_as_series()
+                    .unpack::<T>()
+                    .unwrap()
+                    .get(0)
+            }),
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize),
+                    _ => {
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.var().map(|flt| NumCast::from(flt).unwrap())
+                    }
+                }
+            }),
+        }
     }
-    pub(crate) fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    pub(crate) fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
         let ca = &self.0;
-        agg_helper::<T, _>(groups, |(_first, idx)| {
-            debug_assert!(idx.len() <= ca.len());
-            if idx.is_empty() {
-                return None;
-            }
-            let take = unsafe { ca.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-            take.into_series()
-                .std_as_series()
-                .unpack::<T>()
-                .unwrap()
-                .get(0)
-        })
+        match groups {
+            GroupsProxy::Idx(groups) => agg_helper_idx::<T, _>(groups, |(_first, idx)| {
+                debug_assert!(idx.len() <= ca.len());
+                if idx.is_empty() {
+                    return None;
+                }
+                let take = unsafe { ca.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                take.into_series()
+                    .std_as_series()
+                    .unpack::<T>()
+                    .unwrap()
+                    .get(0)
+            }),
+            GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as u32);
+                match len {
+                    0 => None,
+                    1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                    _ => {
+                        let arr_group = slice_from_offsets(self, first, len);
+                        arr_group.std().map(|flt| NumCast::from(flt).unwrap())
+                    }
+                }
+            }),
+        }
     }
 }
 
@@ -276,191 +479,142 @@ where
         + arrow::compute::aggregate::Sum<T::Native>
         + arrow::compute::aggregate::SimdOrd<T::Native>,
 {
-    pub(crate) fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<Float64Type, _>(groups, |(first, idx)| {
-            // this can fail due to a bug in lazy code.
-            // here users can create filters in aggregations
-            // and thereby creating shorter columns than the original group tuples.
-            // the group tuples are modified, but if that's done incorrect there can be out of bounds
-            // access
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                None
-            } else if idx.len() == 1 {
-                self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
-            } else {
-                match (self.has_validity(), self.chunks.len()) {
-                    (false, 1) => unsafe {
-                        take_agg_no_null_primitive_iter_unchecked(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
+    pub(crate) fn agg_mean(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                agg_helper_idx::<Float64Type, _>(groups, |(first, idx)| {
+                    // this can fail due to a bug in lazy code.
+                    // here users can create filters in aggregations
+                    // and thereby creating shorter columns than the original group tuples.
+                    // the group tuples are modified, but if that's done incorrect there can be out of bounds
+                    // access
+                    debug_assert!(idx.len() <= self.len());
+                    if idx.is_empty() {
+                        None
+                    } else if idx.len() == 1 {
+                        self.get(*first as usize).map(|sum| sum.to_f64().unwrap())
+                    } else {
+                        match (self.has_validity(), self.chunks.len()) {
+                            (false, 1) => unsafe {
+                                take_agg_no_null_primitive_iter_unchecked(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                            .to_f64()
+                            .map(|sum| sum / idx.len() as f64),
+                            (_, 1) => unsafe {
+                                take_agg_primitive_iter_unchecked_count_nulls::<T::Native, _, _>(
+                                    self.downcast_iter().next().unwrap(),
+                                    idx.iter().map(|i| *i as usize),
+                                    |a, b| a + b,
+                                    T::Native::zero(),
+                                )
+                            }
+                            .map(|(sum, null_count)| {
+                                sum.to_f64()
+                                    .map(|sum| sum / (idx.len() as f64 - null_count as f64))
+                                    .unwrap()
+                            }),
+                            _ => {
+                                let take = unsafe {
+                                    self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                                };
+                                let opt_sum: Option<T::Native> = take.sum();
+                                opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                            }
+                        }
                     }
-                    .to_f64()
-                    .map(|sum| sum / idx.len() as f64),
-                    (_, 1) => unsafe {
-                        take_agg_primitive_iter_unchecked_count_nulls::<T::Native, _, _>(
-                            self.downcast_iter().next().unwrap(),
-                            idx.iter().map(|i| *i as usize),
-                            |a, b| a + b,
-                            T::Native::zero(),
-                        )
+                })
+            }
+            GroupsProxy::Slice(groups) => {
+                agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
+                    debug_assert!(len < self.len() as u32);
+                    match first - len {
+                        0 => None,
+                        1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                        _ => {
+                            let arr_group = slice_from_offsets(self, first, len);
+                            arr_group.mean()
+                        }
                     }
-                    .map(|(sum, null_count)| {
-                        sum.to_f64()
-                            .map(|sum| sum / (idx.len() as f64 - null_count as f64))
-                            .unwrap()
-                    }),
-                    _ => {
-                        let take =
-                            unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-                        let opt_sum: Option<T::Native> = take.sum();
-                        opt_sum.map(|sum| sum.to_f64().unwrap() / idx.len() as f64)
+                })
+            }
+        }
+    }
+
+    pub(crate) fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                agg_helper_idx::<Float64Type, _>(groups, |(_first, idx)| {
+                    debug_assert!(idx.len() <= self.len());
+                    if idx.is_empty() {
+                        return None;
                     }
-                }
+                    let take =
+                        unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                    take.into_series()
+                        .var_as_series()
+                        .unpack::<Float64Type>()
+                        .unwrap()
+                        .get(0)
+                })
             }
-        })
-    }
-
-    pub(crate) fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<Float64Type, _>(groups, |(_first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                return None;
+            GroupsProxy::Slice(groups) => {
+                agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
+                    debug_assert!(len <= self.len() as u32);
+                    match len {
+                        0 => None,
+                        1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                        _ => {
+                            let arr_group = slice_from_offsets(self, first, len);
+                            arr_group.var()
+                        }
+                    }
+                })
             }
-            let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-            take.into_series()
-                .var_as_series()
-                .unpack::<Float64Type>()
-                .unwrap()
-                .get(0)
-        })
+        }
     }
-    pub(crate) fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<Float64Type, _>(groups, |(_first, idx)| {
-            debug_assert!(idx.len() <= self.len());
-            if idx.is_empty() {
-                return None;
+    pub(crate) fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                agg_helper_idx::<Float64Type, _>(groups, |(_first, idx)| {
+                    debug_assert!(idx.len() <= self.len());
+                    if idx.is_empty() {
+                        return None;
+                    }
+                    let take =
+                        unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                    take.into_series()
+                        .std_as_series()
+                        .unpack::<Float64Type>()
+                        .unwrap()
+                        .get(0)
+                })
             }
-            let take = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
-            take.into_series()
-                .std_as_series()
-                .unpack::<Float64Type>()
-                .unwrap()
-                .get(0)
-        })
-    }
-}
-
-impl<T> ChunkedArray<T>
-where
-    ChunkedArray<T>: ChunkTake + IntoSeries,
-{
-    pub(crate) fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
-        let iter = groups.iter().map(|(first, idx)| {
-            if idx.is_empty() {
-                None
-            } else {
-                Some(*first as usize)
+            GroupsProxy::Slice(groups) => {
+                agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
+                    debug_assert!(len <= self.len() as u32);
+                    match len {
+                        0 => None,
+                        1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                        _ => {
+                            let arr_group = slice_from_offsets(self, first, len);
+                            arr_group.std()
+                        }
+                    }
+                })
             }
-        });
-        unsafe { self.take_unchecked(iter.into()) }.into_series()
-    }
-
-    pub(crate) fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
-        let iter = groups.iter().map(|(_, idx)| {
-            if idx.is_empty() {
-                None
-            } else {
-                Some(idx[idx.len() - 1] as usize)
-            }
-        });
-        unsafe { self.take_unchecked(iter.into()) }.into_series()
+        }
     }
 }
 
-pub(crate) trait AggNUnique {
-    fn agg_n_unique(&self, _groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        None
-    }
-}
-
-macro_rules! impl_agg_n_unique {
-    ($self:ident, $groups:ident, $ca_type:ty) => {{
-        $groups
-            .into_par_iter()
-            .map(|(_first, idx)| {
-                debug_assert!(idx.len() <= $self.len());
-                if idx.is_empty() {
-                    return 0;
-                }
-                let taker = $self.take_rand();
-
-                let mut set = HashSet::with_hasher(RandomState::new());
-                for i in idx {
-                    let v = unsafe { taker.get_unchecked(*i as usize) };
-                    set.insert(v);
-                }
-                set.len() as u32
-            })
-            .collect::<$ca_type>()
-            .into_inner()
-    }};
-}
-
-impl<T> AggNUnique for ChunkedArray<T>
-where
-    T: PolarsIntegerType + Sync,
-    T::Native: Hash + Eq,
-{
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        Some(impl_agg_n_unique!(self, groups, NoNull<UInt32Chunked>))
-    }
-}
-
-impl AggNUnique for Float32Chunked {
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        self.bit_repr_small().agg_n_unique(groups)
-    }
-}
-impl AggNUnique for Float64Chunked {
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        self.bit_repr_large().agg_n_unique(groups)
-    }
-}
-impl AggNUnique for ListChunked {}
-#[cfg(feature = "dtype-categorical")]
-impl AggNUnique for CategoricalChunked {
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        self.cast(&DataType::UInt32)
-            .unwrap()
-            .agg_n_unique(groups)
-            .map(|mut ca| {
-                ca.categorical_map = self.categorical_map.clone();
-                ca
-            })
-    }
-}
-#[cfg(feature = "object")]
-impl<T> AggNUnique for ObjectChunked<T> {}
-
-// TODO: could be faster as it can only be null, true, or false
-impl AggNUnique for BooleanChunked {
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        Some(impl_agg_n_unique!(self, groups, NoNull<UInt32Chunked>))
-    }
-}
-
-impl AggNUnique for Utf8Chunked {
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
-        Some(impl_agg_n_unique!(self, groups, NoNull<UInt32Chunked>))
-    }
-}
+impl<T> ChunkedArray<T> where ChunkedArray<T>: ChunkTake + IntoSeries {}
 
 pub trait AggList {
-    fn agg_list(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, _groups: &GroupsProxy) -> Option<Series> {
         None
     }
 }
@@ -470,140 +624,235 @@ where
     T: PolarsNumericType,
     ChunkedArray<T>: IntoSeries,
 {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        let mut can_fast_explode = true;
-        let arr = match self.cont_slice() {
-            Ok(values) => {
-                let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
-                let mut length_so_far = 0i64;
-                offsets.push(length_so_far);
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let mut can_fast_explode = true;
+                let arr = match self.cont_slice() {
+                    Ok(values) => {
+                        let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
+                        let mut length_so_far = 0i64;
+                        offsets.push(length_so_far);
 
-                let mut list_values = Vec::<T::Native>::with_capacity(self.len());
-                groups.iter().for_each(|(_, idx)| {
-                    let idx_len = idx.len();
-                    if idx_len == 0 {
-                        can_fast_explode = false;
-                    }
+                        let mut list_values = Vec::<T::Native>::with_capacity(self.len());
+                        groups.iter().for_each(|(_, idx)| {
+                            let idx_len = idx.len();
+                            if idx_len == 0 {
+                                can_fast_explode = false;
+                            }
 
-                    length_so_far += idx_len as i64;
-                    // Safety:
-                    // group tuples are in bounds
-                    unsafe {
-                        list_values
-                            .extend(idx.iter().map(|idx| *values.get_unchecked(*idx as usize)));
-                        // Safety:
-                        // we know that offsets has allocated enough slots
-                        offsets.push_unchecked(length_so_far);
+                            length_so_far += idx_len as i64;
+                            // Safety:
+                            // group tuples are in bounds
+                            unsafe {
+                                list_values.extend(
+                                    idx.iter().map(|idx| *values.get_unchecked(*idx as usize)),
+                                );
+                                // Safety:
+                                // we know that offsets has allocated enough slots
+                                offsets.push_unchecked(length_so_far);
+                            }
+                        });
+                        let array = PrimitiveArray::from_data(
+                            T::get_dtype().to_arrow(),
+                            list_values.into(),
+                            None,
+                        );
+                        let data_type =
+                            ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
+                        ListArray::<i64>::from_data(
+                            data_type,
+                            offsets.into(),
+                            Arc::new(array),
+                            None,
+                        )
                     }
-                });
-                let array =
-                    PrimitiveArray::from_data(T::get_dtype().to_arrow(), list_values.into(), None);
-                let data_type = ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
-                ListArray::<i64>::from_data(data_type, offsets.into(), Arc::new(array), None)
-            }
-            _ => {
-                let mut builder = ListPrimitiveChunkedBuilder::<T::Native>::new(
-                    self.name(),
-                    groups.len(),
-                    self.len(),
-                    self.dtype().clone(),
-                );
-                for (_first, idx) in groups {
-                    let s = unsafe {
-                        self.take_unchecked(idx.iter().map(|i| *i as usize).into())
-                            .into_series()
-                    };
-                    builder.append_opt_series(Some(&s));
+                    _ => {
+                        let mut builder = ListPrimitiveChunkedBuilder::<T::Native>::new(
+                            self.name(),
+                            groups.len(),
+                            self.len(),
+                            self.dtype().clone(),
+                        );
+                        for (_first, idx) in groups {
+                            let s = unsafe {
+                                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
+                                    .into_series()
+                            };
+                            builder.append_opt_series(Some(&s));
+                        }
+                        return Some(builder.finish().into_series());
+                    }
+                };
+                let mut ca = ListChunked::new_from_chunks(self.name(), vec![Arc::new(arr)]);
+                if can_fast_explode {
+                    ca.set_fast_explode()
                 }
-                return Some(builder.finish().into_series());
+                Some(ca.into())
             }
-        };
-        let mut ca = ListChunked::new_from_chunks(self.name(), vec![Arc::new(arr)]);
-        if can_fast_explode {
-            ca.set_fast_explode()
+            GroupsProxy::Slice(groups) => {
+                todo!()
+            }
         }
-        Some(ca.into())
     }
 }
 
 impl AggList for BooleanChunked {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        let mut builder = ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
-        for (_first, idx) in groups {
-            let s = unsafe {
-                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
-                    .into_series()
-            };
-            builder.append_series(&s)
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let mut builder =
+                    ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
+                for (_first, idx) in groups {
+                    let ca = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                    builder.append(&ca)
+                }
+                Some(builder.finish().into_series())
+            }
+            GroupsProxy::Slice(groups) => {
+                let mut builder =
+                    ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
+                for [first, len] in groups {
+                    let ca = self.slice(*first as i64, *len as usize);
+                    builder.append(&ca)
+                }
+                Some(builder.finish().into_series())
+            }
         }
-        Some(builder.finish().into_series())
     }
 }
 
 impl AggList for Utf8Chunked {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        let mut builder = ListUtf8ChunkedBuilder::new(self.name(), groups.len(), self.len());
-        for (_first, idx) in groups {
-            let s = unsafe {
-                self.take_unchecked(idx.iter().map(|i| *i as usize).into())
-                    .into_series()
-            };
-            builder.append_series(&s)
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let mut builder =
+                    ListUtf8ChunkedBuilder::new(self.name(), groups.len(), self.len());
+                for (_first, idx) in groups {
+                    let ca = unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
+                    builder.append(&ca)
+                }
+                Some(builder.finish().into_series())
+            }
+            GroupsProxy::Slice(groups) => {
+                let mut builder =
+                    ListUtf8ChunkedBuilder::new(self.name(), groups.len(), self.len());
+                for [first, len] in groups {
+                    let ca = self.slice(*first as i64, *len as usize);
+                    builder.append(&ca)
+                }
+                Some(builder.finish().into_series())
+            }
         }
-        Some(builder.finish().into_series())
     }
+}
+
+fn agg_list_list<F: Fn(&ListChunked, bool, &mut Vec<i64>, &mut i64, &mut Vec<ArrayRef>) -> bool>(
+    ca: &ListChunked,
+    groups_len: usize,
+    func: F,
+) -> Option<Series> {
+    let mut can_fast_explode = true;
+    let mut offsets = Vec::<i64>::with_capacity(groups_len + 1);
+    let mut length_so_far = 0i64;
+    offsets.push(length_so_far);
+
+    let mut list_values = Vec::with_capacity(groups_len);
+
+    let can_fast_explode = func(
+        ca,
+        can_fast_explode,
+        &mut offsets,
+        &mut length_so_far,
+        &mut list_values,
+    );
+    if groups_len == 0 {
+        list_values.push(ca.chunks[0].slice(0, 0).into())
+    }
+    let arrays = list_values.iter().map(|arr| &**arr).collect::<Vec<_>>();
+    let list_values: ArrayRef = arrow::compute::concatenate::concatenate(&arrays)
+        .unwrap()
+        .into();
+    let data_type = ListArray::<i64>::default_datatype(list_values.data_type().clone());
+    let arr = Arc::new(ListArray::<i64>::from_data(
+        data_type,
+        offsets.into(),
+        list_values,
+        None,
+    )) as ArrayRef;
+    let mut listarr = ListChunked::new_from_chunks(ca.name(), vec![arr]);
+    if can_fast_explode {
+        listarr.set_fast_explode()
+    }
+    Some(listarr.into_series())
 }
 
 impl AggList for ListChunked {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        let mut can_fast_explode = true;
-        let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
-        let mut length_so_far = 0i64;
-        offsets.push(length_so_far);
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
+        match groups {
+            GroupsProxy::Idx(groups) => {
+                let func = |ca: &ListChunked,
+                            mut can_fast_explode: bool,
+                            offsets: &mut Vec<i64>,
+                            length_so_far: &mut i64,
+                            list_values: &mut Vec<ArrayRef>| {
+                    groups.iter().for_each(|(_, idx)| {
+                        let idx_len = idx.len();
+                        if idx_len == 0 {
+                            can_fast_explode = false;
+                        }
 
-        let mut list_values = Vec::with_capacity(groups.len());
-        groups.iter().for_each(|(_, idx)| {
-            let idx_len = idx.len();
-            if idx_len == 0 {
-                can_fast_explode = false;
+                        *length_so_far += idx_len as i64;
+                        // Safety:
+                        // group tuples are in bounds
+                        unsafe {
+                            let mut s =
+                                ca.take_unchecked((idx.iter().map(|idx| *idx as usize)).into());
+                            let arr = s.chunks.pop().unwrap();
+                            list_values.push(arr);
+
+                            // Safety:
+                            // we know that offsets has allocated enough slots
+                            offsets.push_unchecked(*length_so_far);
+                        }
+                    });
+                    can_fast_explode
+                };
+
+                agg_list_list(self, groups.len(), func)
             }
+            GroupsProxy::Slice(groups) => {
+                let func = |ca: &ListChunked,
+                            mut can_fast_explode: bool,
+                            offsets: &mut Vec<i64>,
+                            length_so_far: &mut i64,
+                            list_values: &mut Vec<ArrayRef>| {
+                    groups.iter().for_each(|&[first, len]| {
+                        if len == 0 {
+                            can_fast_explode = false;
+                        }
 
-            length_so_far += idx_len as i64;
-            // Safety:
-            // group tuples are in bounds
-            unsafe {
-                let mut s = self.take_unchecked((idx.iter().map(|idx| *idx as usize)).into());
-                let arr = s.chunks.pop().unwrap();
-                list_values.push(arr);
+                        *length_so_far += len as i64;
+                        let mut s = ca.slice(first as i64, len as usize);
+                        let arr = s.chunks.pop().unwrap();
+                        list_values.push(arr);
 
-                // Safety:
-                // we know that offsets has allocated enough slots
-                offsets.push_unchecked(length_so_far);
+                        unsafe {
+                            // Safety:
+                            // we know that offsets has allocated enough slots
+                            offsets.push_unchecked(*length_so_far);
+                        }
+                    });
+                    can_fast_explode
+                };
+
+                agg_list_list(self, groups.len(), func)
             }
-        });
-        if groups.is_empty() {
-            list_values.push(self.chunks[0].slice(0, 0).into())
         }
-        let arrays = list_values.iter().map(|arr| &**arr).collect::<Vec<_>>();
-        let list_values: ArrayRef = arrow::compute::concatenate::concatenate(&arrays)
-            .unwrap()
-            .into();
-        let data_type = ListArray::<i64>::default_datatype(list_values.data_type().clone());
-        let arr = Arc::new(ListArray::<i64>::from_data(
-            data_type,
-            offsets.into(),
-            list_values,
-            None,
-        )) as ArrayRef;
-        let mut listarr = ListChunked::new_from_chunks(self.name(), vec![arr]);
-        if can_fast_explode {
-            listarr.set_fast_explode()
-        }
-        Some(listarr.into_series())
     }
 }
 impl AggList for CategoricalChunked {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         match self.deref().agg_list(groups) {
             None => None,
             Some(s) => {
@@ -622,7 +871,7 @@ impl AggList for CategoricalChunked {
 }
 #[cfg(feature = "object")]
 impl<T: PolarsObject> AggList for ObjectChunked<T> {
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         let mut can_fast_explode = true;
         let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
         let mut length_so_far = 0i64;
@@ -682,14 +931,14 @@ impl<T: PolarsObject> AggList for ObjectChunked<T> {
 pub(crate) trait AggQuantile {
     fn agg_quantile(
         &self,
-        _groups: &[(u32, Vec<u32>)],
+        _groups: &GroupsProxy,
         _quantile: f64,
         _interpol: QuantileInterpolOptions,
     ) -> Option<Series> {
         None
     }
 
-    fn agg_median(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_median(&self, _groups: &GroupsProxy) -> Option<Series> {
         None
     }
 }
@@ -705,11 +954,11 @@ where
 {
     fn agg_quantile(
         &self,
-        groups: &[(u32, Vec<u32>)],
+        groups: &GroupsProxy,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Option<Series> {
-        agg_helper::<T, _>(groups, |(_first, idx)| {
+        agg_helper_idx::<T, _>(groups, |(_first, idx)| {
             if idx.is_empty() {
                 return None;
             }
@@ -719,8 +968,8 @@ where
         })
     }
 
-    fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
-        agg_helper::<Float64Type, _>(groups, |(_first, idx)| {
+    fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
+        agg_helper_idx::<Float64Type, _>(groups, |(_first, idx)| {
             if idx.is_empty() {
                 return None;
             }

--- a/polars/polars-core/src/frame/groupby/dynamic.rs
+++ b/polars/polars-core/src/frame/groupby/dynamic.rs
@@ -1,4 +1,4 @@
-use crate::frame::groupby::GroupTuples;
+use crate::frame::groupby::GroupsProxy;
 use crate::prelude::*;
 use crate::POOL;
 use polars_time::groupby::ClosedWindow;
@@ -31,7 +31,7 @@ impl DataFrame {
         &self,
         by: Vec<Series>,
         options: &DynamicGroupOptions,
-    ) -> Result<(Series, Vec<Series>, GroupTuples)> {
+    ) -> Result<(Series, Vec<Series>, GroupsProxy)> {
         let time = self.column(&options.index_column)?;
         let time_type = time.dtype();
 
@@ -92,7 +92,7 @@ impl DataFrame {
         options: &DynamicGroupOptions,
         tu: TimeUnit,
         time_type: &DataType,
-    ) -> Result<(Series, Vec<Series>, GroupTuples)> {
+    ) -> Result<(Series, Vec<Series>, GroupsProxy)> {
         let w = Window::new(options.every, options.period, options.offset);
         let dt = dt.datetime().unwrap();
 

--- a/polars/polars-core/src/frame/groupby/dynamic.rs
+++ b/polars/polars-core/src/frame/groupby/dynamic.rs
@@ -128,8 +128,9 @@ impl DataFrame {
                 })
                 .collect::<Vec<_>>()
         } else {
-            let mut groups = self.groupby_with_series(by.clone(), true)?.groups.into_idx();
-            groups.sort_unstable_by_key(|g| g.0);
+            let mut groups = self.groupby_with_series(by.clone(), true)?.groups;
+            groups.sort();
+            let groups = groups.into_idx();
 
             // include boundaries cannot be parallel (easily)
             if options.include_boundaries {

--- a/polars/polars-core/src/frame/groupby/dynamic.rs
+++ b/polars/polars-core/src/frame/groupby/dynamic.rs
@@ -128,7 +128,7 @@ impl DataFrame {
                 })
                 .collect::<Vec<_>>()
         } else {
-            let mut groups = self.groupby_with_series(by.clone(), true)?.groups;
+            let mut groups = self.groupby_with_series(by.clone(), true)?.groups.into_idx();
             groups.sort_unstable_by_key(|g| g.0);
 
             // include boundaries cannot be parallel (easily)
@@ -232,7 +232,7 @@ impl DataFrame {
         dt.into_datetime(tu, None)
             .into_series()
             .cast(time_type)
-            .map(|s| (s, by, groups))
+            .map(|s| (s, by, GroupsProxy::Idx(groups)))
     }
 }
 
@@ -325,14 +325,14 @@ mod test {
         .into_series();
         assert_eq!(&upper, &range);
 
-        let expected = vec![
+        let expected = GroupsProxy::Idx(vec![
             (0u32, vec![0u32, 1, 2]),
             (2u32, vec![2]),
             (5u32, vec![5, 6]),
             (6u32, vec![6]),
             (3u32, vec![3, 4]),
             (4u32, vec![4]),
-        ];
+        ]);
         assert_eq!(expected, groups);
     }
 }

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -1,4 +1,4 @@
-use super::GroupTuples;
+use super::GroupsProxy;
 use crate::prelude::compare_inner::PartialEqInner;
 use crate::prelude::*;
 use crate::utils::CustomIterTools;
@@ -16,7 +16,7 @@ use std::hash::{BuildHasher, Hash};
 // Overallocation seems a lot more expensive than resizing so we start reasonable small.
 pub(crate) const HASHMAP_INIT_SIZE: usize = 512;
 
-pub(crate) fn groupby<T>(a: impl Iterator<Item = T>) -> GroupTuples
+pub(crate) fn groupby<T>(a: impl Iterator<Item = T>) -> GroupsProxy
 where
     T: Hash + Eq,
 {
@@ -50,7 +50,7 @@ pub(crate) fn groupby_threaded_num<T, IntoSlice>(
     keys: Vec<IntoSlice>,
     group_size_hint: usize,
     n_partitions: u64,
-) -> GroupTuples
+) -> GroupsProxy
 where
     T: Send + Hash + Eq + Sync + Copy + AsU64 + CallHasher,
     IntoSlice: AsRef<[T]> + Send + Sync,
@@ -235,7 +235,7 @@ pub(crate) fn populate_multiple_key_hashmap2<'a, V, H, F, G>(
 pub(crate) fn groupby_threaded_multiple_keys_flat(
     keys: DataFrame,
     n_partitions: usize,
-) -> GroupTuples {
+) -> GroupsProxy {
     let dfs = split_df(&keys, n_partitions).unwrap();
     let (hashes, _random_state) = df_rows_to_hashes_threaded(&dfs, None);
     let n_partitions = n_partitions as u64;

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -634,7 +634,7 @@ impl<'df> GroupBy<'df> {
 
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Mean);
-            let opt_agg = agg_col.agg_mean(&self.groups.idx_ref());
+            let opt_agg = agg_col.agg_mean(&self.groups);
             if let Some(mut agg) = opt_agg {
                 agg.rename(&new_name);
                 cols.push(agg);
@@ -673,7 +673,7 @@ impl<'df> GroupBy<'df> {
 
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Sum);
-            let opt_agg = agg_col.agg_sum(&self.groups.idx_ref());
+            let opt_agg = agg_col.agg_sum(&self.groups);
             if let Some(mut agg) = opt_agg {
                 agg.rename(&new_name);
                 cols.push(agg);
@@ -711,7 +711,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Min);
-            let opt_agg = agg_col.agg_min(&self.groups.idx_ref());
+            let opt_agg = agg_col.agg_min(&self.groups);
             if let Some(mut agg) = opt_agg {
                 agg.rename(&new_name);
                 cols.push(agg);
@@ -749,7 +749,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Max);
-            let opt_agg = agg_col.agg_max(&self.groups.idx_ref());
+            let opt_agg = agg_col.agg_max(&self.groups);
             if let Some(mut agg) = opt_agg {
                 agg.rename(&new_name);
                 cols.push(agg);
@@ -859,7 +859,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::NUnique);
-            let opt_agg = agg_col.agg_n_unique(&self.groups.idx_ref());
+            let opt_agg = agg_col.agg_n_unique(&self.groups);
             if let Some(mut agg) = opt_agg {
                 agg.rename(&new_name);
                 cols.push(agg.into_series());

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1,10 +1,9 @@
 use self::hashing::*;
-use crate::chunked_array::builder::PrimitiveChunkedBuilder;
 use crate::prelude::*;
 #[cfg(feature = "groupby_list")]
 use crate::utils::Wrap;
 use crate::utils::{
-    accumulate_dataframes_vertical, copy_from_slice_unchecked, set_partition_size, split_ca, NoNull,
+    accumulate_dataframes_vertical, copy_from_slice_unchecked, set_partition_size, split_ca,
 };
 use crate::vector_hasher::{get_null_hash_value, AsU64, StrHash};
 use crate::POOL;
@@ -17,7 +16,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 #[cfg(feature = "dtype-categorical")]
 use std::ops::Deref;
-use std::ptr::NonNull;
 
 pub mod aggregations;
 #[cfg(feature = "dynamic_groupby")]
@@ -458,7 +456,7 @@ impl DataFrame {
         S: AsRef<str>,
     {
         let mut gb = self.groupby(by)?;
-        &mut gb.groups.idx_mut().sort_unstable_by_key(|t| t.0);
+        gb.groups.idx_mut().sort_unstable_by_key(|t| t.0);
         Ok(gb)
     }
 }
@@ -1478,8 +1476,7 @@ mod test {
             a.sort();
 
             let keys = split.iter().map(|ca| ca.cont_slice().unwrap()).collect();
-            let mut b = groupby_threaded_num(keys, 0, split.len() as u64)
-                .into_idx();
+            let mut b = groupby_threaded_num(keys, 0, split.len() as u64).into_idx();
             b.sort();
 
             assert_eq!(a, b);

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -145,8 +145,8 @@ impl DataFrame {
                     // group tuples are in bounds
                     // shape (1, len(keys)
                     let sub_index_df = match indicator {
-                        GroupsIndicator::Idx(g) => {
-                            unsafe { index_df.take_unchecked_slice(&g.1[..1]) }
+                        GroupsIndicator::Idx(g) => unsafe {
+                            index_df.take_unchecked_slice(&g.1[..1])
                         },
                         GroupsIndicator::Slice([first, len]) => {
                             index_df.slice(first as i64, len as usize)
@@ -179,10 +179,9 @@ impl DataFrame {
                         // safety:
                         // group tuples are in bounds
                         let sub_vals_and_cols = match indicator {
-                            GroupsIndicator::Idx(g) => {
-                                unsafe { values_and_columns[i].take_unchecked_slice(&g.1) }
-
-                            }
+                            GroupsIndicator::Idx(g) => unsafe {
+                                values_and_columns[i].take_unchecked_slice(&g.1)
+                            },
                             GroupsIndicator::Slice([first, len]) => {
                                 values_and_columns[i].slice(first as i64, len as usize)
                             }

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
-use crate::frame::groupby::GroupTuples;
+use crate::frame::groupby::GroupsProxy;
 use crate::utils::accumulate_dataframes_vertical;
 use crate::POOL;
 #[cfg(feature = "dtype-date")]
@@ -98,7 +98,7 @@ impl DataFrame {
         // the rows of this nested groupby will be pivoted as header column values
         columns: &[String],
         // matching a groupby on index
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         // aggregation function
         agg_fn: PivotAgg,
     ) -> Result<DataFrame> {

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -361,7 +361,7 @@ pub(crate) trait ChunkPivot {
         &self,
         _pivot_series: &'a Series,
         _keys: Vec<Series>,
-        _groups: &[(u32, Vec<u32>)],
+        _groups: &GroupsProxy,
         _agg_type: PivotAgg,
     ) -> Result<DataFrame> {
         Err(PolarsError::InvalidOperation(
@@ -373,7 +373,7 @@ pub(crate) trait ChunkPivot {
         &self,
         _pivot_series: &'a Series,
         _keys: Vec<Series>,
-        _groups: &[(u32, Vec<u32>)],
+        _groups: &GroupsProxy,
     ) -> Result<DataFrame> {
         Err(PolarsError::InvalidOperation(
             "Pivot count operation not implemented for this type".into(),

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -1,9 +1,8 @@
-use rayon::iter::plumbing::UnindexedConsumer;
-use polars_arrow::utils::CustomIterTools;
-use crate::prelude::{ListChunked, UInt32Chunked};
+use crate::prelude::*;
 use crate::utils::NoNull;
+use polars_arrow::utils::CustomIterTools;
+use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::prelude::*;
-use crate::series::IntoSeries;
 
 /// Indexes of the groups, the first index is stored separately.
 /// this make sorting fast.
@@ -37,11 +36,24 @@ impl GroupsProxy {
         }
     }
 
-    pub(crate) fn iter(&self) -> GroupsProxyIter {
+    pub fn iter(&self) -> GroupsProxyIter {
         GroupsProxyIter::new(self)
     }
 
-    pub(crate) fn par_iter(&self) -> GroupsProxyParIter {
+    #[cfg(feature = "private")]
+    pub fn sort(&mut self) {
+        match self {
+            GroupsProxy::Idx(groups) => {
+                groups.sort_unstable_by_key(|t| t.0);
+            }
+            GroupsProxy::Slice(groups) => {
+                groups.sort_unstable_by_key(|[first, _]| *first);
+            }
+        }
+    }
+
+    #[cfg(feature = "private")]
+    pub fn par_iter(&self) -> GroupsProxyParIter {
         GroupsProxyParIter::new(self)
     }
 
@@ -50,13 +62,25 @@ impl GroupsProxy {
     /// # Panic
     ///
     /// panics if the groups are a slice.
-    pub(crate) fn idx_ref(&self) -> &GroupsIdx {
+    pub fn idx_ref(&self) -> &GroupsIdx {
         match self {
             GroupsProxy::Idx(groups) => groups,
             GroupsProxy::Slice(_) => panic!("groups are slices not index"),
         }
     }
 
+    pub fn get(&self, index: usize) -> GroupsIndicator {
+        match self {
+            GroupsProxy::Idx(groups) => GroupsIndicator::Idx(&groups[index]),
+            GroupsProxy::Slice(groups) => GroupsIndicator::Slice(groups[index]),
+        }
+    }
+
+    /// Get a mutable reference to the `GroupsIdx`.
+    ///
+    /// # Panic
+    ///
+    /// panics if the groups are a slice.
     pub fn idx_mut(&mut self) -> &mut GroupsIdx {
         match self {
             GroupsProxy::Idx(groups) => groups,
@@ -64,44 +88,49 @@ impl GroupsProxy {
         }
     }
 
-    pub fn len(&self)  -> usize {
+    pub fn len(&self) -> usize {
         match self {
             GroupsProxy::Idx(groups) => groups.len(),
             GroupsProxy::Slice(groups) => groups.len(),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn group_count(&self) -> UInt32Chunked {
         match self {
             GroupsProxy::Idx(groups) => {
-                let ca: NoNull<UInt32Chunked> = groups.iter().map(|(_first, idx)| idx.len() as u32).collect_trusted();
+                let ca: NoNull<UInt32Chunked> = groups
+                    .iter()
+                    .map(|(_first, idx)| idx.len() as u32)
+                    .collect_trusted();
                 ca.into_inner()
-            },
+            }
             GroupsProxy::Slice(groups) => {
-                let ca: NoNull<UInt32Chunked> = groups.iter().map(|[first, len]| *len).collect_trusted();
+                let ca: NoNull<UInt32Chunked> =
+                    groups.iter().map(|[_first, len]| *len).collect_trusted();
                 ca.into_inner()
             }
         }
     }
     pub fn as_list_chunked(&self) -> ListChunked {
         match self {
-            GroupsProxy::Idx(groups) => {
-                groups
-                    .iter()
-                    .map(|(_first, idx)| {
-                        let ca: NoNull<UInt32Chunked> = idx.iter().map(|&v| v as u32).collect();
-                        ca.into_inner().into_series()
-                    })
-                    .collect_trusted()
-            },
-            GroupsProxy::Slice(groups) => {
-                groups
-                    .iter()
-                    .map(|&[first, len]| {
-                        let ca: NoNull<UInt32Chunked> = (first..first + len).collect_trusted();
-                        ca.into_inner().into_series()
-                    })
-                    .collect_trusted()
-            }
+            GroupsProxy::Idx(groups) => groups
+                .iter()
+                .map(|(_first, idx)| {
+                    let ca: NoNull<UInt32Chunked> = idx.iter().map(|&v| v as u32).collect();
+                    ca.into_inner().into_series()
+                })
+                .collect_trusted(),
+            GroupsProxy::Slice(groups) => groups
+                .iter()
+                .map(|&[first, len]| {
+                    let ca: NoNull<UInt32Chunked> = (first..first + len).collect_trusted();
+                    ca.into_inner().into_series()
+                })
+                .collect_trusted(),
         }
     }
 }
@@ -112,27 +141,34 @@ impl From<GroupsIdx> for GroupsProxy {
     }
 }
 
-
 pub enum GroupsIndicator<'a> {
     Idx(&'a (u32, Vec<u32>)),
-    Slice([u32; 2])
+    Slice([u32; 2]),
+}
+
+impl<'a> GroupsIndicator<'a> {
+    pub fn len(&self) -> usize {
+        match self {
+            GroupsIndicator::Idx(g) => g.1.len(),
+            GroupsIndicator::Slice([_, len]) => *len as usize,
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 pub struct GroupsProxyIter<'a> {
     vals: &'a GroupsProxy,
     len: usize,
-    idx: usize
+    idx: usize,
 }
 
 impl<'a> GroupsProxyIter<'a> {
     fn new(vals: &'a GroupsProxy) -> Self {
         let len = vals.len();
         let idx = 0;
-        GroupsProxyIter {
-            vals,
-            len,
-            idx
-        }
+        GroupsProxyIter { vals, len, idx }
     }
 }
 
@@ -141,13 +177,17 @@ impl<'a> Iterator for GroupsProxyIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx == self.len {
-            return None
+            return None;
         }
 
         let out = unsafe {
             match self.vals {
-                GroupsProxy::Idx(groups) => Some(GroupsIndicator::Idx(groups.get_unchecked(self.idx))),
-                GroupsProxy::Slice(groups) => Some(GroupsIndicator::Slice(*groups.get_unchecked(self.idx)))
+                GroupsProxy::Idx(groups) => {
+                    Some(GroupsIndicator::Idx(groups.get_unchecked(self.idx)))
+                }
+                GroupsProxy::Slice(groups) => {
+                    Some(GroupsIndicator::Slice(*groups.get_unchecked(self.idx)))
+                }
             }
         };
         self.idx += 1;
@@ -163,26 +203,25 @@ pub struct GroupsProxyParIter<'a> {
 impl<'a> GroupsProxyParIter<'a> {
     fn new(vals: &'a GroupsProxy) -> Self {
         let len = vals.len();
-        GroupsProxyParIter {
-            vals,
-            len,
-        }
+        GroupsProxyParIter { vals, len }
     }
 }
 
-impl<'a> ParallelIterator for GroupsProxyParIter<'a>  {
+impl<'a> ParallelIterator for GroupsProxyParIter<'a> {
     type Item = GroupsIndicator<'a>;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item> {
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
         (0..self.len)
-            .into_par_iter().map(|i| {
-            unsafe {
+            .into_par_iter()
+            .map(|i| unsafe {
                 match self.vals {
                     GroupsProxy::Idx(groups) => GroupsIndicator::Idx(groups.get_unchecked(i)),
-                    GroupsProxy::Slice(groups) => GroupsIndicator::Slice(*groups.get_unchecked(i))
+                    GroupsProxy::Slice(groups) => GroupsIndicator::Slice(*groups.get_unchecked(i)),
                 }
-            }
-        }).drive_unindexed(consumer)
+            })
+            .drive_unindexed(consumer)
     }
 }

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -1,0 +1,50 @@
+/// Indexes of the groups, the first index is stored separately.
+/// this make sorting fast.
+pub type GroupsIdx = Vec<(u32, Vec<u32>)>;
+/// Every group is indicated by an array where the
+///  - first value is an index to the start of the group
+///  - second value is the length of the group
+/// Only used when group values are stored together
+pub type GroupsSlice = Vec<[u32; 2]>;
+
+pub enum GroupsProxy {
+    Idx(GroupsIdx),
+    Slice(GroupsSlice),
+}
+
+impl GroupsProxy {
+    pub(crate) fn into_idx(self) -> GroupsIdx {
+        match self {
+            GroupsProxy::Idx(groups) => groups,
+            GroupsProxy::Slice(groups) => groups
+                .iter()
+                .map(|&[first, len]| (first, (first..first + len).collect()))
+                .collect(),
+        }
+    }
+
+    /// Get a reference to the `GroupsIdx`.
+    ///
+    /// # Panic
+    ///
+    /// panics if the groups are a slice.
+    pub(crate) fn idx_ref(&self) -> &GroupsIdx {
+        match self {
+            GroupsProxy::Idx(groups) => groups,
+            GroupsProxy::Slice(_) => panic!("groups are slices not index"),
+        }
+    }
+
+    pub(crate) fn idx_mut(&mut self) -> &mut GroupsIdx {
+        match self {
+            GroupsProxy::Idx(groups) => groups,
+            GroupsProxy::Slice(_) => panic!("groups are slices not index"),
+        }
+    }
+}
+
+impl From<GroupsIdx> for GroupsProxy {
+    fn from(groups: GroupsIdx) -> Self {
+        GroupsProxy::Idx(groups)
+    }
+}

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -1,3 +1,10 @@
+use rayon::iter::plumbing::UnindexedConsumer;
+use polars_arrow::utils::CustomIterTools;
+use crate::prelude::{ListChunked, UInt32Chunked};
+use crate::utils::NoNull;
+use rayon::prelude::*;
+use crate::series::IntoSeries;
+
 /// Indexes of the groups, the first index is stored separately.
 /// this make sorting fast.
 pub type GroupsIdx = Vec<(u32, Vec<u32>)>;
@@ -7,9 +14,16 @@ pub type GroupsIdx = Vec<(u32, Vec<u32>)>;
 /// Only used when group values are stored together
 pub type GroupsSlice = Vec<[u32; 2]>;
 
+#[derive(Debug, Clone, PartialEq)]
 pub enum GroupsProxy {
     Idx(GroupsIdx),
     Slice(GroupsSlice),
+}
+
+impl Default for GroupsProxy {
+    fn default() -> Self {
+        GroupsProxy::Idx(vec![])
+    }
 }
 
 impl GroupsProxy {
@@ -21,6 +35,14 @@ impl GroupsProxy {
                 .map(|&[first, len]| (first, (first..first + len).collect()))
                 .collect(),
         }
+    }
+
+    pub(crate) fn iter(&self) -> GroupsProxyIter {
+        GroupsProxyIter::new(self)
+    }
+
+    pub(crate) fn par_iter(&self) -> GroupsProxyParIter {
+        GroupsProxyParIter::new(self)
     }
 
     /// Get a reference to the `GroupsIdx`.
@@ -35,10 +57,51 @@ impl GroupsProxy {
         }
     }
 
-    pub(crate) fn idx_mut(&mut self) -> &mut GroupsIdx {
+    pub fn idx_mut(&mut self) -> &mut GroupsIdx {
         match self {
             GroupsProxy::Idx(groups) => groups,
             GroupsProxy::Slice(_) => panic!("groups are slices not index"),
+        }
+    }
+
+    pub fn len(&self)  -> usize {
+        match self {
+            GroupsProxy::Idx(groups) => groups.len(),
+            GroupsProxy::Slice(groups) => groups.len(),
+        }
+    }
+    pub fn group_count(&self) -> UInt32Chunked {
+        match self {
+            GroupsProxy::Idx(groups) => {
+                let ca: NoNull<UInt32Chunked> = groups.iter().map(|(_first, idx)| idx.len() as u32).collect_trusted();
+                ca.into_inner()
+            },
+            GroupsProxy::Slice(groups) => {
+                let ca: NoNull<UInt32Chunked> = groups.iter().map(|[first, len]| *len).collect_trusted();
+                ca.into_inner()
+            }
+        }
+    }
+    pub fn as_list_chunked(&self) -> ListChunked {
+        match self {
+            GroupsProxy::Idx(groups) => {
+                groups
+                    .iter()
+                    .map(|(_first, idx)| {
+                        let ca: NoNull<UInt32Chunked> = idx.iter().map(|&v| v as u32).collect();
+                        ca.into_inner().into_series()
+                    })
+                    .collect_trusted()
+            },
+            GroupsProxy::Slice(groups) => {
+                groups
+                    .iter()
+                    .map(|&[first, len]| {
+                        let ca: NoNull<UInt32Chunked> = (first..first + len).collect_trusted();
+                        ca.into_inner().into_series()
+                    })
+                    .collect_trusted()
+            }
         }
     }
 }
@@ -46,5 +109,80 @@ impl GroupsProxy {
 impl From<GroupsIdx> for GroupsProxy {
     fn from(groups: GroupsIdx) -> Self {
         GroupsProxy::Idx(groups)
+    }
+}
+
+
+pub enum GroupsIndicator<'a> {
+    Idx(&'a (u32, Vec<u32>)),
+    Slice([u32; 2])
+}
+
+pub struct GroupsProxyIter<'a> {
+    vals: &'a GroupsProxy,
+    len: usize,
+    idx: usize
+}
+
+impl<'a> GroupsProxyIter<'a> {
+    fn new(vals: &'a GroupsProxy) -> Self {
+        let len = vals.len();
+        let idx = 0;
+        GroupsProxyIter {
+            vals,
+            len,
+            idx
+        }
+    }
+}
+
+impl<'a> Iterator for GroupsProxyIter<'a> {
+    type Item = GroupsIndicator<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx == self.len {
+            return None
+        }
+
+        let out = unsafe {
+            match self.vals {
+                GroupsProxy::Idx(groups) => Some(GroupsIndicator::Idx(groups.get_unchecked(self.idx))),
+                GroupsProxy::Slice(groups) => Some(GroupsIndicator::Slice(*groups.get_unchecked(self.idx)))
+            }
+        };
+        self.idx += 1;
+        out
+    }
+}
+
+pub struct GroupsProxyParIter<'a> {
+    vals: &'a GroupsProxy,
+    len: usize,
+}
+
+impl<'a> GroupsProxyParIter<'a> {
+    fn new(vals: &'a GroupsProxy) -> Self {
+        let len = vals.len();
+        GroupsProxyParIter {
+            vals,
+            len,
+        }
+    }
+}
+
+impl<'a> ParallelIterator for GroupsProxyParIter<'a>  {
+    type Item = GroupsIndicator<'a>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item> {
+        (0..self.len)
+            .into_par_iter().map(|i| {
+            unsafe {
+                match self.vals {
+                    GroupsProxy::Idx(groups) => GroupsIndicator::Idx(groups.get_unchecked(i)),
+                    GroupsProxy::Slice(groups) => GroupsIndicator::Slice(*groups.get_unchecked(i))
+                }
+            }
+        }).drive_unindexed(consumer)
     }
 }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2602,7 +2602,7 @@ impl DataFrame {
             None => self.get_column_names(),
         };
         let gb = self.groupby(names)?;
-        let groups = gb.get_groups().iter().map(|v| v.0);
+        let groups = gb.get_groups().idx_ref().iter().map(|v| v.0);
 
         let df = if maintain_order {
             let mut groups = groups.collect::<Vec<_>>();

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -18,7 +18,7 @@ pub use crate::{
     datatypes::*,
     df,
     error::{PolarsError, Result},
-    frame::{groupby::GroupTuples, hash_join::JoinType, DataFrame},
+    frame::{groupby::GroupsProxy, hash_join::JoinType, DataFrame},
     named_from::NamedFrom,
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -261,7 +261,7 @@ impl Series {
                 let iter = keys
                     .into_iter()
                     .map(|opt_key| opt_key.map(|k| unsafe { values.value_unchecked(*k as usize) }));
-                builder.from_iter(iter);
+                builder.drain_iter(iter);
                 Ok(builder.finish().into())
             }
             #[cfg(not(feature = "dtype-u8"))]

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -126,8 +126,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     ) -> Series {
         ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-        IntoGroupTuples::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -77,18 +77,6 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.agg_sum(groups)
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_first(groups)
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_last(groups)
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
-    }
-
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
@@ -104,10 +92,6 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 
     fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_median(groups)
-    }
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
     }
 
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -65,48 +65,48 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_min(groups)
     }
 
-    fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_max(groups)
     }
 
-    fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_sum(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_sum(groups)
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_first(groups)
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_last(groups)
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 
     fn agg_quantile(
         &self,
-        groups: &[(u32, Vec<u32>)],
+        groups: &GroupsProxy,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Option<Series> {
         self.0.agg_quantile(groups, quantile, interpol)
     }
 
-    fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_median(groups)
     }
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -68,26 +68,10 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_first(groups)
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_last(groups)
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
-    }
-
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
-    }
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
         HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -68,24 +68,24 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_first(groups)
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_last(groups)
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -108,8 +108,8 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
             .cast(&DataType::Categorical)
             .unwrap()
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-        IntoGroupTuples::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -91,51 +91,51 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_mean(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
             }
 
-            fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0
                     .agg_min(groups)
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0
                     .agg_max(groups)
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn agg_sum(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_sum(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
             }
 
-            fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_first(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_first(groups).$into_logical().into_series()
             }
 
-            fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_last(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_last(groups).$into_logical().into_series()
             }
 
-            fn agg_std(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
             }
 
-            fn agg_var(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
             }
 
-            fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
                 self.0.agg_n_unique(groups)
             }
 
-            fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
                 // we cannot cast and dispatch as the inner type of the list would be incorrect
                 self.0.agg_list(groups).map(|s| {
                     s.cast(&DataType::List(Box::new(self.dtype().clone())))
@@ -145,7 +145,7 @@ macro_rules! impl_dyn_series {
 
             fn agg_quantile(
                 &self,
-                groups: &[(u32, Vec<u32>)],
+                groups: &GroupsProxy,
                 quantile: f64,
                 interpol: QuantileInterpolOptions,
             ) -> Option<Series> {
@@ -154,13 +154,13 @@ macro_rules! impl_dyn_series {
                     .map(|s| s.$into_logical().into_series())
             }
 
-            fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0
                     .agg_median(groups)
                     .map(|s| s.$into_logical().into_series())
             }
             #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_valid_count(groups)
             }
 

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -626,7 +626,9 @@ mod test {
         let s = Series::new("foo", &[1, 2, 3]);
         let s = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
 
-        let l = s.agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])])).unwrap();
+        let l = s
+            .agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])]))
+            .unwrap();
 
         match l.dtype() {
             DataType::List(inner) => {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -230,7 +230,7 @@ macro_rules! impl_dyn_series {
                     "cannot do remainder operation on logical".into(),
                 ))
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
+            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
                 self.0.group_tuples(multithreaded)
             }
             #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -113,14 +113,6 @@ macro_rules! impl_dyn_series {
                 None
             }
 
-            fn agg_first(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_first(groups).$into_logical().into_series()
-            }
-
-            fn agg_last(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_last(groups).$into_logical().into_series()
-            }
-
             fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
@@ -129,10 +121,6 @@ macro_rules! impl_dyn_series {
             fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
                 // does not make sense on logical
                 None
-            }
-
-            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-                self.0.agg_n_unique(groups)
             }
 
             fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
@@ -158,10 +146,6 @@ macro_rules! impl_dyn_series {
                 self.0
                     .agg_median(groups)
                     .map(|s| s.$into_logical().into_series())
-            }
-            #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-                self.0.agg_valid_count(groups)
             }
 
             fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
@@ -642,7 +626,7 @@ mod test {
         let s = Series::new("foo", &[1, 2, 3]);
         let s = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
 
-        let l = s.agg_list(&[(0, vec![0, 1, 2])]).unwrap();
+        let l = s.agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])])).unwrap();
 
         match l.dtype() {
             DataType::List(inner) => {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -256,7 +256,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             "cannot do remainder operation on logical".into(),
         ))
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
         self.0.group_tuples(multithreaded)
     }
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -113,20 +113,6 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         None
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0
-            .agg_first(groups)
-            .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
-            .into_series()
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0
-            .agg_last(groups)
-            .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
-            .into_series()
-    }
-
     fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
@@ -135,10 +121,6 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
     }
 
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
@@ -166,10 +148,6 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             s.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
                 .into_series()
         })
-    }
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
     }
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
         let other = other.to_physical_repr().into_owned();

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -89,59 +89,59 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_mean(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_min(groups).map(|ca| {
             ca.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
                 .into_series()
         })
     }
 
-    fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_max(groups).map(|ca| {
             ca.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
                 .into_series()
         })
     }
 
-    fn agg_sum(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_sum(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_first(groups)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_last(groups)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }
 
-    fn agg_std(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_var(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0.agg_list(groups).map(|s| {
             s.cast(&DataType::List(Box::new(self.dtype().clone())))
@@ -151,7 +151,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
 
     fn agg_quantile(
         &self,
-        groups: &[(u32, Vec<u32>)],
+        groups: &GroupsProxy,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Option<Series> {
@@ -161,14 +161,14 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         })
     }
 
-    fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_median(groups).map(|s| {
             s.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
                 .into_series()
         })
     }
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -248,7 +248,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             "cannot do remainder operation on logical".into(),
         ))
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
         self.0.group_tuples(multithreaded)
     }
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -110,20 +110,6 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         None
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0
-            .agg_first(groups)
-            .into_duration(self.0.time_unit())
-            .into_series()
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0
-            .agg_last(groups)
-            .into_duration(self.0.time_unit())
-            .into_series()
-    }
-
     fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
@@ -132,10 +118,6 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
     }
 
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
@@ -161,10 +143,6 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0
             .agg_median(groups)
             .map(|s| s.into_duration(self.0.time_unit()).into_series())
-    }
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
     }
 
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -88,57 +88,57 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_mean(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0
             .agg_min(groups)
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0
             .agg_max(groups)
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn agg_sum(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_sum(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_first(groups)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_last(groups)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn agg_std(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_var(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
         // does not make sense on logical
         None
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0.agg_list(groups).map(|s| {
             s.cast(&DataType::List(Box::new(self.dtype().clone())))
@@ -148,7 +148,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
 
     fn agg_quantile(
         &self,
-        groups: &[(u32, Vec<u32>)],
+        groups: &GroupsProxy,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Option<Series> {
@@ -157,13 +157,13 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .map(|s| s.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0
             .agg_median(groups)
             .map(|s| s.into_duration(self.0.time_unit()).into_series())
     }
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -132,60 +132,60 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_mean(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_mean(groups)
             }
 
-            fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_min(groups)
             }
 
-            fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_max(groups)
             }
 
-            fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_sum(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_sum(groups)
             }
 
-            fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_first(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_first(groups)
             }
 
-            fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_last(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_last(groups)
             }
 
-            fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_std(groups)
             }
 
-            fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_var(groups)
             }
 
-            fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
                 self.0.agg_n_unique(groups)
             }
 
-            fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_list(groups)
             }
 
             fn agg_quantile(
                 &self,
-                groups: &[(u32, Vec<u32>)],
+                groups: &GroupsProxy,
                 quantile: f64,
                 interpol: QuantileInterpolOptions,
             ) -> Option<Series> {
                 self.0.agg_quantile(groups, quantile, interpol)
             }
 
-            fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_median(groups)
             }
             #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_valid_count(groups)
             }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -220,8 +220,8 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-                IntoGroupTuples::group_tuples(&self.0, multithreaded)
+            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+                IntoGroupsProxy::group_tuples(&self.0, multithreaded)
             }
 
             #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -148,24 +148,12 @@ macro_rules! impl_dyn_series {
                 self.0.agg_sum(groups)
             }
 
-            fn agg_first(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_first(groups)
-            }
-
-            fn agg_last(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_last(groups)
-            }
-
             fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_std(groups)
             }
 
             fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_var(groups)
-            }
-
-            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-                self.0.agg_n_unique(groups)
             }
 
             fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
@@ -184,11 +172,6 @@ macro_rules! impl_dyn_series {
             fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_median(groups)
             }
-            #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-                self.0.agg_valid_count(groups)
-            }
-
             fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
                 HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -83,8 +83,8 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.agg_valid_count(groups)
     }
 
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-        IntoGroupTuples::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -62,25 +62,8 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_first(groups)
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_last(groups)
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
-    }
-
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
-    }
-
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
     }
 
     fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -62,24 +62,24 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_first(groups)
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_last(groups)
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -266,8 +266,8 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-                IntoGroupTuples::group_tuples(&self.0, multithreaded)
+            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+                IntoGroupsProxy::group_tuples(&self.0, multithreaded)
             }
 
             #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -174,19 +174,19 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_mean(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_mean(groups)
             }
 
-            fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_min(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_min(groups)
             }
 
-            fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_max(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_max(groups)
             }
 
-            fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_sum(&self, groups: &GroupsProxy) -> Option<Series> {
                 use DataType::*;
                 match self.dtype() {
                     Int8 | UInt8 | Int16 | UInt16 => self.cast(&Int64).unwrap().agg_sum(groups),
@@ -194,44 +194,44 @@ macro_rules! impl_dyn_series {
                 }
             }
 
-            fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_first(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_first(groups)
             }
 
-            fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_last(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_last(groups)
             }
 
-            fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_std(groups)
             }
 
-            fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_var(groups)
             }
 
-            fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
                 self.0.agg_n_unique(groups)
             }
 
-            fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_list(groups)
             }
 
             fn agg_quantile(
                 &self,
-                groups: &[(u32, Vec<u32>)],
+                groups: &GroupsProxy,
                 quantile: f64,
                 interpol: QuantileInterpolOptions,
             ) -> Option<Series> {
                 self.0.agg_quantile(groups, quantile, interpol)
             }
 
-            fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_median(groups)
             }
             #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_valid_count(groups)
             }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -194,24 +194,12 @@ macro_rules! impl_dyn_series {
                 }
             }
 
-            fn agg_first(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_first(groups)
-            }
-
-            fn agg_last(&self, groups: &GroupsProxy) -> Series {
-                self.0.agg_last(groups)
-            }
-
             fn agg_std(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_std(groups)
             }
 
             fn agg_var(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_var(groups)
-            }
-
-            fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-                self.0.agg_n_unique(groups)
             }
 
             fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
@@ -230,11 +218,6 @@ macro_rules! impl_dyn_series {
             fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_median(groups)
             }
-            #[cfg(feature = "lazy")]
-            fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-                self.0.agg_valid_count(groups)
-            }
-
             fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
                 HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
             }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -43,15 +43,15 @@ where
     fn _field(&self) -> Cow<Field> {
         Cow::Borrowed(self.0.ref_field())
     }
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_first(groups)
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_last(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -43,13 +43,6 @@ where
     fn _field(&self) -> Cow<Field> {
         Cow::Borrowed(self.0.ref_field())
     }
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_first(groups)
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_last(groups)
-    }
 
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -2,7 +2,7 @@ use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqI
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ChunkIdIter;
 use crate::fmt::FmtList;
-use crate::frame::groupby::{GroupTuples, IntoGroupTuples};
+use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
@@ -67,8 +67,8 @@ where
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-        IntoGroupTuples::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
     }
 }
 #[cfg(feature = "object")]

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -63,24 +63,24 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_first(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_first(groups)
     }
 
-    fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+    fn agg_last(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_last(groups)
     }
 
-    fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
         self.0.agg_n_unique(groups)
     }
 
-    fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
 
     #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_valid_count(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -63,25 +63,8 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_first(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_first(groups)
-    }
-
-    fn agg_last(&self, groups: &GroupsProxy) -> Series {
-        self.0.agg_last(groups)
-    }
-
-    fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<UInt32Chunked> {
-        self.0.agg_n_unique(groups)
-    }
-
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
-    }
-
-    #[cfg(feature = "lazy")]
-    fn agg_valid_count(&self, groups: &GroupsProxy) -> Option<Series> {
-        self.0.agg_valid_count(groups)
     }
 
     fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -115,8 +115,8 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn remainder(&self, rhs: &Series) -> Result<Series> {
         NumOpsDispatch::remainder(&self.0, rhs)
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
-        IntoGroupTuples::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -189,15 +189,6 @@ pub(crate) mod private {
         fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_first(&self, _groups: &GroupsProxy) -> Series {
-            invalid_operation_panic!(self)
-        }
-        fn agg_last(&self, _groups: &GroupsProxy) -> Series {
-            invalid_operation_panic!(self)
-        }
-        fn agg_n_unique(&self, _groups: &GroupsProxy) -> Option<UInt32Chunked> {
-            None
-        }
         fn agg_list(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
@@ -212,10 +203,7 @@ pub(crate) mod private {
         fn agg_median(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        #[cfg(feature = "lazy")]
-        fn agg_valid_count(&self, _groups: &GroupsProxy) -> Option<Series> {
-            None
-        }
+
         fn hash_join_inner(&self, _other: &Series) -> Vec<(u32, u32)> {
             invalid_operation_panic!(self)
         }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -35,7 +35,7 @@ macro_rules! invalid_operation_panic {
 pub(crate) mod private {
     use super::*;
     #[cfg(feature = "rows")]
-    use crate::frame::groupby::GroupTuples;
+    use crate::frame::groupby::GroupsProxy;
 
     use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
     use ahash::RandomState;
@@ -248,7 +248,7 @@ pub(crate) mod private {
         fn remainder(&self, _rhs: &Series) -> Result<Series> {
             invalid_operation_panic!(self)
         }
-        fn group_tuples(&self, _multithreaded: bool) -> GroupTuples {
+        fn group_tuples(&self, _multithreaded: bool) -> GroupsProxy {
             invalid_operation_panic!(self)
         }
         fn zip_with_same_type(&self, _mask: &BooleanChunked, _other: &Series) -> Result<Series> {

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -169,51 +169,51 @@ pub(crate) mod private {
         fn vec_hash_combine(&self, _build_hasher: RandomState, _hashes: &mut [u64]) {
             invalid_operation_panic!(self)
         }
-        fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_mean(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_min(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_min(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_max(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_max(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
         /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16}` the `Series` is
         /// first cast to `Int64` to prevent overflow issues.
-        fn agg_sum(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_sum(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_std(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_std(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_var(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_var(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
-        fn agg_first(&self, _groups: &[(u32, Vec<u32>)]) -> Series {
+        fn agg_first(&self, _groups: &GroupsProxy) -> Series {
             invalid_operation_panic!(self)
         }
-        fn agg_last(&self, _groups: &[(u32, Vec<u32>)]) -> Series {
+        fn agg_last(&self, _groups: &GroupsProxy) -> Series {
             invalid_operation_panic!(self)
         }
-        fn agg_n_unique(&self, _groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+        fn agg_n_unique(&self, _groups: &GroupsProxy) -> Option<UInt32Chunked> {
             None
         }
-        fn agg_list(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_list(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
         fn agg_quantile(
             &self,
-            _groups: &[(u32, Vec<u32>)],
+            _groups: &GroupsProxy,
             _quantile: f64,
             _interpol: QuantileInterpolOptions,
         ) -> Option<Series> {
             None
         }
-        fn agg_median(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_median(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
         #[cfg(feature = "lazy")]
-        fn agg_valid_count(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_valid_count(&self, _groups: &GroupsProxy) -> Option<Series> {
             None
         }
         fn hash_join_inner(&self, _other: &Series) -> Vec<(u32, u32)> {

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -191,7 +191,7 @@ impl ALogicalPlan {
 
 impl ALogicalPlan {
     /// Takes the expressions of an LP node and the inputs of that node and reconstruct
-    pub fn from_exprs_and_input(&self, mut exprs: Vec<Node>, inputs: Vec<Node>) -> ALogicalPlan {
+    pub fn with_exprs_and_input(&self, mut exprs: Vec<Node>, inputs: Vec<Node>) -> ALogicalPlan {
         use ALogicalPlan::*;
 
         match self {

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -72,7 +72,7 @@ impl PredicatePushDown {
             let alp = self.push_down(alp, acc_predicates, lp_arena, expr_arena)?;
             lp_arena.replace(input, alp);
 
-            let lp = lp.from_exprs_and_input(projections, inputs);
+            let lp = lp.with_exprs_and_input(projections, inputs);
             Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
         } else {
             let mut local_predicates = Vec::with_capacity(acc_predicates.len());
@@ -109,7 +109,7 @@ impl PredicatePushDown {
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            let lp = lp.from_exprs_and_input(exprs, new_inputs);
+            let lp = lp.with_exprs_and_input(exprs, new_inputs);
             Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
         }
     }
@@ -134,7 +134,7 @@ impl PredicatePushDown {
                 Ok(node)
             })
             .collect::<Result<Vec<_>>>()?;
-        let lp = lp.from_exprs_and_input(exprs, new_inputs);
+        let lp = lp.with_exprs_and_input(exprs, new_inputs);
 
         // all predicates are done locally
         let local_predicates = acc_predicates.values().copied().collect::<Vec<_>>();

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -848,7 +848,7 @@ impl ProjectionPushDown {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                Ok(lp.from_exprs_and_input(exprs, new_inputs))
+                Ok(lp.with_exprs_and_input(exprs, new_inputs))
             }
         }
     }

--- a/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown.rs
@@ -56,7 +56,7 @@ impl SlicePushDown {
                 Ok(node)
             })
             .collect::<Result<Vec<_>>>()?;
-        let lp = lp.from_exprs_and_input(exprs, new_inputs);
+        let lp = lp.with_exprs_and_input(exprs, new_inputs);
 
         self.no_pushdown_finish_opt(lp, state, lp_arena)
     }
@@ -81,7 +81,7 @@ impl SlicePushDown {
                 Ok(node)
             })
             .collect::<Result<Vec<_>>>()?;
-        Ok(lp.from_exprs_and_input(exprs, new_inputs))
+        Ok(lp.with_exprs_and_input(exprs, new_inputs))
     }
 
     fn pushdown(

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -44,7 +44,7 @@ fn groupby_helper(
     let mut gb = df.groupby_with_series(keys, true)?;
 
     if maintain_order {
-        gb.get_groups_mut().sort_unstable_by_key(|t| t.0)
+        gb.get_groups_mut().idx_mut().sort_unstable_by_key(|t| t.0)
     }
 
     if let Some(f) = apply {

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -91,8 +91,7 @@ impl PhysicalAggregation for AggregationExpr {
                 Ok(rename_option_series(agg_s, &new_name))
             }
             GroupByMethod::Count => {
-                let mut ca: NoNull<UInt32Chunked> =
-                    ac.groups().iter().map(|(_, g)| g.len() as u32).collect();
+                let mut ca = ac.groups.group_count();
                 ca.rename(&new_name);
                 Ok(Some(ca.into_inner().into_series()))
             }
@@ -119,15 +118,7 @@ impl PhysicalAggregation for AggregationExpr {
                 Ok(rename_option_series(Some(agg), &new_name))
             }
             GroupByMethod::Groups => {
-                let mut column: ListChunked = ac
-                    .groups()
-                    .iter()
-                    .map(|(_first, idx)| {
-                        let ca: NoNull<UInt32Chunked> = idx.iter().map(|&v| v as u32).collect();
-                        ca.into_inner().into_series()
-                    })
-                    .collect();
-
+                let mut column: ListChunked = ac.groups().as_list_chunked();
                 column.rename(&new_name);
                 Ok(Some(column.into_series()))
             }

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 use polars_arrow::export::arrow::{array::*, compute::concatenate::concatenate};
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupsProxy};
-use polars_core::utils::NoNull;
 use polars_core::{prelude::*, POOL};
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -93,7 +92,7 @@ impl PhysicalAggregation for AggregationExpr {
             GroupByMethod::Count => {
                 let mut ca = ac.groups.group_count();
                 ca.rename(&new_name);
-                Ok(Some(ca.into_inner().into_series()))
+                Ok(Some(ca.into_series()))
             }
             GroupByMethod::First => {
                 let mut agg_s = ac.flat_naive().into_owned().agg_first(ac.groups());
@@ -210,7 +209,7 @@ impl PhysicalAggregation for AggregationExpr {
                 let mut length_so_far = 0i64;
                 offsets.push(length_so_far);
 
-                for (_, idx) in groups {
+                for (_, idx) in groups.idx_ref() {
                     let ca = unsafe {
                         // Safety
                         // The indexes of the groupby operation are never out of bounds

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -3,7 +3,7 @@ use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
 use polars_arrow::export::arrow::{array::*, compute::concatenate::concatenate};
 use polars_arrow::prelude::QuantileInterpolOptions;
-use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupTuples};
+use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupsProxy};
 use polars_core::utils::NoNull;
 use polars_core::{prelude::*, POOL};
 use std::borrow::Cow;
@@ -32,7 +32,7 @@ impl PhysicalExpr for AggregationExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let out = self.aggregate(df, groups, state)?.ok_or_else(|| {
@@ -63,7 +63,7 @@ impl PhysicalAggregation for AggregationExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.expr.evaluate_on_groups(df, groups, state)?;
@@ -149,7 +149,7 @@ impl PhysicalAggregation for AggregationExpr {
     fn evaluate_partitioned(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Vec<Series>>> {
         match self.agg_type {
@@ -190,7 +190,7 @@ impl PhysicalAggregation for AggregationExpr {
     fn evaluate_partitioned_final(
         &self,
         final_df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         match self.agg_type {
@@ -259,7 +259,7 @@ impl PhysicalAggregation for AggQuantileExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let series = self.expr.evaluate(df, state)?;
@@ -281,7 +281,7 @@ impl PhysicalAggregation for CastExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let agg_expr = self.input.as_agg_expr()?;
@@ -322,7 +322,7 @@ impl PhysicalExpr for AggQuantileExpr {
     fn evaluate_on_groups<'a>(
         &self,
         _df: &DataFrame,
-        _groups: &'a GroupTuples,
+        _groups: &'a GroupsProxy,
         _state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         unimplemented!()

--- a/polars/polars-lazy/src/physical_plan/expressions/alias.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/alias.rs
@@ -1,7 +1,7 @@
 use crate::physical_plan::expressions::utils::as_aggregated;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -39,7 +39,7 @@ impl PhysicalExpr for AliasExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
@@ -69,7 +69,7 @@ impl PhysicalAggregation for AliasExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let opt_agg = as_aggregated(self.physical_expr.as_ref(), df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -1,7 +1,7 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use rayon::prelude::*;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ impl ApplyExpr {
     fn prepare_multiple_inputs<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Vec<AggregationContext<'a>>> {
         self.inputs
@@ -51,7 +51,7 @@ impl PhysicalExpr for ApplyExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         if self.inputs.len() == 1 {
@@ -200,7 +200,7 @@ impl PhysicalAggregation for ApplyExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -1,7 +1,7 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::series::unstable::UnstableSeries;
 use polars_core::{prelude::*, POOL};
 use std::convert::TryFrom;
@@ -76,7 +76,7 @@ impl PhysicalExpr for BinaryExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let (result_a, result_b) = POOL.install(|| {
@@ -216,7 +216,7 @@ impl PhysicalAggregation for BinaryExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         match (self.left.as_agg_expr(), self.right.as_agg_expr()) {

--- a/polars/polars-lazy/src/physical_plan/expressions/binary_function.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary_function.rs
@@ -2,7 +2,7 @@ use crate::logical_plan::Context;
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::{prelude::*, POOL};
 use std::sync::Arc;
 
@@ -50,7 +50,7 @@ impl PhysicalExpr for BinaryFunctionExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let (series_a, series_b) = POOL.install(|| {
@@ -120,7 +120,7 @@ impl PhysicalAggregation for BinaryFunctionExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let (agg_a, agg_b): (Result<Series>, Result<Series>) = POOL.install(|| {

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -67,7 +67,7 @@ impl PhysicalExpr for CastExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/column.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -30,7 +30,7 @@ impl PhysicalExpr for ColumnExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let s = self.evaluate(df, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -1,5 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
+use polars_arrow::is_valid::IsValid;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::{prelude::*, POOL};
 use rayon::prelude::*;
@@ -46,23 +47,54 @@ impl PhysicalExpr for FilterExpr {
 
         let groups = ac_s.groups();
         let predicate_s = ac_predicate.flat_naive();
-        let predicate = predicate_s.bool()?;
+        let predicate = predicate_s.bool()?.rechunk();
+        let predicate = predicate.downcast_iter().next().unwrap();
 
         let groups = POOL.install(|| {
-            groups
-                .par_iter()
-                .map(|(first, idx)| {
-                    let idx: Vec<u32> = idx
-                        .iter()
-                        .filter_map(|i| match predicate.get(*i as usize) {
-                            Some(true) => Some(*i),
-                            _ => None,
+            match groups.as_ref() {
+                GroupsProxy::Idx(groups) => {
+                    let groups = groups
+                        .par_iter()
+                        .map(|(first, idx)| unsafe {
+                            let idx: Vec<u32> = idx
+                                .iter()
+                                // Safety:
+                                // just checked bounds in short circuited lhs
+                                .filter_map(|i| {
+                                    match predicate.value(*i as usize)
+                                        && predicate.is_valid_unchecked(*i as usize)
+                                    {
+                                        true => Some(*i),
+                                        _ => None,
+                                    }
+                                })
+                                .collect();
+
+                            (*idx.get(0).unwrap_or(first), idx)
                         })
                         .collect();
 
-                    (*idx.get(0).unwrap_or(first), idx)
-                })
-                .collect()
+                    GroupsProxy::Idx(groups)
+                }
+                GroupsProxy::Slice(groups) => {
+                    let groups = groups
+                        .par_iter()
+                        .map(|&[first, len]| unsafe {
+                            let idx: Vec<u32> = (first..first + len)
+                                // Safety:
+                                // just checked bounds in short circuited lhs
+                                .filter(|&i| {
+                                    predicate.value(i as usize)
+                                        && predicate.is_valid_unchecked(i as usize)
+                                })
+                                .collect();
+
+                            (*idx.get(0).unwrap_or(&first), idx)
+                        })
+                        .collect();
+                    GroupsProxy::Idx(groups)
+                }
+            }
         });
 
         ac_s.with_groups(groups).set_original_len(false);

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::{prelude::*, POOL};
 use rayon::prelude::*;
 use std::sync::Arc;
@@ -35,7 +35,7 @@ impl PhysicalExpr for FilterExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let ac_s_f = || self.input.evaluate_on_groups(df, groups, state);

--- a/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -31,7 +31,7 @@ impl PhysicalExpr for IsNotNullExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -31,7 +31,7 @@ impl PhysicalExpr for IsNullExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -1,7 +1,7 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
 use std::borrow::Cow;
@@ -113,7 +113,7 @@ impl PhysicalExpr for LiteralExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let s = self.evaluate(df, state)?;
@@ -160,7 +160,7 @@ impl PhysicalAggregation for LiteralExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        _groups: &GroupTuples,
+        _groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         PhysicalExpr::evaluate(self, df, state).map(Some)

--- a/polars/polars-lazy/src/physical_plan/expressions/not.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/not.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ impl PhysicalExpr for NotExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.0.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/shift.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/shift.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ impl PhysicalExpr for ShiftExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         // The Series are aggregate per group, then the shift is applied.
@@ -55,7 +55,7 @@ impl PhysicalAggregation for ShiftExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::utils::{slice_offsets, CustomIterTools};
 use std::sync::Arc;
@@ -25,7 +25,7 @@ impl PhysicalExpr for SliceExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
@@ -59,7 +59,7 @@ impl PhysicalAggregation for SliceExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ impl PhysicalExpr for SortExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
@@ -82,7 +82,7 @@ impl PhysicalAggregation for SortExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -1,5 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
+use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
@@ -18,6 +19,31 @@ impl SortExpr {
             expr,
         }
     }
+}
+
+/// Map argsort result back to the indices on the `GroupIdx`
+pub(crate) fn map_sorted_indices_to_group_idx(sorted_idx: &UInt32Chunked, idx: &[u32]) -> Vec<u32> {
+    sorted_idx
+        .cont_slice()
+        .unwrap()
+        .iter()
+        .map(|&i| {
+            debug_assert!(idx.get(i as usize).is_some());
+            unsafe { *idx.get_unchecked(i as usize) }
+        })
+        .collect_trusted()
+}
+
+pub(crate) fn map_sorted_indices_to_group_slice(
+    sorted_idx: &UInt32Chunked,
+    first: u32,
+) -> Vec<u32> {
+    sorted_idx
+        .cont_slice()
+        .unwrap()
+        .iter()
+        .map(|&i| i + first)
+        .collect_trusted()
 }
 
 impl PhysicalExpr for SortExpr {
@@ -40,29 +66,34 @@ impl PhysicalExpr for SortExpr {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
         let series = ac.flat_naive().into_owned();
 
-        let groups = ac
-            .groups()
-            .iter()
-            .map(|(_first, idx)| {
-                // Safety:
-                // Group tuples are always in bounds
-                let group =
-                    unsafe { series.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize)) };
-
-                let sorted_idx = group.argsort(self.options.descending);
-
-                let new_idx: Vec<_> = sorted_idx
-                    .cont_slice()
-                    .unwrap()
+        let groups = match ac.groups().as_ref() {
+            GroupsProxy::Idx(groups) => {
+                groups
                     .iter()
-                    .map(|&i| {
-                        debug_assert!(idx.get(i as usize).is_some());
-                        unsafe { *idx.get_unchecked(i as usize) }
+                    .map(|(_first, idx)| {
+                        // Safety:
+                        // Group tuples are always in bounds
+                        let group = unsafe {
+                            series.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
+                        };
+
+                        let sorted_idx = group.argsort(self.options.descending);
+                        let new_idx = map_sorted_indices_to_group_idx(&sorted_idx, idx);
+                        (new_idx[0], new_idx)
                     })
-                    .collect();
-                (new_idx[0], new_idx)
-            })
-            .collect();
+                    .collect_trusted()
+            }
+            GroupsProxy::Slice(groups) => groups
+                .iter()
+                .map(|&[first, len]| {
+                    let group = series.slice(first as i64, len as usize);
+                    let sorted_idx = group.argsort(self.options.descending);
+                    let new_idx = map_sorted_indices_to_group_slice(&sorted_idx, first);
+                    (new_idx[0], new_idx)
+                })
+                .collect_trusted(),
+        };
+        let groups = GroupsProxy::Idx(groups);
 
         ac.with_groups(groups);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
@@ -78,7 +78,7 @@ impl PhysicalExpr for SortByExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac_in = self.input.evaluate_on_groups(df, groups, state)?;
@@ -169,7 +169,7 @@ impl PhysicalAggregation for SortByExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac_in = self.input.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -1,6 +1,7 @@
 use crate::physical_plan::state::ExecutionState;
+use crate::prelude::sort::{map_sorted_indices_to_group_idx, map_sorted_indices_to_group_slice};
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupsProxy;
+use polars_core::frame::groupby::{GroupsIndicator, GroupsProxy};
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
@@ -89,29 +90,32 @@ impl PhysicalExpr for SortByExpr {
             let sort_by_s = ac_sort_by.flat_naive().into_owned();
             let groups = ac_sort_by.groups();
 
-            groups
+            let groups = groups
                 .par_iter()
-                .map(|(_first, idx)| {
-                    // Safety:
-                    // Group tuples are always in bounds
-                    let group = unsafe {
-                        sort_by_s.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
+                .map(|indicator| {
+                    let new_idx = match indicator {
+                        GroupsIndicator::Idx((_, idx)) => {
+                            // Safety:
+                            // Group tuples are always in bounds
+                            let group = unsafe {
+                                sort_by_s.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
+                            };
+
+                            let sorted_idx = group.argsort(reverse[0]);
+                            map_sorted_indices_to_group_idx(&sorted_idx, idx)
+                        }
+                        GroupsIndicator::Slice([first, len]) => {
+                            let group = sort_by_s.slice(first as i64, len as usize);
+                            let sorted_idx = group.argsort(reverse[0]);
+                            map_sorted_indices_to_group_slice(&sorted_idx, first)
+                        }
                     };
 
-                    let sorted_idx = group.argsort(reverse[0]);
-
-                    let new_idx: Vec<_> = sorted_idx
-                        .cont_slice()
-                        .unwrap()
-                        .iter()
-                        .map(|&i| {
-                            debug_assert!(idx.get(i as usize).is_some());
-                            unsafe { *idx.get_unchecked(i as usize) }
-                        })
-                        .collect();
                     (new_idx[0], new_idx)
                 })
-                .collect()
+                .collect();
+
+            GroupsProxy::Idx(groups)
         } else {
             let mut ac_sort_by = self
                 .by
@@ -124,32 +128,40 @@ impl PhysicalExpr for SortByExpr {
                 .collect::<Vec<_>>();
             let groups = ac_sort_by[0].groups();
 
-            groups
+            let groups = groups
                 .par_iter()
-                .map(|(_first, idx)| {
-                    // Safety:
-                    // Group tuples are always in bounds
-                    let groups = sort_by_s
-                        .iter()
-                        .map(|s| unsafe {
-                            s.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
-                        })
-                        .collect::<Vec<_>>();
+                .map(|indicator| {
+                    let new_idx = match indicator {
+                        GroupsIndicator::Idx((_first, idx)) => {
+                            // Safety:
+                            // Group tuples are always in bounds
+                            let groups = sort_by_s
+                                .iter()
+                                .map(|s| unsafe {
+                                    s.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
+                                })
+                                .collect::<Vec<_>>();
 
-                    let sorted_idx = groups[0].argsort_multiple(&groups[1..], &reverse).unwrap();
+                            let sorted_idx =
+                                groups[0].argsort_multiple(&groups[1..], &reverse).unwrap();
+                            map_sorted_indices_to_group_idx(&sorted_idx, idx)
+                        }
+                        GroupsIndicator::Slice([first, len]) => {
+                            let groups = sort_by_s
+                                .iter()
+                                .map(|s| s.slice(first as i64, len as usize))
+                                .collect::<Vec<_>>();
+                            let sorted_idx =
+                                groups[0].argsort_multiple(&groups[1..], &reverse).unwrap();
+                            map_sorted_indices_to_group_slice(&sorted_idx, first)
+                        }
+                    };
 
-                    let new_idx: Vec<_> = sorted_idx
-                        .cont_slice()
-                        .unwrap()
-                        .iter()
-                        .map(|&i| {
-                            debug_assert!(idx.get(i as usize).is_some());
-                            unsafe { *idx.get_unchecked(i as usize) }
-                        })
-                        .collect();
                     (new_idx[0], new_idx)
                 })
-                .collect()
+                .collect();
+
+            GroupsProxy::Idx(groups)
         };
 
         ac_in.with_groups(groups);

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -33,7 +33,7 @@ impl PhysicalExpr for TakeExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.phys_expr.evaluate_on_groups(df, groups, state)?;
@@ -65,7 +65,7 @@ impl PhysicalAggregation for TakeExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.phys_expr.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::series::unstable::UnstableSeries;
 use polars_core::POOL;
@@ -33,7 +33,7 @@ impl PhysicalExpr for TernaryExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let required_height = df.height();

--- a/polars/polars-lazy/src/physical_plan/expressions/unique.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/unique.rs
@@ -1,6 +1,6 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ impl PhysicalExpr for UniqueExpr {
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
-        groups: &'a GroupTuples,
+        groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;
@@ -71,7 +71,7 @@ impl PhysicalAggregation for UniqueExpr {
     fn aggregate(
         &self,
         df: &DataFrame,
-        groups: &GroupTuples,
+        groups: &GroupsProxy,
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.physical_expr.evaluate_on_groups(df, groups, state)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/utils.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/utils.rs
@@ -1,13 +1,13 @@
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 
 #[allow(clippy::ptr_arg)]
 pub(crate) fn as_aggregated(
     expr: &dyn PhysicalExpr,
     df: &DataFrame,
-    groups: &GroupTuples,
+    groups: &GroupsProxy,
     state: &ExecutionState,
 ) -> Result<Option<Series>> {
     match expr.as_agg_expr() {

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -66,7 +66,7 @@ impl PhysicalExpr for WindowExpr {
 
         // if we flatten this column we need to make sure the groups are sorted.
         if !cached && self.options.explode {
-            groups.sort_unstable_by_key(|t| t.0);
+            groups.sort()
         }
 
         // 2. create GroupBy object and apply aggregation

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -1,7 +1,7 @@
 use crate::logical_plan::Context;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::frame::groupby::{GroupBy, GroupTuples};
+use polars_core::frame::groupby::{GroupBy, GroupsProxy};
 use polars_core::frame::hash_join::private_left_join_multiple_keys;
 use polars_core::prelude::*;
 use std::sync::Arc;
@@ -40,7 +40,7 @@ impl PhysicalExpr for WindowExpr {
 
         let create_groups = || {
             let mut gb = df.groupby_with_series(groupby_columns.clone(), true)?;
-            let out: Result<GroupTuples> = Ok(std::mem::take(gb.get_groups_mut()));
+            let out: Result<GroupsProxy> = Ok(std::mem::take(gb.get_groups_mut()));
             out
         };
 
@@ -175,7 +175,7 @@ impl PhysicalExpr for WindowExpr {
     fn evaluate_on_groups<'a>(
         &self,
         _df: &DataFrame,
-        _groups: &'a GroupTuples,
+        _groups: &'a GroupsProxy,
         _state: &ExecutionState,
     ) -> Result<AggregationContext<'a>> {
         Err(PolarsError::InvalidOperation(

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,18 +1,18 @@
 use ahash::RandomState;
-use polars_core::frame::groupby::GroupTuples;
+use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub type JoinTuplesCache = Arc<Mutex<HashMap<String, Vec<(u32, Option<u32>)>, RandomState>>>;
-pub type GroupTuplesCache = Arc<Mutex<HashMap<String, GroupTuples, RandomState>>>;
+pub type GroupsProxyCache = Arc<Mutex<HashMap<String, GroupsProxy, RandomState>>>;
 
 /// State/ cache that is maintained during the Execution of the physical plan.
 #[derive(Clone)]
 pub struct ExecutionState {
     df_cache: Arc<Mutex<HashMap<String, DataFrame, RandomState>>>,
     /// Used by Window Expression to prevent redundant grouping
-    pub(crate) group_tuples: GroupTuplesCache,
+    pub(crate) group_tuples: GroupsProxyCache,
     /// Used by Window Expression to prevent redundant joins
     pub(crate) join_tuples: JoinTuplesCache,
     pub(crate) verbose: bool,

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -2,6 +2,14 @@ use super::*;
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::series::ops::NullBehavior;
 
+pub(crate) fn load_df() -> DataFrame {
+    df!("a" => &[1, 2, 3, 4, 5],
+                 "b" => &["a", "a", "b", "c", "c"],
+                 "c" => &[1, 2, 3, 4, 5]
+    )
+    .unwrap()
+}
+
 #[test]
 fn test_lazy_ternary() {
     let df = get_df()
@@ -267,14 +275,6 @@ fn test_lazy_binary_ops() {
         .collect()
         .unwrap();
     assert_eq!(new.column("foo").unwrap().sum::<i32>(), Some(1));
-}
-
-pub(crate) fn load_df() -> DataFrame {
-    df!("a" => &[1, 2, 3, 4, 5],
-                 "b" => &["a", "a", "b", "c", "c"],
-                 "c" => &[1, 2, 3, 4, 5]
-    )
-    .unwrap()
 }
 
 #[test]
@@ -1965,7 +1965,7 @@ fn test_round_after_agg() -> Result<()> {
 }
 
 #[test]
-fn test_power_in_agg_list() -> Result<()> {
+fn test_power_in_agg_list1() -> Result<()> {
     let df = fruits_cars();
 
     // this test if the group tuples are correctly updated after

--- a/polars/polars-time/src/groupby.rs
+++ b/polars/polars-time/src/groupby.rs
@@ -1,7 +1,7 @@
 use crate::bounds::Bounds;
 use crate::window::Window;
 
-pub type GroupsProxy = Vec<(u32, Vec<u32>)>;
+pub type GroupsIdx = Vec<(u32, Vec<u32>)>;
 
 #[derive(Clone, Copy, Debug)]
 pub enum ClosedWindow {
@@ -22,7 +22,7 @@ pub fn groupby(
     include_boundaries: bool,
     closed_window: ClosedWindow,
     tu: TimeUnit,
-) -> (GroupsProxy, Vec<i64>, Vec<i64>) {
+) -> (GroupsIdx, Vec<i64>, Vec<i64>) {
     let start = time[0];
     let boundary = if time.len() > 1 {
         // +1 because left or closed boundary could match the next window if it is on the boundary
@@ -44,7 +44,7 @@ pub fn groupby(
     let mut lower_bound = Vec::with_capacity(size);
     let mut upper_bound = Vec::with_capacity(size);
 
-    let mut group_tuples = match tu {
+    let mut groups = match tu {
         TimeUnit::Nanoseconds => {
             Vec::with_capacity(window.estimate_overlapping_bounds_ns(boundary))
         }
@@ -99,8 +99,8 @@ pub fn groupby(
                 lower_bound.push(bi.start);
                 upper_bound.push(bi.stop);
             }
-            group_tuples.push((group[0], group))
+            groups.push((group[0], group))
         }
     }
-    (group_tuples, lower_bound, upper_bound)
+    (groups, lower_bound, upper_bound)
 }

--- a/polars/polars-time/src/groupby.rs
+++ b/polars/polars-time/src/groupby.rs
@@ -1,7 +1,7 @@
 use crate::bounds::Bounds;
 use crate::window::Window;
 
-pub type GroupTuples = Vec<(u32, Vec<u32>)>;
+pub type GroupsProxy = Vec<(u32, Vec<u32>)>;
 
 #[derive(Clone, Copy, Debug)]
 pub enum ClosedWindow {
@@ -22,7 +22,7 @@ pub fn groupby(
     include_boundaries: bool,
     closed_window: ClosedWindow,
     tu: TimeUnit,
-) -> (GroupTuples, Vec<i64>, Vec<i64>) {
+) -> (GroupsProxy, Vec<i64>, Vec<i64>) {
     let start = time[0];
     let boundary = if time.len() > 1 {
         // +1 because left or closed boundary could match the next window if it is on the boundary

--- a/polars/polars-time/src/test.rs
+++ b/polars/polars-time/src/test.rs
@@ -1,6 +1,6 @@
 use crate::calendar::date_range;
 use crate::duration::Duration;
-use crate::groupby::{groupby, ClosedWindow, GroupTuples, TimeUnit};
+use crate::groupby::{groupby, ClosedWindow, GroupsProxy, TimeUnit};
 use crate::window::Window;
 use chrono::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::timestamp_ns_to_datetime;
@@ -56,7 +56,7 @@ fn print_ns(ts: &[i64]) {
     }
 }
 
-fn take_groups(groups: &GroupTuples, idx: usize, ts: &[i64]) -> Vec<i64> {
+fn take_groups(groups: &GroupsProxy, idx: usize, ts: &[i64]) -> Vec<i64> {
     let group = &groups[idx].1;
     group.iter().map(|idx| ts[*idx as usize]).collect()
 }

--- a/polars/polars-time/src/test.rs
+++ b/polars/polars-time/src/test.rs
@@ -1,6 +1,6 @@
 use crate::calendar::date_range;
 use crate::duration::Duration;
-use crate::groupby::{groupby, ClosedWindow, GroupsProxy, TimeUnit};
+use crate::groupby::{groupby, ClosedWindow, GroupsIdx, TimeUnit};
 use crate::window::Window;
 use chrono::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::timestamp_ns_to_datetime;
@@ -56,7 +56,7 @@ fn print_ns(ts: &[i64]) {
     }
 }
 
-fn take_groups(groups: &GroupsProxy, idx: usize, ts: &[i64]) -> Vec<i64> {
+fn take_groups(groups: &GroupsIdx, idx: usize, ts: &[i64]) -> Vec<i64> {
     let group = &groups[idx].1;
     group.iter().map(|idx| ts[*idx as usize]).collect()
 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -565,6 +565,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 dependencies = [
  "ahash",
  "rayon",
@@ -601,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -873,9 +879,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
+checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
 dependencies = [
  "libc",
 ]
@@ -1091,10 +1097,9 @@ dependencies = [
 [[package]]
 name = "packed_simd_2"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c0c06716cfc81616fa8e22b721ce92fecd594508bc0eb3d04ae3ef35ac10c5"
+source = "git+https://github.com/hkratz/packed_simd?branch=remove_llvm_asm#27e2c89704fc2d1d8dcc506bad210c703187d74e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libm 0.1.4",
 ]
 
@@ -1214,7 +1219,7 @@ name = "polars-arrow"
 version = "0.19.0"
 dependencies = [
  "arrow2",
- "hashbrown",
+ "hashbrown 0.12.0",
  "num",
  "thiserror",
 ]
@@ -1228,7 +1233,7 @@ dependencies = [
  "arrow2",
  "base64",
  "comfy-table",
- "hashbrown",
+ "hashbrown 0.12.0",
  "hex",
  "jsonpath_lib",
  "lazy_static",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "^1.0"
 
 [patch.crates-io]
 pyo3 = { git = "https://github.com/ghuls/pyo3", branch = "polars_pypy_hasattr" }
+packed_simd_2 = { git = "https://github.com/hkratz/packed_simd", branch = "remove_llvm_asm" }
 
 # features are only there to enable building a slim binary for the benchmark in CI
 [features]


### PR DESCRIPTION
This is a large refactor to the internal representation of grouped values. Currently we store the indexes of a group by operation. However when we do a `groupby_dynamic` or a `groupby_rolling` (coming soon ;)) the groups are always consecutive members. So we don't have to store individual indices, but we can store an `offset` and a `length. This allows us to tightly pack the group locators and create faster aggregators for those groups. 

The internal representation of groupby operations also happens to create consecutive groups in complex expressions. If we do a `col("foo").rank().sqrt().sort()` for instance we iterate over the groups in the rank operation. Due to this iteration over groups the values of the `ListArray` are sorted by the groups. We can then update the group indices as being slices instead of indices and then the `sort` operation + index/slice creation will be faster and consume less memory.