### PR TITLE
Literal in groupby context, arange and repeat

### DIFF
--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -1483,6 +1483,8 @@ impl Expr {
 
     #[cfg(feature = "repeat_by")]
     #[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
+    /// Repeat the column `n` times, where `n` is determined by the values in `by`.
+    /// This yields an `Expr` of dtype `List`
     pub fn repeat_by(self, by: Expr) -> Expr {
         let function = |s: &mut [Series]| {
             let by = &s[1];
@@ -1491,7 +1493,7 @@ impl Expr {
             Ok(s.repeat_by(by.idx()?).into_series())
         };
 
-        self.map_many(
+        self.apply_many(
             function,
             &[by],
             GetOutput::map_dtype(|dt| DataType::List(dt.clone().into())),

--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -149,7 +149,10 @@ impl PhysicalExpr for ApplyExpr {
                     let lists = acs
                         .iter_mut()
                         .map(|ac| {
-                            let s = ac.aggregated();
+                            let s = match ac.agg_state() {
+                                AggState::AggregatedFlat(s) => s.reshape(&[-1, 1]).unwrap(),
+                                _ => ac.aggregated(),
+                            };
                             s.list().unwrap().clone()
                         })
                         .collect::<Vec<_>>();

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -132,7 +132,7 @@ impl PhysicalExpr for BinaryExpr {
                 if s.len() != df.height() =>
             {
                 // this is a flat series of len eq to group tuples
-                let l = ac_l.aggregated();
+                let l = ac_l.aggregated_arity_operation();
                 let l = l.as_ref();
                 let arr_l = &l.chunks()[0];
 
@@ -145,7 +145,7 @@ impl PhysicalExpr for BinaryExpr {
                 let mut us = UnstableSeries::new(&dummy);
 
                 // this is now a list
-                let r = ac_r.aggregated();
+                let r = ac_r.aggregated_arity_operation();
                 let r = r.list().unwrap();
 
                 let mut ca: ListChunked = r
@@ -182,11 +182,11 @@ impl PhysicalExpr for BinaryExpr {
                 _,
             ) if s.len() != df.height() => {
                 // this is now a list
-                let l = ac_l.aggregated();
+                let l = ac_l.aggregated_arity_operation();
                 let l = l.list().unwrap();
 
                 // this is a flat series of len eq to group tuples
-                let r = ac_r.aggregated();
+                let r = ac_r.aggregated_arity_operation();
                 assert_eq!(l.len(), groups.len());
                 let r = r.as_ref();
                 let arr_r = &r.chunks()[0];
@@ -289,7 +289,7 @@ impl PhysicalAggregation for BinaryExpr {
         state: &ExecutionState,
     ) -> Result<Option<Series>> {
         let mut ac = self.evaluate_on_groups(df, groups, state)?;
-        let s = ac.aggregated();
+        let s = ac.aggregated_arity_operation();
         Ok(Some(s))
     }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -69,7 +69,7 @@ The predicate produced {} values. Where the original DataFrame has {} values",
                 if s.len() != df.height() =>
             {
                 // this is a flat series of len eq to group tuples
-                let truthy = ac_truthy.aggregated();
+                let truthy = ac_truthy.aggregated_arity_operation();
                 let truthy = truthy.as_ref();
                 let arr_truthy = &truthy.chunks()[0];
                 assert_eq!(truthy.len(), groups.len());
@@ -81,11 +81,11 @@ The predicate produced {} values. Where the original DataFrame has {} values",
                 let mut us = UnstableSeries::new(&dummy);
 
                 // this is now a list
-                let falsy = ac_falsy.aggregated();
+                let falsy = ac_falsy.aggregated_arity_operation();
                 let falsy = falsy.as_ref();
                 let falsy = falsy.list().unwrap();
 
-                let mask = ac_mask.aggregated();
+                let mask = ac_mask.aggregated_arity_operation();
                 let mask = mask.as_ref();
                 let mask = mask.list()?;
                 if !matches!(mask.inner_dtype(), DataType::Boolean) {
@@ -128,12 +128,12 @@ The predicate produced {} values. Where the original DataFrame has {} values",
                 if s.len() != df.height() =>
             {
                 // this is now a list
-                let truthy = ac_truthy.aggregated();
+                let truthy = ac_truthy.aggregated_arity_operation();
                 let truthy = truthy.as_ref();
                 let truthy = truthy.list().unwrap();
 
                 // this is a flat series of len eq to group tuples
-                let falsy = ac_falsy.aggregated();
+                let falsy = ac_falsy.aggregated_arity_operation();
                 assert_eq!(falsy.len(), groups.len());
                 let falsy = falsy.as_ref();
                 let arr_falsy = &falsy.chunks()[0];
@@ -144,7 +144,7 @@ The predicate produced {} values. Where the original DataFrame has {} values",
                 let dummy = Series::try_from(("dummy", vec![arr_falsy.clone()])).unwrap();
                 let mut us = UnstableSeries::new(&dummy);
 
-                let mask = ac_mask.aggregated();
+                let mask = ac_mask.aggregated_arity_operation();
                 let mask = mask.as_ref();
                 let mask = mask.list()?;
                 if !matches!(mask.inner_dtype(), DataType::Boolean) {

--- a/polars/tests/it/lazy/expressions/apply.rs
+++ b/polars/tests/it/lazy/expressions/apply.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+#[cfg(feature = "arange")]
+fn test_arange_agg() -> Result<()> {
+    let df = df![
+        "x" => [5, 5, 4, 4, 2, 2]
+    ]?;
+
+    let out = df
+        .lazy()
+        .with_columns([arange(lit(0i32), count(), 1).over([col("x")])])
+        .collect()?;
+    assert_eq!(
+        Vec::from_iter(out.column("literal")?.i64()?.into_no_null_iter()),
+        &[0, 1, 0, 1, 0, 1]
+    );
+
+    Ok(())
+}

--- a/polars/tests/it/lazy/expressions/mod.rs
+++ b/polars/tests/it/lazy/expressions/mod.rs
@@ -1,3 +1,4 @@
+mod apply;
 mod arity;
 mod is_in;
 mod slice;

--- a/polars/tests/it/lazy/expressions/window.rs
+++ b/polars/tests/it/lazy/expressions/window.rs
@@ -172,7 +172,7 @@ fn test_literal_window_fn() -> Result<()> {
 
     let out = df
         .lazy()
-        .select([lit(1)
+        .select([repeat(1, count())
             .cumsum(false)
             .list()
             .over([col("chars")])

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -40,6 +40,7 @@ These functions can be used as expression and sometimes also in eager contexts.
    groups
    quantile
    arange
+   repeat
    argsort_by
    concat_str
    concat_list

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -54,13 +54,7 @@ from polars.internals.frame import (  # flake8: noqa # TODO: remove need for wra
     DataFrame,
     wrap_df,
 )
-from polars.internals.functions import (
-    arg_where,
-    concat,
-    date_range,
-    get_dummies,
-    repeat,
-)
+from polars.internals.functions import arg_where, concat, date_range, get_dummies
 from polars.internals.lazy_frame import LazyFrame
 from polars.internals.lazy_functions import _date as date
 from polars.internals.lazy_functions import _datetime as datetime
@@ -94,6 +88,7 @@ from polars.internals.lazy_functions import (
     n_unique,
     pearson_corr,
     quantile,
+    repeat,
     select,
     spearman_rank_corr,
     std,

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import Optional, Sequence, Union, overload
 
 from polars import internals as pli
-from polars.datatypes import py_type_to_dtype
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
@@ -126,29 +125,6 @@ def concat(
     if rechunk:
         return out.rechunk()
     return out
-
-
-def repeat(
-    val: Union[int, float, str, bool], n: int, name: Optional[str] = None
-) -> "pli.Series":
-    """
-    Repeat a single value n times and collect into a Series.
-
-    Parameters
-    ----------
-    val
-        Value to repeat.
-    n
-        Number of repeats.
-    name
-        Optional name of the Series.
-    """
-    if name is None:
-        name = ""
-
-    dtype = py_type_to_dtype(type(val))
-    s = pli.Series._repeat(name, val, n, dtype)
-    return s
 
 
 def arg_where(mask: "pli.Series") -> "pli.Series":

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,11 +1,17 @@
+import sys
 from datetime import date, datetime, timedelta
 from inspect import isclass
 from typing import Any, Callable, List, Optional, Sequence, Type, Union, cast, overload
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
+
 import numpy as np
 
 from polars import internals as pli
-from polars.datatypes import DataType, Date, Datetime, Duration
+from polars.datatypes import DataType, Date, Datetime, Duration, py_type_to_dtype
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_timedelta,
@@ -35,6 +41,7 @@ try:
     from polars.polars import min_exprs as _min_exprs
     from polars.polars import pearson_corr as pypearson_corr
     from polars.polars import py_datetime
+    from polars.polars import repeat as _repeat
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
 
     _DOCUMENTING = False
@@ -930,10 +937,44 @@ def quantile(
     return col(column).quantile(quantile, interpolation)
 
 
+@overload
+def arange(
+    low: Union[int, "pli.Expr", "pli.Series"],
+    high: Union[int, "pli.Expr", "pli.Series"],
+    step: int = ...,
+    *,
+    eager: Literal[False],
+) -> "pli.Expr":
+    ...
+
+
+@overload
+def arange(
+    low: Union[int, "pli.Expr", "pli.Series"],
+    high: Union[int, "pli.Expr", "pli.Series"],
+    step: int = ...,
+    *,
+    eager: Literal[True],
+) -> "pli.Series":
+    ...
+
+
+@overload
+def arange(
+    low: Union[int, "pli.Expr", "pli.Series"],
+    high: Union[int, "pli.Expr", "pli.Series"],
+    step: int = ...,
+    *,
+    eager: bool = False,
+) -> Union["pli.Expr", "pli.Series"]:
+    ...
+
+
 def arange(
     low: Union[int, "pli.Expr", "pli.Series"],
     high: Union[int, "pli.Expr", "pli.Series"],
     step: int = 1,
+    *,
     eager: bool = False,
 ) -> Union["pli.Expr", "pli.Series"]:
     """
@@ -1364,3 +1405,69 @@ def struct(exprs: Union[Sequence["pli.Expr"], "pli.Expr"]) -> "pli.Expr":
     """
     exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_as_struct(exprs))
+
+
+@overload
+def repeat(
+    value: Optional[Union[float, int, str, bool]],
+    n: Union["pli.Expr", int],
+    *,
+    eager: Literal[False] = ...,
+    name: Optional[str] = ...,
+) -> "pli.Expr":
+    ...
+
+
+@overload
+def repeat(
+    value: Optional[Union[float, int, str, bool]],
+    n: Union["pli.Expr", int],
+    *,
+    eager: Literal[True],
+    name: Optional[str] = ...,
+) -> "pli.Series":
+    ...
+
+
+@overload
+def repeat(
+    value: Optional[Union[float, int, str, bool]],
+    n: Union["pli.Expr", int],
+    *,
+    eager: bool,
+    name: Optional[str],
+) -> Union["pli.Expr", "pli.Series"]:
+    ...
+
+
+def repeat(
+    value: Optional[Union[float, int, str, bool]],
+    n: Union["pli.Expr", int],
+    *,
+    eager: bool = False,
+    name: Optional[str] = None,
+) -> Union["pli.Expr", "pli.Series"]:
+    """
+    Repeat a single value n times.
+
+    Parameters
+    ----------
+    value
+        Value to repeat.
+    n
+        repeat `n` times
+    eager
+        Run eagerly and collect into a `Series`
+    name
+        Only used in `eager` mode. As expression, us `alias`
+    """
+    if eager:
+        if name is None:
+            name = ""
+        dtype = py_type_to_dtype(type(value))
+        s = pli.Series._repeat(name, value, n, dtype)  # type: ignore
+        return s
+    else:
+        if isinstance(n, int):
+            n = lit(n)
+        return pli.wrap_expr(_repeat(value, n._pyexpr))

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -382,3 +382,21 @@ def test_escaped_null_values() -> None:
     assert df[1, "a"] is None
     assert df[0, "b"] is None
     assert df[0, "c"] is None
+
+
+def quoting_round_trip() -> None:
+    f = io.BytesIO()
+    df = pl.DataFrame(
+        {
+            "a": [
+                "tab,separated,field",
+                "newline\nseparated\nfield",
+                'quote"separated"field',
+            ]
+        }
+    )
+    df.write_csv(f)
+    f.seek(0)
+    read_df = pl.read_csv(f)
+
+    assert read_df.frame_equal(df)

--- a/py-polars/tests/test_queries.py
+++ b/py-polars/tests/test_queries.py
@@ -38,3 +38,13 @@ def test_type_coercion_when_then_otherwise_2806() -> None:
         .to_frame()
         .select(pl.when(pl.col("a") > 2.0).then(pl.col("a")).otherwise(0.0))
     ).to_series().dtype == pl.Float32
+
+
+def test_repeat_expansion_in_groupby() -> None:
+    out = (
+        pl.DataFrame({"g": [1, 2, 2, 3, 3, 3]})
+        .groupby("g", maintain_order=True)
+        .agg(pl.repeat(1, pl.count()).cumsum())
+        .to_dict()
+    )
+    assert out == {"g": [1, 2, 3], "literal": [[1], [1, 2], [1, 2, 3]]}

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -512,17 +512,17 @@ def test_object() -> None:
 
 
 def test_repeat() -> None:
-    s = pl.repeat(1, 10)
+    s = pl.repeat(1, 10, eager=True)
     assert s.dtype == pl.Int64
     assert s.len() == 10
-    s = pl.repeat("foo", 10)
+    s = pl.repeat("foo", 10, eager=True)
     assert s.dtype == pl.Utf8
     assert s.len() == 10
-    s = pl.repeat(1.0, 5)
+    s = pl.repeat(1.0, 5, eager=True)
     assert s.dtype == pl.Float64
     assert s.len() == 5
     assert s == [1.0, 1.0, 1.0, 1.0, 1.0]
-    s = pl.repeat(True, 5)
+    s = pl.repeat(True, 5, eager=True)
     assert s.dtype == pl.Boolean
     assert s.len() == 5
 
@@ -619,8 +619,8 @@ def test_arange_expr() -> None:
     assert out2 == [0, 2, 4, 8, 8]
 
     out3 = pl.arange(pl.Series([0, 19]), pl.Series([3, 39]), step=2, eager=True)
-    assert out3.dtype == pl.List  # type: ignore
-    assert out3[0].to_list() == [0, 2]  # type: ignore
+    assert out3.dtype == pl.List
+    assert out3[0].to_list() == [0, 2]
 
 
 def test_round() -> None:
@@ -631,7 +631,7 @@ def test_round() -> None:
 
 def test_apply_list_out() -> None:
     s = pl.Series("count", [3, 2, 2])
-    out = s.apply(lambda val: pl.repeat(val, val))
+    out = s.apply(lambda val: pl.repeat(val, val, eager=True))
     assert out[0] == [3, 3, 3]
     assert out[1] == [2, 2]
     assert out[2] == [2, 2]

--- a/py-polars/tests/test_window.py
+++ b/py-polars/tests/test_window.py
@@ -94,3 +94,15 @@ def test_window_function_cache() -> None:
     ]
     assert out["values_flat"].to_list() == [0, 1, 2, 3, 4]
     assert out["values_rev"].to_list() == [1, 0, 4, 3, 2]
+
+
+def test_arange_no_rows() -> None:
+    df = pl.DataFrame(dict(x=[5, 5, 4, 4, 2, 2]))
+    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore
+    assert out.frame_equal(
+        pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "literal": [0, 1, 0, 1, 0, 1]})
+    )
+
+    df = pl.DataFrame(dict(x=[]))
+    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore
+    assert out.frame_equal(pl.DataFrame({"x": [], "literal": []}))


### PR DESCRIPTION
1. This fixes the arange function to work in
the groupby context.

2. We improve performance and memory usage of literals in grouping
By doing so we found an inconstency in the literal expansion which
lead to the following expression working in grouping:

`pl.lit(1).cumsum()` would lead to a list of the group length.

This now does what you expect: e.g. [1].

To get old behavior we introduce a new expression: `repeat`

`pl.repeat(1, count()).cumsum()`


```python
(pl.DataFrame({
    "g": [1, 2, 2, 3, 3, 3]
}).groupby("g")
    .agg(pl.repeat(1, pl.count()).cumsum()
))

```

```
shape: (3, 2)
┌─────┬────────────┐
│ g   ┆ literal    │
│ --- ┆ ---        │
│ i64 ┆ list [i32] │
╞═════╪════════════╡
│ 1   ┆ [1]        │
├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2   ┆ [1, 2]     │
├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 3   ┆ [1, 2, 3]  │
└─────┴────────────┘

```
```