### PR TITLE
Extend in place! :100: 

### DIFF
--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -122,6 +122,7 @@ impl<'a> ExactSizeIterator for BoolIterNoNull<'a> {}
 
 impl BooleanChunked {
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     pub fn into_no_null_iter(
         &self,
     ) -> impl Iterator<Item = bool>
@@ -203,6 +204,7 @@ impl<'a> ExactSizeIterator for Utf8IterNoNull<'a> {}
 
 impl Utf8Chunked {
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     pub fn into_no_null_iter<'a>(
         &'a self,
     ) -> impl Iterator<Item = &'a str>
@@ -299,6 +301,7 @@ impl<'a> ExactSizeIterator for ListIterNoNull<'a> {}
 
 impl ListChunked {
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     pub fn into_no_null_iter(
         &self,
     ) -> impl Iterator<Item = Series>
@@ -333,6 +336,7 @@ where
 #[cfg(feature = "object")]
 impl<T: PolarsObject> ObjectChunked<T> {
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     pub fn into_no_null_iter(
         &self,
     ) -> impl Iterator<Item = &T> + '_ + Send + Sync + ExactSizeIterator + DoubleEndedIterator + TrustedLen
@@ -344,15 +348,6 @@ impl<T: PolarsObject> ObjectChunked<T> {
                 .trust_my_length(self.len())
         }
     }
-}
-
-/// Trait for ChunkedArrays that don't have null values.
-/// The result is the most efficient implementation `Iterator`, according to the number of chunks.
-pub trait IntoNoNullIterator {
-    type Item;
-    type IntoIter: Iterator<Item = Self::Item>;
-
-    fn into_no_null_iter(self) -> Self::IntoIter;
 }
 
 /// Wrapper struct to convert an iterator of type `T` into one of type `Option<T>`.  It is useful to make the
@@ -388,8 +383,10 @@ where
 impl<I> ExactSizeIterator for SomeIterator<I> where I: ExactSizeIterator {}
 
 #[cfg(feature = "dtype-categorical")]
+#[doc(hidden)]
 impl CategoricalChunked {
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     pub fn into_no_null_iter(
         &self,
     ) -> impl Iterator<Item = u32>

--- a/polars/polars-core/src/chunked_array/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/ops/append.rs
@@ -13,19 +13,23 @@ impl<T> ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    /// Append in place.
+    /// Append in place. This is done by adding the chunks of `other` to this [`ChunkedArray`].
+    ///
+    /// See also [`extend`](Self::extend) for appends to the underlying memory
     pub fn append(&mut self, other: &Self) {
         let len = self.len();
         new_chunks(&mut self.chunks, &other.chunks, len);
     }
 }
 
+#[doc(hidden)]
 impl BooleanChunked {
     pub fn append(&mut self, other: &Self) {
         let len = self.len();
         new_chunks(&mut self.chunks, &other.chunks, len);
     }
 }
+#[doc(hidden)]
 impl Utf8Chunked {
     pub fn append(&mut self, other: &Self) {
         let len = self.len();
@@ -33,6 +37,7 @@ impl Utf8Chunked {
     }
 }
 
+#[doc(hidden)]
 impl ListChunked {
     pub fn append(&mut self, other: &Self) {
         let len = self.len();
@@ -40,6 +45,7 @@ impl ListChunked {
     }
 }
 #[cfg(feature = "object")]
+#[doc(hidden)]
 impl<T: PolarsObject> ObjectChunked<T> {
     pub fn append(&mut self, other: &Self) {
         let len = self.len();
@@ -47,6 +53,7 @@ impl<T: PolarsObject> ObjectChunked<T> {
     }
 }
 #[cfg(feature = "dtype-categorical")]
+#[doc(hidden)]
 impl CategoricalChunked {
     pub fn append(&mut self, other: &Self) {
         if let (Some(rev_map_l), Some(rev_map_r)) = (

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -36,6 +36,7 @@ impl<'a, T> Chunks<'a, T> {
     }
 }
 
+#[doc(hidden)]
 impl<T> ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -64,6 +65,7 @@ where
     }
 }
 
+#[doc(hidden)]
 impl BooleanChunked {
     pub fn downcast_iter(&self) -> impl Iterator<Item = &BooleanArray> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {
@@ -86,6 +88,7 @@ impl BooleanChunked {
     }
 }
 
+#[doc(hidden)]
 impl Utf8Chunked {
     pub fn downcast_iter(&self) -> impl Iterator<Item = &Utf8Array<i64>> + DoubleEndedIterator {
         // Safety:
@@ -110,6 +113,7 @@ impl Utf8Chunked {
     }
 }
 
+#[doc(hidden)]
 impl ListChunked {
     pub fn downcast_iter(&self) -> impl Iterator<Item = &ListArray<i64>> + DoubleEndedIterator {
         // Safety:
@@ -133,6 +137,7 @@ impl ListChunked {
 }
 
 #[cfg(feature = "object")]
+#[doc(hidden)]
 impl<'a, T> ObjectChunked<T>
 where
     T: PolarsObject,

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -1,0 +1,89 @@
+use crate::prelude::*;
+use arrow::{compute::concatenate::concatenate, Either};
+
+impl<T> ChunkedArray<T>
+where
+    T: PolarsNumericType,
+{
+    pub fn extend(&mut self, other: &Self) {
+        // make sure that we are a single chunk already
+        if self.chunks.len() > 1 {
+            self.rechunk();
+            self.extend(other)
+        }
+        // Depending on the state of the underlying arrow array we
+        // might be able to get a `MutablePrimitiveArray`
+        //
+        // This is only possible if the reference count of the array and its buffers are 1
+        // So the logic below is needed to keep the reference count 1 if it is
+
+        // First we must obtain an owned version of the array
+        let arr = self.downcast_iter().next().unwrap();
+
+        // increments 1
+        let mut arr = arr.clone();
+
+        // now we drop our owned ArrayRefs so that
+        // decrements 1
+        {
+            self.chunks.clear();
+        }
+
+        use Either::*;
+
+        match arr.into_mut() {
+            Left(immutable) => {
+                let out = if other.chunks.len() == 1 {
+                    concatenate(&[&immutable, &*other.chunks[0]]).unwrap()
+                } else {
+                    let mut arrays = Vec::with_capacity(other.chunks.len() + 1);
+                    arrays.push(&immutable as &dyn Array);
+                    arrays.extend(other.chunks.iter().map(|a| &**a));
+                    concatenate(&arrays).unwrap()
+                };
+
+                self.chunks.push(Arc::from(out));
+            }
+            Right(mut mutable) => {
+                for arr in other.downcast_iter() {
+                    match arr.null_count() {
+                        0 => mutable.extend_from_slice(arr.values()),
+                        _ => mutable.extend_trusted_len(arr.into_iter()),
+                    }
+                }
+                let arr: PrimitiveArray<T::Native> = mutable.into();
+                self.chunks.push(Arc::new(arr) as ArrayRef)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn test_extend_primitive() {
+        // create a vec with overcapacity, so that we do not trigger a realloc
+        // this allows us to test if the mutation was successful
+
+        let mut values = Vec::with_capacity(32);
+        values.extend_from_slice(&[1, 2, 3]);
+        let mut arr = Int32Chunked::from_vec("a", values);
+        let location = arr.cont_slice().unwrap().as_ptr() as usize;
+        let to_append = Int32Chunked::new("a", &[4, 5, 6]);
+
+        arr.extend(&to_append);
+        let location2 = arr.cont_slice().unwrap().as_ptr() as usize;
+        assert_eq!(location, location2);
+        assert_eq!(arr.cont_slice().unwrap(), [1, 2, 3, 4, 5, 6]);
+
+        // now check if it succeeds if we cannot do this with a mutable.
+        let temp = arr.chunks.clone();
+        arr.extend(&to_append);
+        let location2 = arr.cont_slice().unwrap().as_ptr() as usize;
+        assert_ne!(location, location2);
+        assert_eq!(arr.cont_slice().unwrap(), [1, 2, 3, 4, 5, 6, 4, 5, 6]);
+    }
+}

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -26,7 +26,7 @@ where
     /// However if this does not cause a reallocation, the resulting data structure will not have any extra chunks
     /// and thus will yield faster queries.
     ///
-    /// Prefer `extend` over `append` when you want do a query after a single append. For instance during
+    /// Prefer `extend` over `append` when you want to do a query after a single append. For instance during
     /// online operations where you add `n` rows and rerun a query.
     ///
     /// Prefer `append` over `extend` when you want to append many times before doing a query. For instance

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -27,6 +27,7 @@ mod concat_str;
 mod cum_agg;
 pub(crate) mod downcast;
 pub(crate) mod explode;
+mod extend;
 mod fill_null;
 mod filter;
 pub mod full;

--- a/polars/polars-core/src/frame/arithmetic.rs
+++ b/polars/polars-core/src/frame/arithmetic.rs
@@ -126,10 +126,10 @@ impl DataFrame {
                 let mut r = r.cast(&st)?;
 
                 if diff_l > 0 {
-                    l = l.extend(AnyValue::Null, diff_l)?;
+                    l = l.extend_constant(AnyValue::Null, diff_l)?;
                 };
                 if diff_r > 0 {
-                    r = r.extend(AnyValue::Null, diff_r)?;
+                    r = r.extend_constant(AnyValue::Null, diff_r)?;
                 };
 
                 f(&l, &r)

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -731,6 +731,8 @@ impl DataFrame {
 
     /// Concatenate a `DataFrame` to this `DataFrame` and return as newly allocated `DataFrame`.
     ///
+    /// If many `vstack` operations are done, it is recommended to call [`DataFrame::rechunk`].
+    ///
     /// # Example
     ///
     /// ```rust
@@ -767,13 +769,45 @@ impl DataFrame {
     /// | Palladium | 1828.05           |
     /// +-----------+-------------------+
     /// ```
-    pub fn vstack(&self, columns: &DataFrame) -> Result<Self> {
+    pub fn vstack(&self, other: &DataFrame) -> Result<Self> {
         let mut df = self.clone();
-        df.vstack_mut(columns)?;
+        df.vstack_mut(other)?;
         Ok(df)
     }
 
+    // utility to test if we can vstack/extend the columns
+    fn can_extend(&self, left: &Series, right: &Series) -> Result<()> {
+        if left.dtype() != right.dtype() || left.name() != right.name() {
+            if left.dtype() != right.dtype() {
+                return Err(PolarsError::SchemaMisMatch(
+                    format!(
+                        "cannot vstack: because column datatypes (dtypes) in the two DataFrames do not match for \
+                                left.name='{}' with left.dtype={} != right.dtype={} with right.name='{}'",
+                        left.name(),
+                        left.dtype(),
+                        right.dtype(),
+                        right.name()
+                    )
+                        .into(),
+                ));
+            } else {
+                return Err(PolarsError::SchemaMisMatch(
+                    format!(
+                        "cannot vstack: because column names in the two DataFrames do not match for \
+                                left.name='{}' != right.name='{}'",
+                        left.name(),
+                        right.name()
+                    )
+                        .into(),
+                ));
+            }
+        };
+        Ok(())
+    }
+
     /// Concatenate a DataFrame to this DataFrame
+    ///
+    /// If many `vstack` operations are done, it is recommended to call [`DataFrame::rechunk`].
     ///
     /// # Example
     ///
@@ -811,49 +845,54 @@ impl DataFrame {
     /// | Palladium | 1828.05           |
     /// +-----------+-------------------+
     /// ```
-    pub fn vstack_mut(&mut self, df: &DataFrame) -> Result<&mut Self> {
-        if self.width() != df.width() {
+    pub fn vstack_mut(&mut self, other: &DataFrame) -> Result<&mut Self> {
+        if self.width() != other.width() {
             return Err(PolarsError::ShapeMisMatch(
-                format!("Could not vertically stack DataFrame. The DataFrames appended width {} differs from the parent DataFrames width {}", self.width(), df.width()).into()
+                format!("Could not vertically stack DataFrame. The DataFrames appended width {} differs from the parent DataFrames width {}", self.width(), other.width()).into()
             ));
         }
 
         self.columns
             .iter_mut()
-            .zip(df.columns.iter())
+            .zip(other.columns.iter())
             .try_for_each(|(left, right)| {
-                if left.dtype() != right.dtype() || left.name() != right.name() {
-                    if left.dtype() != right.dtype() {
-                        return Err(PolarsError::SchemaMisMatch(
-                            format!(
-                                "cannot vstack: because column datatypes (dtypes) in the two DataFrames do not match for \
-                                left.name='{}' with left.dtype={} != right.dtype={} with right.name='{}'",
-                                left.name(),
-                                left.dtype(),
-                                right.dtype(),
-                                right.name()
-                            )
-                            .into(),
-                        ));
-                    }
-                    else {
-                        return Err(PolarsError::SchemaMisMatch(
-                            format!(
-                                "cannot vstack: because column names in the two DataFrames do not match for \
-                                left.name='{}' != right.name='{}'",
-                                left.name(),
-                                right.name()
-                            )
-                            .into(),
-                        ));
-                    }
-                }
-
+                self.can_extend(left, right)?;
                 left.append(right).expect("should not fail");
                 Ok(())
             })?;
-        // don't rechunk here. Chunks in columns always match.
         Ok(self)
+    }
+
+    /// Extend the memory backed by this [`DataFrame`] with the values from `other`.
+    ///
+    /// Different from [`vstack`](Self::vstack) which adds the chunks from `other` to the chunks of this [`DataFrame`]
+    /// `extent` appends the data from `other` to the underlying memory locations and thus may cause a reallocation.
+    ///
+    /// If this does not cause a reallocation, the resulting data structure will not have any extra chunks
+    /// and thus will yield faster queries.
+    ///
+    /// Prefer `extend` over `vstack` when you want do a query after a single append. For instance during
+    /// online operations where you add `n` rows and rerun a query.
+    ///
+    /// Prefer `vstack` over `extend` when you want to append many times before doing a query. For instance
+    /// when you read in multiple files and when to store them in a single `DataFrame`. In the latter case, finish the sequence
+    /// of `append` operations with a [`rechunk`](Self::rechunk).
+    pub fn extend(&mut self, other: &DataFrame) -> Result<()> {
+        if self.width() != other.width() {
+            return Err(PolarsError::ShapeMisMatch(
+                format!("Could not extend DataFrame. The DataFrames extended width {} differs from the parent DataFrames width {}", self.width(), other.width()).into()
+            ));
+        }
+
+        self.columns
+            .iter_mut()
+            .zip(other.columns.iter())
+            .try_for_each(|(left, right)| {
+                self.can_extend(left, right)?;
+                left.extend(right).unwrap();
+                Ok(())
+            })?;
+        Ok(())
     }
 
     /// Remove a column by name and return the column removed.

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -182,7 +182,7 @@ pub fn hor_concat_df(dfs: &[DataFrame]) -> Result<DataFrame> {
                     let diff = max_len - df.height();
                     df.columns
                         .iter_mut()
-                        .for_each(|s| *s = s.extend(AnyValue::Null, diff).unwrap());
+                        .for_each(|s| *s = s.extend_constant(AnyValue::Null, diff).unwrap());
                 }
                 df
             })

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::{
             ListPrimitiveChunkedBuilder, ListUtf8ChunkedBuilder, NewChunkedArray,
             PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
         },
-        iterator::{PolarsIterator},
+        iterator::PolarsIterator,
         ops::{aggregate::*, *},
         ChunkedArray,
     },

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::{
             ListPrimitiveChunkedBuilder, ListUtf8ChunkedBuilder, NewChunkedArray,
             PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
         },
-        iterator::{IntoNoNullIterator, PolarsIterator},
+        iterator::{PolarsIterator},
         ops::{aggregate::*, *},
         ChunkedArray,
     },

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -159,12 +159,22 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
 
     fn append(&mut self, other: &Series) -> Result<()> {
         if self.0.dtype() == other.dtype() {
-            // todo! add object
             self.0.append(other.as_ref().as_ref());
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(
                 "cannot append Series; data types don't match".into(),
+            ))
+        }
+    }
+
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            self.0.extend(other.as_ref().as_ref());
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
             ))
         }
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -153,7 +153,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         if self.0.dtype() == other.dtype() {
             let other = other.categorical()?;
             self.0.append(other);
-            self.0.merge_categorical_map(other);
+            self.0.categorical_map = Some(self.0.merge_categorical_map(other));
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(
@@ -165,7 +165,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         if self.0.dtype() == other.dtype() {
             let other = other.categorical()?;
             self.0.extend(other);
-            self.0.merge_categorical_map(other);
+            self.0.categorical_map = Some(self.0.merge_categorical_map(other));
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -151,12 +151,25 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
 
     fn append(&mut self, other: &Series) -> Result<()> {
         if self.0.dtype() == other.dtype() {
-            // todo! add object
-            self.0.append(other.as_ref().as_ref());
+            let other = other.categorical()?;
+            self.0.append(other);
+            self.0.merge_categorical_map(other);
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(
                 "cannot append Series; data types don't match".into(),
+            ))
+        }
+    }
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            let other = other.categorical()?;
+            self.0.extend(other);
+            self.0.merge_categorical_map(other);
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
             ))
         }
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -298,12 +298,31 @@ macro_rules! impl_dyn_series {
 
             fn append(&mut self, other: &Series) -> Result<()> {
                 if self.0.dtype() == other.dtype() {
-                    let other = other.to_physical_repr().into_owned();
-                    self.0.append(other.as_ref().as_ref());
+                    let other = other.to_physical_repr();
+                    // 3 refs
+                    // ref Cow
+                    // ref SeriesTrait
+                    // ref ChunkedArray
+                    self.0.append(other.as_ref().as_ref().as_ref());
                     Ok(())
                 } else {
                     Err(PolarsError::SchemaMisMatch(
                         "cannot append Series; data types don't match".into(),
+                    ))
+                }
+            }
+            fn extend(&mut self, other: &Series) -> Result<()> {
+                if self.0.dtype() == other.dtype() {
+                    // 3 refs
+                    // ref Cow
+                    // ref SeriesTrait
+                    // ref ChunkedArray
+                    let other = other.to_physical_repr();
+                    self.0.extend(other.as_ref().as_ref().as_ref());
+                    Ok(())
+                } else {
+                    Err(PolarsError::SchemaMisMatch(
+                        "cannot extend Series; data types don't match".into(),
                     ))
                 }
             }

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -296,12 +296,24 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
 
     fn append(&mut self, other: &Series) -> Result<()> {
         if self.0.dtype() == other.dtype() {
-            let other = other.to_physical_repr().into_owned();
-            self.0.append(other.as_ref().as_ref());
+            let other = other.to_physical_repr();
+            self.0.append(other.as_ref().as_ref().as_ref());
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(
                 "cannot append Series; data types don't match".into(),
+            ))
+        }
+    }
+
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            let other = other.to_physical_repr();
+            self.0.extend(other.as_ref().as_ref().as_ref());
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
             ))
         }
     }

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -298,6 +298,18 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         }
     }
 
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            let other = other.to_physical_repr();
+            self.0.append(other.as_ref().as_ref().as_ref());
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
+            ))
+        }
+    }
+
     fn filter(&self, filter: &BooleanChunked) -> Result<Series> {
         self.0
             .filter(filter)

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -301,7 +301,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn extend(&mut self, other: &Series) -> Result<()> {
         if self.0.dtype() == other.dtype() {
             let other = other.to_physical_repr();
-            self.0.append(other.as_ref().as_ref().as_ref());
+            self.0.extend(other.as_ref().as_ref().as_ref());
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -316,12 +316,22 @@ macro_rules! impl_dyn_series {
 
             fn append(&mut self, other: &Series) -> Result<()> {
                 if self.0.dtype() == other.dtype() {
-                    // todo! add object
                     self.0.append(other.as_ref().as_ref());
                     Ok(())
                 } else {
                     Err(PolarsError::SchemaMisMatch(
                         "cannot append Series; data types don't match".into(),
+                    ))
+                }
+            }
+
+            fn extend(&mut self, other: &Series) -> Result<()> {
+                if self.0.dtype() == other.dtype() {
+                    self.0.extend(other.as_ref().as_ref());
+                    Ok(())
+                } else {
+                    Err(PolarsError::SchemaMisMatch(
+                        "cannot extend Series; data types don't match".into(),
                     ))
                 }
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -109,12 +109,21 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
 
     fn append(&mut self, other: &Series) -> Result<()> {
         if self.0.dtype() == other.dtype() {
-            // todo! add object
             self.0.append(other.as_ref().as_ref());
             Ok(())
         } else {
             Err(PolarsError::SchemaMisMatch(
                 "cannot append Series; data types don't match".into(),
+            ))
+        }
+    }
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            self.0.extend(other.as_ref().as_ref());
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
             ))
         }
     }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -494,7 +494,7 @@ macro_rules! impl_dyn_series {
 
             fn extend(&mut self, other: &Series) -> Result<()> {
                 if self.0.dtype() == other.dtype() {
-                    self.0.append(other.as_ref().as_ref());
+                    self.0.extend(other.as_ref().as_ref());
                     Ok(())
                 } else {
                     Err(PolarsError::SchemaMisMatch(

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -483,12 +483,22 @@ macro_rules! impl_dyn_series {
 
             fn append(&mut self, other: &Series) -> Result<()> {
                 if self.0.dtype() == other.dtype() {
-                    // todo! add object
                     self.0.append(other.as_ref().as_ref());
                     Ok(())
                 } else {
                     Err(PolarsError::SchemaMisMatch(
                         "cannot append Series; data types don't match".into(),
+                    ))
+                }
+            }
+
+            fn extend(&mut self, other: &Series) -> Result<()> {
+                if self.0.dtype() == other.dtype() {
+                    self.0.append(other.as_ref().as_ref());
+                    Ok(())
+                } else {
+                    Err(PolarsError::SchemaMisMatch(
+                        "cannot extend Series; data types don't match".into(),
                     ))
                 }
             }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -114,6 +114,10 @@ where
         }
     }
 
+    fn extend(&mut self, _other: &Series) -> Result<()> {
+        panic!("extend not implemented for Object dtypes")
+    }
+
     fn filter(&self, filter: &BooleanChunked) -> Result<Series> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -167,6 +167,17 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         }
     }
 
+    fn extend(&mut self, other: &Series) -> Result<()> {
+        if self.0.dtype() == other.dtype() {
+            self.0.extend(other.as_ref().as_ref());
+            Ok(())
+        } else {
+            Err(PolarsError::SchemaMisMatch(
+                "cannot extend Series; data types don't match".into(),
+            ))
+        }
+    }
+
     fn filter(&self, filter: &BooleanChunked) -> Result<Series> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
     }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -176,9 +176,19 @@ impl Series {
         Ok(self)
     }
 
-    /// Append a Series of the same type in place.
+    /// Append in place. This is done by adding the chunks of `other` to this [`Series`].
+    ///
+    /// See [`ChunkedArray::append`] and [`ChunkedArray::extend`].
     pub fn append(&mut self, other: &Series) -> Result<&mut Self> {
         self.get_inner_mut().append(other)?;
+        Ok(self)
+    }
+
+    /// Extend the memory backed by this array with the values from `other`.
+    ///
+    /// See [`ChunkedArray::extend`] and [`ChunkedArray::append`].
+    pub fn extend(&mut self, other: &Series) -> Result<&mut Self> {
+        self.get_inner_mut().extend(other)?;
         Ok(self)
     }
 

--- a/polars/polars-core/src/series/ops/extend.rs
+++ b/polars/polars-core/src/series/ops/extend.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 impl Series {
     /// Extend with a constant value.
-    pub fn extend(&self, value: AnyValue, n: usize) -> Result<Self> {
+    pub fn extend_constant(&self, value: AnyValue, n: usize) -> Result<Self> {
         use AnyValue::*;
         let s = match value {
             Float32(v) => Series::new("", vec![v]),

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -473,11 +473,15 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
-    /// Append a Series of the same type in place.
+    #[doc(hidden)]
     fn append(&mut self, _other: &Series) -> Result<()> {
         invalid_operation_panic!(self)
     }
 
+    #[doc(hidden)]
+    fn extend(&mut self, _other: &Series) -> Result<()> {
+        invalid_operation_panic!(self)
+    }
 
     /// Filter by boolean mask. This operation clones data.
     fn filter(&self, _filter: &BooleanChunked) -> Result<Series> {

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -478,6 +478,7 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
+
     /// Filter by boolean mask. This operation clones data.
     fn filter(&self, _filter: &BooleanChunked) -> Result<Series> {
         invalid_operation_panic!(self)

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -107,6 +107,7 @@ Manipulation/ selection
     DataFrame.with_column
     DataFrame.hstack
     DataFrame.vstack
+    DataFrame.extend
     DataFrame.groupby
     DataFrame.groupby_dynamic
     DataFrame.groupby_rolling

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -199,6 +199,7 @@ Manipulation/ selection
     Expr.reshape
     Expr.to_physical
     Expr.shuffle
+    Expr.extend_constant
     Expr.extend
 
 Column names

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -178,6 +178,7 @@ Manipulation/ selection
     Series.reshape
     Series.to_dummies
     Series.shuffle
+    Series.extend_constant
     Series.extend
 
 Various

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2303,7 +2303,25 @@ class Expr:
         n
             The number of values to extend.
         """
-        return wrap_expr(self._pyexpr.extend(value, n))
+        return wrap_expr(self._pyexpr.extend_constant(value, n))
+
+    def extend_constant(
+        self, value: Optional[Union[int, float, str, bool]], n: int
+    ) -> "Expr":
+        """
+        Extend the Series with given number of values.
+
+        .. deprecated::0.12.21
+            use extend_constant
+
+        Parameters
+        ----------
+        value
+            The value to extend the Series with. This value may be None to fill with nulls.
+        n
+            The number of values to extend.
+        """
+        return self.extend_constant(value, n)
 
     # Below are the namespaces defined. Keep these at the end of the definition of Expr, as to not confuse mypy with
     # the type annotation `str` with the namespace "str"

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3212,6 +3212,30 @@ class DataFrame:
         else:
             return wrap_df(self._df.vstack(df._df))
 
+    def extend(self, other: "DataFrame") -> None:
+        """
+        Extend the memory backed by this `DataFrame` with the values from `other`.
+
+        Different from `vstack` which adds the chunks from `other` to the chunks of this `DataFrame`
+        `extent` appends the data from `other` to the underlying memory locations and thus may cause a reallocation.
+
+        If this does not cause a reallocation, the resulting data structure will not have any extra chunks
+        and thus will yield faster queries.
+
+        Prefer `extend` over `vstack` when you want to do a query after a single append. For instance during
+        online operations where you add `n` rows and rerun a query.
+
+        Prefer `vstack` over `extend` when you want to append many times before doing a query. For instance
+        when you read in multiple files and when to store them in a single `DataFrame`.
+        In the latter case, finish the sequence of `vstack` operations with a `rechunk`.
+
+        Parameters
+        ----------
+        other
+            DataFrame to vertically add.
+        """
+        self._df.extend(other._df)
+
     def drop(self, name: Union[str, List[str]]) -> "DataFrame":
         """
         Remove column from DataFrame and return as new.

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -654,6 +654,11 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
+    pub fn extend(&mut self, df: &PyDataFrame) -> PyResult<()> {
+        self.df.extend(&df.df).map_err(PyPolarsEr::from)?;
+        Ok(())
+    }
+
     pub fn vstack_mut(&mut self, df: &PyDataFrame) -> PyResult<()> {
         self.df.vstack_mut(&df.df).map_err(PyPolarsEr::from)?;
         Ok(())

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1246,7 +1246,7 @@ impl PyExpr {
         };
         self.inner.clone().ewm_var(options).into()
     }
-    pub fn extend(&self, py: Python, value: Wrap<AnyValue>, n: usize) -> Self {
+    pub fn extend_constant(&self, py: Python, value: Wrap<AnyValue>, n: usize) -> Self {
         let value = value.into_py(py);
         self.inner
             .clone()
@@ -1255,7 +1255,7 @@ impl PyExpr {
                     let gil = Python::acquire_gil();
                     let py = gil.python();
                     let value = value.extract::<Wrap<AnyValue>>(py).unwrap().0;
-                    s.extend(value, n)
+                    s.extend_constant(value, n)
                 },
                 GetOutput::same_type(),
             )

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -433,6 +433,13 @@ impl PySeries {
         Ok(())
     }
 
+    pub fn extend(&mut self, other: &PySeries) -> PyResult<()> {
+        self.series
+            .extend(&other.series)
+            .map_err(PyPolarsEr::from)?;
+        Ok(())
+    }
+
     pub fn filter(&self, filter: &PySeries) -> PyResult<Self> {
         let filter_series = &filter.series;
         if let Ok(ca) = filter_series.bool() {
@@ -1439,9 +1446,12 @@ impl PySeries {
     pub fn shuffle(&self, seed: u64) -> Self {
         self.series.shuffle(seed).into()
     }
-    pub fn extend(&self, value: Wrap<AnyValue>, n: usize) -> PyResult<Self> {
+    pub fn extend_constant(&self, value: Wrap<AnyValue>, n: usize) -> PyResult<Self> {
         let value = value.0;
-        let out = self.series.extend(value, n).map_err(PyPolarsEr::from)?;
+        let out = self
+            .series
+            .extend_constant(value, n)
+            .map_err(PyPolarsEr::from)?;
         Ok(out.into())
     }
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -635,6 +635,55 @@ def test_vstack(in_place: bool) -> None:
         assert out.frame_equal(expected)  # type: ignore
 
 
+def test_extend() -> None:
+    with pl.StringCache():
+        df1 = pl.DataFrame(
+            {
+                "foo": [1, 2],
+                "bar": [True, False],
+                "ham": ["a", "b"],
+                "cat": ["A", "B"],
+                "dates": [datetime(2021, 1, 1), datetime(2021, 2, 1)],
+            }
+        ).with_columns(
+            [
+                pl.col("cat").cast(pl.Categorical),
+            ]
+        )
+        df2 = pl.DataFrame(
+            {
+                "foo": [3, 4],
+                "bar": [True, None],
+                "ham": ["c", "d"],
+                "cat": ["C", "B"],
+                "dates": [datetime(2022, 9, 1), datetime(2021, 2, 1)],
+            }
+        ).with_columns(
+            [
+                pl.col("cat").cast(pl.Categorical),
+            ]
+        )
+
+    df1.extend(df2)
+    expected = pl.DataFrame(
+        {
+            "foo": [1, 2, 3, 4],
+            "bar": [True, False, True, None],
+            "ham": ["a", "b", "c", "d"],
+            "cat": ["A", "B", "C", "B"],
+            "dates": [
+                datetime(2021, 1, 1),
+                datetime(2021, 2, 1),
+                datetime(2022, 9, 1),
+                datetime(2021, 2, 1),
+            ],
+        }
+    ).with_column(
+        pl.col("cat").cast(pl.Categorical),
+    )
+    assert df1.frame_equal(expected)
+
+
 def test_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
     df = df.drop("a")

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -211,6 +211,16 @@ def test_add_string() -> None:
     testing.assert_series_equal(result, pl.Series(["hello world", "weird world"]))
 
 
+def test_append_extend() -> None:
+    a = pl.Series("a", [1, 2])
+    b = pl.Series("b", [8, 9, None])
+    a.append(b, append_chunks=False)
+    expected = pl.Series("a", [1, 2, 8, 9, None])
+    assert a.series_equal(expected, null_equal=True)
+    print(a.chunk_lengths())
+    assert a.n_chunks() == 1
+
+
 def test_various() -> None:
     a = pl.Series("a", [1, 2])
 


### PR DESCRIPTION
This PR is quite a big deal. Until now polars/arrow memory was completely immutable. If we did and append, we simply added an array chunk to the list of chunks (sort of a linked list). This yielded very fast appends, but is detrimental for query performance, because the chunks add a lot of indirection. 

Especially use cases where you have rows coming in on a very slow and you want to do querys between the updates. For instance in online learning cases, Polars was not the right tool for the job, as you would need to call a `rechunk` to get optimal peformance which is a complete reallocation of your table! Very expensive.

With this change, we can now extend the `DataFrame/Series` and write to the same memory allocations. This might still reallocate, but given exponential growth strategies, this operation is amortized `O(1)`.

There is of course no magic. We can only write to the same memory **iff** 

* we are the only owner (The series are not shared with another dataframe)
* the memory is not allocated by pyarrow
