### PR TITLE
Check for dtypes when comparing series equality

### DIFF
--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 impl Series {
     /// Check if series are equal. Note that `None == None` evaluates to `false`
     pub fn series_equal(&self, other: &Series) -> bool {
-        if self.null_count() > 0 || other.null_count() > 0 {
+        if self.null_count() > 0 || other.null_count() > 0 || self.dtype() != other.dtype() {
             false
         } else {
             self.series_equal_missing(other)
@@ -152,6 +152,13 @@ mod test {
 
         let s = Series::new("foo", &[None, Some(1i64)]);
         assert!(s.series_equal_missing(&s));
+    }
+
+    #[test]
+    fn test_series_dtype_noteq() {
+        let s_i32 = Series::new("a", &[1_i32, 2_i32]);
+        let s_i64 = Series::new("a", &[1_i64, 2_i64]);
+        assert!(!s_i32.series_equal(&s_i64));
     }
 
     #[test]

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -179,15 +179,15 @@ fn test_missing_data() {
     assert!(df
         .column("column_1")
         .unwrap()
-        .series_equal(&Series::new("column_1", &[1, 1])));
+        .series_equal(&Series::new("column_1", &[1_i64, 1])));
     assert!(df
         .column("column_2")
         .unwrap()
-        .series_equal_missing(&Series::new("column_2", &[Some(2), None])));
+        .series_equal_missing(&Series::new("column_2", &[Some(2_i64), None])));
     assert!(df
         .column("column_3")
         .unwrap()
-        .series_equal(&Series::new("column_3", &[3, 3])));
+        .series_equal(&Series::new("column_3", &[3_i64, 3])));
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn test_escape_comma() {
     assert!(df
         .column("column_3")
         .unwrap()
-        .series_equal(&Series::new("column_3", &[11, 12])));
+        .series_equal(&Series::new("column_3", &[11_i64, 12])));
 }
 
 #[test]

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -224,7 +224,8 @@ def test_arange() -> None:
 
 def test_arg_unique() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
-    assert df[col("a").arg_unique()]["a"].series_equal(pl.Series("a", [0, 1]))
+    col_a_unique = df[col("a").arg_unique()]["a"]
+    assert col_a_unique.series_equal(pl.Series("a", [0, 1]).cast(pl.UInt32))
 
 
 def test_is_unique() -> None:
@@ -471,14 +472,14 @@ def test_cum_agg() -> None:
 
 def test_floor() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
-    assert df.select(pl.col("a").floor())["a"].series_equal(pl.Series("a", [1, 1, 3]))
+    col_a_floor = df.select(pl.col("a").floor())["a"]
+    assert col_a_floor.series_equal(pl.Series("a", [1, 1, 3]).cast(pl.Float64))
 
 
 def test_round() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
-    assert df.select(pl.col("a").round(decimals=0))["a"].series_equal(
-        pl.Series("a", [2, 1, 3])
-    )
+    col_a_rounded = df.select(pl.col("a").round(decimals=0))["a"]
+    assert col_a_rounded.series_equal(pl.Series("a", [2, 1, 3]).cast(pl.Float64))
 
 
 def test_dot() -> None:
@@ -587,9 +588,8 @@ def test_fill_null() -> None:
 
 def test_backward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    assert df.select([pl.col("a").backward_fill()])["a"].series_equal(
-        pl.Series("a", [1, 3, 3])
-    )
+    col_a_backward_fill = df.select([pl.col("a").backward_fill()])["a"]
+    assert col_a_backward_fill.series_equal(pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
 
 def test_take(fruits_cars: pl.DataFrame) -> None:


### PR DESCRIPTION
This PR broke some python tests that use functions that return u32s instead of the input type (i64s in the tests):
_.backward_fill_ (I think this should return the same dtype as the input)
_.arg_unique_ (I think this should return the same dtype as the input)
_.round_ (in python returns an int, so we could return that (i64) in pypolars instead of f32 or f64)
_.floor_ (in python returns an int, so we could return that (i64) instead of f32 or f64)
I will look into fixing those to return the same dtype as the input.