### PR TITLE
don't rename aggregations

### DIFF
--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -287,7 +287,7 @@ mod test {
             .agg([col("sepal.width").min()])
             .logical_plan;
         println!("{:#?}", lp.schema().fields());
-        assert!(lp.schema().field_with_name("sepal.width_min").is_ok());
+        assert!(lp.schema().field_with_name("sepal.width").is_ok());
     }
 
     #[test]

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -31,7 +31,7 @@ fn test_agg_unique_first() -> Result<()> {
         .lazy()
         .groupby_stable([col("g")])
         .agg([
-            col("v").unique().first(),
+            col("v").unique().first().alias("v_first"),
             col("v").unique().sort(false).first().alias("true_first"),
             col("v").unique().list(),
         ])

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -118,10 +118,6 @@ pub(crate) fn expr_output_name(expr: &Expr) -> Result<Arc<str>> {
     ))
 }
 
-pub(crate) fn rename_field(field: &Field, name: &str) -> Field {
-    Field::new(name, field.data_type().clone())
-}
-
 /// This function should be used to find the name of the start of an expression
 /// Normal iteration would just return the first root column it found
 pub(crate) fn get_single_root(expr: &Expr) -> Result<Arc<str>> {

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -2587,7 +2587,10 @@ class DataFrame:
 
         >>> (
         ...     df.groupby_dynamic("time", every="1h").agg(
-        ...         [pl.col("time").min(), pl.col("time").max()]
+        ...         [
+        ...             pl.col("time").min().alias("time_min"),
+        ...             pl.col("time").max().alias("time_max"),
+        ...         ]
         ...     )
         ... )
         shape: (3, 3)
@@ -2607,7 +2610,7 @@ class DataFrame:
 
         >>> (
         ...     df.groupby_dynamic("time", every="1h", include_boundaries=True).agg(
-        ...         [pl.col("time").count()]
+        ...         [pl.col("time").count().alias("time_count")]
         ...     )
         ... )
         shape: (3, 4)
@@ -2627,7 +2630,10 @@ class DataFrame:
 
         >>> (
         ...     df.groupby_dynamic("time", every="1h", closed="left").agg(
-        ...         [pl.col("time").count(), pl.col("time").list()]
+        ...         [
+        ...             pl.col("time").count().alias("time_count"),
+        ...             pl.col("time").list().alias("time_agg_list"),
+        ...         ]
         ...     )
         ... )
         shape: (4, 3)
@@ -2649,7 +2655,7 @@ class DataFrame:
 
         >>> (
         ...     df.groupby_dynamic("time", every="1h", closed="both").agg(
-        ...         [pl.col("time").count()]
+        ...         [pl.col("time").count().alias("time_count")]
         ...     )
         ... )
         shape: (4, 2)
@@ -2707,7 +2713,7 @@ class DataFrame:
         ...         closed="both",
         ...         by="groups",
         ...         include_boundaries=True,
-        ...     ).agg([pl.col("time").count()])
+        ...     ).agg([pl.col("time").count().alias("time_count")])
         ... )
         shape: (6, 5)
         ┌────────┬─────────────────────┬─────────────────────┬─────────────────────┬────────────┐
@@ -2742,7 +2748,7 @@ class DataFrame:
         ...         every="2i",
         ...         period="3i",
         ...         include_boundaries=True,
-        ...     ).agg(pl.col("A").list())
+        ...     ).agg(pl.col("A").list().alias("A_agg_list"))
         ... )
 
         shape: (3, 4)

--- a/py-polars/tests/db-benchmark/main.py
+++ b/py-polars/tests/db-benchmark/main.py
@@ -82,7 +82,7 @@ out = (
     x.groupby("id6")
     .agg(
         [
-            pl.sum("v1").alias("v1_mean"),
+            pl.sum("v1").alias("v1_sum"),
             pl.sum("v2").alias("v2_sum"),
             pl.sum("v3").alias("v3_sum"),
         ]
@@ -175,7 +175,7 @@ t0 = time.time()
 print("q3")
 out = (
     x.groupby("id3")
-    .agg([pl.sum("v1".alias("v1_sum")), pl.mean("v3").alias("v3_mean")])
+    .agg([pl.sum("v1").alias("v1_sum"), pl.mean("v3").alias("v3_mean")])
     .collect()
 )
 print(time.time() - t0)
@@ -190,7 +190,7 @@ out = (
     .agg(
         [
             pl.mean("v1").alias("v1_mean"),
-            pl.mean("v2".alias("v2_mean")),
+            pl.mean("v2").alias("v2_mean"),
             pl.mean("v3").alias("v3_mean"),
         ]
     )
@@ -208,7 +208,7 @@ out = (
     x.groupby("id6")
     .agg(
         [
-            pl.sum("v1".alias("v1_sum")),
+            pl.sum("v1").alias("v1_sum"),
             pl.sum("v2").alias("v2_sum"),
             pl.sum("v3").alias("v3_sum"),
         ]

--- a/py-polars/tests/db-benchmark/main.py
+++ b/py-polars/tests/db-benchmark/main.py
@@ -32,7 +32,7 @@ x = df.lazy()
 t00 = time.time()
 t0 = time.time()
 print("q1")
-out = x.groupby("id1").agg(pl.sum("v1")).collect()
+out = x.groupby("id1").agg(pl.sum("v1").alias("v1_sum")).collect()
 print(time.time() - t0)
 print("out.shape", out.shape)
 print('out["v1_sum"].sum()', out["v1_sum"].sum())
@@ -40,14 +40,18 @@ print('out["v1_sum"].sum()', out["v1_sum"].sum())
 t0easy = time.time()
 t0 = time.time()
 print("q2")
-out = x.groupby(["id1", "id2"]).agg(pl.sum("v1")).collect()
+out = x.groupby(["id1", "id2"]).agg(pl.sum("v1").alias("v1_sum")).collect()
 print(time.time() - t0)
 print("out.shape", out.shape)
 print('out["v1_sum"].sum()', out["v1_sum"].sum())
 
 t0 = time.time()
 print("q3")
-out = x.groupby("id3").agg([pl.sum("v1"), pl.mean("v3")]).collect()
+out = (
+    x.groupby("id3")
+    .agg([pl.sum("v1").alias("v1_sum"), pl.mean("v3").alias("v3_mean")])
+    .collect()
+)
 print(time.time() - t0)
 print("out.shape", out.shape)
 print('out["v1_sum"].sum()', out["v1_sum"].sum())
@@ -55,7 +59,17 @@ print('out["v3_mean"].sum()', out["v3_mean"].sum())
 
 t0 = time.time()
 print("q4")
-out = x.groupby("id4").agg([pl.mean("v1"), pl.mean("v2"), pl.mean("v3")]).collect()
+out = (
+    x.groupby("id4")
+    .agg(
+        [
+            pl.mean("v1").alias("v1_mean"),
+            pl.mean("v2").alias("v2_mean"),
+            pl.mean("v3").alias("v3_mean"),
+        ]
+    )
+    .collect()
+)
 print(time.time() - t0)
 print("out.shape", out.shape)
 print('out["v1_mean"].sum()', out["v1_mean"].sum())
@@ -64,7 +78,17 @@ print('out["v3_mean"].sum()', out["v3_mean"].sum())
 
 t0 = time.time()
 print("q5")
-out = x.groupby("id6").agg([pl.sum("v1"), pl.sum("v2"), pl.sum("v3")]).collect()
+out = (
+    x.groupby("id6")
+    .agg(
+        [
+            pl.sum("v1").alias("v1_mean"),
+            pl.sum("v2").alias("v2_sum"),
+            pl.sum("v3").alias("v3_sum"),
+        ]
+    )
+    .collect()
+)
 print(time.time() - t0)
 print("out.shape", out.shape)
 print('out["v1_sum"].sum()', out["v1_sum"].sum())
@@ -134,7 +158,7 @@ print("total took:", time.time() - t00, "s")
 t00 = time.time()
 t0 = time.time()
 print("q1")
-out = x.groupby("id1").agg(pl.sum("v1")).collect()
+out = x.groupby("id1").agg(pl.sum("v1").alias("v1_sum")).collect()
 print(time.time() - t0)
 assert out.shape == (96, 2)
 assert out["v1_sum"].sum() == 28501451
@@ -142,14 +166,18 @@ assert out["v1_sum"].sum() == 28501451
 t0easy = time.time()
 t0 = time.time()
 print("q2")
-out = x.groupby(["id1", "id2"]).agg(pl.sum("v1")).collect()
+out = x.groupby(["id1", "id2"]).agg(pl.sum("v1").alias("v1_sum")).collect()
 print(time.time() - t0)
 assert out.shape == (9216, 3)
 assert out["v1_sum"].sum() == 28501451
 
 t0 = time.time()
 print("q3")
-out = x.groupby("id3").agg([pl.sum("v1"), pl.mean("v3")]).collect()
+out = (
+    x.groupby("id3")
+    .agg([pl.sum("v1".alias("v1_sum")), pl.mean("v3").alias("v3_mean")])
+    .collect()
+)
 print(time.time() - t0)
 assert out.shape == (95001, 3)
 assert out["v1_sum"].sum() == 28501451
@@ -157,7 +185,17 @@ assert np.isclose(out["v3_mean"].sum(), 4751358.825104358)
 
 t0 = time.time()
 print("q4")
-out = x.groupby("id4").agg([pl.mean("v1"), pl.mean("v2"), pl.mean("v3")]).collect()
+out = (
+    x.groupby("id4")
+    .agg(
+        [
+            pl.mean("v1").alias("v1_mean"),
+            pl.mean("v2".alias("v2_mean")),
+            pl.mean("v3").alias("v3_mean"),
+        ]
+    )
+    .collect()
+)
 print(time.time() - t0)
 assert out.shape == (96, 4)
 assert np.isclose(out["v1_mean"].sum(), 288.0192364601018)
@@ -166,7 +204,17 @@ assert np.isclose(out["v3_mean"].sum(), 4801.784316931509)
 
 t0 = time.time()
 print("q5")
-out = x.groupby("id6").agg([pl.sum("v1"), pl.sum("v2"), pl.sum("v3")]).collect()
+out = (
+    x.groupby("id6")
+    .agg(
+        [
+            pl.sum("v1".alias("v1_sum")),
+            pl.sum("v2").alias("v2_sum"),
+            pl.sum("v3").alias("v3_sum"),
+        ]
+    )
+    .collect()
+)
 print(time.time() - t0)
 assert out.shape == (95001, 4)
 assert out["v1_sum"].sum() == 28501451
@@ -189,7 +237,15 @@ assert np.isclose(out["v3_std"].sum(), 266052.20492321637)
 t0 = time.time()
 print("q7")
 out = (
-    x.groupby("id3").agg([(pl.max("v1") - pl.min("v2")).alias("range_v1_v2")]).collect()
+    x.groupby("id3")
+    .agg(
+        [
+            (pl.max("v1").alias("v1_max") - pl.min("v2").alias("v2_mean")).alias(
+                "range_v1_v2"
+            )
+        ]
+    )
+    .collect()
 )
 print(time.time() - t0)
 assert out.shape == (95001, 2)

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1457,7 +1457,7 @@ def test_groupby_agg_n_unique_floats() -> None:
         out = df.groupby("a", maintain_order=True).agg(
             [pl.col("b").cast(dtype).n_unique()]
         )
-        assert out["b_n_unique"].to_list() == [2, 1]
+        assert out["b"].to_list() == [2, 1]
 
 
 def test_select_by_dtype(df: pl.DataFrame) -> None:
@@ -1583,7 +1583,7 @@ def test_groupby_order_dispatch() -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
     expected = pl.DataFrame({"x": ["b", "a"], "count": [2, 1]})
     assert df.groupby("x", maintain_order=True).count().frame_equal(expected)
-    expected = pl.DataFrame({"x": ["b", "a"], "y_agg_list": [[0, 2], [1]]})
+    expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})
     assert df.groupby("x", maintain_order=True).agg_list().frame_equal(expected)
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -149,7 +149,7 @@ def test_apply_custom_function() -> None:
             [
                 pl.col("cars").apply(lambda groups: groups.len()).alias("custom_1"),
                 pl.col("cars").apply(lambda groups: groups.len()).alias("custom_2"),
-                pl.count("cars"),
+                pl.count("cars").alias("cars_count"),
             ]
         )
         .sort("custom_1", reverse=True)
@@ -169,7 +169,7 @@ def test_apply_custom_function() -> None:
 def test_groupby() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
 
-    expected = pl.DataFrame({"groups": ["a", "b"], "a_mean": [1.0, 3.5]})
+    expected = pl.DataFrame({"groups": ["a", "b"], "a": [1.0, 3.5]})
 
     out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
     assert out.sort(by="groups").frame_equal(expected)


### PR DESCRIPTION
This removes the automatic aggregations renaming in python polars and polars lazy. I don't like it, it is not really clear what the schema will be if you don't know the renaming mapping.

This may break some code. Bit is easily fixed by adding an explicit `alias(..)` to give your columns a proper name. The default name will be the same as the column you aggregate on.

And other expressions that are your friends in case of duplicates:

* `prefix`
* `suffix`
* `keep_name`