### PR TITLE
Use null count to check for contiguous slices

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -506,7 +506,7 @@ where
 {
     /// Contiguous slice
     pub fn cont_slice(&self) -> Result<&[T::Native]> {
-        if self.chunks.len() == 1 && !self.chunks[0].has_validity() {
+        if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
             Ok(self.downcast_iter().next().map(|arr| arr.values()).unwrap())
         } else {
             Err(PolarsError::ComputeError("cannot take slice".into()))

--- a/polars/tests/it/joins.rs
+++ b/polars/tests/it/joins.rs
@@ -29,3 +29,23 @@ fn join_nans_outer() -> Result<()> {
     assert_eq!(res.shape(), (4, 4));
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "lazy")]
+fn join_empty_datasets() -> Result<()> {
+    let a = DataFrame::new(Vec::from([Series::new_empty("foo", &DataType::Int64)])).unwrap();
+    let b = DataFrame::new(Vec::from([
+        Series::new_empty("foo", &DataType::Int64),
+        Series::new_empty("bar", &DataType::Int64),
+    ]))
+    .unwrap();
+
+    a.lazy()
+        .groupby([col("foo")])
+        .agg([all().last()])
+        .inner_join(b.lazy(), "foo", "foo")
+        .collect()
+        .unwrap();
+
+    Ok(())
+}


### PR DESCRIPTION
fixes #2844 

The existence of the `validity` bitmap is used to determine whether a chunked array contains contiguous valid values. Empty arrays after an aggregation seem to have this bitmap set yet contain no values that are null (or any other value for that matter).

I am not sure if it is the correct approach as I'm not familiar with the internals (the unsafe block hidden behind the downcast seems scary), but the tests seem to pass (at least the Rust ones).

I also haven't run any benchmarks. After a quick glance I don't think this should be noticeably slower, so I hope it isn't.