### PR TITLE
Fix decreasing interpolation of unsigned Series

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -71,12 +71,21 @@ where
                                     // another null
                                     Some(None) => {}
                                     Some(Some(high)) => {
-                                        let diff = high - low;
                                         let steps_n = T::Native::from_u32(steps).unwrap();
-                                        for step_i in 1..steps {
-                                            let step_i = T::Native::from_u32(step_i).unwrap();
-                                            let v = linear_itp(low, step_i, diff, steps_n);
-                                            av.push(v)
+                                        if high >= low {
+                                            let diff = high - low;
+                                            for step_i in 1..steps {
+                                                let step_i = T::Native::from_u32(step_i).unwrap();
+                                                let v = linear_itp(low, step_i, diff, steps_n);
+                                                av.push(v)
+                                            }
+                                        } else {
+                                            let diff = low - high;
+                                            for step_i in (1..steps).rev() {
+                                                let step_i = T::Native::from_u32(step_i).unwrap();
+                                                let v = linear_itp(high, step_i, diff, steps_n);
+                                                av.push(v)
+                                            }
                                         }
                                         av.push(high);
                                         low_val = Some(high);
@@ -143,6 +152,13 @@ mod test {
             Vec::from(&out),
             &[None, Some(1), Some(2), Some(3), Some(4), Some(5), None]
         );
+    }
+
+    #[test]
+    fn test_interpolate_decreasing_unsigned() {
+        let ca = UInt32Chunked::new("", &[Some(4), None, None, Some(1)]);
+        let out = ca.interpolate();
+        assert_eq!(Vec::from(&out), &[Some(4), Some(3), Some(2), Some(1)])
     }
 
     #[test]


### PR DESCRIPTION
Currently, polars fails to interpolate an unsigned Series with decreasing values because the `diff` in the interpolate matches the type of the Series. This PR fixes this by ensuring that diff is always positive, and appropriately flipping the interpolation direction for increasing or decreasing values.

This is literally the first Rust code I've ever written... If this was C++, I'd dispatch on the template parameter to ensure that the conditional is only evaluated if the type is unsigned, but I wasn't sure if that's how Rust's generics worked, and increases increases code complexity enough I figured I'd ask about it first. Anyway, feedback very appreciated, but if it's easier for you to just toss my code and write a better version, that's fine too.

