### PR TITLE
Removed dbg macro and fixed dot definition in ipc scan

### DIFF
--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -278,7 +278,7 @@ impl LogicalPlan {
 
                 let pred = fmt_predicate(predicate.as_ref());
                 let current_node = format!(
-                    "PARQUET SCAN {};\nπ {}/{};\nσ {} [{:?}]",
+                    "IPC SCAN {};\nπ {}/{};\nσ {} [{:?}]",
                     path.to_string_lossy(),
                     n_columns,
                     total_columns,

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -23,7 +23,6 @@ impl Default for ScanArgsIpc {
 
 impl LazyFrame {
     fn scan_ipc_impl(path: String, args: ScanArgsIpc) -> Result<Self> {
-        dbg!(&args.row_count);
         let options = IpcScanOptions {
             n_rows: args.n_rows,
             cache: args.cache,


### PR DESCRIPTION
Fixed very misc problems in IPC scan.
- fix dot definition
- removing dbg macro in `scan_ipc_impl`