### PR TITLE
Preserve DataFrame type after LazyFrame roundtrips

### DIFF
--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -4,9 +4,8 @@ The modules within `polars.internals` are interdependent. To prevent cyclical im
 via this __init__ file using `import polars.internals as pli`. The imports below are being shared across this module.
 """
 from .expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
-from .frame import DataFrame, wrap_df
+from .frame import DataFrame, LazyFrame, wrap_df, wrap_ldf
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
-from .lazy_frame import LazyFrame, wrap_ldf
 from .lazy_functions import all, argsort_by, col, concat_list, lit, select
 from .series import Series, wrap_s
 from .whenthen import when  # used in expr.clip()

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3133,7 +3133,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel.
         """
-        return self._from_pydf(
+        return (
             self.lazy()
             .join_asof(
                 df.lazy(),
@@ -3150,7 +3150,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 force_parallel=force_parallel,
             )
             .collect(no_optimization=True)
-            ._df
         )
 
     def join(
@@ -3283,7 +3282,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             or asof_by_right is not None
             or asof_by is not None
         ):
-            return self._from_pydf(
+            return (
                 self.lazy()
                 .join(
                     df.lazy(),
@@ -3297,7 +3296,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
                     asof_by=asof_by,
                 )
                 .collect(no_optimization=True)
-                ._df
             )
         else:
             return self._from_pydf(
@@ -3669,9 +3667,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             DataFrame with None values replaced by the filling strategy.
         """
         if isinstance(strategy, pli.Expr):
-            return self._from_pydf(
-                self.lazy().fill_null(strategy).collect(no_optimization=True)._df
-            )
+            return self.lazy().fill_null(strategy).collect(no_optimization=True)
         if not isinstance(strategy, str):
             return self.fill_null(pli.lit(strategy))
         return self._from_pydf(self._df.fill_null(strategy))
@@ -3694,9 +3690,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         -------
             DataFrame with NaN replaced with fill_value
         """
-        return self._from_pydf(
-            self.lazy().fill_nan(fill_value).collect(no_optimization=True)._df
-        )
+        return self.lazy().fill_nan(fill_value).collect(no_optimization=True)
 
     def explode(
         self: DF,
@@ -3768,9 +3762,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────────┴─────┘
 
         """
-        return self._from_pydf(
-            self.lazy().explode(columns).collect(no_optimization=True)._df
-        )
+        return self.lazy().explode(columns).collect(no_optimization=True)
 
     def pivot(
         self: DF,
@@ -3992,11 +3984,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴─────┴─────┘
 
         """
-        return self._from_pydf(
+        return (
             self.lazy()
             .shift_and_fill(periods, fill_value)
             .collect(no_optimization=True, string_cache=False)
-            ._df
         )
 
     def is_duplicated(self) -> "pli.Series":
@@ -4108,11 +4099,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┘
 
         """
-        return self._from_pydf(
+        return (
             self.lazy()
             .select(exprs)  # type: ignore
             .collect(no_optimization=True, string_cache=False)
-            ._df
         )
 
     def with_columns(self: DF, exprs: Union["pli.Expr", List["pli.Expr"]]) -> DF:
@@ -4126,11 +4116,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         if not isinstance(exprs, list):
             exprs = [exprs]
-        return self._from_pydf(
+        return (
             self.lazy()
             .with_columns(exprs)
             .collect(no_optimization=True, string_cache=False)
-            ._df
         )
 
     def n_chunks(self) -> int:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -51,6 +51,8 @@ from polars.internals.construction import (
     series_to_pydf,
 )
 
+from .lazy_frame import LazyFrame, wrap_ldf  # noqa: F401
+
 try:
     from polars.polars import PyDataFrame, PySeries
 
@@ -98,7 +100,75 @@ def _prepare_other_arg(other: Any) -> "pli.Series":
     return other
 
 
-class DataFrame:
+class DataFrameMetaClass(type):
+    """
+    Custom metaclass for DataFrame class.
+
+    This metaclass is responsible for constructing the relationship between the
+    DataFrame class and the LazyFrame class. Originally, without inheritance, the
+    relationship is as follows:
+
+    DataFrame <-> LazyFrame
+
+    This two-way relationship is represented by the following pointers:
+        - cls._lazyframe_class: A pointer on the DataFrame (sub)class to a LazyFrame
+            (sub)class. This class property can be used in DataFrame methods in order
+            to construct new lazy dataframes.
+        - cls._lazyframe_class._dataframe_class: A pointer on the LazyFrame (sub)class
+            back to the original DataFrame (sub)class. This allows LazyFrame methods to
+            construct new non-lazy dataframes with the correct type. This pointer should
+            always be set to cls such that the following is always `True`:
+                `type(cls) is type(cls.lazy().collect())`.
+
+    If an end user subclasses DataFrame like so:
+
+    >>> class MyDataFrame(pl.DataFrame):
+    ...     pass
+    ...
+
+    Then the following class is dynamically created by the metaclass and saved on the
+    class variable `MyDataFrame._lazyframe_class`.
+
+    >>> class LazyMyDataFrame(pl.DataFrame):
+    ...     _dataframe_class = MyDataFrame
+    ...
+
+    If an end user needs to extend both `DataFrame` and `LazyFrame`, it can be done like
+    so:
+
+    >>> class MyLazyFrame(pl.LazyFrame):
+    ...     @classmethod
+    ...     @property
+    ...     def _dataframe_class(cls):
+    ...         return MyDataFrame
+    ...
+
+    >>> class MyDataFrame(pl.DataFrame):
+    ...     _lazyframe_class = MyLazyFrame
+    ...
+
+    """
+
+    def __init__(cls, name: str, bases: tuple, clsdict: dict) -> None:
+        """Construct new DataFrame class."""
+        if not bases:
+            # This is not a subclass of DataFrame and we can simply hard-link to
+            # LazyFrame instead of dynamically defining a new subclass of LazyFrame.
+            cls._lazyframe_class = LazyFrame
+        elif cls._lazyframe_class is LazyFrame:
+            # This is a subclass of DataFrame which has *not* specified a custom
+            # LazyFrame subclass by setting `cls._lazyframe_class`. We must therefore
+            # dynamically create a subclass of LazyFrame with `_dataframe_class` set
+            # to `cls` in order to preserve types after `.lazy().collect()` roundtrips.
+            cls._lazyframe_class = type(  # type: ignore
+                f"Lazy{name}",
+                (LazyFrame,),
+                {"_dataframe_class": cls},
+            )
+        super().__init__(name, bases, clsdict)
+
+
+class DataFrame(metaclass=DataFrameMetaClass):
     """
     A DataFrame is a two-dimensional data structure that represents data as a table
     with rows and columns.
@@ -1610,9 +1680,7 @@ class DataFrame:
         └───────┴─────┴─────┘
 
         """
-        return self._from_pydf(
-            self.lazy().rename(mapping).collect(no_optimization=True)._df
-        )
+        return self.lazy().rename(mapping).collect(no_optimization=True)
 
     def insert_at_idx(self, index: int, series: "pli.Series") -> None:
         """
@@ -1674,11 +1742,10 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return self._from_pydf(
+        return (
             self.lazy()
             .filter(predicate)
             .collect(no_optimization=True, string_cache=False)
-            ._df
         )
 
     @property
@@ -2028,12 +2095,11 @@ class DataFrame:
                 self.lazy()
                 .sort(by, reverse)
                 .collect(no_optimization=True, string_cache=False)
-                ._df
             )
             if in_place:
-                self._df = df
+                self._df = df._df
                 return self
-            return self._from_pydf(df)
+            return df
         if in_place:
             self._df.sort_in_place(by, reverse)
             return None
@@ -3985,7 +4051,7 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.is_unique())
 
-    def lazy(self) -> "pli.LazyFrame":
+    def lazy(self: DF) -> "pli.LazyFrame[DF]":
         """
         Start a lazy query from this point. This returns a `LazyFrame` object.
 
@@ -3999,7 +4065,7 @@ class DataFrame:
 
         Lazy operations are advised because they allow for query optimization and more parallelization.
         """
-        return pli.wrap_ldf(self._df.lazy())
+        return self._lazyframe_class._from_pyldf(self._df.lazy())
 
     def select(
         self: DF,


### PR DESCRIPTION
# Preserve inheritance on `DataFrame.lazy().collect()` roundtrips

The following test will currently fail:

```py
import polars as pl

class MyDataFrame(pl.DataFrame):
    pass

assert isinstance(MyDataFrame().lazy().collect(), MyDataFrame)
```

The main reason is that `DataFrame.lazy()` is "forced" to create a new instance of `LazyFrame` which has no notion of which class or subclass of `DataFrame` that originally spawned it.

## Solution

A solution to this issue is to store a pointer in the `LazyFrame` instance to the original `DataFrame` (sub)class that created it. It has the following definition:

* `LazyFrame._dataframe_class` - A pointer to a `DataFrame` class or subclass which must be used whenever a `LazyFrame` must construct a new `DataFrame` instance.

By default, this class variable is hard-coded to `DataFrame` as a class property:

```py
assert pl.LazyFrame()._dataframe_class is pl.DataFrame
```

But for any _subclass_ of `pl.DataFrame`, for example `MyDataFrame`, must use a sub-class of `pl.LazyFrame` where `LazyFrame._dataframe_class` is set to `MyDataFrame` and not `pl.DataFrame`. For this reason, each class or subclass of `pl.DataFrame` has a class variable `_lazyframe_class` set to a class or subclass of `pl.LazyFrame` with a correct value for `_lazyframe_class._dataframe_class`.

* `DataFrame._lazyframe_class` - A pointer to a `LazyFrame` class or subclass which must be used whenever a `DataFrame` must construct a new `LazyFrame` instance.

This is where the logic starts to become pretty circular, but take the following (now passing) test as an example:

```py
assert pl.DataFrame._lazyframe_class is pl.LazyFrame


class MyDataFrame(pl.DataFrame):
    pass


assert MyDataFrame._lazyframe_class._dataframe_class is MyDataFrame
assert isinstance(MyDataFrame().lazy().collect(), MyDataFrame)
```

The end result is that `DataFrame` subclasses are able to spawn `LazyFrame` subclasses which are able to spawn the original `DataFrame` subclasses :recycle: This magic is achieved by specifying a custom metaclass for `DataFrame` as defined [here](https://github.com/JakobGM/polars/blob/b78965e206f0b9fa3e11913bea2555679b11aff3/py-polars/polars/internals/frame.py#L102-L162). `MyDataFrame` automatically gets a custom subclass of `LazyFrame` named `LazyMyDataFrame` which is then stored on `MyDataFrame._lazyframe_class`.

## Allowing end users to extend `pl.LazyFrame`

By default, if an end user extends the functionality of `pl.DataFrame` by inheriting from it, then a custom subclass of `pl.LazyFrame` is created. The only "task" of this subclass is to return the correct `DataFrame` type when casted back into a non-lazy representation. If an end user needs to extend the functionality of `pl.LazyFrame` in addition to `pl.DataFrame`, and must therefore connect these two classes together, it can be done in the following manner:

```py
class MyLazyFrame(pl.LazyFrame):
    @property
    def _dataframe_class(self):
        return MyDataFrame

class MyDataFrame(pl.DataFrame):
    _lazyframe_class = MyLazyFrame

assert isinstance(MyDataFrame().lazy(), MyLazyFrame)
assert isinstance(MyDataFrame().lazy().collect(), MyDataFrame)
```

The reason for the `@property` is to work around the circular references between these two classes.

In the future, if polars would like to _officially_ support extension through inheritance, these class variables `_lazyframe_class` and `_dataframe_class` can be renamed to `lazyframe_class` and `dataframe_class` in order to communicate that these variables are public API. Pydantic's [Model Config class](https://pydantic-docs.helpmanual.io/usage/model_config/) and Django's [Meta class](https://docs.djangoproject.com/en/4.0/topics/db/models/#meta-options) could be API patterns to replicate as well, moving these configuration variables into a nested configuration class.

## Type annotations

Now that the type of `MyDataFrame().lazy().collect()` is correct, we must also provide enough information to type checkers so that they understand this reality:

```py
reveal_type(MyDataFrame().lazy().collect())  # MyDataFrame, not DataFrame
```

In order to achieve this, we must be able to annotate that a given instance of `LazyFrame` is associated to a specific subclass of `DataFrame`. The solution to this problem is [generics](https://mypy.readthedocs.io/en/stable/generics.html). In the same way that you can indicate that a list `x` contains integers by writing `x: list[int]`, making the type checker understand that the return type of `x.pop()` is `int`, we should be able to annotate a lazy dataframe as `ldf: LazyFrame[MyDataFrame]` in order to specify that the return type of `ldf.collect()` is `MyDataFrame` and not `DataFrame`.

```py
reveal_type(MyDataFrame().lazy())  # LazyFrame[MyDataFrame]
```

The solution is to let `LazyFrame` inherit from `typing.Generic` in the following way:

```py
class LazyFrame(Generic[DF]):
    ...

    def collect(self, ...) -> DF:
```

And then type annotate `DataFrame` in the following way.

```py
class DataFrame(...):
    ...

    def lazy(self: DF, ...) -> LazyFrame[DF]:
        ...
```


## Restructuring of imports

Since how a custom subclass of `LazyFrame` must be created at import-time of `DataFrame` (see the implementation of `DataFrameMetaClass`), we must import `polars.internals.lazy_frame.LazyFrame` from `polars.internals.frame`. I have restructured the imports such that `polars.internal` imports all the `lazy_frame` symbols _through_ `frame` instead.