### PR TITLE
Bump arrow2 version

### DIFF
--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -9,9 +9,7 @@ description = "Arrow interfaces for Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "5658512460d64f8eca0d0ce0ae53aea41c35ab9d", default-features = false }
-# arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", branch = "cherry_pick", default-features = false }
-# arrow = { package = "arrow2", version = "0.10", default-features = false, features = ["compute_concatenate"] }
+arrow = { package = "arrow2", version = "0.10.1", default-features = false, features = ["compute_concatenate"] }
 hashbrown = "0.12"
 num = "^0.4"
 thiserror = "^1.0"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -162,16 +162,7 @@ regex = { version = "1.5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "^1.0"
-
-[dependencies.arrow]
-package = "arrow2"
-git = "https://github.com/jorgecarleitao/arrow2"
-# git = "https://github.com/ritchie46/arrow2"
-rev = "5658512460d64f8eca0d0ce0ae53aea41c35ab9d"
-# branch = "cherry_pick"
-version = "0.10"
-default-features = false
-features = [
+arrow = { package = "arrow2", version = "0.10.1", default-features = false, features = [
   "compute_aggregate",
   "compute_arithmetics",
   "compute_boolean",
@@ -182,7 +173,7 @@ features = [
   "compute_filter",
   "compute_if_then_else",
   "compute_take",
-]
+] }
 
 [dev-dependencies]
 bincode = "1"

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -34,9 +34,7 @@ private = ["polars-time/private"]
 [dependencies]
 ahash = "0.7"
 anyhow = "1.0"
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "5658512460d64f8eca0d0ce0ae53aea41c35ab9d", default-features = false }
-# arrow = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", branch = "cherry_pick", default-features = false }
-# arrow = { package = "arrow2", version = "0.10", default-features = false }
+arrow = { package = "arrow2", version = "0.10.1", default-features = false }
 csv-core = { version = "0.1.10", optional = true }
 dirs = "4.0"
 flate2 = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
As of `0.10.1` arrow2 has added support for odbc.

Incrementing the version here so that we can implement #2994 after