### PR TITLE
python polars 0.13.0

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.12.24"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.12.24"
+version = "0.13.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"


### PR DESCRIPTION
Breaking but improved:

- `expression` aggregations don't rename the column
- New rules for `window` expression evalutation:


## Rules
```python
# aggregate and broadcast within a group
# output type: -> Int32
pl.sum("foo").over("groups")

# sum within a group and multiply with group elements
# output type: -> Int32
(pl.col("x").sum() * pl.col("y")).over("groups")

# sum within a group and multiply with group elements 
# and aggregate the group to a list
# output type: -> List(Int32)
(pl.col("x").sum() * pl.col("y")).list().over("groups")

# note that it will require an explicit `list()` call
# sum within a group and multiply with group elements 
# and aggregate the group to a list
# the flatten call explodes that list

# This is the fastest method to do things over groups when the groups are sorted
(pl.col("x").sum() * pl.col("y")).list().over("groups").flatten()
```
 That means that `window` expressions now always map back to the group values. Even if they are scattered all over.
 
 ## Example
```python
pl.Config.set_tbl_width_chars(200)
df = pl.DataFrame({
    "group_a": ["A", "B", "A", "A", "B"],
    "group_b": ["D", "D", "Z", "Z", "D"],
    "values": range(5)
})
print(df)

print(df.select([
    pl.all(),
    pl.col("values").max().over("group_a").alias("aggregation_group_a"),
    pl.col("values").rank().over("group_b").alias("rank_within_group_b"),
    (pl.col("values").rank() + pl.col("values").min() * 10).over("group_a").alias("any_expr_within_group_a"),
]))
```

```
shape: (5, 3)
┌─────────┬─────────┬────────┐
│ group_a ┆ group_b ┆ values │
│ ---     ┆ ---     ┆ ---    │
│ str     ┆ str     ┆ i64    │
╞═════════╪═════════╪════════╡
│ A       ┆ D       ┆ 0      │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤
│ B       ┆ D       ┆ 1      │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤
│ A       ┆ Z       ┆ 2      │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤
│ A       ┆ Z       ┆ 3      │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤
│ B       ┆ D       ┆ 4      │
└─────────┴─────────┴────────┘
shape: (5, 6)
┌─────────┬─────────┬────────┬─────────────────────┬─────────────────────┬─────────────────────────┐
│ group_a ┆ group_b ┆ values ┆ aggregation_group_a ┆ rank_within_group_b ┆ any_expr_within_group_a │
│ ---     ┆ ---     ┆ ---    ┆ ---                 ┆ ---                 ┆ ---                     │
│ str     ┆ str     ┆ i64    ┆ i64                 ┆ f32                 ┆ f32                     │
╞═════════╪═════════╪════════╪═════════════════════╪═════════════════════╪═════════════════════════╡
│ A       ┆ D       ┆ 0      ┆ 3                   ┆ 1.0                 ┆ 1.0                     │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ B       ┆ D       ┆ 1      ┆ 4                   ┆ 2.0                 ┆ 1.0                     │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ A       ┆ Z       ┆ 2      ┆ 3                   ┆ 1.0                 ┆ 2.0                     │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ A       ┆ Z       ┆ 3      ┆ 3                   ┆ 2.0                 ┆ 13.0                    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ B       ┆ D       ┆ 4      ┆ 4                   ┆ 3.0                 ┆ 12.0                    │
└─────────┴─────────┴────────┴─────────────────────┴─────────────────────┴─────────────────────────┘
```