### PR TITLE
New window expression rules

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort.rs
@@ -100,6 +100,20 @@ fn sort_branch<T, Fd, Fr>(
     }
 }
 
+#[cfg(feature = "private")]
+pub fn argsort_no_nulls<Idx, T>(slice: &mut [(Idx, T)], reverse: bool)
+where
+    T: PartialOrd + Send,
+    Idx: PartialOrd + Send,
+{
+    argsort_branch(
+        slice,
+        reverse,
+        |(_, a), (_, b)| order_default(a, b),
+        |(_, a), (_, b)| order_reverse(a, b),
+    );
+}
+
 fn argsort_branch<T, Fd, Fr>(
     slice: &mut [T],
     reverse: bool,
@@ -304,12 +318,7 @@ where
                 vals.extend_trusted_len(iter);
             });
 
-            argsort_branch(
-                vals.as_mut_slice(),
-                reverse,
-                |(_, a), (_, b)| order_default(a, b),
-                |(_, a), (_, b)| order_reverse(a, b),
-            );
+            argsort_no_nulls(vals.as_mut_slice(), reverse);
 
             let ca: NoNull<UInt32Chunked> = vals.into_iter().map(|(idx, _v)| idx).collect_trusted();
             let mut ca = ca.into_inner();

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -11,6 +11,9 @@ use rayon::prelude::*;
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
+#[cfg(feature = "private")]
+pub use crate::chunked_array::ops::sort::argsort_no_nulls;
+
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);
 

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -186,6 +186,8 @@
 //! }
 //! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
+extern crate core;
+
 #[cfg(all(feature = "dot_diagram", feature = "compile"))]
 mod dot;
 #[cfg(feature = "compile")]

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -287,7 +287,7 @@ mod test {
             .agg([col("sepal.width").min()])
             .logical_plan;
         println!("{:#?}", lp.schema().fields());
-        assert!(lp.schema().field_with_name("sepal.width_min").is_ok());
+        assert!(lp.schema().field_with_name("sepal.width").is_ok());
     }
 
     #[test]

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use polars_core::frame::groupby::{GroupBy, GroupsProxy};
 use polars_core::frame::hash_join::private_left_join_multiple_keys;
 use polars_core::prelude::*;
+use polars_core::utils::argsort_no_nulls;
 use std::sync::Arc;
 
 pub struct WindowExpr {
@@ -19,20 +20,83 @@ pub struct WindowExpr {
     pub(crate) expr: Expr,
 }
 
+#[derive(Debug)]
+enum MapStrategy {
+    Join,
+    Explode,
+    Map,
+}
+
 impl WindowExpr {
-    fn run_aggregation(
+    fn run_aggregation<'a>(
         &self,
         df: &DataFrame,
         state: &ExecutionState,
-        gb: &GroupBy,
-    ) -> Result<DataFrame> {
-        let mut acc = self
+        gb: &'a GroupBy,
+    ) -> Result<(DataFrame, AggregationContext<'a>)> {
+        let mut ac = self
             .phys_function
             .evaluate_on_groups(df, gb.get_groups(), state)?;
         let mut cols = gb.keys();
-        let out = acc.aggregated();
+        let out = ac.aggregated();
         cols.push(out);
-        Ok(DataFrame::new_no_checks(cols))
+        Ok((DataFrame::new_no_checks(cols), ac))
+    }
+
+    fn determine_map_strategy(&self, agg_state: &AggState) -> Result<MapStrategy> {
+        // col("foo").list()
+        // col("foo").list().alias()
+        // ..
+        // col("foo").list().alias().alias()
+        //
+        // but not:
+        // col("foo").list().sum().alias()
+        // ..
+        // col("foo").min()
+        let mut explicit_list = false;
+        for e in &self.expr {
+            if let Expr::Window { function, .. } = e {
+                // or list().alias
+                let mut finishes_list = false;
+                for e in &**function {
+                    match e {
+                        Expr::Agg(AggExpr::List(_)) => {
+                            finishes_list = true;
+                        }
+                        Expr::Alias(_, _) => {}
+                        _ => break,
+                    }
+                }
+                explicit_list = finishes_list;
+            }
+        }
+        match (self.options.explode, explicit_list, agg_state) {
+            // Explode
+            // `(col("x").sum() * col("y")).list().over("groups").flatten()`
+            (true, true, _) => Ok(MapStrategy::Explode),
+            // Explode all the aggregated lists. Maybe add later?
+            (true, false, _) => {
+                Err(PolarsError::ComputeError("This operation is likely not what you want. Please open an issue if you really want to do this".into()))
+            }
+            // explicit list
+            // `(col("x").sum() * col("y")).list().over("groups")`
+            (false, true, _) => {
+                Ok(MapStrategy::Join)
+            }
+            // aggregations
+            //`sum("foo").over("groups")`
+            (false, false, AggState::AggregatedFlat(_) | AggState::NotAggregated(_)) => {
+                Ok(MapStrategy::Join)
+            }
+            // no explicit aggregations, map over the groups
+            //`(col("x").sum() * col("y")).over("groups")`
+            (false, false, AggState::AggregatedList(_)) => {
+                Ok(MapStrategy::Map)
+            }
+            (false, false, agg_state) => {
+                panic!("expected aggregation, got {:?}", agg_state)
+            }
+        }
     }
 }
 
@@ -48,6 +112,24 @@ impl PhysicalExpr for WindowExpr {
         // 2. apply an aggregation function
         // 3. join the results back to the original dataframe
         //    this stores all group values on the original df size
+        //
+        //      we have several strategies for this
+        //      - 3.1 JOIN
+        //          Use a join for aggregations like
+        //              `sum("foo").over("groups")`
+        //          and explicit `list` aggregations
+        //              `(col("x").sum() * col("y")).list().over("groups")`
+        //
+        //      - 3.2 EXPLODE
+        //          Explicit list aggregations that are followed by `over().flatten()`
+        //          # the fastest method to do things over groups when the groups are sorted
+        //          # note that it will require an excit `list()` call from now on.
+        //              `(col("x").sum() * col("y")).list().over("groups").flatten()`
+        //
+        //      - 3.3. MAP to original locations
+        //          This will be done for list aggregation that are not excitly aggregated as list
+        //              `(col("x").sum() * col("y")).over("groups")`
+
         // 4. select the final column and return
         let groupby_columns = self
             .group_by
@@ -89,72 +171,150 @@ impl PhysicalExpr for WindowExpr {
             .iter()
             .map(|s| s.as_ref().to_string())
             .collect();
-        let mut gb = GroupBy::new(df, groupby_columns.clone(), groups, Some(apply_columns));
+        let gb = GroupBy::new(df, groupby_columns.clone(), groups, Some(apply_columns));
 
-        let out = self.run_aggregation(df, state, &gb)?;
-
-        if state.cache_window {
-            let groups = std::mem::take(gb.get_groups_mut());
-            let mut gt_map = state.group_tuples.lock().unwrap();
-            gt_map.insert(cache_key.clone(), groups);
-        } else {
-            // drop the group tuples before we do the left join to reduce allocated memory.
-            drop(gb);
-        }
+        let (out, mut ac) = self.run_aggregation(df, state, &gb)?;
 
         // 3. get the join tuples and use them to take the new Series
         let out_column = out.select_at_idx(out.width() - 1).unwrap();
-        if self.options.explode {
-            let mut out = out_column.clone();
-            if let Some(name) = &self.out_name {
-                out.rename(name.as_ref());
-            }
-            return Ok(out);
-        }
 
-        let get_join_tuples = || {
-            if groupby_columns.len() == 1 {
-                // group key from right column
-                let right = out.select_at_idx(0).unwrap();
-                groupby_columns[0].hash_join_left(right)
+        let cache_gb = |mut gb: GroupBy| {
+            if state.cache_window {
+                let groups = std::mem::take(gb.get_groups_mut());
+                let mut gt_map = state.group_tuples.lock().unwrap();
+                gt_map.insert(cache_key.clone(), groups);
             } else {
-                let df_right =
-                    DataFrame::new_no_checks(out.get_columns()[..out.width() - 1].to_vec());
-                let df_left = DataFrame::new_no_checks(groupby_columns);
-                private_left_join_multiple_keys(&df_left, &df_right)
+                // drop the group tuples to reduce allocated memory.
+                drop(gb);
             }
         };
 
-        // try to get cached join_tuples
-        let opt_join_tuples = if state.cache_window {
-            let mut jt_map = state.join_tuples.lock().unwrap();
-            // we run sequential and partitioned
-            // and every partition run the cache should be empty so we expect a max of 1.
-            debug_assert!(jt_map.len() <= 1);
-            if let Some(opt_join_tuples) = jt_map.get_mut(&cache_key) {
-                std::mem::take(opt_join_tuples)
-            } else {
-                get_join_tuples()
+        use MapStrategy::*;
+        match self.determine_map_strategy(ac.agg_state())? {
+            Explode => {
+                cache_gb(gb);
+                let mut out = out_column.clone();
+                if let Some(name) = &self.out_name {
+                    out.rename(name.as_ref());
+                }
+                Ok(out)
             }
-        } else {
-            get_join_tuples()
-        };
+            Map => {
+                // we use an argsort to map the values back
 
-        let mut iter = opt_join_tuples
-            .iter()
-            .map(|(_left, right)| right.map(|i| i as usize));
+                // This is a bit more complicated because the final group tuples may differ from the original
+                // so we use the original indices as idx values to argsort the original column
+                //
+                // The example below shows the naive version without group tuple mapping
 
-        let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
-        if let Some(name) = &self.out_name {
-            out.rename(name.as_ref());
+                // columns
+                // a
+                // b
+                // a
+                // a
+                //
+                // agg list
+                // [0, 2, 3]
+                // [1]
+                //
+                // flatten
+                //
+                // [0, 2, 3, 1]
+                //
+                // argsort
+                //
+                // [0, 3, 1, 2]
+                //
+                // take by argsorted indexes and voila groups mapped
+                // [0, 1, 2, 3]
+                let mut original_idx = Vec::with_capacity(out_column.len());
+                match gb.get_groups() {
+                    GroupsProxy::Idx(groups) => {
+                        for g in groups.all() {
+                            original_idx.extend_from_slice(g)
+                        }
+                    }
+                    GroupsProxy::Slice(groups) => {
+                        for g in groups {
+                            original_idx.extend(g[0]..g[0] + 1)
+                        }
+                    }
+                };
+
+                let mut original_idx = original_idx.into_iter();
+                let flattened = out_column.explode()?;
+
+                // idx (new-idx, original-idx)
+                let mut idx = Vec::with_capacity(out_column.len());
+                match ac.groups().as_ref() {
+                    GroupsProxy::Idx(groups) => {
+                        for g in groups.all() {
+                            idx.extend(g.iter().copied().zip(&mut original_idx));
+                        }
+                    }
+                    GroupsProxy::Slice(groups) => {
+                        for g in groups {
+                            idx.extend((g[0]..g[0] + g[1]).zip(&mut original_idx));
+                        }
+                    }
+                }
+                cache_gb(gb);
+
+                argsort_no_nulls(&mut idx, false);
+                let out = unsafe {
+                    flattened.take_iter_unchecked(&mut idx.into_iter().map(|(idx, _)| idx as usize))
+                };
+
+                Ok(out)
+            }
+            Join => {
+                cache_gb(gb);
+
+                let get_join_tuples = || {
+                    if groupby_columns.len() == 1 {
+                        // group key from right column
+                        let right = out.select_at_idx(0).unwrap();
+                        groupby_columns[0].hash_join_left(right)
+                    } else {
+                        let df_right =
+                            DataFrame::new_no_checks(out.get_columns()[..out.width() - 1].to_vec());
+                        let df_left = DataFrame::new_no_checks(groupby_columns);
+                        private_left_join_multiple_keys(&df_left, &df_right)
+                    }
+                };
+
+                // try to get cached join_tuples
+                let opt_join_tuples = if state.cache_window {
+                    let mut jt_map = state.join_tuples.lock().unwrap();
+                    // we run sequential and partitioned
+                    // and every partition run the cache should be empty so we expect a max of 1.
+                    debug_assert!(jt_map.len() <= 1);
+                    if let Some(opt_join_tuples) = jt_map.get_mut(&cache_key) {
+                        std::mem::take(opt_join_tuples)
+                    } else {
+                        get_join_tuples()
+                    }
+                } else {
+                    get_join_tuples()
+                };
+
+                let mut iter = opt_join_tuples
+                    .iter()
+                    .map(|(_left, right)| right.map(|i| i as usize));
+
+                let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
+                if let Some(name) = &self.out_name {
+                    out.rename(name.as_ref());
+                }
+
+                if state.cache_window {
+                    let mut jt_map = state.join_tuples.lock().unwrap();
+                    jt_map.insert(cache_key, opt_join_tuples);
+                }
+
+                Ok(out)
+            }
         }
-
-        if state.cache_window {
-            let mut jt_map = state.join_tuples.lock().unwrap();
-            jt_map.insert(cache_key, opt_join_tuples);
-        }
-
-        Ok(out)
     }
 
     fn to_field(&self, input_schema: &Schema) -> Result<Field> {

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -31,7 +31,7 @@ fn test_agg_unique_first() -> Result<()> {
         .lazy()
         .groupby_stable([col("g")])
         .agg([
-            col("v").unique().first(),
+            col("v").unique().first().alias("v_first"),
             col("v").unique().sort(false).first().alias("true_first"),
             col("v").unique().list(),
         ])

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -118,10 +118,6 @@ pub(crate) fn expr_output_name(expr: &Expr) -> Result<Arc<str>> {
     ))
 }
 
-pub(crate) fn rename_field(field: &Field, name: &str) -> Field {
-    Field::new(name, field.data_type().clone())
-}
-
 /// This function should be used to find the name of the start of an expression
 /// Normal iteration would just return the first root column it found
 pub(crate) fn get_single_root(expr: &Expr) -> Result<Arc<str>> {

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -78,7 +78,7 @@ def test_diff_datetime() -> None:
             [
                 pl.col("timestamp").str.strptime(pl.Date, fmt="%Y-%m-%d"),
             ]
-        ).with_columns([pl.col("timestamp").diff().over("char")])
+        ).with_columns([pl.col("timestamp").diff().list().over("char")])
     )["timestamp"]
     assert out[0] == out[1]
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1457,7 +1457,7 @@ def test_groupby_agg_n_unique_floats() -> None:
         out = df.groupby("a", maintain_order=True).agg(
             [pl.col("b").cast(dtype).n_unique()]
         )
-        assert out["b_n_unique"].to_list() == [2, 1]
+        assert out["b"].to_list() == [2, 1]
 
 
 def test_select_by_dtype(df: pl.DataFrame) -> None:
@@ -1583,7 +1583,7 @@ def test_groupby_order_dispatch() -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
     expected = pl.DataFrame({"x": ["b", "a"], "count": [2, 1]})
     assert df.groupby("x", maintain_order=True).count().frame_equal(expected)
-    expected = pl.DataFrame({"x": ["b", "a"], "y_agg_list": [[0, 2], [1]]})
+    expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})
     assert df.groupby("x", maintain_order=True).agg_list().frame_equal(expected)
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -149,7 +149,7 @@ def test_apply_custom_function() -> None:
             [
                 pl.col("cars").apply(lambda groups: groups.len()).alias("custom_1"),
                 pl.col("cars").apply(lambda groups: groups.len()).alias("custom_2"),
-                pl.count("cars"),
+                pl.count("cars").alias("cars_count"),
             ]
         )
         .sort("custom_1", reverse=True)
@@ -169,7 +169,7 @@ def test_apply_custom_function() -> None:
 def test_groupby() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
 
-    expected = pl.DataFrame({"groups": ["a", "b"], "a_mean": [1.0, 3.5]})
+    expected = pl.DataFrame({"groups": ["a", "b"], "a": [1.0, 3.5]})
 
     out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
     assert out.sort(by="groups").frame_equal(expected)

--- a/py-polars/tests/test_window.py
+++ b/py-polars/tests/test_window.py
@@ -68,14 +68,17 @@ def test_window_function_cache() -> None:
     ).with_columns(
         [
             pl.col("values")
+            .list()
             .over("groups")
             .alias("values_list"),  # aggregation to list + join
             pl.col("values")
+            .list()
             .over("groups")
             .flatten()
             .alias("values_flat"),  # aggregation to list + explode and concat back
             pl.col("values")
             .reverse()
+            .list()
             .over("groups")
             .flatten()
             .alias("values_rev"),  # use flatten to reverse within a group


### PR DESCRIPTION
This continues on top of #2603. This changes the window expression rules into the following:

```python
# aggregate and join back (broadcast)
pl.sum("foo").over("groups")

# semantically only sum do over unique groups.
# don't aggregate to a list, as is done currently.
# will need to do the mapping intenally
(pl.col("x").sum() * pl.col("y")).over("groups")

# return a list column
# this is currently default behavior
(pl.col("x").sum() * pl.col("y")).list().over("groups")

# the fastest method to do things over groups when the groups are sorted
# note that it will require an explicit `list()` call from now on.
(pl.col("x").sum() * pl.col("y")).list().over("groups").flatten()
```

So you can think of the `over` expression  as a special case of a `select` context that only works on the groups. Literal values and single value results will be broadcasted to the length of the group (and mapped to the correct position, as group members may be scattered all over the place).

If your `DataFrame` is already sorted by groups, by far the most performant way to use window funcitons is by calling `values.list().over("groups").flatten()`. This seems like more work, (the `list()` call). But internally the `list` is always called and the `flatten` is free. This would save a remap.

@qiemem FYI