### PR TITLE
`groupby_rolling().agg()`

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -32,6 +32,11 @@ pub use pivot::PivotAgg;
 pub struct DynamicGroupOptions {
     pub index_column: String,
 }
+#[cfg(not(feature = "dynamic_groupby"))]
+#[derive(Clone, Debug)]
+pub struct RollingGroupOptions {
+    pub index_column: String,
+}
 
 pub use proxy::*;
 

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::utils;
 use crate::utils::{combine_predicates_expr, has_expr};
 use ahash::RandomState;
-use polars_core::frame::groupby::DynamicGroupOptions;
+use polars_core::frame::groupby::{DynamicGroupOptions, RollingGroupOptions};
 use polars_core::prelude::*;
 #[cfg(feature = "csv-file")]
 use polars_io::csv_core::utils::infer_file_schema;
@@ -274,8 +274,8 @@ impl LogicalPlanBuilder {
         apply: Option<Arc<dyn DataFrameUdf>>,
         maintain_order: bool,
         dynamic_options: Option<DynamicGroupOptions>,
+        rolling_options: Option<RollingGroupOptions>,
     ) -> Self {
-        debug_assert!(!(keys.is_empty() && dynamic_options.is_none()));
         let current_schema = self.0.schema();
         let aggs = rewrite_projections(aggs.as_ref().to_vec(), current_schema, keys.as_ref());
 
@@ -290,7 +290,10 @@ impl LogicalPlanBuilder {
             schema: Arc::new(schema),
             apply,
             maintain_order,
-            dynamic_options,
+            options: GroupbyOptions {
+                dynamic: dynamic_options,
+                rolling: rolling_options,
+            },
         }
         .into()
     }

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -313,7 +313,7 @@ pub(crate) fn to_alp(
             schema,
             apply,
             maintain_order,
-            dynamic_options,
+            options,
         } => {
             let i = to_alp(*input, expr_arena, lp_arena);
             let aggs_new = aggs.into_iter().map(|x| to_aexpr(x, expr_arena)).collect();
@@ -329,7 +329,7 @@ pub(crate) fn to_alp(
                 schema,
                 apply,
                 maintain_order,
-                dynamic_options,
+                options,
             }
         }
         LogicalPlan::Join {
@@ -776,7 +776,7 @@ pub(crate) fn node_to_lp(
             schema,
             apply,
             maintain_order,
-            dynamic_options,
+            options: dynamic_options,
         } => {
             let i = node_to_lp(input, expr_arena, lp_arena);
 
@@ -787,7 +787,7 @@ pub(crate) fn node_to_lp(
                 schema,
                 apply,
                 maintain_order,
-                dynamic_options,
+                options: dynamic_options,
             }
         }
         ALogicalPlan::Join {

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod optimizer;
 mod options;
 mod projection;
 
-use polars_core::frame::groupby::DynamicGroupOptions;
+use polars_core::frame::groupby::{DynamicGroupOptions, RollingGroupOptions};
 
 pub(crate) use apply::*;
 pub(crate) use builder::*;
@@ -36,6 +36,12 @@ pub enum Context {
     Aggregation,
     /// Any operation that is done while projection/ selection of data
     Default,
+}
+
+#[derive(Clone, Debug)]
+pub struct GroupbyOptions {
+    pub(crate) dynamic: Option<DynamicGroupOptions>,
+    pub(crate) rolling: Option<RollingGroupOptions>,
 }
 
 // https://stackoverflow.com/questions/1031076/what-are-projection-and-selection
@@ -107,7 +113,7 @@ pub enum LogicalPlan {
         schema: SchemaRef,
         apply: Option<Arc<dyn DataFrameUdf>>,
         maintain_order: bool,
-        dynamic_options: Option<DynamicGroupOptions>,
+        options: GroupbyOptions,
     },
     /// Join operation
     Join {

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -563,7 +563,7 @@ impl ProjectionPushDown {
                 apply,
                 schema,
                 maintain_order,
-                dynamic_options,
+                options,
             } => {
                 // the custom function may need all columns so we do the projections here.
                 if let Some(f) = apply {
@@ -574,7 +574,7 @@ impl ProjectionPushDown {
                         schema,
                         apply: Some(f),
                         maintain_order,
-                        dynamic_options,
+                        options,
                     };
                     let input = lp_arena.add(lp);
 
@@ -600,7 +600,13 @@ impl ProjectionPushDown {
                     }
 
                     // make sure that the dynamic key is projected
-                    if let Some(options) = &dynamic_options {
+                    if let Some(options) = &options.dynamic {
+                        let node =
+                            expr_arena.add(AExpr::Column(Arc::from(options.index_column.as_str())));
+                        add_expr_to_accumulated(node, &mut acc_projections, &mut names, expr_arena);
+                    }
+                    // make sure that the rolling key is projected
+                    if let Some(options) = &options.rolling {
                         let node =
                             expr_arena.add(AExpr::Column(Arc::from(options.index_column.as_str())));
                         add_expr_to_accumulated(node, &mut acc_projections, &mut names, expr_arena);
@@ -620,7 +626,7 @@ impl ProjectionPushDown {
                         aggs,
                         apply,
                         maintain_order,
-                        dynamic_options,
+                        options,
                     );
                     Ok(builder.build())
                 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -1,0 +1,49 @@
+use super::*;
+use crate::prelude::utils::as_aggregated;
+use polars_core::frame::groupby::RollingGroupOptions;
+use polars_core::POOL;
+use rayon::prelude::*;
+
+pub(crate) struct GroupByRollingExec {
+    pub(crate) input: Box<dyn Executor>,
+    pub(crate) aggs: Vec<Arc<dyn PhysicalExpr>>,
+    pub(crate) options: RollingGroupOptions,
+}
+
+impl Executor for GroupByRollingExec {
+    fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
+        #[cfg(feature = "dynamic_groupby")]
+        {
+            let df = self.input.execute(state)?;
+
+            let (time_key, groups) = df.groupby_rolling(&self.options)?;
+
+            let agg_columns = POOL.install(|| {
+                    self.aggs
+                        .par_iter()
+                        .map(|expr| {
+                            let opt_agg = as_aggregated(expr.as_ref(), &df, &groups, state)?;
+                            if let Some(agg) = &opt_agg {
+                                if agg.len() != groups.len() {
+                                    return Err(PolarsError::ComputeError(
+                                        format!("returned aggregation is a different length: {} than the group lengths: {}",
+                                                agg.len(),
+                                                groups.len()).into()
+                                    ))
+                                }
+                            };
+                            Ok(opt_agg)
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })?;
+
+            let mut columns = Vec::with_capacity(agg_columns.len() + 1);
+            columns.push(time_key);
+            columns.extend(agg_columns.into_iter().flatten());
+
+            DataFrame::new(columns)
+        }
+        #[cfg(not(feature = "dynamic_groupby"))]
+        panic!("activate feature dynamic_groupby")
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod explode;
 pub(crate) mod filter;
 pub(crate) mod groupby;
 pub(crate) mod groupby_dynamic;
+pub(crate) mod groupby_rolling;
 pub(crate) mod join;
 pub(crate) mod melt;
 pub(crate) mod projection;

--- a/polars/polars-time/src/bounds.rs
+++ b/polars/polars-time/src/bounds.rs
@@ -7,15 +7,21 @@ pub struct Bounds {
 }
 
 impl Bounds {
-    pub fn new(start: i64, stop: i64) -> Self {
+    /// Create a new `Bounds` and check the input is correct.
+    pub fn new_checked(start: i64, stop: i64) -> Self {
         assert!(
             start <= stop,
             "boundary start must be smaller than stop; is your time column sorted in ascending order?"
         );
+        Self::new(start, stop)
+    }
+
+    /// Create a new `Bounds` without checking input correctness.
+    pub fn new(start: i64, stop: i64) -> Self {
         Bounds { start, stop }
     }
 
-    /// Duration in nanoseconcds for this Boundary
+    /// Duration in unit for this Boundary
     pub fn duration(&self) -> i64 {
         self.stop - self.start
     }
@@ -24,7 +30,7 @@ impl Bounds {
         self.stop == self.start
     }
 
-    // check if nanoseconds is within bounds
+    // check if unit is within bounds
     pub fn is_member(&self, t: i64, closed: ClosedWindow) -> bool {
         match closed {
             ClosedWindow::Right => t > self.start && t <= self.stop,
@@ -36,5 +42,8 @@ impl Bounds {
 
     pub fn is_future(&self, t: i64) -> bool {
         t > self.stop
+    }
+    pub fn is_past(&self, t: i64) -> bool {
+        t < self.start
     }
 }

--- a/polars/polars-time/src/window.rs
+++ b/polars/polars-time/src/window.rs
@@ -53,14 +53,14 @@ impl Window {
         let start = self.truncate_ns(t);
         let stop = self.period.add_ns(start);
 
-        Bounds::new(start, stop)
+        Bounds::new_checked(start, stop)
     }
 
     pub fn get_earliest_bounds_ms(&self, t: i64) -> Bounds {
         let start = self.truncate_ms(t);
         let stop = self.period.add_ms(start);
 
-        Bounds::new(start, stop)
+        Bounds::new_checked(start, stop)
     }
 
     pub(crate) fn estimate_overlapping_bounds_ns(&self, boundary: Bounds) -> usize {

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -109,6 +109,7 @@ Manipulation/ selection
     DataFrame.vstack
     DataFrame.groupby
     DataFrame.groupby_dynamic
+    DataFrame.groupby_rolling
     DataFrame.select
     DataFrame.with_columns
     DataFrame.with_column_renamed

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -36,6 +36,8 @@ Manipulation/ selection
     LazyFrame.filter
     LazyFrame.select
     LazyFrame.groupby
+    LazyFrame.groupby_dynamic
+    LazyFrame.groupby_rolling
     LazyFrame.join
     LazyFrame.with_columns
     LazyFrame.with_column

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -2365,6 +2365,121 @@ class DataFrame:
             by = [by]
         return GroupBy(self._df, by, maintain_order=maintain_order)  # type: ignore
 
+    def groupby_rolling(
+        self,
+        index_column: str,
+        period: str,
+        offset: Optional[str] = None,
+        closed: str = "right",
+    ) -> "RollingGroupBy":
+        """
+        Create rolling groups based on a time column (or index value of type Int32, Int64).
+
+        Different from a rolling groupby the windows are now determined by the individual values and are not of constant
+        intervals. For constant intervals use *groupby_dynamic*
+
+        .. seealso::
+
+            groupby_rolling
+
+
+        The `period` and `offset` arguments are created with
+        the following string language:
+
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 day)
+        - 1w    (1 week)
+        - 1mo   (1 calendar month)
+        - 1y    (1 calendar year)
+        - 1i    (1 index count)
+
+        Or combine them:
+        "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        In case of a groupby_rolling on an integer column, the windows are defined by:
+
+        - "1i"      # length 1
+        - "10i"     # length 2
+
+        .. warning::
+            This API is experimental and may change without it being considered a breaking change.
+
+        Parameters
+        ----------
+        index_column
+            Column used to group based on the time window.
+            Often to type Date/Datetime
+            This column must be sorted in ascending order. If not the output will not make sense.
+
+            In case of a rolling groupby on indices, dtype needs to be one of {Int32, Int64}. Note that
+            Int32 gets temporarely cast to Int64, so if performance matters use an Int64 column.
+        period
+            length of the window
+        offset
+            offset of the window. Default is -period
+        closed
+            Defines if the window interval is closed or not.
+            Any of {"left", "right", "both" "none"}
+
+        Examples
+        --------
+
+        >>> dates = [
+        ...     "2020-01-01 13:45:48",
+        ...     "2020-01-01 16:42:13",
+        ...     "2020-01-01 16:45:09",
+        ...     "2020-01-02 18:12:48",
+        ...     "2020-01-03 19:45:32",
+        ...     "2020-01-08 23:16:43",
+        ... ]
+        >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_column(
+        ...     pl.col("dt").str.strptime(pl.Datetime)
+        ... )
+        >>> out = df.groupby_rolling(index_column="dt", period="2d").agg(
+        ...     [
+        ...         pl.sum("a").alias("sum_a"),
+        ...         pl.min("a").alias("min_a"),
+        ...         pl.max("a").alias("max_a"),
+        ...     ]
+        ... )
+        >>> assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
+        >>> assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]
+        >>> assert out["min_a"].to_list() == [3, 3, 3, 3, 2, 1]
+        >>> out
+        shape: (6, 4)
+        ┌─────────────────────┬───────┬───────┬───────┐
+        │ dt                  ┆ a_sum ┆ a_max ┆ a_min │
+        │ ---                 ┆ ---   ┆ ---   ┆ ---   │
+        │ datetime[ms]        ┆ i64   ┆ i64   ┆ i64   │
+        ╞═════════════════════╪═══════╪═══════╪═══════╡
+        │ 2020-01-01 13:45:48 ┆ 3     ┆ 3     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-01 16:42:13 ┆ 10    ┆ 7     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-01 16:45:09 ┆ 15    ┆ 7     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-02 18:12:48 ┆ 24    ┆ 9     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-03 19:45:32 ┆ 11    ┆ 9     ┆ 2     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-08 23:16:43 ┆ 1     ┆ 1     ┆ 1     │
+        └─────────────────────┴───────┴───────┴───────┘
+
+        """
+
+        return RollingGroupBy(
+            self,
+            index_column,
+            period,
+            offset,
+            closed,
+        )
+
     def groupby_dynamic(
         self,
         index_column: str,
@@ -4146,6 +4261,48 @@ class DataFrame:
         Check if the dataframe is empty
         """
         return self.height == 0
+
+
+class RollingGroupBy:
+    """
+    A rolling grouper. This has an `.agg` method which will allow you to run all polars expressions
+    in a groupby context.
+    """
+
+    def __init__(
+        self,
+        df: "DataFrame",
+        index_column: str,
+        period: str,
+        offset: Optional[str],
+        closed: str = "none",
+    ):
+        self.df = df
+        self.time_column = index_column
+        self.period = period
+        self.offset = offset
+        self.closed = closed
+
+    def agg(
+        self,
+        column_to_agg: Union[
+            List[Tuple[str, List[str]]],
+            Dict[str, Union[str, List[str]]],
+            List["pli.Expr"],
+            "pli.Expr",
+        ],
+    ) -> DataFrame:
+        return (
+            self.df.lazy()
+            .groupby_rolling(
+                self.time_column,
+                self.period,
+                self.offset,
+                self.closed,
+            )
+            .agg(column_to_agg)  # type: ignore[arg-type]
+            .collect(no_optimization=True, string_cache=False)
+        )
 
 
 class DynamicGroupBy:

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -531,6 +531,125 @@ class LazyFrame:
         lgb = self._ldf.groupby(new_by, maintain_order)
         return LazyGroupBy(lgb)
 
+    def groupby_rolling(
+        self,
+        index_column: str,
+        period: str,
+        offset: Optional[str] = None,
+        closed: str = "right",
+    ) -> "LazyGroupBy":
+        """
+        Create rolling groups based on a time column (or index value of type Int32, Int64).
+
+        Different from a rolling groupby the windows are now determined by the individual values and are not of constant
+        intervals. For constant intervals use *groupby_dynamic*
+
+        .. seealso::
+
+            groupby_rolling
+
+
+        The `period` and `offset` arguments are created with
+        the following string language:
+
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 day)
+        - 1w    (1 week)
+        - 1mo   (1 calendar month)
+        - 1y    (1 calendar year)
+        - 1i    (1 index count)
+
+        Or combine them:
+        "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        In case of a groupby_rolling on an integer column, the windows are defined by:
+
+        - "1i"      # length 1
+        - "10i"     # length 2
+
+        .. warning::
+            This API is experimental and may change without it being considered a breaking change.
+
+        Parameters
+        ----------
+        index_column
+            Column used to group based on the time window.
+            Often to type Date/Datetime
+            This column must be sorted in ascending order. If not the output will not make sense.
+
+            In case of a rolling groupby on indices, dtype needs to be one of {Int32, Int64}. Note that
+            Int32 gets temporarely cast to Int64, so if performance matters use an Int64 column.
+        period
+            length of the window
+        offset
+            offset of the window. Default is -period
+        closed
+            Defines if the window interval is closed or not.
+            Any of {"left", "right", "both" "none"}
+
+        Examples
+        --------
+
+        >>> dates = [
+        ...     "2020-01-01 13:45:48",
+        ...     "2020-01-01 16:42:13",
+        ...     "2020-01-01 16:45:09",
+        ...     "2020-01-02 18:12:48",
+        ...     "2020-01-03 19:45:32",
+        ...     "2020-01-08 23:16:43",
+        ... ]
+        >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_column(
+        ...     pl.col("dt").str.strptime(pl.Datetime)
+        ... )
+        >>> out = df.groupby_rolling(index_column="dt", period="2d").agg(
+        ...     [
+        ...         pl.sum("a").alias("sum_a"),
+        ...         pl.min("a").alias("min_a"),
+        ...         pl.max("a").alias("max_a"),
+        ...     ]
+        ... )
+        >>> assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
+        >>> assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]
+        >>> assert out["min_a"].to_list() == [3, 3, 3, 3, 2, 1]
+        >>> out
+        shape: (6, 4)
+        ┌─────────────────────┬───────┬───────┬───────┐
+        │ dt                  ┆ a_sum ┆ a_max ┆ a_min │
+        │ ---                 ┆ ---   ┆ ---   ┆ ---   │
+        │ datetime[ms]        ┆ i64   ┆ i64   ┆ i64   │
+        ╞═════════════════════╪═══════╪═══════╪═══════╡
+        │ 2020-01-01 13:45:48 ┆ 3     ┆ 3     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-01 16:42:13 ┆ 10    ┆ 7     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-01 16:45:09 ┆ 15    ┆ 7     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-02 18:12:48 ┆ 24    ┆ 9     ┆ 3     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-03 19:45:32 ┆ 11    ┆ 9     ┆ 2     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2020-01-08 23:16:43 ┆ 1     ┆ 1     ┆ 1     │
+        └─────────────────────┴───────┴───────┴───────┘
+
+
+        """
+
+        if offset is None:
+            offset = f"-{period}"
+
+        lgb = self._ldf.groupby_rolling(
+            index_column,
+            period,
+            offset,
+            closed,
+        )
+        return LazyGroupBy(lgb)
+
     def groupby_dynamic(
         self,
         index_column: str,
@@ -546,6 +665,10 @@ class LazyFrame:
         Groups based on a time value (or index value of type Int32, Int64). Time windows are calculated and rows are assigned to windows.
         Different from a normal groupby is that a row can be member of multiple groups. The time/index window could
         be seen as a rolling window, with a window size determined by dates/times/values instead of slots in the DataFrame.
+
+        .. seealso::
+
+            groupby_rolling
 
         A window is defined by:
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -7,7 +7,7 @@ use crate::utils::str_to_polarstype;
 use polars::lazy::frame::{AllowedOptimizations, LazyCsvReader, LazyFrame, LazyGroupBy};
 use polars::lazy::prelude::col;
 use polars::prelude::{ClosedWindow, DataFrame, Field, JoinType, Schema};
-use polars_core::frame::groupby::DynamicGroupOptions;
+use polars_core::frame::groupby::{DynamicGroupOptions, RollingGroupOptions};
 use polars_core::prelude::{Duration, QuantileInterpolOptions};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
@@ -290,6 +290,25 @@ impl PyLazyFrame {
         } else {
             ldf.groupby(by)
         };
+
+        PyLazyGroupBy { lgb: Some(lazy_gb) }
+    }
+
+    pub fn groupby_rolling(
+        &mut self,
+        index_column: String,
+        period: &str,
+        offset: &str,
+        closed: Wrap<ClosedWindow>,
+    ) -> PyLazyGroupBy {
+        let closed_window = closed.0;
+        let ldf = self.ldf.clone();
+        let lazy_gb = ldf.groupby_rolling(RollingGroupOptions {
+            index_column,
+            period: Duration::parse(period),
+            offset: Duration::parse(offset),
+            closed_window,
+        });
 
         PyLazyGroupBy { lgb: Some(lazy_gb) }
     }


### PR DESCRIPTION
This adds a new entrance in the expression API. With #2431this now can be done without blowing up memory and performance.

This differs from `groupby_dynamic` because the windows are not constant. With `groupby_dynamic` we create a grid of intervals and see which values fit.

With `groupby_rolling` we take the value and offset the window based on the value found. Windows can still be controlled with an `offset` argument.

closes #2407

```python
dates = ["2020-01-01 13:45:48",
"2020-01-01 16:42:13",
"2020-01-01 16:45:09",
"2020-01-02 18:12:48",
"2020-01-03 19:45:32",
"2020-01-08 23:16:43"]


df = pl.DataFrame({
    "dt": dates,
    "a": [3, 7, 5, 9, 2, 1]
}).with_column(pl.col("dt").str.strptime(pl.Datetime))


(df
.groupby_rolling(index_column="dt", period="2d")
     .agg([
         pl.sum("a"),
         pl.max("a"),
         pl.min("a"),
  ])
)
```

```
shape: (6, 4)
┌─────────────────────┬───────┬───────┬───────┐
│ dt                  ┆ a_sum ┆ a_max ┆ a_min │
│ ---                 ┆ ---   ┆ ---   ┆ ---   │
│ datetime[ms]        ┆ i64   ┆ i64   ┆ i64   │
╞═════════════════════╪═══════╪═══════╪═══════╡
│ 2020-01-01 13:45:48 ┆ 3     ┆ 3     ┆ 3     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2020-01-01 16:42:13 ┆ 10    ┆ 7     ┆ 3     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2020-01-01 16:45:09 ┆ 15    ┆ 7     ┆ 3     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2020-01-02 18:12:48 ┆ 24    ┆ 9     ┆ 3     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2020-01-03 19:45:32 ┆ 11    ┆ 9     ┆ 2     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2020-01-08 23:16:43 ┆ 1     ┆ 1     ┆ 1     │
└─────────────────────┴───────┴───────┴───────┘

```

