### PR TITLE
python: add apply on struct dtype

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -43,6 +43,9 @@ fn slice(
             break;
         }
     }
+    if new_chunks.is_empty() {
+        new_chunks.push(chunks[0].slice(0, 0).into());
+    }
     new_chunks
 }
 

--- a/polars/polars-core/src/series/iterator.rs
+++ b/polars/polars-core/src/series/iterator.rs
@@ -57,7 +57,7 @@ impl FromIterator<String> for Series {
     }
 }
 
-#[cfg(feature = "rows")]
+#[cfg(any(feature = "rows", feature = "dtype-struct"))]
 impl Series {
     pub fn iter(&self) -> SeriesIter<'_> {
         let dtype = self.dtype();

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -296,6 +296,7 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Date => $self.date().unwrap().$method($($args),*),
             DataType::Datetime(_, _) => $self.datetime().unwrap().$method($($args),*),
             DataType::List(_) => $self.list().unwrap().$method($($args),*),
+            DataType::Struct(_) => $self.struct_().unwrap().$method($($args),*),
             dt => panic!("dtype {:?} not supported", dt)
         }
     }

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1350,7 +1350,7 @@ def select(
     return pli.DataFrame([]).select(exprs)
 
 
-def struct(exprs: Union[Sequence["pli.Expr"], "pli.Expr"]) -> "pli.Expr":
+def struct(exprs: Union[Sequence[Union["pli.Expr", str]], "pli.Expr"]) -> "pli.Expr":
     """
     Collect several columns into a Series of dtype Struct
 

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::conversion::to_wrapped;
 use crate::series::PySeries;
 use crate::Wrap;
 use polars::chunked_array::builder::get_list_builder;
@@ -14,15 +15,10 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
     out: &'a PyAny,
     null_count: usize,
 ) -> PyResult<PySeries> {
-    if out.is_instance::<PyInt>().unwrap() {
-        let first_value = out.extract::<i64>().unwrap();
+    if out.is_instance::<PyBool>().unwrap() {
+        let first_value = out.extract::<bool>().unwrap();
         applyer
-            .apply_lambda_with_primitive_out_type::<Int64Type>(
-                py,
-                lambda,
-                null_count,
-                Some(first_value),
-            )
+            .apply_lambda_with_bool_out_type(py, lambda, null_count, Some(first_value))
             .map(|ca| ca.into_series().into())
     } else if out.is_instance::<PyFloat>().unwrap() {
         let first_value = out.extract::<f64>().unwrap();
@@ -34,10 +30,15 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
                 Some(first_value),
             )
             .map(|ca| ca.into_series().into())
-    } else if out.is_instance::<PyBool>().unwrap() {
-        let first_value = out.extract::<bool>().unwrap();
+    } else if out.is_instance::<PyInt>().unwrap() {
+        let first_value = out.extract::<i64>().unwrap();
         applyer
-            .apply_lambda_with_bool_out_type(py, lambda, null_count, Some(first_value))
+            .apply_lambda_with_primitive_out_type::<Int64Type>(
+                py,
+                lambda,
+                null_count,
+                Some(first_value),
+            )
             .map(|ca| ca.into_series().into())
     } else if out.is_instance::<PyString>().unwrap() {
         let first_value = out.extract::<&str>().unwrap();
@@ -1681,5 +1682,207 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 self.len(),
             ))
         }
+    }
+}
+
+impl<'a> ApplyLambda<'a> for StructChunked {
+    fn apply_lambda_unknown(&'a self, py: Python, lambda: &'a PyAny) -> PyResult<PySeries> {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let mut null_count = 0;
+        for val in self.into_iter() {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            let out = lambda.call1((arg,))?;
+            if out.is_none() {
+                null_count += 1;
+                continue;
+            }
+            return infer_and_finish(self, py, lambda, out, null_count);
+        }
+
+        // todo! full null
+        Ok(self.clone().into_series().into())
+    }
+
+    fn apply_lambda(&'a self, py: Python, lambda: &'a PyAny) -> PyResult<PySeries> {
+        self.apply_lambda_unknown(py, lambda)
+    }
+
+    fn apply_to_struct(
+        &'a self,
+        py: Python,
+        lambda: &'a PyAny,
+        init_null_count: usize,
+        first_value: AnyValue<'a>,
+    ) -> PyResult<PySeries> {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let skip = 1;
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            let out = lambda.call1((arg,)).unwrap();
+            Some(out)
+        });
+        iterator_to_struct(it, init_null_count, first_value, self.name(), self.len())
+    }
+
+    fn apply_lambda_with_primitive_out_type<D>(
+        &'a self,
+        py: Python,
+        lambda: &'a PyAny,
+        init_null_count: usize,
+        first_value: Option<D::Native>,
+    ) -> PyResult<ChunkedArray<D>>
+    where
+        D: PyArrowPrimitiveType,
+        D::Native: ToPyObject + FromPyObject<'a>,
+    {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let skip = if first_value.is_some() { 1 } else { 0 };
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            call_lambda_and_extract(py, lambda, arg).ok()
+        });
+
+        Ok(iterator_to_primitive(
+            it,
+            init_null_count,
+            first_value,
+            self.name(),
+            self.len(),
+        ))
+    }
+
+    fn apply_lambda_with_bool_out_type(
+        &'a self,
+        py: Python,
+        lambda: &'a PyAny,
+        init_null_count: usize,
+        first_value: Option<bool>,
+    ) -> PyResult<BooleanChunked> {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let skip = if first_value.is_some() { 1 } else { 0 };
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            call_lambda_and_extract(py, lambda, arg).ok()
+        });
+
+        Ok(iterator_to_bool(
+            it,
+            init_null_count,
+            first_value,
+            self.name(),
+            self.len(),
+        ))
+    }
+
+    fn apply_lambda_with_utf8_out_type(
+        &'a self,
+        py: Python,
+        lambda: &'a PyAny,
+        init_null_count: usize,
+        first_value: Option<&str>,
+    ) -> PyResult<Utf8Chunked> {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let skip = if first_value.is_some() { 1 } else { 0 };
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            call_lambda_and_extract(py, lambda, arg).ok()
+        });
+
+        Ok(iterator_to_utf8(
+            it,
+            init_null_count,
+            first_value,
+            self.name(),
+            self.len(),
+        ))
+    }
+    fn apply_lambda_with_list_out_type(
+        &'a self,
+        py: Python,
+        lambda: PyObject,
+        init_null_count: usize,
+        first_value: &Series,
+        dt: &DataType,
+    ) -> PyResult<ListChunked> {
+        let skip = 1;
+
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let lambda = lambda.as_ref(py);
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            call_lambda_series_out(py, lambda, arg).ok()
+        });
+        Ok(iterator_to_list(
+            dt,
+            it,
+            init_null_count,
+            Some(first_value),
+            self.name(),
+            self.len(),
+        ))
+    }
+    fn apply_lambda_with_object_out_type(
+        &'a self,
+        py: Python,
+        lambda: &'a PyAny,
+        init_null_count: usize,
+        first_value: Option<ObjectValue>,
+    ) -> PyResult<ObjectChunked<ObjectValue>> {
+        let collections_module = PyModule::import(py, "collections").unwrap();
+        let namedtuple = collections_module.getattr("namedtuple").unwrap();
+        let names = self.fields().iter().map(|s| s.name()).collect::<Vec<_>>();
+        let names = names.join(" ");
+        let namedtuple_constructor = namedtuple.call1(("struct", names)).unwrap();
+
+        let skip = if first_value.is_some() { 1 } else { 0 };
+        let it = self.into_iter().skip(init_null_count + skip).map(|val| {
+            let val = to_wrapped(val);
+            let arg = namedtuple_constructor.call1(PyTuple::new(py, val)).unwrap();
+            call_lambda_and_extract(py, lambda, arg).ok()
+        });
+
+        Ok(iterator_to_object(
+            it,
+            init_null_count,
+            first_value,
+            self.name(),
+            self.len(),
+        ))
     }
 }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -19,6 +19,12 @@ use pyo3::{PyAny, PyResult};
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
+pub(crate) fn to_wrapped<T>(slice: &[T]) -> &[Wrap<T>] {
+    // Safety:
+    // Wrap is transparent.
+    unsafe { std::mem::transmute(slice) }
+}
+
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);
 

--- a/py-polars/tests/test_apply.py
+++ b/py-polars/tests/test_apply.py
@@ -83,3 +83,27 @@ def test_apply_arithmetic_consistency() -> None:
     assert df.groupby("A").agg(pl.col("B").apply(lambda x: x + 1.0))["B"].to_list() == [
         [3.0, 4.0]
     ]
+
+
+def test_apply_struct() -> None:
+    df = pl.DataFrame(
+        {"A": ["a", "a"], "B": [2, 3], "C": [True, False], "D": [12.0, None]}
+    )
+    out = df.with_column(pl.struct(df.columns).alias("struct")).select(
+        [
+            pl.col("struct").apply(lambda x: x.A).alias("A_field"),
+            pl.col("struct").apply(lambda x: x.B).alias("B_field"),
+            pl.col("struct").apply(lambda x: x.C).alias("C_field"),
+            pl.col("struct").apply(lambda x: x.D).alias("D_field"),
+        ]
+    )
+    expected = pl.DataFrame(
+        {
+            "A_field": ["a", "a"],
+            "B_field": [2, 3],
+            "C_field": [True, False],
+            "D_field": [12.0, None],
+        }
+    )
+
+    assert out.frame_equal(expected)


### PR DESCRIPTION
Apply python functions over dtype `Struct`. The argument to the function will be of python type: `namedtuple` allow attribute and index access.

```python
df = pl.DataFrame({"A": ["a", "a"], 
                   "B": [2, 3],
                   "C": [True, False],
                   "D": [12.0, None]
                  })

out = df.with_column(pl.struct(df.columns).alias("struct")).select([
    pl.col("struct").apply(lambda x: x.A).alias("A_field"),
    pl.col("struct").apply(lambda x: x.B).alias("B_field"),
    pl.col("struct").apply(lambda x: x.C).alias("C_field"),
    pl.col("struct").apply(lambda x: x.D).alias("D_field"),
])
expected = pl.DataFrame(
{
 'A_field': ['a', 'a'],
 'B_field': [2, 3],
 'C_field': [True, False],
 'D_field': [12.0, None]}
)


assert out.frame_equal(expected)

```