### PR TITLE
Allow read_json/to_json to interop with StringIO

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from io import BytesIO, StringIO
+from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
     Any,
@@ -169,7 +169,7 @@ def read_csv(
     Parameters
     ----------
     file
-        Path to a file or a file like object.
+        Path to a file or a file-like object.
         By file-like object, we refer to objects with a ``read()``
         method, such as a file handler (e.g. via builtin ``open``
         function) or ``StringIO`` or ``BytesIO``.
@@ -687,7 +687,7 @@ def read_ipc_schema(
     Parameters
     ----------
     file
-        Path to a file or a file like object.
+        Path to a file or a file-like object.
 
     Returns
     -------
@@ -705,7 +705,7 @@ def read_avro(
     Parameters
     ----------
     file
-        Path to a file or a file like object.
+        Path to a file or a file-like object.
     n_rows
         Stop reading from Apache Avro file after reading ``n_rows``.
 
@@ -736,7 +736,7 @@ def read_ipc(
     Parameters
     ----------
     file
-        Path to a file or a file like object.
+        Path to a file or a file-like object.
         If ``fsspec`` is installed, it will be used to open remote files.
     columns
         Columns to select. Accepts a list of column indices (starting at zero) or a list of column names.
@@ -812,7 +812,7 @@ def read_parquet(
     Parameters
     ----------
     source
-        Path to a file, list of files, or a file like object. If the path is a directory, that directory will be used
+        Path to a file, list of files, or a file-like object. If the path is a directory, that directory will be used
         as partition aware scan.
         If ``fsspec`` is installed, it will be used to open remote files.
     columns
@@ -878,14 +878,14 @@ def read_parquet(
         )
 
 
-def read_json(source: Union[str, BytesIO]) -> DataFrame:
+def read_json(source: Union[str, IOBase]) -> DataFrame:
     """
     Read into a DataFrame from JSON format.
 
     Parameters
     ----------
     source
-        Path to a file or a file like object.
+        Path to a file or a file-like object.
     """
     return DataFrame._read_json(source)
 

--- a/py-polars/tests/io/test_json.py
+++ b/py-polars/tests/io/test_json.py
@@ -8,14 +8,14 @@ import polars as pl
 
 
 def test_to_from_buffer(df: pl.DataFrame) -> None:
-    buf = io.BytesIO()
-    df.to_json(buf)
-    buf.seek(0)
-    read_df = pl.read_json(buf)
-    read_df = read_df.with_columns(
-        [pl.col("cat").cast(pl.Categorical), pl.col("time").cast(pl.Time)]
-    )
-    assert df.frame_equal(read_df)
+    for buf in (io.BytesIO(), io.StringIO()):
+        df.to_json(buf)
+        buf.seek(0)
+        read_df = pl.read_json(buf)
+        read_df = read_df.with_columns(
+            [pl.col("cat").cast(pl.Categorical), pl.col("time").cast(pl.Time)]
+        )
+        assert df.frame_equal(read_df)
 
 
 def test_to_from_file(io_test_dir: str, df: pl.DataFrame) -> None:
@@ -52,7 +52,7 @@ def test_to_json() -> None:
 
 
 def test_to_json2(df: pl.DataFrame) -> None:
-    # text based conversion loses time info
+    # text-based conversion loses time info
     df = df.select(pl.all().exclude(["cat", "time"]))
     s = df.to_json(to_string=True)
     f = io.BytesIO()

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1174,4 +1174,8 @@ def test_self_join() -> None:
         )
         .fetch()
     )
-    assert out.shape == (3, 3)
+    assert set(out.rows()) == {
+        (100, "James", None),
+        (101, "Alice", "James"),
+        (102, "Bob", "Alice"),
+    }


### PR DESCRIPTION
Both methods currently accept `BytesIO` and file-like objects; given that JSON is typically UTF8, seems reasonable to automatically handle `StringIO` buffers as well. Unit tests extended accordingly, to cover both. 

**Before**
```python
strbuf = StringIO( json_string )
df = pl.read_json( strbuf )

>> pyo3_runtime.PanicException: Expecting to be able to downcast into bytes from read result.
```

**After**
```python
strbuf = StringIO( json_string )
df = pl.read_json( strbuf )
df ... # successful init
```
(Also applied a trivial docstring update: "file like" => "file-like").
