### PR TITLE
Enhanced columns param for DataFrame init, additionally allowing for inline type specification

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -354,8 +354,8 @@ def _unpack_columns(
     lookup = {
         col: name for col, name in zip_longest(column_names, lookup_names or []) if name
     }
-    return (  # type: ignore[return-value]
-        column_names or None,
+    return (
+        column_names or None,  # type: ignore[return-value]
         {
             lookup.get(col[0], col[0]): col[1]
             for col in (columns or [])

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1,6 +1,18 @@
 import warnings
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Type, Union
+from itertools import zip_longest
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 
@@ -41,6 +53,12 @@ else:
         _PYARROW_AVAILABLE = True
     except ImportError:  # pragma: no cover
         _PYARROW_AVAILABLE = False
+
+ColumnsType = Union[
+    Union[List[str], Sequence[str]],  # ['x','y','z']
+    Dict[str, Type[DataType]],  # {'x':date,'y':str,'z':int}
+    Sequence[Tuple[str, Type[DataType]]],  # [('x',date),('y',str),('z',int)]
+]
 
 ################################
 # Series constructor interface #
@@ -282,7 +300,7 @@ def _handle_columns_arg(
     """
     Rename data according to columns argument.
     """
-    if columns is None:
+    if not columns:
         return data
     else:
         if not data:
@@ -295,34 +313,105 @@ def _handle_columns_arg(
             raise ValueError("Dimensions of columns arg must match data dimensions.")
 
 
+def _post_apply_columns(
+    pydf: "PyDataFrame",
+    columns: ColumnsType,
+) -> "PyDataFrame":
+    """
+    Apply 'columns' param _after_ PyDataFrame creation (if no alternative).
+    """
+    pydf_columns, pydf_dtypes = pydf.columns(), pydf.dtypes()
+    columns, dtypes = _unpack_columns(columns or pydf_columns)
+    if columns != pydf_columns:
+        pydf.set_column_names(columns)
+
+    column_casts = [
+        pli.col(col).cast(dtypes[col])._pyexpr
+        for i, col in enumerate(columns)
+        if col in dtypes and dtypes[col] != pydf_dtypes[i]
+    ]
+    if column_casts:
+        pydf = pydf.lazy().with_columns(column_casts).collect()
+    return pydf
+
+
+def _unpack_columns(
+    columns: Optional[ColumnsType],
+    lookup_names: Optional[Iterable[str]] = None,
+    n_expected: Optional[int] = None,
+) -> Tuple[List[str], Dict[str, Type[DataType]]]:
+    """
+    Unpack column names and create dtype lookup for any (name,dtype) pairs or schema dict input.
+    """
+    if isinstance(columns, dict):
+        columns = list(columns.items())
+    column_names = [
+        (col or f"column_{i}") if isinstance(col, str) else col[0]
+        for i, col in enumerate((columns or []))
+    ]
+    if not column_names and n_expected:
+        column_names = [f"column_{i}" for i in range(n_expected)]
+    lookup = {
+        col: name for col, name in zip_longest(column_names, lookup_names or []) if name
+    }
+    return (  # type: ignore[return-value]
+        column_names or None,
+        {
+            lookup.get(col[0], col[0]): col[1]
+            for col in (columns or [])
+            if not isinstance(col, str) and col[1]
+        },
+    )
+
+
 def dict_to_pydf(
     data: Dict[str, Sequence[Any]],
-    columns: Optional[Sequence[str]] = None,
+    columns: Optional[ColumnsType] = None,
 ) -> "PyDataFrame":
     """
     Construct a PyDataFrame from a dictionary of sequences.
     """
-    data_series = [pli.Series(name, values).inner() for name, values in data.items()]
+    columns, dtypes = _unpack_columns(columns, lookup_names=data.keys())
+    if not data and dtypes:
+        data_series = [
+            pli.Series(name, [], dtypes.get(name)).inner() for name in columns
+        ]
+    else:
+        data_series = [
+            pli.Series(name, values, dtypes.get(name)).inner()
+            for name, values in data.items()
+        ]
     data_series = _handle_columns_arg(data_series, columns=columns)
     return PyDataFrame(data_series)
 
 
 def numpy_to_pydf(
     data: np.ndarray,
-    columns: Optional[Sequence[str]] = None,
+    columns: Optional[ColumnsType] = None,
     orient: Optional[str] = None,
 ) -> "PyDataFrame":
     """
     Construct a PyDataFrame from a numpy ndarray.
     """
     shape = data.shape
+    n_columns = (
+        0
+        if shape == (0,)
+        else (
+            1
+            if len(shape) == 1
+            else (shape[1] if orient in ("row", None) else shape[0])
+        )
+    )
+    columns, dtypes = _unpack_columns(columns, n_expected=n_columns)
+    if columns and len(columns) != n_columns:
+        raise ValueError("Dimensions of columns arg must match data dimensions.")
 
     if shape == (0,):
         data_series = []
 
     elif len(shape) == 1:
-        s = pli.Series("column_0", data).inner()
-        data_series = [s]
+        data_series = [pli.Series(columns[0], data, dtypes.get(columns[0])).inner()]
 
     elif len(shape) == 2:
         # Infer orientation
@@ -338,46 +427,54 @@ def numpy_to_pydf(
         # Exchange if-block above for block below when removing warning
         # if orientation is None and columns is not None:
         #     orientation = "col" if len(columns) == shape[0] else "row"
-
         if orient == "row":
             data_series = [
-                pli.Series(f"column_{i}", data[:, i]).inner() for i in range(shape[1])
+                pli.Series(columns[i], data[:, i], dtypes.get(columns[i])).inner()
+                for i in range(n_columns)
             ]
         else:
             data_series = [
-                pli.Series(f"column_{i}", data[i]).inner() for i in range(shape[0])
+                pli.Series(columns[i], data[i], dtypes.get(columns[i])).inner()
+                for i in range(n_columns)
             ]
     else:
         raise ValueError("A numpy array should not have more than two dimensions.")
 
     data_series = _handle_columns_arg(data_series, columns=columns)
-
     return PyDataFrame(data_series)
 
 
 def sequence_to_pydf(
     data: Sequence[Any],
-    columns: Optional[Sequence[str]] = None,
+    columns: Optional[ColumnsType] = None,
     orient: Optional[str] = None,
 ) -> "PyDataFrame":
     """
     Construct a PyDataFrame from a sequence.
     """
     data_series: List["PySeries"]
+
     if len(data) == 0:
         data_series = []
 
     elif isinstance(data[0], pli.Series):
+        series_names = [s.name for s in data]
+        columns, dtypes = _unpack_columns(columns or series_names, n_expected=len(data))
         data_series = []
         for i, s in enumerate(data):
             if not s.name:  # TODO: Replace by `if s.name is None` once allowed
-                s.rename(f"column_{i}", in_place=True)
+                s.rename(columns[i], in_place=True)
+
+            new_dtype = dtypes.get(columns[i])
+            if new_dtype and new_dtype != s.dtype:
+                s = s.cast(new_dtype)
+
             data_series.append(s.inner())
 
     elif isinstance(data[0], dict):
         pydf = PyDataFrame.read_dicts(data)
-        if columns is not None:
-            pydf.set_column_names(columns)
+        if columns:
+            pydf = _post_apply_columns(pydf, columns)
         return pydf
 
     elif isinstance(data[0], Sequence) and not isinstance(data[0], str):
@@ -387,24 +484,26 @@ def sequence_to_pydf(
 
         if orient == "row":
             pydf = PyDataFrame.read_rows(data)
-            if columns is not None:
-                pydf.set_column_names(columns)
+            if columns:
+                pydf = _post_apply_columns(pydf, columns)
             return pydf
         else:
+            columns, dtypes = _unpack_columns(columns, n_expected=len(data))
             data_series = [
-                pli.Series(f"column_{i}", data[i]).inner() for i in range(len(data))
+                pli.Series(columns[i], data[i], dtypes.get(columns[i])).inner()
+                for i in range(len(data))
             ]
 
     else:
-        s = pli.Series("column_0", data).inner()
-        data_series = [s]
+        columns, dtypes = _unpack_columns(columns, n_expected=1)
+        data_series = [pli.Series(columns[0], data, dtypes.get(columns[0])).inner()]
 
-    data_series = _handle_columns_arg(data_series, columns=columns)
+    data_series = _handle_columns_arg(data_series, columns=columns)  # type: ignore[arg-type]
     return PyDataFrame(data_series)
 
 
 def arrow_to_pydf(
-    data: "pa.Table", columns: Optional[Sequence[str]] = None, rechunk: bool = True
+    data: "pa.Table", columns: Optional[ColumnsType] = None, rechunk: bool = True
 ) -> "PyDataFrame":
     """
     Construct a PyDataFrame from an Arrow Table.
@@ -413,6 +512,8 @@ def arrow_to_pydf(
         raise ImportError(
             "'pyarrow' is required when constructing a PyDataFrame from an Arrow Table."
         )
+    original_columns = columns
+    columns, dtypes = _unpack_columns(columns)
     if columns is not None:
         try:
             data = data.rename_columns(columns)
@@ -460,24 +561,34 @@ def arrow_to_pydf(
             df[s.name] = s
         df = df[names]
         pydf = df._df
+
+    if dtypes and original_columns:
+        pydf = _post_apply_columns(pydf, original_columns)
     return pydf
 
 
 def series_to_pydf(
     data: "pli.Series",
-    columns: Optional[Sequence[str]] = None,
+    columns: Optional[ColumnsType] = None,
 ) -> "PyDataFrame":
     """
     Construct a PyDataFrame from a Polars Series.
     """
     data_series = [data.inner()]
+    series_name = [s.name() for s in data_series]
+    columns, dtypes = _unpack_columns(columns or series_name, n_expected=1)
+    if dtypes:
+        new_dtype = list(dtypes.values())[0]
+        if new_dtype != data.dtype:
+            data_series[0] = data_series[0].cast(new_dtype, True)
+
     data_series = _handle_columns_arg(data_series, columns=columns)
     return PyDataFrame(data_series)
 
 
 def pandas_to_pydf(
     data: "pd.DataFrame",
-    columns: Optional[Sequence[str]] = None,
+    columns: Optional[ColumnsType] = None,
     rechunk: bool = True,
     nan_to_none: bool = True,
 ) -> "PyDataFrame":
@@ -488,10 +599,10 @@ def pandas_to_pydf(
         raise ImportError(
             "'pyarrow' is required when constructing a PyDataFrame from a pandas DataFrame."
         )
-    len = data.shape[0]
+    length = data.shape[0]
     arrow_dict = {
         str(col): _pandas_series_to_arrow(
-            data[col], nan_to_none=nan_to_none, min_len=len
+            data[col], nan_to_none=nan_to_none, min_len=length
         )
         for col in data.columns
     }

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -44,6 +44,7 @@ except ImportError:  # pragma: no cover
 
 from polars import internals as pli
 from polars.internals.construction import (
+    ColumnsType,
     arrow_to_pydf,
     dict_to_pydf,
     numpy_to_pydf,
@@ -180,7 +181,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     data : dict, Sequence, ndarray, Series, or pandas.DataFrame
         Two-dimensional data in various forms. dict must contain Sequences.
         Sequence may contain Series or other Sequences.
-    columns : Sequence of str, default None
+    columns : Sequence of str or (str,DataType) pairs, default None
         Column labels to use for resulting DataFrame. If specified, overrides any
         labels already present in the data. Must match data dimensions.
     orient : {'col', 'row'}, default None
@@ -212,7 +213,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Int64'>]
 
     In order to specify dtypes for your columns, initialize the DataFrame with a list
-    of Series instead:
+    of typed Series, or set the columns parameter with a list of (name,dtype) pairs:
 
     >>> data = [
     ...     pl.Series("col1", [1, 2], dtype=pl.Float32),
@@ -226,17 +227,30 @@ class DataFrame(metaclass=DataFrameMetaClass):
     │ ---  ┆ ---  │
     │ f32  ┆ i64  │
     ╞══════╪══════╡
-    │ 1    ┆ 3    │
+    │ 1.0  ┆ 3    │
     ├╌╌╌╌╌╌┼╌╌╌╌╌╌┤
-    │ 2    ┆ 4    │
+    │ 2.0  ┆ 4    │
+    └──────┴──────┘
+
+    # or, equivalent... (and also compatible with all of the other valid data parameter types):
+    >>> df3 = pl.DataFrame(data, columns=[("col1", pl.Float32), ("col2", pl.Int64)])
+    >>> df3
+    ┌──────┬──────┐
+    │ col1 ┆ col2 │
+    │ ---  ┆ ---  │
+    │ f32  ┆ i64  │
+    ╞══════╪══════╡
+    │ 1.0  ┆ 3    │
+    ├╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+    │ 2.0  ┆ 4    │
     └──────┴──────┘
 
     Constructing a DataFrame from a numpy ndarray, specifying column names:
 
     >>> import numpy as np
     >>> data = np.array([(1, 2), (3, 4)], dtype=np.int64)
-    >>> df3 = pl.DataFrame(data, columns=["a", "b"], orient="col")
-    >>> df3
+    >>> df4 = pl.DataFrame(data, columns=["a", "b"], orient="col")
+    >>> df4
     shape: (2, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -278,7 +292,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 "pli.Series",
             ]
         ] = None,
-        columns: Optional[Sequence[str]] = None,
+        columns: Optional[ColumnsType] = None,
         orient: Optional[str] = None,
     ):
         if data is None:
@@ -4942,8 +4956,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> "pli.Series":
         """
         Hash and combine the rows in this DataFrame.
-
-        Hash value is UInt64
+        Hash value is UInt64.
 
         Parameters
         ----------

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -105,7 +105,6 @@ def test_init_ndarray() -> None:
     df = pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
     truth = pl.DataFrame({"a": [1, 2, 3]})
     assert df.frame_equal(truth)
-    assert df.dtypes == [pl.Int64]
 
     df = pl.DataFrame(np.array([1, 2, 3]), columns=[("a", pl.Int32)])
     truth = pl.DataFrame({"a": [1, 2, 3]}).with_column(pl.col("a").cast(pl.Int32))
@@ -121,11 +120,6 @@ def test_init_ndarray() -> None:
         {"column_0": [1, None], "column_1": [2.0, None], "column_2": ["a", None]}
     )
     assert df.frame_equal(truth)
-    assert df.schema == {
-        "column_0": pl.Int64,
-        "column_1": pl.Float64,
-        "column_2": pl.Utf8,
-    }
 
     df = pl.DataFrame(
         data=[[1, 2.0, "a"], [None, None, None]],
@@ -211,10 +205,11 @@ def test_init_series() -> None:
     assert df.frame_equal(truth)
 
     df = pl.DataFrame(
-        (pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))), columns=["x", "y"]
+        (pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))),
+        columns=[("x", pl.Float64), ("y", pl.Float64)],
     )
-    assert df.schema == {"x": pl.Int64, "y": pl.Int64}
-    assert df.rows() == [(1, 4), (2, 5), (3, 6)]
+    assert df.schema == {"x": pl.Float64, "y": pl.Float64}
+    assert df.rows() == [(1.0, 4.0), (2.0, 5.0), (3.0, 6.0)]
 
     # List of unnamed Series
     df = pl.DataFrame([pl.Series([1, 2, 3]), pl.Series([4, 5, 6])])
@@ -223,9 +218,9 @@ def test_init_series() -> None:
     )
     assert df.frame_equal(truth)
 
-    df = pl.DataFrame([pl.Series([None]), pl.Series([1.0])])
+    df = pl.DataFrame([pl.Series([0.0]), pl.Series([1.0])])
     assert df.schema == {"column_0": pl.Float64, "column_1": pl.Float64}
-    assert df.rows() == [(None, 1.0)]
+    assert df.rows() == [(0.0, 1.0)]
 
     df = pl.DataFrame(
         [pl.Series([None]), pl.Series([1.0])],

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -31,6 +31,21 @@ def test_init_only_columns() -> None:
     truth = pl.DataFrame({"a": [], "b": [], "c": []})
     assert df.shape == (0, 3)
     assert df.frame_equal(truth, null_equal=True)
+    assert df.dtypes == [pl.Float32, pl.Float32, pl.Float32]
+
+    df = pl.DataFrame(
+        columns=[("a", pl.Date), ("b", pl.UInt64), ("c", pl.datatypes.Int8)]
+    )
+    truth = pl.DataFrame({"a": [], "b": [], "c": []}).with_columns(
+        [
+            pl.col("a").cast(pl.Date),
+            pl.col("b").cast(pl.UInt64),
+            pl.col("c").cast(pl.Int8),
+        ]
+    )
+    assert df.shape == (0, 3)
+    assert df.frame_equal(truth, null_equal=True)
+    assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8]
 
 
 def test_init_dict() -> None:
@@ -38,18 +53,47 @@ def test_init_dict() -> None:
     df = pl.DataFrame({})
     assert df.shape == (0, 0)
 
+    # Empty dictionary/values
+    df = pl.DataFrame({"a": [], "b": []})
+    assert df.shape == (0, 2)
+    assert df.schema == {"a": pl.Float32, "b": pl.Float32}
+
+    for df in (
+        pl.DataFrame({}, columns={"a": pl.Date, "b": pl.Utf8}),
+        pl.DataFrame({"a": [], "b": []}, columns={"a": pl.Date, "b": pl.Utf8}),
+    ):
+        assert df.shape == (0, 2)
+        assert df.schema == {"a": pl.Date, "b": pl.Utf8}
+
     # Mixed dtypes
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     assert df.shape == (3, 2)
     assert df.columns == ["a", "b"]
+    assert df.dtypes == [pl.Int64, pl.Float64]
+
+    df = pl.DataFrame(
+        {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+        columns=[("a", pl.Int8), ("b", pl.Float32)],
+    )
+    assert df.schema == {"a": pl.Int8, "b": pl.Float32}
 
     # Values contained in tuples
     df = pl.DataFrame({"a": (1, 2, 3), "b": [1.0, 2.0, 3.0]})
     assert df.shape == (3, 2)
 
-    # Overriding dict column names
+    # Overriding dict column names/types
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["c", "d"])
     assert df.columns == ["c", "d"]
+
+    df = pl.DataFrame(
+        {"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["c", ("d", pl.Int8)]  # type: ignore[arg-type]
+    )  # partial type info (allowed, but mypy doesn't like it ;p)
+    assert df.schema == {"c": pl.Int64, "d": pl.Int8}
+
+    df = pl.DataFrame(
+        {"a": [1, 2, 3], "b": [4, 5, 6]}, columns=[("c", pl.Int8), ("d", pl.Int16)]
+    )
+    assert df.schema == {"c": pl.Int8, "d": pl.Int16}
 
 
 def test_init_ndarray() -> None:
@@ -60,6 +104,11 @@ def test_init_ndarray() -> None:
     # 1D array
     df = pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
     truth = pl.DataFrame({"a": [1, 2, 3]})
+    assert df.frame_equal(truth)
+    assert df.dtypes == [pl.Int64]
+
+    df = pl.DataFrame(np.array([1, 2, 3]), columns=[("a", pl.Int32)])
+    truth = pl.DataFrame({"a": [1, 2, 3]}).with_column(pl.col("a").cast(pl.Int32))
     assert df.frame_equal(truth)
 
     # 2D array - default to column orientation
@@ -72,6 +121,19 @@ def test_init_ndarray() -> None:
         {"column_0": [1, None], "column_1": [2.0, None], "column_2": ["a", None]}
     )
     assert df.frame_equal(truth)
+    assert df.schema == {
+        "column_0": pl.Int64,
+        "column_1": pl.Float64,
+        "column_2": pl.Utf8,
+    }
+
+    df = pl.DataFrame(
+        data=[[1, 2.0, "a"], [None, None, None]],
+        columns=[("x", pl.Boolean), ("y", pl.Int32), "z"],  # type: ignore[arg-type]
+        orient="row",
+    )
+    assert df.rows() == [(True, 2, "a"), (None, None, None)]
+    assert df.schema == {"x": pl.Boolean, "y": pl.Int32, "z": pl.Utf8}
 
     # TODO: Uncomment tests below when removing deprecation warning
     # # 2D array - default to column orientation
@@ -92,6 +154,12 @@ def test_init_ndarray() -> None:
     # 2D array - orientation conflicts with columns
     with pytest.raises(ValueError):
         pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b"], orient="row")
+    with pytest.raises(ValueError):
+        pl.DataFrame(
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            columns=[("a", pl.UInt32), ("b", pl.UInt32)],
+            orient="row",
+        )
 
     # 3D array
     with pytest.raises(ValueError):
@@ -118,6 +186,13 @@ def test_init_arrow() -> None:
     truth = pl.DataFrame({"c": [1, 2], "d": [3, 4]})
     assert df.frame_equal(truth)
 
+    df = pl.DataFrame(
+        pa.table({"a": [1, 2], None: [3, 4]}),
+        columns=[("c", pl.Int32), ("d", pl.Float32)],
+    )
+    assert df.schema == {"c": pl.Int32, "d": pl.Float32}
+    assert df.rows() == [(1, 3.0), (2, 4.0)]
+
     # Bad columns argument
     with pytest.raises(ValueError):
         pl.DataFrame(
@@ -135,6 +210,12 @@ def test_init_series() -> None:
     df = pl.DataFrame((pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))))
     assert df.frame_equal(truth)
 
+    df = pl.DataFrame(
+        (pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))), columns=["x", "y"]
+    )
+    assert df.schema == {"x": pl.Int64, "y": pl.Int64}
+    assert df.rows() == [(1, 4), (2, 5), (3, 6)]
+
     # List of unnamed Series
     df = pl.DataFrame([pl.Series([1, 2, 3]), pl.Series([4, 5, 6])])
     truth = pl.DataFrame(
@@ -142,10 +223,26 @@ def test_init_series() -> None:
     )
     assert df.frame_equal(truth)
 
+    df = pl.DataFrame([pl.Series([None]), pl.Series([1.0])])
+    assert df.schema == {"column_0": pl.Float64, "column_1": pl.Float64}
+    assert df.rows() == [(None, 1.0)]
+
+    df = pl.DataFrame(
+        [pl.Series([None]), pl.Series([1.0])],
+        columns=[("x", pl.Date), ("y", pl.Boolean)],
+    )
+    assert df.schema == {"x": pl.Date, "y": pl.Boolean}
+    assert df.rows() == [(None, True)]
+
     # Single Series
     df = pl.DataFrame(pl.Series("a", [1, 2, 3]))
     truth = pl.DataFrame({"a": [1, 2, 3]})
+    assert df.schema == {"a": pl.Int64}
     assert df.frame_equal(truth)
+
+    df = pl.DataFrame(pl.Series("a", [1, 2, 3]), columns=[("a", pl.UInt32)])
+    assert df.rows() == [(1,), (2,), (3,)]
+    assert df.schema == {"a": pl.UInt32}
 
 
 def test_init_seq_of_seq() -> None:
@@ -153,6 +250,13 @@ def test_init_seq_of_seq() -> None:
     df = pl.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
     truth = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
     assert df.frame_equal(truth)
+
+    df = pl.DataFrame(
+        [[1, 2, 3], [4, 5, 6]],
+        columns=[("a", pl.Int8), ("b", pl.Int16), ("c", pl.Int32)],
+    )
+    assert df.schema == {"a": pl.Int8, "b": pl.Int16, "c": pl.Int32}
+    assert df.rows() == [(1, 2, 3), (4, 5, 6)]
 
     # Tuple of tuples, default to column orientation
     df = pl.DataFrame(((1, 2, 3), (4, 5, 6)))
@@ -163,6 +267,12 @@ def test_init_seq_of_seq() -> None:
     df = pl.DataFrame(((1, 2), (3, 4)), columns=("a", "b"), orient="row")
     truth = pl.DataFrame({"a": [1, 3], "b": [2, 4]})
     assert df.frame_equal(truth)
+
+    df = pl.DataFrame(
+        ((1, 2), (3, 4)), columns=(("a", pl.Float32), ("b", pl.Float32)), orient="row"
+    )
+    assert df.schema == {"a": pl.Float32, "b": pl.Float32}
+    assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
 
 def test_init_1d_sequence() -> None:
@@ -175,6 +285,10 @@ def test_init_1d_sequence() -> None:
     truth = pl.DataFrame({"hi": ["a", "b", "c"]})
     assert df.frame_equal(truth)
 
+    df = pl.DataFrame([None, True, False], columns=[("xx", pl.Int8)])
+    assert df.schema == {"xx": pl.Int8}
+    assert df.rows() == [(None,), (1,), (0,)]
+
     # String sequence
     with pytest.raises(ValueError):
         pl.DataFrame("abc")
@@ -183,11 +297,18 @@ def test_init_1d_sequence() -> None:
 def test_init_pandas() -> None:
     pandas_df = pd.DataFrame([[1, 2], [3, 4]], columns=[1, 2])
 
-    # pandas is available; integer column names
+    # pandas is available
     with patch("polars.internals.frame._PANDAS_AVAILABLE", True):
+        # integer column names
         df = pl.DataFrame(pandas_df)
         truth = pl.DataFrame({"1": [1, 3], "2": [2, 4]})
         assert df.frame_equal(truth)
+        assert df.schema == {"1": pl.Int64, "2": pl.Int64}
+
+        # override column names, types
+        df = pl.DataFrame(pandas_df, columns=[("x", pl.Float64), ("y", pl.Float64)])
+        assert df.schema == {"x": pl.Float64, "y": pl.Float64}
+        assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
     # pandas is not available
     with patch("polars.internals.frame._PANDAS_AVAILABLE", False):
@@ -223,6 +344,14 @@ def test_init_records() -> None:
     df_cd = pl.DataFrame(dicts, columns=["c", "d"])
     expected = pl.DataFrame({"c": [1, 2, 1], "d": [2, 1, 2]})
     assert df_cd.frame_equal(expected)
+
+    df_xy = pl.DataFrame(dicts, columns=[("x", pl.UInt32), ("y", pl.UInt32)])
+    expected = pl.DataFrame({"x": [1, 2, 1], "y": [2, 1, 2]}).with_columns(
+        [pl.col("x").cast(pl.UInt32), pl.col("y").cast(pl.UInt32)]
+    )
+    assert df_xy.frame_equal(expected)
+    assert df_xy.schema == {"x": pl.UInt32, "y": pl.UInt32}
+    assert df_xy.rows() == [(1, 2), (2, 1), (1, 2)]
 
 
 def test_selection() -> None:


### PR DESCRIPTION
* **Motivation**

  Empty frames/columns currently pickup a default type of Float32; providing more specific type information at init time is currently best done by setting up individual Series explicitly and using those. As well as improving the empty data/no rows case, you may want to modify the inferred type (eg: 1/0 => bool True/False), or more tightly specify integer types to allocate less memory, such as by using Int8, Int16, or Int32 instead of Int64:
  
  Currently - can break out the data into Series and initialise...
  ```python
  df = pl.DataFrame([
      pl.Series("x", some_data, dtype=pl.Float32),
      pl.Series("y", more_data, dtype=pl.Int8),
  ])
  ```
  ...or initialise with the defaults, and post-apply specific dtypes by casting:
  ```python
  df = pl.DataFrame( data ).with_columns(
      [pl.col("x").cast(pl.Float32),
       pl.col("y").cast(pl.Int8)]
  )
  ```
  However, breaking up all input into individual Series, given how many types of data can be used (col/row sequences, one dict, sequence of dicts, numpy arrays, pandas frames, arrow tables) can be a little unwieldy, and post-applying the cast is less efficient memory-wise if you know you only require one of the smaller types.
  

* **Patch**: more flexible `columns` param

  This patch allows the column _type_ information to be passed-in alongside the column name, in the existing `columns` param (so no new parameter required, and also no change to existing behaviour), irrespective of what form that data takes (dicts, sequences, frames, etc). Where possible, the type information is passed directly to the underlying Series constructors to avoid unnecessary up-front allocation or post-init casts.
  ```python
  df = pl.DataFrame( data, columns=[("x",pl.Float32),("y",pl.Int8)] )
  ```
  The parsing of the `columns` param is extended such that it can handle optional name/type pairs (or even a dict of such, as you would get from calling `schema` on an existing DataFrame).
  
  This makes it much easier to init an empty frame with the correct types, or otherwise ensure a more efficient schema when smaller types are sufficient, and allows the caller to specify the desired types without having to account too closely for the flavour of the input data.


* **Unit tests**: existing pass, new ones added

  All unit tests pass with no changes required - the extension is completely optional, and does not change existing behaviour. Plenty of new unit tests added for each type of valid input.

* **Minor request** (potentially even more efficient init of rows/dicts)
  
  If the Rust-side `read_dicts` and `read_rows` functions could take an additional -optional- parameter, this extra type information could be passed-in, avoiding unnecessary inference or subsequent casts. 
  
  Specifically: a `{name:type}` map for `read_dicts`, and an `{index:type}` map for `read_rows` would be ideal. 


Cheers :)
  
      
