### PR TITLE
Add `u64` as index type

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -19,4 +19,4 @@ thiserror = "^1.0"
 [features]
 strings = []
 compute = ["arrow/compute_cast"]
-bigint = []
+bigidx = []

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "^1.0"
 [features]
 strings = []
 compute = ["arrow/compute_cast"]
+bigint = []

--- a/polars/polars-arrow/src/index.rs
+++ b/polars/polars-arrow/src/index.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 use arrow::array::UInt32Array;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 use arrow::array::UInt64Array;
 
 pub trait IndexToUsize {
@@ -24,12 +24,12 @@ impl IndexToUsize for i64 {
 }
 
 /// The type used by polars to index data.
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub type IdxSize = u32;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub type IdxSize = u64;
 
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub type IdxArr = UInt32Array;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub type IdxArr = UInt64Array;

--- a/polars/polars-arrow/src/index.rs
+++ b/polars/polars-arrow/src/index.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "bigint"))]
+use arrow::array::UInt32Array;
+#[cfg(feature = "bigint")]
+use arrow::array::UInt64Array;
+
 pub trait IndexToUsize {
     /// Translate the negative index to an offset.
     fn negative_to_usize(self, index: usize) -> Option<usize>;
@@ -17,3 +22,14 @@ impl IndexToUsize for i64 {
         }
     }
 }
+
+/// The type used by polars to index data.
+#[cfg(not(feature = "bigint"))]
+pub type IdxSize = u32;
+#[cfg(feature = "bigint")]
+pub type IdxSize = u64;
+
+#[cfg(not(feature = "bigint"))]
+pub type IdxArr = UInt32Array;
+#[cfg(feature = "bigint")]
+pub type IdxArr = UInt64Array;

--- a/polars/polars-arrow/src/kernels/list.rs
+++ b/polars/polars-arrow/src/kernels/list.rs
@@ -1,8 +1,8 @@
-use crate::index::IndexToUsize;
+use crate::index::*;
 use crate::kernels::take::take_unchecked;
 use crate::trusted_len::PushUnchecked;
 use crate::utils::CustomIterTools;
-use arrow::array::{ArrayRef, ListArray, PrimitiveArray};
+use arrow::array::{ArrayRef, ListArray};
 use arrow::buffer::Buffer;
 
 /// Get the indices that would result in a get operation on the lists values.
@@ -29,13 +29,13 @@ use arrow::buffer::Buffer;
 ///     [3, 5, 6]
 ///
 /// ```
-fn sublist_get_indexes(arr: &ListArray<i64>, index: i64) -> PrimitiveArray<u32> {
+fn sublist_get_indexes(arr: &ListArray<i64>, index: i64) -> IdxArr {
     let mut iter = arr.offsets().iter();
 
-    let mut cum_offset = 0u32;
+    let mut cum_offset: IdxSize = 0;
 
     if let Some(mut previous) = iter.next().copied() {
-        let a: PrimitiveArray<u32> = iter
+        let a: IdxArr = iter
             .map(|&offset| {
                 let len = offset - previous;
                 // make sure that empty lists don't get accessed
@@ -46,15 +46,15 @@ fn sublist_get_indexes(arr: &ListArray<i64>, index: i64) -> PrimitiveArray<u32> 
 
                 let out = index
                     .negative_to_usize(len as usize)
-                    .map(|idx| idx as u32 + cum_offset);
-                cum_offset += len as u32;
+                    .map(|idx| idx as IdxSize + cum_offset);
+                cum_offset += len as IdxSize;
                 out
             })
             .collect_trusted();
 
         a
     } else {
-        PrimitiveArray::<u32>::from_slice(&[])
+        IdxArr::from_slice(&[])
     }
 }
 

--- a/polars/polars-arrow/src/kernels/list.rs
+++ b/polars/polars-arrow/src/kernels/list.rs
@@ -87,7 +87,7 @@ pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use arrow::array::Int32Array;
+    use arrow::array::{Int32Array, PrimitiveArray};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
     use std::sync::Arc;

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -556,10 +556,7 @@ pub unsafe fn take_value_indices_from_list(
         }
     }
 
-    (
-        IdxArr::from_data_default(values.into(), None),
-        new_offsets,
-    )
+    (IdxArr::from_data_default(values.into(), None), new_offsets)
 }
 
 #[cfg(test)]

--- a/polars/polars-arrow/src/kernels/take.rs
+++ b/polars/polars-arrow/src/kernels/take.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 /// # Safety
 /// Does not do bounds checks
-pub unsafe fn take_unchecked(arr: &dyn Array, idx: &UInt32Array) -> ArrayRef {
+pub unsafe fn take_unchecked(arr: &dyn Array, idx: &IdxArr) -> ArrayRef {
     use PhysicalType::*;
     match arr.data_type().to_physical_type() {
         Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
@@ -39,7 +39,7 @@ pub unsafe fn take_unchecked(arr: &dyn Array, idx: &UInt32Array) -> ArrayRef {
 /// caller must ensure indices are in bounds
 pub unsafe fn take_primitive_unchecked<T: NativeType>(
     arr: &PrimitiveArray<T>,
-    indices: &UInt32Array,
+    indices: &IdxArr,
 ) -> Arc<PrimitiveArray<T>> {
     let array_values = arr.values().as_slice();
     let index_values = indices.values().as_slice();
@@ -89,7 +89,7 @@ pub unsafe fn take_primitive_unchecked<T: NativeType>(
 /// caller must ensure indices are in bounds
 pub unsafe fn take_no_null_primitive<T: NativeType>(
     arr: &PrimitiveArray<T>,
-    indices: &UInt32Array,
+    indices: &IdxArr,
 ) -> Arc<PrimitiveArray<T>> {
     debug_assert!(!arr.has_validity());
     let array_values = arr.values().as_slice();
@@ -380,7 +380,7 @@ pub unsafe fn take_utf8_opt_iter_unchecked<I: IntoIterator<Item = Option<usize>>
 /// caller must ensure indices are in bounds
 pub unsafe fn take_utf8_unchecked(
     arr: &LargeStringArray,
-    indices: &UInt32Array,
+    indices: &IdxArr,
 ) -> Arc<LargeStringArray> {
     let data_len = indices.len();
 
@@ -502,8 +502,8 @@ pub unsafe fn take_utf8_unchecked(
 /// No bounds checks
 pub unsafe fn take_value_indices_from_list(
     list: &ListArray<i64>,
-    indices: &UInt32Array,
-) -> (UInt32Array, Vec<i64>) {
+    indices: &IdxArr,
+) -> (IdxArr, Vec<i64>) {
     let offsets = list.offsets().as_slice();
 
     let mut new_offsets = Vec::with_capacity(indices.len());
@@ -528,7 +528,7 @@ pub unsafe fn take_value_indices_from_list(
 
             // if start == end, this slot is empty
             while curr < end {
-                values.push(curr as u32);
+                values.push(curr as IdxSize);
                 curr += 1;
             }
         }
@@ -547,7 +547,7 @@ pub unsafe fn take_value_indices_from_list(
 
                 // if start == end, this slot is empty
                 while curr < end {
-                    values.push(curr as u32);
+                    values.push(curr as IdxSize);
                     curr += 1;
                 }
             } else {
@@ -557,7 +557,7 @@ pub unsafe fn take_value_indices_from_list(
     }
 
     (
-        PrimitiveArray::from_data(DataType::UInt32, values.into(), None),
+        IdxArr::from_data_default(values.into(), None),
         new_offsets,
     )
 }
@@ -570,13 +570,13 @@ mod test {
     fn test_utf8_kernel() {
         let s = LargeStringArray::from(vec![Some("foo"), None, Some("bar")]);
         unsafe {
-            let out = take_utf8_unchecked(&s, &UInt32Array::from_slice(&[1, 2]));
+            let out = take_utf8_unchecked(&s, &IdxArr::from_slice(&[1, 2]));
             assert!(out.is_null(0));
             assert!(out.is_valid(1));
-            let out = take_utf8_unchecked(&s, &UInt32Array::from(vec![None, Some(2)]));
+            let out = take_utf8_unchecked(&s, &IdxArr::from(vec![None, Some(2)]));
             assert!(out.is_null(0));
             assert!(out.is_valid(1));
-            let out = take_utf8_unchecked(&s, &UInt32Array::from(vec![None, None]));
+            let out = take_utf8_unchecked(&s, &IdxArr::from(vec![None, None]));
             assert!(out.is_null(0));
             assert!(out.is_null(1));
         }

--- a/polars/polars-arrow/src/prelude.rs
+++ b/polars/polars-arrow/src/prelude.rs
@@ -1,9 +1,6 @@
 pub use crate::array::default_arrays::*;
-pub use crate::{
-    array::*,
-    index::*
-};
 pub use crate::kernels::rolling::no_nulls::QuantileInterpolOptions;
+pub use crate::{array::*, index::*};
 use arrow::array::{ListArray, Utf8Array};
 
 pub type LargeStringArray = Utf8Array<i64>;

--- a/polars/polars-arrow/src/prelude.rs
+++ b/polars/polars-arrow/src/prelude.rs
@@ -1,5 +1,8 @@
 pub use crate::array::default_arrays::*;
-pub use crate::array::*;
+pub use crate::{
+    array::*,
+    index::*
+};
 pub use crate::kernels::rolling::no_nulls::QuantileInterpolOptions;
 use arrow::array::{ListArray, Utf8Array};
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -93,7 +93,7 @@ dtype-categorical = []
 parquet = ["arrow/io_parquet"]
 
 # scale to terrabytes?
-bigint = []
+bigint = ["polars-arrow/bigint"]
 
 docs-selection = [
   "ndarray",

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -93,7 +93,7 @@ dtype-categorical = []
 parquet = ["arrow/io_parquet"]
 
 # scale to terrabytes?
-bigint = ["polars-arrow/bigint"]
+bigidx = ["polars-arrow/bigidx"]
 
 docs-selection = [
   "ndarray",

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -92,6 +92,9 @@ dtype-categorical = []
 
 parquet = ["arrow/io_parquet"]
 
+# scale to terrabytes?
+bigint = []
+
 docs-selection = [
   "ndarray",
   "is_in",

--- a/polars/polars-core/src/chunked_array/boolean.rs
+++ b/polars/polars-core/src/chunked_array/boolean.rs
@@ -2,9 +2,8 @@ use crate::prelude::*;
 use crate::utils::NoNull;
 
 impl BooleanChunked {
-    pub fn arg_true(&self) -> UInt32Chunked {
-        // the allocation is probably cheaper as the filter is super fast
-        let ca: NoNull<UInt32Chunked> = (0u32..self.len() as u32).collect_trusted();
+    pub fn arg_true(&self) -> IdxCa {
+        let ca: NoNull<IdxCa> = (0..self.len() as IdxSize).collect_trusted();
         ca.into_inner().filter(self).unwrap()
     }
 }

--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -37,7 +37,7 @@ pub(crate) fn take_primitive_opt_iter_n_chunks<
 /// No bounds checks
 pub(crate) unsafe fn take_list_unchecked(
     values: &ListArray<i64>,
-    indices: &UInt32Array,
+    indices: &IdxArr,
 ) -> ListArray<i64> {
     // taking the whole list or a contiguous sublist
     let (list_indices, offsets) = take_value_indices_from_list(values, indices);
@@ -45,7 +45,7 @@ pub(crate) unsafe fn take_list_unchecked(
     // tmp series so that we can take primitives from it
     let s = Series::try_from(("", values.values().clone() as ArrayRef)).unwrap();
     let taken = s
-        .take_unchecked(&UInt32Chunked::from_chunks(
+        .take_unchecked(&IdxCa::from_chunks(
             "",
             vec![Arc::new(list_indices) as ArrayRef],
         ))

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -190,8 +190,7 @@ mod test {
         let values = &[Some(foo1), None, Some(foo2), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups =
-            GroupsProxy::Idx(vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into());
+        let groups = GroupsProxy::Idx(vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into());
         let out = ca.agg_list(&groups).unwrap();
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -191,7 +191,7 @@ mod test {
         let ca = ObjectChunked::new("", values);
 
         let groups =
-            GroupsProxy::Idx(vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])].into());
+            GroupsProxy::Idx(vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into());
         let out = ca.agg_list(&groups).unwrap();
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());
@@ -214,7 +214,7 @@ mod test {
         let values = &[Some(foo1.clone()), None, Some(foo2.clone()), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups = vec![(0u32, vec![0u32, 1]), (2, vec![2]), (3, vec![3])].into();
+        let groups = vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into();
         let out = ca.agg_list(&GroupsProxy::Idx(groups)).unwrap();
         let a = out.explode().unwrap();
 

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -197,7 +197,7 @@ impl ExplodeByOffsets for CategoricalChunked {
 }
 
 /// Convert Arrow array offsets to indexes of the original list
-pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> Vec<u32> {
+pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> Vec<IdxSize> {
     let mut idx = Vec::with_capacity(capacity);
 
     let mut count = 0;

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -465,7 +465,7 @@ pub trait ChunkUnique<T> {
 
     /// Get first index of the unique values in a `ChunkedArray`.
     /// This Vec is sorted.
-    fn arg_unique(&self) -> Result<UInt32Chunked>;
+    fn arg_unique(&self) -> Result<IdxCa>;
 
     /// Number of unique values in the `ChunkedArray`
     fn n_unique(&self) -> Result<usize> {

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -526,10 +526,10 @@ pub trait ChunkSort<T> {
     fn sort(&self, reverse: bool) -> ChunkedArray<T>;
 
     /// Retrieve the indexes needed to sort this array.
-    fn argsort(&self, reverse: bool) -> UInt32Chunked;
+    fn argsort(&self, reverse: bool) -> IdxCa;
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    fn argsort_multiple(&self, _other: &[Series], _reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, _other: &[Series], _reverse: &[bool]) -> Result<IdxCa> {
         Err(PolarsError::InvalidOperation(
             "argsort_multiple not implemented for this dtype".into(),
         ))

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -752,7 +752,7 @@ pub trait ArgAgg {
 #[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
 pub trait RepeatBy {
     /// Repeat the values `n` times, where `n` is determined by the values in `by`.
-    fn repeat_by(&self, _by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, _by: &IdxCa) -> ListChunked {
         unimplemented!()
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/repeat_by.rs
+++ b/polars/polars-core/src/chunked_array/ops/repeat_by.rs
@@ -10,7 +10,7 @@ impl<T> RepeatBy for ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         let iter = self
             .into_iter()
             .zip(by.into_iter())
@@ -30,7 +30,7 @@ where
     }
 }
 impl RepeatBy for BooleanChunked {
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         let iter = self
             .into_iter()
             .zip(by.into_iter())
@@ -47,7 +47,7 @@ impl RepeatBy for BooleanChunked {
     }
 }
 impl RepeatBy for Utf8Chunked {
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         let iter = self
             .into_iter()
             .zip(by.into_iter())
@@ -66,7 +66,7 @@ impl RepeatBy for Utf8Chunked {
 
 #[cfg(feature = "dtype-categorical")]
 impl RepeatBy for CategoricalChunked {
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         let mut ca = self.deref().repeat_by(by);
         ca.categorical_map = self.categorical_map.clone();
         ca

--- a/polars/polars-core/src/chunked_array/ops/take/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/mod.rs
@@ -374,7 +374,7 @@ impl ChunkTake for ListChunked {
             // todo! fast path for single chunk
             TakeIdx::Iter(iter) => {
                 if ca_self.chunks.len() == 1 {
-                    let idx: NoNull<UInt32Chunked> = iter.map(|v| v as u32).collect();
+                    let idx: NoNull<IdxCa> = iter.map(|v| v as IdxSize).collect();
                     ca_self.take_unchecked((&idx.into_inner()).into())
                 } else {
                     let mut ca: ListChunked = take_iter_n_chunks_unchecked!(ca_self.as_ref(), iter);
@@ -384,7 +384,7 @@ impl ChunkTake for ListChunked {
             }
             TakeIdx::IterNulls(iter) => {
                 if ca_self.chunks.len() == 1 {
-                    let idx: UInt32Chunked = iter.map(|v| v.map(|v| v as u32)).collect();
+                    let idx: IdxCa = iter.map(|v| v.map(|v| v as IdxSize)).collect();
                     ca_self.take_unchecked((&idx).into())
                 } else {
                     let mut ca: ListChunked =

--- a/polars/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/traits.rs
@@ -1,7 +1,6 @@
 //! Traits that indicate the allowed arguments in a ChunkedArray::take operation.
 use crate::frame::groupby::GroupsProxyIter;
 use crate::prelude::*;
-use arrow::array::UInt32Array;
 use polars_arrow::array::PolarsArray;
 
 // Utility traits
@@ -84,7 +83,7 @@ where
     I: TakeIterator,
     INulls: TakeIteratorNulls,
 {
-    Array(&'a UInt32Array),
+    Array(&'a IdxArr),
     Iter(I),
     // will return a null where None
     IterNulls(INulls),
@@ -101,7 +100,7 @@ where
             TakeIdx::IterNulls(i) => i.check_bounds(bound),
             TakeIdx::Array(arr) => {
                 let mut inbounds = true;
-                let len = bound as u32;
+                let len = bound as IdxSize;
                 if !arr.has_validity() {
                     for &i in arr.values().as_slice() {
                         if i >= len {
@@ -145,8 +144,8 @@ pub type Dummy<T> = std::iter::Once<T>;
 // Unchecked conversions
 
 /// Conversion from UInt32Chunked to Unchecked TakeIdx
-impl<'a> From<&'a UInt32Chunked> for TakeIdx<'a, Dummy<usize>, Dummy<Option<usize>>> {
-    fn from(ca: &'a UInt32Chunked) -> Self {
+impl<'a> From<&'a IdxCa> for TakeIdx<'a, Dummy<usize>, Dummy<Option<usize>>> {
+    fn from(ca: &'a IdxCa) -> Self {
         if ca.chunks.len() == 1 {
             TakeIdx::Array(ca.downcast_iter().next().unwrap())
         } else {

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -176,9 +176,9 @@ macro_rules! impl_value_counts {
         let group_tuples = $self.group_tuples(true, false).into_idx();
         let values =
             unsafe { $self.take_unchecked(group_tuples.iter().map(|t| t.0 as usize).into()) };
-        let mut counts: NoNull<UInt32Chunked> = group_tuples
+        let mut counts: NoNull<IdxCa> = group_tuples
             .into_iter()
-            .map(|(_, groups)| groups.len() as u32)
+            .map(|(_, groups)| groups.len() as IdxSize)
             .collect();
         counts.rename("counts");
         let cols = vec![values.into_series(), counts.into_inner().into_series()];
@@ -329,7 +329,7 @@ fn dummies_helper(mut groups: Vec<IdxSize>, len: usize, name: &str) -> UInt8Chun
 }
 
 #[cfg(not(feature = "dtype-u8"))]
-fn dummies_helper(mut groups: Vec<u32>, len: usize, name: &str) -> Int32Chunked {
+fn dummies_helper(mut groups: Vec<IdxSize>, len: usize, name: &str) -> Int32Chunked {
     groups.sort_unstable();
 
     // let mut group_member_iter = groups.into_iter();

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -15,8 +15,8 @@ use std::hash::Hash;
 use std::ops::Deref;
 
 fn finish_is_unique_helper(
-    mut unique_idx: Vec<u32>,
-    len: u32,
+    mut unique_idx: Vec<IdxSize>,
+    len: IdxSize,
     unique_val: bool,
     duplicated_val: bool,
 ) -> BooleanChunked {
@@ -40,8 +40,8 @@ fn finish_is_unique_helper(
 }
 
 pub(crate) fn is_unique_helper2(
-    unique_idx: Vec<u32>,
-    len: u32,
+    unique_idx: Vec<IdxSize>,
+    len: IdxSize,
     unique_val: bool,
     duplicated_val: bool,
 ) -> BooleanChunked {
@@ -51,7 +51,7 @@ pub(crate) fn is_unique_helper2(
 
 pub(crate) fn is_unique_helper(
     groups: GroupsProxy,
-    len: u32,
+    len: IdxSize,
     unique_val: bool,
     duplicated_val: bool,
 ) -> BooleanChunked {
@@ -75,15 +75,15 @@ macro_rules! is_unique_duplicated {
         $ca.into_iter().enumerate().for_each(|(idx, key)| {
             idx_key
                 .entry(key)
-                .and_modify(|v: &mut (u32, bool)| v.1 = false)
-                .or_insert((idx as u32, true));
+                .and_modify(|v: &mut (IdxSize, bool)| v.1 = false)
+                .or_insert((idx as IdxSize, true));
         });
 
         let idx: Vec<_> = idx_key
             .into_iter()
             .filter_map(|(_k, v)| if v.1 { Some(v.0) } else { None })
             .collect();
-        let mut out = is_unique_helper2(idx, $ca.len() as u32, !$inverse, $inverse);
+        let mut out = is_unique_helper2(idx, $ca.len() as IdxSize, !$inverse, $inverse);
         out.rename($ca.name());
         Ok(out)
     }};
@@ -315,7 +315,7 @@ impl ChunkUnique<CategoricalType> for CategoricalChunked {
 }
 
 #[cfg(feature = "dtype-u8")]
-fn dummies_helper(mut groups: Vec<u32>, len: usize, name: &str) -> UInt8Chunked {
+fn dummies_helper(mut groups: Vec<IdxSize>, len: usize, name: &str) -> UInt8Chunked {
     groups.sort_unstable();
 
     let mut av: Vec<_> = (0..len).map(|_| 0u8).collect();

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -97,7 +97,7 @@ impl<T> ChunkUnique<ObjectType<T>> for ObjectChunked<T> {
         ))
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         Err(PolarsError::InvalidOperation(
             "unique not supported for object".into(),
         ))
@@ -111,7 +111,7 @@ where
     a.collect()
 }
 
-fn arg_unique<T>(a: impl Iterator<Item = T>, capacity: usize) -> Vec<u32>
+fn arg_unique<T>(a: impl Iterator<Item = T>, capacity: usize) -> Vec<IdxSize>
 where
     T: Hash + Eq,
 {
@@ -119,7 +119,7 @@ where
     let mut unique = Vec::with_capacity(capacity);
     a.enumerate().for_each(|(idx, val)| {
         if set.insert(val) {
-            unique.push(idx as u32)
+            unique.push(idx as IdxSize)
         }
     });
     unique
@@ -198,8 +198,8 @@ where
         Ok(Self::from_iter_options(self.name(), set.iter().copied()))
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
-        Ok(UInt32Chunked::from_vec(self.name(), arg_unique_ca!(self)))
+    fn arg_unique(&self) -> Result<IdxCa> {
+        Ok(IdxCa::from_vec(self.name(), arg_unique_ca!(self)))
     }
 
     fn is_unique(&self) -> Result<BooleanChunked> {
@@ -238,8 +238,8 @@ impl ChunkUnique<Utf8Type> for Utf8Chunked {
         ))
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
-        Ok(UInt32Chunked::from_vec(self.name(), arg_unique_ca!(self)))
+    fn arg_unique(&self) -> Result<IdxCa> {
+        Ok(IdxCa::from_vec(self.name(), arg_unique_ca!(self)))
     }
 
     fn is_unique(&self) -> Result<BooleanChunked> {
@@ -287,7 +287,7 @@ impl ChunkUnique<CategoricalType> for CategoricalChunked {
         Ok(ca.into())
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         self.deref().arg_unique()
     }
 
@@ -415,8 +415,8 @@ impl ChunkUnique<BooleanType> for BooleanChunked {
         Ok(ChunkedArray::new(self.name(), &unique))
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
-        Ok(UInt32Chunked::from_vec(self.name(), arg_unique_ca!(self)))
+    fn arg_unique(&self) -> Result<IdxCa> {
+        Ok(IdxCa::from_vec(self.name(), arg_unique_ca!(self)))
     }
 
     fn is_unique(&self) -> Result<BooleanChunked> {
@@ -437,7 +437,7 @@ impl ChunkUnique<Float32Type> for Float32Chunked {
             .collect())
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         self.bit_repr_small().arg_unique()
     }
 
@@ -462,7 +462,7 @@ impl ChunkUnique<Float64Type> for Float64Chunked {
             .collect())
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         self.bit_repr_large().arg_unique()
     }
 

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 
+use polars_arrow::prelude::FromData;
 #[cfg(feature = "random")]
 use rand::prelude::SliceRandom;
 #[cfg(feature = "random")]
 use rand::thread_rng;
-use polars_arrow::prelude::FromData;
 
 #[derive(Copy, Clone)]
 pub enum RankMethod {
@@ -188,8 +188,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
                 }
                 dense.push(cumsum)
             });
-            let arr =
-                IdxArr::from_data_default(dense.into(), validity);
+            let arr = IdxArr::from_data_default(dense.into(), validity);
             let dense: IdxCa = (s.name(), arr).into();
             // Safety:
             // in bounds

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use rand::prelude::SliceRandom;
 #[cfg(feature = "random")]
 use rand::thread_rng;
+use polars_arrow::prelude::FromData;
 
 #[derive(Copy, Clone)]
 pub enum RankMethod {
@@ -69,7 +70,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
     let sort_idx_ca = s.argsort(reverse);
     let sort_idx = sort_idx_ca.downcast_iter().next().unwrap().values();
 
-    let mut inv: Vec<u32> = Vec::with_capacity(len);
+    let mut inv: Vec<IdxSize> = Vec::with_capacity(len);
     // Safety:
     // Values will be filled next and there is only primitive data
     #[allow(clippy::uninit_vec)]
@@ -80,14 +81,14 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
 
     #[cfg(feature = "random")]
     let mut count = if let RankMethod::Ordinal | RankMethod::Random = method {
-        1u32
+        1 as IdxSize
     } else {
         0
     };
 
     #[cfg(not(feature = "random"))]
     let mut count = if let RankMethod::Ordinal = method {
-        1u32
+        1 as IdxSize
     } else {
         0
     };
@@ -104,7 +105,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
     use RankMethod::*;
     match method {
         Ordinal => {
-            let inv_ca = UInt32Chunked::from_vec(s.name(), inv);
+            let inv_ca = IdxCa::from_vec(s.name(), inv);
             inv_ca.into_series()
         }
         #[cfg(feature = "random")]
@@ -147,7 +148,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
             }
 
             // Recreate inv_ca (where ties are randomly shuffled compared with Ordinal).
-            let mut count = 1u32;
+            let mut count = 1 as IdxSize;
             unsafe {
                 sort_idx.iter().for_each(|&i| {
                     *inv_values.get_unchecked_mut(i as usize) = count;
@@ -155,11 +156,11 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
                 });
             }
 
-            let inv_ca = UInt32Chunked::from_vec(s.name(), inv);
+            let inv_ca = IdxCa::from_vec(s.name(), inv);
             inv_ca.into_series()
         }
         _ => {
-            let inv_ca = UInt32Chunked::from_vec(s.name(), inv);
+            let inv_ca = IdxCa::from_vec(s.name(), inv);
             // Safety:
             // in bounds
             let arr = unsafe { s.take_unchecked(&sort_idx_ca).unwrap() };
@@ -178,7 +179,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
             //     if method == 'min':
             //         return count[dense - 1] + 1
             // ```
-            let mut cumsum: u32 = if let RankMethod::Min = method { 0 } else { 1 };
+            let mut cumsum: IdxSize = if let RankMethod::Min = method { 0 } else { 1 };
 
             dense.push(cumsum);
             obs.values_iter().for_each(|b| {
@@ -188,8 +189,8 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
                 dense.push(cumsum)
             });
             let arr =
-                PrimitiveArray::from_data(DataType::UInt32.to_arrow(), dense.into(), validity);
-            let dense: UInt32Chunked = (s.name(), arr).into();
+                IdxArr::from_data_default(dense.into(), validity);
+            let dense: IdxCa = (s.name(), arr).into();
             // Safety:
             // in bounds
             let dense = unsafe { dense.take_unchecked((&inv_ca).into()) };
@@ -201,7 +202,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
             let bitmap = obs.values();
             let cap = bitmap.len() - bitmap.null_count();
             let mut count = Vec::with_capacity(cap + 1);
-            let mut cnt = 0u32;
+            let mut cnt: IdxSize = 0;
             count.push(cnt);
 
             if null_count > 0 {
@@ -222,8 +223,8 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
                 });
             }
 
-            count.push((len - null_count) as u32);
-            let count = UInt32Chunked::from_vec(s.name(), count);
+            count.push((len - null_count) as IdxSize);
+            let count = IdxCa::from_vec(s.name(), count);
 
             match method {
                 Max => {

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -38,13 +38,13 @@ pub(crate) fn rank(s: &Series, method: RankMethod, reverse: bool) -> Series {
         1 => {
             return match method {
                 Average => Series::new(s.name(), &[1.0f32]),
-                _ => Series::new(s.name(), &[1u32]),
+                _ => Series::new(s.name(), &[1 as IdxSize]),
             };
         }
         0 => {
             return match method {
                 Average => Float32Chunked::from_slice(s.name(), &[]).into_series(),
-                _ => UInt32Chunked::from_slice(s.name(), &[]).into_series(),
+                _ => IdxCa::from_slice(s.name(), &[]).into_series(),
             };
         }
         _ => {}
@@ -376,7 +376,7 @@ mod test {
         let out = rank(&s, RankMethod::Average, false);
         assert_eq!(out.dtype(), &DataType::Float32);
         let out = rank(&s, RankMethod::Max, false);
-        assert_eq!(out.dtype(), &DataType::UInt32);
+        assert_eq!(out.dtype(), &IDX_DTYPE);
     }
 
     #[test]

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -266,15 +266,15 @@ mod test {
         let s = Series::new("a", &[1, 2, 3, 2, 2, 3, 0]);
 
         let out = rank(&s, RankMethod::Ordinal, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
-        assert_eq!(out, &[2, 3, 6, 4, 5, 7, 1]);
+        assert_eq!(out, &[2 as IdxSize, 3, 6, 4, 5, 7, 1]);
 
         #[cfg(feature = "random")]
         {
             let out = rank(&s, RankMethod::Random, false)
-                .u32()?
+                .idx()?
                 .into_no_null_iter()
                 .collect::<Vec<_>>();
             assert_eq!(out[0], 2);
@@ -287,19 +287,19 @@ mod test {
         }
 
         let out = rank(&s, RankMethod::Dense, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
         assert_eq!(out, &[2, 3, 4, 3, 3, 4, 1]);
 
         let out = rank(&s, RankMethod::Max, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
         assert_eq!(out, &[2, 5, 7, 5, 5, 7, 1]);
 
         let out = rank(&s, RankMethod::Min, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
         assert_eq!(out, &[2, 3, 6, 3, 3, 6, 1]);
@@ -346,7 +346,7 @@ mod test {
             ],
         );
         let out = rank(&s, RankMethod::Max, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
         assert_eq!(out, &[5, 6, 4, 1, 8, 4, 2, 7]);
@@ -363,7 +363,7 @@ mod test {
             .collect::<Vec<_>>();
         assert_eq!(out, &[2.0f32, 2.0, 2.0]);
         let out = rank(&s, RankMethod::Dense, false)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
         assert_eq!(out, &[1, 1, 1]);
@@ -383,10 +383,10 @@ mod test {
     fn test_rank_reverse() -> Result<()> {
         let s = Series::new("", &[None, Some(1), Some(1), Some(5), None]);
         let out = rank(&s, RankMethod::Dense, true)
-            .u32()?
+            .idx()?
             .into_no_null_iter()
             .collect::<Vec<_>>();
-        assert_eq!(out, &[1, 3, 3, 2, 1]);
+        assert_eq!(out, &[1 as IdxSize, 3, 3, 2, 1]);
 
         Ok(())
     }

--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -121,7 +121,7 @@ impl DataFrame {
             ));
         }
         // all columns should used the same indices. So we first create the indices.
-        let idx= match with_replacement {
+        let idx = match with_replacement {
             true => create_rand_index_with_replacement(n, self.height(), seed),
             false => create_rand_index_no_replacement(n, self.height(), seed),
         };

--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -5,20 +5,20 @@ use rand::distributions::Bernoulli;
 use rand::prelude::*;
 use rand_distr::{Distribution, Normal, Standard, StandardNormal, Uniform};
 
-fn create_rand_index_with_replacement(n: usize, len: usize, seed: u64) -> UInt32Chunked {
+fn create_rand_index_with_replacement(n: usize, len: usize, seed: u64) -> IdxCa {
     let mut rng = StdRng::seed_from_u64(seed);
-    (0u32..n as u32)
-        .map(move |_| Uniform::new(0u32, len as u32).sample(&mut rng))
-        .collect_trusted::<NoNull<UInt32Chunked>>()
+    (0..n as IdxSize)
+        .map(move |_| Uniform::new(0, len as IdxSize).sample(&mut rng))
+        .collect_trusted::<NoNull<IdxCa>>()
         .into_inner()
 }
 
-fn create_rand_index_no_replacement(n: usize, len: usize, seed: u64) -> UInt32Chunked {
+fn create_rand_index_no_replacement(n: usize, len: usize, seed: u64) -> IdxCa {
     let mut rng = StdRng::seed_from_u64(seed);
-    let mut idx = Vec::from_iter_trusted_length(0u32..len as u32);
+    let mut idx = Vec::from_iter_trusted_length(0..len as IdxSize);
     idx.shuffle(&mut rng);
     idx.truncate(n);
-    UInt32Chunked::new_vec("", idx)
+    IdxCa::new_vec("", idx)
 }
 
 impl<T> ChunkedArray<T>
@@ -121,7 +121,7 @@ impl DataFrame {
             ));
         }
         // all columns should used the same indices. So we first create the indices.
-        let idx: UInt32Chunked = match with_replacement {
+        let idx= match with_replacement {
             true => create_rand_index_with_replacement(n, self.height(), seed),
             false => create_rand_index_no_replacement(n, self.height(), seed),
         };

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -1028,14 +1028,11 @@ pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
 #[cfg(feature = "private")]
 pub type PlHashSet<V> = hashbrown::HashSet<V, RandomState>;
 
-
 #[cfg(not(feature = "bigint"))]
 pub type IdxCa = UInt32Chunked;
 #[cfg(feature = "bigint")]
 pub type IdxCa = UInt64Chunked;
-pub use polars_arrow::index::{
-    IdxSize, IdxArr
-};
+pub use polars_arrow::index::{IdxArr, IdxSize};
 
 #[cfg(not(feature = "bigint"))]
 pub const IDX_DTYPE: DataType = DataType::UInt32;

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -1028,17 +1028,24 @@ pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
 #[cfg(feature = "private")]
 pub type PlHashSet<V> = hashbrown::HashSet<V, RandomState>;
 
-/// The type used by polars to index data.
-#[cfg(not(feature = "bigint"))]
-pub type IdxSize = u32;
-#[cfg(feature = "bigint")]
-pub type IdxSize = u64;
 
 #[cfg(not(feature = "bigint"))]
 pub type IdxCa = UInt32Chunked;
-
 #[cfg(feature = "bigint")]
 pub type IdxCa = UInt64Chunked;
+pub use polars_arrow::index::{
+    IdxSize, IdxArr
+};
+
+#[cfg(not(feature = "bigint"))]
+pub const IDX_DTYPE: DataType = DataType::UInt32;
+#[cfg(feature = "bigint")]
+pub const IDX_DTYPE: DataType = DataType::UInt64;
+
+#[cfg(not(feature = "bigint"))]
+pub type IdxType = UInt32Type;
+#[cfg(feature = "bigint")]
+pub type IdxType = UInt64Type;
 
 #[cfg(test)]
 mod test {

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -1028,6 +1028,18 @@ pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
 #[cfg(feature = "private")]
 pub type PlHashSet<V> = hashbrown::HashSet<V, RandomState>;
 
+/// The type used by polars to index data.
+#[cfg(not(feature = "bigint"))]
+pub type IdxSize = u32;
+#[cfg(feature = "bigint")]
+pub type IdxSize = u64;
+
+#[cfg(not(feature = "bigint"))]
+pub type IdxCa = UInt32Chunked;
+
+#[cfg(feature = "bigint")]
+pub type IdxCa = UInt64Chunked;
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -1028,20 +1028,20 @@ pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
 #[cfg(feature = "private")]
 pub type PlHashSet<V> = hashbrown::HashSet<V, RandomState>;
 
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub type IdxCa = UInt32Chunked;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub type IdxCa = UInt64Chunked;
 pub use polars_arrow::index::{IdxArr, IdxSize};
 
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub const IDX_DTYPE: DataType = DataType::UInt32;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub const IDX_DTYPE: DataType = DataType::UInt64;
 
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub type IdxType = UInt32Type;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub type IdxType = UInt64Type;
 
 #[cfg(test)]

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 
 use crate::frame::hash_join::{get_hash_tbl_threaded_join_partitioned, multiple_keys as mk};
 
-fn find_latest_leq<T>(left_val: T, right_asof: &[T], subset_idx: &[u32]) -> Option<u32>
+fn find_latest_leq<T>(left_val: T, right_asof: &[T], subset_idx: &[IdxSize]) -> Option<IdxSize>
 where
     T: Copy + PartialOrd,
 {
@@ -28,7 +28,7 @@ fn asof_join_by<T>(
     b: &DataFrame,
     left_asof: &ChunkedArray<T>,
     right_asof: &ChunkedArray<T>,
-) -> Vec<Option<u32>>
+) -> Vec<Option<IdxSize>>
 where
     T: PolarsNumericType,
 {
@@ -65,7 +65,7 @@ where
                     Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
                 let local_offset = offset;
 
-                let mut idx_a = local_offset as u32;
+                let mut idx_a = local_offset as IdxSize;
                 for probe_hashes in probe_hashes.data_views() {
                     for (idx, &h) in probe_hashes.iter().enumerate() {
                         debug_assert!(idx + offset < left_asof.len());

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -10,7 +10,7 @@ where
     T: PolarsNumericType,
     T::Native: Bounded + PartialOrd,
 {
-    pub(crate) fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+    pub(crate) fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
         let other = self.unpack_series_matching_type(other)?;
         let mut rhs_iter = other.into_iter().peekable();
         let mut tuples = Vec::with_capacity(self.len());

--- a/polars/polars-core/src/frame/cross_join.rs
+++ b/polars/polars-core/src/frame/cross_join.rs
@@ -5,8 +5,8 @@ use crate::POOL;
 impl DataFrame {
     /// Creates the cartesian product from both frames, preserves the order of the left keys.
     pub fn cross_join(&self, other: &DataFrame) -> Result<DataFrame> {
-        let n_rows_left = self.height() as u32;
-        let n_rows_right = other.height() as u32;
+        let n_rows_left = self.height() as IdxSize;
+        let n_rows_right = other.height() as IdxSize;
         let total_rows = n_rows_right * n_rows_left;
 
         // the left side has the Nth row combined with every row from right.
@@ -18,7 +18,7 @@ impl DataFrame {
         // right take idx:  012301230123
 
         let create_left_df = || {
-            let take_left: NoNull<UInt32Chunked> =
+            let take_left: NoNull<IdxCa> =
                 (0..total_rows).map(|i| i / n_rows_right).collect_trusted();
             // Safety:
             // take left is in bounds

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -35,7 +35,7 @@ impl DataFrame {
                 // expand all the other columns based the exploded first column
                 if i == 0 {
                     let row_idx = offsets_to_indexes(&offsets, exploded.len());
-                    let row_idx = UInt32Chunked::from_vec("", row_idx);
+                    let row_idx = IdxCa::from_vec("", row_idx);
                     // Safety
                     // We just created indices that are in bounds.
                     df = unsafe { df.take_unchecked(&row_idx) };

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -97,19 +97,17 @@ impl Series {
                     Some((take.len() - take.null_count()) as IdxSize)
                 }
             }),
-            GroupsProxy::Slice(groups) => {
-                agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as IdxSize);
-                    if len == 0 {
-                        None
-                    } else if !self.has_validity() {
-                        Some(len)
-                    } else {
-                        let take = self.slice_from_offsets(first, len);
-                        Some((take.len() - take.null_count()) as IdxSize)
-                    }
-                })
-            }
+            GroupsProxy::Slice(groups) => agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as IdxSize);
+                if len == 0 {
+                    None
+                } else if !self.has_validity() {
+                    Some(len)
+                } else {
+                    let take = self.slice_from_offsets(first, len);
+                    Some((take.len() - take.null_count()) as IdxSize)
+                }
+            }),
         }
     }
 
@@ -160,17 +158,15 @@ impl Series {
                     take.n_unique().ok().map(|v| v as IdxSize)
                 }
             }),
-            GroupsProxy::Slice(groups) => {
-                agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as IdxSize);
-                    if len == 0 {
-                        None
-                    } else {
-                        let take = self.slice_from_offsets(first, len);
-                        take.n_unique().ok().map(|v| v as IdxSize)
-                    }
-                })
-            }
+            GroupsProxy::Slice(groups) => agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
+                debug_assert!(len <= self.len() as IdxSize);
+                if len == 0 {
+                    None
+                } else {
+                    let take = self.slice_from_offsets(first, len);
+                    take.n_unique().ok().map(|v| v as IdxSize)
+                }
+            }),
         }
     }
 
@@ -664,7 +660,7 @@ where
             }),
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as IdxSize);
+                    debug_assert!(len <= self.len() as IdxSize);
                     match len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -98,7 +98,7 @@ impl Series {
                 }
             }),
             GroupsProxy::Slice(groups) => {
-                agg_helper_slice::<UInt32Type, _>(groups, |[first, len]| {
+                agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
                     debug_assert!(len <= self.len() as IdxSize);
                     if len == 0 {
                         None
@@ -150,24 +150,24 @@ impl Series {
     #[cfg(feature = "private")]
     pub fn agg_n_unique(&self, groups: &GroupsProxy) -> Option<Series> {
         match groups {
-            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<UInt32Type, _>(groups, |idx| {
+            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<IdxType, _>(groups, |idx| {
                 debug_assert!(idx.len() <= self.len());
                 if idx.is_empty() {
                     None
                 } else {
                     let take =
                         unsafe { self.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize)) };
-                    take.n_unique().ok().map(|v| v as u32)
+                    take.n_unique().ok().map(|v| v as IdxSize)
                 }
             }),
             GroupsProxy::Slice(groups) => {
-                agg_helper_slice::<UInt32Type, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as u32);
+                agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
+                    debug_assert!(len <= self.len() as IdxSize);
                     if len == 0 {
                         None
                     } else {
                         let take = self.slice_from_offsets(first, len);
-                        take.n_unique().ok().map(|v| v as u32)
+                        take.n_unique().ok().map(|v| v as IdxSize)
                     }
                 })
             }
@@ -248,7 +248,7 @@ where
                 }
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -297,7 +297,7 @@ where
                 }
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -346,7 +346,7 @@ where
                 }
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -425,7 +425,7 @@ where
                 })
             }
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -450,7 +450,7 @@ where
                 take.var_as_series().unpack::<T>().unwrap().get(0)
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -474,7 +474,7 @@ where
                 take.std_as_series().unpack::<T>().unwrap().get(0)
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -509,7 +509,7 @@ where
                     .get(0)
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize),
@@ -537,7 +537,7 @@ where
                 take.median_as_series().unpack::<T>().unwrap().get(0)
             }),
             GroupsProxy::Slice(groups) => agg_helper_slice::<T, _>(groups, |[first, len]| {
-                debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                 match len {
                     0 => None,
                     1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -613,7 +613,7 @@ where
             }
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                    debug_assert!(len < self.len() as u32);
+                    debug_assert!(len < self.len() as IdxSize);
                     match first - len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -639,7 +639,7 @@ where
             }),
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as u32);
+                    debug_assert!(len <= self.len() as IdxSize);
                     match len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -664,7 +664,7 @@ where
             }),
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as u32);
+                debug_assert!(len <= self.len() as IdxSize);
                     match len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -699,7 +699,7 @@ where
             }),
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as u32);
+                    debug_assert!(len <= self.len() as IdxSize);
                     match len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -727,7 +727,7 @@ where
             }),
             GroupsProxy::Slice(groups) => {
                 agg_helper_slice::<Float64Type, _>(groups, |[first, len]| {
-                    debug_assert!(len <= self.len() as u32);
+                    debug_assert!(len <= self.len() as IdxSize);
                     match len {
                         0 => None,
                         1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
@@ -1075,7 +1075,7 @@ impl<T: PolarsObject> AggList for ObjectChunked<T> {
                             let group_vals =
                                 self.take_unchecked((idx.iter().map(|idx| *idx as usize)).into());
 
-                            (group_vals, idx.len() as u32)
+                            (group_vals, idx.len() as IdxSize)
                         }
                         GroupsIndicator::Slice([first, len]) => {
                             let group_vals = slice_from_offsets(self, first, len);

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -33,7 +33,8 @@ pub(crate) fn groupby<T>(a: impl Iterator<Item = T>, sorted: bool) -> GroupsProx
 where
     T: Hash + Eq,
 {
-    let mut hash_tbl: PlHashMap<T, (IdxSize, Vec<IdxSize>)> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+    let mut hash_tbl: PlHashMap<T, (IdxSize, Vec<IdxSize>)> =
+        PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
     let mut cnt = 0;
     a.for_each(|k| {
         let idx = cnt;

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -33,7 +33,7 @@ pub(crate) fn groupby<T>(a: impl Iterator<Item = T>, sorted: bool) -> GroupsProx
 where
     T: Hash + Eq,
 {
-    let mut hash_tbl: PlHashMap<T, (u32, Vec<u32>)> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+    let mut hash_tbl: PlHashMap<T, (IdxSize, Vec<IdxSize>)> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
     let mut cnt = 0;
     a.for_each(|k| {
         let idx = cnt;
@@ -89,13 +89,13 @@ where
             (0..n_partitions).into_par_iter().map(|thread_no| {
                 let thread_no = thread_no as u64;
 
-                let mut hash_tbl: PlHashMap<T, (u32, Vec<u32>)> =
+                let mut hash_tbl: PlHashMap<T, (IdxSize, Vec<IdxSize>)> =
                     PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
 
                 let mut offset = 0;
                 for keys in &keys {
                     let keys = keys.as_ref();
-                    let len = keys.len() as u32;
+                    let len = keys.len() as IdxSize;
                     let hasher = hash_tbl.hasher().clone();
 
                     let mut cnt = 0;
@@ -160,7 +160,7 @@ pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: usize, idx_b: usiz
 pub(crate) fn populate_multiple_key_hashmap<V, H, F, G>(
     hash_tbl: &mut HashMap<IdxHash, V, H>,
     // row index
-    idx: u32,
+    idx: IdxSize,
     // hash
     original_h: u64,
     // keys of the hash table (will not be inserted, the indexes will be used)
@@ -218,7 +218,7 @@ pub(crate) unsafe fn compare_keys<'a>(
 pub(crate) fn populate_multiple_key_hashmap2<'a, V, H, F, G>(
     hash_tbl: &mut HashMap<IdxHash, V, H>,
     // row index
-    idx: u32,
+    idx: IdxSize,
     // hash
     original_h: u64,
     // keys of the hash table (will not be inserted, the indexes will be used)
@@ -281,12 +281,12 @@ pub(crate) fn groupby_threaded_multiple_keys_flat(
                 let hashes = &hashes;
                 let thread_no = thread_no as u64;
 
-                let mut hash_tbl: HashMap<IdxHash, (u32, Vec<u32>), IdBuildHasher> =
+                let mut hash_tbl: HashMap<IdxHash, (IdxSize, Vec<IdxSize>), IdBuildHasher> =
                     HashMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
 
                 let mut offset = 0;
                 for hashes in hashes {
-                    let len = hashes.len() as u32;
+                    let len = hashes.len() as IdxSize;
 
                     let mut idx = 0;
                     for hashes_chunk in hashes.data_views() {

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -28,8 +28,6 @@ pub use pivot::PivotAgg;
 
 pub use proxy::*;
 
-pub type GroupedMap<T> = HashMap<T, Vec<u32>, RandomState>;
-
 /// Used to create the tuples for a groupby operation.
 pub trait IntoGroupsProxy {
     /// Create the tuples need for a groupby operation.
@@ -1284,7 +1282,7 @@ mod test {
         let out = df.groupby_stable(["date"])?.select(["temp"]).count()?;
         assert_eq!(
             out.column("temp_count")?,
-            &Series::new("temp_count", [2u32, 2, 1])
+            &Series::new("temp_count", [2 as IdxSize, 2, 1])
         );
 
         // Select multiple

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -78,7 +78,8 @@ impl GroupsIdx {
 
     pub fn iter(
         &self,
-    ) -> std::iter::Zip<std::iter::Copied<std::slice::Iter<IdxSize>>, std::slice::Iter<Vec<IdxSize>>> {
+    ) -> std::iter::Zip<std::iter::Copied<std::slice::Iter<IdxSize>>, std::slice::Iter<Vec<IdxSize>>>
+    {
         self.into_iter()
     }
 
@@ -277,8 +278,7 @@ impl GroupsProxy {
                 ca.into_inner()
             }
             GroupsProxy::Slice(groups) => {
-                let ca: NoNull<IdxCa> =
-                    groups.iter().map(|[_first, len]| *len).collect_trusted();
+                let ca: NoNull<IdxCa> = groups.iter().map(|[_first, len]| *len).collect_trusted();
                 ca.into_inner()
             }
         }

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -267,17 +267,17 @@ impl GroupsProxy {
         self.len() == 0
     }
 
-    pub fn group_count(&self) -> UInt32Chunked {
+    pub fn group_count(&self) -> IdxCa {
         match self {
             GroupsProxy::Idx(groups) => {
-                let ca: NoNull<UInt32Chunked> = groups
+                let ca: NoNull<IdxCa> = groups
                     .iter()
                     .map(|(_first, idx)| idx.len() as IdxSize)
                     .collect_trusted();
                 ca.into_inner()
             }
             GroupsProxy::Slice(groups) => {
-                let ca: NoNull<UInt32Chunked> =
+                let ca: NoNull<IdxCa> =
                     groups.iter().map(|[_first, len]| *len).collect_trusted();
                 ca.into_inner()
             }
@@ -288,14 +288,14 @@ impl GroupsProxy {
             GroupsProxy::Idx(groups) => groups
                 .iter()
                 .map(|(_first, idx)| {
-                    let ca: NoNull<UInt32Chunked> = idx.iter().map(|&v| v as IdxSize).collect();
+                    let ca: NoNull<IdxCa> = idx.iter().map(|&v| v as IdxSize).collect();
                     ca.into_inner().into_series()
                 })
                 .collect_trusted(),
             GroupsProxy::Slice(groups) => groups
                 .iter()
                 .map(|&[first, len]| {
-                    let ca: NoNull<UInt32Chunked> = (first..first + len).collect_trusted();
+                    let ca: NoNull<IdxCa> = (first..first + len).collect_trusted();
                     ca.into_inner().into_series()
                 })
                 .collect_trusted(),

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -71,9 +71,9 @@ pub enum JoinType {
 
 pub(crate) unsafe fn get_hash_tbl_threaded_join_partitioned<T, H>(
     h: u64,
-    hash_tables: &[HashMap<T, Vec<u32>, H>],
+    hash_tables: &[HashMap<T, Vec<IdxSize>, H>],
     len: u64,
-) -> &HashMap<T, Vec<u32>, H> {
+) -> &HashMap<T, Vec<IdxSize>, H> {
     let mut idx = 0;
     for i in 0..len {
         // can only be done for powers of two.
@@ -88,9 +88,9 @@ pub(crate) unsafe fn get_hash_tbl_threaded_join_partitioned<T, H>(
 #[allow(clippy::type_complexity)]
 unsafe fn get_hash_tbl_threaded_join_mut_partitioned<T, H>(
     h: u64,
-    hash_tables: &mut [HashMap<T, (bool, Vec<u32>), H>],
+    hash_tables: &mut [HashMap<T, (bool, Vec<IdxSize>), H>],
     len: u64,
-) -> &mut HashMap<T, (bool, Vec<u32>), H> {
+) -> &mut HashMap<T, (bool, Vec<IdxSize>), H> {
     let mut idx = 0;
     for i in 0..len {
         // can only be done for powers of two.
@@ -105,18 +105,18 @@ unsafe fn get_hash_tbl_threaded_join_mut_partitioned<T, H>(
 /// Probe the build table and add tuples to the results (inner join)
 fn probe_inner<T, F>(
     probe: &[T],
-    hash_tbls: &[PlHashMap<T, Vec<u32>>],
-    results: &mut Vec<(u32, u32)>,
+    hash_tbls: &[PlHashMap<T, Vec<IdxSize>>],
+    results: &mut Vec<(IdxSize, IdxSize)>,
     local_offset: usize,
     n_tables: u64,
     swap_fn: F,
 ) where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
-    F: Fn(u32, u32) -> (u32, u32),
+    F: Fn(IdxSize, IdxSize) -> (IdxSize, IdxSize),
 {
     assert!(hash_tbls.len().is_power_of_two());
     probe.iter().enumerate().for_each(|(idx_a, k)| {
-        let idx_a = (idx_a + local_offset) as u32;
+        let idx_a = (idx_a + local_offset) as IdxSize;
         // probe table that contains the hashed value
         let current_probe_table =
             unsafe { get_hash_tbl_threaded_join_partitioned(k.as_u64(), hash_tbls, n_tables) };
@@ -130,7 +130,7 @@ fn probe_inner<T, F>(
     });
 }
 
-pub(crate) fn create_probe_table<T, IntoSlice>(keys: Vec<IntoSlice>) -> Vec<PlHashMap<T, Vec<u32>>>
+pub(crate) fn create_probe_table<T, IntoSlice>(keys: Vec<IntoSlice>) -> Vec<PlHashMap<T, Vec<IdxSize>>>
 where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
     IntoSlice: AsRef<[T]> + Send + Sync,
@@ -144,13 +144,13 @@ where
         (0..n_partitions).into_par_iter().map(|partition_no| {
             let partition_no = partition_no as u64;
 
-            let mut hash_tbl: PlHashMap<T, Vec<u32>> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+            let mut hash_tbl: PlHashMap<T, Vec<IdxSize>> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
 
             let n_partitions = n_partitions as u64;
             let mut offset = 0;
             for keys in &keys {
                 let keys = keys.as_ref();
-                let len = keys.len() as u32;
+                let len = keys.len() as IdxSize;
 
                 let mut cnt = 0;
                 keys.iter().for_each(|k| {
@@ -184,7 +184,7 @@ fn hash_join_tuples_inner<T, IntoSlice>(
     build: Vec<IntoSlice>,
     // Because b should be the shorter relation we could need to swap to keep left left and right right.
     swap: bool,
-) -> Vec<(u32, u32)>
+) -> Vec<(IdxSize, IdxSize)>
 where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
@@ -249,7 +249,7 @@ where
 fn hash_join_tuples_left<T, IntoSlice>(
     probe: Vec<IntoSlice>,
     build: Vec<IntoSlice>,
-) -> Vec<(u32, Option<u32>)>
+) -> Vec<(IdxSize, Option<IdxSize>)>
 where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
@@ -287,7 +287,7 @@ where
                 let mut results = Vec::with_capacity(probe.len());
 
                 probe.iter().enumerate().for_each(|(idx_a, k)| {
-                    let idx_a = (idx_a + offset) as u32;
+                    let idx_a = (idx_a + offset) as IdxSize;
                     // probe table that contains the hashed value
                     let current_probe_table = unsafe {
                         get_hash_tbl_threaded_join_partitioned(k.as_u64(), hash_tbls, n_tables)
@@ -315,8 +315,8 @@ where
 /// Probe the build table and add tuples to the results (inner join)
 fn probe_outer<T, F, G, H>(
     probe_hashes: &[Vec<(u64, T)>],
-    hash_tbls: &mut [PlHashMap<T, (bool, Vec<u32>)>],
-    results: &mut Vec<(Option<u32>, Option<u32>)>,
+    hash_tbls: &mut [PlHashMap<T, (bool, Vec<IdxSize>)>],
+    results: &mut Vec<(Option<IdxSize>, Option<IdxSize>)>,
     n_tables: u64,
     // Function that get index_a, index_b when there is a match and pushes to result
     swap_fn_match: F,
@@ -327,11 +327,11 @@ fn probe_outer<T, F, G, H>(
 ) where
     T: Send + Hash + Eq + Sync + Copy,
     // idx_a, idx_b -> ...
-    F: Fn(u32, u32) -> (Option<u32>, Option<u32>),
+    F: Fn(IdxSize, IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
     // idx_a -> ...
-    G: Fn(u32) -> (Option<u32>, Option<u32>),
+    G: Fn(IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
     // idx_b -> ...
-    H: Fn(u32) -> (Option<u32>, Option<u32>),
+    H: Fn(IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
 {
     // needed for the partition shift instead of modulo to make sense
     assert!(n_tables.is_power_of_two());
@@ -376,7 +376,7 @@ fn hash_join_tuples_outer<T, I, J>(
     a: Vec<I>,
     b: Vec<J>,
     swap: bool,
-) -> Vec<(Option<u32>, Option<u32>)>
+) -> Vec<(Option<IdxSize>, Option<IdxSize>)>
 where
     I: Iterator<Item = T> + Send + TrustedLen,
     J: Iterator<Item = T> + Send + TrustedLen,
@@ -433,29 +433,29 @@ where
 }
 
 pub(crate) trait HashJoin<T> {
-    fn hash_join_inner(&self, _other: &ChunkedArray<T>) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, _other: &ChunkedArray<T>) -> Vec<(IdxSize, IdxSize)> {
         unimplemented!()
     }
-    fn hash_join_left(&self, _other: &ChunkedArray<T>) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, _other: &ChunkedArray<T>) -> Vec<(IdxSize, Option<IdxSize>)> {
         unimplemented!()
     }
-    fn hash_join_outer(&self, _other: &ChunkedArray<T>) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, _other: &ChunkedArray<T>) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         unimplemented!()
     }
 }
 
 impl HashJoin<Float32Type> for Float32Chunked {
-    fn hash_join_inner(&self, other: &Float32Chunked) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Float32Chunked) -> Vec<(IdxSize, IdxSize)> {
         let ca = self.bit_repr_small();
         let other = other.bit_repr_small();
         ca.hash_join_inner(&other)
     }
-    fn hash_join_left(&self, other: &Float32Chunked) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Float32Chunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         let ca = self.bit_repr_small();
         let other = other.bit_repr_small();
         ca.hash_join_left(&other)
     }
-    fn hash_join_outer(&self, other: &Float32Chunked) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Float32Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let ca = self.bit_repr_small();
         let other = other.bit_repr_small();
         ca.hash_join_outer(&other)
@@ -463,17 +463,17 @@ impl HashJoin<Float32Type> for Float32Chunked {
 }
 
 impl HashJoin<Float64Type> for Float64Chunked {
-    fn hash_join_inner(&self, other: &Float64Chunked) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Float64Chunked) -> Vec<(IdxSize, IdxSize)> {
         let ca = self.bit_repr_large();
         let other = other.bit_repr_large();
         ca.hash_join_inner(&other)
     }
-    fn hash_join_left(&self, other: &Float64Chunked) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Float64Chunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         let ca = self.bit_repr_large();
         let other = other.bit_repr_large();
         ca.hash_join_left(&other)
     }
-    fn hash_join_outer(&self, other: &Float64Chunked) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Float64Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let ca = self.bit_repr_large();
         let other = other.bit_repr_large();
         ca.hash_join_outer(&other)
@@ -481,18 +481,18 @@ impl HashJoin<Float64Type> for Float64Chunked {
 }
 
 impl HashJoin<CategoricalType> for CategoricalChunked {
-    fn hash_join_inner(&self, other: &CategoricalChunked) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &CategoricalChunked) -> Vec<(IdxSize, IdxSize)> {
         self.deref().hash_join_inner(other.deref())
     }
-    fn hash_join_left(&self, other: &CategoricalChunked) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &CategoricalChunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         self.deref().hash_join_left(other.deref())
     }
-    fn hash_join_outer(&self, other: &CategoricalChunked) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &CategoricalChunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         self.deref().hash_join_outer(other.deref())
     }
 }
 
-fn num_group_join_inner<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> Vec<(u32, u32)>
+fn num_group_join_inner<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> Vec<(IdxSize, IdxSize)>
 where
     T: PolarsIntegerType,
     T::Native: Hash + Eq + Send + AsU64 + Copy,
@@ -567,7 +567,7 @@ where
 fn num_group_join_left<T>(
     left: &ChunkedArray<T>,
     right: &ChunkedArray<T>,
-) -> Vec<(u32, Option<u32>)>
+) -> Vec<(IdxSize, Option<IdxSize>)>
 where
     T: PolarsIntegerType,
     T::Native: Hash + Eq + Send + AsU64,
@@ -659,7 +659,7 @@ where
     T: PolarsIntegerType + Sync,
     T::Native: Eq + Hash + num::NumCast,
 {
-    fn hash_join_inner(&self, other: &ChunkedArray<T>) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &ChunkedArray<T>) -> Vec<(IdxSize, IdxSize)> {
         match self.dtype() {
             DataType::UInt64 => {
                 // convince the compiler that we are this type.
@@ -701,7 +701,7 @@ where
         }
     }
 
-    fn hash_join_left(&self, other: &ChunkedArray<T>) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &ChunkedArray<T>) -> Vec<(IdxSize, Option<IdxSize>)> {
         match self.dtype() {
             DataType::UInt64 => {
                 // convince the compiler that we are this type.
@@ -743,7 +743,7 @@ where
         }
     }
 
-    fn hash_join_outer(&self, other: &ChunkedArray<T>) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &ChunkedArray<T>) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
         let n_partitions = set_partition_size();
@@ -778,7 +778,7 @@ where
 }
 
 impl HashJoin<BooleanType> for BooleanChunked {
-    fn hash_join_inner(&self, other: &BooleanChunked) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &BooleanChunked) -> Vec<(IdxSize, IdxSize)> {
         let ca = self.cast(&DataType::UInt32).unwrap();
         let ca = ca.u32().unwrap();
         let other = other.cast(&DataType::UInt32).unwrap();
@@ -786,7 +786,7 @@ impl HashJoin<BooleanType> for BooleanChunked {
         ca.hash_join_inner(other)
     }
 
-    fn hash_join_left(&self, other: &BooleanChunked) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &BooleanChunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         let ca = self.cast(&DataType::UInt32).unwrap();
         let ca = ca.u32().unwrap();
         let other = other.cast(&DataType::UInt32).unwrap();
@@ -794,7 +794,7 @@ impl HashJoin<BooleanType> for BooleanChunked {
         ca.hash_join_left(other)
     }
 
-    fn hash_join_outer(&self, other: &BooleanChunked) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &BooleanChunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
         let n_partitions = set_partition_size();
@@ -847,7 +847,7 @@ fn prepare_strs<'a>(been_split: &'a [Utf8Chunked], hb: &RandomState) -> Vec<Vec<
 }
 
 impl HashJoin<Utf8Type> for Utf8Chunked {
-    fn hash_join_inner(&self, other: &Utf8Chunked) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Utf8Chunked) -> Vec<(IdxSize, IdxSize)> {
         let n_threads = POOL.current_num_threads();
 
         let (a, b, swap) = det_hash_prone_order!(self, other);
@@ -861,7 +861,7 @@ impl HashJoin<Utf8Type> for Utf8Chunked {
         hash_join_tuples_inner(str_hashes_a, str_hashes_b, swap)
     }
 
-    fn hash_join_left(&self, other: &Utf8Chunked) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Utf8Chunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         let n_threads = POOL.current_num_threads();
 
         let hb = RandomState::default();
@@ -873,7 +873,7 @@ impl HashJoin<Utf8Type> for Utf8Chunked {
         hash_join_tuples_left(str_hashes_a, str_hashes_b)
     }
 
-    fn hash_join_outer(&self, other: &Utf8Chunked) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Utf8Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
         let n_partitions = set_partition_size();
@@ -911,7 +911,7 @@ pub trait ZipOuterJoinColumn {
     fn zip_outer_join_column(
         &self,
         _right_column: &Series,
-        _opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        _opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         unimplemented!()
     }
@@ -925,7 +925,7 @@ where
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         let right_ca = self.unpack_series_matching_type(right_column).unwrap();
 
@@ -955,7 +955,7 @@ macro_rules! impl_zip_outer_join {
             fn zip_outer_join_column(
                 &self,
                 right_column: &Series,
-                opt_join_tuples: &[(Option<u32>, Option<u32>)],
+                opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
             ) -> Series {
                 let right_ca = self.unpack_series_matching_type(right_column).unwrap();
 
@@ -987,7 +987,7 @@ impl ZipOuterJoinColumn for Float32Chunked {
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         self.apply_as_ints(|s| {
             s.zip_outer_join_column(
@@ -1002,7 +1002,7 @@ impl ZipOuterJoinColumn for Float64Chunked {
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         self.apply_as_ints(|s| {
             s.zip_outer_join_column(
@@ -1044,7 +1044,7 @@ impl DataFrame {
         Ok(df_left)
     }
 
-    fn create_left_df<B: Sync>(&self, join_tuples: &[(u32, B)], left_join: bool) -> DataFrame {
+    fn create_left_df<B: Sync>(&self, join_tuples: &[(IdxSize, B)], left_join: bool) -> DataFrame {
         if left_join && join_tuples.len() == self.height() {
             self.clone()
         } else {

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -130,7 +130,9 @@ fn probe_inner<T, F>(
     });
 }
 
-pub(crate) fn create_probe_table<T, IntoSlice>(keys: Vec<IntoSlice>) -> Vec<PlHashMap<T, Vec<IdxSize>>>
+pub(crate) fn create_probe_table<T, IntoSlice>(
+    keys: Vec<IntoSlice>,
+) -> Vec<PlHashMap<T, Vec<IdxSize>>>
 where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
     IntoSlice: AsRef<[T]> + Send + Sync,
@@ -144,7 +146,8 @@ where
         (0..n_partitions).into_par_iter().map(|partition_no| {
             let partition_no = partition_no as u64;
 
-            let mut hash_tbl: PlHashMap<T, Vec<IdxSize>> = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+            let mut hash_tbl: PlHashMap<T, Vec<IdxSize>> =
+                PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
 
             let n_partitions = n_partitions as u64;
             let mut offset = 0;
@@ -487,12 +490,18 @@ impl HashJoin<CategoricalType> for CategoricalChunked {
     fn hash_join_left(&self, other: &CategoricalChunked) -> Vec<(IdxSize, Option<IdxSize>)> {
         self.deref().hash_join_left(other.deref())
     }
-    fn hash_join_outer(&self, other: &CategoricalChunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
+    fn hash_join_outer(
+        &self,
+        other: &CategoricalChunked,
+    ) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         self.deref().hash_join_outer(other.deref())
     }
 }
 
-fn num_group_join_inner<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> Vec<(IdxSize, IdxSize)>
+fn num_group_join_inner<T>(
+    left: &ChunkedArray<T>,
+    right: &ChunkedArray<T>,
+) -> Vec<(IdxSize, IdxSize)>
 where
     T: PolarsIntegerType,
     T::Native: Hash + Eq + Send + AsU64 + Copy,

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -238,13 +238,19 @@ pub(crate) fn inner_join_multiple_keys(
 }
 
 #[cfg(feature = "private")]
-pub fn private_left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(IdxSize, Option<IdxSize>)> {
+pub fn private_left_join_multiple_keys(
+    a: &DataFrame,
+    b: &DataFrame,
+) -> Vec<(IdxSize, Option<IdxSize>)> {
     let a = DataFrame::new_no_checks(to_physical_and_bit_repr(a.get_columns()));
     let b = DataFrame::new_no_checks(to_physical_and_bit_repr(b.get_columns()));
     left_join_multiple_keys(&a, &b)
 }
 
-pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(IdxSize, Option<IdxSize>)> {
+pub(crate) fn left_join_multiple_keys(
+    a: &DataFrame,
+    b: &DataFrame,
+) -> Vec<(IdxSize, Option<IdxSize>)> {
     // we should not join on logical types
     debug_assert!(!a.iter().any(|s| s.is_logical()));
     debug_assert!(!b.iter().any(|s| s.is_logical()));

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -30,7 +30,7 @@ pub(crate) unsafe fn compare_df_rows2(
 pub(crate) fn create_build_table(
     hashes: &[UInt64Chunked],
     keys: &DataFrame,
-) -> Vec<HashMap<IdxHash, Vec<u32>, IdBuildHasher>> {
+) -> Vec<HashMap<IdxHash, Vec<IdxSize>, IdBuildHasher>> {
     let n_partitions = set_partition_size();
 
     // We will create a hashtable in every thread.
@@ -39,7 +39,7 @@ pub(crate) fn create_build_table(
     POOL.install(|| {
         (0..n_partitions).into_par_iter().map(|part_no| {
             let part_no = part_no as u64;
-            let mut hash_tbl: HashMap<IdxHash, Vec<u32>, IdBuildHasher> =
+            let mut hash_tbl: HashMap<IdxHash, Vec<IdxSize>, IdBuildHasher> =
                 HashMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
 
             let n_partitions = n_partitions as u64;
@@ -65,7 +65,7 @@ pub(crate) fn create_build_table(
                         idx += 1;
                     });
 
-                    offset += len as u32;
+                    offset += len as IdxSize;
                 }
             }
             hash_tbl
@@ -77,7 +77,7 @@ pub(crate) fn create_build_table(
 fn create_build_table_outer(
     hashes: &[UInt64Chunked],
     keys: &DataFrame,
-) -> Vec<HashMap<IdxHash, (bool, Vec<u32>), IdBuildHasher>> {
+) -> Vec<HashMap<IdxHash, (bool, Vec<IdxSize>), IdBuildHasher>> {
     // Outer join equivalent of create_build_table() adds a bool in the hashmap values for tracking
     // whether a value in the hash table has already been matched to a value in the probe hashes.
     let n_partitions = set_partition_size();
@@ -88,7 +88,7 @@ fn create_build_table_outer(
     POOL.install(|| {
         (0..n_partitions).into_par_iter().map(|part_no| {
             let part_no = part_no as u64;
-            let mut hash_tbl: HashMap<IdxHash, (bool, Vec<u32>), IdBuildHasher> =
+            let mut hash_tbl: HashMap<IdxHash, (bool, Vec<IdxSize>), IdBuildHasher> =
                 HashMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
 
             let n_partitions = n_partitions as u64;
@@ -114,7 +114,7 @@ fn create_build_table_outer(
                         idx += 1;
                     });
 
-                    offset += len as u32;
+                    offset += len as IdxSize;
                 }
             }
             hash_tbl
@@ -127,17 +127,17 @@ fn create_build_table_outer(
 #[allow(clippy::too_many_arguments)]
 fn probe_inner<F>(
     probe_hashes: &UInt64Chunked,
-    hash_tbls: &[HashMap<IdxHash, Vec<u32>, IdBuildHasher>],
-    results: &mut Vec<(u32, u32)>,
+    hash_tbls: &[HashMap<IdxHash, Vec<IdxSize>, IdBuildHasher>],
+    results: &mut Vec<(IdxSize, IdxSize)>,
     local_offset: usize,
     n_tables: u64,
     a: &DataFrame,
     b: &DataFrame,
     swap_fn: F,
 ) where
-    F: Fn(u32, u32) -> (u32, u32),
+    F: Fn(IdxSize, IdxSize) -> (IdxSize, IdxSize),
 {
-    let mut idx_a = local_offset as u32;
+    let mut idx_a = local_offset as IdxSize;
     for probe_hashes in probe_hashes.data_views() {
         for &h in probe_hashes {
             // probe table that contains the hashed value
@@ -176,7 +176,7 @@ pub(crate) fn inner_join_multiple_keys(
     a: &DataFrame,
     b: &DataFrame,
     swap: bool,
-) -> Vec<(u32, u32)> {
+) -> Vec<(IdxSize, IdxSize)> {
     // we assume that the b DataFrame is the shorter relation.
     // b will be used for the build phase.
 
@@ -238,13 +238,13 @@ pub(crate) fn inner_join_multiple_keys(
 }
 
 #[cfg(feature = "private")]
-pub fn private_left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(u32, Option<u32>)> {
+pub fn private_left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(IdxSize, Option<IdxSize>)> {
     let a = DataFrame::new_no_checks(to_physical_and_bit_repr(a.get_columns()));
     let b = DataFrame::new_no_checks(to_physical_and_bit_repr(b.get_columns()));
     left_join_multiple_keys(&a, &b)
 }
 
-pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(u32, Option<u32>)> {
+pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(IdxSize, Option<IdxSize>)> {
     // we should not join on logical types
     debug_assert!(!a.iter().any(|s| s.is_logical()));
     debug_assert!(!b.iter().any(|s| s.is_logical()));
@@ -276,7 +276,7 @@ pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(u32,
                     Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
                 let local_offset = offset;
 
-                let mut idx_a = local_offset as u32;
+                let mut idx_a = local_offset as IdxSize;
                 for probe_hashes in probe_hashes.data_views() {
                     for &h in probe_hashes {
                         // probe table that contains the hashed value
@@ -315,8 +315,8 @@ pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<(u32,
 #[allow(clippy::type_complexity)]
 fn probe_outer<F, G, H>(
     probe_hashes: &[UInt64Chunked],
-    hash_tbls: &mut [HashMap<IdxHash, (bool, Vec<u32>), IdBuildHasher>],
-    results: &mut Vec<(Option<u32>, Option<u32>)>,
+    hash_tbls: &mut [HashMap<IdxHash, (bool, Vec<IdxSize>), IdBuildHasher>],
+    results: &mut Vec<(Option<IdxSize>, Option<IdxSize>)>,
     n_tables: u64,
     a: &DataFrame,
     b: &DataFrame,
@@ -328,11 +328,11 @@ fn probe_outer<F, G, H>(
     swap_fn_drain: H,
 ) where
     // idx_a, idx_b -> ...
-    F: Fn(u32, u32) -> (Option<u32>, Option<u32>),
+    F: Fn(IdxSize, IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
     // idx_a -> ...
-    G: Fn(u32) -> (Option<u32>, Option<u32>),
+    G: Fn(IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
     // idx_b -> ...
-    H: Fn(u32) -> (Option<u32>, Option<u32>),
+    H: Fn(IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
 {
     let mut idx_a = 0;
 
@@ -384,7 +384,7 @@ pub(crate) fn outer_join_multiple_keys(
     a: &DataFrame,
     b: &DataFrame,
     swap: bool,
-) -> Vec<(Option<u32>, Option<u32>)> {
+) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
     // we assume that the b DataFrame is the shorter relation.
     // b will be used for the build phase.
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1470,7 +1470,10 @@ impl DataFrame {
         I: Iterator<Item = Option<usize>> + Clone + Sync + TrustedLen,
     {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
-            let idx_ca: IdxCa = iter.into_iter().map(|opt| opt.map(|v| v as IdxSize)).collect();
+            let idx_ca: IdxCa = iter
+                .into_iter()
+                .map(|opt| opt.map(|v| v as IdxSize))
+                .collect();
             return self.take_unchecked_vectical(&idx_ca);
         }
 
@@ -1485,7 +1488,10 @@ impl DataFrame {
             .any(|s| matches!(s.dtype(), DataType::Utf8));
 
         if (n_chunks == 1 && self.width() > 1) || has_utf8 {
-            let idx_ca: IdxCa = iter.into_iter().map(|opt| opt.map(|v| v as IdxSize)).collect();
+            let idx_ca: IdxCa = iter
+                .into_iter()
+                .map(|opt| opt.map(|v| v as IdxSize))
+                .collect();
             return self.take_unchecked(&idx_ca);
         }
 
@@ -2798,7 +2804,12 @@ impl DataFrame {
     pub fn is_unique(&self) -> Result<BooleanChunked> {
         let mut gb = self.groupby(self.get_column_names())?;
         let groups = std::mem::take(&mut gb.groups);
-        Ok(is_unique_helper(groups, self.height() as IdxSize, true, false))
+        Ok(is_unique_helper(
+            groups,
+            self.height() as IdxSize,
+            true,
+            false,
+        ))
     }
 
     /// Get a mask of all the duplicated rows in the `DataFrame`.
@@ -2817,7 +2828,12 @@ impl DataFrame {
     pub fn is_duplicated(&self) -> Result<BooleanChunked> {
         let mut gb = self.groupby(self.get_column_names())?;
         let groups = std::mem::take(&mut gb.groups);
-        Ok(is_unique_helper(groups, self.height() as IdxSize, false, true))
+        Ok(is_unique_helper(
+            groups,
+            self.height() as IdxSize,
+            false,
+            true,
+        ))
     }
 
     /// Create a new `DataFrame` that shows the null counts per column.

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1540,7 +1540,7 @@ impl DataFrame {
     }
 
     #[cfg(feature = "rows")]
-    pub(crate) unsafe fn take_unchecked_slice(&self, idx: &[u32]) -> Self {
+    pub(crate) unsafe fn take_unchecked_slice(&self, idx: &[IdxSize]) -> Self {
         self.take_iter_unchecked(idx.iter().map(|i| *i as usize))
     }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1420,7 +1420,7 @@ impl DataFrame {
         I: Iterator<Item = usize> + Clone + Sync + TrustedLen,
     {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
-            let idx_ca: NoNull<UInt32Chunked> = iter.into_iter().map(|idx| idx as u32).collect();
+            let idx_ca: NoNull<IdxCa> = iter.into_iter().map(|idx| idx as IdxSize).collect();
             return self.take_unchecked_vectical(&idx_ca.into_inner());
         }
 
@@ -1434,7 +1434,7 @@ impl DataFrame {
             .any(|s| matches!(s.dtype(), DataType::Utf8));
 
         if (n_chunks == 1 && self.width() > 1) || has_utf8 {
-            let idx_ca: NoNull<UInt32Chunked> = iter.into_iter().map(|idx| idx as u32).collect();
+            let idx_ca: NoNull<IdxCa> = iter.into_iter().map(|idx| idx as IdxSize).collect();
             let idx_ca = idx_ca.into_inner();
             return self.take_unchecked(&idx_ca);
         }
@@ -1470,7 +1470,7 @@ impl DataFrame {
         I: Iterator<Item = Option<usize>> + Clone + Sync + TrustedLen,
     {
         if std::env::var("POLARS_VERT_PAR").is_ok() {
-            let idx_ca: UInt32Chunked = iter.into_iter().map(|opt| opt.map(|v| v as u32)).collect();
+            let idx_ca: IdxCa = iter.into_iter().map(|opt| opt.map(|v| v as IdxSize)).collect();
             return self.take_unchecked_vectical(&idx_ca);
         }
 
@@ -1485,7 +1485,7 @@ impl DataFrame {
             .any(|s| matches!(s.dtype(), DataType::Utf8));
 
         if (n_chunks == 1 && self.width() > 1) || has_utf8 {
-            let idx_ca: UInt32Chunked = iter.into_iter().map(|opt| opt.map(|v| v as u32)).collect();
+            let idx_ca: IdxCa = iter.into_iter().map(|opt| opt.map(|v| v as IdxSize)).collect();
             return self.take_unchecked(&idx_ca);
         }
 
@@ -1516,11 +1516,11 @@ impl DataFrame {
     /// ```
     /// # use polars_core::prelude::*;
     /// fn example(df: &DataFrame) -> Result<DataFrame> {
-    ///     let idx = UInt32Chunked::new("idx", &[0, 1, 9]);
+    ///     let idx = IdxCa::new("idx", &[0, 1, 9]);
     ///     df.take(&idx)
     /// }
     /// ```
-    pub fn take(&self, indices: &UInt32Chunked) -> Result<Self> {
+    pub fn take(&self, indices: &IdxCa) -> Result<Self> {
         let indices = if indices.chunks.len() > 1 {
             Cow::Owned(indices.rechunk())
         } else {
@@ -1544,7 +1544,7 @@ impl DataFrame {
         self.take_iter_unchecked(idx.iter().map(|i| *i as usize))
     }
 
-    pub(crate) unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Self {
+    pub(crate) unsafe fn take_unchecked(&self, idx: &IdxCa) -> Self {
         let cols = POOL.install(|| {
             self.columns
                 .par_iter()
@@ -1557,7 +1557,7 @@ impl DataFrame {
         DataFrame::new_no_checks(cols)
     }
 
-    unsafe fn take_unchecked_vectical(&self, indices: &UInt32Chunked) -> Self {
+    unsafe fn take_unchecked_vectical(&self, indices: &IdxCa) -> Self {
         let n_threads = POOL.current_num_threads();
         let idxs = split_ca(indices, n_threads).unwrap();
 
@@ -2752,9 +2752,9 @@ impl DataFrame {
         let gb = self.groupby(names)?;
         let groups = gb.get_groups().idx_ref();
 
-        let finish_maintain_order = |mut groups: Vec<u32>| {
+        let finish_maintain_order = |mut groups: Vec<IdxSize>| {
             groups.sort_unstable();
-            let ca = UInt32Chunked::from_vec("", groups);
+            let ca = IdxCa::from_vec("", groups);
             unsafe { self.take_unchecked(&ca) }
         };
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2798,7 +2798,7 @@ impl DataFrame {
     pub fn is_unique(&self) -> Result<BooleanChunked> {
         let mut gb = self.groupby(self.get_column_names())?;
         let groups = std::mem::take(&mut gb.groups);
-        Ok(is_unique_helper(groups, self.height() as u32, true, false))
+        Ok(is_unique_helper(groups, self.height() as IdxSize, true, false))
     }
 
     /// Get a mask of all the duplicated rows in the `DataFrame`.
@@ -2817,7 +2817,7 @@ impl DataFrame {
     pub fn is_duplicated(&self) -> Result<BooleanChunked> {
         let mut gb = self.groupby(self.get_column_names())?;
         let groups = std::mem::take(&mut gb.groups);
-        Ok(is_unique_helper(groups, self.height() as u32, false, true))
+        Ok(is_unique_helper(groups, self.height() as IdxSize, false, true))
     }
 
     /// Create a new `DataFrame` that shows the null counts per column.

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -52,7 +52,7 @@ where
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
-pub fn argsort_by(by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+pub fn argsort_by(by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
     if by.len() != reverse.len() {
         return Err(PolarsError::ValueError(
             format!(

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -18,7 +18,11 @@ pub use crate::{
     datatypes::*,
     df,
     error::{PolarsError, Result},
-    frame::{groupby::GroupsProxy, hash_join::JoinType, *},
+    frame::{
+        groupby::{GroupsIdx, GroupsProxy, GroupsSlice},
+        hash_join::JoinType,
+        *,
+    },
     named_from::{NamedFrom, NamedFromOwned},
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -286,7 +286,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         ChunkUnique::n_unique(&self.0)
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         ChunkUnique::arg_unique(&self.0)
     }
 

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -102,7 +102,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         self.0.argsort_multiple(by, reverse)
     }
 }
@@ -198,7 +198,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.mean()
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         let indices = if indices.chunks.len() > 1 {
             Cow::Owned(indices.rechunk())
         } else {
@@ -219,7 +219,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         let idx = if idx.chunks.len() > 1 {
             Cow::Owned(idx.rechunk())
         } else {
@@ -266,7 +266,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         ChunkSort::sort_with(&self.0, options).into_series()
     }
 
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, reverse: bool) -> IdxCa {
         ChunkSort::argsort(&self.0, reverse)
     }
 
@@ -298,7 +298,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         ArgAgg::arg_max(&self.0)
     }
 
-    fn arg_true(&self) -> Result<UInt32Chunked> {
+    fn arg_true(&self) -> Result<IdxCa> {
         let ca: &BooleanChunked = self.bool()?;
         Ok(ca.arg_true())
     }
@@ -373,7 +373,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         IsIn::is_in(&self.0, other)
     }
     #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         RepeatBy::repeat_by(&self.0, by)
     }
 

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -81,19 +81,19 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn agg_list(&self, groups: &GroupsProxy) -> Option<Series> {
         self.0.agg_list(groups)
     }
-    fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
         HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
         HashJoin::hash_join_left(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         HashJoin::hash_join_outer(&self.0, other.as_ref().as_ref())
     }
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -289,7 +289,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         ChunkUnique::n_unique(&self.0)
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         ChunkUnique::arg_unique(&self.0)
     }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -72,19 +72,19 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.agg_list(groups)
     }
 
-    fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
         HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
         HashJoin::hash_join_left(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         HashJoin::hash_join_outer(&self.0, other.as_ref().as_ref())
     }
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         let categorical_map_out = Some(
             self.0

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -106,7 +106,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         self.0.argsort_multiple(by, reverse)
     }
 }
@@ -197,7 +197,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         let indices = if indices.chunks.len() > 1 {
             Cow::Owned(indices.rechunk())
         } else {
@@ -218,7 +218,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         let idx = if idx.chunks.len() > 1 {
             Cow::Owned(idx.rechunk())
         } else {
@@ -269,7 +269,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         ChunkSort::sort_with(&self.0, options).into_series()
     }
 
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, reverse: bool) -> IdxCa {
         ChunkSort::argsort(&self.0, reverse)
     }
 
@@ -363,7 +363,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         IsIn::is_in(&self.0, other)
     }
     #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         RepeatBy::repeat_by(&self.0, by)
     }
 

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -444,7 +444,7 @@ macro_rules! impl_dyn_series {
                 self.0.n_unique()
             }
 
-            fn arg_unique(&self) -> Result<UInt32Chunked> {
+            fn arg_unique(&self) -> Result<IdxCa> {
                 self.0.arg_unique()
             }
 

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -59,7 +59,7 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "asof_join")]
-            fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+            fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
                 let other = other.to_physical_repr();
                 self.0.deref().join_asof(&other)
             }
@@ -150,22 +150,22 @@ macro_rules! impl_dyn_series {
                     .map(|s| s.$into_logical().into_series())
             }
 
-            fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+            fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
                 let other = other.to_physical_repr().into_owned();
                 self.0.hash_join_inner(&other.as_ref().as_ref())
             }
-            fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+            fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
                 let other = other.to_physical_repr().into_owned();
                 self.0.hash_join_left(&other.as_ref().as_ref())
             }
-            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
                 let other = other.to_physical_repr().into_owned();
                 self.0.hash_join_outer(&other.as_ref().as_ref())
             }
             fn zip_outer_join_column(
                 &self,
                 right_column: &Series,
-                opt_join_tuples: &[(Option<u32>, Option<u32>)],
+                opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
             ) -> Series {
                 let right_column = right_column.to_physical_repr().into_owned();
                 self.0

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -221,7 +221,7 @@ macro_rules! impl_dyn_series {
                 self.0.group_tuples(multithreaded, sorted)
             }
             #[cfg(feature = "sort_multiple")]
-            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
                 self.0.deref().argsort_multiple(by, reverse)
             }
         }
@@ -346,7 +346,7 @@ macro_rules! impl_dyn_series {
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+            fn take(&self, indices: &IdxCa) -> Result<Series> {
                 ChunkTake::take(self.0.deref(), indices.into())
                     .map(|ca| ca.$into_logical().into_series())
             }
@@ -366,7 +366,7 @@ macro_rules! impl_dyn_series {
                     .into_series()
             }
 
-            unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+            unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
                 Ok(ChunkTake::take_unchecked(self.0.deref(), idx.into())
                     .$into_logical()
                     .into_series())
@@ -424,7 +424,7 @@ macro_rules! impl_dyn_series {
                 self.0.sort_with(options).$into_logical().into_series()
             }
 
-            fn argsort(&self, reverse: bool) -> UInt32Chunked {
+            fn argsort(&self, reverse: bool) -> IdxCa {
                 self.0.argsort(reverse)
             }
 
@@ -557,7 +557,7 @@ macro_rules! impl_dyn_series {
                 self.0.is_in(other)
             }
             #[cfg(feature = "repeat_by")]
-            fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+            fn repeat_by(&self, by: &IdxCa) -> ListChunked {
                 match self.0.dtype() {
                     DataType::Date => self
                         .0

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -60,7 +60,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     }
 
     #[cfg(feature = "asof_join")]
-    fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+    fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
         let other = other.to_physical_repr();
         self.0.deref().join_asof(&other)
     }
@@ -150,22 +150,22 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
                 .into_series()
         })
     }
-    fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_inner(other.as_ref().as_ref())
     }
-    fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_left(other.as_ref().as_ref())
     }
-    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_outer(other.as_ref().as_ref())
     }
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         let right_column = right_column.to_physical_repr().into_owned();
         self.0

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -239,7 +239,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
-    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         self.0.deref().argsort_multiple(by, reverse)
     }
 }
@@ -336,7 +336,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         })
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         ChunkTake::take(self.0.deref(), indices.into()).map(|ca| {
             ca.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
                 .into_series()
@@ -363,7 +363,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         Ok(ChunkTake::take_unchecked(self.0.deref(), idx.into())
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series())
@@ -431,7 +431,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, reverse: bool) -> IdxCa {
         self.0.argsort(reverse)
     }
 
@@ -567,7 +567,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         self.0.is_in(other)
     }
     #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         self.0
             .repeat_by(by)
             .cast(&DataType::List(Box::new(DataType::Datetime(

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -454,7 +454,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         self.0.n_unique()
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         self.0.arg_unique()
     }
 

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -438,7 +438,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         self.0.n_unique()
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         self.0.arg_unique()
     }
 

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -231,7 +231,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
-    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         self.0.deref().argsort_multiple(by, reverse)
     }
 }
@@ -327,7 +327,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         ChunkTake::take(self.0.deref(), indices.into())
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
@@ -350,7 +350,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         Ok(ChunkTake::take_unchecked(self.0.deref(), idx.into())
             .into_duration(self.0.time_unit())
             .into_series())
@@ -416,7 +416,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, reverse: bool) -> IdxCa {
         self.0.argsort(reverse)
     }
 
@@ -546,7 +546,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         self.0.is_in(other)
     }
     #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         self.0
             .repeat_by(by)
             .cast(&DataType::List(Box::new(DataType::Duration(

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -60,7 +60,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     }
 
     #[cfg(feature = "asof_join")]
-    fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+    fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
         let other = other.to_physical_repr();
         self.0.deref().join_asof(&other)
     }
@@ -146,22 +146,22 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .map(|s| s.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_inner(other.as_ref().as_ref())
     }
-    fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_left(other.as_ref().as_ref())
     }
-    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let other = other.to_physical_repr().into_owned();
         self.0.hash_join_outer(other.as_ref().as_ref())
     }
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         let right_column = right_column.to_physical_repr().into_owned();
         self.0

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -96,7 +96,7 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "asof_join")]
-            fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+            fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
                 self.0.join_asof(other)
             }
 
@@ -173,19 +173,19 @@ macro_rules! impl_dyn_series {
             fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.agg_median(groups)
             }
-            fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+            fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
                 HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
             }
-            fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+            fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
                 HashJoin::hash_join_left(&self.0, other.as_ref().as_ref())
             }
-            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
                 HashJoin::hash_join_outer(&self.0, other.as_ref().as_ref())
             }
             fn zip_outer_join_column(
                 &self,
                 right_column: &Series,
-                opt_join_tuples: &[(Option<u32>, Option<u32>)],
+                opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
             ) -> Series {
                 ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
             }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -209,7 +209,7 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "sort_multiple")]
-            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
                 self.0.argsort_multiple(by, reverse)
             }
         }
@@ -359,7 +359,7 @@ macro_rules! impl_dyn_series {
                 self.0.median().map(|v| v as f64)
             }
 
-            fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+            fn take(&self, indices: &IdxCa) -> Result<Series> {
                 let indices = if indices.chunks.len() > 1 {
                     Cow::Owned(indices.rechunk())
                 } else {
@@ -380,7 +380,7 @@ macro_rules! impl_dyn_series {
                 ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
             }
 
-            unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+            unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
                 let idx = if idx.chunks.len() > 1 {
                     Cow::Owned(idx.rechunk())
                 } else {
@@ -435,7 +435,7 @@ macro_rules! impl_dyn_series {
                 ChunkSort::sort_with(&self.0, options).into_series()
             }
 
-            fn argsort(&self, reverse: bool) -> UInt32Chunked {
+            fn argsort(&self, reverse: bool) -> IdxCa {
                 ChunkSort::argsort(&self.0, reverse)
             }
 
@@ -559,7 +559,7 @@ macro_rules! impl_dyn_series {
                 IsIn::is_in(&self.0, other)
             }
             #[cfg(feature = "repeat_by")]
-            fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+            fn repeat_by(&self, by: &IdxCa) -> ListChunked {
                 RepeatBy::repeat_by(&self.0, by)
             }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -455,7 +455,7 @@ macro_rules! impl_dyn_series {
                 ChunkUnique::n_unique(&self.0)
             }
 
-            fn arg_unique(&self) -> Result<UInt32Chunked> {
+            fn arg_unique(&self) -> Result<IdxCa> {
                 ChunkUnique::arg_unique(&self.0)
             }
 

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -132,7 +132,7 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         let indices = if indices.chunks.len() > 1 {
             Cow::Owned(indices.rechunk())
         } else {
@@ -153,7 +153,7 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         let idx = if idx.chunks.len() > 1 {
             Cow::Owned(idx.rechunk())
         } else {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -255,7 +255,7 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "sort_multiple")]
-            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+            fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
                 self.0.argsort_multiple(by, reverse)
             }
         }
@@ -526,7 +526,7 @@ macro_rules! impl_dyn_series {
                 self.0.median()
             }
 
-            fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+            fn take(&self, indices: &IdxCa) -> Result<Series> {
                 let indices = if indices.chunks.len() > 1 {
                     Cow::Owned(indices.rechunk())
                 } else {
@@ -547,7 +547,7 @@ macro_rules! impl_dyn_series {
                 ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
             }
 
-            unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+            unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
                 let idx = if idx.chunks.len() > 1 {
                     Cow::Owned(idx.rechunk())
                 } else {
@@ -602,7 +602,7 @@ macro_rules! impl_dyn_series {
                 ChunkSort::sort_with(&self.0, options).into_series()
             }
 
-            fn argsort(&self, reverse: bool) -> UInt32Chunked {
+            fn argsort(&self, reverse: bool) -> IdxCa {
                 ChunkSort::argsort(&self.0, reverse)
             }
 
@@ -726,7 +726,7 @@ macro_rules! impl_dyn_series {
                 IsIn::is_in(&self.0, other)
             }
             #[cfg(feature = "repeat_by")]
-            fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+            fn repeat_by(&self, by: &IdxCa) -> ListChunked {
                 RepeatBy::repeat_by(&self.0, by)
             }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -622,7 +622,7 @@ macro_rules! impl_dyn_series {
                 ChunkUnique::n_unique(&self.0)
             }
 
-            fn arg_unique(&self) -> Result<UInt32Chunked> {
+            fn arg_unique(&self) -> Result<IdxCa> {
                 ChunkUnique::arg_unique(&self.0)
             }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -138,7 +138,7 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "asof_join")]
-            fn join_asof(&self, other: &Series) -> Result<Vec<Option<u32>>> {
+            fn join_asof(&self, other: &Series) -> Result<Vec<Option<IdxSize>>> {
                 self.0.join_asof(other)
             }
 
@@ -219,19 +219,19 @@ macro_rules! impl_dyn_series {
             fn agg_median(&self, groups: &GroupsProxy) -> Option<Series> {
                 self.0.agg_median(groups)
             }
-            fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+            fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
                 HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
             }
-            fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+            fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
                 HashJoin::hash_join_left(&self.0, other.as_ref().as_ref())
             }
-            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+            fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
                 HashJoin::hash_join_outer(&self.0, other.as_ref().as_ref())
             }
             fn zip_outer_join_column(
                 &self,
                 right_column: &Series,
-                opt_join_tuples: &[(Option<u32>, Option<u32>)],
+                opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
             ) -> Series {
                 ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
             }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -193,7 +193,7 @@ where
         ChunkUnique::n_unique(&self.0)
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         ChunkUnique::arg_unique(&self.0)
     }
 

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -130,7 +130,7 @@ where
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         let idx = if idx.chunks.len() > 1 {
             Cow::Owned(idx.rechunk())
         } else {

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -68,19 +68,19 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.agg_list(groups)
     }
 
-    fn hash_join_inner(&self, other: &Series) -> Vec<(u32, u32)> {
+    fn hash_join_inner(&self, other: &Series) -> Vec<(IdxSize, IdxSize)> {
         HashJoin::hash_join_inner(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_left(&self, other: &Series) -> Vec<(u32, Option<u32>)> {
+    fn hash_join_left(&self, other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
         HashJoin::hash_join_left(&self.0, other.as_ref().as_ref())
     }
-    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+    fn hash_join_outer(&self, other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         HashJoin::hash_join_outer(&self.0, other.as_ref().as_ref())
     }
     fn zip_outer_join_column(
         &self,
         right_column: &Series,
-        opt_join_tuples: &[(Option<u32>, Option<u32>)],
+        opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
     ) -> Series {
         ZipOuterJoinColumn::zip_outer_join_column(&self.0, right_column, opt_join_tuples)
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -289,7 +289,7 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         ChunkUnique::n_unique(&self.0)
     }
 
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         ChunkUnique::arg_unique(&self.0)
     }
 

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -104,7 +104,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         self.0.argsort_multiple(by, reverse)
     }
 }
@@ -193,7 +193,7 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         ChunkFilter::filter(&self.0, filter).map(|ca| ca.into_series())
     }
 
-    fn take(&self, indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, indices: &IdxCa) -> Result<Series> {
         let indices = if indices.chunks.len() > 1 {
             Cow::Owned(indices.rechunk())
         } else {
@@ -214,7 +214,7 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }
 
-    unsafe fn take_unchecked(&self, idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, idx: &IdxCa) -> Result<Series> {
         let idx = if idx.chunks.len() > 1 {
             Cow::Owned(idx.rechunk())
         } else {
@@ -269,7 +269,7 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         ChunkSort::sort_with(&self.0, options).into_series()
     }
 
-    fn argsort(&self, reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, reverse: bool) -> IdxCa {
         ChunkSort::argsort(&self.0, reverse)
     }
 
@@ -371,7 +371,7 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         IsIn::is_in(&self.0, other)
     }
     #[cfg(feature = "repeat_by")]
-    fn repeat_by(&self, by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         RepeatBy::repeat_by(&self.0, by)
     }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -948,6 +948,11 @@ impl Series {
             s
         }
     }
+
+    /// Returns the unique values in the order they occur. This is slower than colling [`Series::unique`].
+    pub fn unique_ordered(&self) -> Result<Series> {
+        let args = self.arg_unique()?;
+    }
 }
 
 impl Deref for Series {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -946,11 +946,11 @@ impl Series {
     }
 
     pub fn idx(&self) -> Result<&IdxCa> {
-        #[cfg(feature = "bigint")]
+        #[cfg(feature = "bigidx")]
         {
             self.u64()
         }
-        #[cfg(not(feature = "bigint"))]
+        #[cfg(not(feature = "bigidx"))]
         {
             self.u32()
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -360,11 +360,7 @@ impl Series {
     ///
     /// # Safety
     /// This doesn't check any bounds. Null validity is checked.
-    pub unsafe fn take_unchecked_threaded(
-        &self,
-        idx: &IdxCa,
-        rechunk: bool,
-    ) -> Result<Series> {
+    pub unsafe fn take_unchecked_threaded(&self, idx: &IdxCa, rechunk: bool) -> Result<Series> {
         let n_threads = POOL.current_num_threads();
         let idx = split_ca(idx, n_threads)?;
 
@@ -946,6 +942,17 @@ impl Series {
             s.cast(self.dtype()).unwrap()
         } else {
             s
+        }
+    }
+
+    pub fn idx(&self) -> Result<&IdxCa> {
+        #[cfg(feature = "bigint")]
+        {
+            self.u64()
+        }
+        #[cfg(not(feature = "bigint"))]
+        {
+            self.u32()
         }
     }
 }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -362,7 +362,7 @@ impl Series {
     /// This doesn't check any bounds. Null validity is checked.
     pub unsafe fn take_unchecked_threaded(
         &self,
-        idx: &UInt32Chunked,
+        idx: &IdxCa,
         rechunk: bool,
     ) -> Result<Series> {
         let n_threads = POOL.current_num_threads();
@@ -390,7 +390,7 @@ impl Series {
     /// # Safety
     ///
     /// Out of bounds access doesn't Error but will return a Null value
-    pub fn take_threaded(&self, idx: &UInt32Chunked, rechunk: bool) -> Result<Series> {
+    pub fn take_threaded(&self, idx: &IdxCa, rechunk: bool) -> Result<Series> {
         let n_threads = POOL.current_num_threads();
         let idx = split_ca(idx, n_threads).unwrap();
 
@@ -952,6 +952,9 @@ impl Series {
     /// Returns the unique values in the order they occur. This is slower than colling [`Series::unique`].
     pub fn unique_ordered(&self) -> Result<Series> {
         let args = self.arg_unique()?;
+        // Safety:
+        // args are in bounds
+        Ok(unsafe { self.take_unchecked(&args) })
     }
 }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -948,14 +948,6 @@ impl Series {
             s
         }
     }
-
-    /// Returns the unique values in the order they occur. This is slower than colling [`Series::unique`].
-    pub fn unique_ordered(&self) -> Result<Series> {
-        let args = self.arg_unique()?;
-        // Safety:
-        // args are in bounds
-        Ok(unsafe { self.take_unchecked(&args) })
-    }
 }
 
 impl Deref for Series {

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -250,7 +250,7 @@ pub(crate) mod private {
             invalid_operation_panic!(self)
         }
         #[cfg(feature = "sort_multiple")]
-        fn argsort_multiple(&self, _by: &[Series], _reverse: &[bool]) -> Result<UInt32Chunked> {
+        fn argsort_multiple(&self, _by: &[Series], _reverse: &[bool]) -> Result<IdxCa> {
             Err(PolarsError::InvalidOperation(
                 "argsort_multiple is not implemented for this Series".into(),
             ))
@@ -523,7 +523,7 @@ pub trait SeriesTrait:
     ///
     /// # Safety
     /// This doesn't check any bounds.
-    unsafe fn take_unchecked(&self, _idx: &UInt32Chunked) -> Result<Series> {
+    unsafe fn take_unchecked(&self, _idx: &IdxCa) -> Result<Series> {
         invalid_operation_panic!(self)
     }
 
@@ -545,7 +545,7 @@ pub trait SeriesTrait:
     }
 
     /// Take by index. This operation is clone.
-    fn take(&self, _indices: &UInt32Chunked) -> Result<Series> {
+    fn take(&self, _indices: &IdxCa) -> Result<Series> {
         invalid_operation_panic!(self)
     }
 
@@ -635,7 +635,7 @@ pub trait SeriesTrait:
     }
 
     /// Retrieve the indexes needed for a sort.
-    fn argsort(&self, _reverse: bool) -> UInt32Chunked {
+    fn argsort(&self, _reverse: bool) -> IdxCa {
         invalid_operation_panic!(self)
     }
 
@@ -674,7 +674,7 @@ pub trait SeriesTrait:
     }
 
     /// Get indexes that evaluate true
-    fn arg_true(&self) -> Result<UInt32Chunked> {
+    fn arg_true(&self) -> Result<IdxCa> {
         Err(PolarsError::InvalidOperation(
             "arg_true can only be called for boolean dtype".into(),
         ))
@@ -1081,7 +1081,7 @@ pub trait SeriesTrait:
     }
     #[cfg(feature = "repeat_by")]
     #[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
-    fn repeat_by(&self, _by: &UInt32Chunked) -> ListChunked {
+    fn repeat_by(&self, _by: &IdxCa) -> ListChunked {
         invalid_operation_panic!(self)
     }
     #[cfg(feature = "checked_arithmetic")]

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -146,7 +146,7 @@ pub(crate) mod private {
         }
 
         #[cfg(feature = "asof_join")]
-        fn join_asof(&self, _other: &Series) -> Result<Vec<Option<u32>>> {
+        fn join_asof(&self, _other: &Series) -> Result<Vec<Option<IdxSize>>> {
             invalid_operation!(self)
         }
 
@@ -211,19 +211,19 @@ pub(crate) mod private {
             None
         }
 
-        fn hash_join_inner(&self, _other: &Series) -> Vec<(u32, u32)> {
+        fn hash_join_inner(&self, _other: &Series) -> Vec<(IdxSize, IdxSize)> {
             invalid_operation_panic!(self)
         }
-        fn hash_join_left(&self, _other: &Series) -> Vec<(u32, Option<u32>)> {
+        fn hash_join_left(&self, _other: &Series) -> Vec<(IdxSize, Option<IdxSize>)> {
             invalid_operation_panic!(self)
         }
-        fn hash_join_outer(&self, _other: &Series) -> Vec<(Option<u32>, Option<u32>)> {
+        fn hash_join_outer(&self, _other: &Series) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
             invalid_operation_panic!(self)
         }
         fn zip_outer_join_column(
             &self,
             _right_column: &Series,
-            _opt_join_tuples: &[(Option<u32>, Option<u32>)],
+            _opt_join_tuples: &[(Option<IdxSize>, Option<IdxSize>)],
         ) -> Series {
             invalid_operation_panic!(self)
         }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -659,7 +659,7 @@ pub trait SeriesTrait:
     }
 
     /// Get first indexes of unique values.
-    fn arg_unique(&self) -> Result<UInt32Chunked> {
+    fn arg_unique(&self) -> Result<IdxCa> {
         invalid_operation_panic!(self)
     }
 

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -323,7 +323,7 @@ pub type IdBuildHasher = BuildHasherDefault<IdHasher>;
 /// accidental quadratic behavior. So do not use an Identity function!
 pub(crate) struct IdxHash {
     // idx in row of Series, DataFrame
-    pub(crate) idx: u32,
+    pub(crate) idx: IdxSize,
     // precomputed hash of T
     hash: u64,
 }
@@ -336,7 +336,7 @@ impl Hash for IdxHash {
 
 impl IdxHash {
     #[inline]
-    pub(crate) fn new(idx: u32, hash: u64) -> Self {
+    pub(crate) fn new(idx: IdxSize, hash: u64) -> Self {
         IdxHash { idx, hash }
     }
 }
@@ -383,7 +383,7 @@ pub(crate) fn this_partition(h: u64, thread_no: u64, n_partitions: u64) -> bool 
 
 pub(crate) fn prepare_hashed_relation_threaded<T, I>(
     iters: Vec<I>,
-) -> Vec<HashMap<T, (bool, Vec<u32>), RandomState>>
+) -> Vec<HashMap<T, (bool, Vec<IdxSize>), RandomState>>
 where
     I: Iterator<Item = T> + Send + TrustedLen,
     T: Send + Hash + Eq + Sync + Copy,
@@ -401,7 +401,7 @@ where
             let build_hasher = build_hasher.clone();
             let hashes_and_keys = &hashes_and_keys;
             let partition_no = partition_no as u64;
-            let mut hash_tbl: HashMap<T, (bool, Vec<u32>), RandomState> =
+            let mut hash_tbl: HashMap<T, (bool, Vec<IdxSize>), RandomState> =
                 HashMap::with_hasher(build_hasher);
 
             let n_threads = n_partitions as u64;
@@ -412,7 +412,7 @@ where
                     .iter()
                     .enumerate()
                     .for_each(|(idx, (h, k))| {
-                        let idx = idx as u32;
+                        let idx = idx as IdxSize;
                         // partition hashes by thread no.
                         // So only a part of the hashes go to this hashmap
                         if this_partition(*h, partition_no, n_threads) {
@@ -434,7 +434,7 @@ where
                         }
                     });
 
-                offset += len as u32;
+                offset += len as IdxSize;
             }
             hash_tbl
         })

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -64,6 +64,8 @@ dot_diagram = []
 # no guarantees whatsoever
 private = []
 
+bigint = ["polars-arrow/bigint", "polars-core/bigint", "polars-utils/bigint"]
+
 test = [
   "private",
   "rolling_window",

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -64,7 +64,7 @@ dot_diagram = []
 # no guarantees whatsoever
 private = []
 
-bigint = ["polars-arrow/bigint", "polars-core/bigint", "polars-utils/bigint"]
+bigidx = ["polars-arrow/bigidx", "polars-core/bigidx", "polars-utils/bigidx"]
 
 test = [
   "private",

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -755,7 +755,7 @@ impl Expr {
         );
         self.apply(
             |s: Series| s.arg_unique().map(|ca| ca.into_series()),
-            GetOutput::from_type(DataType::UInt32),
+            GetOutput::from_type(IDX_DTYPE),
         )
         .with_fmt("arg_unique")
     }
@@ -771,7 +771,7 @@ impl Expr {
 
         self.function_with_options(
             move |s: Series| Ok(Series::new(s.name(), &[s.arg_min().map(|idx| idx as u32)])),
-            GetOutput::from_type(DataType::UInt32),
+            GetOutput::from_type(IDX_DTYPE),
             options,
         )
     }
@@ -787,7 +787,7 @@ impl Expr {
 
         self.function_with_options(
             move |s: Series| Ok(Series::new(s.name(), &[s.arg_max().map(|idx| idx as u32)])),
-            GetOutput::from_type(DataType::UInt32),
+            GetOutput::from_type(IDX_DTYPE),
             options,
         )
     }
@@ -807,7 +807,7 @@ impl Expr {
 
         self.function_with_options(
             move |s: Series| Ok(s.argsort(reverse).into_series()),
-            GetOutput::from_type(DataType::UInt32),
+            GetOutput::from_type(IDX_DTYPE),
             options,
         )
     }
@@ -1837,7 +1837,7 @@ impl Expr {
             move |s| Ok(s.rank(options)),
             GetOutput::map_field(move |fld| match options.method {
                 RankMethod::Average => Field::new(fld.name(), DataType::Float32),
-                _ => Field::new(fld.name(), DataType::UInt32),
+                _ => Field::new(fld.name(), IDX_DTYPE),
             }),
         )
         .with_fmt("rank")
@@ -2001,7 +2001,7 @@ impl Expr {
                     Ok(ca.into_series())
                 }
             },
-            GetOutput::from_type(DataType::UInt32),
+            GetOutput::from_type(IDX_DTYPE),
         )
         .with_fmt("cumcount")
     }

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -1521,8 +1521,8 @@ impl Expr {
         let function = |s: &mut [Series]| {
             let by = &s[1];
             let s = &s[0];
-            let by = by.cast(&DataType::UInt32)?;
-            Ok(s.repeat_by(by.u32()?).into_series())
+            let by = by.cast(&IDX_DTYPE)?;
+            Ok(s.repeat_by(by.idx()?).into_series())
         };
 
         self.map_many(

--- a/polars/polars-lazy/src/physical_plan/expressions/count.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/count.rs
@@ -21,7 +21,7 @@ impl PhysicalExpr for CountExpr {
     }
 
     fn evaluate(&self, df: &DataFrame, _state: &ExecutionState) -> Result<Series> {
-        Ok(Series::new("count", [df.height() as u32]))
+        Ok(Series::new("count", [df.height() as IdxSize]))
     }
 
     fn evaluate_on_groups<'a>(
@@ -32,15 +32,15 @@ impl PhysicalExpr for CountExpr {
     ) -> Result<AggregationContext<'a>> {
         let mut ca = match groups {
             GroupsProxy::Idx(groups) => {
-                let ca: NoNull<UInt32Chunked> = groups
+                let ca: NoNull<IdxCa> = groups
                     .all()
                     .iter()
-                    .map(|g| g.len() as u32)
+                    .map(|g| g.len() as IdxSize)
                     .collect_trusted();
                 ca.into_inner()
             }
             GroupsProxy::Slice(groups) => {
-                let ca: NoNull<UInt32Chunked> = groups.iter().map(|g| g[1]).collect_trusted();
+                let ca: NoNull<IdxCa> = groups.iter().map(|g| g[1]).collect_trusted();
                 ca.into_inner()
             }
         };

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -56,7 +56,7 @@ impl PhysicalExpr for FilterExpr {
                     let groups = groups
                         .par_iter()
                         .map(|(first, idx)| unsafe {
-                            let idx: Vec<u32> = idx
+                            let idx: Vec<IdxSize> = idx
                                 .iter()
                                 // Safety:
                                 // just checked bounds in short circuited lhs
@@ -80,7 +80,7 @@ impl PhysicalExpr for FilterExpr {
                     let groups = groups
                         .par_iter()
                         .map(|&[first, len]| unsafe {
-                            let idx: Vec<u32> = (first..first + len)
+                            let idx: Vec<IdxSize> = (first..first + len)
                                 // Safety:
                                 // just checked bounds in short circuited lhs
                                 .filter(|&i| {

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -106,14 +106,14 @@ impl<'a> AggregationContext<'a> {
                 // and the series is aggregated with this groups
                 // so we need to recreate new grouptuples that
                 // match the exploded Series
-                let mut offset = 0u32;
+                let mut offset = 0 as IdxSize;
 
                 match self.groups.as_ref() {
                     GroupsProxy::Idx(groups) => {
                         let groups = groups
                             .iter()
                             .map(|g| {
-                                let len = g.1.len() as u32;
+                                let len = g.1.len() as IdxSize;
                                 let new_offset = offset + len;
                                 let out = [offset, len];
                                 offset = new_offset;
@@ -128,7 +128,7 @@ impl<'a> AggregationContext<'a> {
                 self.update_groups = UpdateGroups::No;
             }
             UpdateGroups::WithSeriesLen => {
-                let mut offset = 0u32;
+                let mut offset = 0 as IdxSize;
                 let list = self
                     .series()
                     .list()
@@ -143,7 +143,7 @@ impl<'a> AggregationContext<'a> {
                         let groups = offsets[1..]
                             .iter()
                             .map(|&o| {
-                                let len = (o - previous) as u32;
+                                let len = (o - previous) as IdxSize;
                                 let new_offset = offset + len;
                                 previous = o;
                                 let out = [offset, len];
@@ -161,7 +161,7 @@ impl<'a> AggregationContext<'a> {
                             .amortized_iter()
                             .map(|s| {
                                 if let Some(s) = s {
-                                    let len = s.as_ref().len() as u32;
+                                    let len = s.as_ref().len() as IdxSize;
                                     let new_offset = offset + len;
                                     let out = [offset, len];
                                     offset = new_offset;

--- a/polars/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -37,7 +37,10 @@ impl PhysicalExpr for SliceExpr {
                     .iter()
                     .map(|(first, idx)| {
                         let (offset, len) = slice_offsets(self.offset as i64, self.len, idx.len());
-                        (first + offset as u32, idx[offset..offset + len].to_vec())
+                        (
+                            first + offset as IdxSize,
+                            idx[offset..offset + len].to_vec(),
+                        )
                     })
                     .collect();
                 GroupsProxy::Idx(groups)
@@ -48,7 +51,7 @@ impl PhysicalExpr for SliceExpr {
                     .map(|&[first, len]| {
                         let (offset, len) =
                             slice_offsets(self.offset as i64, self.len, len as usize);
-                        [first + offset as u32, len as u32]
+                        [first + offset as IdxSize, len as IdxSize]
                     })
                     .collect_trusted();
                 GroupsProxy::Slice(groups)

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -22,7 +22,7 @@ impl SortExpr {
 }
 
 /// Map argsort result back to the indices on the `GroupIdx`
-pub(crate) fn map_sorted_indices_to_group_idx(sorted_idx: &UInt32Chunked, idx: &[u32]) -> Vec<u32> {
+pub(crate) fn map_sorted_indices_to_group_idx(sorted_idx: &IdxCa, idx: &[IdxSize]) -> Vec<IdxSize> {
     sorted_idx
         .cont_slice()
         .unwrap()
@@ -35,9 +35,9 @@ pub(crate) fn map_sorted_indices_to_group_idx(sorted_idx: &UInt32Chunked, idx: &
 }
 
 pub(crate) fn map_sorted_indices_to_group_slice(
-    sorted_idx: &UInt32Chunked,
-    first: u32,
-) -> Vec<u32> {
+    sorted_idx: &IdxCa,
+    first: IdxSize,
+) -> Vec<IdxSize> {
     sorted_idx
         .cont_slice()
         .unwrap()

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -365,7 +365,7 @@ impl PhysicalExpr for WindowExpr {
 
                 // groups are not changed, we can map by doing a standard argsort.
                 if std::ptr::eq(ac.groups.as_ref(), gb.get_groups()) {
-                    let mut iter = 0..flattened.len() as u32;
+                    let mut iter = 0..flattened.len() as IdxSize;
                     match ac.groups().as_ref() {
                         GroupsProxy::Idx(groups) => {
                             for g in groups.all() {
@@ -399,7 +399,7 @@ impl PhysicalExpr for WindowExpr {
                 // Safety:
                 // we only have unique indices ranging from 0..len
                 let idx = unsafe { perfect_sort(&POOL, &idx_mapping) };
-                let idx = UInt32Chunked::from_vec("", idx);
+                let idx = IdxCa::from_vec("", idx);
 
                 // Safety:
                 // groups should always be in bounds.

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -4,7 +4,8 @@ use polars_core::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-pub type JoinTuplesCache = Arc<Mutex<HashMap<String, Vec<(u32, Option<u32>)>, RandomState>>>;
+pub type JoinTuplesCache =
+    Arc<Mutex<HashMap<String, Vec<(IdxSize, Option<IdxSize>)>, RandomState>>>;
 pub type GroupsProxyCache = Arc<Mutex<HashMap<String, GroupsProxy, RandomState>>>;
 
 /// State/ cache that is maintained during the Execution of the physical plan.

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -457,7 +457,9 @@ fn test_take_consistency() -> Result<()> {
         .select([col("A").arg_sort(true).take(lit(0))])
         .collect()?;
 
-    assert_eq!(out.column("A")?.get(0), AnyValue::UInt32(4));
+    let a = out.column("A")?;
+    let a = a.idx()?;
+    assert_eq!(a.get(0), Some(4));
 
     let out = df
         .clone()
@@ -467,7 +469,7 @@ fn test_take_consistency() -> Result<()> {
         .collect()?;
 
     let out = out.column("A")?;
-    let out = out.u32()?;
+    let out = out.idx()?;
     assert_eq!(Vec::from(out), &[Some(3), Some(0)]);
 
     let out_df = df
@@ -488,7 +490,7 @@ fn test_take_consistency() -> Result<()> {
     assert_eq!(Vec::from(out), &[Some(5), Some(2)]);
 
     let out = out_df.column("1")?;
-    let out = out.u32()?;
+    let out = out.idx()?;
     assert_eq!(Vec::from(out), &[Some(3), Some(0)]);
 
     Ok(())

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1082,7 +1082,7 @@ fn test_argsort_multiple() -> Result<()> {
         .collect()?;
 
     assert_eq!(
-        Vec::from(out.column("int")?.u32()?),
+        Vec::from(out.column("int")?.idx()?),
         [2, 4, 1, 3, 0]
             .iter()
             .copied()
@@ -1682,7 +1682,7 @@ fn test_groupby_rank() -> Result<()> {
 
     let out = out.column("B")?;
     let out = out.list()?.get(1).unwrap();
-    let out = out.u32()?;
+    let out = out.idx()?;
 
     assert_eq!(Vec::from(out), &[Some(1)]);
     Ok(())
@@ -1847,7 +1847,7 @@ fn test_single_group_result() -> Result<()> {
         .select([col("a").arg_sort(false).list().over([col("a")]).flatten()])
         .collect()?;
 
-    let a = out.column("a")?.u32()?;
+    let a = out.column("a")?.idx()?;
     assert_eq!(Vec::from(a), &[Some(0), Some(0)]);
 
     Ok(())

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -357,7 +357,10 @@ impl Wrap<&DataFrame> {
     }
 }
 
-fn update_subgroups(sub_groups: &[[u32; 2]], base_g: (u32, &Vec<u32>)) -> GroupsIdx {
+fn update_subgroups(
+    sub_groups: &[[IdxSize; 2]],
+    base_g: (IdxSize, &Vec<IdxSize>),
+) -> Vec<(IdxSize, Vec<IdxSize>)> {
     sub_groups
         .iter()
         .map(|&[first, len]| {
@@ -506,12 +509,12 @@ mod test {
 
         let expected = GroupsProxy::Idx(
             vec![
-                (0u32, vec![0u32, 1, 2]),
-                (2u32, vec![2]),
-                (5u32, vec![5, 6]),
-                (6u32, vec![6]),
-                (3u32, vec![3, 4]),
-                (4u32, vec![4]),
+                (0 as IdxSize, vec![0 as IdxSize, 1, 2]),
+                (2, vec![2]),
+                (5, vec![5, 6]),
+                (6, vec![6]),
+                (3, vec![3, 4]),
+                (4, vec![4]),
             ]
             .into(),
         );

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -2,9 +2,6 @@ use crate::prelude::*;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::prelude::*;
 
-pub type GroupsIdx = Vec<(u32, Vec<u32>)>;
-pub type GroupsSlice = Vec<[u32; 2]>;
-
 #[derive(Clone, Copy, Debug)]
 pub enum ClosedWindow {
     Left,
@@ -99,12 +96,12 @@ pub fn groupby_windows(
                     lower_bound.push(bi.start);
                     upper_bound.push(bi.stop);
                 }
-                groups.push([i as u32, 1])
+                groups.push([i as IdxSize, 1])
             }
             continue;
         }
 
-        let first = start_offset as u32;
+        let first = start_offset as IdxSize;
 
         while i < time.len() {
             let t = time[i];
@@ -113,7 +110,7 @@ pub fn groupby_windows(
             }
             i += 1
         }
-        let len = (i as u32) - first;
+        let len = (i as IdxSize) - first;
 
         if include_boundaries {
             lower_bound.push(bi.start);
@@ -172,7 +169,7 @@ pub fn groupby_values(
             let slice = &time[lagging_offset..];
             let len = find_offset(slice, b, closed_window).unwrap_or(slice.len());
 
-            [lagging_offset as u32, len as u32]
+            [lagging_offset as IdxSize, len as IdxSize]
         })
         .collect_trusted()
 }

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -13,4 +13,4 @@ parking_lot = "0.11"
 rayon = "1.5"
 
 [features]
-bigint = []
+bigidx = []

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -11,3 +11,6 @@ description = "private utils for the polars dataframe library"
 [dependencies]
 parking_lot = "0.11"
 rayon = "1.5"
+
+[features]
+bigint = []

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -3,3 +3,8 @@ pub mod contention_pool;
 mod error;
 pub mod mem;
 pub mod sort;
+
+#[cfg(not(feature = "bigint"))]
+pub type IdxSize = u32;
+#[cfg(feature = "bigint")]
+pub type IdxSize = u64;

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 pub mod mem;
 pub mod sort;
 
-#[cfg(not(feature = "bigint"))]
+#[cfg(not(feature = "bigidx"))]
 pub type IdxSize = u32;
-#[cfg(feature = "bigint")]
+#[cfg(feature = "bigidx")]
 pub type IdxSize = u64;

--- a/polars/polars-utils/src/sort.rs
+++ b/polars/polars-utils/src/sort.rs
@@ -1,3 +1,4 @@
+use crate::IdxSize;
 use rayon::{prelude::*, ThreadPool};
 
 /// This is a perfect sort particularly useful for an argsort of an argsort
@@ -12,19 +13,19 @@ use rayon::{prelude::*, ThreadPool};
 /// - The left indices are placed at the location right points to.
 ///
 /// # Safety
-/// The caller must ensure that the right indexes fo `&[(_, u32)]` are integers ranging from `0..idx.len`
-pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(u32, u32)]) -> Vec<u32> {
+/// The caller must ensure that the right indexes fo `&[(_, IdxSize)]` are integers ranging from `0..idx.len`
+pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)]) -> Vec<IdxSize> {
     let chunk_size = std::cmp::max(
         idx.len() / pool.current_num_threads(),
         pool.current_num_threads(),
     );
 
-    let mut out: Vec<u32> = Vec::with_capacity(idx.len());
-    let ptr = out.as_mut_ptr() as *const u32 as usize;
+    let mut out: Vec<IdxSize> = Vec::with_capacity(idx.len());
+    let ptr = out.as_mut_ptr() as *const IdxSize as usize;
 
     pool.install(|| {
         idx.par_chunks(chunk_size).for_each(|indices| {
-            let ptr = ptr as *mut u32;
+            let ptr = ptr as *mut IdxSize;
             for (idx_val, idx_location) in indices {
                 // Safety:
                 // idx_location is in bounds by invariant of this function


### PR DESCRIPTION
This allows polars to compile with a feature gate `bigidx`, which replaces the current limit of `u32::MAX` rows to `u64::MAX` rows in polars. 

Now I am curious how long it will take before someone needs to compile polars this way. ;)

Note that the default index is faster and consumes less memory, so don't activate it unless you really need it.