### PR TITLE
Improve Error handling

### DIFF
--- a/polars/polars-arrow/src/kernels/set.rs
+++ b/polars/polars-arrow/src/kernels/set.rs
@@ -82,7 +82,7 @@ where
     idx.into_iter().try_for_each::<_, Result<_>>(|idx| {
         let val = mut_slice
             .get_mut(idx)
-            .ok_or_else(|| PolarsError::OutOfBounds("idx is out of bounds".into()))?;
+            .ok_or_else(|| PolarsError::ComputeError("idx is out of bounds".into()))?;
         *val = set_value;
         Ok(())
     })?;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -509,7 +509,7 @@ where
         if self.chunks.len() == 1 && !self.chunks[0].has_validity() {
             Ok(self.downcast_iter().next().map(|arr| arr.values()).unwrap())
         } else {
-            Err(PolarsError::NoSlice)
+            Err(PolarsError::ComputeError("cannot take slice".into()))
         }
     }
 

--- a/polars/polars-core/src/chunked_array/ndarray.rs
+++ b/polars/polars-core/src/chunked_array/ndarray.rs
@@ -23,7 +23,7 @@ impl ListChunked {
         N: PolarsNumericType,
     {
         if self.null_count() != 0 {
-            Err(PolarsError::HasNullValues(
+            Err(PolarsError::ComputeError(
                 "Creation of ndarray with null values is not supported.".into(),
             ))
         } else {
@@ -127,7 +127,7 @@ impl DataFrame {
 
         columns.par_iter().enumerate().map(|(col_idx, s)| {
             if s.null_count() != 0 {
-                return Err(PolarsError::HasNullValues(
+                return Err(PolarsError::ComputeError(
                     "Creation of ndarray with null values is not supported. Consider using floats and NaNs".into(),
                 ));
             }

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -169,7 +169,7 @@ where
 {
     fn quantile(&self, quantile: f64, interpol: QuantileInterpolOptions) -> Result<Option<f64>> {
         if !(0.0..=1.0).contains(&quantile) {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 "quantile should be between 0.0 and 1.0".into(),
             ));
         }
@@ -239,7 +239,7 @@ where
 impl ChunkQuantile<f32> for Float32Chunked {
     fn quantile(&self, quantile: f64, interpol: QuantileInterpolOptions) -> Result<Option<f32>> {
         if !(0.0..=1.0).contains(&quantile) {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 "quantile should be between 0.0 and 1.0".into(),
             ));
         }
@@ -309,7 +309,7 @@ impl ChunkQuantile<f32> for Float32Chunked {
 impl ChunkQuantile<f64> for Float64Chunked {
     fn quantile(&self, quantile: f64, interpol: QuantileInterpolOptions) -> Result<Option<f64>> {
         if !(0.0..=1.0).contains(&quantile) {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 "quantile should be between 0.0 and 1.0".into(),
             ));
         }

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -269,7 +269,7 @@ mod inner_mod {
     /// utility
     fn check_input(window_size: usize, min_periods: usize) -> Result<()> {
         if min_periods > window_size {
-            Err(PolarsError::ValueError(
+            Err(PolarsError::ComputeError(
                 "`windows_size` should be >= `min_periods`".into(),
             ))
         } else {

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -14,7 +14,7 @@ macro_rules! impl_set_at_idx_with {
 
         while let Some(current_idx) = idx_iter.next() {
             if current_idx > $self.len() {
-                return Err(PolarsError::OutOfBounds(
+                return Err(PolarsError::ComputeError(
                     format!(
                         "index: {} outside of ChunkedArray with length: {}",
                         current_idx,
@@ -80,7 +80,7 @@ where
 
                     idx.into_iter().try_for_each::<_, Result<_>>(|idx| {
                         let val = data.get_mut(idx).ok_or_else(|| {
-                            PolarsError::OutOfBounds(
+                            PolarsError::ComputeError(
                                 format!("{} out of bounds on array of length: {}", idx, self.len())
                                     .into(),
                             )
@@ -241,7 +241,7 @@ impl<'a> ChunkSet<'a, &'a str, String> for Utf8Chunked {
 
         for current_idx in idx_iter {
             if current_idx > self.len() {
-                return Err(PolarsError::OutOfBounds(
+                return Err(PolarsError::ComputeError(
                     format!(
                         "index: {} outside of ChunkedArray with length: {}",
                         current_idx,

--- a/polars/polars-core/src/chunked_array/ops/sort/argsort_multiple.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/argsort_multiple.rs
@@ -9,7 +9,7 @@ pub(crate) fn args_validate<T: PolarsDataType>(
         assert_eq!(ca.len(), s.len());
     }
     if other.len() != (reverse.len() - 1) {
-        return Err(PolarsError::ValueError(
+        return Err(PolarsError::ComputeError(
             format!(
                 "The amount of ordering booleans: {} does not match that no. of Series: {}",
                 reverse.len(),

--- a/polars/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/traits.rs
@@ -58,7 +58,7 @@ where
         if inbounds {
             Ok(())
         } else {
-            Err(PolarsError::OutOfBounds(
+            Err(PolarsError::ComputeError(
                 "take indices are out of bounds".into(),
             ))
         }
@@ -86,7 +86,7 @@ where
         if inbounds {
             Ok(())
         } else {
-            Err(PolarsError::OutOfBounds(
+            Err(PolarsError::ComputeError(
                 "take indices are out of bounds".into(),
             ))
         }
@@ -142,7 +142,7 @@ where
                 if inbounds {
                     Ok(())
                 } else {
-                    Err(PolarsError::OutOfBounds(
+                    Err(PolarsError::ComputeError(
                         "take indices are out of bounds".into(),
                     ))
                 }

--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -146,7 +146,7 @@ where
     pub fn rand_normal(name: &str, length: usize, mean: f64, std_dev: f64) -> Result<Self> {
         let normal = match Normal::new(mean, std_dev) {
             Ok(dist) => dist,
-            Err(e) => return Err(PolarsError::RandError(format!("{:?}", e))),
+            Err(e) => return Err(PolarsError::ComputeError(format!("{:?}", e).into())),
         };
         let mut builder = PrimitiveChunkedBuilder::<T>::new(name, length);
         let mut rng = rand::thread_rng();
@@ -189,7 +189,7 @@ impl BooleanChunked {
     pub fn rand_bernoulli(name: &str, length: usize, p: f64) -> Result<Self> {
         let dist = match Bernoulli::new(p) {
             Ok(dist) => dist,
-            Err(e) => return Err(PolarsError::RandError(format!("{:?}", e))),
+            Err(e) => return Err(PolarsError::ComputeError(format!("{:?}", e).into())),
         };
         let mut rng = rand::thread_rng();
         let mut builder = BooleanChunkedBuilder::new(name, length);

--- a/polars/polars-core/src/chunked_array/strings/encoding.rs
+++ b/polars/polars-core/src/chunked_array/strings/encoding.rs
@@ -17,7 +17,7 @@ impl Utf8Chunked {
         });
 
         if strict.unwrap_or(false) && (ca.null_count() != self.null_count()) {
-            Err(PolarsError::ValueError("Unable to decode inputs".into()))
+            Err(PolarsError::ComputeError("Unable to decode inputs".into()))
         } else {
             Ok(ca)
         }
@@ -41,7 +41,7 @@ impl Utf8Chunked {
         });
 
         if strict.unwrap_or(false) && (ca.null_count() != self.null_count()) {
-            Err(PolarsError::ValueError("Unable to decode inputs".into()))
+            Err(PolarsError::ComputeError("Unable to decode inputs".into()))
         } else {
             Ok(ca)
         }

--- a/polars/polars-core/src/chunked_array/strings/json_path.rs
+++ b/polars/polars-core/src/chunked_array/strings/json_path.rs
@@ -25,7 +25,7 @@ impl Utf8Chunked {
     pub fn json_path_match(&self, json_path: &str) -> Result<Utf8Chunked> {
         match Compiled::compile(json_path) {
             Ok(pat) => Ok(self.apply_on_opt(|opt_s| opt_s.and_then(|s| extract_json(&pat, s)))),
-            Err(e) => Err(PolarsError::ValueError(
+            Err(e) => Err(PolarsError::ComputeError(
                 format!("error compiling JSONpath expression {:?}", e).into(),
             )),
         }

--- a/polars/polars-core/src/chunked_array/temporal/utf8.rs
+++ b/polars/polars-core/src/chunked_array/temporal/utf8.rs
@@ -102,7 +102,7 @@ impl Utf8Chunked {
         let idx = match self.first_non_null() {
             Some(idx) => idx,
             None => {
-                return Err(PolarsError::HasNullValues(
+                return Err(PolarsError::ComputeError(
                     "Cannot determine date parsing format, all values are null".into(),
                 ))
             }

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -23,7 +23,7 @@ pub struct AsOfOptions {
 
 fn check_asof_columns(a: &Series, b: &Series) -> Result<()> {
     if a.dtype() != b.dtype() {
-        return Err(PolarsError::ValueError(
+        return Err(PolarsError::ComputeError(
             format!(
                 "keys used in asof-join must have equal dtypes. We got: left: {:?}\tright: {:?}",
                 a.dtype(),
@@ -58,7 +58,7 @@ where
         let other = self.unpack_series_matching_type(other)?;
 
         if self.null_count() > 0 || other.null_count() > 0 {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 "asof join must not have null values in 'on' arguments".into(),
             ));
         }

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn check_categorical_src(l: &DataType, r: &DataType) -> Result<()> {
     match (l, r) {
         (DataType::Categorical(Some(l)), DataType::Categorical(Some(r))) => {
             if !l.same_src(&*r) {
-                return Err(PolarsError::ValueError("joins/or comparisons on categorical dtypes can only happen if they are created under the same global string cache".into()));
+                return Err(PolarsError::ComputeError("joins/or comparisons on categorical dtypes can only happen if they are created under the same global string cache".into()));
             }
             Ok(())
         }
@@ -1059,7 +1059,7 @@ impl DataFrame {
         suffix: Option<String>,
     ) -> Result<DataFrame> {
         if selected_right.len() != selected_left.len() {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 "the number of columns given as join key should be equal".into(),
             ));
         }
@@ -1068,7 +1068,7 @@ impl DataFrame {
             .zip(&selected_right)
             .any(|(l, r)| l.dtype() != r.dtype())
         {
-            return Err(PolarsError::ValueError("the dtype of the join keys don't match. first cast your columns to the correct dtype".into()));
+            return Err(PolarsError::ComputeError("the dtype of the join keys don't match. first cast your columns to the correct dtype".into()));
         }
 
         #[cfg(feature = "dtype-categorical")]
@@ -1208,7 +1208,7 @@ impl DataFrame {
                 self.finish_join(df_left, df_right, suffix)
             }
             #[cfg(feature = "asof_join")]
-            JoinType::AsOf(_) => Err(PolarsError::ValueError(
+            JoinType::AsOf(_) => Err(PolarsError::ComputeError(
                 "asof join not supported for join on multiple keys".into(),
             )),
             JoinType::Cross => {

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1739,7 +1739,7 @@ impl DataFrame {
                 ).into()));
         };
         if idx >= self.width() {
-            return Err(PolarsError::OutOfBounds(
+            return Err(PolarsError::ComputeError(
                 format!(
                     "Column index: {} outside of DataFrame with {} columns",
                     idx,
@@ -1840,7 +1840,7 @@ impl DataFrame {
         let df_height = self.height();
         let width = self.width();
         let col = self.columns.get_mut(idx).ok_or_else(|| {
-            PolarsError::OutOfBounds(
+            PolarsError::ComputeError(
                 format!(
                     "Column index: {} outside of DataFrame with {} columns",
                     idx, width
@@ -1925,7 +1925,7 @@ impl DataFrame {
     {
         let width = self.width();
         let col = self.columns.get_mut(idx).ok_or_else(|| {
-            PolarsError::OutOfBounds(
+            PolarsError::ComputeError(
                 format!(
                     "Column index: {} outside of DataFrame with {} columns",
                     idx, width

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -105,7 +105,7 @@ impl DataFrame {
             .iter_dtypes()
             .any(|dtype| matches!(dtype, DataType::Null));
         if has_nulls {
-            return Err(PolarsError::HasNullValues(
+            return Err(PolarsError::ComputeError(
                 "Could not infer row types, because of the null values".into(),
             ));
         }
@@ -395,7 +395,7 @@ impl AnyValueBuffer {
 
     pub(crate) fn add_falible(&mut self, val: &AnyValue) -> Result<()> {
         self.add(val.clone()).ok_or_else(|| {
-            PolarsError::ValueError(format!("Could not append {:?} to builder; make sure that all rows have the same schema.", val).into())
+            PolarsError::ComputeError(format!("Could not append {:?} to builder; make sure that all rows have the same schema.", val).into())
         })
     }
 

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -90,7 +90,7 @@ where
 /// be used and so on.
 pub fn argsort_by(by: &[Series], reverse: &[bool]) -> Result<IdxCa> {
     if by.len() != reverse.len() {
-        return Err(PolarsError::ValueError(
+        return Err(PolarsError::ComputeError(
             format!(
                 "The amount of ordering booleans: {} does not match amount of Series: {}",
                 reverse.len(),
@@ -149,7 +149,7 @@ pub fn concat_str(s: &[Series], delimiter: &str) -> Result<Utf8Chunked> {
         .collect::<Result<Vec<_>>>()?;
 
     if !s.iter().all(|s| s.len() == 1 || s.len() == len) {
-        return Err(PolarsError::ValueError(
+        return Err(PolarsError::ComputeError(
             "all series in concat_str function should have equal length or unit length".into(),
         ));
     }

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -35,6 +35,21 @@ where
 }
 
 impl Schema {
+    // could not implement TryFrom
+    pub fn try_from_fallible<I>(flds: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = Result<Field>>,
+    {
+        let iter = flds.into_iter();
+        let mut map: PlIndexMap<_, _> =
+            IndexMap::with_capacity_and_hasher(iter.size_hint().0, ahash::RandomState::default());
+        for fld in iter {
+            let fld = fld?;
+            map.insert(fld.name().clone(), fld.data_type().clone());
+        }
+        Ok(Self { inner: map })
+    }
+
     pub fn new() -> Self {
         Self::with_capacity(0)
     }

--- a/polars/polars-core/src/series/ops/to_list.rs
+++ b/polars/polars-core/src/series/ops/to_list.rs
@@ -50,7 +50,7 @@ impl Series {
 
         let prod = dims.iter().product::<i64>() as usize;
         if prod != s_ref.len() {
-            return Err(PolarsError::ValueError(
+            return Err(PolarsError::ComputeError(
                 format!("cannot reshape len {} into shape {:?}", s_ref.len(), dims).into(),
             ));
         }

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -383,7 +383,7 @@ impl<'a> CoreReader<'a> {
         let mut str_columns = Vec::with_capacity(projection.len());
         for i in &projection {
             let (name, dtype) = self.schema.get_index(*i).ok_or_else(||
-                PolarsError::ValueError(
+                PolarsError::ComputeError(
                     format!("the given projection index: {} is out of bounds for csv schema with {} columns", i, self.schema.len()).into())
                 )?;
 

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -13,7 +13,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 # make sure we don't compile unneeded things even though
 # this depeadency gets activated
 compile = []
-default = ["compile"]
+default = ["compile", "private"]
 parquet = ["polars-core/parquet", "polars-io/parquet"]
 ipc = ["polars-io/ipc"]
 csv-file = ["polars-io/csv-file"]

--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -314,6 +314,10 @@ impl LogicalPlan {
                 self.write_dot(acc_str, prev_node, &current_node, id)?;
                 input.dot(acc_str, (branch, id + 1), &current_node)
             }
+            Error { err, .. } => {
+                let current_node = format!("{:?}", &**err);
+                self.write_dot(acc_str, prev_node, &current_node, id)
+            }
         }
     }
 }

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -2194,29 +2194,3 @@ pub fn first() -> Expr {
 pub fn last() -> Expr {
     Expr::Nth(-1)
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use polars_core::df;
-
-    #[test]
-    #[cfg(feature = "is_in")]
-    fn test_is_in() -> Result<()> {
-        let df = df![
-            "x" => [1, 2, 3],
-            "y" => ["a", "b", "c"]
-        ]?;
-        let s = Series::new("a", ["a", "b"]);
-
-        let out = df
-            .lazy()
-            .select([col("y").is_in(lit(s)).alias("isin")])
-            .collect()?;
-        assert_eq!(
-            Vec::from(out.column("isin")?.bool()?),
-            &[Some(true), Some(true), Some(false)]
-        );
-        Ok(())
-    }
-}

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -568,6 +568,7 @@ impl Expr {
     /// Overwrite the function name used for formatting
     /// this is not intended to be used
     #[cfg(feature = "private")]
+    #[doc(hidden)]
     pub fn with_fmt(self, name: &'static str) -> Expr {
         self.with_function_options(|mut options| {
             options.fmt_str = name;

--- a/polars/polars-lazy/src/dummies.rs
+++ b/polars/polars-lazy/src/dummies.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 impl Default for NoEq<Arc<dyn SeriesBinaryUdf>> {
     fn default() -> Self {
-        NoEq::new(Arc::new(|_, _| Err(PolarsError::ImplementationError)))
+        panic!("implementation error");
     }
 }
 

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -234,7 +234,7 @@ impl<'a> LazyCsvReader<'a> {
     pub fn finish(self) -> Result<LazyFrame> {
         if self.path.contains('*') {
             let paths = glob::glob(&self.path)
-                .map_err(|_| PolarsError::ValueError("invalid glob pattern given".into()))?;
+                .map_err(|_| PolarsError::ComputeError("invalid glob pattern given".into()))?;
 
             let lfs = paths
                 .map(|r| {

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -41,7 +41,7 @@ impl LazyFrame {
     pub fn scan_ipc(path: String, args: ScanArgsIpc) -> Result<Self> {
         if path.contains('*') {
             let paths = glob::glob(&path)
-                .map_err(|_| PolarsError::ValueError("invalid glob pattern given".into()))?;
+                .map_err(|_| PolarsError::ComputeError("invalid glob pattern given".into()))?;
             let lfs = paths
                 .map(|r| {
                     let path = r.map_err(|e| PolarsError::ComputeError(format!("{}", e).into()))?;

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -152,7 +152,7 @@ impl LazyFrame {
     pub(crate) fn into_alp(self) -> (Node, Arena<AExpr>, Arena<ALogicalPlan>) {
         let mut expr_arena = Arena::with_capacity(64);
         let mut lp_arena = Arena::with_capacity(32);
-        let root = to_alp(self.logical_plan, &mut expr_arena, &mut lp_arena);
+        let root = to_alp(self.logical_plan, &mut expr_arena, &mut lp_arena).unwrap();
         (root, expr_arena, lp_arena)
     }
 
@@ -490,7 +490,7 @@ impl LazyFrame {
         #[cfg(debug_assertions)]
         let prev_schema = logical_plan.schema().clone();
 
-        let mut lp_top = to_alp(logical_plan, expr_arena, lp_arena);
+        let mut lp_top = to_alp(logical_plan, expr_arena, lp_arena)?;
 
         // simplify expression is valuable for projection and predicate pushdown optimizers, so we
         // run that first

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -45,7 +45,7 @@ impl LazyFrame {
     pub fn scan_parquet(path: String, args: ScanArgsParquet) -> Result<Self> {
         if path.contains('*') {
             let paths = glob::glob(&path)
-                .map_err(|_| PolarsError::ValueError("invalid glob pattern given".into()))?;
+                .map_err(|_| PolarsError::ComputeError("invalid glob pattern given".into()))?;
             let lfs = paths
                 .map(|r| {
                     let path = r.map_err(|e| PolarsError::ComputeError(format!("{}", e).into()))?;

--- a/polars/polars-lazy/src/functions.rs
+++ b/polars/polars-lazy/src/functions.rs
@@ -410,7 +410,7 @@ pub fn concat<L: AsRef<[LazyFrame]>>(inputs: L, rechunk: bool) -> Result<LazyFra
     let lf = std::mem::take(
         inputs
             .get_mut(0)
-            .ok_or_else(|| PolarsError::ValueError("empty container given".into()))?,
+            .ok_or_else(|| PolarsError::ComputeError("empty container given".into()))?,
     );
     let opt_state = lf.opt_state;
     let mut lps = Vec::with_capacity(inputs.len());

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -153,10 +153,9 @@ impl AExpr {
                 name,
                 arena.get(*expr).get_type(schema, ctxt, arena)?,
             )),
-            Column(name) => {
-                let field = schema.get_field(name).unwrap();
-                Ok(field)
-            }
+            Column(name) => schema
+                .get_field(name)
+                .ok_or_else(|| PolarsError::NotFound(name.to_string())),
             Literal(sv) => Ok(Field::new("literal", sv.get_datatype())),
             BinaryExpr { left, right, op } => {
                 use DataType::*;

--- a/polars/polars-lazy/src/logical_plan/format.rs
+++ b/polars/polars-lazy/src/logical_plan/format.rs
@@ -155,6 +155,7 @@ FROM
                 write!(f, "{:?}\nSLICE[offset: {}, len: {}]", input, offset, len)
             }
             Udf { input, options, .. } => write!(f, "{} \n{:?}", options.fmt_str, input),
+            Error { input, err } => write!(f, "{:?}\n{:?}", err, input),
         }
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -87,7 +87,7 @@ impl Executor for JoinExec {
                 if let Some(tol) = &options.tolerance_str {
                     let duration = polars_time::Duration::parse(tol);
                     if duration.months() != 0 {
-                        return Err(PolarsError::ValueError("Cannot use month offset in timedelta of an asof join. Consider using 4 weeks".into()));
+                        return Err(PolarsError::ComputeError("Cannot use month offset in timedelta of an asof join. Consider using 4 weeks".into()));
                     }
                     let left_asof = df_left.column(&left_names[0])?;
                     use DataType::*;

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -111,7 +111,7 @@ impl PhysicalExpr for TakeExpr {
 
                     return if idx.len() == 1 {
                         match idx.get(0) {
-                            None => Err(PolarsError::ValueError("cannot take by a null".into())),
+                            None => Err(PolarsError::ComputeError("cannot take by a null".into())),
                             Some(idx) => {
                                 if idx != 0 {
                                     // We must make sure that the column we take from is sorted by

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -517,7 +517,7 @@ impl DefaultPlanner {
                         apply_columns.push(Arc::from("literal"))
                     } else {
                         let e = node_to_expr(function, expr_arena);
-                        return Err(PolarsError::ValueError(
+                        return Err(PolarsError::ComputeError(
                             format!(
                                 "Cannot apply a window function, did not find a root column. \
                             This is likely due to a syntax error in this expression: {:?}",

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -1,11 +1,18 @@
+#[cfg(feature = "test")]
 mod aggregations;
+#[cfg(feature = "test")]
 mod arity;
 #[cfg(feature = "parquet")]
 mod io;
+#[cfg(feature = "test")]
 mod logical;
+#[cfg(feature = "test")]
 mod optimization_checks;
+#[cfg(feature = "test")]
 mod predicate_queries;
+#[cfg(feature = "test")]
 mod projection_queries;
+#[cfg(feature = "test")]
 mod queries;
 
 fn load_df() -> DataFrame {

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -592,7 +592,7 @@ fn test_simplify_expr() {
     let rules: &mut [Box<dyn OptimizationRule>] = &mut [Box::new(SimplifyExprRule {})];
 
     let optimizer = StackOptimizer {};
-    let mut lp_top = to_alp(plan, &mut expr_arena, &mut lp_arena);
+    let mut lp_top = to_alp(plan, &mut expr_arena, &mut lp_arena).unwrap();
     lp_top = optimizer.optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top);
     let plan = node_to_lp(lp_top, &mut expr_arena, &mut lp_arena);
     assert!(
@@ -688,7 +688,7 @@ fn test_type_coercion() {
     let rules: &mut [Box<dyn OptimizationRule>] = &mut [Box::new(TypeCoercionRule {})];
 
     let optimizer = StackOptimizer {};
-    let mut lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena);
+    let mut lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena).unwrap();
     lp_top = optimizer.optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top);
     let lp = node_to_lp(lp_top, &mut expr_arena, &mut lp_arena);
 

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -95,7 +95,7 @@ impl Wrap<&DataFrame> {
                 return Ok((out, gt));
             }
             dt => {
-                return Err(PolarsError::ValueError(
+                return Err(PolarsError::ComputeError(
                     format!(
                     "expected any of the following dtypes {{Date, Datetime, Int32, Int64}}, got {}",
                     dt
@@ -163,7 +163,7 @@ impl Wrap<&DataFrame> {
                 return Ok((out, keys, gt));
             }
             dt => {
-                return Err(PolarsError::ValueError(
+                return Err(PolarsError::ComputeError(
                     format!(
                     "expected any of the following dtypes {{Date, Datetime, Int32, Int64}}, got {}",
                     dt
@@ -362,7 +362,6 @@ fn update_subgroups(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::prelude::*;
     use chrono::prelude::*;
 
     #[test]

--- a/polars/tests/it/lazy/expressions/is_in.rs
+++ b/polars/tests/it/lazy/expressions/is_in.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[test]
+#[cfg(feature = "is_in")]
+fn test_is_in() -> Result<()> {
+    let df = df![
+        "x" => [1, 2, 3],
+        "y" => ["a", "b", "c"]
+    ]?;
+    let s = Series::new("a", ["a", "b"]);
+
+    let out = df
+        .lazy()
+        .select([col("y").is_in(lit(s)).alias("isin")])
+        .collect()?;
+    assert_eq!(
+        Vec::from(out.column("isin")?.bool()?),
+        &[Some(true), Some(true), Some(false)]
+    );
+    Ok(())
+}

--- a/polars/tests/it/lazy/expressions/mod.rs
+++ b/polars/tests/it/lazy/expressions/mod.rs
@@ -1,3 +1,4 @@
+mod is_in;
 mod slice;
 mod window;
 

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -40,6 +40,14 @@ from polars.datatypes import (
     UInt64,
     Utf8,
 )
+from polars.exceptions import (
+    ArrowError,
+    ComputeError,
+    NoDataError,
+    NotFoundError,
+    SchemaError,
+    ShapeError,
+)
 from polars.internals.expr import Expr
 from polars.internals.frame import (  # flake8: noqa # TODO: remove need for wrap_df
     DataFrame,
@@ -113,6 +121,13 @@ from polars.io import (
 from polars.string_cache import StringCache
 
 __all__ = [
+    "exceptions",
+    "NotFoundError",
+    "ShapeError",
+    "SchemaError",
+    "ArrowError",
+    "ComputeError",
+    "NoDataError",
     "DataFrame",
     "Series",
     "LazyFrame",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -1,0 +1,40 @@
+try:
+    from polars.polars import (
+        ArrowError,
+        ComputeError,
+        NoDataError,
+        NotFoundError,
+        SchemaError,
+        ShapeError,
+    )
+except ImportError:  # pragma: no cover
+    # They are only redefined for documentation purposes
+    # when there is no binary yet
+
+    class ArrowError:  # type: ignore
+        pass
+
+    class ComputeError:  # type: ignore
+        pass
+
+    class NoDataError:  # type: ignore
+        pass
+
+    class NotFoundError:  # type: ignore
+        pass
+
+    class SchemaError:  # type: ignore
+        pass
+
+    class ShapeError:  # type: ignore
+        pass
+
+
+__all__ = [
+    "ArrowError",
+    "ComputeError",
+    "NoDataError",
+    "NotFoundError",
+    "SchemaError",
+    "ShapeError",
+]

--- a/py-polars/src/apply/dataframe.rs
+++ b/py-polars/src/apply/dataframe.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::conversion::Wrap;
-use crate::error::PyPolarsEr;
+use crate::error::PyPolarsErr;
 use crate::series::PySeries;
 use crate::PyDataFrame;
 use polars::prelude::*;
@@ -104,23 +104,23 @@ pub fn apply_lambda_unknown<'a>(
                         first_value,
                         inference_size,
                     )
-                    .map_err(PyPolarsEr::from)?,
+                    .map_err(PyPolarsErr::from)?,
                 )
                 .into_py(py),
                 true,
             ));
         } else if out.is_instance::<PyList>().unwrap() {
-            return Err(PyPolarsEr::Other(
+            return Err(PyPolarsErr::Other(
                 "A list output type is invalid. Do you mean to create polars List Series?\
 Then return a Series object."
                     .into(),
             )
             .into());
         } else {
-            return Err(PyPolarsEr::Other("Could not determine output type".into()).into());
+            return Err(PyPolarsErr::Other("Could not determine output type".into()).into());
         }
     }
-    Err(PyPolarsEr::Other("Could not determine output type".into()).into())
+    Err(PyPolarsErr::Other("Could not determine output type".into()).into())
 }
 
 fn apply_iter<'a, T>(

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::error::PyPolarsEr;
+use crate::error::PyPolarsErr;
 use crate::series::PySeries;
 use polars::chunked_array::builder::get_list_builder;
 use polars::prelude::*;
@@ -1440,7 +1440,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                         .apply_lambda_with_list_out_type(py, lambda, null_count, &series, dt)
                         .map(|ca| ca.into_series().into());
                 } else {
-                    return Err(PyPolarsEr::Other("Could not determine output type".into()).into());
+                    return Err(PyPolarsErr::Other("Could not determine output type".into()).into());
                 }
             } else {
                 null_count += 1

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -1,5 +1,5 @@
 use crate::dataframe::PyDataFrame;
-use crate::error::PyPolarsEr;
+use crate::error::PyPolarsErr;
 use crate::lazy::dataframe::PyLazyFrame;
 use crate::prelude::*;
 use crate::series::PySeries;
@@ -146,7 +146,7 @@ impl<'a> FromPyObject<'a> for Wrap<NullValues> {
             Ok(Wrap(NullValues::Named(s)))
         } else {
             Err(
-                PyPolarsEr::Other("could not extract value from null_values argument".into())
+                PyPolarsErr::Other("could not extract value from null_values argument".into())
                     .into(),
             )
         }
@@ -439,7 +439,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
         } else if ob.is_none() {
             Ok(AnyValue::Null.into())
         } else {
-            Err(PyErr::from(PyPolarsEr::Other(format!(
+            Err(PyErr::from(PyPolarsErr::Other(format!(
                 "row type not supported {:?}",
                 ob
             ))))

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -1,20 +1,32 @@
 use polars::prelude::PolarsError;
 use polars_core::error::ArrowError;
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
+use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub enum PyPolarsEr {
+#[derive(Error)]
+pub enum PyPolarsErr {
     #[error(transparent)]
-    Any(#[from] PolarsError),
+    Polars(#[from] PolarsError),
     #[error("{0}")]
     Other(String),
     #[error(transparent)]
-    ArrowError(#[from] ArrowError),
+    Arrow(#[from] ArrowError),
 }
 
-impl std::convert::From<PyPolarsEr> for PyErr {
-    fn from(err: PyPolarsEr) -> PyErr {
+impl std::convert::From<PyPolarsErr> for PyErr {
+    fn from(err: PyPolarsErr) -> PyErr {
         PyRuntimeError::new_err(format!("{:?}", err))
+    }
+}
+
+impl Debug for PyPolarsErr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use PyPolarsErr::*;
+        match self {
+            Polars(err) => write!(f, "{:?}", err),
+            Other(err) => write!(f, "BindingsError: {:?}", err),
+            Arrow(err) => write!(f, "{:?}", err),
+        }
     }
 }

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -1,6 +1,11 @@
 use polars::prelude::PolarsError;
 use polars_core::error::ArrowError;
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
+use pyo3::exceptions::{PyIOError, PyValueError};
+use pyo3::{
+    create_exception,
+    exceptions::{PyException, PyRuntimeError},
+    prelude::*,
+};
 use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 
@@ -16,7 +21,24 @@ pub enum PyPolarsErr {
 
 impl std::convert::From<PyPolarsErr> for PyErr {
     fn from(err: PyPolarsErr) -> PyErr {
-        PyRuntimeError::new_err(format!("{:?}", err))
+        let default = || PyRuntimeError::new_err(format!("{:?}", &err));
+
+        use PyPolarsErr::*;
+        match &err {
+            Polars(err) => match err {
+                PolarsError::NotFound(name) => NotFoundError::new_err(name.clone()),
+                PolarsError::ComputeError(err) => ComputeError::new_err(err.to_string()),
+                PolarsError::NoData(err) => NoDataError::new_err(err.to_string()),
+                PolarsError::ShapeMisMatch(err) => ShapeError::new_err(err.to_string()),
+                PolarsError::SchemaMisMatch(err) => SchemaError::new_err(err.to_string()),
+                PolarsError::Io(err) => PyIOError::new_err(err.to_string()),
+                PolarsError::InvalidOperation(err) => PyValueError::new_err(err.to_string()),
+                PolarsError::ArrowError(err) => ArrowErrorException::new_err(format!("{:?}", err)),
+                _ => default(),
+            },
+            Arrow(err) => ArrowErrorException::new_err(format!("{:?}", err)),
+            _ => default(),
+        }
     }
 }
 
@@ -30,3 +52,10 @@ impl Debug for PyPolarsErr {
         }
     }
 }
+
+create_exception!(exceptions, NotFoundError, PyException);
+create_exception!(exceptions, ComputeError, PyException);
+create_exception!(exceptions, NoDataError, PyException);
+create_exception!(exceptions, ArrowErrorException, PyException);
+create_exception!(exceptions, ShapeError, PyException);
+create_exception!(exceptions, SchemaError, PyException);

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -1,6 +1,6 @@
 use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
-use crate::error::PyPolarsEr;
+use crate::error::PyPolarsErr;
 use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
 use crate::prelude::{NullValues, ScanArgsIpc, ScanArgsParquet};
 use crate::utils::str_to_polarstype;
@@ -123,7 +123,7 @@ impl PyLazyFrame {
             "utf8-lossy" => CsvEncoding::LossyUtf8,
             e => {
                 return Err(
-                    PyPolarsEr::Other(format!("encoding not {} not implemented.", e)).into(),
+                    PyPolarsErr::Other(format!("encoding not {} not implemented.", e)).into(),
                 )
             }
         };
@@ -174,10 +174,10 @@ impl PyLazyFrame {
                     .map(|(dtype, name)| Field::from_owned(name, dtype.clone()));
                 Ok(Schema::from(fields))
             };
-            r = r.with_schema_modify(f).map_err(PyPolarsEr::from)?
+            r = r.with_schema_modify(f).map_err(PyPolarsErr::from)?
         }
 
-        Ok(r.finish().map_err(PyPolarsEr::from)?.into())
+        Ok(r.finish().map_err(PyPolarsErr::from)?.into())
     }
 
     #[staticmethod]
@@ -198,7 +198,7 @@ impl PyLazyFrame {
             rechunk,
             row_count,
         };
-        let lf = LazyFrame::scan_parquet(path, args).map_err(PyPolarsEr::from)?;
+        let lf = LazyFrame::scan_parquet(path, args).map_err(PyPolarsErr::from)?;
         Ok(lf.into())
     }
 
@@ -217,7 +217,7 @@ impl PyLazyFrame {
             rechunk,
             row_count,
         };
-        let lf = LazyFrame::scan_ipc(path, args).map_err(PyPolarsEr::from)?;
+        let lf = LazyFrame::scan_ipc(path, args).map_err(PyPolarsErr::from)?;
         Ok(lf.into())
     }
 
@@ -229,11 +229,11 @@ impl PyLazyFrame {
         let result = self
             .ldf
             .describe_optimized_plan()
-            .map_err(PyPolarsEr::from)?;
+            .map_err(PyPolarsErr::from)?;
         Ok(result)
     }
     pub fn to_dot(&self, optimized: bool) -> PyResult<String> {
-        let result = self.ldf.to_dot(optimized).map_err(PyPolarsEr::from)?;
+        let result = self.ldf.to_dot(optimized).map_err(PyPolarsErr::from)?;
         Ok(result)
     }
 
@@ -277,7 +277,7 @@ impl PyLazyFrame {
         // threads we deadlock.
         let df = py.allow_threads(|| {
             let ldf = self.ldf.clone();
-            ldf.collect().map_err(PyPolarsEr::from)
+            ldf.collect().map_err(PyPolarsErr::from)
         })?;
         Ok(df.into())
     }
@@ -286,7 +286,7 @@ impl PyLazyFrame {
         let ldf = self.ldf.clone();
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let df = py.allow_threads(|| ldf.fetch(n_rows).map_err(PyPolarsEr::from))?;
+        let df = py.allow_threads(|| ldf.fetch(n_rows).map_err(PyPolarsErr::from))?;
         Ok(df.into())
     }
 

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -32,7 +32,9 @@ pub mod series;
 pub mod utils;
 
 use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
-use crate::error::PyPolarsErr;
+use crate::error::{
+    ArrowErrorException, ComputeError, NoDataError, NotFoundError, PyPolarsErr, SchemaError,
+};
 use crate::file::get_either_file;
 use crate::prelude::{ClosedWindow, DataType, Duration, PyDataType};
 use dsl::ToExprs;
@@ -353,7 +355,17 @@ fn max_exprs(exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pymodule]
-fn polars(_py: Python, m: &PyModule) -> PyResult<()> {
+fn polars(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("NotFoundError", py.get_type::<NotFoundError>())
+        .unwrap();
+    m.add("NoDataError", py.get_type::<NoDataError>()).unwrap();
+    m.add("ComputeError", py.get_type::<ComputeError>())
+        .unwrap();
+    m.add("ShapeError", py.get_type::<crate::error::ShapeError>())
+        .unwrap();
+    m.add("SchemaError", py.get_type::<SchemaError>()).unwrap();
+    m.add("ArrowError", py.get_type::<ArrowErrorException>())
+        .unwrap();
     m.add_class::<PySeries>().unwrap();
     m.add_class::<PyDataFrame>().unwrap();
     m.add_class::<PyLazyFrame>().unwrap();

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -32,7 +32,7 @@ pub mod series;
 pub mod utils;
 
 use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
-use crate::error::PyPolarsEr;
+use crate::error::PyPolarsErr;
 use crate::file::get_either_file;
 use crate::prelude::{ClosedWindow, DataType, Duration, PyDataType};
 use dsl::ToExprs;
@@ -206,7 +206,7 @@ fn concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
     for res in iter {
         let item = res?;
         let other = get_df(item)?;
-        df.vstack_mut(&other).map_err(PyPolarsEr::from)?;
+        df.vstack_mut(&other).map_err(PyPolarsErr::from)?;
     }
     Ok(df.into())
 }
@@ -222,7 +222,7 @@ fn concat_lf(lfs: &PyAny, rechunk: bool) -> PyResult<PyLazyFrame> {
         lfs.push(lf);
     }
 
-    let lf = polars::lazy::functions::concat(lfs, rechunk).map_err(PyPolarsEr::from)?;
+    let lf = polars::lazy::functions::concat(lfs, rechunk).map_err(PyPolarsErr::from)?;
     Ok(lf.into())
 }
 
@@ -238,7 +238,7 @@ fn py_diag_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
         })
         .collect::<PyResult<Vec<_>>>()?;
 
-    let df = diag_concat_df(&dfs).map_err(PyPolarsEr::from)?;
+    let df = diag_concat_df(&dfs).map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 
@@ -254,7 +254,7 @@ fn py_hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
         })
         .collect::<PyResult<Vec<_>>>()?;
 
-    let df = hor_concat_df(&dfs).map_err(PyPolarsEr::from)?;
+    let df = hor_concat_df(&dfs).map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 
@@ -269,7 +269,7 @@ fn concat_series(series: &PyAny) -> PyResult<PySeries> {
     for res in iter {
         let item = res?;
         let item = get_series(item)?;
-        s.append(&item).map_err(PyPolarsEr::from)?;
+        s.append(&item).map_err(PyPolarsErr::from)?;
     }
     Ok(s.into())
 }
@@ -278,9 +278,9 @@ fn concat_series(series: &PyAny) -> PyResult<PySeries> {
 fn ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     let metadata = match get_either_file(py_f, false)? {
         EitherRustPythonFile::Rust(mut r) => {
-            read_file_metadata(&mut r).map_err(PyPolarsEr::from)?
+            read_file_metadata(&mut r).map_err(PyPolarsErr::from)?
         }
-        EitherRustPythonFile::Py(mut r) => read_file_metadata(&mut r).map_err(PyPolarsEr::from)?,
+        EitherRustPythonFile::Py(mut r) => read_file_metadata(&mut r).map_err(PyPolarsErr::from)?,
     };
 
     let dict = PyDict::new(py);
@@ -303,7 +303,7 @@ fn collect_all(lfs: Vec<PyLazyFrame>, py: Python) -> PyResult<Vec<PyDataFrame>> 
                     Ok(PyDataFrame::new(df))
                 })
                 .collect::<polars_core::error::Result<Vec<_>>>()
-                .map_err(PyPolarsEr::from)
+                .map_err(PyPolarsErr::from)
         })
     });
 

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -19,7 +19,7 @@ def test_to_from_buffer(df: pl.DataFrame, compressions: List[str]) -> None:
     for compression in compressions:
         if compression == "lzo":
             # lzo compression is not supported now
-            with pytest.raises(RuntimeError):
+            with pytest.raises(pl.ArrowError):
                 buf = io.BytesIO()
                 df.to_parquet(buf, compression=compression)
                 buf.seek(0)
@@ -45,7 +45,7 @@ def test_to_from_file(
     for compression in compressions:
         if compression == "lzo":
             # lzo compression is not supported now
-            with pytest.raises(RuntimeError):
+            with pytest.raises(pl.ArrowError):
                 df.to_parquet(f, compression=compression)
                 _ = pl.read_parquet(f)
 

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -198,7 +198,7 @@ def test_string_cache(environ: None) -> None:
     pl.Config.unset_global_string_cache()
     df1a = df1.with_column(pl.col("a").cast(pl.Categorical))
     df2a = df2.with_column(pl.col("a").cast(pl.Categorical))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ComputeError):
         _ = df1a.join(df2a, on="a", how="inner")
 
     # now turn on the cache

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -197,11 +197,11 @@ def test_init_pandas() -> None:
 
 def test_init_errors() -> None:
     # Length mismatch
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ShapeError):
         pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0, 4.0]})
 
     # Columns don't match data dimensions
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ShapeError):
         pl.DataFrame([[1, 2], [3, 4]], columns=["a", "b", "c"])
 
     # Unmatched input
@@ -705,7 +705,7 @@ def test_file_buffer() -> None:
     f.write(b"1,2,3,4,5,6\n7,8,9,10,11,12")
     f.seek(0)
     # check if not fails on TryClone and Length impl in file.rs
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(pl.ArrowError) as e:
         pl.read_parquet(f)
     assert "Invalid Parquet file" in str(e.value)
 
@@ -1732,7 +1732,7 @@ def test_getattr() -> None:
     df = pl.DataFrame({"a": [1.0, 2.0]})
     testing.assert_series_equal(df.a, pl.Series("a", [1.0, 2.0]))
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(pl.NotFoundError):
         _ = df.b
 
 

--- a/py-polars/tests/test_fallible.py
+++ b/py-polars/tests/test_fallible.py
@@ -8,5 +8,5 @@ import polars as pl
 def test_not_found_error() -> None:
     csv = "a,b,c\n2,1,1"
     df = pl.read_csv(io.StringIO(csv))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.NotFoundError):
         df.select("d")

--- a/py-polars/tests/test_fallible.py
+++ b/py-polars/tests/test_fallible.py
@@ -1,0 +1,12 @@
+import io
+
+import pytest
+
+import polars as pl
+
+
+def test_not_found_error() -> None:
+    csv = "a,b,c\n2,1,1"
+    df = pl.read_csv(io.StringIO(csv))
+    with pytest.raises(RuntimeError):
+        df.select("d")

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -596,7 +596,7 @@ def test_take(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
 
     # out of bounds error
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ComputeError):
         (
             df.sort("fruits").select(
                 [col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -789,9 +789,9 @@ def test_range() -> None:
 
 
 def test_strict_cast() -> None:
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ComputeError):
         pl.Series("a", [2 ** 16]).cast(dtype=pl.Int16, strict=True)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(pl.ComputeError):
         pl.DataFrame({"a": [2 ** 16]}).select([pl.col("a").cast(pl.Int16, strict=True)])
 
 


### PR DESCRIPTION

* **Rust** Make the `LogicalPLan` creation fallible with a delay. This means that we don't panic on an invalid query, but will return an error on the moment we call `collect`. This is less tedious than returning an error at every new node added.
* Make the error type simpler (less variants) and smaller (box larger variants) so that the happy path is most performant.
* **Python** Add proper exceptions. Those are now accessible under `pl.*` or `pl.exceptions.*` and contain:

    - ArrowError
    - ComputeError
    - NoDataError
    - NotFoundError
    - SchemaError
    - ShapeError

Also fixes #2828 