### PR TITLE
allow nested groupby in groupby_rolling

### DIFF
--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -716,12 +716,16 @@ impl LazyFrame {
         }
     }
 
-    pub fn groupby_rolling(self, options: RollingGroupOptions) -> LazyGroupBy {
+    pub fn groupby_rolling<E: AsRef<[Expr]>>(
+        self,
+        by: E,
+        options: RollingGroupOptions,
+    ) -> LazyGroupBy {
         let opt_state = self.get_opt_state();
         LazyGroupBy {
             logical_plan: self.logical_plan,
             opt_state,
-            keys: vec![],
+            keys: by.as_ref().to_vec(),
             maintain_order: true,
             dynamic_options: None,
             rolling_options: Some(options),

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -52,7 +52,7 @@ impl Executor for GroupByDynamicExec {
 
         state.clear_schema_cache();
         let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
-        columns.extend(keys);
+        columns.extend_from_slice(&keys);
         columns.push(time_key);
         columns.extend(agg_columns.into_iter().flatten());
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -3,6 +3,7 @@ use super::*;
 #[cfg_attr(not(feature = "dynamic_groupby"), allow(dead_code))]
 pub(crate) struct GroupByRollingExec {
     pub(crate) input: Box<dyn Executor>,
+    pub(crate) keys: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) aggs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) options: RollingGroupOptions,
     pub(crate) input_schema: SchemaRef,
@@ -21,7 +22,13 @@ impl Executor for GroupByRollingExec {
         let df = self.input.execute(state)?;
         state.set_schema(self.input_schema.clone());
 
-        let (time_key, groups) = df.groupby_rolling(&self.options)?;
+        let keys = self
+            .keys
+            .iter()
+            .map(|e| e.evaluate(&df, state))
+            .collect::<Result<Vec<_>>>()?;
+
+        let (time_key, keys, groups) = df.groupby_rolling(keys, &self.options)?;
 
         let agg_columns = POOL.install(|| {
                     self.aggs
@@ -43,7 +50,8 @@ impl Executor for GroupByRollingExec {
                 })?;
 
         state.clear_schema_cache();
-        let mut columns = Vec::with_capacity(agg_columns.len() + 1);
+        let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
+        columns.extend_from_slice(&keys);
         columns.push(time_key);
         columns.extend(agg_columns.into_iter().flatten());
 

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -331,6 +331,7 @@ impl DefaultPlanner {
                 if let Some(options) = options.rolling {
                     return Ok(Box::new(GroupByRollingExec {
                         input,
+                        keys: phys_keys,
                         aggs: phys_aggs,
                         options,
                         input_schema,

--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -20,4 +20,10 @@ dtype-time = []
 dtype-duration = []
 private = []
 
+test = [
+  "dtype-date",
+  "dtype-datetime",
+  "polars-core/fmt",
+]
+
 default = ["private"]

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -714,6 +714,7 @@ class LazyFrame(Generic[DF]):
         period: str,
         offset: Optional[str] = None,
         closed: str = "right",
+        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
     ) -> "LazyGroupBy[LDF]":
         """
         Create rolling groups based on a time column (or index value of type Int32, Int64).
@@ -765,6 +766,8 @@ class LazyFrame(Generic[DF]):
         closed
             Defines if the window interval is closed or not.
             Any of {"left", "right", "both" "none"}
+        by
+            Also group by this column/these columns
 
         Examples
         --------
@@ -815,13 +818,9 @@ class LazyFrame(Generic[DF]):
 
         if offset is None:
             offset = f"-{period}"
+        by = _prepare_groupby_inputs(by)
 
-        lgb = self._ldf.groupby_rolling(
-            index_column,
-            period,
-            offset,
-            closed,
-        )
+        lgb = self._ldf.groupby_rolling(index_column, period, offset, closed, by)
         return LazyGroupBy(lgb, lazyframe_class=self.__class__)
 
     def groupby_dynamic(

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -327,15 +327,23 @@ impl PyLazyFrame {
         period: &str,
         offset: &str,
         closed: Wrap<ClosedWindow>,
+        by: Vec<PyExpr>,
     ) -> PyLazyGroupBy {
         let closed_window = closed.0;
         let ldf = self.ldf.clone();
-        let lazy_gb = ldf.groupby_rolling(RollingGroupOptions {
-            index_column,
-            period: Duration::parse(period),
-            offset: Duration::parse(offset),
-            closed_window,
-        });
+        let by = by
+            .into_iter()
+            .map(|pyexpr| pyexpr.inner)
+            .collect::<Vec<_>>();
+        let lazy_gb = ldf.groupby_rolling(
+            by,
+            RollingGroupOptions {
+                index_column,
+                period: Duration::parse(period),
+                offset: Duration::parse(offset),
+                closed_window,
+            },
+        );
 
         PyLazyGroupBy { lgb: Some(lazy_gb) }
     }

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -637,3 +637,32 @@ def test_duration_function() -> None:
     )
 
     assert out.frame_equal(expected)
+
+
+def test_rolling_groupby_by_argument() -> None:
+    df = pl.DataFrame({"times": range(10), "groups": [1] * 4 + [2] * 6})
+
+    out = df.groupby_rolling("times", "5i", by=["groups"]).agg(
+        pl.col("times").list().alias("agg_list")
+    )
+
+    expected = pl.DataFrame(
+        {
+            "groups": [1, 1, 1, 1, 2, 2, 2, 2, 2, 2],
+            "times": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "agg_list": [
+                [0],
+                [0, 1],
+                [0, 1, 2],
+                [0, 1, 2, 3],
+                [4],
+                [4, 5],
+                [4, 5, 6],
+                [4, 5, 6, 7],
+                [4, 5, 6, 7, 8],
+                [5, 6, 7, 8, 9],
+            ],
+        }
+    )
+
+    assert out.frame_equal(expected)


### PR DESCRIPTION
closes #3012 

```python
df = pl.DataFrame({
    "times": range(5),
    "groups": [1] * 2 + [2] * 3
})

(df.groupby_rolling("times", "5i", by=["groups"])
     .agg(pl.col("times").list().alias("agg_list"))
)
```

```
shape: (5, 3)
┌────────┬───────┬────────────┐
│ groups ┆ times ┆ agg_list   │
│ ---    ┆ ---   ┆ ---        │
│ i64    ┆ i64   ┆ list [i64] │
╞════════╪═══════╪════════════╡
│ 1      ┆ 0     ┆ [0]        │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 1      ┆ 1     ┆ [0, 1]     │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2      ┆ 2     ┆ [2]        │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2      ┆ 3     ┆ [2, 3]     │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2      ┆ 4     ┆ [2, 3, 4]  │
└────────┴───────┴────────────┘

```