### PR TITLE
fix(scan_csv): handle empty csv file exception

### DIFF
--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -127,7 +127,9 @@ impl LogicalPlanBuilder {
         let path = path.into();
         let mut file = std::fs::File::open(&path)?;
         let mut magic_nr = [0u8; 2];
-        file.read_exact(&mut magic_nr)?;
+        file.read_exact(&mut magic_nr)
+            .map_err(|_| PolarsError::NoData("empty csv".into()))?;
+
         if is_compressed(&magic_nr) {
             return Err(PolarsError::ComputeError(
                 "cannot scan compressed csv; use read_csv for compressed data".into(),

--- a/py-polars/tests/io/test_lazy_csv.py
+++ b/py-polars/tests/io/test_lazy_csv.py
@@ -1,8 +1,10 @@
 # flake8: noqa: W191,E101
+import io
 from os import path
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import polars as pl
 
@@ -10,6 +12,12 @@ import polars as pl
 def test_scan_csv() -> None:
     df = pl.scan_csv(Path(__file__).parent.parent / "files" / "small.csv")
     assert df.collect().shape == (4, 3)
+
+
+def test_scan_empty_csv() -> None:
+    with pytest.raises(Exception) as excinfo:
+        pl.scan_csv(Path(__file__).parent.parent / "files" / "empty.csv").collect()
+    assert str(excinfo.value) == "empty csv"
 
 
 def test_invalid_utf8() -> None:


### PR DESCRIPTION
# Summary

Closes the issue #2714 📕  

`file.read_exact()` was throwing an error while trying to read an empty `csv` file.

The error is sensible. We expect a certain length (enough to complete the file header), and it's not there .

However, the message wasn't very helpful:

```
RuntimeError: Any(Io(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }))
```

# The solution

I added a `map_err` to handle the exception and throws the correct message:

```rust
file.read_exact(&mut magic_nr)
            .map_err(|_| PolarsError::NoData("empty csv".into()))?;
```

```
RuntimeError: Any(NoData("empty csv"))
```