### PR TITLE
struct rename fields

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -354,3 +354,4 @@ The following methods are available under the `expr.struct` attribute.
    :toctree: api/
 
     ExprStructNameSpace.field
+    ExprStructNameSpace.rename_fields

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -318,3 +318,4 @@ The following methods are available under the `Series.struct` attribute.
     StructNameSpace.to_frame
     StructNameSpace.field
     StructNameSpace.fields
+    StructNameSpace.rename_fields

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2847,6 +2847,17 @@ class ExprStructNameSpace:
         """
         return wrap_expr(self._pyexpr.struct_field_by_name(name))
 
+    def rename_fields(self, names: List[str]) -> Expr:
+        """
+        Rename the fields of the struct
+
+        Parameters
+        ----------
+        names
+            New names in the order of the struct's fields
+        """
+        return wrap_expr(self._pyexpr.struct_rename_fields(names))
+
 
 class ExprListNameSpace:
     """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3560,11 +3560,23 @@ class StructNameSpace:
         """
         return pli.select(pli.lit(self.s).struct.field(name)).to_series()
 
+    @property
     def fields(self) -> List[str]:
         """
         Get the names of the fields
         """
         return self.s._s.struct_fields()
+
+    def rename_fields(self, names: List[str]) -> Series:
+        """
+        Rename the fields of the struct
+
+        Parameters
+        ----------
+        names
+            New names in the order of the struct's fields
+        """
+        return pli.select(pli.lit(self.s).struct.rename_fields(names)).to_series()
 
 
 class StringNameSpace:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1267,6 +1267,10 @@ impl PyExpr {
     pub fn struct_field_by_name(&self, name: &str) -> PyExpr {
         self.inner.clone().struct_().field_by_name(name).into()
     }
+
+    pub fn struct_rename_fields(&self, names: Vec<String>) -> PyExpr {
+        self.inner.clone().struct_().rename_fields(names).into()
+    }
 }
 
 impl From<dsl::Expr> for PyExpr {

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -7,7 +7,7 @@ def test_struct_various() -> None:
     )
     s = df.to_struct("my_struct")
 
-    assert s.struct.fields() == ["int", "str", "bool", "list"]
+    assert s.struct.fields == ["int", "str", "bool", "list"]
     assert s[0] == (1, "a", True, pl.Series([1, 2]))
     assert s[1] == (2, "b", None, pl.Series([3]))
     assert s.struct.field("list").to_list() == [[1, 2], [3]]
@@ -43,3 +43,11 @@ def test_apply_to_struct() -> None:
     )
 
     assert df.frame_equal(expected)
+
+
+def test_rename_fields() -> None:
+    df = pl.DataFrame({"int": [1, 2], "str": ["a", "b"], "bool": [True, None]})
+    assert df.to_struct("my_struct").struct.rename_fields(["a", "b"]).struct.fields == [
+        "a",
+        "b",
+    ]


### PR DESCRIPTION
```python
df = pl.DataFrame(
    {"int": [1, 2], "str": ["a", "b"], "bool": [True, None]}
)
df.to_struct("my_struct").struct.rename_fields(["a", "b"])

```

```
shape: (2,)
Series: 'my_struct' [struct[2]{'a': i64, 'b': str}]
[
	{1,"a"}
	{2,"b"}
]
```