### PR TITLE
reduce monomorphization

### DIFF
--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -243,7 +243,7 @@ where
 
     fn div(self, rhs: N) -> Self::Output {
         let rhs: T::Native = NumCast::from(rhs).expect("could not cast");
-        self.apply_kernel(|arr| Arc::new(basic::div_scalar(arr, &rhs)))
+        self.apply_kernel(&|arr| Arc::new(basic::div_scalar(arr, &rhs)))
     }
 }
 
@@ -269,7 +269,7 @@ where
 
     fn rem(self, rhs: N) -> Self::Output {
         let rhs: T::Native = NumCast::from(rhs).expect("could not cast");
-        self.apply_kernel(|arr| Arc::new(basic::rem_scalar(arr, &rhs)))
+        self.apply_kernel(&|arr| Arc::new(basic::rem_scalar(arr, &rhs)))
     }
 }
 
@@ -419,7 +419,7 @@ where
 {
     fn pow_f32(&self, exp: f32) -> Float32Chunked {
         let s = self.cast(&DataType::Float32).unwrap();
-        s.f32().unwrap().apply_kernel(|arr| {
+        s.f32().unwrap().apply_kernel(&|arr| {
             Arc::new(compute::arity::unary(
                 arr,
                 |x| x.powf(exp),
@@ -430,7 +430,7 @@ where
 
     fn pow_f64(&self, exp: f64) -> Float64Chunked {
         let s = self.cast(&DataType::Float64).unwrap();
-        s.f64().unwrap().apply_kernel(|arr| {
+        s.f64().unwrap().apply_kernel(&|arr| {
             Arc::new(compute::arity::unary(
                 arr,
                 |x| x.powf(exp),

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -602,7 +602,7 @@ where
         let rhs: T::Native =
             NumCast::from(rhs).expect("could not cast to underlying chunkedarray type");
         let scalar = PrimitiveScalar::new(T::get_dtype().to_arrow(), Some(rhs));
-        self.apply_kernel_cast(|arr| Arc::new(f(arr, &scalar)))
+        self.apply_kernel_cast(&|arr| Arc::new(f(arr, &scalar)))
     }
 }
 
@@ -647,7 +647,7 @@ impl Utf8Chunked {
         f: impl Fn(&Utf8Array<i64>, &dyn Scalar) -> BooleanArray,
     ) -> BooleanChunked {
         let scalar = Utf8Scalar::<i64>::new(Some(rhs));
-        self.apply_kernel_cast(|arr| Arc::new(f(arr, &scalar)))
+        self.apply_kernel_cast(&|arr| Arc::new(f(arr, &scalar)))
     }
 }
 

--- a/polars/polars-core/src/chunked_array/float.rs
+++ b/polars/polars-core/src/chunked_array/float.rs
@@ -9,16 +9,16 @@ where
     T::Native: Float,
 {
     pub fn is_nan(&self) -> BooleanChunked {
-        self.apply_kernel_cast(is_nan::<T::Native>)
+        self.apply_kernel_cast(&is_nan::<T::Native>)
     }
     pub fn is_not_nan(&self) -> BooleanChunked {
-        self.apply_kernel_cast(is_not_nan::<T::Native>)
+        self.apply_kernel_cast(&is_not_nan::<T::Native>)
     }
     pub fn is_finite(&self) -> BooleanChunked {
-        self.apply_kernel_cast(is_finite)
+        self.apply_kernel_cast(&is_finite)
     }
     pub fn is_infinite(&self) -> BooleanChunked {
-        self.apply_kernel_cast(is_infinite)
+        self.apply_kernel_cast(&is_infinite)
     }
 
     #[must_use]

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -115,7 +115,7 @@ where
     T: PolarsNumericType,
 {
     fn fill_null_with_values(&self, value: T::Native) -> Result<Self> {
-        Ok(self.apply_kernel(|arr| Arc::new(set_at_nulls(arr, value))))
+        Ok(self.apply_kernel(&|arr| Arc::new(set_at_nulls(arr, value))))
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -704,14 +704,11 @@ pub trait ChunkZip<T> {
 pub trait ChunkApplyKernel<A: Array> {
     /// Apply kernel and return result as a new ChunkedArray.
     #[must_use]
-    fn apply_kernel<F>(&self, f: F) -> Self
-    where
-        F: Fn(&A) -> ArrayRef;
+    fn apply_kernel(&self, f: &dyn Fn(&A) -> ArrayRef) -> Self;
 
     /// Apply a kernel that outputs an array of different type.
-    fn apply_kernel_cast<F, S>(&self, f: F) -> ChunkedArray<S>
+    fn apply_kernel_cast<S>(&self, f: &dyn Fn(&A) -> ArrayRef) -> ChunkedArray<S>
     where
-        F: Fn(&A) -> ArrayRef,
         S: PolarsDataType;
 }
 

--- a/polars/polars-core/src/chunked_array/strings/mod.rs
+++ b/polars/polars-core/src/chunked_array/strings/mod.rs
@@ -18,7 +18,7 @@ fn f_regex_extract<'a>(reg: &Regex, input: &'a str, group_index: usize) -> Optio
 impl Utf8Chunked {
     /// Get the length of the string values.
     pub fn str_lengths(&self) -> UInt32Chunked {
-        self.apply_kernel_cast(string_lengths)
+        self.apply_kernel_cast(&string_lengths)
     }
 
     /// Check if strings contain a regex pattern

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -24,7 +24,7 @@ impl DateChunked {
     /// Extract month from underlying NaiveDate representation.
     /// Returns the year number in the calendar date.
     pub fn year(&self) -> Int32Chunked {
-        self.apply_kernel_cast::<_, Int32Type>(date_to_year)
+        self.apply_kernel_cast::<Int32Type>(&date_to_year)
     }
 
     /// Extract month from underlying NaiveDateTime representation.
@@ -32,19 +32,19 @@ impl DateChunked {
     ///
     /// The return value ranges from 1 to 12.
     pub fn month(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(date_to_month)
+        self.apply_kernel_cast::<UInt32Type>(&date_to_month)
     }
 
     /// Extract weekday from underlying NaiveDate representation.
     /// Returns the weekday number where monday = 0 and sunday = 6
     pub fn weekday(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(date_to_weekday)
+        self.apply_kernel_cast::<UInt32Type>(&date_to_weekday)
     }
 
     /// Returns the ISO week number starting from 1.
     /// The return value ranges from 1 to 53. (The last week of year differs by years.)
     pub fn week(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(date_to_week)
+        self.apply_kernel_cast::<UInt32Type>(&date_to_week)
     }
 
     /// Extract day from underlying NaiveDate representation.
@@ -52,19 +52,19 @@ impl DateChunked {
     ///
     /// The return value ranges from 1 to 31. (The last day of month differs by months.)
     pub fn day(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(date_to_day)
+        self.apply_kernel_cast::<UInt32Type>(&date_to_day)
     }
 
     /// Returns the day of year starting from 1.
     ///
     /// The return value ranges from 1 to 366. (The last day of year differs by years.)
     pub fn ordinal(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(date_to_ordinal)
+        self.apply_kernel_cast::<UInt32Type>(&date_to_ordinal)
     }
 
     /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn strftime(&self, fmt: &str) -> Utf8Chunked {
-        let mut ca: Utf8Chunked = self.apply_kernel_cast(|arr| {
+        let mut ca: Utf8Chunked = self.apply_kernel_cast(&|arr| {
             let arr: Utf8Array<i64> = arr
                 .into_iter()
                 .map(|opt| opt.map(|date| format!("{}", date32_to_date(*date).format(fmt))))

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -40,11 +40,12 @@ impl DatetimeChunked {
     /// Extract month from underlying NaiveDateTime representation.
     /// Returns the year number in the calendar date.
     pub fn year(&self) -> Int32Chunked {
-        match self.time_unit() {
-            TimeUnit::Nanoseconds => self.apply_kernel_cast::<_, Int32Type>(datetime_to_year_ns),
-            TimeUnit::Microseconds => self.apply_kernel_cast::<_, Int32Type>(datetime_to_year_us),
-            TimeUnit::Milliseconds => self.apply_kernel_cast::<_, Int32Type>(datetime_to_year_ms),
-        }
+        let f = match self.time_unit() {
+            TimeUnit::Nanoseconds => datetime_to_year_ns,
+            TimeUnit::Microseconds => datetime_to_year_us,
+            TimeUnit::Milliseconds => datetime_to_year_ms,
+        };
+        self.apply_kernel_cast::<Int32Type>(&f)
     }
 
     /// Extract month from underlying NaiveDateTime representation.
@@ -52,11 +53,12 @@ impl DatetimeChunked {
     ///
     /// The return value ranges from 1 to 12.
     pub fn month(&self) -> UInt32Chunked {
-        match self.time_unit() {
-            TimeUnit::Nanoseconds => self.apply_kernel_cast::<_, UInt32Type>(datetime_to_month_ns),
-            TimeUnit::Microseconds => self.apply_kernel_cast::<_, UInt32Type>(datetime_to_month_us),
-            TimeUnit::Milliseconds => self.apply_kernel_cast::<_, UInt32Type>(datetime_to_month_ms),
-        }
+        let f = match self.time_unit() {
+            TimeUnit::Nanoseconds => datetime_to_month_ns,
+            TimeUnit::Microseconds => datetime_to_month_us,
+            TimeUnit::Milliseconds => datetime_to_month_ms,
+        };
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract weekday from underlying NaiveDateTime representation.
@@ -67,7 +69,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_weekday_us,
             TimeUnit::Milliseconds => datetime_to_weekday_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Returns the ISO week number starting from 1.
@@ -78,7 +80,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_week_us,
             TimeUnit::Milliseconds => datetime_to_week_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract day from underlying NaiveDateTime representation.
@@ -91,7 +93,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_day_us,
             TimeUnit::Milliseconds => datetime_to_day_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract hour from underlying NaiveDateTime representation.
@@ -102,7 +104,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_hour_us,
             TimeUnit::Milliseconds => datetime_to_hour_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract minute from underlying NaiveDateTime representation.
@@ -113,7 +115,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_minute_us,
             TimeUnit::Milliseconds => datetime_to_minute_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
@@ -124,7 +126,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_second_us,
             TimeUnit::Milliseconds => datetime_to_second_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
@@ -136,7 +138,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_nanosecond_us,
             TimeUnit::Milliseconds => datetime_to_nanosecond_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Returns the day of year starting from 1.
@@ -148,7 +150,7 @@ impl DatetimeChunked {
             TimeUnit::Microseconds => datetime_to_ordinal_us,
             TimeUnit::Milliseconds => datetime_to_ordinal_ms,
         };
-        self.apply_kernel_cast::<_, UInt32Type>(f)
+        self.apply_kernel_cast::<UInt32Type>(&f)
     }
 
     /// Format Datetime with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
@@ -159,7 +161,7 @@ impl DatetimeChunked {
             TimeUnit::Milliseconds => timestamp_ms_to_datetime,
         };
 
-        let mut ca: Utf8Chunked = self.apply_kernel_cast(|arr| {
+        let mut ca: Utf8Chunked = self.apply_kernel_cast(&|arr| {
             let arr: Utf8Array<i64> = arr
                 .into_iter()
                 .map(|opt| opt.map(|v| format!("{}", conversion_f(*v).format(fmt))))

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -25,7 +25,7 @@ impl TimeChunked {
 
     /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn strftime(&self, fmt: &str) -> Utf8Chunked {
-        let mut ca: Utf8Chunked = self.apply_kernel_cast(|arr| {
+        let mut ca: Utf8Chunked = self.apply_kernel_cast(&|arr| {
             let arr: Utf8Array<i64> = arr
                 .into_iter()
                 .map(|opt| opt.map(|v| format!("{}", time64ns_to_time(*v).format(fmt))))
@@ -39,26 +39,26 @@ impl TimeChunked {
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
     pub fn hour(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(time_to_hour)
+        self.apply_kernel_cast::<UInt32Type>(&time_to_hour)
     }
 
     /// Extract minute from underlying NaiveDateTime representation.
     /// Returns the minute number from 0 to 59.
     pub fn minute(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(time_to_minute)
+        self.apply_kernel_cast::<UInt32Type>(&time_to_minute)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the second number from 0 to 59.
     pub fn second(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(time_to_second)
+        self.apply_kernel_cast::<UInt32Type>(&time_to_second)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the number of nanoseconds since the whole non-leap second.
     /// The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
     pub fn nanosecond(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<_, UInt32Type>(time_to_nanosecond)
+        self.apply_kernel_cast::<UInt32Type>(&time_to_nanosecond)
     }
 
     /// Construct a new [`TimeChunked`] from an iterator over [`NaiveTime`].


### PR DESCRIPTION
Apply that works on kernel level doesn't need to be monomorphized. An array typically has only a few chunks.