### PR TITLE
fix any and python dispatch to proper any impl

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -73,7 +73,13 @@ impl PhysicalExpr for CastExpr {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
         let s = ac.flat_naive();
         let s = self.finish(s.as_ref())?;
-        ac.with_series(s, false);
+
+        if ac.is_literal() {
+            ac.with_literal(s);
+        } else {
+            ac.with_series(s, false);
+        }
+
         Ok(ac)
     }
 

--- a/polars/tests/it/lazy/window_expressions.rs
+++ b/polars/tests/it/lazy/window_expressions.rs
@@ -362,3 +362,26 @@ fn test_window_exprs_any_all() -> Result<()> {
     assert!(df.frame_equal(&expected));
     Ok(())
 }
+
+#[test]
+fn test_window_naive_any() -> Result<()> {
+    let df = df![
+        "row_id" => [0, 0, 1, 1, 1],
+        "boolvar" => [true, false, true, false, false]
+    ]?;
+
+    let df = df
+        .lazy()
+        .with_column(
+            col("boolvar")
+                .sum()
+                .gt(lit(0))
+                .over([col("row_id")])
+                .alias("res"),
+        )
+        .collect()?;
+
+    let res = df.column("res")?;
+    assert_eq!(res.sum::<usize>(), Some(5));
+    Ok(())
+}

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -811,7 +811,7 @@ def any(name: Union[str, List["pli.Expr"]]) -> "pli.Expr":
     """
     if isinstance(name, list):
         return fold(lit(0), lambda a, b: a | b, name).alias("any")
-    return col(name).sum() > 0
+    return col(name).any()
 
 
 def exclude(columns: Union[str, List[str]]) -> "pli.Expr":
@@ -906,7 +906,7 @@ def all(name: Optional[Union[str, List["pli.Expr"]]] = None) -> "pli.Expr":
         return col("*")
     if isinstance(name, list):
         return fold(lit(0), lambda a, b: a & b, name).alias("all")
-    return col(name).cast(bool).sum() == col(name).count()
+    return col(name).all()
 
 
 def groups(column: str) -> "pli.Expr":

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -506,7 +506,7 @@ def test_all_expr() -> None:
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.select(pl.any("A"))[0, 0]
+    assert fruits_cars.with_column(pl.col("A").cast(bool)).select(pl.any("A"))[0, 0]
     assert fruits_cars.select(pl.any([pl.col("A"), pl.col("B")]))[0, 0]
 
 


### PR DESCRIPTION
fixes #2676 

Also improves python `any` and `all` performance by dispatching to the realy `any` and `all` implementations.