### PR TITLE
comment out patch.crates-io in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ members = [
   "examples/python_rust_compiled_function",
 ]
 
-[patch.crates-io]
+# [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }


### PR DESCRIPTION
## Problem

rust-analyzer doesn't cooperate with a workspace in VSCode with `[patch.crates-io]` unused like this.

## Solution

Commenting it should resolve this issue. Maybe we can remove this entirely. Let me know and I'll pull it out.