### PR TITLE
Fix weighted rolling functions and centering

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -12,9 +12,10 @@ fn det_offsets(i: Idx, window_size: WindowSize, _len: Len) -> (usize, usize) {
     (i.saturating_sub(window_size - 1), i + 1)
 }
 fn det_offsets_center(i: Idx, window_size: WindowSize, len: Len) -> (usize, usize) {
+    let right_window = (window_size + 1) / 2;
     (
-        i.saturating_sub(window_size / 2),
-        std::cmp::min(len, i + window_size / 2),
+        i.saturating_sub(window_size - right_window),
+        std::cmp::min(len, i + right_window),
     )
 }
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -722,19 +722,19 @@ def test_rolling_apply() -> None:
     assert (roll_app_sum - roll_sum).abs().sum() < 0.0001
 
     s = pl.Series("A", list(range(6)), dtype=pl.Float64)
-    roll_app_sum = s.rolling_apply(
-        function=lambda s: s.sum(),
+    roll_app_std = s.rolling_apply(
+        function=lambda s: s.std(),
         window_size=4,
         weights=[1.0, 2.0, 3.0, 0.1],
         min_periods=3,
         center=False,
     )
 
-    roll_sum = s.rolling_sum(
+    roll_std = s.rolling_std(
         window_size=4, weights=[1.0, 2.0, 3.0, 0.1], min_periods=3, center=False
     )
 
-    assert (roll_app_sum - roll_sum).abs().sum() < 0.0001
+    assert (roll_app_std - roll_std).abs().sum() < 0.0001
 
 
 def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -624,16 +624,10 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
             pl.col("A").rolling_sum(3, min_periods=1).alias("4"),
             pl.col("A").rolling_sum(3).alias("4b"),
             # below we use .round purely for the ability to do .frame_equal()
-            pl.col("A").rolling_std(3, min_periods=1).round(decimals=4).alias("std"),
-            pl.col("A").rolling_std(3).alias("std2"),
-            pl.col("A").rolling_var(3, min_periods=1).round(decimals=4).alias("var"),
-            pl.col("A").rolling_var(3).alias("var2"),
+            pl.col("A").rolling_std(3).round(1).alias("std"),
+            pl.col("A").rolling_var(3).round(1).alias("var"),
         ]
     )
-
-    # TODO: rolling_std & rolling_var return nan instead of null if it cant compute
-    out[0, "std"] = None
-    out[0, "var"] = None
 
     assert out.frame_equal(
         pl.DataFrame(
@@ -646,13 +640,21 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
                 "3b": [None, None, 3, 4, 5],
                 "4": [1, 3, 6, 9, 12],
                 "4b": [None, None, 6, 9, 12],
-                "std": [None, 0.7071, 1, 1, 1],
-                "std2": [None, None, 1, 1, 1],
-                "var": [None, 0.5, 1, 1, 1],
-                "var2": [None, None, 1, 1, 1],
+                "std": [None, None, 1.0, 1.0, 1.0],
+                "var": [None, None, 1.0, 1.0, 1.0],
             }
         )
     )
+
+    out_nan = df.select(
+        [
+            pl.col("A").rolling_std(3, min_periods=1).round(decimals=4).alias("std"),
+            pl.col("A").rolling_var(3, min_periods=1).round(decimals=1).alias("var"),
+        ]
+    )
+
+    assert out_nan[0, "std"] != out_nan[0, "std"]  # true if value is NaN
+    assert out_nan[0, "var"] != out_nan[0, "var"]  # true if value is NaN
 
 
 def test_rolling_apply() -> None:


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/2350

Changes so far result in 10-25% speed up for rolling sum, min, max, mean, var, std. 

work in progress, still need to:
- add more tests
- check rolling_quantile
- check that centering is working correctly

