### PR TITLE
Home directory support

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -66,11 +66,11 @@ from polars.datatypes import Boolean, DataType, UInt32, Utf8, py_type_to_dtype
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
+    format_path,
     handle_projection_columns,
     is_int_sequence,
     is_str_sequence,
     range_to_slice,
-    format_path,
 )
 
 try:

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -560,8 +560,8 @@ def scan_csv(
     dtypes = kwargs.pop("dtype", dtypes)
     n_rows = kwargs.pop("stop_after_n_rows", n_rows)
 
-    if isinstance(file, Path):
-        file = str(file)
+    if isinstance(file, (str, Path)):
+        file = format_path(file)
 
     return LazyFrame.scan_csv(
         file=file,
@@ -621,8 +621,8 @@ def scan_ipc(
     # Map legacy arguments to current ones and remove them from kwargs.
     n_rows = kwargs.pop("stop_after_n_rows", n_rows)
 
-    if isinstance(file, Path):
-        file = str(file)
+    if isinstance(file, (str, Path)):
+        file = format_path(file)
 
     return LazyFrame.scan_ipc(
         file=file,
@@ -671,8 +671,8 @@ def scan_parquet(
     # Map legacy arguments to current ones and remove them from kwargs.
     n_rows = kwargs.pop("stop_after_n_rows", n_rows)
 
-    if isinstance(file, Path):
-        file = str(file)
+    if isinstance(file, (str, Path)):
+        file = format_path(file)
 
     return LazyFrame.scan_parquet(
         file=file,
@@ -725,8 +725,8 @@ def read_avro(
     -------
     DataFrame
     """
-    if isinstance(file, Path):
-        file = str(file)
+    if isinstance(file, (str, Path)):
+        file = format_path(file)
     if columns is None:
         columns = kwargs.pop("projection", None)
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -19,7 +19,7 @@ from typing import (
 )
 from urllib.request import urlopen
 
-from polars.utils import handle_projection_columns, format_path
+from polars.utils import format_path, handle_projection_columns
 
 try:
     import pyarrow as pa

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,8 +1,8 @@
-import os
 import ctypes
+import os
 import sys
-from pathlib import Path
 from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
@@ -205,7 +205,7 @@ def _in_notebook() -> bool:
     return True
 
 
-def format_path(path: Union[str, Path])-> str:
+def format_path(path: Union[str, Path]) -> str:
     """
     Returnsa string path, expanding the home directory if present.
     """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,5 +1,7 @@
+import os
 import ctypes
 import sys
+from pathlib import Path
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
@@ -201,3 +203,10 @@ def _in_notebook() -> bool:
     except AttributeError:
         return False
     return True
+
+
+def format_path(path: Union[str, Path])-> str:
+    """
+    Returnsa string path, expanding the home directory if present.
+    """
+    return os.path.expanduser(path)

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -52,3 +52,12 @@ for _ in range(10):
     )
     assert computed[0, "min"] == minimum
     assert computed[0, "max"] == maximum
+
+# test home directory support
+# https://github.com/pola-rs/polars/pull/2940
+filename = "~/test.parquet"
+
+df.to_parquet(filename)
+df = pl.read_parquet(filename)
+
+os.remove(filename)

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -1,5 +1,6 @@
 # may contain many things that seemed to go wrong at scale
 
+import os
 import time
 
 import numpy as np


### PR DESCRIPTION
This PR adds support for passing in file paths that use the home directory (e.g. `"~/test.parquet"`). At present this returns a file not found error, as the `~` is not interpreted correctly. Paths with the home directory are also not currently supported in `pyarrow` (and by extension `read_parquet("~/test.parquet", use_pyarrow=True)`, but I put up a fix in apache/arrow#12675. This is helpful for working with local files and is consistent with `pandas` behavior.

```
import polars as pl
df = pl.read_parquet("~/test.parquet")
```
I'm not sure the best place to add tests for this. I was thinking to use mock and avoid actually testing in the home directory. :smile: Any suggestions?

I added the functionality to `_prepare_file_arg` to add support broadly. Are there other places that need to be included?