### PR TITLE
Adding nested struct support by fixing ArrayRef determination

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -1,6 +1,7 @@
 mod from;
 
 use super::*;
+use crate::datatypes::*;
 
 /// This is logical type [`StructChunked`] that
 /// dispatches most logic to the `fields` implementations
@@ -17,14 +18,23 @@ pub struct StructChunked {
     arrow_array: ArrayRef,
 }
 
+/// Returns an ['ArrayRef'](arrow::array::ArrayRef) for a given
+/// [`Series`], handling nested Struct-type series seperately.
+fn array_ref_for_series(series: &Series) -> ArrayRef {
+    match series.dtype() {
+        DataType::Struct(_) => {
+            let s = series.struct_().unwrap();
+            s.arrow_array.clone()
+        }
+        _ => series.chunks()[0].clone() as ArrayRef,
+    }
+}
+
 fn fields_to_struct_array(fields: &[Series]) -> (ArrayRef, Vec<Series>) {
     let fields = fields.iter().map(|s| s.rechunk()).collect::<Vec<_>>();
 
     let new_fields = fields.iter().map(|s| s.field().to_arrow()).collect();
-    let field_arrays = fields
-        .iter()
-        .map(|s| s.chunks()[0].clone() as ArrayRef)
-        .collect::<Vec<_>>();
+    let field_arrays = fields.iter().map(array_ref_for_series).collect::<Vec<_>>();
     let arr = StructArray::new(ArrowDataType::Struct(new_fields), field_arrays, None);
     (Arc::new(arr), fields)
 }

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -122,3 +122,17 @@ def test_value_counts_expr() -> None:
 
     out = sorted(out)  # type: ignore
     assert out == [("a", 1), ("b", 2), ("c", 3)]
+
+
+def test_nested_struct() -> None:
+    df = pl.DataFrame({"d": [1, 2, 3], "e": ["foo", "bar", "biz"]})
+    # Nest the datafame
+    nest_l1 = df.to_struct("c").to_frame()
+    # Add another column on the same level
+    nest_l1 = nest_l1.with_column(pl.col("c").is_nan().alias("b"))
+    # Nest the dataframe again
+    nest_l2 = nest_l1.to_struct("a").to_frame()
+
+    assert isinstance(nest_l2.dtypes[0], pl.datatypes.Struct)
+    assert nest_l2.dtypes[0].inner_types == nest_l1.dtypes
+    assert isinstance(nest_l1.dtypes[0], pl.datatypes.Struct)


### PR DESCRIPTION
This resolves #3015 by fixing the ArrayRef determination for nested structs. This allows nested structs to be created directly with `to_struct`, and also fixes issues reading from parquet files with nested structs.