### PR TITLE
Several projection improvements

### DIFF
--- a/polars/clippy.toml
+++ b/polars/clippy.toml
@@ -1,0 +1,1 @@
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -16,7 +16,6 @@ use ahash::RandomState;
 use hashbrown::hash_map::{Entry, RawEntryMut};
 use hashbrown::HashMap;
 use rayon::prelude::*;
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash, Hasher};
 
@@ -1017,7 +1016,7 @@ impl DataFrame {
         mut df_right: DataFrame,
         suffix: Option<String>,
     ) -> Result<DataFrame> {
-        let mut left_names = HashSet::with_capacity_and_hasher(df_left.width(), RandomState::new());
+        let mut left_names = PlHashSet::with_capacity(df_left.width());
 
         df_left.columns.iter().for_each(|series| {
             left_names.insert(series.name());
@@ -1036,6 +1035,7 @@ impl DataFrame {
             df_right.rename(&name, &format!("{}{}", name, suffix))?;
         }
 
+        drop(left_names);
         df_left.hstack_mut(&df_right.columns)?;
         Ok(df_left)
     }

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -86,6 +86,7 @@ test = [
 [dependencies]
 ahash = "0.7"
 glob = "0.3"
+parking_lot = "0.12"
 rayon = "1.5"
 regex = { version = "1.5", optional = true }
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -10,6 +10,7 @@ pub(crate) struct GroupByDynamicExec {
     pub(crate) keys: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) aggs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) options: DynamicGroupOptions,
+    pub(crate) input_schema: SchemaRef,
 }
 
 impl Executor for GroupByDynamicExec {
@@ -17,7 +18,7 @@ impl Executor for GroupByDynamicExec {
         #[cfg(feature = "dynamic_groupby")]
         {
             let df = self.input.execute(state)?;
-            state.set_schema(&df, self.keys.len() + self.aggs.len());
+            state.set_schema(self.input_schema.clone());
             let keys = self
                 .keys
                 .iter()

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -17,6 +17,7 @@ impl Executor for GroupByDynamicExec {
         #[cfg(feature = "dynamic_groupby")]
         {
             let df = self.input.execute(state)?;
+            state.set_schema(&df, self.keys.len() + self.aggs.len());
             let keys = self
                 .keys
                 .iter()
@@ -44,6 +45,7 @@ impl Executor for GroupByDynamicExec {
                     .collect::<Result<Vec<_>>>()
             })?;
 
+            state.clear_schema_cache();
             let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
             columns.extend(keys);
             columns.push(time_key);

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -7,6 +7,7 @@ pub(crate) struct GroupByRollingExec {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) aggs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) options: RollingGroupOptions,
+    pub(crate) input_schema: SchemaRef,
 }
 
 impl Executor for GroupByRollingExec {
@@ -14,7 +15,7 @@ impl Executor for GroupByRollingExec {
         #[cfg(feature = "dynamic_groupby")]
         {
             let df = self.input.execute(state)?;
-            state.set_schema(&df, self.aggs.len());
+            state.set_schema(self.input_schema.clone());
 
             let (time_key, groups) = df.groupby_rolling(&self.options)?;
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -14,6 +14,7 @@ impl Executor for GroupByRollingExec {
         #[cfg(feature = "dynamic_groupby")]
         {
             let df = self.input.execute(state)?;
+            state.set_schema(&df, self.aggs.len());
 
             let (time_key, groups) = df.groupby_rolling(&self.options)?;
 
@@ -36,6 +37,7 @@ impl Executor for GroupByRollingExec {
                         .collect::<Result<Vec<_>>>()
                 })?;
 
+            state.clear_schema_cache();
             let mut columns = Vec::with_capacity(agg_columns.len() + 1);
             columns.push(time_key);
             columns.extend(agg_columns.into_iter().flatten());

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -132,7 +132,6 @@ pub(crate) fn evaluate_physical_expressions(
     state: &ExecutionState,
     has_windows: bool,
 ) -> Result<DataFrame> {
-    state.set_schema(df, exprs.len());
     let zero_length = df.height() == 0;
     let selected_columns = if has_windows {
         execute_projection_cached_window_fns(df, exprs, state)?

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -132,6 +132,9 @@ pub(crate) fn evaluate_physical_expressions(
     state: &ExecutionState,
     has_windows: bool,
 ) -> Result<DataFrame> {
+    if exprs.len() > 1 && df.get_columns().len() > 10 {
+        state.set_schema(Arc::new(df.schema()));
+    }
     let zero_length = df.height() == 0;
     let selected_columns = if has_windows {
         execute_projection_cached_window_fns(df, exprs, state)?
@@ -143,6 +146,7 @@ pub(crate) fn evaluate_physical_expressions(
                 .collect::<Result<_>>()
         })?
     };
+    state.clear_schema_cache();
 
     check_expand_literals(selected_columns, zero_length)
 }

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -132,9 +132,7 @@ pub(crate) fn evaluate_physical_expressions(
     state: &ExecutionState,
     has_windows: bool,
 ) -> Result<DataFrame> {
-    if exprs.len() > 1 && df.get_columns().len() > 10 {
-        state.set_schema(Arc::new(df.schema()));
-    }
+    state.set_schema(df, exprs.len());
     let zero_length = df.height() == 0;
     let selected_columns = if has_windows {
         execute_projection_cached_window_fns(df, exprs, state)?

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -9,6 +9,7 @@ pub struct ProjectionExec {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) expr: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) has_windows: bool,
+    pub(crate) input_schema: SchemaRef,
     #[cfg(test)]
     pub(crate) schema: SchemaRef,
 }
@@ -16,6 +17,7 @@ pub struct ProjectionExec {
 impl Executor for ProjectionExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let df = self.input.execute(state)?;
+        state.set_schema(self.input_schema.clone());
 
         let df = evaluate_physical_expressions(&df, &self.expr, state, self.has_windows);
 

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -264,6 +264,7 @@ impl Executor for DataFrameExec {
         // projection should be before selection as those are free
         // TODO: this is only the case if we don't create new columns
         if let Some(projection) = &self.projection {
+            state.may_set_schema(&df, projection.len());
             df = evaluate_physical_expressions(&df, projection, state, self.has_windows)?;
         }
 
@@ -274,6 +275,7 @@ impl Executor for DataFrameExec {
             })?;
             df = df.filter(mask)?;
         }
+        state.clear_schema_cache();
 
         if let Some(limit) = set_n_rows(None) {
             Ok(df.head(Some(limit)))

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -14,6 +14,7 @@ impl Executor for StackExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let mut df = self.input.execute(state)?;
 
+        state.set_schema(Arc::new(df.schema()));
         let res = if self.has_windows {
             // we have a different run here
             // to ensure the window functions run sequential and share caches
@@ -26,12 +27,13 @@ impl Executor for StackExec {
                     .collect::<Result<Vec<_>>>()
             })?
         };
+        state.clear_schema_cache();
+        state.clear_expr_cache();
 
         for s in res {
             df.with_column(s)?;
         }
 
-        state.clear_expr_cache();
         Ok(df)
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -14,7 +14,7 @@ impl Executor for StackExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let mut df = self.input.execute(state)?;
 
-        state.set_schema(Arc::new(df.schema()));
+        state.set_schema(&df, self.expr.len());
         let res = if self.has_windows {
             // we have a different run here
             // to ensure the window functions run sequential and share caches

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -8,13 +8,14 @@ pub struct StackExec {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) has_windows: bool,
     pub(crate) expr: Vec<Arc<dyn PhysicalExpr>>,
+    pub(crate) input_schema: SchemaRef,
 }
 
 impl Executor for StackExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let mut df = self.input.execute(state)?;
 
-        state.set_schema(&df, self.expr.len());
+        state.set_schema(self.input_schema.clone());
         let res = if self.has_windows {
             // we have a different run here
             // to ensure the window functions run sequential and share caches

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -248,7 +248,7 @@ impl PhysicalExpr for WindowExpr {
                 cache_key.push_str(s.name());
             }
 
-            let mut gt_map = state.group_tuples.lock().unwrap();
+            let mut gt_map = state.group_tuples.lock();
             // we run sequential and partitioned
             // and every partition run the cache should be empty so we expect a max of 1.
             debug_assert!(gt_map.len() <= 1);
@@ -274,7 +274,7 @@ impl PhysicalExpr for WindowExpr {
         let cache_gb = |mut gb: GroupBy| {
             if state.cache_window {
                 let groups = std::mem::take(gb.get_groups_mut());
-                let mut gt_map = state.group_tuples.lock().unwrap();
+                let mut gt_map = state.group_tuples.lock();
                 gt_map.insert(cache_key.clone(), groups);
             } else {
                 // drop the group tuples to reduce allocated memory.
@@ -424,7 +424,7 @@ impl PhysicalExpr for WindowExpr {
 
                 // try to get cached join_tuples
                 let opt_join_tuples = if state.cache_window {
-                    let mut jt_map = state.join_tuples.lock().unwrap();
+                    let mut jt_map = state.join_tuples.lock();
                     // we run sequential and partitioned
                     // and every partition run the cache should be empty so we expect a max of 1.
                     debug_assert!(jt_map.len() <= 1);
@@ -447,7 +447,7 @@ impl PhysicalExpr for WindowExpr {
                 }
 
                 if state.cache_window {
-                    let mut jt_map = state.join_tuples.lock().unwrap();
+                    let mut jt_map = state.join_tuples.lock();
                     jt_map.insert(cache_key, opt_join_tuples);
                 }
 

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -13,12 +13,10 @@ use crate::{
     logical_plan::iterator::ArenaExprIter,
     utils::{aexpr_to_root_names, aexpr_to_root_nodes, agg_source_paths, has_aexpr},
 };
-use ahash::RandomState;
 use polars_core::prelude::*;
 use polars_core::{frame::groupby::GroupByMethod, utils::parallel_op_series};
 #[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
 use polars_io::aggregations::ScanAggregation;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 #[cfg(any(feature = "parquet", feature = "csv-file"))]
@@ -430,11 +428,9 @@ impl DefaultPlanner {
                     // check if two DataFrames come from a separate source.
                     // If they don't we can parallelize,
                     // Otherwise it is in cache.
-                    let mut sources_left =
-                        HashSet::with_capacity_and_hasher(16, RandomState::default());
+                    let mut sources_left = PlHashSet::with_capacity(16);
                     agg_source_paths(input_left, &mut sources_left, lp_arena);
-                    let mut sources_right =
-                        HashSet::with_capacity_and_hasher(16, RandomState::default());
+                    let mut sources_right = PlHashSet::with_capacity(16);
                     agg_source_paths(input_right, &mut sources_right, lp_arena);
                     sources_left.intersection(&sources_right).next().is_none()
                 } else {

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -195,6 +195,7 @@ impl DefaultPlanner {
                 schema: _schema,
                 ..
             } => {
+                let input_schema = lp_arena.get(input).schema(lp_arena).clone();
                 let has_windows = expr.iter().any(|node| has_window_aexpr(*node, expr_arena));
                 let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
                 let phys_expr =
@@ -203,6 +204,7 @@ impl DefaultPlanner {
                     input,
                     expr: phys_expr,
                     has_windows,
+                    input_schema,
                     #[cfg(test)]
                     schema: _schema,
                 }))
@@ -210,9 +212,12 @@ impl DefaultPlanner {
             LocalProjection {
                 expr,
                 input,
-                schema: _schema,
+                #[cfg(test)]
+                    schema: _schema,
                 ..
             } => {
+                let input_schema = lp_arena.get(input).schema(lp_arena).clone();
+
                 let has_windows = expr.iter().any(|node| has_window_aexpr(*node, expr_arena));
                 let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
                 let phys_expr =
@@ -221,6 +226,7 @@ impl DefaultPlanner {
                     input,
                     expr: phys_expr,
                     has_windows,
+                    input_schema,
                     #[cfg(test)]
                     schema: _schema,
                 }))
@@ -301,7 +307,6 @@ impl DefaultPlanner {
                 maintain_order,
                 options,
             } => {
-                #[cfg(feature = "object")]
                 let input_schema = lp_arena.get(input).schema(lp_arena).clone();
                 let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
 
@@ -317,6 +322,7 @@ impl DefaultPlanner {
                         keys: phys_keys,
                         aggs: phys_aggs,
                         options,
+                        input_schema,
                     }));
                 }
 
@@ -325,6 +331,7 @@ impl DefaultPlanner {
                         input,
                         aggs: phys_aggs,
                         options,
+                        input_schema,
                     }));
                 }
 
@@ -411,6 +418,7 @@ impl DefaultPlanner {
                         phys_aggs,
                         apply,
                         maintain_order,
+                        input_schema,
                     )))
                 }
             }
@@ -454,6 +462,7 @@ impl DefaultPlanner {
                 )))
             }
             HStack { input, exprs, .. } => {
+                let input_schema = lp_arena.get(input).schema(lp_arena).clone();
                 let has_windows = exprs.iter().any(|node| has_window_aexpr(*node, expr_arena));
                 let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
                 let phys_expr =
@@ -462,6 +471,7 @@ impl DefaultPlanner {
                     input,
                     has_windows,
                     expr: phys_expr,
+                    input_schema,
                 }))
             }
             Udf {

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -32,9 +32,12 @@ impl ExecutionState {
     }
 
     /// Set the schema. Typically at the start of a projection.
-    pub(crate) fn set_schema(&self, schema: SchemaRef) {
-        let mut opt = self.schema_cache.write();
-        *opt = Some(schema)
+    pub(crate) fn set_schema(&self, df: &DataFrame, exprs_len: usize) {
+        if exprs_len > 1 && df.get_columns().len() > 10 {
+            let schema = Arc::new(df.schema());
+            let mut opt = self.schema_cache.write();
+            *opt = Some(schema)
+        }
     }
 
     /// Clear the schema. Typically at the end of a projection.

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,18 +1,15 @@
-use ahash::RandomState;
 use parking_lot::{Mutex, RwLock};
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::collections::HashMap;
 use std::ops::Deref;
 
-pub type JoinTuplesCache =
-    Arc<Mutex<HashMap<String, Vec<(IdxSize, Option<IdxSize>)>, RandomState>>>;
-pub type GroupsProxyCache = Arc<Mutex<HashMap<String, GroupsProxy, RandomState>>>;
+pub type JoinTuplesCache = Arc<Mutex<PlHashMap<String, Vec<(IdxSize, Option<IdxSize>)>>>>;
+pub type GroupsProxyCache = Arc<Mutex<PlHashMap<String, GroupsProxy>>>;
 
 /// State/ cache that is maintained during the Execution of the physical plan.
 #[derive(Clone)]
 pub struct ExecutionState {
-    df_cache: Arc<Mutex<HashMap<String, DataFrame, RandomState>>>,
+    df_cache: Arc<Mutex<PlHashMap<String, DataFrame>>>,
     pub schema_cache: Arc<RwLock<Option<SchemaRef>>>,
     /// Used by Window Expression to prevent redundant grouping
     pub(crate) group_tuples: GroupsProxyCache,
@@ -25,10 +22,10 @@ pub struct ExecutionState {
 impl ExecutionState {
     pub fn new() -> Self {
         Self {
-            df_cache: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
+            df_cache: Arc::new(Mutex::new(PlHashMap::default())),
             schema_cache: Arc::new(RwLock::new(None)),
-            group_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
-            join_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
+            group_tuples: Arc::new(Mutex::new(PlHashMap::default())),
+            join_tuples: Arc::new(Mutex::new(PlHashMap::default())),
             verbose: std::env::var("POLARS_VERBOSE").is_ok(),
             cache_window: true,
         }

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,8 +1,9 @@
 use ahash::RandomState;
+use parking_lot::{Mutex, RwLock};
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::ops::Deref;
 
 pub type JoinTuplesCache =
     Arc<Mutex<HashMap<String, Vec<(IdxSize, Option<IdxSize>)>, RandomState>>>;
@@ -12,6 +13,7 @@ pub type GroupsProxyCache = Arc<Mutex<HashMap<String, GroupsProxy, RandomState>>
 #[derive(Clone)]
 pub struct ExecutionState {
     df_cache: Arc<Mutex<HashMap<String, DataFrame, RandomState>>>,
+    pub schema_cache: Arc<RwLock<Option<SchemaRef>>>,
     /// Used by Window Expression to prevent redundant grouping
     pub(crate) group_tuples: GroupsProxyCache,
     /// Used by Window Expression to prevent redundant joins
@@ -24,6 +26,7 @@ impl ExecutionState {
     pub fn new() -> Self {
         Self {
             df_cache: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
+            schema_cache: Arc::new(RwLock::new(None)),
             group_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
             join_tuples: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
             verbose: std::env::var("POLARS_VERBOSE").is_ok(),
@@ -31,25 +34,43 @@ impl ExecutionState {
         }
     }
 
+    /// Set the schema. Typically at the start of a projection.
+    pub(crate) fn set_schema(&self, schema: SchemaRef) {
+        let mut opt = self.schema_cache.write();
+        *opt = Some(schema)
+    }
+
+    /// Clear the schema. Typically at the end of a projection.
+    pub(crate) fn clear_schema_cache(&self) {
+        let mut lock = self.schema_cache.write();
+        *lock = None;
+    }
+
+    /// Get the schema.
+    pub(crate) fn get_schema(&self) -> Option<SchemaRef> {
+        let opt = self.schema_cache.read();
+        opt.deref().clone()
+    }
+
     /// Check if we have DataFrame in cache
-    pub fn cache_hit(&self, key: &str) -> Option<DataFrame> {
-        let guard = self.df_cache.lock().unwrap();
+    pub(crate) fn cache_hit(&self, key: &str) -> Option<DataFrame> {
+        let guard = self.df_cache.lock();
         guard.get(key).cloned()
     }
 
     /// Store DataFrame in cache.
-    pub fn store_cache(&self, key: String, df: DataFrame) {
-        let mut guard = self.df_cache.lock().unwrap();
+    pub(crate) fn store_cache(&self, key: String, df: DataFrame) {
+        let mut guard = self.df_cache.lock();
         guard.insert(key, df);
     }
 
     /// Clear the cache used by the Window expressions
-    pub fn clear_expr_cache(&self) {
+    pub(crate) fn clear_expr_cache(&self) {
         {
-            let mut lock = self.group_tuples.lock().unwrap();
+            let mut lock = self.group_tuples.lock();
             lock.clear();
         }
-        let mut lock = self.join_tuples.lock().unwrap();
+        let mut lock = self.join_tuples.lock();
         lock.clear();
     }
 }

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -30,13 +30,16 @@ impl ExecutionState {
             cache_window: true,
         }
     }
+    pub(crate) fn set_schema(&self, schema: SchemaRef) {
+        let mut opt = self.schema_cache.write();
+        *opt = Some(schema)
+    }
 
     /// Set the schema. Typically at the start of a projection.
-    pub(crate) fn set_schema(&self, df: &DataFrame, exprs_len: usize) {
+    pub(crate) fn may_set_schema(&self, df: &DataFrame, exprs_len: usize) {
         if exprs_len > 1 && df.get_columns().len() > 10 {
             let schema = Arc::new(df.schema());
-            let mut opt = self.schema_cache.write();
-            *opt = Some(schema)
+            self.set_schema(schema);
         }
     }
 

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -1,9 +1,7 @@
 use crate::logical_plan::iterator::{ArenaExprIter, ArenaLpIter};
 use crate::logical_plan::Context;
 use crate::prelude::*;
-use ahash::RandomState;
 use polars_core::prelude::*;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -235,7 +233,7 @@ pub(crate) fn expressions_to_schema(expr: &[Expr], schema: &Schema, ctxt: Contex
 /// Get a set of the data source paths in this LogicalPlan
 pub(crate) fn agg_source_paths(
     root_lp: Node,
-    paths: &mut HashSet<PathBuf, RandomState>,
+    paths: &mut PlHashSet<PathBuf>,
     lp_arena: &Arena<ALogicalPlan>,
 ) {
     lp_arena.iter(root_lp).for_each(|(_, lp)| {

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -9,7 +9,7 @@ description = "private utils for the polars dataframe library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parking_lot = "0.11"
+parking_lot = "0.12"
 rayon = "1.5"
 
 [features]

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -146,6 +146,7 @@ fn test_tab_sep() {
         .with_ignore_parser_errors(true)
         .finish()
         .unwrap();
+    assert_eq!(df.shape(), (8, 26))
 }
 
 #[test]

--- a/polars/tests/it/schema.rs
+++ b/polars/tests/it/schema.rs
@@ -9,7 +9,7 @@ fn test_schema_rename() {
         Field::new("c", Int8),
     ]);
     schema.rename("a", "anton".to_string()).unwrap();
-    let mut expected = Schema::from([
+    let expected = Schema::from([
         Field::new("anton", UInt64),
         Field::new("b", Int32),
         Field::new("c", Int8),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1364,6 +1364,7 @@ version = "0.19.1"
 dependencies = [
  "ahash",
  "glob",
+ "parking_lot 0.12.0",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -1386,7 +1387,7 @@ dependencies = [
 name = "polars-utils"
 version = "0.1.0"
 dependencies = [
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "rayon",
 ]
 


### PR DESCRIPTION
The lazy computation graph has schema for every node. This PR makes sure we actually use it and therefore save a lot column name lookups.

## Test run

```rust
use polars::prelude::*;

fn main() -> Result<()> {
    let cols = (0..100000)
        .map(|i| Series::new(&format!("{i}"), [i]))
        .collect();
    let df = DataFrame::new_no_checks(cols);
    dbg!("created df");
    let names = df.get_column_names();
    dbg!("created names");

    let exprs: Vec<_> = (0..1000).map(|i| col(names[names.len() - 1 - i])).collect();

    for i in 0..10 {
        dbg!(i);
        df.clone().lazy().select(exprs.clone()).collect().unwrap();
    }

    Ok(())
}
```

## Master

```
         38.066,31 msec task-clock                #   10,185 CPUs utilized          
             9.725      context-switches          #  255,475 /sec                   
                85      cpu-migrations            #    2,233 /sec                   
            17.976      page-faults               #  472,229 /sec                   
   117.932.283.930      cycles                    #    3,098 GHz                    
    43.582.787.522      instructions              #    0,37  insn per cycle         
    12.368.895.419      branches                  #  324,930 M/sec                  
         1.413.148      branch-misses             #    0,01% of all branches        

       3,737638335 seconds time elapsed

      37,864670000 seconds user
       0,181020000 seconds sys

```

## This PR
```
            551,74 msec task-clock                #    1,040 CPUs utilized          
               569      context-switches          #    1,031 K/sec                  
                65      cpu-migrations            #  117,810 /sec                   
            17.982      page-faults               #   32,592 K/sec                  
     1.705.472.128      cycles                    #    3,091 GHz                    
     2.583.767.201      instructions              #    1,51  insn per cycle         
       497.490.863      branches                  #  901,681 M/sec                  
           436.293      branch-misses             #    0,09% of all branches        

       0,530435470 seconds time elapsed

       0,496682000 seconds user
       0,059751000 seconds sys
```