### PR TITLE
Change default behavior of `.sample()` to random seeding

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -67,11 +67,11 @@ from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
     format_path,
+    get_random_seed,
     handle_projection_columns,
     is_int_sequence,
     is_str_sequence,
     range_to_slice,
-    get_random_seed
 )
 
 try:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -71,6 +71,7 @@ from polars.utils import (
     is_int_sequence,
     is_str_sequence,
     range_to_slice,
+    get_random_seed
 )
 
 try:
@@ -4725,7 +4726,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         n: Optional[int] = None,
         frac: Optional[float] = None,
         with_replacement: bool = False,
-        seed: int = 0,
+        seed: Optional[int] = None,
     ) -> DF:
         """
         Sample from this DataFrame by setting either `n` or `frac`.
@@ -4750,7 +4751,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... )
-        >>> df.sample(n=2)  # doctest: +IGNORE_RESULT
+        >>> df.sample(n=2, seed=0)  # doctest: +IGNORE_RESULT
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -4763,6 +4764,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴─────┴─────┘
 
         """
+        if seed is None:
+            seed = get_random_seed()
+
         if n is not None:
             return self._from_pydf(self._df.sample_n(n, with_replacement, seed))
         return self._from_pydf(self._df.sample_frac(frac, with_replacement, seed))

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -73,8 +73,8 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _ptr_to_numpy,
     _to_python_datetime,
+    get_random_seed,
     range_to_slice,
-    get_random_seed
 )
 
 try:

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -74,6 +74,7 @@ from polars.utils import (
     _ptr_to_numpy,
     _to_python_datetime,
     range_to_slice,
+    get_random_seed
 )
 
 try:
@@ -3015,7 +3016,7 @@ class Series:
         n: Optional[int] = None,
         frac: Optional[float] = None,
         with_replacement: bool = False,
-        seed: int = 0,
+        seed: Optional[int] = None,
     ) -> "Series":
         """
         Sample from this Series by setting either `n` or `frac`.
@@ -3034,7 +3035,7 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3, 4, 5])
-        >>> s.sample(2)  # doctest: +IGNORE_RESULT
+        >>> s.sample(2, seed=0)  # doctest: +IGNORE_RESULT
         shape: (2,)
         Series: 'a' [i64]
         [
@@ -3043,6 +3044,9 @@ class Series:
         ]
 
         """
+        if seed is None:
+            seed = get_random_seed()
+
         if n is not None:
             return wrap_s(self._s.sample_n(n, with_replacement, seed))
         return wrap_s(self._s.sample_frac(frac, with_replacement, seed))

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, U
 import numpy as np
 
 from polars.datatypes import DataType, Date, Datetime
+from random import SystemRandom
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -210,3 +211,12 @@ def format_path(path: Union[str, Path]) -> str:
     Returnsa string path, expanding the home directory if present.
     """
     return os.path.expanduser(path)
+
+def get_random_seed() -> int:
+    """
+    Returns a randomly generated unsigned integer.
+    """
+    generator = SystemRandom()
+    seed = generator.randint(0, sys.maxsize * 2)
+
+    return seed

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -3,12 +3,12 @@ import os
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from random import SystemRandom
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 
 from polars.datatypes import DataType, Date, Datetime
-from random import SystemRandom
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -211,6 +211,7 @@ def format_path(path: Union[str, Path]) -> str:
     Returnsa string path, expanding the home directory if present.
     """
     return os.path.expanduser(path)
+
 
 def get_random_seed() -> int:
     """

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1652,8 +1652,8 @@ def test_is_unique() -> None:
 
 def test_sample() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]})
-    assert df.sample(n=2).shape == (2, 3)
-    assert df.sample(frac=0.4).shape == (1, 3)
+    assert df.sample(n=2, seed=0).shape == (2, 3)
+    assert df.sample(frac=0.4, seed=0).shape == (1, 3)
 
 
 @pytest.mark.parametrize("in_place", [True, False])

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1082,16 +1082,16 @@ def test_dot() -> None:
 
 def test_sample() -> None:
     s = pl.Series("a", [1, 2, 3, 4, 5])
-    assert len(s.sample(n=2)) == 2
-    assert len(s.sample(frac=0.4)) == 2
+    assert len(s.sample(n=2, seed=0)) == 2
+    assert len(s.sample(frac=0.4, seed=0)) == 2
 
-    assert len(s.sample(n=2, with_replacement=True)) == 2
+    assert len(s.sample(n=2, seed=0, with_replacement=True)) == 2
 
     # on a series of length 5, you cannot sample more than 5 items
     with pytest.raises(Exception):
-        s.sample(n=10, with_replacement=False)
+        s.sample(n=10, seed=0, with_replacement=False)
     # unless you use with_replacement=True
-    assert len(s.sample(n=10, with_replacement=True)) == 10
+    assert len(s.sample(n=10, seed=0, with_replacement=True)) == 10
 
 
 def test_peak_max_peak_min() -> None:


### PR DESCRIPTION
## Problem

See #3044 for context.

## Implementation

`SystemRandom` from `random` implements conversion for `os.urandom()` for generating integer values from native resources. The `os.urandom` function is also used by `numpy` to initialize seeds. 

This change intends to mimic that to generate a `seed` for when a `seed` is not passed to `.sample()`.

I'd love feedback on this approach since it will create different default behavior between the Python and Rust APIs. I'd think we'd want to sync this up if this change were to be accepted.

Steps:
- [x] Initial `get_random_seed()` implementation
- [x] Updated tests and existing docstrings
- [ ] Move to core
- [ ] New tests for default behavior
- [ ] Check perf
- [ ] Docs

**Update**: This PR will be replaced with a new PR focused on the core changes rather than just making changes to the Python API.