### PR TITLE
improve datetime inference

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -89,6 +89,7 @@ impl CategoricalChunked {
     }
 
     /// Retrieve the indexes need to sort this and the other arrays.
+    #[cfg(feature = "sort_multiple")]
     pub(crate) fn argsort_multiple(&self, other: &[Series], reverse: &[bool]) -> Result<IdxCa> {
         if self.use_lexical_sort() {
             args_validate(self.logical(), other, reverse)?;

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -29,7 +29,7 @@ decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng-compat"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
 # don't use this
-private = []
+private = ["polars-time/private"]
 
 [dependencies]
 ahash = "0.7"

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -49,10 +49,10 @@ use crate::utils::resolve_homedir;
 use crate::{RowCount, SerReader, SerWriter};
 pub use arrow::io::csv::write;
 use polars_core::prelude::*;
+#[cfg(feature = "temporal")]
 use polars_time::prelude::*;
 #[cfg(feature = "temporal")]
 use rayon::prelude::*;
-#[cfg(feature = "temporal")]
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Write;
@@ -225,7 +225,6 @@ where
     aggregate: Option<&'a [ScanAggregation]>,
     quote_char: Option<u8>,
     skip_rows_after_header: usize,
-    #[cfg(feature = "temporal")]
     parse_dates: bool,
     row_count: Option<RowCount>,
 }
@@ -393,7 +392,6 @@ where
     }
 
     /// Automatically try to parse dates/ datetimes and time. If parsing fails, columns remain of dtype `[DataType::Utf8]`.
-    #[cfg(feature = "temporal")]
     pub fn with_parse_dates(mut self, toggle: bool) -> Self {
         self.parse_dates = toggle;
         self
@@ -452,7 +450,6 @@ where
             aggregate: None,
             quote_char: Some(b'"'),
             skip_rows_after_header: 0,
-            #[cfg(feature = "temporal")]
             parse_dates: false,
             row_count: None,
         }
@@ -534,6 +531,7 @@ where
                 &to_cast,
                 self.skip_rows_after_header,
                 self.row_count,
+                self.parse_dates,
             )?;
             csv_reader.as_df()?
         } else {
@@ -564,6 +562,7 @@ where
                 &[],
                 self.skip_rows_after_header,
                 self.row_count,
+                self.parse_dates,
             )?;
             csv_reader.as_df()?
         };
@@ -577,7 +576,9 @@ where
                 df.as_single_chunk_par();
             }
         }
+
         #[cfg(feature = "temporal")]
+        // only needed until we also can parse time columns in place
         if self.parse_dates {
             // determine the schema that's given by the user. That should not be changed
             let fixed_schema = match (self.schema_overwrite, self.dtype_overwrite) {
@@ -602,32 +603,23 @@ where
 }
 
 #[cfg(feature = "temporal")]
-fn parse_dates(df: DataFrame, fixed_schema: &Schema) -> DataFrame {
-    let cols = df
-        .get_columns()
-        .par_iter()
+fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
+    let cols = std::mem::take(df.get_columns_mut())
+        .into_par_iter()
         .map(|s| {
             if let Ok(ca) = s.utf8() {
                 // don't change columns that are in the fixed schema.
                 if fixed_schema.index_of(s.name()).is_some() {
-                    return s.clone();
+                    return s;
                 }
 
                 #[cfg(feature = "dtype-time")]
                 if let Ok(ca) = ca.as_time(None) {
                     return ca.into_series();
                 }
-                #[cfg(feature = "dtype-date")]
-                if let Ok(ca) = ca.as_date(None) {
-                    return ca.into_series();
-                }
-                #[cfg(feature = "dtype-datetime")]
-                if let Ok(ca) = ca.as_datetime(None, TimeUnit::Milliseconds) {
-                    return ca.into_series();
-                }
-                s.clone()
+                s
             } else {
-                s.clone()
+                s
             }
         })
         .collect::<Vec<_>>();

--- a/polars/polars-io/src/csv_core/buffer.rs
+++ b/polars/polars-io/src/csv_core/buffer.rs
@@ -5,6 +5,10 @@ use arrow::array::Utf8Array;
 use arrow::bitmap::MutableBitmap;
 use polars_arrow::prelude::FromDataUtf8;
 use polars_core::prelude::*;
+#[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
+use polars_time::chunkedarray::utf8::Pattern;
+#[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
+use polars_time::prelude::utf8::infer::{compile_single, DatetimeInfer};
 
 pub(crate) trait PrimitiveParser: PolarsNumericType {
     fn parse(bytes: &[u8]) -> Option<Self::Native>;
@@ -48,7 +52,7 @@ impl PrimitiveParser for Int64Type {
     }
 }
 
-trait ParsedBuffer<T> {
+trait ParsedBuffer {
     fn parse_bytes(
         &mut self,
         bytes: &[u8],
@@ -57,7 +61,7 @@ trait ParsedBuffer<T> {
     ) -> Result<()>;
 }
 
-impl<T> ParsedBuffer<T> for PrimitiveChunkedBuilder<T>
+impl<T> ParsedBuffer for PrimitiveChunkedBuilder<T>
 where
     T: PolarsNumericType + PrimitiveParser,
 {
@@ -133,7 +137,7 @@ fn delay_utf8_validation(encoding: CsvEncoding, ignore_errors: bool) -> bool {
     !(matches!(encoding, CsvEncoding::LossyUtf8) || ignore_errors)
 }
 
-impl ParsedBuffer<Utf8Type> for Utf8Field {
+impl ParsedBuffer for Utf8Field {
     #[inline]
     fn parse_bytes(
         &mut self,
@@ -215,7 +219,7 @@ impl ParsedBuffer<Utf8Type> for Utf8Field {
     }
 }
 
-impl ParsedBuffer<BooleanType> for BooleanChunkedBuilder {
+impl ParsedBuffer for BooleanChunkedBuilder {
     #[inline]
     fn parse_bytes(
         &mut self,
@@ -243,6 +247,82 @@ impl ParsedBuffer<BooleanType> for BooleanChunkedBuilder {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
+pub(crate) struct DatetimeField<T: PolarsNumericType> {
+    compiled: Option<DatetimeInfer<T::Native>>,
+    builder: PrimitiveChunkedBuilder<T>,
+}
+
+#[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
+impl<T: PolarsNumericType> DatetimeField<T> {
+    fn new(name: &str, capacity: usize) -> Self {
+        let builder = PrimitiveChunkedBuilder::<T>::new(name, capacity);
+
+        Self {
+            compiled: None,
+            builder,
+        }
+    }
+}
+
+#[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
+impl<T> ParsedBuffer for DatetimeField<T>
+where
+    T: PolarsNumericType,
+    DatetimeInfer<T::Native>: TryFrom<Pattern>,
+{
+    #[inline]
+    fn parse_bytes(
+        &mut self,
+        bytes: &[u8],
+        ignore_errors: bool,
+        _needs_escaping: bool,
+    ) -> Result<()> {
+        // we only check ascii, as we don't expect non ascii values in dates
+        if bytes.is_ascii() {
+            // Safety:
+            // we just checked it is ascii
+            let val = unsafe { std::str::from_utf8_unchecked(bytes) };
+            match &mut self.compiled {
+                None => match compile_single(val) {
+                    None => {
+                        self.builder.append_null();
+                        Ok(())
+                    }
+                    Some(pattern) => match DatetimeInfer::<T::Native>::try_from(pattern) {
+                        Ok(mut infer) => {
+                            let parsed = infer.parse(val);
+                            self.compiled = Some(infer);
+                            self.builder.append_option(parsed);
+                            Ok(())
+                        }
+                        Err(_) => {
+                            self.builder.append_null();
+                            Ok(())
+                        }
+                    },
+                },
+                Some(compiled) => {
+                    let parsed = compiled.parse(val);
+                    self.builder.append_option(parsed);
+                    Ok(())
+                }
+            }
+        } else if ignore_errors {
+            self.builder.append_null();
+            Ok(())
+        } else {
+            Err(PolarsError::ComputeError(
+                format!(
+                    "could not parse {:?} as date/time",
+                    std::str::from_utf8(bytes)
+                )
+                .into(),
+            ))
+        }
     }
 }
 
@@ -286,6 +366,10 @@ pub(crate) fn init_buffers(
                     encoding,
                     ignore_errors,
                 )),
+                #[cfg(feature = "dtype-datetime")]
+                &DataType::Datetime(_, _) => Buffer::Datetime(DatetimeField::new(name, capacity)),
+                #[cfg(feature = "dtype-date")]
+                &DataType::Date => Buffer::Date(DatetimeField::new(name, capacity)),
                 other => {
                     return Err(PolarsError::ComputeError(
                         format!("Unsupported data type {:?} when reading a csv", other).into(),
@@ -308,6 +392,10 @@ pub(crate) enum Buffer {
     Float64(PrimitiveChunkedBuilder<Float64Type>),
     /// Stores the Utf8 fields and the total string length seen for that column
     Utf8(Utf8Field),
+    #[cfg(feature = "dtype-datetime")]
+    Datetime(DatetimeField<Int64Type>),
+    #[cfg(feature = "dtype-date")]
+    Date(DatetimeField<Int32Type>),
 }
 
 impl Buffer {
@@ -320,6 +408,20 @@ impl Buffer {
             Buffer::UInt64(v) => v.finish().into_series(),
             Buffer::Float32(v) => v.finish().into_series(),
             Buffer::Float64(v) => v.finish().into_series(),
+            #[cfg(feature = "dtype-datetime")]
+            Buffer::Datetime(v) => v
+                .builder
+                .finish()
+                .into_series()
+                .cast(&DataType::Datetime(TimeUnit::Microseconds, None))
+                .unwrap(),
+            #[cfg(feature = "dtype-date")]
+            Buffer::Date(v) => v
+                .builder
+                .finish()
+                .into_series()
+                .cast(&DataType::Date)
+                .unwrap(),
             // Safety:
             // We already checked utf8 validity during parsing
             Buffer::Utf8(mut v) => unsafe {
@@ -383,6 +485,10 @@ impl Buffer {
                 v.offsets.push(v.data.len() as i64);
                 v.validity.push(false);
             }
+            #[cfg(feature = "dtype-datetime")]
+            Buffer::Datetime(v) => v.builder.append_null(),
+            #[cfg(feature = "dtype-date")]
+            Buffer::Date(v) => v.builder.append_null(),
         };
     }
 
@@ -396,6 +502,10 @@ impl Buffer {
             Buffer::Float32(_) => DataType::Float32,
             Buffer::Float64(_) => DataType::Float64,
             Buffer::Utf8(_) => DataType::Utf8,
+            #[cfg(feature = "dtype-datetime")]
+            Buffer::Datetime(_) => DataType::Datetime(TimeUnit::Microseconds, None),
+            #[cfg(feature = "dtype-date")]
+            Buffer::Date(_) => DataType::Date,
         }
     }
 
@@ -408,61 +518,60 @@ impl Buffer {
     ) -> Result<()> {
         use Buffer::*;
         match self {
-            Boolean(buf) => <BooleanChunkedBuilder as ParsedBuffer<BooleanType>>::parse_bytes(
+            Boolean(buf) => <BooleanChunkedBuilder as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
                 ignore_errors,
                 needs_escaping,
             ),
-            Int32(buf) => {
-                <PrimitiveChunkedBuilder<Int32Type> as ParsedBuffer<Int32Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
+            Int32(buf) => <PrimitiveChunkedBuilder<Int32Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            Int64(buf) => <PrimitiveChunkedBuilder<Int64Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            UInt64(buf) => <PrimitiveChunkedBuilder<UInt64Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            UInt32(buf) => <PrimitiveChunkedBuilder<UInt32Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            Float32(buf) => <PrimitiveChunkedBuilder<Float32Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            Float64(buf) => <PrimitiveChunkedBuilder<Float64Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            Utf8(buf) => {
+                <Utf8Field as ParsedBuffer>::parse_bytes(buf, bytes, ignore_errors, needs_escaping)
             }
-            Int64(buf) => {
-                <PrimitiveChunkedBuilder<Int64Type> as ParsedBuffer<Int64Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
-            }
-            UInt64(buf) => {
-                <PrimitiveChunkedBuilder<UInt64Type> as ParsedBuffer<UInt64Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
-            }
-            UInt32(buf) => {
-                <PrimitiveChunkedBuilder<UInt32Type> as ParsedBuffer<UInt32Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
-            }
-            Float32(buf) => {
-                <PrimitiveChunkedBuilder<Float32Type> as ParsedBuffer<Float32Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
-            }
-            Float64(buf) => {
-                <PrimitiveChunkedBuilder<Float64Type> as ParsedBuffer<Float64Type>>::parse_bytes(
-                    buf,
-                    bytes,
-                    ignore_errors,
-                    needs_escaping,
-                )
-            }
-            Utf8(buf) => <Utf8Field as ParsedBuffer<Utf8Type>>::parse_bytes(
+            #[cfg(feature = "dtype-datetime")]
+            Datetime(buf) => <DatetimeField<Int64Type> as ParsedBuffer>::parse_bytes(
+                buf,
+                bytes,
+                ignore_errors,
+                needs_escaping,
+            ),
+            #[cfg(feature = "dtype-date")]
+            Date(buf) => <DatetimeField<Int32Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
                 ignore_errors,

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -168,6 +168,7 @@ impl<'a> CoreReader<'a> {
         to_cast: &'a [Field],
         skip_rows_after_header: usize,
         row_count: Option<RowCount>,
+        parse_dates: bool,
     ) -> Result<CoreReader<'a>> {
         #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
         let mut reader_bytes = reader_bytes;
@@ -202,6 +203,7 @@ impl<'a> CoreReader<'a> {
                         comment_char,
                         quote_char,
                         null_values.as_ref(),
+                        parse_dates,
                     )?;
                     Cow::Owned(inferred_schema)
                 }
@@ -217,6 +219,7 @@ impl<'a> CoreReader<'a> {
                         comment_char,
                         quote_char,
                         null_values.as_ref(),
+                        parse_dates,
                     )?;
                     Cow::Owned(inferred_schema)
                 }

--- a/polars/polars-io/src/csv_core/utils.rs
+++ b/polars/polars-io/src/csv_core/utils.rs
@@ -7,6 +7,8 @@ use crate::prelude::NullValues;
 use lazy_static::lazy_static;
 use polars_core::datatypes::PlHashSet;
 use polars_core::prelude::*;
+use polars_time::chunkedarray::utf8::infer as date_infer;
+use polars_time::prelude::utf8::Pattern;
 use regex::{Regex, RegexBuilder};
 use std::borrow::Cow;
 use std::io::Read;
@@ -83,19 +85,37 @@ lazy_static! {
 }
 
 /// Infer the data type of a record
-fn infer_field_schema(string: &str) -> DataType {
+fn infer_field_schema(string: &str, parse_dates: bool) -> DataType {
     // when quoting is enabled in the reader, these quotes aren't escaped, we default to
     // Utf8 for them
     if string.starts_with('"') {
-        return DataType::Utf8;
+        if parse_dates {
+            match date_infer::compile_single(&string[1..string.len() - 1]) {
+                Some(Pattern::DatetimeYMD | Pattern::DatetimeDMY) => {
+                    DataType::Datetime(TimeUnit::Microseconds, None)
+                }
+                Some(Pattern::DateYMD | Pattern::DateDMY) => DataType::Date,
+                None => DataType::Utf8,
+            }
+        } else {
+            DataType::Utf8
+        }
     }
     // match regex in a particular order
-    if BOOLEAN_RE.is_match(string) {
+    else if BOOLEAN_RE.is_match(string) {
         DataType::Boolean
     } else if FLOAT_RE.is_match(string) {
         DataType::Float64
     } else if INTEGER_RE.is_match(string) {
         DataType::Int64
+    } else if parse_dates {
+        match date_infer::compile_single(string) {
+            Some(Pattern::DatetimeYMD | Pattern::DatetimeDMY) => {
+                DataType::Datetime(TimeUnit::Microseconds, None)
+            }
+            Some(Pattern::DateYMD | Pattern::DateDMY) => DataType::Date,
+            None => DataType::Utf8,
+        }
     } else {
         DataType::Utf8
     }
@@ -131,6 +151,7 @@ pub fn infer_file_schema(
     comment_char: Option<u8>,
     quote_char: Option<u8>,
     null_values: Option<&NullValues>,
+    parse_dates: bool,
 ) -> Result<(Schema, usize)> {
     // We use lossy utf8 here because we don't want the schema inference to fail on utf8.
     // It may later.
@@ -257,16 +278,16 @@ pub fn infer_file_schema(
                     let s = parse_bytes_with_encoding(slice_escaped, encoding)?;
                     match &null_values {
                         None => {
-                            column_types[i].insert(infer_field_schema(&s));
+                            column_types[i].insert(infer_field_schema(&s, parse_dates));
                         }
                         Some(NullValues::Columns(names)) => {
                             if !names.iter().any(|name| name == s.as_ref()) {
-                                column_types[i].insert(infer_field_schema(&s));
+                                column_types[i].insert(infer_field_schema(&s, parse_dates));
                             }
                         }
                         Some(NullValues::AllColumns(name)) => {
                             if s.as_ref() != name {
-                                column_types[i].insert(infer_field_schema(&s));
+                                column_types[i].insert(infer_field_schema(&s, parse_dates));
                             }
                         }
                         Some(NullValues::Named(names)) => {
@@ -275,10 +296,10 @@ pub fn infer_file_schema(
 
                             if let Some(null_name) = null_name {
                                 if null_name.1 != s.as_ref() {
-                                    column_types[i].insert(infer_field_schema(&s));
+                                    column_types[i].insert(infer_field_schema(&s, parse_dates));
                                 }
                             } else {
-                                column_types[i].insert(infer_field_schema(&s));
+                                column_types[i].insert(infer_field_schema(&s, parse_dates));
                             }
                         }
                     }
@@ -313,6 +334,21 @@ pub fn infer_file_schema(
                 {
                     // we have an integer and double, fall down to double
                     fields.push(Field::new(field_name, DataType::Float64));
+                }
+                // prefer a datelike parse above a no parse so choose the date type
+                else if possibilities.contains(&DataType::Utf8)
+                    && possibilities.contains(&DataType::Date)
+                {
+                    fields.push(Field::new(field_name, DataType::Date));
+                }
+                // prefer a datelike parse above a no parse so choose the date type
+                else if possibilities.contains(&DataType::Utf8)
+                    && possibilities.contains(&DataType::Datetime(TimeUnit::Microseconds, None))
+                {
+                    fields.push(Field::new(
+                        field_name,
+                        DataType::Datetime(TimeUnit::Microseconds, None),
+                    ));
                 } else {
                     // default to Utf8 for conflicting datatypes (e.g bool and int)
                     fields.push(Field::new(field_name, DataType::Utf8));
@@ -338,6 +374,7 @@ pub fn infer_file_schema(
             comment_char,
             quote_char,
             null_values,
+            parse_dates,
         );
     }
 

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -26,6 +26,7 @@ pub struct LazyCsvReader<'a> {
     skip_rows_after_header: usize,
     encoding: CsvEncoding,
     row_count: Option<RowCount>,
+    parse_dates: bool,
 }
 
 #[cfg(feature = "csv-file")]
@@ -50,6 +51,7 @@ impl<'a> LazyCsvReader<'a> {
             skip_rows_after_header: 0,
             encoding: CsvEncoding::Utf8,
             row_count: None,
+            parse_dates: false,
         }
     }
 
@@ -176,6 +178,13 @@ impl<'a> LazyCsvReader<'a> {
         self
     }
 
+    /// Automatically try to parse dates/ datetimes and time. If parsing fails, columns remain of dtype `[DataType::Utf8]`.
+    #[cfg(feature = "temporal")]
+    pub fn with_parse_dates(mut self, toggle: bool) -> Self {
+        self.parse_dates = toggle;
+        self
+    }
+
     /// Modify a schema before we run the lazy scanning.
     ///
     /// Important! Run this function latest in the builder!
@@ -198,6 +207,7 @@ impl<'a> LazyCsvReader<'a> {
             self.comment_char,
             self.quote_char,
             None,
+            self.parse_dates,
         )?;
         let mut schema = f(schema)?;
 
@@ -231,6 +241,7 @@ impl<'a> LazyCsvReader<'a> {
             self.skip_rows_after_header,
             self.encoding,
             self.row_count,
+            self.parse_dates,
         )?
         .build()
         .into();

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -122,6 +122,7 @@ impl LogicalPlanBuilder {
         skip_rows_after_header: usize,
         encoding: CsvEncoding,
         row_count: Option<RowCount>,
+        parse_dates: bool,
     ) -> Result<Self> {
         let path = path.into();
         let mut file = std::fs::File::open(&path)?;
@@ -146,6 +147,7 @@ impl LogicalPlanBuilder {
                 comment_char,
                 quote_char,
                 null_values.as_ref(),
+                parse_dates,
             )
             .expect("could not read schema");
             Arc::new(schema)
@@ -169,6 +171,7 @@ impl LogicalPlanBuilder {
                 rechunk,
                 encoding,
                 row_count,
+                parse_dates,
             },
             predicate: None,
             aggregate: vec![],

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -19,6 +19,7 @@ pub struct CsvParserOptions {
     pub(crate) rechunk: bool,
     pub(crate) encoding: CsvEncoding,
     pub(crate) row_count: Option<RowCount>,
+    pub(crate) parse_dates: bool,
 }
 #[cfg(feature = "parquet")]
 #[derive(Clone, Debug)]

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -235,6 +235,7 @@ impl Executor for CsvExec {
             .with_encoding(self.options.encoding)
             .with_rechunk(self.options.rechunk)
             .with_row_count(std::mem::take(&mut self.options.row_count))
+            .with_parse_dates(self.options.parse_dates)
             .finish()?;
 
         if self.options.cache {

--- a/polars/polars-time/src/chunkedarray/mod.rs
+++ b/polars/polars-time/src/chunkedarray/mod.rs
@@ -8,7 +8,7 @@ mod duration;
 mod kernels;
 #[cfg(feature = "dtype-time")]
 mod time;
-mod utf8;
+pub mod utf8;
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "dtype-date")]

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -1,0 +1,146 @@
+use super::patterns;
+#[cfg(feature = "dtype-date")]
+use crate::chunkedarray::date::naive_date_to_date;
+use crate::chunkedarray::utf8::patterns::Pattern;
+use chrono::{NaiveDate, NaiveDateTime};
+use polars_arrow::export::arrow::array::{ArrayRef, PrimitiveArray};
+use polars_core::prelude::*;
+use polars_core::utils::arrow::types::NativeType;
+
+#[derive(Clone)]
+pub struct DatetimeInfer<T> {
+    patterns: &'static [&'static str],
+    latest: &'static str,
+    transform: fn(&str, &str) -> Option<T>,
+    logical_type: DataType,
+}
+
+impl TryFrom<Pattern> for DatetimeInfer<i64> {
+    type Error = PolarsError;
+
+    fn try_from(value: Pattern) -> Result<Self> {
+        match value {
+            Pattern::DatetimeDMY => Ok(DatetimeInfer {
+                patterns: patterns::DATETIME_D_M_Y,
+                latest: patterns::DATETIME_D_M_Y[0],
+                transform: transform_datetime,
+                logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
+            }),
+            Pattern::DatetimeYMD => Ok(DatetimeInfer {
+                patterns: patterns::DATETIME_Y_M_D,
+                latest: patterns::DATETIME_Y_M_D[0],
+                transform: transform_datetime,
+                logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
+            }),
+            _ => Err(PolarsError::ComputeError(
+                "could not convert pattern".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+impl TryFrom<Pattern> for DatetimeInfer<i32> {
+    type Error = PolarsError;
+
+    fn try_from(value: Pattern) -> Result<Self> {
+        match value {
+            Pattern::DateDMY => Ok(DatetimeInfer {
+                patterns: patterns::DATE_D_M_Y,
+                latest: patterns::DATE_D_M_Y[0],
+                transform: transform_date,
+                logical_type: DataType::Date,
+            }),
+            Pattern::DateYMD => Ok(DatetimeInfer {
+                patterns: patterns::DATE_Y_M_D,
+                latest: patterns::DATE_Y_M_D[0],
+                transform: transform_date,
+                logical_type: DataType::Date,
+            }),
+            _ => Err(PolarsError::ComputeError(
+                "could not convert pattern".into(),
+            )),
+        }
+    }
+}
+
+impl<T: NativeType> DatetimeInfer<T> {
+    pub fn parse(&mut self, val: &str) -> Option<T> {
+        match (self.transform)(val, self.latest) {
+            Some(parsed) => Some(parsed),
+            // try other patterns
+            None => {
+                for fmt in self.patterns {
+                    if let Some(parsed) = (self.transform)(val, fmt) {
+                        self.latest = fmt;
+                        return Some(parsed);
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    pub fn coerce_utf8(&mut self, ca: &Utf8Chunked) -> Series {
+        let chunks = ca
+            .downcast_iter()
+            .into_iter()
+            .map(|array| {
+                let iter = array
+                    .into_iter()
+                    .map(|opt_val| opt_val.and_then(|val| self.parse(val)));
+                Arc::new(PrimitiveArray::from_trusted_len_iter(iter)) as ArrayRef
+            })
+            .collect();
+        match self.logical_type {
+            DataType::Date => Int32Chunked::from_chunks(ca.name(), chunks)
+                .into_series()
+                .cast(&self.logical_type)
+                .unwrap(),
+            DataType::Datetime(_, _) => Int64Chunked::from_chunks(ca.name(), chunks)
+                .into_series()
+                .cast(&self.logical_type)
+                .unwrap(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+fn transform_date(val: &str, fmt: &str) -> Option<i32> {
+    NaiveDate::parse_from_str(val, fmt)
+        .ok()
+        .map(naive_date_to_date)
+}
+
+fn transform_datetime(val: &str, fmt: &str) -> Option<i64> {
+    NaiveDateTime::parse_from_str(val, fmt)
+        .ok()
+        .map(datetime_to_timestamp_us)
+}
+
+pub fn compile_single(val: &str) -> Option<Pattern> {
+    if patterns::DATE_D_M_Y
+        .iter()
+        .any(|fmt| NaiveDate::parse_from_str(val, fmt).is_ok())
+    {
+        Some(Pattern::DateDMY)
+    } else if patterns::DATE_Y_M_D
+        .iter()
+        .any(|fmt| NaiveDate::parse_from_str(val, fmt).is_ok())
+    {
+        Some(Pattern::DateYMD)
+    } else if patterns::DATETIME_D_M_Y
+        .iter()
+        .any(|fmt| NaiveDateTime::parse_from_str(val, fmt).is_ok())
+    {
+        Some(Pattern::DatetimeDMY)
+    } else if patterns::DATETIME_Y_M_D
+        .iter()
+        .any(|fmt| NaiveDateTime::parse_from_str(val, fmt).is_ok())
+    {
+        Some(Pattern::DatetimeYMD)
+    } else {
+        None
+    }
+}

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -1,9 +1,13 @@
+pub mod infer;
+mod patterns;
+
 use super::*;
 #[cfg(feature = "dtype-date")]
 use crate::chunkedarray::date::naive_date_to_date;
 #[cfg(feature = "dtype-time")]
 use crate::chunkedarray::time::time_to_time64ns;
 use chrono::ParseError;
+pub use patterns::Pattern;
 
 #[cfg(feature = "dtype-time")]
 fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
@@ -28,7 +32,7 @@ where
         // 21/12/31 12:54:98
         "%y/%m/%d %H:%M:%S",
         // 2021-12-31 24:58:01
-        "%y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
         // 21/12/31 24:58:01
         "%y/%m/%d %H:%M:%S",
         //210319 23:58:50

--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -1,0 +1,69 @@
+//! Patterns are grouped together by order of month, day, year. This is to prevent
+//! parsing different orders of dates in a single column.
+
+pub(super) static DATE_D_M_Y: &[&str] = &[
+    // 8-Jul-2001
+    "%v",       // 31-12-2021
+    "%d-%m-%Y", // 31-12-21
+    "%d-%m-%y", // 31_12_2021
+    "%d_%m_%Y", // 31_12_21
+    "%d_%m_%y",
+];
+
+pub(super) static DATE_Y_M_D: &[&str] = &[
+    // 2021-12-31
+    "%Y-%m-%d", // 21-12-21
+    "%y-%m-%d", // 2021_12_31
+    "%Y_%m_%d", // 21_12_21
+    "%y_%m_%d",
+];
+
+pub(super) static DATETIME_D_M_Y: &[&str] = &[
+    // 31/12/21 12:54:98
+    "%d/%m/%y %H:%M:%S",
+    // 31-12-2021 24:58:01
+    "%d-%m-%Y %H:%M:%S",
+    // 31-04-2021T02:45:55.555000000
+    // microseconds
+    "%d-%m-%YT%H:%M:%S.%6f",
+    // 31-04-21T02:45:55.555000000
+    "%d-%m-%yT%H:%M:%S.%6f",
+    // nanoseconds
+    "%d-%m-%YT%H:%M:%S.%9f",
+    "%d-%m-%yT%H:%M:%S.%9f",
+];
+
+pub(super) static DATETIME_Y_M_D: &[&str] = &[
+    // 21/12/31 12:54:98
+    "%y/%m/%d %H:%M:%S",
+    // 2021-12-31 24:58:01
+    "%Y-%m-%d %H:%M:%S",
+    // 21/12/31 24:58:01
+    "%y/%m/%d %H:%M:%S",
+    //210319 23:58:50
+    "%y%m%d %H:%M:%S",
+    // 2019-04-18T02:45:55
+    // 2021/12/31 12:54:98
+    "%Y/%m/%d %H:%M:%S",
+    // 2021-12-31 24:58:01
+    "%Y-%m-%d %H:%M:%S",
+    // 2021/12/31 24:58:01
+    "%Y/%m/%d %H:%M:%S",
+    // 20210319 23:58:50
+    "%Y%m%d %H:%M:%S",
+    // 2019-04-18T02:45:55
+    "%FT%H:%M:%S",
+    // 2019-04-18T02:45:55.555000000
+    // microseconds
+    "%FT%H:%M:%S.%6f",
+    // nanoseconds
+    "%FT%H:%M:%S.%9f",
+];
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum Pattern {
+    DateDMY,
+    DateYMD,
+    DatetimeYMD,
+    DatetimeDMY,
+}

--- a/polars/polars-time/src/lib.rs
+++ b/polars/polars-time/src/lib.rs
@@ -1,4 +1,4 @@
-mod chunkedarray;
+pub mod chunkedarray;
 mod date_range;
 mod groupby;
 pub mod prelude;

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -569,7 +569,7 @@ fn test_automatic_datetime_parsing() -> Result<()> {
     let ts = df.column("timestamp")?;
     assert_eq!(
         ts.dtype(),
-        &DataType::Datetime(TimeUnit::Milliseconds, None)
+        &DataType::Datetime(TimeUnit::Microseconds, None)
     );
     assert_eq!(ts.null_count(), 0);
 
@@ -964,4 +964,22 @@ fn test_empty_csv() {
             Err(PolarsError::NoData(_))
         ))
     }
+}
+
+#[test]
+fn test_parse_dates() -> Result<()> {
+    let csv = "date
+1745-04-02
+1742-03-21
+1743-06-16
+1730-07-22
+''
+1739-03-16
+";
+    let file = Cursor::new(csv);
+
+    let out = CsvReader::new(file).with_parse_dates(true).finish()?;
+    assert_eq!(out.dtypes(), &[DataType::Date]);
+    assert_eq!(out.column("date")?.null_count(), 1);
+    Ok(())
 }

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -117,6 +117,7 @@ class LazyFrame(Generic[DF]):
         skip_rows_after_header: int = 0,
         row_count_name: Optional[str] = None,
         row_count_offset: int = 0,
+        parse_dates: bool = False,
     ) -> LDF:
         """
         See Also: `pl.scan_csv`
@@ -148,6 +149,7 @@ class LazyFrame(Generic[DF]):
             skip_rows_after_header,
             encoding,
             _prepare_row_count_args(row_count_name, row_count_offset),
+            parse_dates,
         )
         return self
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -442,6 +442,7 @@ def scan_csv(
     skip_rows_after_header: int = 0,
     row_count_name: Optional[str] = None,
     row_count_offset: int = 0,
+    parse_dates: bool = False,
     **kwargs: Any,
 ) -> LazyFrame:
     """
@@ -508,6 +509,9 @@ def scan_csv(
         If not None, this will insert a row count column with give name into the DataFrame
     row_count_offset
         Offset to start the row_count column (only use if the name is set)
+    parse_dates
+        Try to automatically parse dates. If this does not succeed,
+        the column remains of data type ``pl.Utf8``.
 
     Examples
     --------
@@ -577,6 +581,7 @@ def scan_csv(
         encoding=encoding,
         row_count_name=row_count_name,
         row_count_offset=row_count_offset,
+        parse_dates=parse_dates,
     )
 
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -111,6 +111,7 @@ impl PyLazyFrame {
         skip_rows_after_header: usize,
         encoding: &str,
         row_count: Option<(String, u32)>,
+        parse_dates: bool,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let comment_char = comment_char.map(|s| s.as_bytes()[0]);
@@ -151,6 +152,7 @@ impl PyLazyFrame {
             .with_skip_rows_after_header(skip_rows_after_header)
             .with_encoding(encoding)
             .with_row_count(row_count)
+            .with_parse_dates(parse_dates)
             .with_null_values(null_values);
 
         if let Some(lambda) = with_schema_modify {


### PR DESCRIPTION
Csv inference of `Date/Datetime` now happens in place, so this will likely be a lot faster because we don't have to first create a `Utf8` column.

We also allow parsing with different `fmt groups`. E.g. instead of a single `fmt` polars will try a group of `fmt` values. To prevent linear searching a lot, we save the latest match as a cached one.

To prevent strange matches the groups are separated by date order. We have the following groups:

* Dates: year-month-day
* Dates: day-month-year
* Datetimes: year-month-day
* Datetimes: day-month-year