### PR TITLE
Include mmap module in polars-io when parquet feature is enabled

### DIFF
--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -18,7 +18,7 @@ pub mod ipc;
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
-#[cfg(feature = "csv-file")]
+#[cfg(any(feature = "csv-file", feature = "parquet"))]
 pub mod mmap;
 #[cfg(feature = "parquet")]
 #[cfg_attr(docsrs, doc(cfg(feature = "feature")))]


### PR DESCRIPTION
In the `polars-io` crate 0.19 the parquet format support depends on the `mmap` module, but this module is only included when the  `csv-file` feature is enabled.

This PR includes `mmap` also upon enabling the `parquet` feature.