### PR TITLE
Refactor schema

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -143,6 +143,7 @@ chrono = { version = "0.4", optional = true }
 comfy-table = { version = "5.0", optional = true }
 hashbrown = { version = "0.12", features = ["rayon"] }
 hex = { version = "0.4", optional = true }
+indexmap = { version = "1", features = ["std"] }
 jsonpath_lib = { version = "0.3.0", optional = true, git = "https://github.com/ritchie46/jsonpath", branch = "improve_compiled" }
 lazy_static = "1.4"
 ndarray = { version = "0.15", optional = true, default_features = false }

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -159,7 +159,6 @@ regex = { version = "1.5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "^1.0"
-unsafe_unwrap = "^0.1.0"
 
 [dependencies.arrow]
 package = "arrow2"

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -366,8 +366,7 @@ impl Display for DataFrame {
         #[cfg(not(feature = "pretty_fmt"))]
         {
             let field_to_str = |f: &Field| format!("{}\n---\n{}", f.name(), f.data_type());
-            let schema = self.schema();
-            let fields = schema.fields();
+            let fields = self.fields();
             for field in fields[0..n_first].iter() {
                 names.push(field_to_str(field));
             }
@@ -391,8 +390,7 @@ impl Display for DataFrame {
                 comfy_table::ColumnConstraint::LowerBoundary(comfy_table::Width::Fixed(l as u16))
             };
             let mut constraints = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
-            let schema = self.schema();
-            let fields = schema.fields();
+            let fields = self.fields();
             for field in fields[0..n_first].iter() {
                 let (s, l) = field_to_str(field);
                 names.push(s);

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -19,7 +19,6 @@ use rayon::prelude::*;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash, Hasher};
-use unsafe_unwrap::UnsafeUnwrap;
 
 #[cfg(feature = "private")]
 pub use self::multiple_keys::private_left_join_multiple_keys;
@@ -936,7 +935,7 @@ where
                     unsafe { left_rand_access.get_unchecked(*left_idx as usize) }
                 } else {
                     unsafe {
-                        let right_idx = opt_right_idx.unsafe_unwrap();
+                        let right_idx = opt_right_idx.unwrap_unchecked();
                         right_rand_access.get_unchecked(right_idx as usize)
                     }
                 }
@@ -966,7 +965,7 @@ macro_rules! impl_zip_outer_join {
                             unsafe { left_rand_access.get_unchecked(*left_idx as usize) }
                         } else {
                             unsafe {
-                                let right_idx = opt_right_idx.unsafe_unwrap();
+                                let right_idx = opt_right_idx.unwrap_unchecked();
                                 right_rand_access.get_unchecked(right_idx as usize)
                             }
                         }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -415,14 +415,13 @@ impl DataFrame {
     ///
     /// let f1: Field = Field::new("Thing", DataType::Utf8);
     /// let f2: Field = Field::new("Diameter (m)", DataType::Float64);
-    /// let sc: Schema = Schema::new(vec![f1, f2]);
+    /// let sc: Schema = Schema::from(vec![f1, f2]);
     ///
     /// assert_eq!(df.schema(), sc);
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn schema(&self) -> Schema {
-        let fields = Self::create_fields(&self.columns);
-        Schema::new(fields)
+        Schema::from(self.iter().map(|s| s.field().into_owned()))
     }
 
     /// Get a reference to the `DataFrame` columns.
@@ -551,11 +550,6 @@ impl DataFrame {
             })?
             .chunks()
             .len())
-    }
-
-    /// Get fields from the columns.
-    fn create_fields(columns: &[Series]) -> Vec<Field> {
-        columns.iter().map(|s| s.field().into_owned()).collect()
     }
 
     /// Get a reference to the schema fields of the `DataFrame`.

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod frame;
 pub mod functions;
 mod named_from;
 pub mod prelude;
+pub mod schema;
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde;

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -24,6 +24,7 @@ pub use crate::{
         *,
     },
     named_from::{NamedFrom, NamedFromOwned},
+    schema::*,
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},
         IntoSeries, Series, SeriesTrait,

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -1,0 +1,178 @@
+use crate::prelude::*;
+use indexmap::IndexMap;
+use std::fmt::{Debug, Formatter};
+
+#[derive(PartialEq, Eq, Clone, Default)]
+pub struct Schema {
+    inner: PlIndexMap<String, DataType>,
+}
+
+impl Debug for Schema {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Schema:")?;
+        for (name, dtype) in self.inner.iter() {
+            writeln!(f, "name: {}, data type: {:?}", name, dtype)?;
+        }
+        Ok(())
+    }
+}
+
+impl<I, J> From<I> for Schema
+where
+    I: IntoIterator<Item = J>,
+    J: Into<Field>,
+{
+    fn from(flds: I) -> Self {
+        let iter = flds.into_iter();
+        let mut map: PlIndexMap<_, _> =
+            IndexMap::with_capacity_and_hasher(iter.size_hint().0, ahash::RandomState::default());
+        for fld in iter {
+            let fld = fld.into();
+            map.insert(fld.name().clone(), fld.data_type().clone());
+        }
+        Self { inner: map }
+    }
+}
+
+impl Schema {
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let map: PlIndexMap<_, _> =
+            IndexMap::with_capacity_and_hasher(capacity, ahash::RandomState::default());
+        Self { inner: map }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn rename(&mut self, old: &str, new: String) -> Option<()> {
+        // we first append the new name
+        // and then remove the old name
+        // this works because the removed slot is swapped with the last value in the indexmap
+        let dtype = self.inner.get(old)?.clone();
+        self.inner.insert(new, dtype);
+        self.inner.swap_remove(old);
+        Some(())
+    }
+
+    pub fn insert_index(&self, index: usize, name: String, dtype: DataType) -> Option<Self> {
+        // 0 and self.len() 0 is allowed
+        if index > self.len() {
+            return None;
+        }
+        let mut new = Self::default();
+        let mut iter = self
+            .inner
+            .iter()
+            .map(|(name, dtype)| (name.clone(), dtype.clone()));
+        new.inner.extend((&mut iter).take(index));
+        new.inner.insert(name, dtype);
+        new.inner.extend(iter);
+        Some(new)
+    }
+
+    pub fn get(&self, name: &str) -> Option<&DataType> {
+        self.inner.get(name)
+    }
+
+    pub fn get_full(&self, name: &str) -> Option<(usize, &String, &DataType)> {
+        self.inner.get_full(name)
+    }
+
+    pub fn get_field(&self, name: &str) -> Option<Field> {
+        self.inner
+            .get(name)
+            .map(|dtype| Field::new(name, dtype.clone()))
+    }
+
+    pub fn get_index(&self, index: usize) -> Option<(&String, &DataType)> {
+        self.inner.get_index(index)
+    }
+
+    pub fn coerce_by_name(&mut self, name: &str, dtype: DataType) -> Option<()> {
+        *self.inner.get_mut(name)? = dtype;
+        Some(())
+    }
+
+    pub fn coerce_by_index(&mut self, index: usize, dtype: DataType) -> Option<()> {
+        *self.inner.get_index_mut(index)?.1 = dtype;
+        Some(())
+    }
+
+    pub fn with_column(&mut self, name: String, dtype: DataType) {
+        self.inner.insert(name, dtype);
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.inner.extend(other.inner.into_iter())
+    }
+
+    pub fn to_arrow(&self) -> ArrowSchema {
+        let fields: Vec<_> = self
+            .inner
+            .iter()
+            .map(|(name, dtype)| ArrowField::new(name, dtype.to_arrow(), true))
+            .collect();
+        ArrowSchema::from(fields)
+    }
+
+    pub fn iter_fields(&self) -> impl Iterator<Item = Field> + '_ {
+        self.inner
+            .iter()
+            .map(|(name, dtype)| Field::new(name, dtype.clone()))
+    }
+
+    pub fn iter_dtypes(&self) -> impl Iterator<Item = &DataType> + '_ {
+        self.inner.iter().map(|(_name, dtype)| dtype)
+    }
+
+    pub fn iter_names(&self) -> impl Iterator<Item = &String> + '_ + ExactSizeIterator {
+        self.inner.iter().map(|(name, _dtype)| name)
+    }
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &DataType)> + '_ {
+        self.inner.iter()
+    }
+}
+
+pub type SchemaRef = Arc<Schema>;
+
+/// This trait exists to be unify the API of polars Schema and arrows Schema
+#[cfg(feature = "private")]
+pub trait IndexOfSchema: Debug {
+    /// Get the index of column by name.
+    fn index_of(&self, name: &str) -> Option<usize>;
+
+    fn try_index_of(&self, name: &str) -> Result<usize> {
+        self.index_of(name).ok_or_else(|| {
+            PolarsError::SchemaMisMatch(
+                format!(
+                    "Unable to get field named \"{}\" from schema: {:?}",
+                    name, self
+                )
+                .into(),
+            )
+        })
+    }
+}
+
+impl IndexOfSchema for Schema {
+    fn index_of(&self, name: &str) -> Option<usize> {
+        self.inner.get_index_of(name)
+    }
+}
+
+impl IndexOfSchema for ArrowSchema {
+    fn index_of(&self, name: &str) -> Option<usize> {
+        self.fields.iter().position(|f| f.name == name)
+    }
+}

--- a/polars/polars-io/src/avro.rs
+++ b/polars/polars-io/src/avro.rs
@@ -34,7 +34,7 @@ impl<R: Read + Seek> AvroReader<R> {
     /// Get schema of the Avro File
     pub fn schema(&mut self) -> Result<Schema> {
         let (_, schema, _, _) = read::read_metadata(&mut self.reader)?;
-        Ok(schema.into())
+        Ok((&schema.fields).into())
     }
 
     /// Get arrow schema of the avro File, this is faster than a polars schema.

--- a/polars/polars-io/src/csv_core/buffer.rs
+++ b/polars/polars-io/src/csv_core/buffer.rs
@@ -258,38 +258,24 @@ pub(crate) fn init_buffers(
     projection
         .iter()
         .map(|&i| {
-            let field = schema.field(i).unwrap();
+            let (name, dtype) = schema.get_index(i).unwrap();
             let mut str_capacity = 0;
             // determine the needed capacity for this column
-            if field.data_type() == &DataType::Utf8 {
+            if dtype == &DataType::Utf8 {
                 str_capacity = str_capacities[str_index].size_hint();
                 str_index += 1;
             }
 
-            let builder = match field.data_type() {
-                &DataType::Boolean => {
-                    Buffer::Boolean(BooleanChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::Int32 => {
-                    Buffer::Int32(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::Int64 => {
-                    Buffer::Int64(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::UInt32 => {
-                    Buffer::UInt32(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::UInt64 => {
-                    Buffer::UInt64(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::Float32 => {
-                    Buffer::Float32(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
-                &DataType::Float64 => {
-                    Buffer::Float64(PrimitiveChunkedBuilder::new(field.name(), capacity))
-                }
+            let builder = match dtype {
+                &DataType::Boolean => Buffer::Boolean(BooleanChunkedBuilder::new(name, capacity)),
+                &DataType::Int32 => Buffer::Int32(PrimitiveChunkedBuilder::new(name, capacity)),
+                &DataType::Int64 => Buffer::Int64(PrimitiveChunkedBuilder::new(name, capacity)),
+                &DataType::UInt32 => Buffer::UInt32(PrimitiveChunkedBuilder::new(name, capacity)),
+                &DataType::UInt64 => Buffer::UInt64(PrimitiveChunkedBuilder::new(name, capacity)),
+                &DataType::Float32 => Buffer::Float32(PrimitiveChunkedBuilder::new(name, capacity)),
+                &DataType::Float64 => Buffer::Float64(PrimitiveChunkedBuilder::new(name, capacity)),
                 &DataType::Utf8 => Buffer::Utf8(Utf8Field::new(
-                    field.name(),
+                    name,
                     capacity,
                     str_capacity,
                     quote_char,

--- a/polars/polars-io/src/csv_core/utils.rs
+++ b/polars/polars-io/src/csv_core/utils.rs
@@ -290,8 +290,8 @@ pub fn infer_file_schema(
         let field_name = &headers[i];
 
         if let Some(schema_overwrite) = schema_overwrite {
-            if let Ok(field_ovw) = schema_overwrite.field_with_name(field_name) {
-                fields.push(field_ovw.clone());
+            if let Some((_, name, dtype)) = schema_overwrite.get_full(field_name) {
+                fields.push(Field::new(name, dtype.clone()));
                 continue;
             }
         }
@@ -338,7 +338,7 @@ pub fn infer_file_schema(
         );
     }
 
-    Ok((Schema::new(fields), rows_count))
+    Ok((Schema::from(fields), rows_count))
 }
 
 // magic numbers

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -74,7 +74,7 @@ impl<R: Read + Seek> IpcReader<R> {
     /// Get schema of the Ipc File
     pub fn schema(&mut self) -> Result<Schema> {
         let metadata = read::read_file_metadata(&mut self.reader)?;
-        Ok((&metadata.schema).into())
+        Ok((&metadata.schema.fields).into())
     }
 
     /// Get arrow schema of the Ipc File, this is faster than creating a polars schema.
@@ -202,7 +202,7 @@ where
                 }
             } else {
                 for column in cols.iter() {
-                    let i = schema.index_of(column)?;
+                    let i = schema.try_index_of(column)?;
                     prj.push(i);
                 }
             }

--- a/polars/polars-io/src/parquet/read.rs
+++ b/polars/polars-io/src/parquet/read.rs
@@ -90,7 +90,7 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         let metadata = read::read_metadata(&mut self.reader)?;
 
         let schema = read::infer_schema(&metadata)?;
-        Ok(schema.into())
+        Ok((&schema.fields).into())
     }
 }
 
@@ -119,7 +119,7 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
         if let Some(cols) = self.columns {
             let mut prj = Vec::with_capacity(cols.len());
             for col in cols.iter() {
-                let i = schema.index_of(col)?;
+                let i = schema.try_index_of(col)?;
                 prj.push(i);
             }
 

--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -90,7 +90,7 @@ impl LogicalPlan {
                 predicate,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());
@@ -118,7 +118,7 @@ impl LogicalPlan {
                 selection,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = projection {
                     n_columns = format!("{}", columns.len());
@@ -143,7 +143,7 @@ impl LogicalPlan {
                 let current_node = format!(
                     "π {}/{} [{:?}]",
                     expr.len(),
-                    input.schema().fields().len(),
+                    input.schema().len(),
                     (branch, id)
                 );
                 self.write_dot(acc_str, prev_node, &current_node, id)?;
@@ -160,7 +160,7 @@ impl LogicalPlan {
                 let current_node = format!(
                     "LOCAL π {}/{} [{:?}]",
                     expr.len(),
-                    input.schema().fields().len(),
+                    input.schema().len(),
                     (branch, id)
                 );
                 self.write_dot(acc_str, prev_node, &current_node, id)?;
@@ -240,7 +240,7 @@ impl LogicalPlan {
                 options,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());
@@ -270,7 +270,7 @@ impl LogicalPlan {
                 predicate,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -154,7 +154,7 @@ impl AExpr {
                 arena.get(*expr).get_type(schema, ctxt, arena)?,
             )),
             Column(name) => {
-                let field = schema.field_with_name(name).map(|f| f.clone())?;
+                let field = schema.get_field(name).unwrap();
                 Ok(field)
             }
             Literal(sv) => Ok(Field::new("literal", sv.get_datatype())),

--- a/polars/polars-lazy/src/logical_plan/format.rs
+++ b/polars/polars-lazy/src/logical_plan/format.rs
@@ -17,7 +17,7 @@ impl fmt::Debug for LogicalPlan {
                 options,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());
@@ -39,7 +39,7 @@ impl fmt::Debug for LogicalPlan {
                 predicate,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());
@@ -67,7 +67,7 @@ impl fmt::Debug for LogicalPlan {
                 predicate,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = &options.with_columns {
                     n_columns = format!("{}", columns.len());
@@ -87,7 +87,7 @@ impl fmt::Debug for LogicalPlan {
                 selection,
                 ..
             } => {
-                let total_columns = schema.fields().len();
+                let total_columns = schema.len();
                 let mut n_columns = "*".to_string();
                 if let Some(columns) = projection {
                     n_columns = format!("{}", columns.len());
@@ -101,12 +101,7 @@ impl fmt::Debug for LogicalPlan {
                     f,
                     "DATAFRAME(in-memory): {:?};\n\tproject {}/{} columns\t|\tdetails: {:?};\n\
                     \tselection: {:?}\n\n",
-                    schema
-                        .fields()
-                        .iter()
-                        .map(|f| f.name())
-                        .take(4)
-                        .collect::<Vec<_>>(),
+                    schema.iter_names().take(4).collect::<Vec<_>>(),
                     n_columns,
                     total_columns,
                     projection,

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -278,16 +278,14 @@ mod test {
             .select(&[col("variety").alias("foo")])
             .logical_plan;
 
-        println!("{:#?}", lp.schema().fields());
-        assert!(lp.schema().field_with_name("foo").is_ok());
+        assert!(lp.schema().get("foo").is_some());
 
         let lp = df
             .lazy()
             .groupby([col("variety")])
             .agg([col("sepal.width").min()])
             .logical_plan;
-        println!("{:#?}", lp.schema().fields());
-        assert!(lp.schema().field_with_name("sepal.width").is_ok());
+        assert!(lp.schema().get("sepal.width").is_some());
     }
 
     #[test]

--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
@@ -94,7 +94,7 @@ impl OptimizationRule for AggregatePushdown {
                     let input_schema = lp_arena.get(new_node).schema(lp_arena);
 
                     let nodes: Vec<_> = self.process_nodes();
-                    let fields = self
+                    let fields: Vec<_> = self
                         .accumulated_projections
                         .iter()
                         .map(|n| {
@@ -108,7 +108,7 @@ impl OptimizationRule for AggregatePushdown {
                     Some(ALogicalPlan::Projection {
                         expr: nodes,
                         input: new_node,
-                        schema: Arc::new(Schema::new(fields)),
+                        schema: Arc::new(Schema::from(fields)),
                     })
                 }
             }

--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_scan_projections.rs
@@ -25,10 +25,9 @@ fn process_with_columns(
         None => {
             cols.extend(
                 schema
-                    .fields()
-                    .iter()
+                    .iter_names()
                     .enumerate()
-                    .map(|t| (t.0, t.1.name().to_string())),
+                    .map(|t| (t.0, t.1.to_string())),
             );
         }
     }

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -43,7 +43,7 @@ fn split_acc_projections(
     expr_arena: &mut Arena<AExpr>,
 ) -> (Vec<Node>, Vec<Node>, PlHashSet<Arc<str>>) {
     // If node above has as many columns as the projection there is nothing to pushdown.
-    if down_schema.fields().len() == acc_projections.len() {
+    if down_schema.len() == acc_projections.len() {
         let local_projections = acc_projections;
         (vec![], local_projections, PlHashSet::new())
     } else {
@@ -93,15 +93,15 @@ fn update_scan_schema(
     acc_projections: &[Node],
     expr_arena: &Arena<AExpr>,
     schema: &Schema,
-) -> Result<Schema> {
-    let mut new_fields = Vec::with_capacity(acc_projections.len());
+) -> Schema {
+    let mut new_schema = Schema::with_capacity(acc_projections.len());
     for node in acc_projections.iter() {
         for name in aexpr_to_root_names(*node, expr_arena) {
-            let field = schema.field_with_name(&*name)?;
-            new_fields.push(field.clone())
+            let dtype = schema.get(&*name).unwrap();
+            new_schema.with_column(name.to_string(), dtype.clone())
         }
     }
-    Ok(Schema::new(new_fields))
+    new_schema
 }
 
 pub(crate) struct ProjectionPushDown {}
@@ -330,7 +330,7 @@ impl ProjectionPushDown {
             } => {
                 let mut projection = None;
                 if !acc_projections.is_empty() {
-                    schema = Arc::new(update_scan_schema(&acc_projections, expr_arena, &*schema)?);
+                    schema = Arc::new(update_scan_schema(&acc_projections, expr_arena, &*schema));
                     projection = Some(acc_projections);
                 }
                 let lp = DataFrameScan {
@@ -358,7 +358,7 @@ impl ProjectionPushDown {
                         &acc_projections,
                         expr_arena,
                         &*schema,
-                    )?))
+                    )))
                 };
                 options.with_columns = with_columns;
 
@@ -390,7 +390,7 @@ impl ProjectionPushDown {
                         &acc_projections,
                         expr_arena,
                         &*schema,
-                    )?))
+                    )))
                 };
                 options.with_columns = with_columns;
 
@@ -422,7 +422,7 @@ impl ProjectionPushDown {
                         &acc_projections,
                         expr_arena,
                         &*schema,
-                    )?))
+                    )))
                 };
 
                 let lp = CsvScan {
@@ -805,8 +805,7 @@ impl ProjectionPushDown {
 
                 for proj in &mut local_projection {
                     for name in aexpr_to_root_names(*proj, expr_arena) {
-                        if name.contains(suffix.as_ref())
-                            && schema_after_join.column_with_name(&*name).is_none()
+                        if name.contains(suffix.as_ref()) && schema_after_join.get(&*name).is_none()
                         {
                             let new_name = &name.as_ref()[..name.len() - suffix.len()];
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
@@ -242,7 +242,7 @@ mod test {
     #[test]
     fn test_categorical_utf8() {
         let mut rules: Vec<Box<dyn OptimizationRule>> = vec![Box::new(TypeCoercionRule {})];
-        let schema = Schema::new(vec![Field::new("fruits", DataType::Categorical(None))]);
+        let schema = Schema::from(vec![Field::new("fruits", DataType::Categorical(None))]);
 
         let expr = col("fruits").eq(lit("somestr"));
         let out = optimize_expr(expr.clone(), schema.clone(), &mut rules);

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -25,8 +25,8 @@ impl Executor for ProjectionExec {
         {
             // TODO: check also the types.
             df.as_ref().map(|df| {
-                for (l, r) in df.schema().fields().iter().zip(self.schema.fields()) {
-                    assert_eq!(l.name(), r.name());
+                for (l, r) in df.iter().zip(self.schema.iter_names()) {
+                    assert_eq!(l.name(), r);
                 }
             });
         }

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -49,7 +49,7 @@ fn prepare_scan_args<'a>(
     let projection: Option<Vec<_>> = with_columns.map(|with_columns| {
         with_columns
             .iter()
-            .map(|name| schema.column_with_name(name).unwrap().0)
+            .map(|name| schema.index_of(name).unwrap())
             .collect()
     });
 

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -389,6 +389,7 @@ mod stats {
     impl BinaryExpr {
         fn impl_should_read(&self, stats: &BatchStats) -> Result<bool> {
             let schema = stats.schema();
+            dbg!(schema);
             let fld_l = self.left.to_field(schema)?;
             let fld_r = self.right.to_field(schema)?;
 

--- a/polars/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/column.rs
@@ -37,7 +37,12 @@ impl PhysicalExpr for ColumnExpr {
         Ok(AggregationContext::new(s, Cow::Borrowed(groups), false))
     }
     fn to_field(&self, input_schema: &Schema) -> Result<Field> {
-        let field = input_schema.field_with_name(&self.0).map(|f| f.clone())?;
+        let field = input_schema.get_field(&self.0).ok_or_else(|| {
+            PolarsError::NotFound(format!(
+                "could not find column: {} in schema: {:?}",
+                self.0, &input_schema
+            ))
+        })?;
         Ok(field)
     }
 }

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1527,7 +1527,7 @@ fn test_when_then_schema() -> Result<()> {
             .then(Null {}.lit())
             .otherwise(col("A"))])
         .schema();
-    assert_ne!(schema.fields()[0].data_type(), &DataType::Null);
+    assert_ne!(schema.get_index(0).unwrap().1, &DataType::Null);
 
     Ok(())
 }

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -228,12 +228,8 @@ pub(crate) fn expr_to_root_column_exprs(expr: &Expr) -> Vec<Expr> {
 
 /// Take a list of expressions and a schema and determine the output schema.
 pub(crate) fn expressions_to_schema(expr: &[Expr], schema: &Schema, ctxt: Context) -> Schema {
-    let fields = expr
-        .iter()
-        .map(|expr| expr.to_field(schema, ctxt))
-        .collect::<Result<Vec<_>>>()
-        .unwrap();
-    Schema::new(fields)
+    let fields = expr.iter().map(|expr| expr.to_field(schema, ctxt).unwrap());
+    Schema::from(fields)
 }
 
 /// Get a set of the data source paths in this LogicalPlan
@@ -301,7 +297,7 @@ pub(crate) fn check_input_node(
 ) -> bool {
     aexpr_to_root_names(node, expr_arena)
         .iter()
-        .all(|name| input_schema.index_of(name).is_ok())
+        .all(|name| input_schema.index_of(name).is_some())
 }
 
 pub(crate) fn aexprs_to_schema(
@@ -312,10 +308,8 @@ pub(crate) fn aexprs_to_schema(
 ) -> Schema {
     let fields = expr
         .iter()
-        .map(|expr| arena.get(*expr).to_field(schema, ctxt, arena))
-        .collect::<Result<Vec<_>>>()
-        .unwrap();
-    Schema::new(fields)
+        .map(|expr| arena.get(*expr).to_field(schema, ctxt, arena).unwrap());
+    Schema::from(fields)
 }
 
 pub(crate) fn combine_predicates_expr<I>(iter: I) -> Expr

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -337,18 +337,12 @@ fn test_quoted_numeric() {
 #[test]
 fn test_empty_bytes_to_dataframe() {
     let fields = vec![Field::new("test_field", DataType::Utf8)];
-    let schema = Schema::new(fields);
+    let schema = Schema::from(fields);
     let file = Cursor::new(vec![]);
 
     let result = CsvReader::new(file)
         .has_header(false)
-        .with_columns(Some(
-            schema
-                .fields()
-                .iter()
-                .map(|s| s.name().to_string())
-                .collect(),
-        ))
+        .with_columns(Some(schema.iter_names().cloned().collect()))
         .with_schema(&schema)
         .finish();
     assert!(result.is_ok())
@@ -378,7 +372,7 @@ fn test_missing_value() {
     let file = Cursor::new(csv);
     let df = CsvReader::new(file)
         .has_header(true)
-        .with_schema(&Schema::new(vec![
+        .with_schema(&Schema::from(vec![
             Field::new("foo", DataType::UInt32),
             Field::new("bar", DataType::UInt32),
             Field::new("ham", DataType::UInt32),
@@ -400,7 +394,7 @@ AUDCAD,1616455921,0.96212,0.95666,1
     let file = Cursor::new(csv);
     let df = CsvReader::new(file)
         .has_header(true)
-        .with_dtypes(Some(&Schema::new(vec![Field::new(
+        .with_dtypes(Some(&Schema::from(vec![Field::new(
             "b",
             DataType::Datetime(TimeUnit::Nanoseconds, None),
         )])))

--- a/polars/tests/it/main.rs
+++ b/polars/tests/it/main.rs
@@ -3,5 +3,6 @@ mod io;
 mod joins;
 #[cfg(feature = "lazy")]
 mod lazy;
+mod schema;
 
 pub static FOODS_CSV: &str = "../examples/aggregate_multiple_files_in_chunks/datasets/foods1.csv";

--- a/polars/tests/it/schema.rs
+++ b/polars/tests/it/schema.rs
@@ -1,0 +1,19 @@
+use polars::prelude::*;
+
+#[test]
+fn test_schema_rename() {
+    use DataType::*;
+    let mut schema = Schema::from([
+        Field::new("a", UInt64),
+        Field::new("b", Int32),
+        Field::new("c", Int8),
+    ]);
+    schema.rename("a", "anton".to_string()).unwrap();
+    let mut expected = Schema::from([
+        Field::new("anton", UInt64),
+        Field::new("b", Int32),
+        Field::new("c", Int8),
+    ]);
+
+    assert_eq!(schema, expected);
+}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "comfy-table",
  "hashbrown 0.12.0",
  "hex",
+ "indexmap",
  "jsonpath_lib",
  "lazy_static",
  "ndarray",
@@ -1331,7 +1332,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "unsafe_unwrap",
 ]
 
 [[package]]
@@ -1815,12 +1815,6 @@ name = "unindent"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
-
-[[package]]
-name = "unsafe_unwrap"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230ec65f13e0f9b28d789da20d2d419511893ea9dac2c1f4ef67b8b14e5da80"
 
 [[package]]
 name = "vcpkg"


### PR DESCRIPTION
Every node in a lazy computation gets a schema. Evaluating an expression requires several schema lookups. This was backed by a `Vec`. But the data in the schema is `&str` so there is a lot of indirection and thus cache misses. Besides that the usage of polars with regards of number of expressions ran on a `DataFrame` and number of `columns` that are stored in a `DataFrame` far exceed my initial exprectations/ guesses. Both are in the millions, meaning we need `O(1)` instead of `O(n)` schema lookups.

This PR refactors the schema to be backed by [IndexMap](https://docs.rs/indexmap/latest/indexmap/). This is a hashmap that also stores insertion order.

@ghuls FYI