### PR TITLE
Row count in csv parser

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -312,6 +312,17 @@ impl DataFrame {
         DataFrame::new(columns)
     }
 
+    /// Add a row count in place.
+    pub fn with_row_count_mut(&mut self, name: &str, offset: Option<u32>) -> &mut Self {
+        let offset = offset.unwrap_or(0);
+        self.columns.insert(
+            0,
+            UInt32Chunked::from_vec(name, (offset..(self.height() as u32) + offset).collect())
+                .into_series(),
+        );
+        self
+    }
+
     /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the `Series`.
     ///
     /// It is advised to use [Series::new](Series::new) in favor of this method.

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -308,7 +308,7 @@ impl DataFrame {
                 .into_series(),
         );
 
-        self.columns.iter().for_each(|s| columns.push(s.clone()));
+        columns.extend_from_slice(&self.columns);
         DataFrame::new(columns)
     }
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -246,12 +246,8 @@ where
     }
 
     /// Add a `row_count` column.
-    pub fn with_row_count(mut self, name: Option<&str>, offset: u32) -> Self {
-        let rc = RowCount {
-            name: name.unwrap_or("row_count").to_string(),
-            offset,
-        };
-        self.row_count = Some(rc);
+    pub fn with_row_count(mut self, rc: Option<RowCount>) -> Self {
+        self.row_count = rc;
         self
     }
 
@@ -453,7 +449,7 @@ where
             schema_overwrite: None,
             dtype_overwrite: None,
             sample_size: 1024,
-            chunk_size: 1 << 16,
+            chunk_size: 1 << 18,
             low_memory: false,
             comment_char: None,
             null_values: None,
@@ -643,6 +639,7 @@ fn parse_dates(df: DataFrame, fixed_schema: &Schema) -> DataFrame {
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
+    use crate::RowCount;
     use polars_core::datatypes::AnyValue;
     use polars_core::prelude::*;
     use std::io::Cursor;
@@ -1519,7 +1516,10 @@ foo,bar
     #[test]
     fn test_with_row_count() -> Result<()> {
         let df = CsvReader::from_path(FOODS_CSV)?
-            .with_row_count(Some("rc"), 0)
+            .with_row_count(Some(RowCount {
+                name: "rc".into(),
+                offset: 0,
+            }))
             .finish()?;
         let rc = df.column("rc")?;
         assert_eq!(
@@ -1527,7 +1527,10 @@ foo,bar
             (0u32..27).collect::<Vec<_>>()
         );
         let df = CsvReader::from_path(FOODS_CSV)?
-            .with_row_count(Some("rc_2"), 10)
+            .with_row_count(Some(RowCount {
+                name: "rc_2".into(),
+                offset: 10,
+            }))
             .finish()?;
         let rc = df.column("rc_2")?;
         assert_eq!(

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -23,6 +23,7 @@ pub mod ipc;
 pub mod json;
 #[cfg(any(feature = "csv-file", feature = "parquet"))]
 pub mod mmap;
+mod options;
 #[cfg(feature = "parquet")]
 #[cfg_attr(docsrs, doc(cfg(feature = "feature")))]
 pub mod parquet;
@@ -34,6 +35,8 @@ pub mod prelude;
 #[cfg(all(test, feature = "csv-file"))]
 mod tests;
 pub(crate) mod utils;
+
+pub use options::*;
 
 use arrow::error::Result as ArrowResult;
 

--- a/polars/polars-io/src/options.rs
+++ b/polars/polars-io/src/options.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug)]
+pub struct RowCount {
+    pub name: String,
+    pub offset: u32,
+}

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -1,6 +1,5 @@
 #[cfg(any(feature = "ipc", feature = "parquet"))]
 use crate::ArrowSchema;
-use crate::RowCount;
 use dirs::home_dir;
 use polars_core::frame::DataFrame;
 use std::path::{Path, PathBuf};
@@ -33,7 +32,9 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, u32)]) {
     if !dfs.is_empty() {
         let mut previous = dfs[0].1;
         for (df, n_read) in &mut dfs[1..] {
-            df.get_columns_mut().get_mut(0).map(|s| *s = &*s + previous);
+            if let Some(s) = df.get_columns_mut().get_mut(0) {
+                *s = &*s + previous;
+            }
             previous = *n_read;
         }
     }

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -4,6 +4,7 @@ use polars_core::prelude::*;
 use polars_io::csv::{CsvEncoding, NullValues};
 use polars_io::csv_core::utils::get_reader_bytes;
 use polars_io::csv_core::utils::infer_file_schema;
+use polars_io::RowCount;
 
 #[derive(Clone)]
 #[cfg(feature = "csv-file")]
@@ -25,6 +26,7 @@ pub struct LazyCsvReader<'a> {
     rechunk: bool,
     skip_rows_after_header: usize,
     encoding: CsvEncoding,
+    row_count: Option<RowCount>,
 }
 
 #[cfg(feature = "csv-file")]
@@ -49,6 +51,7 @@ impl<'a> LazyCsvReader<'a> {
             rechunk: true,
             skip_rows_after_header: 0,
             encoding: CsvEncoding::Utf8,
+            row_count: None,
         }
     }
 
@@ -56,6 +59,13 @@ impl<'a> LazyCsvReader<'a> {
     #[must_use]
     pub fn with_skip_rows_after_header(mut self, offset: usize) -> Self {
         self.skip_rows_after_header = offset;
+        self
+    }
+
+    /// Add a `row_count` column.
+    #[must_use]
+    pub fn with_row_count(mut self, rc: Option<RowCount>) -> Self {
+        self.row_count = rc;
         self
     }
 
@@ -213,6 +223,7 @@ impl<'a> LazyCsvReader<'a> {
             self.rechunk,
             self.skip_rows_after_header,
             self.encoding,
+            self.row_count,
         )?
         .build()
         .into();

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -11,6 +11,7 @@ use polars_io::csv_core::utils::infer_file_schema;
 use polars_io::ipc::IpcReader;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::ParquetReader;
+use polars_io::RowCount;
 #[cfg(feature = "csv-file")]
 use polars_io::{
     csv::NullValues,
@@ -103,6 +104,7 @@ impl LogicalPlanBuilder {
         rechunk: bool,
         skip_rows_after_header: usize,
         encoding: CsvEncoding,
+        row_count: Option<RowCount>,
     ) -> Result<Self> {
         let path = path.into();
         let mut file = std::fs::File::open(&path)?;
@@ -149,6 +151,7 @@ impl LogicalPlanBuilder {
                 null_values,
                 rechunk,
                 encoding,
+                row_count,
             },
             predicate: None,
             aggregate: vec![],

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::csv::{CsvEncoding, NullValues};
+use polars_io::RowCount;
 
 #[derive(Clone, Debug)]
 pub struct CsvParserOptions {
@@ -17,6 +18,7 @@ pub struct CsvParserOptions {
     pub(crate) null_values: Option<NullValues>,
     pub(crate) rechunk: bool,
     pub(crate) encoding: CsvEncoding,
+    pub(crate) row_count: Option<RowCount>,
 }
 #[cfg(feature = "parquet")]
 #[derive(Clone, Debug)]

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -232,6 +232,7 @@ impl Executor for CsvExec {
             .with_quote_char(self.options.quote_char)
             .with_encoding(self.options.encoding)
             .with_rechunk(self.options.rechunk)
+            .with_row_count(std::mem::take(&mut self.options.row_count))
             .finish()?;
 
         if self.options.cache {

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -389,83 +389,11 @@ class DataFrame:
         low_memory: bool = False,
         rechunk: bool = True,
         skip_rows_after_header: int = 0,
+        row_count_name: Optional[str] = None,
+        row_count_offset: int = 0,
     ) -> "DataFrame":
         """
-        Read a CSV file into a Dataframe.
-
-        Parameters
-        ----------
-        file
-            Path to a file or file like object.
-        has_header
-            Indicate if the first row of dataset is a header or not.
-            If set to False, column names will be autogenrated in the
-            following format: ``column_x``, with ``x`` being an
-            enumeration over every column in the dataset starting at 1.
-        columns
-            Columns to select. Accepts a list of column indices (starting
-            at zero) or a list of column names.
-        sep
-            Character to use as delimiter in the file.
-        comment_char
-            Character that indicates the start of a comment line, for
-            instance ``#``.
-        quote_char
-            Single byte character used for csv quoting, default = ''.
-            Set to None to turn off special handling and escaping of quotes.
-        skip_rows
-            Start reading after ``skip_rows`` lines. The header is also inferred at
-            this offset
-        dtypes
-            Overwrite dtypes during inference.
-        null_values
-            Values to interpret as null values. You can provide a:
-              - ``str``: All values equal to this string will be null.
-              - ``List[str]``: A null value per column.
-              - ``Dict[str, str]``: A dictionary that maps column name to a
-                                    null value string.
-        ignore_errors
-            Try to keep reading lines if some lines yield errors.
-            First try ``infer_schema_length=0`` to read all columns as
-            ``pl.Utf8`` to check which values might cause an issue.
-        parse_dates
-            Try to automatically parse dates. If this does not succeed,
-            the column remains of data type ``pl.Utf8``.
-        n_threads
-            Number of threads to use in csv parsing.
-            Defaults to the number of physical cpu's of your system.
-        infer_schema_length
-            Maximum number of lines to read to infer schema.
-            If set to 0, all columns will be read as ``pl.Utf8``.
-            If set to ``None``, a full table scan will be done (slow).
-        batch_size
-            Number of lines to read into the buffer at once.
-            Modify this to change performance.
-        n_rows
-            Stop reading from CSV file after reading ``n_rows``.
-            During multi-threaded parsing, an upper bound of ``n_rows``
-            rows cannot be guaranteed.
-        encoding
-            Allowed encodings: ``utf8`` or ``utf8-lossy``.
-            Lossy means that invalid utf8 values are replaced with ``�``
-            characters.
-        low_memory
-            Reduce memory usage at expense of performance.
-        rechunk
-            Make sure that all columns are contiguous in memory by
-            aggregating the chunks into a single array.
-        skip_rows_after_header
-            These number of rows will be skipped when the header is parsed.
-
-        Returns
-        -------
-        DataFrame
-
-        Examples
-        --------
-
-        >>> df = pl.read_csv("file.csv", sep=";", n_rows=25)  # doctest: +SKIP
-
+        see pl.read_csv
         """
         self = DataFrame.__new__(DataFrame)
 
@@ -518,6 +446,8 @@ class DataFrame:
                 low_memory=low_memory,
                 rechunk=rechunk,
                 skip_rows_after_header=skip_rows_after_header,
+                row_count_name=row_count_name,
+                row_count_offset=row_count_offset,
             )
             if columns is None:
                 return scan.collect()
@@ -529,6 +459,12 @@ class DataFrame:
                 )
 
         projection, columns = handle_projection_columns(columns)
+
+        row_count: Optional[Tuple[str, int]]
+        if row_count_name is not None:
+            row_count = (row_count_name, row_count_offset)
+        else:
+            row_count = None
 
         self._df = PyDataFrame.read_csv(
             file,
@@ -553,6 +489,7 @@ class DataFrame:
             processed_null_values,
             parse_dates,
             skip_rows_after_header,
+            row_count,
         )
         return self
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -74,6 +74,8 @@ class LazyFrame:
         low_memory: bool = False,
         rechunk: bool = True,
         skip_rows_after_header: int = 0,
+        row_count_name: Optional[str] = None,
+        row_count_offset: int = 0,
     ) -> "LazyFrame":
         """
         See Also: `pl.scan_csv`
@@ -84,6 +86,12 @@ class LazyFrame:
             for k, v in dtypes.items():
                 dtype_list.append((k, py_type_to_dtype(v)))
         processed_null_values = _process_null_values(null_values)
+
+        row_count: Optional[Tuple[str, int]]
+        if row_count_name is not None:
+            row_count = (row_count_name, row_count_offset)
+        else:
+            row_count = None
 
         self = LazyFrame.__new__(LazyFrame)
         self._ldf = PyLazyFrame.new_from_csv(
@@ -104,6 +112,7 @@ class LazyFrame:
             rechunk,
             skip_rows_after_header,
             encoding,
+            row_count,
         )
         return self
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -159,6 +159,8 @@ def read_csv(
     use_pyarrow: bool = False,
     storage_options: Optional[Dict] = None,
     skip_rows_after_header: int = 0,
+    row_count_name: Optional[str] = None,
+    row_count_offset: int = 0,
     **kwargs: Any,
 ) -> DataFrame:
     """
@@ -245,6 +247,10 @@ def read_csv(
         e.g. host, port, username, password, etc.
     skip_rows_after_header
         Skip these number of rows when the header is parsed
+    row_count_name
+        If not None, this will insert a row count column with give name into the DataFrame
+    row_count_offset
+        Offset to start the row_count column (only use if the name is set)
 
     Returns
     -------
@@ -407,6 +413,8 @@ def read_csv(
             low_memory=low_memory,
             rechunk=rechunk,
             skip_rows_after_header=skip_rows_after_header,
+            row_count_name=row_count_name,
+            row_count_offset=row_count_offset,
         )
 
     if new_columns:
@@ -432,6 +440,8 @@ def scan_csv(
     low_memory: bool = False,
     rechunk: bool = True,
     skip_rows_after_header: int = 0,
+    row_count_name: Optional[str] = None,
+    row_count_offset: int = 0,
     **kwargs: Any,
 ) -> LazyFrame:
     """
@@ -494,6 +504,10 @@ def scan_csv(
         Reallocate to contiguous memory when all chunks/ files are parsed.
     skip_rows_after_header
         Skip these number of rows when the header is parsed
+    row_count_name
+        If not None, this will insert a row count column with give name into the DataFrame
+    row_count_offset
+        Offset to start the row_count column (only use if the name is set)
 
     Examples
     --------
@@ -561,6 +575,8 @@ def scan_csv(
         rechunk=rechunk,
         skip_rows_after_header=skip_rows_after_header,
         encoding=encoding,
+        row_count_name=row_count_name,
+        row_count_offset=row_count_offset,
     )
 
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -21,6 +21,7 @@ use crate::{
     series::{to_pyseries_collection, to_series_collection, PySeries},
 };
 use polars::frame::row::{rows_to_schema, Row};
+use polars::io::RowCount;
 use polars_core::export::arrow::datatypes::IntegerType;
 use polars_core::frame::groupby::PivotAgg;
 use polars_core::frame::ArrowChunk;
@@ -103,9 +104,12 @@ impl PyDataFrame {
         null_values: Option<Wrap<NullValues>>,
         parse_dates: bool,
         skip_rows_after_header: usize,
+        row_count: Option<(String, u32)>,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let comment_char = comment_char.map(|s| s.as_bytes()[0]);
+
+        let row_count = row_count.map(|(name, offset)| RowCount { name, offset });
 
         let quote_char = if let Some(s) = quote_char {
             if s.is_empty() {
@@ -171,6 +175,7 @@ impl PyDataFrame {
             .with_parse_dates(parse_dates)
             .with_quote_char(quote_char)
             .with_skip_rows_after_header(skip_rows_after_header)
+            .with_row_count(row_count)
             .finish()
             .map_err(PyPolarsEr::from)?;
         Ok(df.into())

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -591,3 +591,22 @@ def test_from_different_chunks() -> None:
     out = df.to_pandas()
     assert list(out.columns) == ["a", "b"]
     assert out.shape == (5, 2)
+
+
+def test_row_count(foods_csv: str) -> None:
+    df = pl.read_csv(foods_csv, row_count_name="row_count")
+    assert df["row_count"].to_list() == list(range(27))
+    df = (
+        pl.scan_csv(foods_csv, row_count_name="row_count")
+        .filter(pl.col("category") == pl.lit("vegetables"))
+        .collect()
+    )
+    assert df["row_count"].to_list() == [0, 6, 11, 13, 14, 20, 25]
+    # make sure that row count is correct even though predicate is pushed down
+    df = (
+        pl.scan_csv(foods_csv)
+        .with_row_count("foo", 10)
+        .filter(pl.col("category") == pl.lit("vegetables"))
+        .collect()
+    )
+    assert df["foo"].to_list() == [10, 16, 21, 23, 24, 30, 35]


### PR DESCRIPTION
This adds a row_count argument to the csv parsers. 

If polars lazy finds a query in this form:

```python
    df = (
        pl.scan_csv(foods_csv)
        .with_row_count("row_count", 10)
        .filter(pl.col("category") == pl.lit("vegetables"))
        .collect()
    )
```

It will rewrite it to:

```python
   df = (
        pl.scan_csv(foods_csv, row_count_name="row_count")
        .filter(pl.col("category") == pl.lit("vegetables"))
        .collect()
    )
```

So that predicate pushdown does not have to be blocked. 

#2576 