### PR TITLE
impl namedfrom for temporal types

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/date.rs
+++ b/polars/polars-core/src/chunked_array/logical/date.rs
@@ -5,13 +5,13 @@ pub type DateChunked = Logical<DateType, Int32Type>;
 
 impl From<Int32Chunked> for DateChunked {
     fn from(ca: Int32Chunked) -> Self {
-        DateChunked::new(ca)
+        DateChunked::new_logical(ca)
     }
 }
 
 impl Int32Chunked {
     pub fn into_date(self) -> DateChunked {
-        DateChunked::new(self)
+        DateChunked::new_logical(self)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/logical/datetime.rs
+++ b/polars/polars-core/src/chunked_array/logical/datetime.rs
@@ -5,7 +5,7 @@ pub type DatetimeChunked = Logical<DatetimeType, Int64Type>;
 
 impl Int64Chunked {
     pub fn into_datetime(self, timeunit: TimeUnit, tz: Option<TimeZone>) -> DatetimeChunked {
-        let mut dt = DatetimeChunked::new(self);
+        let mut dt = DatetimeChunked::new_logical(self);
         dt.2 = Some(DataType::Datetime(timeunit, tz));
         dt
     }

--- a/polars/polars-core/src/chunked_array/logical/duration.rs
+++ b/polars/polars-core/src/chunked_array/logical/duration.rs
@@ -5,7 +5,7 @@ pub type DurationChunked = Logical<DurationType, Int64Type>;
 
 impl Int64Chunked {
     pub fn into_duration(self, timeunit: TimeUnit) -> DurationChunked {
-        let mut dt = DurationChunked::new(self);
+        let mut dt = DurationChunked::new_logical(self);
         dt.2 = Some(DataType::Duration(timeunit));
         dt
     }

--- a/polars/polars-core/src/chunked_array/logical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/mod.rs
@@ -19,7 +19,7 @@ pub struct Logical<K: PolarsDataType, T: PolarsDataType>(
 
 impl<K: PolarsDataType, T: PolarsDataType> Clone for Logical<K, T> {
     fn clone(&self) -> Self {
-        let mut new = Logical::<K, _>::new(self.0.clone());
+        let mut new = Logical::<K, _>::new_logical(self.0.clone());
         new.2 = self.2.clone();
         new
     }
@@ -40,7 +40,7 @@ impl<K: PolarsDataType, T: PolarsDataType> DerefMut for Logical<K, T> {
 }
 
 impl<K: PolarsDataType, T: PolarsDataType> Logical<K, T> {
-    pub fn new<J: PolarsDataType>(ca: ChunkedArray<T>) -> Logical<J, T> {
+    pub fn new_logical<J: PolarsDataType>(ca: ChunkedArray<T>) -> Logical<J, T> {
         Logical(ca, PhantomData, None)
     }
 }

--- a/polars/polars-core/src/chunked_array/logical/time.rs
+++ b/polars/polars-core/src/chunked_array/logical/time.rs
@@ -5,13 +5,13 @@ pub type TimeChunked = Logical<TimeType, Int64Type>;
 
 impl From<Int64Chunked> for TimeChunked {
     fn from(ca: Int64Chunked) -> Self {
-        TimeChunked::new(ca)
+        TimeChunked::new_logical(ca)
     }
 }
 
 impl Int64Chunked {
     pub fn into_time(self) -> TimeChunked {
-        TimeChunked::new(self)
+        TimeChunked::new_logical(self)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -702,7 +702,9 @@ pub(crate) fn prepare_argsort(
         .map(|s| {
             use DataType::*;
             match s.dtype() {
-                Float32 | Float64 | Int32 | Int64 | Utf8 | UInt32 | UInt64 => s.clone(),
+                Categorical | Float32 | Float64 | Int32 | Int64 | Utf8 | UInt32 | UInt64 => {
+                    s.clone()
+                }
                 _ => {
                     // small integers i8, u8 etc are casted to reduce compiler bloat
                     // not that we don't expect any logical types at this point

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -81,6 +81,15 @@ impl DateChunked {
         Int32Chunked::from_vec(name, unit).into()
     }
 
+    /// Construct a new [`DateChunked`] from an iterator over optional [`NaiveDate`].
+    pub fn from_naive_date_options<I: IntoIterator<Item = Option<NaiveDate>>>(
+        name: &str,
+        v: I,
+    ) -> Self {
+        let unit = v.into_iter().map(|opt| opt.map(naive_date_to_date));
+        Int32Chunked::from_iter_options(name, unit).into()
+    }
+
     pub fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> Self {
         Int32Chunked::from_iter_options(
             name,

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -183,6 +183,19 @@ impl DatetimeChunked {
         Int64Chunked::from_vec(name, vals).into_datetime(tu, None)
     }
 
+    pub fn from_naive_datetime_options<I: IntoIterator<Item = Option<NaiveDateTime>>>(
+        name: &str,
+        v: I,
+        tu: TimeUnit,
+    ) -> Self {
+        let func = match tu {
+            TimeUnit::Nanoseconds => naive_datetime_to_datetime_ns,
+            TimeUnit::Milliseconds => naive_datetime_to_datetime_ms,
+        };
+        let vals = v.into_iter().map(|opt_nd| opt_nd.map(|nd| (func(&nd))));
+        Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+    }
+
     pub fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str, tu: TimeUnit) -> Self {
         let func = match tu {
             TimeUnit::Nanoseconds => naive_datetime_to_datetime_ns,

--- a/polars/polars-core/src/chunked_array/temporal/duration.rs
+++ b/polars/polars-core/src/chunked_array/temporal/duration.rs
@@ -32,6 +32,20 @@ impl DurationChunked {
         Int64Chunked::from_vec(name, vals).into_duration(tu)
     }
 
+    /// Construct a new [`DurationChunked`] from an iterator over optional [`ChronoDuration`].
+    pub fn from_duration_options<I: IntoIterator<Item = Option<ChronoDuration>>>(
+        name: &str,
+        v: I,
+        tu: TimeUnit,
+    ) -> Self {
+        let func = match tu {
+            TimeUnit::Nanoseconds => |v: ChronoDuration| v.num_nanoseconds().unwrap(),
+            TimeUnit::Milliseconds => |v: ChronoDuration| v.num_milliseconds(),
+        };
+        let vals = v.into_iter().map(|opt| opt.map(func));
+        Int64Chunked::from_iter_options(name, vals).into_duration(tu)
+    }
+
     /// Extract the hours from a `Duration`
     pub fn hours(&self) -> Int64Chunked {
         match self.time_unit() {

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -1,5 +1,13 @@
 use crate::chunked_array::builder::{get_list_builder, AnonymousListBuilder};
 use crate::prelude::*;
+#[cfg(feature = "dtype-duration")]
+use chrono::Duration as ChronoDuration;
+#[cfg(feature = "dtype-date")]
+use chrono::NaiveDate;
+#[cfg(feature = "dtype-datetime")]
+use chrono::NaiveDateTime;
+#[cfg(feature = "dtype-time")]
+use chrono::NaiveTime;
 use std::borrow::Cow;
 
 pub trait NamedFrom<T, Phantom: ?Sized> {
@@ -194,6 +202,132 @@ impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> 
     }
 }
 
+#[cfg(feature = "dtype-date")]
+impl<T: AsRef<[NaiveDate]>> NamedFrom<T, [NaiveDate]> for DateChunked {
+    fn new(name: &str, v: T) -> Self {
+        DateChunked::from_naive_date(name, v.as_ref().iter().copied())
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+impl<T: AsRef<[NaiveDate]>> NamedFrom<T, [NaiveDate]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DateChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+impl<T: AsRef<[Option<NaiveDate>]>> NamedFrom<T, [Option<NaiveDate>]> for DateChunked {
+    fn new(name: &str, v: T) -> Self {
+        DateChunked::from_naive_date_options(name, v.as_ref().iter().copied())
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+impl<T: AsRef<[Option<NaiveDate>]>> NamedFrom<T, [Option<NaiveDate>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DateChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-datetime")]
+impl<T: AsRef<[NaiveDateTime]>> NamedFrom<T, [NaiveDateTime]> for DatetimeChunked {
+    fn new(name: &str, v: T) -> Self {
+        DatetimeChunked::from_naive_datetime(
+            name,
+            v.as_ref().iter().copied(),
+            TimeUnit::Milliseconds,
+        )
+    }
+}
+
+#[cfg(feature = "dtype-datetime")]
+impl<T: AsRef<[NaiveDateTime]>> NamedFrom<T, [NaiveDateTime]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DatetimeChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-datetime")]
+impl<T: AsRef<[Option<NaiveDateTime>]>> NamedFrom<T, [Option<NaiveDateTime>]> for DatetimeChunked {
+    fn new(name: &str, v: T) -> Self {
+        DatetimeChunked::from_naive_datetime_options(
+            name,
+            v.as_ref().iter().copied(),
+            TimeUnit::Milliseconds,
+        )
+    }
+}
+
+#[cfg(feature = "dtype-datetime")]
+impl<T: AsRef<[Option<NaiveDateTime>]>> NamedFrom<T, [Option<NaiveDateTime>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DatetimeChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-duration")]
+impl<T: AsRef<[ChronoDuration]>> NamedFrom<T, [ChronoDuration]> for DurationChunked {
+    fn new(name: &str, v: T) -> Self {
+        DurationChunked::from_duration(name, v.as_ref().iter().copied(), TimeUnit::Nanoseconds)
+    }
+}
+
+#[cfg(feature = "dtype-duration")]
+impl<T: AsRef<[ChronoDuration]>> NamedFrom<T, [ChronoDuration]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DurationChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-duration")]
+impl<T: AsRef<[Option<ChronoDuration>]>> NamedFrom<T, [Option<ChronoDuration>]>
+    for DurationChunked
+{
+    fn new(name: &str, v: T) -> Self {
+        DurationChunked::from_duration_options(
+            name,
+            v.as_ref().iter().copied(),
+            TimeUnit::Nanoseconds,
+        )
+    }
+}
+
+#[cfg(feature = "dtype-duration")]
+impl<T: AsRef<[Option<ChronoDuration>]>> NamedFrom<T, [Option<ChronoDuration>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        DurationChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-time")]
+impl<T: AsRef<[NaiveTime]>> NamedFrom<T, [NaiveTime]> for TimeChunked {
+    fn new(name: &str, v: T) -> Self {
+        TimeChunked::from_naive_time(name, v.as_ref().iter().copied())
+    }
+}
+
+#[cfg(feature = "dtype-time")]
+impl<T: AsRef<[NaiveTime]>> NamedFrom<T, [NaiveTime]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        TimeChunked::new(name, v).into_series()
+    }
+}
+
+#[cfg(feature = "dtype-time")]
+impl<T: AsRef<[Option<NaiveTime>]>> NamedFrom<T, [Option<NaiveTime>]> for TimeChunked {
+    fn new(name: &str, v: T) -> Self {
+        TimeChunked::from_naive_time_options(name, v.as_ref().iter().copied())
+    }
+}
+
+#[cfg(feature = "dtype-time")]
+impl<T: AsRef<[Option<NaiveTime>]>> NamedFrom<T, [Option<NaiveTime>]> for Series {
+    fn new(name: &str, v: T) -> Self {
+        TimeChunked::new(name, v).into_series()
+    }
+}
+
 #[cfg(feature = "object")]
 impl<T: PolarsObject> NamedFrom<&[T], &[T]> for ObjectChunked<T> {
     fn new(name: &str, v: &[T]) -> Self {
@@ -213,5 +347,31 @@ impl<T: PolarsNumericType> ChunkedArray<T> {
     /// prefer this over ChunkedArray::new when you have a `Vec<T::Native>` and no null values.
     pub fn new_vec(name: &str, v: Vec<T::Native>) -> Self {
         ChunkedArray::from_vec(name, v)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(all(
+        feature = "dtype-datetime",
+        feature = "dtype-duration",
+        feature = "dtype-date",
+        feature = "dtype-time"
+    ))]
+    #[test]
+    fn test_temporal_df_construction() {
+        // check if we can construct.
+        let _df = df![
+            "date" => [NaiveDate::from_ymd(2021, 1, 1)],
+            "datetime" => [NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0)],
+            "optional_date" => [Some(NaiveDate::from_ymd(2021, 1, 1))],
+            "optional_datetime" => [Some(NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0))],
+            "time" => [NaiveTime::from_hms(23, 23, 23)],
+            "optional_time" => [Some(NaiveTime::from_hms(23, 23, 23))],
+            "duration" => [ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap()],
+            "optional_duration" => [Some(ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap())],
+        ].unwrap();
     }
 }


### PR DESCRIPTION
closes #2569

Allows for the following rust macro:

```rust
        let df = df![
            "date" => [NaiveDate::from_ymd(2021, 1, 1)],
            "datetime" => [NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0)],
            "optional_date" => [Some(NaiveDate::from_ymd(2021, 1, 1))],
            "optional_datetime" => [Some(NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0))],
            "time" => [NaiveTime::from_hms(23, 23, 23)],
            "optional_time" => [Some(NaiveTime::from_hms(23, 23, 23))],
            "duration" => [ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap()],
            "optional_duration" => [Some(ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap())],
        ].unwrap();
```