### PR TITLE
Improve groupby performance and reduce memory usage.

### DIFF
--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -190,7 +190,8 @@ mod test {
         let values = &[Some(foo1), None, Some(foo2), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups = GroupsProxy::Idx(vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])]);
+        let groups =
+            GroupsProxy::Idx(vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])].into());
         let out = ca.agg_list(&groups).unwrap();
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());
@@ -213,7 +214,7 @@ mod test {
         let values = &[Some(foo1.clone()), None, Some(foo2.clone()), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])];
+        let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])].into();
         let out = ca.agg_list(&GroupsProxy::Idx(groups)).unwrap();
         let a = out.explode().unwrap();
 

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -135,12 +135,11 @@ where
         return ca.clone();
     }
     let mut groups = ca
-        .group_tuples(true)
+        .group_tuples(true, false)
         .into_idx()
         .into_iter()
         .collect_trusted::<Vec<_>>();
-    // groups.sort_unstable_by_key(|k| k.1.len());
-    // TODO! sort by key
+    groups.sort_unstable_by_key(|k| k.1.len());
     let first = &groups[0];
 
     let max_occur = first.1.len();
@@ -174,7 +173,7 @@ macro_rules! arg_unique_ca {
 
 macro_rules! impl_value_counts {
     ($self:expr) => {{
-        let group_tuples = $self.group_tuples(true).into_idx();
+        let group_tuples = $self.group_tuples(true, false).into_idx();
         let values =
             unsafe { $self.take_unchecked(group_tuples.iter().map(|t| t.0 as usize).into()) };
         let mut counts: NoNull<UInt32Chunked> = group_tuples
@@ -357,7 +356,7 @@ fn sort_columns(mut columns: Vec<Series>) -> Vec<Series> {
 
 impl ToDummies<Utf8Type> for Utf8Chunked {
     fn to_dummies(&self) -> Result<DataFrame> {
-        let groups = self.group_tuples(true).into_idx();
+        let groups = self.group_tuples(true, false).into_idx();
         let col_name = self.name();
         let taker = self.take_rand();
 
@@ -383,7 +382,7 @@ where
     ChunkedArray<T>: ChunkOps + ChunkCompare<T::Native> + ChunkUnique<T>,
 {
     fn to_dummies(&self) -> Result<DataFrame> {
-        let groups = self.group_tuples(true).into_idx();
+        let groups = self.group_tuples(true, false).into_idx();
         let col_name = self.name();
         let taker = self.take_rand();
 

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -134,8 +134,13 @@ where
     if ca.is_empty() {
         return ca.clone();
     }
-    let mut groups = ca.group_tuples(true).into_idx();
-    groups.sort_unstable_by_key(|k| k.1.len());
+    let mut groups = ca
+        .group_tuples(true)
+        .into_idx()
+        .into_iter()
+        .collect_trusted::<Vec<_>>();
+    // groups.sort_unstable_by_key(|k| k.1.len());
+    // TODO! sort by key
     let first = &groups[0];
 
     let max_occur = first.1.len();

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -38,7 +38,7 @@ where
         }
     });
 
-    GroupsProxy::Idx(hash_tbl.into_iter().map(|(_k, tpl)| tpl).collect_trusted())
+    GroupsProxy::Idx(hash_tbl.into_iter().map(|(_k, tpl)| tpl).collect())
 }
 
 /// Determine group tuples over different threads. The hash of the key is used to determine the partitions.

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -446,7 +446,7 @@ impl DataFrame {
         S: AsRef<str>,
     {
         let mut gb = self.groupby(by)?;
-        gb.groups.idx_mut().sort_unstable_by_key(|t| t.0);
+        gb.groups.idx_mut().sort();
         Ok(gb)
     }
 }
@@ -570,7 +570,7 @@ impl<'df> GroupBy<'df> {
                     // groupby indexes are in bound.
                     unsafe {
                         s.take_iter_unchecked(
-                            &mut self.groups.idx_ref().iter().map(|(idx, _)| *idx as usize),
+                            &mut self.groups.idx_ref().iter().map(|(idx, _)| idx as usize),
                         )
                     }
                 })

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -181,7 +181,7 @@ impl DataFrame {
                         // group tuples are in bounds
                         let sub_vals_and_cols = match indicator {
                             GroupsIndicator::Idx(g) => unsafe {
-                                values_and_columns[i].take_unchecked_slice(&g.1)
+                                values_and_columns[i].take_unchecked_slice(g.1)
                             },
                             GroupsIndicator::Slice([first, len]) => {
                                 values_and_columns[i].slice(first as i64, len as usize)
@@ -190,7 +190,7 @@ impl DataFrame {
 
                         let s = sub_vals_and_cols.column(column).unwrap().clone();
                         let gb = sub_vals_and_cols
-                            .groupby_with_series(vec![s], false)
+                            .groupby_with_series(vec![s], false, false)
                             .unwrap();
 
                         use PivotAgg::*;

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -96,8 +96,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     ) -> Series {
         ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -92,8 +92,8 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
             .cast(&DataType::Categorical)
             .unwrap()
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -627,7 +627,7 @@ mod test {
         let s = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
 
         let l = s
-            .agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])]))
+            .agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])].into()))
             .unwrap();
 
         match l.dtype() {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -214,8 +214,8 @@ macro_rules! impl_dyn_series {
                     "cannot do remainder operation on logical".into(),
                 ))
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-                self.0.group_tuples(multithreaded)
+            fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+                self.0.group_tuples(multithreaded, sorted)
             }
             #[cfg(feature = "sort_multiple")]
             fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -234,8 +234,8 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             "cannot do remainder operation on logical".into(),
         ))
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        self.0.group_tuples(multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
     fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -226,8 +226,8 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             "cannot do remainder operation on logical".into(),
         ))
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        self.0.group_tuples(multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
     fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -203,8 +203,8 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-                IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+            fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+                IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
             #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -66,8 +66,8 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.agg_list(groups)
     }
 
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -249,8 +249,8 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
-            fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-                IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+            fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+                IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
             #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -60,8 +60,8 @@ where
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 }
 #[cfg(feature = "object")]

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -98,8 +98,8 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn remainder(&self, rhs: &Series) -> Result<Series> {
         NumOpsDispatch::remainder(&self.0, rhs)
     }
-    fn group_tuples(&self, multithreaded: bool) -> GroupsProxy {
-        IntoGroupsProxy::group_tuples(&self.0, multithreaded)
+    fn group_tuples(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
+        IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
     #[cfg(feature = "sort_multiple")]

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -236,7 +236,7 @@ pub(crate) mod private {
         fn remainder(&self, _rhs: &Series) -> Result<Series> {
             invalid_operation_panic!(self)
         }
-        fn group_tuples(&self, _multithreaded: bool) -> GroupsProxy {
+        fn group_tuples(&self, _multithreaded: bool, _sorted: bool) -> GroupsProxy {
             invalid_operation_panic!(self)
         }
         fn zip_with_same_type(&self, _mask: &BooleanChunked, _other: &Series) -> Result<Series> {

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -70,7 +70,7 @@ impl PhysicalExpr for FilterExpr {
                                 })
                                 .collect();
 
-                            (*idx.get(0).unwrap_or(first), idx)
+                            (*idx.get(0).unwrap_or(&first), idx)
                         })
                         .collect();
 

--- a/polars/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -39,7 +39,7 @@ impl PhysicalExpr for SliceExpr {
                         let (offset, len) = slice_offsets(self.offset, self.len, idx.len());
                         (offset as u32, idx[offset..offset + len].to_vec())
                     })
-                    .collect_trusted();
+                    .collect();
                 GroupsProxy::Idx(groups)
             }
             GroupsProxy::Slice(groups) => {

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -81,7 +81,7 @@ impl PhysicalExpr for SortExpr {
                         let new_idx = map_sorted_indices_to_group_idx(&sorted_idx, idx);
                         (new_idx[0], new_idx)
                     })
-                    .collect_trusted()
+                    .collect()
             }
             GroupsProxy::Slice(groups) => groups
                 .iter()
@@ -91,7 +91,7 @@ impl PhysicalExpr for SortExpr {
                     let new_idx = map_sorted_indices_to_group_slice(&sorted_idx, first);
                     (new_idx[0], new_idx)
                 })
-                .collect_trusted(),
+                .collect(),
         };
         let groups = GroupsProxy::Idx(groups);
 

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -336,8 +336,7 @@ impl DefaultPlanner {
                 //      1. complex expressions in the groupby itself are also not partitionable
                 //          in this case anything more than col("foo")
                 //      2. a custom function cannot be partitioned
-                //      3. maintain order is likely cheaper in default groupby
-                if keys.len() == 1 && apply.is_none() && !maintain_order {
+                if keys.len() == 1 && apply.is_none() {
                     // complex expressions in the groupby itself are also not partitionable
                     // in this case anything more than col("foo")
                     if (&*expr_arena).iter(keys[0]).count() > 1 {
@@ -403,6 +402,7 @@ impl DefaultPlanner {
                         aggs.into_iter()
                             .map(|n| node_to_expr(n, expr_arena))
                             .collect(),
+                        maintain_order,
                     )))
                 } else {
                     Ok(Box::new(GroupByExec::new(

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -226,8 +226,10 @@ impl Wrap<&DataFrame> {
                 GroupsProxy::Slice(groups_slice.into_iter().flatten().collect())
             }
         } else {
-            let mut groups = self.0.groupby_with_series(by.clone(), true)?.take_groups();
-            groups.sort();
+            let groups = self
+                .0
+                .groupby_with_series(by.clone(), true, true)?
+                .take_groups();
             let groups = groups.into_idx();
 
             // include boundaries cannot be parallel (easily)

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -354,7 +354,7 @@ impl Wrap<&DataFrame> {
     }
 }
 
-fn update_subgroups(sub_groups: &[[u32; 2]], base_g: &(u32, Vec<u32>)) -> GroupsIdx {
+fn update_subgroups(sub_groups: &[[u32; 2]], base_g: (u32, &Vec<u32>)) -> GroupsIdx {
     sub_groups
         .iter()
         .map(|&[first, len]| {

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -259,7 +259,7 @@ impl Wrap<&DataFrame> {
                         update_bounds(lower, upper);
                         update_subgroups(&sub_groups, base_g)
                     })
-                    .collect::<Vec<_>>();
+                    .collect();
                 GroupsProxy::Idx(groupsidx)
             } else {
                 let groupsidx = POOL.install(|| {
@@ -280,7 +280,7 @@ impl Wrap<&DataFrame> {
                             );
                             update_subgroups(&sub_groups, base_g)
                         })
-                        .collect::<Vec<_>>()
+                        .collect()
                 });
                 GroupsProxy::Idx(groupsidx)
             }
@@ -495,14 +495,17 @@ mod test {
         .into_series();
         assert_eq!(&upper, &range);
 
-        let expected = GroupsProxy::Idx(vec![
-            (0u32, vec![0u32, 1, 2]),
-            (2u32, vec![2]),
-            (5u32, vec![5, 6]),
-            (6u32, vec![6]),
-            (3u32, vec![3, 4]),
-            (4u32, vec![4]),
-        ]);
+        let expected = GroupsProxy::Idx(
+            vec![
+                (0u32, vec![0u32, 1, 2]),
+                (2u32, vec![2]),
+                (5u32, vec![5, 6]),
+                (6u32, vec![6]),
+                (3u32, vec![3, 4]),
+                (4u32, vec![4]),
+            ]
+            .into(),
+        );
         assert_eq!(expected, groups);
     }
 


### PR DESCRIPTION
This improves performance for the common case where you don't do a `stable groupby` as that requires an extra sort, which has gotten more expensive by this PR.

The groups were represented by a `Vec<(u32, Vec<u32>)>`  where the first `u32` is the first value of the group. This could not be tightly packed int he tuples, meaning that there were 4 bytes of padding, thus less use of cache lines and extra memory.

This PR refactors the representation to 

```rust
struct {
    first: Vec<u32>,
    all: Vec<Vec<u32>>
```

We clearly see a win in the database benchmark on the latest question `~15%` imrovement. 

Besides this we also allow partitioned groupbys on stable group by operations. This wins back the performance lost by the more expensive sort in that case.