### PR TITLE
allow using py-polars without parquet or feathers support

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -34,7 +34,13 @@ import numpy as np
 try:
     import pyarrow as pa
     import pyarrow.compute
-    import pyarrow.parquet
+
+    try:
+        import pyarrow.parquet
+
+        _PYARROW_PARQUET_AVAILABLE = True
+    except ImportError:  # pragma: no cover
+        _PYARROW_PARQUET_AVAILABLE = False
 
     _PYARROW_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -1131,9 +1137,9 @@ class DataFrame:
             file = str(file)
 
         if use_pyarrow:
-            if not _PYARROW_AVAILABLE:
+            if not _PYARROW_AVAILABLE or not _PYARROW_PARQUET_AVAILABLE:
                 raise ImportError(  # pragma: no cover
-                    "'pyarrow' is required when using 'to_parquet(..., use_pyarrow=True)'."
+                    "'pyarrow' with parquets support is required when using 'to_parquet(..., use_pyarrow=True)'."
                 )
 
             tbl = self.to_arrow()

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -24,8 +24,19 @@ from polars.utils import handle_projection_columns
 try:
     import pyarrow as pa
     import pyarrow.csv
-    import pyarrow.feather
-    import pyarrow.parquet
+
+    try:
+        import pyarrow.feather
+
+        _PYARROW_FEATHER_AVAILABLE = True
+    except ImportError:  # pragma: no cover
+        _PYARROW_FEATHER_AVAILABLE = False
+    try:
+        import pyarrow.parquet
+
+        _PYARROW_PARQUET_AVAILABLE = True
+    except ImportError:  # pragma: no cover
+        _PYARROW_PARQUET_AVAILABLE = False
 
     _PYARROW_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -777,9 +788,9 @@ def read_ipc(
     storage_options = storage_options or {}
     with _prepare_file_arg(file, **storage_options) as data:
         if use_pyarrow:
-            if not _PYARROW_AVAILABLE:
+            if not _PYARROW_AVAILABLE or not _PYARROW_FEATHER_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_ipc(..., use_pyarrow=True)'."
+                    "'pyarrow' with feather support is required when using 'read_ipc(..., use_pyarrow=True)'."
                 )
 
             tbl = pa.feather.read_table(data, memory_map=memory_map, columns=columns)
@@ -854,9 +865,9 @@ def read_parquet(
     storage_options = storage_options or {}
     with _prepare_file_arg(source, **storage_options) as source_prep:
         if use_pyarrow:
-            if not _PYARROW_AVAILABLE:
+            if not _PYARROW_AVAILABLE or not _PYARROW_PARQUET_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_parquet(..., use_pyarrow=True)'."
+                    "'pyarrow' with parquet support is required when using 'read_parquet(..., use_pyarrow=True)'."
                 )
 
             return from_arrow(  # type: ignore[return-value]

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -2,7 +2,11 @@ use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
-use crate::prelude::{NullValues, ScanArgsIpc, ScanArgsParquet};
+use crate::prelude::NullValues;
+#[cfg(feature = "ipc")]
+use crate::prelude::ScanArgsIpc;
+#[cfg(feature = "parquet")]
+use crate::prelude::ScanArgsParquet;
 use crate::utils::str_to_polarstype;
 use polars::io::RowCount;
 use polars::lazy::frame::{AllowedOptimizations, LazyCsvReader, LazyFrame, LazyGroupBy};
@@ -11,6 +15,7 @@ use polars::prelude::{ClosedWindow, CsvEncoding, DataFrame, Field, JoinType, Sch
 use polars::time::*;
 use polars_core::frame::DistinctKeepStrategy;
 use polars_core::prelude::{AnyValue, AsOfOptions, AsofStrategy, QuantileInterpolOptions};
+use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
@@ -201,7 +206,22 @@ impl PyLazyFrame {
         let lf = LazyFrame::scan_parquet(path, args).map_err(PyPolarsErr::from)?;
         Ok(lf.into())
     }
+    #[cfg(not(feature = "parquet"))]
+    #[staticmethod]
+    pub fn new_from_parquet(
+        _path: String,
+        _n_rows: Option<usize>,
+        _cache: bool,
+        _parallel: bool,
+        _rechunk: bool,
+        _row_count: Option<(String, u32)>,
+    ) -> PyResult<Self> {
+        Err(PyNotImplementedError::new_err(
+            "new_from_parquet needs parquet feature support",
+        ))
+    }
 
+    #[cfg(feature = "ipc")]
     #[staticmethod]
     pub fn new_from_ipc(
         path: String,
@@ -219,6 +239,19 @@ impl PyLazyFrame {
         };
         let lf = LazyFrame::scan_ipc(path, args).map_err(PyPolarsErr::from)?;
         Ok(lf.into())
+    }
+    #[cfg(not(feature = "ipc"))]
+    #[staticmethod]
+    pub fn new_from_ipc(
+        _path: String,
+        _n_rows: Option<usize>,
+        _cache: bool,
+        _rechunk: bool,
+        _row_count: Option<(String, u32)>,
+    ) -> PyResult<Self> {
+        Err(PyNotImplementedError::new_err(
+            "new_from_ipc needs parquet feature support",
+        ))
     }
 
     pub fn describe_plan(&self) -> String {


### PR DESCRIPTION
Trying to use polars in an environment without those features I found two issues:
 - the rust part of py-polars package does not compile 
 - some function in the python package are not accessible anymore even though they do not depend on the parquet feature of the pyarrow module, for instance the conversion from and to pandas
 
Those issues can be reproduced with the following command:
`cargo +nightly build --features "json,avro,is_in,json,polars/repeat_by" --no-default-features`

This PR tries to address the issues.

