### PR TITLE
Fix read_parquet with list having nested struct

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -953,6 +953,11 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Time64(_) | ArrowDataType::Time32(_) => DataType::Time,
             #[cfg(feature = "dtype-categorical")]
             ArrowDataType::Dictionary(_, _, _) => DataType::Categorical(None),
+            #[cfg(feature = "dtype-struct")]
+            ArrowDataType::Struct(fields) => {
+                let fields: Vec<Field> = fields.iter().map(|fld| fld.into()).collect();
+                DataType::Struct(fields)
+            }
             ArrowDataType::Extension(name, _, _) if name == "POLARS_EXTENSION_TYPE" => {
                 #[cfg(feature = "object")]
                 {

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -130,3 +130,17 @@ def test_parquet_datetime() -> None:
     f.seek(0)
     read = pl.read_parquet(f)
     assert read.frame_equal(df)
+
+
+def test_nested_parquet() -> None:
+    f = io.BytesIO()
+    data = [
+        {"a": [{"b": 0}]},
+        {"a": [{"b": 1}, {"b": 2}]},
+    ]
+    df = pd.DataFrame(data)
+    df.to_parquet(f)
+
+    read = pl.read_parquet(f, use_pyarrow=True)
+    assert read.columns == ['a']
+    assert isinstance(read.dtypes[0].inner, pl.datatypes.Struct)

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -142,5 +142,6 @@ def test_nested_parquet() -> None:
     df.to_parquet(f)
 
     read = pl.read_parquet(f, use_pyarrow=True)
-    assert read.columns == ['a']
+    assert read.columns == ["a"]
+    assert isinstance(read.dtypes[0], pl.datatypes.List)
     assert isinstance(read.dtypes[0].inner, pl.datatypes.Struct)


### PR DESCRIPTION
I mentioned issues with reading Parquet files with nested structs in https://github.com/pola-rs/polars/issues/2448#issuecomment-1073394024. This PR is a work-in-progress to improve support for reading parquet files with nested structs. The current changes allow for the following to succeed.

```python
import pandas as pd
import polars as pl

# Write out a nested example
data = [                                                                                                       
    {'a': [{'b': 0}]},                                                                                         
    {'a': [{'b': 1}, {'b': 2}]},                                                                               
]
pd.DataFrame(data).to_parquet("~/test.parquet")

# Read it in polars
df = pl.read_parquet("~/test.parquet", use_pyarrow=True)
```