### PR TITLE
split exact expression

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -296,6 +296,7 @@ The following methods are available under the `Expr.str` attribute.
     ExprStringNameSpace.json_path_match
     ExprStringNameSpace.extract
     ExprStringNameSpace.split
+    ExprStringNameSpace.split_exact
     ExprStringNameSpace.replace
     ExprStringNameSpace.replace_all
     ExprStringNameSpace.slice

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -252,6 +252,7 @@ The following methods are available under the `Series.str` attribute.
     StringNameSpace.json_path_match
     StringNameSpace.extract
     StringNameSpace.split
+    StringNameSpace.split_exact
     StringNameSpace.replace
     StringNameSpace.replace_all
     StringNameSpace.to_lowercase

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3587,6 +3587,52 @@ class ExprStringNameSpace:
             return wrap_expr(self._pyexpr.str_split_inclusive(by))
         return wrap_expr(self._pyexpr.str_split(by))
 
+    def split_exact(self, by: str, n: int, inclusive: bool = False) -> Expr:
+        """
+        Split the string by a substring into a struct of `n` fields.
+        The return type will by of type Struct<Utf8>
+
+        If it cannot make `n` splits, the remaiming field elements will be null
+
+        Parameters
+        ----------
+        by
+            substring
+        n
+            Number of splits to make
+        inclusive
+            Include the split character/string in the results
+
+        Examples
+        --------
+
+        >>> (
+        ...     pl.DataFrame({"x": ["a_1", None, "c", "d_4"]}).select(
+        ...         [
+        ...             pl.col("x").str.split_exact("_", 2).alias("fields"),
+        ...         ]
+        ...     )
+        ... )
+        shape: (4, 1)
+        ┌───────────────────────────────────────────┐
+        │ fields                                    │
+        │ ---                                       │
+        │ struct[2]{'field_0': str, 'field_1': str} │
+        ╞═══════════════════════════════════════════╡
+        │ {"a","1"}                                 │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {null,null}                               │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {"c",null}                                │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {"d","4"}                                 │
+        └───────────────────────────────────────────┘
+
+        """
+        if inclusive:
+            return wrap_expr(self._pyexpr.str_split_exact_inclusive(by, n))
+        return wrap_expr(self._pyexpr.str_split_exact(by, n))
+
     def replace(self, pattern: str, value: str) -> Expr:
         """
         Replace first regex match with a string value.

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3868,6 +3868,55 @@ class StringNameSpace:
         s = wrap_s(self._s)
         return s.to_frame().select(pli.col(s.name).str.split(by, inclusive)).to_series()
 
+    def split_exact(self, by: str, n: int, inclusive: bool = False) -> Series:
+        """
+        Split the string by a substring into a struct of `n` fields.
+        The return type will by of type Struct<Utf8>
+
+        If it cannot make `n` splits, the remaiming field elements will be null
+
+        Parameters
+        ----------
+        by
+            substring
+        n
+            Number of splits to make
+        inclusive
+            Include the split character/string in the results
+
+        Examples
+        --------
+
+        >>> (
+        ...     pl.DataFrame({"x": ["a_1", None, "c", "d_4"]}).select(
+        ...         [
+        ...             pl.col("x").str.split_exact("_", 2).alias("fields"),
+        ...         ]
+        ...     )
+        ... )
+        shape: (4, 1)
+        ┌───────────────────────────────────────────┐
+        │ fields                                    │
+        │ ---                                       │
+        │ struct[2]{'field_0': str, 'field_1': str} │
+        ╞═══════════════════════════════════════════╡
+        │ {"a","1"}                                 │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {null,null}                               │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {"c",null}                                │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ {"d","4"}                                 │
+        └───────────────────────────────────────────┘
+
+        """
+        s = wrap_s(self._s)
+        return (
+            s.to_frame()
+            .select(pli.col(s.name).str.split_exact(by, n, inclusive))
+            .to_series()
+        )
+
     def replace(self, pattern: str, value: str) -> Series:
         """
         Replace first regex match with a string value.

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -592,6 +592,13 @@ impl PyExpr {
         self.inner.clone().str().split_inclusive(by).into()
     }
 
+    pub fn str_split_exact(&self, by: &str, n: usize) -> PyExpr {
+        self.inner.clone().str().split_exact(by, n).into()
+    }
+    pub fn str_split_exact_inclusive(&self, by: &str, n: usize) -> PyExpr {
+        self.inner.clone().str().split_exact_inclusive(by, n).into()
+    }
+
     pub fn arr_lengths(&self) -> PyExpr {
         self.inner.clone().arr().lengths().into()
     }


### PR DESCRIPTION
```python
>>> (
...     pl.DataFrame({"x": ["a_1", None, "c", "d_4"]}).select(
...         [
...             pl.col("x").str.split_exact("_", 2).alias("fields"),
...         ]
...     )
... )
shape: (4, 1)
┌───────────────────────────────────────────┐
│ fields                                    │
│ ---                                       │
│ struct[2]{'field_0': str, 'field_1': str} │
╞═══════════════════════════════════════════╡
│ {"a","1"}                                 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ {null,null}                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ {"c",null}                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ {"d","4"}                                 │
└───────────────────────────────────────────┘
```