### PR TITLE
fix polars.read_csv inadvertently closing BytesIO input buffers

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -108,7 +108,7 @@ def _prepare_file_arg(
     if isinstance(file, StringIO):
         return BytesIO(file.read().encode("utf8"))
     if isinstance(file, BytesIO):
-        return file
+        return managed_file(file)
     if isinstance(file, Path):
         return managed_file(str(file))
     if isinstance(file, str):

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -242,6 +242,18 @@ def test_read_csv_columns_argument(
     assert df.columns == col_out
 
 
+def test_read_csv_buffer_ownership() -> None:
+    buf = io.BytesIO(b"\xf0\x9f\x98\x80,5.55,333\n\xf0\x9f\x98\x86,-5.0,666")
+    df = pl.read_csv(
+        buf,
+        has_header=False,
+        new_columns=["emoji", "flt", "int"],
+    )
+    # confirm that read_csv succeeded, and didn't close the input buffer (#2696)
+    assert df.shape == (2, 3)
+    assert not buf.closed
+
+
 def test_column_rename_and_dtype_overwrite() -> None:
     csv = """
 a,b,c


### PR DESCRIPTION
Fixes #2696.

Returning BytesIO objects directly from the `io._prepare_file_arg` helper (eg: during a call to `read_csv`) triggers their own context manager implementation, resulting in the inadvertent side-effect of closing an externally-supplied buffer on scope exit from the helper, like so:

```python
buf = BytesIO( b'colx,coly\n123,xyz' )
df = pl.read_csv( buf, ... )

buf.getvalue()
>>> ValueError: I/O operation on closed file.
```

...because `io._prepare_file_arg` usage on BytesIO results in the following behaviour...

```python
with BytesIO( b'xyz' ) as b:
    pass

b.closed
>>> True
```

The patch wraps the BytesIO returned from `io._prepare_file_arg` with `managed_file` to avoid the unintended close on scope exit. (The BytesIO object created on StringIO encode -two Iines up- _is_ still returned directly and gets properly cleaned-up, as the read_csv method owns that buffer and it's internal/temporary).

(Added a unit test to validate the fix and confirm that externally-supplied buffers don't get closed on `read_csv` calls).