### PR TITLE
[polars-sql] Adding SQL Context, SELECT and GROUP BY

### DIFF
--- a/polars-sql/Cargo.toml
+++ b/polars-sql/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlparser = { version= "0.15.0" }
+sqlparser = { version = "0.15.0" }
 serde = "1"
 serde_json = { version = "1" }
 

--- a/polars-sql/Cargo.toml
+++ b/polars-sql/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlparser = { version= "0.15.0"}
+sqlparser = { version= "0.15.0" }
 serde = "1"
 serde_json = { version = "1" }
 
@@ -66,7 +66,7 @@ features = [
   "parquet",
   "ipc",
   "is_in",
-  "serde"
+  "serde",
 ]
 
 [workspace]

--- a/polars-sql/Cargo.toml
+++ b/polars-sql/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = "polars-sql"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sqlparser = { version= "0.15.0"}
+serde = "1"
+serde_json = { version = "1" }
+
+[dependencies.polars]
+path = "../polars"
+default-features = false
+features = [
+  "dynamic_groupby",
+  "zip_with",
+  "simd",
+  "lazy",
+  "strings",
+  "temporal",
+  "random",
+  "object",
+  "csv-file",
+  "fmt",
+  "performant",
+  "dtype-full",
+  "rows",
+  "private",
+  "round_series",
+  "is_first",
+  "asof_join",
+  "cross_join",
+  "dot_product",
+  "concat_str",
+  "row_hash",
+  "reinterpret",
+  "decompress-fast",
+  "mode",
+  "extract_jsonpath",
+  "lazy_regex",
+  "cum_agg",
+  "rolling_window",
+  "interpolate",
+  "list",
+  "rank",
+  "diff",
+  "pct_change",
+  "moment",
+  "arange",
+  "true_div",
+  "dtype-categorical",
+  "diagonal_concat",
+  "horizontal_concat",
+  "abs",
+  "ewma",
+  "dot_diagram",
+  "dataframe_arithmetic",
+  "json",
+  "string_encoding",
+  "product",
+  "ndarray",
+  "series_from_anyvalue",
+  "avro",
+  "parquet",
+  "ipc",
+  "is_in",
+  "serde"
+]
+
+[workspace]

--- a/polars-sql/Cargo.toml
+++ b/polars-sql/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlparser = { version = "0.15.0" }
 serde = "1"
 serde_json = { version = "1" }
+sqlparser = { version = "0.15.0" }
 
 [dependencies.polars]
 path = "../polars"

--- a/polars-sql/rust-toolchain
+++ b/polars-sql/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/polars-sql/src/context.rs
+++ b/polars-sql/src/context.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+
+use crate::sql_expr::parse_sql_expr;
+use polars::error::PolarsError;
+use polars::prelude::{col, DataFrame, IntoLazy, LazyFrame};
+use sqlparser::ast::{
+    Expr as SqlExpr, Select, SelectItem, SetExpr, Statement, TableFactor, Value as SQLValue,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+#[derive(Default)]
+pub struct SQLContext {
+    table_map: HashMap<String, LazyFrame>,
+    dialect: GenericDialect,
+}
+
+impl SQLContext {
+    pub fn new() -> Self {
+        Self {
+            table_map: HashMap::new(),
+            dialect: GenericDialect::default(),
+        }
+    }
+
+    pub fn register(&mut self, name: &str, df: &DataFrame) {
+        self.table_map.insert(name.to_owned(), df.clone().lazy());
+    }
+
+    fn execute_select(&self, select_stmt: &Select) -> Result<LazyFrame, PolarsError> {
+        // Determine involved dataframe
+        // Implicit join require some more work in query parsers, Explicit join are preferred for now.
+        let tbl = select_stmt.from.get(0).unwrap();
+        let mut alias_map = HashMap::new();
+        let tbl_name = match &tbl.relation {
+            TableFactor::Table { name, alias, .. } => {
+                let tbl_name = name.0.get(0).unwrap().value.as_str();
+                if self.table_map.contains_key(tbl_name) {
+                    if let Some(alias) = alias {
+                        alias_map.insert(alias.name.value.clone(), tbl_name.to_owned());
+                    };
+                    tbl_name
+                } else {
+                    return Err(PolarsError::ComputeError(
+                        format!("Table name {tbl_name} was not found").into(),
+                    ));
+                }
+            }
+            // sqlparser::ast::TableFactor::Derived { lateral, subquery, alias } => todo!(),
+            // sqlparser::ast::TableFactor::TableFunction { expr, alias } => todo!(),
+            // sqlparser::ast::TableFactor::NestedJoin(_) => todo!(),
+            // Support bare table, optional with alias for now
+            _ => return Err(PolarsError::ComputeError("Not implemented".into())),
+        };
+        let df = &self.table_map[tbl_name];
+        let mut raw_projection_before_alias: HashMap<String, usize> = HashMap::new();
+        let mut contain_wildcard = false;
+        // Column Projections
+        let projection = select_stmt
+            .projection
+            .iter()
+            .enumerate()
+            .map(|(i, select_item)| {
+                Ok(match select_item {
+                    SelectItem::UnnamedExpr(expr) => {
+                        let expr = parse_sql_expr(expr)?;
+                        raw_projection_before_alias.insert(format!("{:?}", expr), i);
+                        expr
+                    }
+                    SelectItem::ExprWithAlias { expr, alias } => {
+                        let expr = parse_sql_expr(expr)?;
+                        raw_projection_before_alias.insert(format!("{:?}", expr), i);
+                        expr.alias(&alias.value)
+                    }
+                    SelectItem::QualifiedWildcard(_) | SelectItem::Wildcard => {
+                        contain_wildcard = true;
+                        col("*")
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, PolarsError>>()?;
+        // Check for group by
+        // After projection since there might be number.
+        let group_by = select_stmt
+            .group_by
+            .iter()
+            .map(
+                |e|match e {
+                  SqlExpr::Value(SQLValue::Number(idx, _)) => {
+                    let idx = match idx.parse::<usize>() {
+                        Ok(0)| Err(_) => Err(
+                        PolarsError::ComputeError(
+                            format!("Group By Error: Only positive number or expression are supported, got {idx}").into()
+                        )),
+                        Ok(idx) => Ok(idx)
+                    }?;
+                    Ok(projection[idx].clone())
+                  }
+                  SqlExpr::Value(_) => Err(
+                      PolarsError::ComputeError("Group By Error: Only positive number or expression are supported".into())
+                  ),
+                  _ => parse_sql_expr(e)
+                }
+            )
+            .collect::<Result<Vec<_>, PolarsError>>()?;
+
+        // println!("before plan: {:?}", df.schema());
+        let df = if group_by.is_empty() {
+            df.clone().select(projection)
+        } else {
+            // check groupby and projection due to difference between SQL and polars
+            // Return error on wild card, shouldn't process this
+            if contain_wildcard {
+                return Err(PolarsError::ComputeError(
+                    "Group By Error: Can't processed wildcard in groupby".into(),
+                ));
+            }
+            // Default polars group by will have group by columns at the front
+            // need some container to contain position of group by columns and its position
+            // at the final agg projection, check the schema for the existant of group by column
+            // and its projections columns, keeping the original index
+            let (exclude_expr, groupby_pos): (Vec<_>, Vec<_>) = group_by
+                .iter()
+                .map(|expr| raw_projection_before_alias.get(&format!("{:?}", expr)))
+                .enumerate()
+                .filter(|(_, proj_p)| proj_p.is_some())
+                .map(|(gb_p, proj_p)| (*proj_p.unwrap(), (*proj_p.unwrap(), gb_p)))
+                .unzip();
+            let (agg_projection, agg_proj_pos): (Vec<_>, Vec<_>) = projection
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !exclude_expr.contains(i))
+                .enumerate()
+                .map(|(agg_pj, (proj_p, expr))| (expr.clone(), (proj_p, agg_pj + group_by.len())))
+                .unzip();
+            // println!("Group By: {:?}, {:?}, {:?}", projection, group_by, agg_projection);
+            let agg_df = df.clone().groupby(group_by).agg(agg_projection);
+            let mut final_proj_pos = groupby_pos.into_iter()
+                .chain(agg_proj_pos.into_iter())
+                .collect::<Vec<_>>()
+                // .map(|(proj_p, schema_p)|)
+            ;
+
+            final_proj_pos.sort_by(|(proj_pa, _), (proj_pb, _)| proj_pa.cmp(proj_pb));
+            // println!("after plan: {:?}", agg_df.schema(), );
+            let final_proj = final_proj_pos
+                .into_iter()
+                .map(|(_, shm_p)| col(agg_df.schema().get_index(shm_p).unwrap().0))
+                .collect::<Vec<_>>();
+            agg_df.select(final_proj)
+        };
+        // println!("after plan: {:?}", df.schema());
+        Ok(df)
+    }
+
+    pub fn execute(&self, query: &str) -> Result<LazyFrame, PolarsError> {
+        let ast = Parser::parse_sql(&self.dialect, query)
+            .map_err(|e| PolarsError::ComputeError(format!("{:?}", e).into()))?;
+        if ast.len() != 1 {
+            Err(PolarsError::ComputeError(
+                "One and only one statement at a time please".into(),
+            ))
+        } else {
+            let ast = ast.get(0).unwrap();
+            Ok(match ast {
+                Statement::Query(query) => {
+                    let rs = match &query.body {
+                        SetExpr::Select(select_stmt) => self.execute_select(&*select_stmt)?,
+                        // SetExpr::Query(_) => todo!(), // Subqueries
+                        // SetExpr::SetOperation {
+                        //     op,
+                        //     all,
+                        //     left,
+                        //     right,
+                        // } => todo!(), // Union, Except, Intersect
+                        // SetExpr::Values(_) => todo!(), // Should not be implemented, return an errors here
+                        // SetExpr::Insert(_) => todo!(),
+                        _ => {
+                            return Err(PolarsError::ComputeError(
+                                "INSERT, UPDATE is not supported for polars".into(),
+                            ))
+                        }
+                    };
+                    match &query.limit {
+                        Some(SqlExpr::Value(SQLValue::Number(nrow, _))) => {
+                            let nrow = nrow.parse().map_err(|err| {
+                                PolarsError::ComputeError(
+                                    format!("Conversion Error: {:?}", err).into(),
+                                )
+                            })?;
+                            rs.limit(nrow)
+                        }
+                        None => rs,
+                        _ => {
+                            return Err(PolarsError::ComputeError(
+                                "Only support number argument to LIMIT clause".into(),
+                            ))
+                        }
+                    }
+                }
+                _ => {
+                    return Err(PolarsError::ComputeError(
+                        format!("Statement type {:?} is not supported", ast).into(),
+                    ))
+                }
+            })
+        }
+    }
+}

--- a/polars-sql/src/lib.rs
+++ b/polars-sql/src/lib.rs
@@ -7,19 +7,6 @@ mod sql_expr;
 mod test {
     use super::*;
     use polars::prelude::*;
-    use sqlparser::dialect::GenericDialect;
-    use sqlparser::parser::Parser;
-
-    #[test]
-    fn test_expr() {
-        let dialect = GenericDialect {};
-        let sql =
-            "SELECT a, (b::int + a)/a as c, count(b) + (-1.0) as b1 FROM t WHERE a > 0 and a < 10 group by a limit 100;";
-        let ast = Parser::parse_sql(&dialect, sql).unwrap();
-        if !ast.is_empty() {
-            println!("{:?}", ast);
-        };
-    }
 
     fn create_sample_df() -> Result<DataFrame> {
         let a = Series::new("a", (1..10000i64).map(|i| i / 100).collect::<Vec<_>>());
@@ -48,8 +35,6 @@ mod test {
             .select(&[col("a"), col("b"), (col("a") + col("b")).alias("c")])
             .limit(100)
             .collect()?;
-        println!("{:?}", df_sql);
-        println!("{:?}", df_pl);
         assert_eq!(df_sql, df_pl);
         Ok(())
     }

--- a/polars-sql/src/lib.rs
+++ b/polars-sql/src/lib.rs
@@ -14,7 +14,7 @@ mod test {
     fn test_expr() {
         let dialect = GenericDialect {};
         let sql =
-            "SELECT a, (b::int + a)/a as c, count(b) + (-1.0) as b1 FROM t group by a limit 100;";
+            "SELECT a, (b::int + a)/a as c, count(b) + (-1.0) as b1 FROM t WHERE a > 0 and a < 10 group by a limit 100;";
         let ast = Parser::parse_sql(&dialect, sql).unwrap();
         if !ast.is_empty() {
             println!("{:?}", ast);
@@ -37,15 +37,19 @@ mod test {
                 r#"
             SELECT a, b, a + b as c
             FROM df
+            where a > 10 and a < 20
             LIMIT 100
         "#,
             )?
             .collect()?;
         let df_pl = df
             .lazy()
+            .filter(col("a").gt(lit(10)).and(col("a").lt(lit(20))))
             .select(&[col("a"), col("b"), (col("a") + col("b")).alias("c")])
             .limit(100)
             .collect()?;
+        println!("{:?}", df_sql);
+        println!("{:?}", df_pl);
         assert_eq!(df_sql, df_pl);
         Ok(())
     }

--- a/polars-sql/src/lib.rs
+++ b/polars-sql/src/lib.rs
@@ -1,0 +1,95 @@
+pub use context::SQLContext;
+
+mod context;
+mod sql_expr;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use polars::prelude::*;
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    #[test]
+    fn test_expr() {
+        let dialect = GenericDialect {};
+        let sql =
+            "SELECT a, (b::int + a)/a as c, count(b) + (-1.0) as b1 FROM t group by a limit 100;";
+        let ast = Parser::parse_sql(&dialect, sql).unwrap();
+        if !ast.is_empty() {
+            println!("{:?}", ast);
+        };
+    }
+
+    fn create_sample_df() -> Result<DataFrame> {
+        let a = Series::new("a", (1..10000i64).map(|i| i / 100).collect::<Vec<_>>());
+        let b = Series::new("b", 1..10000i64);
+        DataFrame::new(vec![a, b])
+    }
+
+    #[test]
+    fn test_simple_select() -> Result<()> {
+        let df = create_sample_df()?;
+        let mut context = SQLContext::new();
+        context.register("df", &df);
+        let df_sql = context
+            .execute(
+                r#"
+            SELECT a, b, a + b as c
+            FROM df
+            LIMIT 100
+        "#,
+            )?
+            .collect()?;
+        let df_pl = df
+            .lazy()
+            .select(&[col("a"), col("b"), (col("a") + col("b")).alias("c")])
+            .limit(100)
+            .collect()?;
+        assert_eq!(df_sql, df_pl);
+        Ok(())
+    }
+
+    #[test]
+    fn test_groupby_simple() -> Result<()> {
+        let df = create_sample_df()?;
+        let mut context = SQLContext::new();
+        context.register("df", &df);
+        let df_sql = context
+            .execute(
+                r#"
+            SELECT a, sum(b) as b , sum(a + b) as c, count(a) as total_count
+            FROM df
+            GROUP BY a
+            LIMIT 100
+        "#,
+            )?
+            .sort(
+                "a",
+                SortOptions {
+                    descending: false,
+                    nulls_last: false,
+                },
+            )
+            .collect()?;
+        let df_pl = df
+            .lazy()
+            .groupby(&[col("a")])
+            .agg(&[
+                col("b").sum().alias("b"),
+                (col("a") + col("b")).sum().alias("c"),
+                col("a").count().alias("total_count"),
+            ])
+            .limit(100)
+            .sort(
+                "a",
+                SortOptions {
+                    descending: false,
+                    nulls_last: false,
+                },
+            )
+            .collect()?;
+        assert_eq!(df_sql, df_pl);
+        Ok(())
+    }
+}

--- a/polars-sql/src/sql_expr.rs
+++ b/polars-sql/src/sql_expr.rs
@@ -1,0 +1,221 @@
+use polars::error::PolarsError;
+use polars::prelude::{col, lit, DataType, Expr, LiteralValue, Result, TimeUnit};
+
+use sqlparser::ast::{
+    BinaryOperator as SQLBinaryOperator, DataType as SQLDataType, Expr as SqlExpr,
+    Function as SQLFunction, Value as SqlValue,
+};
+
+fn cast_(expr: Expr, data_type: &SQLDataType) -> Result<Expr> {
+    let polars_type = match data_type {
+        SQLDataType::Char(_)
+        | SQLDataType::Varchar(_)
+        | SQLDataType::Uuid
+        | SQLDataType::Clob(_)
+        | SQLDataType::Text
+        | SQLDataType::String => DataType::Utf8,
+
+        // SQLDataType::Binary(_) => todo!(),
+        // SQLDataType::Varbinary(_) => todo!(),
+        // SQLDataType::Blob(_) => todo!(),
+        // SQLDataType::Bytea => todo!(),
+        // SQLDataType::Decimal(_, _) => todo!(),
+        SQLDataType::Float(_) => DataType::Float32,
+        SQLDataType::Real => DataType::Float32,
+        SQLDataType::Double => DataType::Float64,
+        SQLDataType::TinyInt(_) => DataType::Int8,
+        SQLDataType::UnsignedTinyInt(_) => DataType::UInt8,
+        SQLDataType::SmallInt(_) => DataType::Int16,
+        SQLDataType::UnsignedSmallInt(_) => DataType::UInt16,
+        SQLDataType::Int(_) => DataType::Int32,
+        SQLDataType::UnsignedInt(_) => DataType::UInt32,
+        SQLDataType::BigInt(_) => DataType::Int64,
+        SQLDataType::UnsignedBigInt(_) => DataType::UInt64,
+
+        SQLDataType::Boolean => DataType::Boolean,
+        SQLDataType::Date => DataType::Date,
+        SQLDataType::Time => DataType::Time,
+        SQLDataType::Timestamp => DataType::Datetime(TimeUnit::Milliseconds, None),
+        SQLDataType::Interval => DataType::Duration(TimeUnit::Milliseconds),
+        // SQLDataType::Regclass => todo!(),
+        // SQLDataType::Custom(_) => todo!(),
+        // SQLDataType::Array(_) => todo!(),
+        // SQLDataType::Enum(_) => todo!(),
+        // SQLDataType::Set(_) => todo!(),
+        _ => {
+            return Err(PolarsError::ComputeError(
+                format!(
+                    "Casting for SQL Datatype {:?} was not supported in polars-sql yet!",
+                    data_type
+                )
+                .into(),
+            ))
+        }
+    };
+    Ok(expr.cast(polars_type))
+}
+
+fn binary_op_(left: Expr, right: Expr, op: &SQLBinaryOperator) -> Result<Expr> {
+    Ok(match op {
+        SQLBinaryOperator::Plus => {
+            left + right
+        },
+        SQLBinaryOperator::Minus => {
+            left -  right
+        },
+        SQLBinaryOperator::Multiply => {
+            left * right
+        },
+        SQLBinaryOperator::Divide => {
+            left / right
+        },
+        SQLBinaryOperator::Modulo => {
+            left % right
+        },
+        _ => return Err(PolarsError::ComputeError(format!("SQL Operator {:?} was not supported in polars-sql yet!", op).into()))
+        // SQLBinaryOperator::StringConcat => todo!(),
+        // SQLBinaryOperator::Gt => todo!(),
+        // SQLBinaryOperator::Lt => todo!(),
+        // SQLBinaryOperator::GtEq => todo!(),
+        // SQLBinaryOperator::LtEq => todo!(),
+        // SQLBinaryOperator::Spaceship => todo!(),
+        // SQLBinaryOperator::Eq => todo!(),
+        // SQLBinaryOperator::NotEq => todo!(),
+        // SQLBinaryOperator::And => todo!(),
+        // SQLBinaryOperator::Or => todo!(),
+        // SQLBinaryOperator::Xor => todo!(),
+        // SQLBinaryOperator::Like => todo!(),
+        // SQLBinaryOperator::NotLike => todo!(),
+        // SQLBinaryOperator::ILike => todo!(),
+        // SQLBinaryOperator::NotILike => todo!(),
+        // SQLBinaryOperator::BitwiseOr => todo!(),
+        // SQLBinaryOperator::BitwiseAnd => todo!(),
+        // SQLBinaryOperator::BitwiseXor => todo!(),
+        // SQLBinaryOperator::PGBitwiseXor => todo!(),
+        // SQLBinaryOperator::PGBitwiseShiftLeft => todo!(),
+        // SQLBinaryOperator::PGBitwiseShiftRight => todo!(),
+        // SQLBinaryOperator::PGRegexMatch => todo!(),
+        // SQLBinaryOperator::PGRegexIMatch => todo!(),
+        // SQLBinaryOperator::PGRegexNotMatch => todo!(),
+        // SQLBinaryOperator::PGRegexNotIMatch => todo!(),
+    })
+}
+
+fn literal_expr(value: &SqlValue) -> Result<Expr> {
+    Ok(match value {
+        SqlValue::Number(s, _) => {
+            // Check for existence of decimal separator dot
+            if s.contains('.') {
+                s.parse::<f64>().map(lit).map_err(|_| {
+                    PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
+                })
+            } else {
+                s.parse::<i64>().map(lit).map_err(|_| {
+                    PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
+                })
+            }?
+        }
+        SqlValue::SingleQuotedString(s) => lit(s.clone()),
+        SqlValue::NationalStringLiteral(s) => lit(s.clone()),
+        SqlValue::HexStringLiteral(s) => lit(s.clone()),
+        SqlValue::DoubleQuotedString(s) => lit(s.clone()),
+        SqlValue::Boolean(b) => lit(*b),
+        // SqlValue::Interval { value, leading_field, leading_precision, last_field, fractional_seconds_precision } => todo!(),
+        SqlValue::Null => Expr::Literal(LiteralValue::Null),
+        // SqlValue::Placeholder(_) => todo!(),
+        _ => {
+            return Err(PolarsError::ComputeError(
+                format!(
+                    "Parsing SQL Value {:?} was not supported in polars-sql yet!",
+                    value
+                )
+                .into(),
+            ))
+        }
+    })
+}
+
+pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> Result<Expr> {
+    Ok(match expr {
+        SqlExpr::Identifier(e) => col(&e.value),
+        SqlExpr::BinaryOp { left, op, right } => {
+            let left = parse_sql_expr(left)?;
+            let right = parse_sql_expr(right)?;
+            binary_op_(left, right, op)?
+        }
+        SqlExpr::Function(sql_function) => parse_sql_function(sql_function)?,
+        SqlExpr::Cast { expr, data_type } => cast_(parse_sql_expr(expr)?, data_type)?,
+        SqlExpr::Nested(expr) => parse_sql_expr(expr)?,
+        SqlExpr::Value(value) => literal_expr(value)?,
+        _ => {
+            return Err(PolarsError::ComputeError(
+                format!(
+                    "Expression: {:?} was not supported in polars-sql yet!",
+                    expr
+                )
+                .into(),
+            ))
+        }
+    })
+}
+
+// trait FunctionKernel<T> {
+//     fn parse_args(args: &[FunctionArg]) -> T;
+// }
+
+fn parse_sql_function(sql_function: &SQLFunction) -> Result<Expr> {
+    use sqlparser::ast::{FunctionArg, FunctionArgExpr, WindowSpec};
+    // Function name mostly do not have name space, so it mostly take the first args
+    let function_name = sql_function.name.0[0].value.to_lowercase();
+    let args = sql_function
+        .args
+        .iter()
+        .map(|arg| match arg {
+            FunctionArg::Named { arg, .. } => arg,
+            FunctionArg::Unnamed(arg) => arg,
+        })
+        .collect::<Vec<_>>();
+    fn apply_window_spec(expr: Expr, window_spec: &Option<WindowSpec>) -> Result<Expr> {
+        Ok(match &window_spec {
+            Some(window_spec) => {
+                // Process for simple window specification, partitionn by first
+                let partition_by = window_spec
+                    .partition_by
+                    .iter()
+                    .map(parse_sql_expr)
+                    .collect::<Result<Vec<_>>>()?;
+                expr.over(partition_by)
+                // Order by and Row range may not be supported at the moment
+            }
+            None => expr,
+        })
+    }
+    Ok(
+        match (
+            function_name.as_str(),
+            args.as_slice(),
+            sql_function.distinct,
+        ) {
+            ("sum", [FunctionArgExpr::Expr(expr)], false) => {
+                apply_window_spec(parse_sql_expr(expr)?, &sql_function.over)?.sum()
+            }
+            ("count", [FunctionArgExpr::Expr(expr)], false) => {
+                apply_window_spec(parse_sql_expr(expr)?, &sql_function.over)?.count()
+            }
+            ("count", [FunctionArgExpr::Expr(expr)], true) => {
+                apply_window_spec(parse_sql_expr(expr)?, &sql_function.over)?.n_unique()
+            }
+            // Special case for wildcard args to count function.
+            ("count", [FunctionArgExpr::Wildcard], false) => lit(1i32).count(),
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    format!(
+                        "Function {:?} with args {:?} was not supported in polars-sql yet!",
+                        function_name, args
+                    )
+                    .into(),
+                ))
+            }
+        },
+    )
+}


### PR DESCRIPTION
This is the another attempt at adding SQL support to `polars`, in separate crate.

This PR add:
- SQL Context Object, which currently support register DataFrame.
- SELECT, GROUP BY on a single DataFrame