### PR TITLE
check output length of all 'map' expressions

### DIFF
--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import polars as pl
@@ -8,3 +9,15 @@ def test_error_on_empty_groupby() -> None:
         pl.ComputeError, match="expected keys in groupby operation, got nothing"
     ):
         pl.DataFrame(dict(x=[0, 0, 1, 1])).groupby([]).agg(pl.count())
+
+
+def test_error_on_reducing_map() -> None:
+    df = pl.DataFrame(
+        dict(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4])
+    )
+
+    with pytest.raises(
+        pl.ComputeError,
+        match="A 'map' functions output length must be equal to that of the input length. Consider using 'apply' in favor of 'map'.",
+    ):
+        df.groupby("id").agg(pl.map(["t", "y"], np.trapz))


### PR DESCRIPTION
Fixes UB on invalid user inputs.

```python
>>> df = pl.DataFrame(dict(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4]))
>>> df.groupby('id').agg(pl.map(['t', 'y'], np.trapz))
---------------------------------------------------------------------------
ComputeError                              Traceback (most recent call last)
/tmp/ipykernel_37312/3193676698.py in <module>
      1 df = pl.DataFrame(dict(id=[0, 0, 0, 1, 1, 1], t=[2, 4, 5, 10, 11, 14], y=[0, 1, 1, 2, 3, 4]))
----> 2 df.groupby('id').agg(pl.map(['t', 'y'], np.trapz))

~/code/polars/py-polars/polars/internals/frame.py in agg(self, column_to_agg)
   5432             elif isinstance(column_to_agg[0], pli.Expr):
   5433                 return (
-> 5434                     self._dataframe_class._from_pydf(self._df)
   5435                     .lazy()
   5436                     .groupby(self.by, maintain_order=self.maintain_order)

~/code/polars/py-polars/polars/internals/lazy_frame.py in collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, string_cache, no_optimization, slice_pushdown)
    474             slice_pushdown,
    475         )
--> 476         return self._dataframe_class._from_pydf(ldf.collect())
    477 
    478     def fetch(

ComputeError: A 'map' functions return length must be equal to that of the input length. Consider using 'apply' in favor of 'map'.


```