### PR TITLE
Minor: Updating ValueError on empty bytes for clarity

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -268,7 +268,7 @@ def read_csv(
     projection, columns = handle_projection_columns(columns)
 
     if isinstance(file, bytes) and len(file) == 0:
-        raise ValueError("no date in bytes")
+        raise ValueError("Empty bytes data provided")
 
     storage_options = storage_options or {}
 


### PR DESCRIPTION
This PR improves the clarity of the `ValueError` raised when an empty bytes is passed to `pl.read_csv`, fixing a typo in the previous error message. It can be reproduced by `pl.read_csv(b'')`.