### PR TITLE
Preserve types of DataFrame subclasses

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -20,6 +20,7 @@ from typing import (
     TextIO,
     Tuple,
     Type,
+    TypeVar,
     Union,
     overload,
 )
@@ -74,6 +75,11 @@ try:
     _PANDAS_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PANDAS_AVAILABLE = False
+
+
+# A type variable used to refer to a polars.DataFrame or any subclass of it.
+# Used to annotate DataFrame methods which returns the same type as self.
+DataFrameType = TypeVar("DataFrameType", bound="DataFrame")
 
 
 def wrap_df(df: "PyDataFrame") -> "DataFrame":
@@ -232,7 +238,7 @@ class DataFrame:
             raise ValueError("DataFrame constructor not called properly.")
 
     @classmethod
-    def _from_pydf(cls, py_df: "PyDataFrame") -> "DataFrame":
+    def _from_pydf(cls: Type[DataFrameType], py_df: "PyDataFrame") -> DataFrameType:
         """
         Construct Polars DataFrame from FFI PyDataFrame object.
         """
@@ -241,16 +247,19 @@ class DataFrame:
         return df
 
     @classmethod
-    def _from_dicts(cls, data: Sequence[Dict[str, Any]]) -> "DataFrame":
+    def _from_dicts(
+        cls: Type[DataFrameType],
+        data: Sequence[Dict[str, Any]],
+    ) -> DataFrameType:
         pydf = PyDataFrame.read_dicts(data)
-        return DataFrame._from_pydf(pydf)
+        return cls._from_pydf(pydf)
 
     @classmethod
     def _from_dict(
-        cls,
+        cls: Type[DataFrameType],
         data: Dict[str, Sequence[Any]],
         columns: Optional[Sequence[str]] = None,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Construct a DataFrame from a dictionary of sequences.
 
@@ -271,11 +280,11 @@ class DataFrame:
 
     @classmethod
     def _from_records(
-        cls,
+        cls: Type[DataFrameType],
         data: Union[np.ndarray, Sequence[Sequence[Any]]],
         columns: Optional[Sequence[str]] = None,
         orient: Optional[str] = None,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Construct a DataFrame from a numpy ndarray or sequence of sequences.
 
@@ -303,11 +312,11 @@ class DataFrame:
 
     @classmethod
     def _from_arrow(
-        cls,
+        cls: Type[DataFrameType],
         data: "pa.Table",
         columns: Optional[Sequence[str]] = None,
         rechunk: bool = True,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Construct a DataFrame from an Arrow table.
 
@@ -333,12 +342,12 @@ class DataFrame:
 
     @classmethod
     def _from_pandas(
-        cls,
+        cls: Type[DataFrameType],
         data: "pd.DataFrame",
         columns: Optional[Sequence[str]] = None,
         rechunk: bool = True,
         nan_to_none: bool = True,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Construct a Polars DataFrame from a pandas DataFrame.
 
@@ -368,7 +377,7 @@ class DataFrame:
                 else:
                     col = pli.Series(name, pd_series)
                     series.append(pli.Series(name, col))
-            return DataFrame(series)
+            return cls(series)
 
         return cls._from_pydf(
             pandas_to_pydf(
@@ -376,8 +385,9 @@ class DataFrame:
             )
         )
 
-    @staticmethod
+    @classmethod
     def _read_csv(
+        cls: Type[DataFrameType],
         file: Union[str, BinaryIO, bytes],
         has_header: bool = True,
         columns: Optional[Union[List[int], List[str]]] = None,
@@ -401,11 +411,11 @@ class DataFrame:
         skip_rows_after_header: int = 0,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         see pl.read_csv
         """
-        self = DataFrame.__new__(DataFrame)
+        self = cls.__new__(cls)
 
         path: Optional[str]
         if isinstance(file, str):
@@ -460,9 +470,9 @@ class DataFrame:
                 row_count_offset=row_count_offset,
             )
             if columns is None:
-                return scan.collect()
+                return self._from_pydf(scan.collect()._df)
             elif is_str_sequence(columns, False):
-                return scan.select(columns).collect()
+                return self._from_pydf(scan.select(columns).collect()._df)
             else:
                 raise ValueError(
                     "cannot use glob patterns and integer based projection as `columns` argument; Use columns: List[str]"
@@ -497,15 +507,16 @@ class DataFrame:
         )
         return self
 
-    @staticmethod
+    @classmethod
     def _read_parquet(
+        cls: Type[DataFrameType],
         file: Union[str, BinaryIO],
         columns: Optional[Union[List[int], List[str]]] = None,
         n_rows: Optional[int] = None,
         parallel: bool = True,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Read into a DataFrame from a parquet file.
 
@@ -542,7 +553,7 @@ class DataFrame:
                 )
 
         projection, columns = handle_projection_columns(columns)
-        self = DataFrame.__new__(DataFrame)
+        self = cls.__new__(cls)
         self._df = PyDataFrame.read_parquet(
             file,
             columns,
@@ -553,10 +564,12 @@ class DataFrame:
         )
         return self
 
-    @staticmethod
+    @classmethod
     def _read_avro(
-        file: Union[str, BinaryIO], n_rows: Optional[int] = None
-    ) -> "DataFrame":
+        cls: Type[DataFrameType],
+        file: Union[str, BinaryIO],
+        n_rows: Optional[int] = None,
+    ) -> DataFrameType:
         """
         Read into a DataFrame from Apache Avro format.
 
@@ -571,18 +584,19 @@ class DataFrame:
         -------
         DataFrame
         """
-        self = DataFrame.__new__(DataFrame)
+        self = cls.__new__(cls)
         self._df = PyDataFrame.read_avro(file, n_rows)
         return self
 
-    @staticmethod
+    @classmethod
     def _read_ipc(
+        cls: Type[DataFrameType],
         file: Union[str, BinaryIO],
         columns: Optional[Union[List[int], List[str]]] = None,
         n_rows: Optional[int] = None,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Read into a DataFrame from Arrow IPC stream format. This is also called the Feather (v2) format.
 
@@ -620,7 +634,7 @@ class DataFrame:
                 )
 
         projection, columns = handle_projection_columns(columns)
-        self = DataFrame.__new__(DataFrame)
+        self = cls.__new__(cls)
         self._df = PyDataFrame.read_ipc(
             file,
             columns,
@@ -630,15 +644,19 @@ class DataFrame:
         )
         return self
 
-    @staticmethod
-    def _read_json(file: Union[str, IOBase], json_lines: bool = False) -> "DataFrame":
+    @classmethod
+    def _read_json(
+        cls: Type[DataFrameType],
+        file: Union[str, IOBase],
+        json_lines: bool = False,
+    ) -> DataFrameType:
         """
         See Also pl.read_json
         """
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
 
-        self = DataFrame.__new__(DataFrame)
+        self = cls.__new__(cls)
         self._df = PyDataFrame.read_json(file, json_lines)
         return self
 
@@ -979,11 +997,11 @@ class DataFrame:
         ]
 
     def transpose(
-        self,
+        self: DataFrameType,
         include_header: bool = False,
         header_name: str = "column",
         column_names: Optional[Union[Iterator[str], Sequence[str]]] = None,
-    ) -> "pli.DataFrame":
+    ) -> DataFrameType:
         """
         Transpose a DataFrame over the diagonal.
 
@@ -1072,7 +1090,7 @@ class DataFrame:
         └─────────────┴─────────────┴─────────────┘
 
         """
-        df = wrap_df(self._df.transpose(include_header, header_name))
+        df = self._from_pydf(self._df.transpose(include_header, header_name))
         if column_names is not None:
             names = []
             n = df.width
@@ -1191,46 +1209,47 @@ class DataFrame:
         self._df = DataFrame(state)._df
 
     def __mul__(
-        self, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> "DataFrame":
+        self: DataFrameType, other: Union["DataFrame", "pli.Series", int, float, bool]
+    ) -> DataFrameType:
         if isinstance(other, DataFrame):
-            return wrap_df(self._df.mul_df(other._df))
+            return self._from_pydf(self._df.mul_df(other._df))
 
         other = _prepare_other_arg(other)
-        return wrap_df(self._df.mul(other._s))
+        return self._from_pydf(self._df.mul(other._s))
 
     def __truediv__(
-        self, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> "DataFrame":
+        self: DataFrameType, other: Union["DataFrame", "pli.Series", int, float, bool]
+    ) -> DataFrameType:
         if isinstance(other, DataFrame):
-            return wrap_df(self._df.div_df(other._df))
+            return self._from_pydf(self._df.div_df(other._df))
 
         other = _prepare_other_arg(other)
-        return wrap_df(self._df.div(other._s))
+        return self._from_pydf(self._df.div(other._s))
 
     def __add__(
-        self, other: Union["DataFrame", "pli.Series", int, float, bool, str]
-    ) -> "DataFrame":
+        self: DataFrameType,
+        other: Union["DataFrame", "pli.Series", int, float, bool, str],
+    ) -> DataFrameType:
         if isinstance(other, DataFrame):
-            return wrap_df(self._df.add_df(other._df))
+            return self._from_pydf(self._df.add_df(other._df))
         other = _prepare_other_arg(other)
-        return wrap_df(self._df.add(other._s))
+        return self._from_pydf(self._df.add(other._s))
 
     def __sub__(
-        self, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> "DataFrame":
+        self: DataFrameType, other: Union["DataFrame", "pli.Series", int, float, bool]
+    ) -> DataFrameType:
         if isinstance(other, DataFrame):
-            return wrap_df(self._df.sub_df(other._df))
+            return self._from_pydf(self._df.sub_df(other._df))
         other = _prepare_other_arg(other)
-        return wrap_df(self._df.sub(other._s))
+        return self._from_pydf(self._df.sub(other._s))
 
     def __mod__(
-        self, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> "DataFrame":
+        self: DataFrameType, other: Union["DataFrame", "pli.Series", int, float, bool]
+    ) -> DataFrameType:
         if isinstance(other, DataFrame):
-            return wrap_df(self._df.rem_df(other._df))
+            return self._from_pydf(self._df.rem_df(other._df))
         other = _prepare_other_arg(other)
-        return wrap_df(self._df.rem(other._s))
+        return self._from_pydf(self._df.rem(other._s))
 
     def __str__(self) -> str:
         return self._df.as_str()
@@ -1293,19 +1312,19 @@ class DataFrame:
 
     @overload
     def __getitem__(
-        self,
+        self: DataFrameType,
         item: Union[
             int, range, slice, np.ndarray, "pli.Expr", "pli.Series", List, tuple
         ],
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         ...
 
     def __getitem__(
-        self,
+        self: DataFrameType,
         item: Union[
             str, int, range, slice, np.ndarray, "pli.Expr", "pli.Series", List, tuple
         ],
-    ) -> Union["DataFrame", "pli.Series"]:
+    ) -> Union[DataFrameType, "pli.Series"]:
         """
         Does quite a lot. Read the comments.
         """
@@ -1384,7 +1403,7 @@ class DataFrame:
                 # select by column indexes
                 if isinstance(col_selection[0], int):
                     series_list = [self.to_series(i) for i in col_selection]
-                    df = DataFrame(series_list)
+                    df = self.__class__(series_list)
                     return df[row_selection]
             df = self.__getitem__(col_selection)
             return df.__getitem__(row_selection)
@@ -1434,30 +1453,32 @@ class DataFrame:
         # df[[true, false, true]]
         if isinstance(item, np.ndarray):
             if item.dtype == int:
-                return wrap_df(self._df.take(item))
+                return self._from_pydf(self._df.take(item))
             if isinstance(item[0], str):
-                return wrap_df(self._df.select(item))
+                return self._from_pydf(self._df.select(item))
             if item.dtype == bool:
-                return wrap_df(self._df.filter(pli.Series("", item).inner()))
+                return self._from_pydf(self._df.filter(pli.Series("", item).inner()))
 
         if isinstance(item, Sequence):
             if isinstance(item[0], str):
                 # select multiple columns
                 # df[["foo", "bar"]]
-                return wrap_df(self._df.select(item))
+                return self._from_pydf(self._df.select(item))
             elif isinstance(item[0], pli.Expr):
                 return self.select(item)
             elif type(item[0]) == bool:
                 item = pli.Series("", item)  # fall through to next if isinstance
             elif is_int_sequence(item):
-                return wrap_df(self._df.take([self._pos_idx(i, dim=0) for i in item]))
+                return self._from_pydf(
+                    self._df.take([self._pos_idx(i, dim=0) for i in item])
+                )
 
         if isinstance(item, pli.Series):
             dtype = item.dtype
             if dtype == Boolean:
-                return wrap_df(self._df.filter(item.inner()))
+                return self._from_pydf(self._df.filter(item.inner()))
             if dtype == UInt32:
-                return wrap_df(self._df.take_with_series(item.inner()))
+                return self._from_pydf(self._df.take_with_series(item.inner()))
 
         # if no data has been returned, the operation is not supported
         raise NotImplementedError
@@ -1557,7 +1578,7 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.select_at_idx(index))
 
-    def rename(self, mapping: Dict[str, str]) -> "DataFrame":
+    def rename(self: DataFrameType, mapping: Dict[str, str]) -> DataFrameType:
         """
         Rename column names.
 
@@ -1587,7 +1608,9 @@ class DataFrame:
         └───────┴─────┴─────┘
 
         """
-        return self.lazy().rename(mapping).collect(no_optimization=True)
+        return self._from_pydf(
+            self.lazy().rename(mapping).collect(no_optimization=True)._df
+        )
 
     def insert_at_idx(self, index: int, series: "pli.Series") -> None:
         """
@@ -1602,7 +1625,7 @@ class DataFrame:
         """
         self._df.insert_at_idx(index, series._s)
 
-    def filter(self, predicate: "pli.Expr") -> "DataFrame":
+    def filter(self: DataFrameType, predicate: "pli.Expr") -> DataFrameType:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -1649,10 +1672,11 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return (
+        return self._from_pydf(
             self.lazy()
             .filter(predicate)
             .collect(no_optimization=True, string_cache=False)
+            ._df
         )
 
     @property
@@ -1806,7 +1830,7 @@ class DataFrame:
         """
         return dict(zip(self.columns, self.dtypes))
 
-    def describe(self) -> "DataFrame":
+    def describe(self: DataFrameType) -> DataFrameType:
         """
         Summary statistics for a DataFrame. Only summarizes numeric datatypes at the moment and returns nulls for non numeric datatypes.
 
@@ -1839,23 +1863,25 @@ class DataFrame:
 
         """
 
-        def describe_cast(self: "DataFrame") -> "DataFrame":
+        def describe_cast(self: DataFrameType) -> DataFrameType:
             columns = []
             for s in self:
                 if s.is_numeric() or s.is_boolean():
                     columns.append(s.cast(float))
                 else:
                     columns.append(s)
-            return DataFrame(columns)
+            return self.__class__(columns)
 
-        summary = pli.concat(
-            [
-                describe_cast(self.mean()),
-                describe_cast(self.std()),
-                describe_cast(self.min()),
-                describe_cast(self.max()),
-                describe_cast(self.median()),
-            ]
+        summary = self._from_pydf(
+            pli.concat(
+                [
+                    describe_cast(self.mean()),
+                    describe_cast(self.std()),
+                    describe_cast(self.min()),
+                    describe_cast(self.max()),
+                    describe_cast(self.median()),
+                ]
+            )._df
         )
         summary.insert_at_idx(
             0, pli.Series("describe", ["mean", "std", "min", "max", "median"])
@@ -1903,12 +1929,12 @@ class DataFrame:
 
     @overload
     def sort(
-        self,
+        self: DataFrameType,
         by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
         reverse: Union[bool, List[bool]] = ...,
         *,
         in_place: Literal[False] = ...,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         ...
 
     @overload
@@ -1923,21 +1949,21 @@ class DataFrame:
 
     @overload
     def sort(
-        self,
+        self: DataFrameType,
         by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
         reverse: Union[bool, List[bool]] = ...,
         *,
         in_place: bool,
-    ) -> Optional["DataFrame"]:
+    ) -> Optional[DataFrameType]:
         ...
 
     def sort(
-        self,
+        self: DataFrameType,
         by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
         reverse: Union[bool, List[bool]] = False,
         *,
         in_place: bool = False,
-    ) -> Optional["DataFrame"]:
+    ) -> Optional[DataFrameType]:
         """
         Sort the DataFrame by column.
 
@@ -2000,16 +2026,17 @@ class DataFrame:
                 self.lazy()
                 .sort(by, reverse)
                 .collect(no_optimization=True, string_cache=False)
+                ._df
             )
             if in_place:
-                self._df = df._df
+                self._df = df
                 return self
-            return df
+            return self._from_pydf(df)
         if in_place:
             self._df.sort_in_place(by, reverse)
             return None
         else:
-            return wrap_df(self._df.sort(by, reverse))
+            return self._from_pydf(self._df.sort(by, reverse))
 
     def frame_equal(self, other: "DataFrame", null_equal: bool = True) -> bool:
         """
@@ -2059,7 +2086,7 @@ class DataFrame:
         """
         self._df.replace(column, new_col.inner())
 
-    def slice(self, offset: int, length: int) -> "DataFrame":
+    def slice(self: DataFrameType, offset: int, length: int) -> DataFrameType:
         """
         Slice this DataFrame over the rows direction.
 
@@ -2095,9 +2122,9 @@ class DataFrame:
         """
         if length < 0:
             length = self.height - offset + length
-        return wrap_df(self._df.slice(offset, length))
+        return self._from_pydf(self._df.slice(offset, length))
 
-    def limit(self, length: int = 5) -> "DataFrame":
+    def limit(self: DataFrameType, length: int = 5) -> DataFrameType:
         """
         Get first N rows as DataFrame.
 
@@ -2132,7 +2159,7 @@ class DataFrame:
         """
         return self.head(length)
 
-    def head(self, length: int = 5) -> "DataFrame":
+    def head(self: DataFrameType, length: int = 5) -> DataFrameType:
         """
         Get first N rows as DataFrame.
 
@@ -2165,9 +2192,9 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return wrap_df(self._df.head(length))
+        return self._from_pydf(self._df.head(length))
 
-    def tail(self, length: int = 5) -> "DataFrame":
+    def tail(self: DataFrameType, length: int = 5) -> DataFrameType:
         """
         Get last N rows as DataFrame.
 
@@ -2200,9 +2227,11 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return wrap_df(self._df.tail(length))
+        return self._from_pydf(self._df.tail(length))
 
-    def drop_nulls(self, subset: Optional[Union[str, List[str]]] = None) -> "DataFrame":
+    def drop_nulls(
+        self: DataFrameType, subset: Optional[Union[str, List[str]]] = None
+    ) -> DataFrameType:
         """
         Return a new DataFrame where the null values are dropped.
 
@@ -2298,7 +2327,7 @@ class DataFrame:
         """
         if isinstance(subset, str):
             subset = [subset]
-        return wrap_df(self._df.drop_nulls(subset))
+        return self._from_pydf(self._df.drop_nulls(subset))
 
     def pipe(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         """
@@ -2339,7 +2368,9 @@ class DataFrame:
         """
         return func(self, *args, **kwargs)
 
-    def with_row_count(self, name: str = "row_nr", offset: int = 0) -> "DataFrame":
+    def with_row_count(
+        self: DataFrameType, name: str = "row_nr", offset: int = 0
+    ) -> DataFrameType:
         """
         Add a column at index 0 that counts the rows.
 
@@ -2374,7 +2405,7 @@ class DataFrame:
         └────────┴─────┴─────┘
 
         """
-        return wrap_df(self._df.with_row_count(name, offset))
+        return self._from_pydf(self._df.with_row_count(name, offset))
 
     def groupby(
         self,
@@ -2864,13 +2895,13 @@ class DataFrame:
         )
 
     def upsample(
-        self,
+        self: DataFrameType,
         time_column: str,
         every: str,
         offset: Optional[str] = None,
         by: Optional[Union[str, Sequence[str]]] = None,
         maintain_order: bool = False,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Upsample a DataFrame at a regular frequency.
 
@@ -2958,12 +2989,12 @@ class DataFrame:
         if offset is None:
             offset = "0ns"
 
-        return wrap_df(
+        return self._from_pydf(
             self._df.upsample(by, time_column, every, offset, maintain_order)
         )
 
     def join_asof(
-        self,
+        self: DataFrameType,
         df: "DataFrame",
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
@@ -2976,7 +3007,7 @@ class DataFrame:
         tolerance: Optional[Union[str, int, float]] = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Perform an asof join. This is similar to a left-join except that we
         match on nearest key rather than equal keys.
@@ -3038,7 +3069,7 @@ class DataFrame:
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel.
         """
-        return (
+        return self._from_pydf(
             self.lazy()
             .join_asof(
                 df.lazy(),
@@ -3055,10 +3086,11 @@ class DataFrame:
                 force_parallel=force_parallel,
             )
             .collect(no_optimization=True)
+            ._df
         )
 
     def join(
-        self,
+        self: DataFrameType,
         df: "DataFrame",
         left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
@@ -3068,7 +3100,7 @@ class DataFrame:
         asof_by: Optional[Union[str, List[str]]] = None,
         asof_by_left: Optional[Union[str, List[str]]] = None,
         asof_by_right: Optional[Union[str, List[str]]] = None,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         SQL like joins.
 
@@ -3156,7 +3188,7 @@ class DataFrame:
                 "using asof join via DataFrame.join is deprecated, please use DataFrame.join_asof"
             )
         if how == "cross":
-            return wrap_df(self._df.join(df._df, [], [], how, suffix))
+            return self._from_pydf(self._df.join(df._df, [], [], how, suffix))
 
         left_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(left_on, (str, pli.Expr)):
@@ -3187,7 +3219,7 @@ class DataFrame:
             or asof_by_right is not None
             or asof_by is not None
         ):
-            return (
+            return self._from_pydf(
                 self.lazy()
                 .join(
                     df.lazy(),
@@ -3201,16 +3233,19 @@ class DataFrame:
                     asof_by=asof_by,
                 )
                 .collect(no_optimization=True)
+                ._df
             )
         else:
-            return wrap_df(self._df.join(df._df, left_on_, right_on_, how, suffix))
+            return self._from_pydf(
+                self._df.join(df._df, left_on_, right_on_, how, suffix)
+            )
 
     def apply(
-        self,
+        self: DataFrameType,
         f: Callable[[Tuple[Any, ...]], Any],
         return_dtype: Optional[Type[DataType]] = None,
         inference_size: int = 256,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Apply a custom function over the rows of the DataFrame. The rows are passed as tuple.
 
@@ -3229,11 +3264,13 @@ class DataFrame:
         """
         out, is_df = self._df.apply(f, return_dtype, inference_size)
         if is_df:
-            return wrap_df(out)
+            return self._from_pydf(out)
         else:
-            return pli.wrap_s(out).to_frame()
+            return self._from_pydf(pli.wrap_s(out).to_frame()._df)
 
-    def with_column(self, column: Union["pli.Series", "pli.Expr"]) -> "DataFrame":
+    def with_column(
+        self: DataFrameType, column: Union["pli.Series", "pli.Expr"]
+    ) -> DataFrameType:
         """
         Return a new DataFrame with the column added or replaced.
 
@@ -3282,11 +3319,13 @@ class DataFrame:
         if isinstance(column, pli.Expr):
             return self.with_columns([column])
         else:
-            return wrap_df(self._df.with_column(column._s))
+            return self._from_pydf(self._df.with_column(column._s))
 
     def hstack(
-        self, columns: Union[List["pli.Series"], "DataFrame"], in_place: bool = False
-    ) -> Optional["DataFrame"]:
+        self: DataFrameType,
+        columns: Union[List["pli.Series"], "DataFrame"],
+        in_place: bool = False,
+    ) -> Optional[DataFrameType]:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
 
@@ -3328,21 +3367,27 @@ class DataFrame:
             self._df.hstack_mut([s.inner() for s in columns])
             return None
         else:
-            return wrap_df(self._df.hstack([s.inner() for s in columns]))
+            return self._from_pydf(self._df.hstack([s.inner() for s in columns]))
 
     @overload
     def vstack(self, df: "DataFrame", in_place: Literal[True]) -> None:
         ...
 
     @overload
-    def vstack(self, df: "DataFrame", in_place: Literal[False] = ...) -> "DataFrame":
+    def vstack(
+        self: DataFrameType, df: "DataFrame", in_place: Literal[False] = ...
+    ) -> DataFrameType:
         ...
 
     @overload
-    def vstack(self, df: "DataFrame", in_place: bool) -> Optional["DataFrame"]:
+    def vstack(
+        self: DataFrameType, df: "DataFrame", in_place: bool
+    ) -> Optional[DataFrameType]:
         ...
 
-    def vstack(self, df: "DataFrame", in_place: bool = False) -> Optional["DataFrame"]:
+    def vstack(
+        self: DataFrameType, df: "DataFrame", in_place: bool = False
+    ) -> Optional[DataFrameType]:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
 
@@ -3391,7 +3436,7 @@ class DataFrame:
             self._df.vstack_mut(df._df)
             return None
         else:
-            return wrap_df(self._df.vstack(df._df))
+            return self._from_pydf(self._df.vstack(df._df))
 
     def extend(self, other: "DataFrame") -> None:
         """
@@ -3417,7 +3462,7 @@ class DataFrame:
         """
         self._df.extend(other._df)
 
-    def drop(self, name: Union[str, List[str]]) -> "DataFrame":
+    def drop(self: DataFrameType, name: Union[str, List[str]]) -> DataFrameType:
         """
         Remove column from DataFrame and return as new.
 
@@ -3458,7 +3503,7 @@ class DataFrame:
                 df._df.drop_in_place(name)
             return df
 
-        return wrap_df(self._df.drop(name))
+        return self._from_pydf(self._df.drop(name))
 
     def drop_in_place(self, name: str) -> "pli.Series":
         """
@@ -3522,16 +3567,16 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.select_at_idx(idx))
 
-    def clone(self) -> "DataFrame":
+    def clone(self: DataFrameType) -> DataFrameType:
         """
         Very cheap deep clone.
         """
-        return wrap_df(self._df.clone())
+        return self._from_pydf(self._df.clone())
 
-    def __copy__(self) -> "DataFrame":
+    def __copy__(self: DataFrameType) -> DataFrameType:
         return self.clone()
 
-    def __deepcopy__(self, memodict={}) -> "DataFrame":  # type: ignore
+    def __deepcopy__(self: DataFrameType, memodict={}) -> DataFrameType:  # type: ignore
         return self.clone()
 
     def get_columns(self) -> List["pli.Series"]:
@@ -3546,7 +3591,9 @@ class DataFrame:
         """
         return self[name]
 
-    def fill_null(self, strategy: Union[str, "pli.Expr", Any]) -> "DataFrame":
+    def fill_null(
+        self: DataFrameType, strategy: Union[str, "pli.Expr", Any]
+    ) -> DataFrameType:
         """
         Fill null values using a filling strategy, literal, or Expr.
 
@@ -3568,12 +3615,16 @@ class DataFrame:
             DataFrame with None values replaced by the filling strategy.
         """
         if isinstance(strategy, pli.Expr):
-            return self.lazy().fill_null(strategy).collect(no_optimization=True)
+            return self._from_pydf(
+                self.lazy().fill_null(strategy).collect(no_optimization=True)._df
+            )
         if not isinstance(strategy, str):
             return self.fill_null(pli.lit(strategy))
-        return wrap_df(self._df.fill_null(strategy))
+        return self._from_pydf(self._df.fill_null(strategy))
 
-    def fill_nan(self, fill_value: Union["pli.Expr", int, float]) -> "DataFrame":
+    def fill_nan(
+        self: DataFrameType, fill_value: Union["pli.Expr", int, float]
+    ) -> DataFrameType:
         """
         Fill floating point NaN values by an Expression evaluation.
 
@@ -3591,11 +3642,14 @@ class DataFrame:
         -------
             DataFrame with NaN replaced with fill_value
         """
-        return self.lazy().fill_nan(fill_value).collect(no_optimization=True)
+        return self._from_pydf(
+            self.lazy().fill_nan(fill_value).collect(no_optimization=True)._df
+        )
 
     def explode(
-        self, columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]]
-    ) -> "DataFrame":
+        self: DataFrameType,
+        columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
+    ) -> DataFrameType:
         """
         Explode `DataFrame` to long format by exploding a column with Lists.
 
@@ -3662,16 +3716,18 @@ class DataFrame:
         └─────────┴─────┘
 
         """
-        return self.lazy().explode(columns).collect(no_optimization=True)
+        return self._from_pydf(
+            self.lazy().explode(columns).collect(no_optimization=True)._df
+        )
 
     def pivot(
-        self,
+        self: DataFrameType,
         values: Union[List[str], str],
         index: Union[List[str], str],
         columns: Union[List[str], str],
         aggregate_fn: str = "first",
         maintain_order: bool = False,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Create a spreadsheet-style pivot table as a DataFrame.
 
@@ -3730,15 +3786,15 @@ class DataFrame:
             index = [index]
         if isinstance(columns, str):
             columns = [columns]
-        return wrap_df(
+        return self._from_pydf(
             self._df.pivot2(values, index, columns, aggregate_fn, maintain_order)
         )
 
     def melt(
-        self,
+        self: DataFrameType,
         id_vars: Optional[Union[List[str], str]] = None,
         value_vars: Optional[Union[List[str], str]] = None,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
 
@@ -3795,9 +3851,9 @@ class DataFrame:
             value_vars = []
         if id_vars is None:
             id_vars = []
-        return wrap_df(self._df.melt(id_vars, value_vars))
+        return self._from_pydf(self._df.melt(id_vars, value_vars))
 
-    def shift(self, periods: int) -> "DataFrame":
+    def shift(self: DataFrameType, periods: int) -> DataFrameType:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with `Nones`.
@@ -3844,11 +3900,11 @@ class DataFrame:
         └──────┴──────┴──────┘
 
         """
-        return wrap_df(self._df.shift(periods))
+        return self._from_pydf(self._df.shift(periods))
 
     def shift_and_fill(
-        self, periods: int, fill_value: Union[int, str, float]
-    ) -> "DataFrame":
+        self: DataFrameType, periods: int, fill_value: Union[int, str, float]
+    ) -> DataFrameType:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.
@@ -3884,10 +3940,11 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return (
+        return self._from_pydf(
             self.lazy()
             .shift_and_fill(periods, fill_value)
             .collect(no_optimization=True, string_cache=False)
+            ._df
         )
 
     def is_duplicated(self) -> "pli.Series":
@@ -3959,14 +4016,14 @@ class DataFrame:
         return pli.wrap_ldf(self._df.lazy())
 
     def select(
-        self,
+        self: DataFrameType,
         exprs: Union[
             str,
             "pli.Expr",
             Sequence[Union[str, "pli.Expr", bool, int, float, "pli.Series"]],
             "pli.Series",
         ],
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Select columns from this DataFrame.
 
@@ -3999,11 +4056,16 @@ class DataFrame:
         └─────┘
 
         """
-        return (
-            self.lazy().select(exprs).collect(no_optimization=True, string_cache=False)  # type: ignore
+        return self._from_pydf(
+            self.lazy()
+            .select(exprs)  # type: ignore
+            .collect(no_optimization=True, string_cache=False)
+            ._df
         )
 
-    def with_columns(self, exprs: Union["pli.Expr", List["pli.Expr"]]) -> "DataFrame":
+    def with_columns(
+        self: DataFrameType, exprs: Union["pli.Expr", List["pli.Expr"]]
+    ) -> DataFrameType:
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -4014,10 +4076,11 @@ class DataFrame:
         """
         if not isinstance(exprs, list):
             exprs = [exprs]
-        return (
+        return self._from_pydf(
             self.lazy()
             .with_columns(exprs)
             .collect(no_optimization=True, string_cache=False)
+            ._df
         )
 
     def n_chunks(self) -> int:
@@ -4027,7 +4090,7 @@ class DataFrame:
         return self._df.n_chunks()
 
     @overload
-    def max(self, axis: Literal[0] = ...) -> "DataFrame":
+    def max(self: DataFrameType, axis: Literal[0] = ...) -> DataFrameType:
         ...
 
     @overload
@@ -4035,10 +4098,10 @@ class DataFrame:
         ...
 
     @overload
-    def max(self, axis: int = 0) -> Union["DataFrame", "pli.Series"]:
+    def max(self: DataFrameType, axis: int = 0) -> Union[DataFrameType, "pli.Series"]:
         ...
 
-    def max(self, axis: int = 0) -> Union["DataFrame", "pli.Series"]:
+    def max(self: DataFrameType, axis: int = 0) -> Union[DataFrameType, "pli.Series"]:
         """
         Aggregate the columns of this DataFrame to their maximum value.
 
@@ -4063,13 +4126,13 @@ class DataFrame:
 
         """
         if axis == 0:
-            return wrap_df(self._df.max())
+            return self._from_pydf(self._df.max())
         if axis == 1:
             return pli.wrap_s(self._df.hmax())
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
     @overload
-    def min(self, axis: Literal[0] = ...) -> "DataFrame":
+    def min(self: DataFrameType, axis: Literal[0] = ...) -> DataFrameType:
         ...
 
     @overload
@@ -4077,10 +4140,10 @@ class DataFrame:
         ...
 
     @overload
-    def min(self, axis: int = 0) -> Union["DataFrame", "pli.Series"]:
+    def min(self: DataFrameType, axis: int = 0) -> Union[DataFrameType, "pli.Series"]:
         ...
 
-    def min(self, axis: int = 0) -> Union["DataFrame", "pli.Series"]:
+    def min(self: DataFrameType, axis: int = 0) -> Union[DataFrameType, "pli.Series"]:
         """
         Aggregate the columns of this DataFrame to their minimum value.
 
@@ -4105,15 +4168,15 @@ class DataFrame:
 
         """
         if axis == 0:
-            return wrap_df(self._df.min())
+            return self._from_pydf(self._df.min())
         if axis == 1:
             return pli.wrap_s(self._df.hmin())
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
     @overload
     def sum(
-        self, *, axis: Literal[0] = ..., null_strategy: str = "ignore"
-    ) -> "DataFrame":
+        self: DataFrameType, *, axis: Literal[0] = ..., null_strategy: str = "ignore"
+    ) -> DataFrameType:
         ...
 
     @overload
@@ -4122,13 +4185,13 @@ class DataFrame:
 
     @overload
     def sum(
-        self, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union["DataFrame", "pli.Series"]:
+        self: DataFrameType, *, axis: int = 0, null_strategy: str = "ignore"
+    ) -> Union[DataFrameType, "pli.Series"]:
         ...
 
     def sum(
-        self, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union["DataFrame", "pli.Series"]:
+        self: DataFrameType, *, axis: int = 0, null_strategy: str = "ignore"
+    ) -> Union[DataFrameType, "pli.Series"]:
         """
         Aggregate the columns of this DataFrame to their sum value.
 
@@ -4161,15 +4224,15 @@ class DataFrame:
 
         """
         if axis == 0:
-            return wrap_df(self._df.sum())
+            return self._from_pydf(self._df.sum())
         if axis == 1:
             return pli.wrap_s(self._df.hsum(null_strategy))
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
     @overload
     def mean(
-        self, *, axis: Literal[0] = ..., null_strategy: str = "ignore"
-    ) -> "DataFrame":
+        self: DataFrameType, *, axis: Literal[0] = ..., null_strategy: str = "ignore"
+    ) -> DataFrameType:
         ...
 
     @overload
@@ -4178,13 +4241,13 @@ class DataFrame:
 
     @overload
     def mean(
-        self, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union["DataFrame", "pli.Series"]:
+        self: DataFrameType, *, axis: int = 0, null_strategy: str = "ignore"
+    ) -> Union[DataFrameType, "pli.Series"]:
         ...
 
     def mean(
-        self, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union["DataFrame", "pli.Series"]:
+        self: DataFrameType, axis: int = 0, null_strategy: str = "ignore"
+    ) -> Union[DataFrameType, "pli.Series"]:
         """
         Aggregate the columns of this DataFrame to their mean value.
 
@@ -4246,12 +4309,12 @@ class DataFrame:
 
         """
         if axis == 0:
-            return wrap_df(self._df.mean())
+            return self._from_pydf(self._df.mean())
         if axis == 1:
             return pli.wrap_s(self._df.hmean(null_strategy))
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
-    def std(self) -> "DataFrame":
+    def std(self: DataFrameType) -> DataFrameType:
         """
         Aggregate the columns of this DataFrame to their standard deviation value.
 
@@ -4275,9 +4338,9 @@ class DataFrame:
         └─────┴─────┴──────┘
 
         """
-        return wrap_df(self._df.std())
+        return self._from_pydf(self._df.std())
 
-    def var(self) -> "DataFrame":
+    def var(self: DataFrameType) -> DataFrameType:
         """
         Aggregate the columns of this DataFrame to their variance value.
 
@@ -4301,9 +4364,9 @@ class DataFrame:
         └─────┴─────┴──────┘
 
         """
-        return wrap_df(self._df.var())
+        return self._from_pydf(self._df.var())
 
-    def median(self) -> "DataFrame":
+    def median(self: DataFrameType) -> DataFrameType:
         """
         Aggregate the columns of this DataFrame to their median value.
 
@@ -4327,15 +4390,17 @@ class DataFrame:
         └─────┴─────┴──────┘
 
         """
-        return wrap_df(self._df.median())
+        return self._from_pydf(self._df.median())
 
-    def product(self) -> "DataFrame":
+    def product(self: DataFrameType) -> DataFrameType:
         """
         Aggregate the columns of this DataFrame to their product values
         """
         return self.select(pli.all().product())
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> "DataFrame":
+    def quantile(
+        self: DataFrameType, quantile: float, interpolation: str = "nearest"
+    ) -> DataFrameType:
         """
         Aggregate the columns of this DataFrame to their quantile value.
 
@@ -4367,9 +4432,9 @@ class DataFrame:
         └─────┴─────┴──────┘
 
         """
-        return wrap_df(self._df.quantile(quantile, interpolation))
+        return self._from_pydf(self._df.quantile(quantile, interpolation))
 
-    def to_dummies(self) -> "DataFrame":
+    def to_dummies(self: DataFrameType) -> DataFrameType:
         """
         Get one hot encoded dummy variables.
 
@@ -4397,14 +4462,14 @@ class DataFrame:
         └───────┴───────┴───────┴───────┴─────┴───────┴───────┴───────┴───────┘
 
         """
-        return wrap_df(self._df.to_dummies())
+        return self._from_pydf(self._df.to_dummies())
 
     def distinct(
-        self,
+        self: DataFrameType,
         maintain_order: bool = True,
         subset: Optional[Union[str, List[str]]] = None,
         keep: str = "first",
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Drop duplicate rows from this DataFrame.
         Note that this fails if there is a column of type `List` in the DataFrame or subset.
@@ -4424,17 +4489,17 @@ class DataFrame:
         """
         if subset is not None and not isinstance(subset, list):
             subset = [subset]
-        return wrap_df(self._df.distinct(maintain_order, subset, keep))
+        return self._from_pydf(self._df.distinct(maintain_order, subset, keep))
 
-    def rechunk(self) -> "DataFrame":
+    def rechunk(self: DataFrameType) -> DataFrameType:
         """
         Rechunk the data in this DataFrame to a contiguous allocation.
 
         This will make sure all subsequent operations have optimal and predictable performance.
         """
-        return wrap_df(self._df.rechunk())
+        return self._from_pydf(self._df.rechunk())
 
-    def null_count(self) -> "DataFrame":
+    def null_count(self: DataFrameType) -> DataFrameType:
         """
         Create a new DataFrame that shows the null counts per column.
 
@@ -4458,15 +4523,15 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return wrap_df(self._df.null_count())
+        return self._from_pydf(self._df.null_count())
 
     def sample(
-        self,
+        self: DataFrameType,
         n: Optional[int] = None,
         frac: Optional[float] = None,
         with_replacement: bool = False,
         seed: int = 0,
-    ) -> "DataFrame":
+    ) -> DataFrameType:
         """
         Sample from this DataFrame by setting either `n` or `frac`.
 
@@ -4504,8 +4569,8 @@ class DataFrame:
 
         """
         if n is not None:
-            return wrap_df(self._df.sample_n(n, with_replacement, seed))
-        return wrap_df(self._df.sample_frac(frac, with_replacement, seed))
+            return self._from_pydf(self._df.sample_n(n, with_replacement, seed))
+        return self._from_pydf(self._df.sample_frac(frac, with_replacement, seed))
 
     def fold(
         self, operation: Callable[["pli.Series", "pli.Series"], "pli.Series"]
@@ -4644,7 +4709,9 @@ class DataFrame:
         return self._df.row_tuples()
 
     @overload
-    def shrink_to_fit(self, in_place: Literal[False] = ...) -> "DataFrame":
+    def shrink_to_fit(
+        self: DataFrameType, in_place: Literal[False] = ...
+    ) -> DataFrameType:
         ...
 
     @overload
@@ -4652,10 +4719,12 @@ class DataFrame:
         ...
 
     @overload
-    def shrink_to_fit(self, in_place: bool) -> Optional["DataFrame"]:
+    def shrink_to_fit(self: DataFrameType, in_place: bool) -> Optional[DataFrameType]:
         ...
 
-    def shrink_to_fit(self, in_place: bool = False) -> Optional["DataFrame"]:
+    def shrink_to_fit(
+        self: DataFrameType, in_place: bool = False
+    ) -> Optional[DataFrameType]:
         """
         Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
         """
@@ -4706,7 +4775,7 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.hash_rows(k0, k1, k2, k3))
 
-    def interpolate(self) -> "DataFrame":
+    def interpolate(self: DataFrameType) -> DataFrameType:
         """
         Interpolate intermediate values. The interpolation method is linear.
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -6,10 +6,21 @@ import shutil
 import subprocess
 import tempfile
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 try:
-    from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
+    from polars.polars import PyDataFrame, PyExpr, PyLazyFrame, PyLazyGroupBy
 
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover
@@ -18,6 +29,12 @@ except ImportError:  # pragma: no cover
 from polars import internals as pli
 from polars.datatypes import DataType, py_type_to_dtype
 from polars.utils import _in_notebook, _prepare_row_count_args, _process_null_values
+
+
+# Used to type any type or subclass of LazyFrame.
+# Used to indicate when LazyFrame methods return the same type as self,
+# including sub-classes.
+LazyFrameType = TypeVar("LazyFrameType", bound="LazyFrame")
 
 
 def wrap_ldf(ldf: "PyLazyFrame") -> "LazyFrame":
@@ -50,14 +67,15 @@ class LazyFrame:
     def __init__(self) -> None:
         self._ldf: PyLazyFrame
 
-    @staticmethod
-    def _from_pyldf(ldf: "PyLazyFrame") -> "LazyFrame":
-        self = LazyFrame.__new__(LazyFrame)
+    @classmethod
+    def _from_pyldf(cls: Type[LazyFrameType], ldf: "PyLazyFrame") -> LazyFrameType:
+        self = cls.__new__(cls)
         self._ldf = ldf
         return self
 
-    @staticmethod
+    @classmethod
     def scan_csv(
+        cls: Type[LazyFrameType],
         file: str,
         has_header: bool = True,
         sep: str = ",",
@@ -77,7 +95,7 @@ class LazyFrame:
         skip_rows_after_header: int = 0,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         See Also: `pl.scan_csv`
         """
@@ -88,7 +106,7 @@ class LazyFrame:
                 dtype_list.append((k, py_type_to_dtype(v)))
         processed_null_values = _process_null_values(null_values)
 
-        self = LazyFrame.__new__(LazyFrame)
+        self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_csv(
             file,
             sep,
@@ -111,8 +129,9 @@ class LazyFrame:
         )
         return self
 
-    @staticmethod
+    @classmethod
     def scan_parquet(
+        cls: Type[LazyFrameType],
         file: str,
         n_rows: Optional[int] = None,
         cache: bool = True,
@@ -120,12 +139,12 @@ class LazyFrame:
         rechunk: bool = True,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         See Also: `pl.scan_parquet`
         """
 
-        self = LazyFrame.__new__(LazyFrame)
+        self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_parquet(
             file,
             n_rows,
@@ -136,20 +155,21 @@ class LazyFrame:
         )
         return self
 
-    @staticmethod
+    @classmethod
     def scan_ipc(
+        cls: Type[LazyFrameType],
         file: str,
         n_rows: Optional[int] = None,
         cache: bool = True,
         rechunk: bool = True,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         See Also: `pl.scan_ipc`
         """
 
-        self = LazyFrame.__new__(LazyFrame)
+        self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ipc(
             file,
             n_rows,
@@ -314,7 +334,7 @@ class LazyFrame:
                 plt.show()
         return None
 
-    def inspect(self, fmt: str = "{}") -> "LazyFrame":
+    def inspect(self: LazyFrameType, fmt: str = "{}") -> LazyFrameType:
         """
         Prints the value that this node in the computation graph evaluates to and passes on the value.
 
@@ -339,10 +359,10 @@ class LazyFrame:
         return self.map(inspect, predicate_pushdown=True, projection_pushdown=True)
 
     def sort(
-        self,
+        self: LazyFrameType,
         by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
         reverse: Union[bool, List[bool]] = False,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Sort the DataFrame by:
 
@@ -358,12 +378,12 @@ class LazyFrame:
             Whether or not to sort in reverse order.
         """
         if type(by) is str:
-            return wrap_ldf(self._ldf.sort(by, reverse))
+            return self._from_pyldf(self._ldf.sort(by, reverse))
         if type(reverse) is bool:
             reverse = [reverse]
 
         by = pli.selection_to_pyexpr_list(by)
-        return wrap_ldf(self._ldf.sort_by_exprs(by, reverse))
+        return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse))
 
     def collect(
         self,
@@ -506,15 +526,13 @@ class LazyFrame:
         """
         return self._ldf.columns()
 
-    def cache(
-        self,
-    ) -> "LazyFrame":
+    def cache(self: LazyFrameType) -> LazyFrameType:
         """
         Cache the result once the execution of the physical plan hits this node.
         """
-        return wrap_ldf(self._ldf.cache())
+        return self._from_pyldf(self._ldf.cache())
 
-    def filter(self, predicate: Union["pli.Expr", str]) -> "LazyFrame":
+    def filter(self: LazyFrameType, predicate: Union["pli.Expr", str]) -> LazyFrameType:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -563,14 +581,14 @@ class LazyFrame:
         """
         if isinstance(predicate, str):
             predicate = pli.col(predicate)
-        return wrap_ldf(self._ldf.filter(predicate._pyexpr))
+        return self._from_pyldf(self._ldf.filter(predicate._pyexpr))
 
     def select(
-        self,
+        self: LazyFrameType,
         exprs: Union[
             str, "pli.Expr", Sequence[str], Sequence["pli.Expr"], "pli.Series"
         ],
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Select columns from this DataFrame.
 
@@ -605,7 +623,7 @@ class LazyFrame:
 
         """
         exprs = pli.selection_to_pyexpr_list(exprs)
-        return wrap_ldf(self._ldf.select(exprs))
+        return self._from_pyldf(self._ldf.select(exprs))
 
     def groupby(
         self,
@@ -869,7 +887,7 @@ class LazyFrame:
         return LazyGroupBy(lgb)
 
     def join_asof(
-        self,
+        self: LazyFrameType,
         ldf: "LazyFrame",
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
@@ -882,7 +900,7 @@ class LazyFrame:
         tolerance: Optional[Union[str, int, float]] = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Perform an asof join. This is similar to a left-join except that we
         match on nearest key rather than equal keys.
@@ -978,7 +996,7 @@ class LazyFrame:
         else:
             tolerance_num = tolerance
 
-        return wrap_ldf(
+        return self._from_pyldf(
             self._ldf.join_asof(
                 ldf._ldf,
                 pli.col(left_on)._pyexpr,
@@ -995,7 +1013,7 @@ class LazyFrame:
         )
 
     def join(
-        self,
+        self: LazyFrameType,
         ldf: "LazyFrame",
         left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
@@ -1007,7 +1025,7 @@ class LazyFrame:
         asof_by: Optional[Union[str, List[str]]] = None,
         asof_by_left: Optional[Union[str, List[str]]] = None,
         asof_by_right: Optional[Union[str, List[str]]] = None,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Add a join operation to the Logical Plan.
 
@@ -1094,7 +1112,7 @@ class LazyFrame:
                 "using asof join via LazyFrame.join is deprecated, please use LazyFrame.join_asof"
             )
         if how == "cross":
-            return wrap_ldf(
+            return self._from_pyldf(
                 self._ldf.join(
                     ldf._ldf,
                     [],
@@ -1167,7 +1185,7 @@ class LazyFrame:
         if right_asof_by_ is None:
             right_asof_by_ = []
 
-        return wrap_ldf(
+        return self._from_pyldf(
             self._ldf.join(
                 ldf._ldf,
                 new_left_on,
@@ -1181,7 +1199,9 @@ class LazyFrame:
             )
         )
 
-    def with_columns(self, exprs: Union[List["pli.Expr"], "pli.Expr"]) -> "LazyFrame":
+    def with_columns(
+        self: LazyFrameType, exprs: Union[List["pli.Expr"], "pli.Expr"]
+    ) -> LazyFrameType:
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -1201,9 +1221,9 @@ class LazyFrame:
             elif isinstance(e, pli.Series):
                 pyexprs.append(pli.lit(e)._pyexpr)
 
-        return wrap_ldf(self._ldf.with_columns(pyexprs))
+        return self._from_pyldf(self._ldf.with_columns(pyexprs))
 
-    def with_column(self, expr: "pli.Expr") -> "LazyFrame":
+    def with_column(self: LazyFrameType, expr: "pli.Expr") -> LazyFrameType:
         """
         Add or overwrite column in a DataFrame.
 
@@ -1251,7 +1271,7 @@ class LazyFrame:
         """
         return self.with_columns([expr])
 
-    def drop(self, columns: Union[str, List[str]]) -> "LazyFrame":
+    def drop(self: LazyFrameType, columns: Union[str, List[str]]) -> LazyFrameType:
         """
         Remove one or multiple columns from a DataFrame.
 
@@ -1264,9 +1284,9 @@ class LazyFrame:
         """
         if isinstance(columns, str):
             columns = [columns]
-        return wrap_ldf(self._ldf.drop_columns(columns))
+        return self._from_pyldf(self._ldf.drop_columns(columns))
 
-    def rename(self, mapping: Dict[str, str]) -> "LazyFrame":
+    def rename(self: LazyFrameType, mapping: Dict[str, str]) -> LazyFrameType:
         """
         Rename column names.
 
@@ -1277,15 +1297,15 @@ class LazyFrame:
         """
         existing = list(mapping.keys())
         new = list(mapping.values())
-        return wrap_ldf(self._ldf.rename(existing, new))
+        return self._from_pyldf(self._ldf.rename(existing, new))
 
-    def reverse(self) -> "LazyFrame":
+    def reverse(self: LazyFrameType) -> LazyFrameType:
         """
         Reverse the DataFrame.
         """
-        return wrap_ldf(self._ldf.reverse())
+        return self._from_pyldf(self._ldf.reverse())
 
-    def shift(self, periods: int) -> "LazyFrame":
+    def shift(self: LazyFrameType, periods: int) -> LazyFrameType:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with `Nones`.
@@ -1332,11 +1352,13 @@ class LazyFrame:
         └──────┴──────┘
 
         """
-        return wrap_ldf(self._ldf.shift(periods))
+        return self._from_pyldf(self._ldf.shift(periods))
 
     def shift_and_fill(
-        self, periods: int, fill_value: Union["pli.Expr", int, str, float]
-    ) -> "LazyFrame":
+        self: LazyFrameType,
+        periods: int,
+        fill_value: Union["pli.Expr", int, str, float],
+    ) -> LazyFrameType:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.
@@ -1387,9 +1409,9 @@ class LazyFrame:
         """
         if not isinstance(fill_value, pli.Expr):
             fill_value = pli.lit(fill_value)
-        return wrap_ldf(self._ldf.shift_and_fill(periods, fill_value._pyexpr))
+        return self._from_pyldf(self._ldf.shift_and_fill(periods, fill_value._pyexpr))
 
-    def slice(self, offset: int, length: int) -> "LazyFrame":
+    def slice(self: LazyFrameType, offset: int, length: int) -> LazyFrameType:
         """
         Slice the DataFrame.
 
@@ -1424,9 +1446,9 @@ class LazyFrame:
         └─────┴─────┴─────┘
 
         """
-        return wrap_ldf(self._ldf.slice(offset, length))
+        return self._from_pyldf(self._ldf.slice(offset, length))
 
-    def limit(self, n: int) -> "LazyFrame":
+    def limit(self: LazyFrameType, n: int) -> LazyFrameType:
         """
         Limit the DataFrame to the first `n` rows. Note if you don't want the rows to be scanned,
         use the `fetch` operation.
@@ -1438,7 +1460,7 @@ class LazyFrame:
         """
         return self.slice(0, n)
 
-    def head(self, n: int) -> "LazyFrame":
+    def head(self: LazyFrameType, n: int) -> LazyFrameType:
         """
         Gets the first `n` rows of the DataFrame. You probably don't want to use this!
 
@@ -1454,7 +1476,7 @@ class LazyFrame:
         """
         return self.limit(n)
 
-    def tail(self, n: int) -> "LazyFrame":
+    def tail(self: LazyFrameType, n: int) -> LazyFrameType:
         """
         Get the last `n` rows of the DataFrame.
 
@@ -1463,21 +1485,23 @@ class LazyFrame:
         n
             Number of rows.
         """
-        return wrap_ldf(self._ldf.tail(n))
+        return self._from_pyldf(self._ldf.tail(n))
 
-    def last(self) -> "LazyFrame":
+    def last(self: LazyFrameType) -> LazyFrameType:
         """
         Get the last row of the DataFrame.
         """
         return self.tail(1)
 
-    def first(self) -> "LazyFrame":
+    def first(self: LazyFrameType) -> LazyFrameType:
         """
         Get the first row of the DataFrame.
         """
         return self.slice(0, 1)
 
-    def with_row_count(self, name: str = "row_nr", offset: int = 0) -> "LazyFrame":
+    def with_row_count(
+        self: LazyFrameType, name: str = "row_nr", offset: int = 0
+    ) -> LazyFrameType:
         """
         Add a column at index 0 that counts the rows.
 
@@ -1516,9 +1540,11 @@ class LazyFrame:
         └────────┴─────┴─────┘
 
         """
-        return wrap_ldf(self._ldf.with_row_count(name, offset))
+        return self._from_pyldf(self._ldf.with_row_count(name, offset))
 
-    def fill_null(self, fill_value: Union[int, str, "pli.Expr"]) -> "LazyFrame":
+    def fill_null(
+        self: LazyFrameType, fill_value: Union[int, str, "pli.Expr"]
+    ) -> LazyFrameType:
         """
         Fill missing values with a literal or Expr.
 
@@ -1529,9 +1555,11 @@ class LazyFrame:
         """
         if not isinstance(fill_value, pli.Expr):
             fill_value = pli.lit(fill_value)
-        return wrap_ldf(self._ldf.fill_null(fill_value._pyexpr))
+        return self._from_pyldf(self._ldf.fill_null(fill_value._pyexpr))
 
-    def fill_nan(self, fill_value: Union[int, str, float, "pli.Expr"]) -> "LazyFrame":
+    def fill_nan(
+        self: LazyFrameType, fill_value: Union[int, str, float, "pli.Expr"]
+    ) -> LazyFrameType:
         """
         Fill floating point NaN values.
 
@@ -1548,59 +1576,62 @@ class LazyFrame:
         """
         if not isinstance(fill_value, pli.Expr):
             fill_value = pli.lit(fill_value)
-        return wrap_ldf(self._ldf.fill_nan(fill_value._pyexpr))
+        return self._from_pyldf(self._ldf.fill_nan(fill_value._pyexpr))
 
-    def std(self) -> "LazyFrame":
+    def std(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their standard deviation value.
         """
-        return wrap_ldf(self._ldf.std())
+        return self._from_pyldf(self._ldf.std())
 
-    def var(self) -> "LazyFrame":
+    def var(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their variance value.
         """
-        return wrap_ldf(self._ldf.var())
+        return self._from_pyldf(self._ldf.var())
 
-    def max(self) -> "LazyFrame":
+    def max(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their maximum value.
         """
-        return wrap_ldf(self._ldf.max())
+        return self._from_pyldf(self._ldf.max())
 
-    def min(self) -> "LazyFrame":
+    def min(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their minimum value.
         """
-        return wrap_ldf(self._ldf.min())
+        return self._from_pyldf(self._ldf.min())
 
-    def sum(self) -> "LazyFrame":
+    def sum(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their sum value.
         """
-        return wrap_ldf(self._ldf.sum())
+        return self._from_pyldf(self._ldf.sum())
 
-    def mean(self) -> "LazyFrame":
+    def mean(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their mean value.
         """
-        return wrap_ldf(self._ldf.mean())
+        return self._from_pyldf(self._ldf.mean())
 
-    def median(self) -> "LazyFrame":
+    def median(self: LazyFrameType) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their median value.
         """
-        return wrap_ldf(self._ldf.median())
+        return self._from_pyldf(self._ldf.median())
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> "LazyFrame":
+    def quantile(
+        self: LazyFrameType, quantile: float, interpolation: str = "nearest"
+    ) -> LazyFrameType:
         """
         Aggregate the columns in the DataFrame to their quantile value.
         """
-        return wrap_ldf(self._ldf.quantile(quantile, interpolation))
+        return self._from_pyldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(
-        self, columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]]
-    ) -> "LazyFrame":
+        self: LazyFrameType,
+        columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
+    ) -> LazyFrameType:
         """
         Explode lists to long format.
 
@@ -1660,14 +1691,14 @@ class LazyFrame:
 
         """
         columns = pli.selection_to_pyexpr_list(columns)
-        return wrap_ldf(self._ldf.explode(columns))
+        return self._from_pyldf(self._ldf.explode(columns))
 
     def distinct(
-        self,
+        self: LazyFrameType,
         maintain_order: bool = True,
         subset: Optional[Union[str, List[str]]] = None,
         keep: str = "first",
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Drop duplicate rows from this DataFrame.
         Note that this fails if there is a column of type `List` in the DataFrame or subset.
@@ -1687,9 +1718,11 @@ class LazyFrame:
         """
         if subset is not None and not isinstance(subset, list):
             subset = [subset]
-        return wrap_ldf(self._ldf.distinct(maintain_order, subset, keep))
+        return self._from_pyldf(self._ldf.distinct(maintain_order, subset, keep))
 
-    def drop_nulls(self, subset: Optional[Union[List[str], str]] = None) -> "LazyFrame":
+    def drop_nulls(
+        self: LazyFrameType, subset: Optional[Union[List[str], str]] = None
+    ) -> LazyFrameType:
         """
         Drop rows with null values from this DataFrame.
 
@@ -1767,13 +1800,13 @@ class LazyFrame:
         """
         if subset is not None and not isinstance(subset, list):
             subset = [subset]
-        return wrap_ldf(self._ldf.drop_nulls(subset))
+        return self._from_pyldf(self._ldf.drop_nulls(subset))
 
     def melt(
-        self,
+        self: LazyFrameType,
         id_vars: Optional[Union[str, List[str]]] = None,
         value_vars: Optional[Union[str, List[str]]] = None,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
 
@@ -1828,15 +1861,15 @@ class LazyFrame:
             value_vars = []
         if id_vars is None:
             id_vars = []
-        return wrap_ldf(self._ldf.melt(id_vars, value_vars))
+        return self._from_pyldf(self._ldf.melt(id_vars, value_vars))
 
     def map(
-        self,
+        self: LazyFrameType,
         f: Callable[[pli.DataFrame], pli.DataFrame],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         no_optimizations: bool = False,
-    ) -> "LazyFrame":
+    ) -> LazyFrameType:
         """
         Apply a custom function. It is important that the function returns a Polars DataFrame.
 
@@ -1854,9 +1887,11 @@ class LazyFrame:
         if no_optimizations:
             predicate_pushdown = False
             projection_pushdown = False
-        return wrap_ldf(self._ldf.map(f, predicate_pushdown, projection_pushdown))
+        return self._from_pyldf(
+            self._ldf.map(f, predicate_pushdown, projection_pushdown)
+        )
 
-    def interpolate(self) -> "LazyFrame":
+    def interpolate(self: LazyFrameType) -> LazyFrameType:
         """
         Interpolate intermediate values. The interpolation method is linear.
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -34,7 +34,7 @@ from polars.utils import _in_notebook, _prepare_row_count_args, _process_null_va
 # Used to type any type or subclass of LazyFrame.
 # Used to indicate when LazyFrame methods return the same type as self,
 # including sub-classes.
-LazyFrameType = TypeVar("LazyFrameType", bound="LazyFrame")
+LDF = TypeVar("LDF", bound="LazyFrame")
 
 
 def wrap_ldf(ldf: "PyLazyFrame") -> "LazyFrame":
@@ -68,14 +68,14 @@ class LazyFrame:
         self._ldf: PyLazyFrame
 
     @classmethod
-    def _from_pyldf(cls: Type[LazyFrameType], ldf: "PyLazyFrame") -> LazyFrameType:
+    def _from_pyldf(cls: Type[LDF], ldf: "PyLazyFrame") -> LDF:
         self = cls.__new__(cls)
         self._ldf = ldf
         return self
 
     @classmethod
     def scan_csv(
-        cls: Type[LazyFrameType],
+        cls: Type[LDF],
         file: str,
         has_header: bool = True,
         sep: str = ",",
@@ -95,7 +95,7 @@ class LazyFrame:
         skip_rows_after_header: int = 0,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         See Also: `pl.scan_csv`
         """
@@ -131,7 +131,7 @@ class LazyFrame:
 
     @classmethod
     def scan_parquet(
-        cls: Type[LazyFrameType],
+        cls: Type[LDF],
         file: str,
         n_rows: Optional[int] = None,
         cache: bool = True,
@@ -139,7 +139,7 @@ class LazyFrame:
         rechunk: bool = True,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         See Also: `pl.scan_parquet`
         """
@@ -157,14 +157,14 @@ class LazyFrame:
 
     @classmethod
     def scan_ipc(
-        cls: Type[LazyFrameType],
+        cls: Type[LDF],
         file: str,
         n_rows: Optional[int] = None,
         cache: bool = True,
         rechunk: bool = True,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         See Also: `pl.scan_ipc`
         """
@@ -334,7 +334,7 @@ class LazyFrame:
                 plt.show()
         return None
 
-    def inspect(self: LazyFrameType, fmt: str = "{}") -> LazyFrameType:
+    def inspect(self: LDF, fmt: str = "{}") -> LDF:
         """
         Prints the value that this node in the computation graph evaluates to and passes on the value.
 
@@ -359,10 +359,10 @@ class LazyFrame:
         return self.map(inspect, predicate_pushdown=True, projection_pushdown=True)
 
     def sort(
-        self: LazyFrameType,
+        self: LDF,
         by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
         reverse: Union[bool, List[bool]] = False,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Sort the DataFrame by:
 
@@ -526,13 +526,13 @@ class LazyFrame:
         """
         return self._ldf.columns()
 
-    def cache(self: LazyFrameType) -> LazyFrameType:
+    def cache(self: LDF) -> LDF:
         """
         Cache the result once the execution of the physical plan hits this node.
         """
         return self._from_pyldf(self._ldf.cache())
 
-    def filter(self: LazyFrameType, predicate: Union["pli.Expr", str]) -> LazyFrameType:
+    def filter(self: LDF, predicate: Union["pli.Expr", str]) -> LDF:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -584,11 +584,11 @@ class LazyFrame:
         return self._from_pyldf(self._ldf.filter(predicate._pyexpr))
 
     def select(
-        self: LazyFrameType,
+        self: LDF,
         exprs: Union[
             str, "pli.Expr", Sequence[str], Sequence["pli.Expr"], "pli.Series"
         ],
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Select columns from this DataFrame.
 
@@ -887,7 +887,7 @@ class LazyFrame:
         return LazyGroupBy(lgb)
 
     def join_asof(
-        self: LazyFrameType,
+        self: LDF,
         ldf: "LazyFrame",
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
@@ -900,7 +900,7 @@ class LazyFrame:
         tolerance: Optional[Union[str, int, float]] = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Perform an asof join. This is similar to a left-join except that we
         match on nearest key rather than equal keys.
@@ -1013,7 +1013,7 @@ class LazyFrame:
         )
 
     def join(
-        self: LazyFrameType,
+        self: LDF,
         ldf: "LazyFrame",
         left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
@@ -1025,7 +1025,7 @@ class LazyFrame:
         asof_by: Optional[Union[str, List[str]]] = None,
         asof_by_left: Optional[Union[str, List[str]]] = None,
         asof_by_right: Optional[Union[str, List[str]]] = None,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Add a join operation to the Logical Plan.
 
@@ -1199,9 +1199,7 @@ class LazyFrame:
             )
         )
 
-    def with_columns(
-        self: LazyFrameType, exprs: Union[List["pli.Expr"], "pli.Expr"]
-    ) -> LazyFrameType:
+    def with_columns(self: LDF, exprs: Union[List["pli.Expr"], "pli.Expr"]) -> LDF:
         """
         Add or overwrite multiple columns in a DataFrame.
 
@@ -1223,7 +1221,7 @@ class LazyFrame:
 
         return self._from_pyldf(self._ldf.with_columns(pyexprs))
 
-    def with_column(self: LazyFrameType, expr: "pli.Expr") -> LazyFrameType:
+    def with_column(self: LDF, expr: "pli.Expr") -> LDF:
         """
         Add or overwrite column in a DataFrame.
 
@@ -1271,7 +1269,7 @@ class LazyFrame:
         """
         return self.with_columns([expr])
 
-    def drop(self: LazyFrameType, columns: Union[str, List[str]]) -> LazyFrameType:
+    def drop(self: LDF, columns: Union[str, List[str]]) -> LDF:
         """
         Remove one or multiple columns from a DataFrame.
 
@@ -1286,7 +1284,7 @@ class LazyFrame:
             columns = [columns]
         return self._from_pyldf(self._ldf.drop_columns(columns))
 
-    def rename(self: LazyFrameType, mapping: Dict[str, str]) -> LazyFrameType:
+    def rename(self: LDF, mapping: Dict[str, str]) -> LDF:
         """
         Rename column names.
 
@@ -1299,13 +1297,13 @@ class LazyFrame:
         new = list(mapping.values())
         return self._from_pyldf(self._ldf.rename(existing, new))
 
-    def reverse(self: LazyFrameType) -> LazyFrameType:
+    def reverse(self: LDF) -> LDF:
         """
         Reverse the DataFrame.
         """
         return self._from_pyldf(self._ldf.reverse())
 
-    def shift(self: LazyFrameType, periods: int) -> LazyFrameType:
+    def shift(self: LDF, periods: int) -> LDF:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with `Nones`.
@@ -1355,10 +1353,10 @@ class LazyFrame:
         return self._from_pyldf(self._ldf.shift(periods))
 
     def shift_and_fill(
-        self: LazyFrameType,
+        self: LDF,
         periods: int,
         fill_value: Union["pli.Expr", int, str, float],
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.
@@ -1411,7 +1409,7 @@ class LazyFrame:
             fill_value = pli.lit(fill_value)
         return self._from_pyldf(self._ldf.shift_and_fill(periods, fill_value._pyexpr))
 
-    def slice(self: LazyFrameType, offset: int, length: int) -> LazyFrameType:
+    def slice(self: LDF, offset: int, length: int) -> LDF:
         """
         Slice the DataFrame.
 
@@ -1448,7 +1446,7 @@ class LazyFrame:
         """
         return self._from_pyldf(self._ldf.slice(offset, length))
 
-    def limit(self: LazyFrameType, n: int) -> LazyFrameType:
+    def limit(self: LDF, n: int) -> LDF:
         """
         Limit the DataFrame to the first `n` rows. Note if you don't want the rows to be scanned,
         use the `fetch` operation.
@@ -1460,7 +1458,7 @@ class LazyFrame:
         """
         return self.slice(0, n)
 
-    def head(self: LazyFrameType, n: int) -> LazyFrameType:
+    def head(self: LDF, n: int) -> LDF:
         """
         Gets the first `n` rows of the DataFrame. You probably don't want to use this!
 
@@ -1476,7 +1474,7 @@ class LazyFrame:
         """
         return self.limit(n)
 
-    def tail(self: LazyFrameType, n: int) -> LazyFrameType:
+    def tail(self: LDF, n: int) -> LDF:
         """
         Get the last `n` rows of the DataFrame.
 
@@ -1487,21 +1485,19 @@ class LazyFrame:
         """
         return self._from_pyldf(self._ldf.tail(n))
 
-    def last(self: LazyFrameType) -> LazyFrameType:
+    def last(self: LDF) -> LDF:
         """
         Get the last row of the DataFrame.
         """
         return self.tail(1)
 
-    def first(self: LazyFrameType) -> LazyFrameType:
+    def first(self: LDF) -> LDF:
         """
         Get the first row of the DataFrame.
         """
         return self.slice(0, 1)
 
-    def with_row_count(
-        self: LazyFrameType, name: str = "row_nr", offset: int = 0
-    ) -> LazyFrameType:
+    def with_row_count(self: LDF, name: str = "row_nr", offset: int = 0) -> LDF:
         """
         Add a column at index 0 that counts the rows.
 
@@ -1542,9 +1538,7 @@ class LazyFrame:
         """
         return self._from_pyldf(self._ldf.with_row_count(name, offset))
 
-    def fill_null(
-        self: LazyFrameType, fill_value: Union[int, str, "pli.Expr"]
-    ) -> LazyFrameType:
+    def fill_null(self: LDF, fill_value: Union[int, str, "pli.Expr"]) -> LDF:
         """
         Fill missing values with a literal or Expr.
 
@@ -1557,9 +1551,7 @@ class LazyFrame:
             fill_value = pli.lit(fill_value)
         return self._from_pyldf(self._ldf.fill_null(fill_value._pyexpr))
 
-    def fill_nan(
-        self: LazyFrameType, fill_value: Union[int, str, float, "pli.Expr"]
-    ) -> LazyFrameType:
+    def fill_nan(self: LDF, fill_value: Union[int, str, float, "pli.Expr"]) -> LDF:
         """
         Fill floating point NaN values.
 
@@ -1578,60 +1570,58 @@ class LazyFrame:
             fill_value = pli.lit(fill_value)
         return self._from_pyldf(self._ldf.fill_nan(fill_value._pyexpr))
 
-    def std(self: LazyFrameType) -> LazyFrameType:
+    def std(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their standard deviation value.
         """
         return self._from_pyldf(self._ldf.std())
 
-    def var(self: LazyFrameType) -> LazyFrameType:
+    def var(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their variance value.
         """
         return self._from_pyldf(self._ldf.var())
 
-    def max(self: LazyFrameType) -> LazyFrameType:
+    def max(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their maximum value.
         """
         return self._from_pyldf(self._ldf.max())
 
-    def min(self: LazyFrameType) -> LazyFrameType:
+    def min(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their minimum value.
         """
         return self._from_pyldf(self._ldf.min())
 
-    def sum(self: LazyFrameType) -> LazyFrameType:
+    def sum(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their sum value.
         """
         return self._from_pyldf(self._ldf.sum())
 
-    def mean(self: LazyFrameType) -> LazyFrameType:
+    def mean(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their mean value.
         """
         return self._from_pyldf(self._ldf.mean())
 
-    def median(self: LazyFrameType) -> LazyFrameType:
+    def median(self: LDF) -> LDF:
         """
         Aggregate the columns in the DataFrame to their median value.
         """
         return self._from_pyldf(self._ldf.median())
 
-    def quantile(
-        self: LazyFrameType, quantile: float, interpolation: str = "nearest"
-    ) -> LazyFrameType:
+    def quantile(self: LDF, quantile: float, interpolation: str = "nearest") -> LDF:
         """
         Aggregate the columns in the DataFrame to their quantile value.
         """
         return self._from_pyldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(
-        self: LazyFrameType,
+        self: LDF,
         columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Explode lists to long format.
 
@@ -1694,11 +1684,11 @@ class LazyFrame:
         return self._from_pyldf(self._ldf.explode(columns))
 
     def distinct(
-        self: LazyFrameType,
+        self: LDF,
         maintain_order: bool = True,
         subset: Optional[Union[str, List[str]]] = None,
         keep: str = "first",
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Drop duplicate rows from this DataFrame.
         Note that this fails if there is a column of type `List` in the DataFrame or subset.
@@ -1720,9 +1710,7 @@ class LazyFrame:
             subset = [subset]
         return self._from_pyldf(self._ldf.distinct(maintain_order, subset, keep))
 
-    def drop_nulls(
-        self: LazyFrameType, subset: Optional[Union[List[str], str]] = None
-    ) -> LazyFrameType:
+    def drop_nulls(self: LDF, subset: Optional[Union[List[str], str]] = None) -> LDF:
         """
         Drop rows with null values from this DataFrame.
 
@@ -1803,10 +1791,10 @@ class LazyFrame:
         return self._from_pyldf(self._ldf.drop_nulls(subset))
 
     def melt(
-        self: LazyFrameType,
+        self: LDF,
         id_vars: Optional[Union[str, List[str]]] = None,
         value_vars: Optional[Union[str, List[str]]] = None,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
 
@@ -1864,12 +1852,12 @@ class LazyFrame:
         return self._from_pyldf(self._ldf.melt(id_vars, value_vars))
 
     def map(
-        self: LazyFrameType,
+        self: LDF,
         f: Callable[[pli.DataFrame], pli.DataFrame],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         no_optimizations: bool = False,
-    ) -> LazyFrameType:
+    ) -> LDF:
         """
         Apply a custom function. It is important that the function returns a Polars DataFrame.
 
@@ -1891,7 +1879,7 @@ class LazyFrame:
             self._ldf.map(f, predicate_pushdown, projection_pushdown)
         )
 
-    def interpolate(self: LazyFrameType) -> LazyFrameType:
+    def interpolate(self: LDF) -> LDF:
         """
         Interpolate intermediate values. The interpolation method is linear.
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 try:
-    from polars.polars import PyDataFrame, PyExpr, PyLazyFrame, PyLazyGroupBy
+    from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
 
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover
@@ -29,7 +29,6 @@ except ImportError:  # pragma: no cover
 from polars import internals as pli
 from polars.datatypes import DataType, py_type_to_dtype
 from polars.utils import _in_notebook, _prepare_row_count_args, _process_null_values
-
 
 # Used to type any type or subclass of LazyFrame.
 # Used to indicate when LazyFrame methods return the same type as self,

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1879,3 +1879,21 @@ def test_join_suffixes() -> None:
         df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
 
     df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
+
+
+def test_preservation_of_subclasses() -> None:
+    """Tests for DataFrame inheritance."""
+
+    # We should be able to inherit from polars.DataFrame
+    class SubClassedDataFrame(pl.DataFrame):
+        pass
+
+    # The constructor creates an object which is an instance of both the
+    # superclass and subclass
+    df = SubClassedDataFrame({"column_1": [1, 2, 3]})
+    assert isinstance(df, pl.DataFrame)
+    assert isinstance(df, SubClassedDataFrame)
+
+    # Methods which yield new dataframes should preserve the subclass,
+    # and here we choose a random method to test with
+    assert isinstance(df.transpose(), SubClassedDataFrame)

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1179,3 +1179,19 @@ def test_self_join() -> None:
         (101, "Alice", "James"),
         (102, "Bob", "Alice"),
     }
+
+
+def test_preservation_of_subclasses() -> None:
+    """Tests for LazyFrame inheritance."""
+
+    # We should be able to inherit from polars.LazyFrame
+    class SubClassedLazyFrame(pl.LazyFrame):
+        pass
+
+    # The constructor creates an object which is an instance of both the
+    # superclass and subclass
+    ldf = pl.DataFrame({"column_1": [1, 2, 3]}).lazy()
+    ldf.__class__ = SubClassedLazyFrame
+    extended_ldf = ldf.with_column(pl.lit(1).alias("column_2"))
+    assert isinstance(extended_ldf, pl.LazyFrame)
+    assert isinstance(extended_ldf, SubClassedLazyFrame)


### PR DESCRIPTION
# Preserve types of DataFrame subclasses

TL;DR: This PR introduces the necessary changes such that all methods of `DataFrame` and `LazyFrame` which return a new `DataFrame` or `LazyFrame` objects, respectively, preserve the type when these classes have been inherited from.

This PR implements solutions for tasks 1-3 as outlined in #2846. Preservation of data types after roundtrips from `DataFrame` to `GroupBy`/`LazyFrame` and back still remains to be done as well. I have a solution in mind for task 4 and 5 as outlined in the issue, but I will introduce that one in a separate PR in order to make the review process a bit simpler ☺️ 

Here is an outline of what has been done in this PR:

## Replacing the use of `wrap_df`

A lot of methods on `polars.DataFrame` that return new `DataFrame` objects follow the following pattern:

1. Delegate to `PyDataFrame` method on `self._df`.
2. Return new `DataFrame` object by wrapping the resulting `PyDataFrame` with `wrap_df`.

The problem is how `wrap_df` knows nothing about the original `DataFrame` type and must therefore use the `DataFrame._from_df` constructor. My solution is to replace the following call-stack:

* `self.X()` -> `wrap_df()` -> `DataFrame._from_pydf()`

With the following call-stack:

* `self.X()` -> `self._from_pydf()`

With other words, I have removed the use of `wrap_df()` altogether. The next step is then to make `DataFrame._from_pydf()` preserve the type of `self` with the following implementation.

```py
class DataFrame:
    ...

    @classmethod
    def _from_pydf(cls: Type[DataFrameType], py_df: "PyDataFrame") -> DataFrameType:
        """
        Construct Polars DataFrame from FFI PyDataFrame object.
        """
        df = cls.__new__(cls)
        df._df = py_df
        return df
```

The same as :point_up: has been done for `LazyFrame`, replacing invocations of `wrap_ldf` with `self._from_pyldf()`.

## Replacing hard-coded return type annotations with dynamic ones

Take the following type annotation:

```py
class DataFrame:
    ...
    def join(self, other: "DataFrame", ...) -> "DataFrame": ...
```

This type annotation becomes wrong for subclasses of `DataFrame` since the return type is hard-coded to `DataFrame`. Until [PEP 673 -- Self Type](https://www.python.org/dev/peps/pep-0673/) is usable, the solution is to define a type variable:

```
# A type variable used to refer to a polars.DataFrame or any subclass of it.
# Used to annotate DataFrame methods which returns the same type as self.
DataFrameType = TypeVar("DataFrameType", bound="DataFrame")
```

This type, `DataFrameType`, references `DataFrame`, but also any sub-type of of `DataFrame`. We can now type annotate `DataFrame.join()` in the following way:

```py
class DataFrame:
    ...
    def join(self: DataFrameType, other: "DataFrame", ...) -> DataFrameType: ...
```

This annotation says basically the following:

* The return type is the _exact_ same type as `self`.
* The `other` parameter can have any type or sub-type of `DataFrame`, but not necessarily the same type as `self`.

This allows users to join sub-classes with regular `polars.DataFrame` objects, mixing and matching as desired. The return type will be the same as the "left object", i.e. `x.join(y)` will yield the type of `x`, not `y`. That is why `DataFrame` is used to annotate `other`, not `DataFrameType`.

Most documentation for the `mypy` library and the `typing` stdlib module use _really_ short variable names for `TypeVar` annotations. See [here](https://docs.python.org/3/library/typing.html#typing.TypeVar) for examples. I, on the other hand, have usually opted for longer names in my code, but we might consider using shorter ones here as well. I guess `DataFrameType` could be simply renamed to `DF`, and likewise for `LazyFrameType` to `LDF`, or something like that. I will leave that decision up to you, and possibly implement the necessary changes if required ☺️ 

Sorry for the wall of text; thanks for taking the time to review this PR 🙇 