### PR TITLE
NodeJS updates

### DIFF
--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib"]
 name = "nodejs_polars"
 
 [dependencies]
-bincode = "1.3"
 ahash = "0.7"
+bincode = "1.3"
 dirs = "4.0"
 napi-derive = "1"
 polars-core = { path = "../polars/polars-core", default-features = false }

--- a/nodejs-polars/Cargo.toml
+++ b/nodejs-polars/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 name = "nodejs_polars"
 
 [dependencies]
+bincode = "1.3"
 ahash = "0.7"
 dirs = "4.0"
 napi-derive = "1"
@@ -67,6 +68,7 @@ features = [
   "arange", # "true_div",
   "diagonal_concat",
   "serde", # "asof_join",  # "cross_join",
+  "serde-lazy",
   "lazy",
   "repeat_by",
   "horizontal_concat",

--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -8,7 +8,11 @@ describe("dataframe", () => {
     pl.Series("foo", [1, 2, 9], pl.Int16),
     pl.Series("bar", [6, 2, 8], pl.Int16),
   ]);
-
+  test("to/fromBinary round trip", () => {
+    const buf = df.toBinary();
+    const actual = pl.DataFrame.fromBinary(buf);
+    expect(df).toStrictEqual(actual);
+  });
   test("dtypes", () => {
     const expected = ["Float64", "Utf8"];
     const actual = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).dtypes;

--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -105,12 +105,12 @@ describe("dataframe", () => {
     const actual = df.drop("apple", "ham");
     expect(actual).toFrameEqual(expected);
   });
-  test("dropDuplicates", () => {
+  test("unique", () => {
     const actual = pl.DataFrame({
       "foo": [1, 2, 2, 3],
       "bar": [1, 2, 2, 4],
       "ham": ["a", "d", "d", "c"],
-    }).dropDuplicates();
+    }).unique();
     const expected = pl.DataFrame({
       "foo": [1, 2, 3],
       "bar": [1, 2, 4],
@@ -118,12 +118,12 @@ describe("dataframe", () => {
     });
     expect(actual).toFrameEqualIgnoringOrder(expected);
   });
-  test("dropDuplicates:subset", () => {
+  test("unique:subset", () => {
     const actual = pl.DataFrame({
       "foo": [1, 2, 2, 2],
       "bar": [1, 2, 2, 2],
       "ham": ["a", "b", "c", "c"],
-    }).dropDuplicates({subset: ["foo", "ham"]});
+    }).unique({subset: ["foo", "ham"]});
     const expected = pl.DataFrame({
       "foo": [1, 2, 2],
       "bar": [1, 2, 2],
@@ -132,13 +132,13 @@ describe("dataframe", () => {
     expect(actual).toFrameEqualIgnoringOrder(expected);
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder", () => {
+  test("unique:maintainOrder", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "b", "b"],
-      }).dropDuplicates({maintainOrder: true});
+      }).unique({maintainOrder: true});
 
       const expected = pl.DataFrame({
         "foo": [0, 1, 2],
@@ -149,13 +149,13 @@ describe("dataframe", () => {
     });
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder:single subset", () => {
+  test("unique:maintainOrder:single subset", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "c", "d"],
-      }).dropDuplicates({maintainOrder: true, subset: "foo"});
+      }).unique({maintainOrder: true, subset: "foo"});
 
       const expected = pl.DataFrame({
         "foo": [0, 1, 2],
@@ -166,13 +166,13 @@ describe("dataframe", () => {
     });
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder:multi subset", () => {
+  test("unique:maintainOrder:multi subset", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "c", "c"],
-      }).dropDuplicates({maintainOrder: true, subset: ["foo", "ham"]});
+      }).unique({maintainOrder: true, subset: ["foo", "ham"]});
 
       const expected = pl.DataFrame({
         "foo": [0, 1, 2, 2],

--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -1267,22 +1267,22 @@ describe("io", () => {
     pl.Series("foo", [1, 2, 9], pl.Int16),
     pl.Series("bar", [6, 2, 8], pl.Int16),
   ]);
-  test("toCSV:string", () => {
-    const actual = df.clone().toCSV();
+  test("writeCSV:string", () => {
+    const actual = df.clone().writeCSV();
     const expected  = "foo,bar\n1,6\n2,2\n9,8\n";
     expect(actual).toEqual(expected);
   });
-  test("toCSV:string:sep", () => {
-    const actual = df.clone().toCSV({sep: "X"});
+  test("writeCSV:string:sep", () => {
+    const actual = df.clone().writeCSV({sep: "X"});
     const expected  = "fooXbar\n1X6\n2X2\n9X8\n";
     expect(actual).toEqual(expected);
   });
-  test("toCSV:string:header", () => {
-    const actual = df.clone().toCSV({sep: "X", hasHeader: false});
+  test("writeCSV:string:header", () => {
+    const actual = df.clone().writeCSV({sep: "X", hasHeader: false});
     const expected  = "1X6\n2X2\n9X8\n";
     expect(actual).toEqual(expected);
   });
-  test("toCSV:stream", (done) => {
+  test("writeCSV:stream", (done) => {
     const df = pl.DataFrame([
       pl.Series("foo", [1, 2, 3], pl.UInt32),
       pl.Series("bar", ["a", "b", "c"])
@@ -1295,17 +1295,17 @@ describe("io", () => {
 
       }
     });
-    df.toCSV(writeStream);
+    df.writeCSV(writeStream);
     const newDF = pl.readCSV(body);
     expect(newDF).toFrameEqual(df);
     done();
   });
-  test("toCSV:path", (done) => {
+  test("writeCSV:path", (done) => {
     const df = pl.DataFrame([
       pl.Series("foo", [1, 2, 3], pl.UInt32),
       pl.Series("bar", ["a", "b", "c"])
     ]);
-    df.toCSV("./test.csv");
+    df.writeCSV("./test.csv");
     const newDF = pl.readCSV("./test.csv");
     expect(newDF).toFrameEqual(df);
     fs.rmSync("./test.csv");
@@ -1366,17 +1366,17 @@ describe("io", () => {
     const actual = df.toObject();
     expect(actual).toEqual(expected);
   });
-  test("toJSON:multiline", () => {
+  test("writeJSON:multiline", () => {
     const rows = [
       {foo: 1.1},
       {foo: 3.1},
       {foo: 3.1}
     ];
-    const actual = pl.DataFrame(rows).toJSON({multiline:true});
+    const actual = pl.DataFrame(rows).writeJSON({multiline:true});
     const expected = rows.map(r => JSON.stringify(r)).join("\n").concat("\n");
     expect(actual).toEqual(expected);
   });
-  test("toJSON:stream", (done) => {
+  test("writeJSON:stream", (done) => {
     const df = pl.DataFrame([
       pl.Series("foo", [1, 2, 3], pl.UInt32),
       pl.Series("bar", ["a", "b", "c"])
@@ -1390,17 +1390,17 @@ describe("io", () => {
 
       }
     });
-    df.toJSON(writeStream, {multiline:true});
+    df.writeJSON(writeStream, {multiline:true});
     const newDF = pl.readJSON(body);
     expect(newDF).toFrameEqual(df);
     done();
   });
-  test("toJSON:path", (done) => {
+  test("writeJSON:path", (done) => {
     const df = pl.DataFrame([
       pl.Series("foo", [1, 2, 3], pl.UInt32),
       pl.Series("bar", ["a", "b", "c"])
     ]);
-    df.toJSON("./test.json", {multiline:true});
+    df.writeJSON("./test.json", {multiline:true});
     const newDF = pl.readJSON("./test.json");
     expect(newDF).toFrameEqual(df);
     fs.rmSync("./test.json");
@@ -1413,27 +1413,27 @@ describe("io", () => {
       {foo: 3.1}
     ];
     const df = pl.DataFrame(rows);
-    const expected = pl.DataFrame(rows).toJSON();
+    const expected = pl.DataFrame(rows).writeJSON();
     const actual = JSON.stringify(df);
     expect(actual).toEqual(expected);
   });
-  test("toJSON:rows", () => {
+  test("writeJSON:rows", () => {
     const rows = [
       {foo: 1.1},
       {foo: 3.1},
       {foo: 3.1}
     ];
     const expected = JSON.stringify(rows);
-    const actual = pl.DataFrame(rows).toJSON({orient:"row"});
+    const actual = pl.DataFrame(rows).writeJSON({orient:"row"});
     expect(actual).toEqual(expected);
   });
-  test("toJSON:col", () => {
+  test("writeJSON:col", () => {
     const cols = {
       foo: [1, 2, 3],
       bar: ["a", "b", "c"]
     };
     const expected = JSON.stringify(cols);
-    const actual = pl.DataFrame(cols).toJSON({orient:"col"});
+    const actual = pl.DataFrame(cols).writeJSON({orient:"col"});
     expect(actual).toEqual(expected);
   });
   test("toSeries", () => {

--- a/nodejs-polars/__tests__/dataframe.test.ts
+++ b/nodejs-polars/__tests__/dataframe.test.ts
@@ -865,6 +865,14 @@ describe("dataframe", () => {
     }).sample(2);
     expect(actual.height).toStrictEqual(2);
   });
+  test("sample:default", () => {
+    const actual = pl.DataFrame({
+      "foo": [1, 2, 3],
+      "bar": [6, 7, 8],
+      "ham": ["a", "b", "c"]
+    }).sample();
+    expect(actual.height).toStrictEqual(1);
+  });
   test("sample:frac", () => {
     const actual = pl.DataFrame({
       "foo": [1, 2, 3, 1],

--- a/nodejs-polars/__tests__/expr.test.ts
+++ b/nodejs-polars/__tests__/expr.test.ts
@@ -1,7 +1,15 @@
 import {df} from "./setup";
 import pl, {col, lit} from "@polars/index";
 
-describe("expr", () => {
+describe.only("expr", () => {
+  test.only("to/fromBinary round trip", () => {
+    const expr = pl.col("foo").sum();
+    const buf = expr.toBinary();
+
+    const actual = pl.Expr.fromBinary(buf);
+    expect(actual.toString()).toStrictEqual(expr.toString());
+  });
+
   test("abs", () => {
     const expected = pl.Series("abs", [1, 2, 3]);
     const actual = pl.select(pl.lit(pl.Series([1, -2, -3])).abs()

--- a/nodejs-polars/__tests__/io.test.ts
+++ b/nodejs-polars/__tests__/io.test.ts
@@ -127,7 +127,7 @@ describe("scan", () => {
         hasHeader: false,
         startRows: 1,
         endRows: 4
-      }).toParquet(parquetpath);
+      }).writeParquet(parquetpath);
 
     const df = pl.readParquet(parquetpath);
 
@@ -137,7 +137,7 @@ describe("scan", () => {
 
 describe("parquet", () => {
   beforeEach(() => {
-    pl.readCSV(csvpath).toParquet(parquetpath);
+    pl.readCSV(csvpath).writeParquet(parquetpath);
   });
   afterEach(() => {
     fs.rmSync(parquetpath);
@@ -155,7 +155,7 @@ describe("parquet", () => {
 
   test("read:compressed", () => {
     const csvDF = pl.readCSV(csvpath);
-    csvDF.toParquet(parquetpath, {compression: "lz4"});
+    csvDF.writeParquet(parquetpath, {compression: "lz4"});
     const df = pl.readParquet(parquetpath);
     expect(df).toFrameEqual(csvDF);
   });
@@ -177,7 +177,7 @@ describe("parquet", () => {
 });
 describe("ipc", () => {
   beforeEach(() => {
-    pl.readCSV(csvpath).toIPC(ipcpath);
+    pl.readCSV(csvpath).writeIPC(ipcpath);
   });
   afterEach(() => {
     fs.rmSync(ipcpath);
@@ -189,13 +189,13 @@ describe("ipc", () => {
   });
   test("read/write:buffer", () => {
 
-    const buff =  pl.readCSV(csvpath).toIPC();
+    const buff =  pl.readCSV(csvpath).writeIPC();
     const df = pl.readIPC(buff);
     expect(df.shape).toStrictEqual({height: 27, width: 4});
   });
   test("read:compressed", () => {
     const csvDF = pl.readCSV(csvpath);
-    csvDF.toIPC(ipcpath, {compression: "lz4"});
+    csvDF.writeIPC(ipcpath, {compression: "lz4"});
     const ipcDF = pl.readIPC(ipcpath);
     expect(ipcDF).toFrameEqual(csvDF);
   });
@@ -215,9 +215,9 @@ describe("ipc", () => {
     expect(df.shape).toStrictEqual({height: 4, width: 4});
   });
 
-  test("toIPC", () => {
+  test("writeIPC", () => {
     const csvDF = pl.readCSV(csvpath);
-    csvDF.toIPC(ipcpath);
+    csvDF.writeIPC(ipcpath);
     const ipcDF = pl.readIPC(ipcpath);
     expect(ipcDF).toFrameEqual(csvDF);
   });

--- a/nodejs-polars/__tests__/lazyframe.test.ts
+++ b/nodejs-polars/__tests__/lazyframe.test.ts
@@ -95,13 +95,13 @@ selection: "None" `.replace(/\s+/g, " "));
       .collectSync();
     expect(actual).toFrameEqualIgnoringOrder(expected);
   });
-  test("dropDuplicates", () => {
+  test("unique", () => {
     const actual = pl.DataFrame({
       "foo": [1, 2, 2, 3],
       "bar": [1, 2, 2, 4],
       "ham": ["a", "d", "d", "c"],
     }).lazy()
-      .dropDuplicates()
+      .unique()
       .collectSync();
     const expected = pl.DataFrame({
       "foo": [1, 2, 3],
@@ -110,13 +110,13 @@ selection: "None" `.replace(/\s+/g, " "));
     });
     expect(actual).toFrameEqualIgnoringOrder(expected);
   });
-  test("dropDuplicates:subset", () => {
+  test("unique:subset", () => {
     const actual = pl.DataFrame({
       "foo": [1, 2, 2, 2],
       "bar": [1, 2, 2, 2],
       "ham": ["a", "b", "c", "c"],
     }).lazy()
-      .dropDuplicates({subset: ["foo", "ham"]})
+      .unique({subset: ["foo", "ham"]})
       .collectSync();
     const expected = pl.DataFrame({
       "foo": [1, 2, 2],
@@ -126,14 +126,14 @@ selection: "None" `.replace(/\s+/g, " "));
     expect(actual).toFrameEqualIgnoringOrder(expected);
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder", () => {
+  test("unique:maintainOrder", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "b", "b"],
       }).lazy()
-        .dropDuplicates({maintainOrder: true})
+        .unique({maintainOrder: true})
         .collectSync();
       const expected = pl.DataFrame({
         "foo": [0, 1, 2],
@@ -144,14 +144,14 @@ selection: "None" `.replace(/\s+/g, " "));
     });
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder:single subset", () => {
+  test("unique:maintainOrder:single subset", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "c", "d"],
       }).lazy()
-        .dropDuplicates({maintainOrder: true, subset: "foo"})
+        .unique({maintainOrder: true, subset: "foo"})
         .collectSync();
       const expected = pl.DataFrame({
         "foo": [0, 1, 2],
@@ -162,14 +162,14 @@ selection: "None" `.replace(/\s+/g, " "));
     });
   });
   // run this test 100 times to make sure it is deterministic.
-  test("dropDuplicates:maintainOrder:multi subset", () => {
+  test("unique:maintainOrder:multi subset", () => {
     Array.from({length:100}).forEach(() => {
       const actual = pl.DataFrame({
         "foo": [0, 1, 2, 2, 2],
         "bar": [0, 1, 2, 2, 2],
         "ham": ["0", "a", "b", "c", "c"],
       }).lazy()
-        .dropDuplicates({maintainOrder: true, subset: ["foo", "ham"]})
+        .unique({maintainOrder: true, subset: ["foo", "ham"]})
         .collectSync();
       const expected = pl.DataFrame({
         "foo": [0, 1, 2, 2],

--- a/nodejs-polars/__tests__/series.test.ts
+++ b/nodejs-polars/__tests__/series.test.ts
@@ -352,6 +352,12 @@ describe("series", () => {
 
   const chance = new Chance();
 
+  test("to/fromBinary round trip", () => {
+    const s = pl.Series("serde", [1, 2, 3, 4, 5, 2]);
+    const buf = s.toBinary();
+    const actual = pl.Series.fromBinary(buf);
+    expect(s).toStrictEqual(actual);
+  });
   it.each`
   series        | getter
   ${numSeries()}  | ${"dtype"}

--- a/nodejs-polars/__tests__/series.test.ts
+++ b/nodejs-polars/__tests__/series.test.ts
@@ -498,6 +498,9 @@ describe("series", () => {
   ${numSeries()}  | ${"sample"}       | ${[{frac: 0.5}]}
   ${numSeries()}  | ${"sample"}       | ${[{n: 1, withReplacement: true}]}
   ${numSeries()}  | ${"sample"}       | ${[{frac: 0.1, withReplacement: true}]}
+  ${numSeries()}  | ${"sample"}       | ${[{frac: 0.1, withReplacement: true, seed: 1n}]}
+  ${numSeries()}  | ${"sample"}       | ${[{frac: 0.1, withReplacement: true, seed: 1}]}
+  ${numSeries()}  | ${"sample"}       | ${[{n: 1, withReplacement: true, seed: 1}]}
   ${numSeries()}  | ${"seriesEqual"}  | ${[other()]}
   ${numSeries()}  | ${"seriesEqual"}  | ${[other(), true]}
   ${numSeries()}  | ${"seriesEqual"}  | ${[other(), false]}
@@ -623,7 +626,7 @@ describe("series", () => {
   ${"rollingMean"}   | ${pl.Series([1, 2, 3, 2, 1]).rollingMean(2)}         | ${pl.Series("", [null, 1.5, 2.5, 2.5, 1.5], pl.Float64)}
   ${"rollingVar"}    | ${pl.Series([1, 2, 3, 2, 1]).rollingVar(2)[1]}       | ${0.5}
   ${"sample:n"}      | ${pl.Series([1, 2, 3, 4, 5]).sample(2).len()}        | ${2}
-  ${"sample:frac"}   | ${pl.Series([1, 2, 3, 4, 5]).sample({frac:.4}).len()}| ${2}
+  ${"sample:frac"}   | ${pl.Series([1, 2, 3, 4, 5]).sample({frac:.4, seed:0}).len()}| ${2}
   ${"shift"}         | ${pl.Series([1, 2, 3]).shift(1)}                     | ${pl.Series([null, 1, 2])}
   ${"shift"}         | ${pl.Series([1, 2, 3]).shift(-1)}                    | ${pl.Series([2, 3, null])}
   ${"skew"}          | ${pl.Series([1, 2, 3, 3, 0]).skew()?.toPrecision(6)} | ${"-0.363173"}

--- a/nodejs-polars/__tests__/series.test.ts
+++ b/nodejs-polars/__tests__/series.test.ts
@@ -492,6 +492,7 @@ describe("series", () => {
   ${numSeries()}  | ${"rollingVar"}   | ${[1, [.11], 1]}
   ${numSeries()}  | ${"rollingVar"}   | ${[1, [.23], 1, true]}
   ${fltSeries()}  | ${"round"}        | ${[1]}
+  ${numSeries()}  | ${"sample"}       | ${[]}
   ${numSeries()}  | ${"sample"}       | ${[1, null, true]}
   ${numSeries()}  | ${"sample"}       | ${[null, 1]}
   ${numSeries()}  | ${"sample"}       | ${[{n: 1}]}

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -1565,9 +1565,6 @@ export const dfWrapper = (_df: JsDataFrame): DataFrame => {
 
       return wrap("unique", {...defaultOptions, ...opts});
     },
-    dropDuplicates(opts: any=false, subset?) {
-      return this.unique(opts, subset);
-    },
     explode(...columns)  {
       return dfWrapper(_df)
         .lazy()

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -172,13 +172,13 @@ export interface DataFrame extends Arithmetic<DataFrame> {
    * ```
    */
   describe(): DataFrame
-
   /**
    * Drop duplicate rows from this DataFrame.
    * Note that this fails if there is a column of type `List` in the DataFrame.
    * @param maintainOrder
    * @param subset - subset to drop duplicates for
    * @param keep "first" | "last"
+   * @deprecated *since 0.4.0* use {@link unique}
    */
   distinct(maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first"| "last"): DataFrame
   distinct(opts: {maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first"| "last"}): DataFrame
@@ -214,17 +214,6 @@ export interface DataFrame extends Arithmetic<DataFrame> {
   drop(name: string): DataFrame
   drop(names: string[]): DataFrame
   drop(name: string, ...names: string[]): DataFrame
-  /**
-   * __Drop duplicate rows from this DataFrame.__
-   *
-   * Note that this fails if there is a column of type `List` in the DataFrame.
-   * @param maintainOrder
-   * @param subset - subset to drop duplicates for
-   * @deprecated @since 0.2.1 @use {@link distinct}
-   */
-  dropDuplicates(maintainOrder?: boolean, subset?: ColumnSelection): DataFrame
-  /** @deprecated @since 0.2.1 @use {@link distinct} ==*/
-  dropDuplicates(opts: {maintainOrder?: boolean, subset?: ColumnSelection}): DataFrame
   /**
    * __Return a new DataFrame where the null values are dropped.__
    *
@@ -1334,6 +1323,15 @@ export interface DataFrame extends Arithmetic<DataFrame> {
    * └─────────────┴─────────────┴─────────────┘
    */
   transpose(options?: {includeHeader?: boolean, headerName?: string, columnNames?: Iterable<string>})
+  /**
+   * Drop duplicate rows from this DataFrame.
+   * Note that this fails if there is a column of type `List` in the DataFrame.
+   * @param maintainOrder
+   * @param subset - subset to drop duplicates for
+   * @param keep "first" | "last"
+   */
+   unique(maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first"| "last"): DataFrame
+   unique(opts: {maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first"| "last"}): DataFrame
    /**
    * Aggregate the columns of this DataFrame to their variance value.
    * @example
@@ -1576,23 +1574,26 @@ export const dfWrapper = (_df: JsDataFrame): DataFrame => {
       }
     },
     distinct(opts: any = false, subset?, keep = "first") {
+      return this.unique(opts, subset);
+    },
+    unique(opts: any = false, subset?, keep = "first") {
       const defaultOptions = {
         maintainOrder: false,
         keep,
       };
 
       if(typeof opts === "boolean") {
-        return wrap("distinct", {...defaultOptions, maintainOrder: opts, subset, keep});
+        return wrap("unique", {...defaultOptions, maintainOrder: opts, subset, keep});
       }
 
       if(opts.subset) {
         opts.subset = [opts.subset].flat(3);
       }
 
-      return wrap("distinct", {...defaultOptions, ...opts});
+      return wrap("unique", {...defaultOptions, ...opts});
     },
     dropDuplicates(opts: any=false, subset?) {
-      return this.distinct(opts, subset);
+      return this.unique(opts, subset);
     },
     explode(...columns)  {
       return dfWrapper(_df)

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -1165,6 +1165,11 @@ export interface DataFrame extends Arithmetic<DataFrame>, Sample<DataFrame>, Wri
    * ```
    */
   tail(length?: number): DataFrame
+  /** serializes the DataFrame to a [bincode buffer](https://docs.rs/bincode/latest/bincode/index.html)
+   * @example
+   * pl.DataFrame.fromBinary(df.toBinary())
+   */
+  toBinary(): Buffer
   /** @deprecated *since 0.4.0* use {@link writeCSV} */
   toCSV(destOrOptions?, options?);
   /**
@@ -1800,6 +1805,9 @@ export const dfWrapper = (_df: JsDataFrame): DataFrame => {
       return wrap("sum");
     },
     tail: (length=5) => wrap("tail", {length}),
+    toBinary() {
+      return unwrap("to_bincode");
+    },
     toCSV(...args) {
       return this.writeCSV(...args);
     },
@@ -2031,6 +2039,10 @@ export interface DataFrameConstructor {
     inferSchemaLength?: number,
   }): DataFrame
   isDataFrame(arg: any): arg is DataFrame;
+  /**
+  * @param binary used to serialize/deserialize dataframe. This will only work with the output from expr.toBinary().
+  */
+  fromBinary(binary: Buffer): DataFrame
 }
 function DataFrameConstructor(data?, options?): DataFrame {
 
@@ -2058,5 +2070,13 @@ function objToDF(obj: Record<string, Array<any>>): any {
 }
 const isDataFrame = (ty: any): ty is DataFrame => isExternal(ty?._df);
 
+const fromBinary = (buf: Buffer)  => {
+  return dfWrapper(pli.df.from_bincode(buf));
+};
 
-export const DataFrame: DataFrameConstructor = Object.assign(DataFrameConstructor, {isDataFrame});
+export const DataFrame: DataFrameConstructor = Object.assign(
+  DataFrameConstructor, {
+    isDataFrame,
+    fromBinary
+  }
+);

--- a/nodejs-polars/polars/dataframe.ts
+++ b/nodejs-polars/polars/dataframe.ts
@@ -1711,6 +1711,13 @@ export const dfWrapper = (_df: JsDataFrame): DataFrame => {
     },
     rows: noArgUnwrap("to_rows"),
     sample(opts?, frac?, withReplacement = false, seed?) {
+      if(arguments.length === 0) {
+        return wrap("sample_n", {
+          n: 1,
+          withReplacement,
+          seed
+        });
+      }
       if(opts?.n  !== undefined || opts?.frac  !== undefined) {
         return this.sample(opts.n, opts.frac, opts.withReplacement, seed);
       }

--- a/nodejs-polars/polars/lazy/dataframe.ts
+++ b/nodejs-polars/polars/lazy/dataframe.ts
@@ -84,17 +84,10 @@ export interface LazyDataFrame {
    * @param maintainOrder
    * @param subset - subset to drop duplicates for
    * @param keep "first" | "last"
+   * @deprecated @since 0.4.0 @use {@link unique}
    */
   distinct(maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first" | "last"): LazyDataFrame
   distinct(opts: {maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first" | "last"}): LazyDataFrame
-  /**
-   * Drop duplicate rows from this DataFrame.
-   * Note that this fails if there is a column of type `List` in the DataFrame.
-   * @deprecated @since 0.2.1 @use {@link distinct}
-   */
-  dropDuplicates(opts: {maintainOrder?: boolean, subset?: ColumnSelection}): LazyDataFrame
-  /** @deprecated @since 0.2.1 @use {@link distinct} */
-  dropDuplicates(maintainOrder?: boolean, subset?: ColumnSelection): LazyDataFrame
   /**
    * Drop rows with null values from this DataFrame.
    * This method only drops nulls row-wise if any single value of the row is null.
@@ -258,6 +251,15 @@ export interface LazyDataFrame {
    */
   tail(length?: number): LazyDataFrame
   /**
+   * Drop duplicate rows from this DataFrame.
+   * Note that this fails if there is a column of type `List` in the DataFrame.
+   * @param maintainOrder
+   * @param subset - subset to drop duplicates for
+   * @param keep "first" | "last"
+   */
+   unique(maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first" | "last"): LazyDataFrame
+   unique(opts: {maintainOrder?: boolean, subset?: ColumnSelection, keep?: "first" | "last"}): LazyDataFrame
+  /**
    * Aggregate the columns in the DataFrame to their variance value.
    */
   var(): LazyDataFrame
@@ -311,24 +313,24 @@ export const LazyDataFrame = (ldf: JsLazyFrame): LazyDataFrame => {
     drop(...cols) {
       return wrap("dropColumns", {cols: cols.flat(2)});
     },
-    distinct(opts: any = false, subset?, keep = "first") {
+    distinct(...args: any[]) {
+      return this.unique(...args);
+    },
+    unique(opts: any = false, subset?, keep = "first") {
       const defaultOptions = {
         maintainOrder: false,
         keep: "first",
       };
 
       if(typeof opts === "boolean") {
-        return wrap("distinct", {...defaultOptions, maintainOrder: opts, subset, keep});
+        return wrap("unique", {...defaultOptions, maintainOrder: opts, subset, keep});
       }
 
       if(opts.subset) {
         opts.subset = [opts.subset].flat(3);
       }
 
-      return wrap("distinct", {...defaultOptions, ...opts});
-    },
-    dropDuplicates(opts, subset?) {
-      return this.distinct(opts, subset);
+      return wrap("unique", {...defaultOptions, ...opts});
     },
     dropNulls(...subset) {
       if(subset.length) {

--- a/nodejs-polars/polars/lazy/expr.ts
+++ b/nodejs-polars/polars/lazy/expr.ts
@@ -492,7 +492,7 @@ export interface Expr extends
   /** Take every nth value in the Series and return as a new Series. */
   takeEvery(n: number): Expr
   /**
-   * Get the unique/distinct values in the list
+   * Get the unique values of this expression;
    * @param maintainOrder Maintain order of data. This requires more work.
    */
   unique(maintainOrder?: boolean | {maintainOrder: boolean}): Expr

--- a/nodejs-polars/polars/lazy/expr.ts
+++ b/nodejs-polars/polars/lazy/expr.ts
@@ -12,13 +12,14 @@ import {isExternal} from "util/types";
 import {Series} from "../series/series";
 
 import * as expr from "./expr/";
-import {Arithmetic, Comparison, Cumulative, Rolling, Round} from "../shared_traits";
+import {Arithmetic, Comparison, Cumulative, Rolling, Round, Sample} from "../shared_traits";
 
 export interface Expr extends
   Rolling<Expr>,
   Arithmetic<Expr>,
   Comparison<Expr>,
   Cumulative<Expr>,
+  Sample<Expr>,
   Round<Expr> {
   /** @ignore */
   _expr: any;
@@ -727,6 +728,25 @@ const _Expr = (_expr: any): Expr => {
       return wrap("rollingSkew", {bias:true, ...val});
     },
     round: wrapUnaryNumber("round", "decimals"),
+    sample(opts?, frac?, withReplacement = false, seed?) {
+      if(opts?.n  !== undefined || opts?.frac  !== undefined) {
+
+        return this.sample(opts.n, opts.frac, opts.withReplacement, seed);
+      }
+      if (typeof opts === "number") {
+        throw new Error("sample_n is not yet supported for expr");
+      }
+      if(typeof frac === "number") {
+        return wrap("sampleFrac", {
+          frac,
+          withReplacement,
+          seed
+        });
+      }
+      else {
+        throw new TypeError("must specify either 'frac' or 'n'");
+      }
+    },
     shift: wrapUnary("shift", "periods"),
     shiftAndFill(optOrPeriods, fillValue?) {
       if(typeof optOrPeriods === "number") {

--- a/nodejs-polars/polars/lazy/expr/datetime.ts
+++ b/nodejs-polars/polars/lazy/expr/datetime.ts
@@ -97,7 +97,7 @@ export interface ExprDateTime {
 
 export const ExprDateTimeFunctions = (_expr: any): ExprDateTime => {
   const wrap = (method, args?): Expr => {
-    return Expr(pli.expr.date[method]({_expr, ...args }));
+    return (Expr as any)(pli.expr.date[method]({_expr, ...args }));
   };
 
   const wrapNullArgs = (method: string) => () => wrap(method);

--- a/nodejs-polars/polars/lazy/expr/list.ts
+++ b/nodejs-polars/polars/lazy/expr/list.ts
@@ -37,7 +37,7 @@ export interface ExprList {
 export const ExprListFunctions = (_expr: any): ExprList => {
   const wrap = (method, args?): Expr => {
 
-    return Expr(pli.expr.lst[method]({_expr, ...args }));
+    return (Expr as any)(pli.expr.lst[method]({_expr, ...args }));
   };
 
   return {

--- a/nodejs-polars/polars/lazy/expr/string.ts
+++ b/nodejs-polars/polars/lazy/expr/string.ts
@@ -164,6 +164,8 @@ export interface ExprString {
    * @param inclusive Include the split character/string in the results
    */
   split(by: string, options?: {inclusive?: boolean} | boolean): Expr
+  /** Remove leading and trailing whitespace. */
+  strip(): Expr
   /**
    * Parse a Series of dtype Utf8 to a Date/Datetime Series.
    * @param datatype Date or Datetime.
@@ -223,7 +225,7 @@ export const ExprStringFunctions = (_expr: any): ExprString => {
       return wrap("lengths");
     },
     lstrip() {
-      return wrap("replace", {pat: /^\s*/.source, val: ""});
+      return wrap("lstrip");
     },
     replace(pat: RegExp, val: string) {
       return wrap("replace", {pat: regexToString(pat), val});
@@ -232,7 +234,7 @@ export const ExprStringFunctions = (_expr: any): ExprString => {
       return wrap("replaceAll", {pat: regexToString(pat), val});
     },
     rstrip() {
-      return wrap("replace", {pat: /[ \t]+$/.source, val: ""});
+      return wrap("rstrip");
     },
     slice(start: number, length?: number) {
       return wrap("slice", {start, length});
@@ -241,6 +243,9 @@ export const ExprStringFunctions = (_expr: any): ExprString => {
       const inclusive = typeof options === "boolean" ? options : options?.inclusive;
 
       return wrap("split", {by, inclusive});
+    },
+    strip() {
+      return wrap("strip");
     },
     strftime(dtype, fmt?) {
       if (dtype === DataType.Date) {

--- a/nodejs-polars/polars/lazy/expr/string.ts
+++ b/nodejs-polars/polars/lazy/expr/string.ts
@@ -178,7 +178,7 @@ export interface ExprString {
 export const ExprStringFunctions = (_expr: any): ExprString => {
   const wrap = (method, args?): Expr => {
 
-    return Expr(pli.expr.str[method]({_expr, ...args }));
+    return (Expr as any)(pli.expr.str[method]({_expr, ...args }));
   };
   const handleDecode = (encoding, strict) => {
     switch (encoding) {

--- a/nodejs-polars/polars/lazy/functions.ts
+++ b/nodejs-polars/polars/lazy/functions.ts
@@ -102,9 +102,9 @@ export function col(col: string | string[] | Series<string>): Expr {
     col = col.toArray();
   }
   if(Array.isArray(col)) {
-    return Expr(pli.cols({name: col}));
+    return (Expr as any)(pli.cols({name: col}));
   } else {
-    return Expr(pli.col({name: col}));
+    return (Expr as any)(pli.col({name: col}));
   }
 }
 
@@ -121,10 +121,10 @@ export function lit(value: any): Expr {
   }
   if(Series.isSeries(value)){
 
-    return Expr(pli.lit({value: value._series}));
+    return (Expr as any)(pli.lit({value: value._series}));
   }
 
-  return Expr(pli.lit({value}));
+  return (Expr as any)(pli.lit({value}));
 }
 
 // ----------
@@ -163,7 +163,7 @@ export function arange<T>(opts: any, high?, step?, eager?): Series<T> | Expr {
       return df.select(arange(low, high, step).alias("arange") as any).getColumn("arange") as any;
     }
 
-    return Expr(pli.arange({low: low._expr, high: high._expr, step}));
+    return (Expr as any)(pli.arange({low: low._expr, high: high._expr, step}));
   }
 }
 /**
@@ -180,7 +180,7 @@ export function argSortBy(exprs: Expr[] | string[], reverse: boolean | boolean[]
   }
   const by = selectionToExprList(exprs);
 
-  return Expr(pli.argSortBy({by, reverse}));
+  return (Expr as any)(pli.argSortBy({by, reverse}));
 }
 /** Alias for mean. @see {@link mean} */
 export function avg(column: string): Expr;
@@ -199,7 +199,7 @@ export function concatList(expr: ExprOrString, expr2: ExprOrString,  ...exprs: E
 export function concatList(...exprs): Expr {
   const items = selectionToExprList(exprs as any, false);
 
-  return Expr(pli.concatList({items}));
+  return (Expr as any)(pli.concatList({items}));
 }
 
 /** Concat Utf8 Series in linear time. Non utf8 columns are cast to utf8. */
@@ -211,7 +211,7 @@ export function concatString(opts, sep=",") {
   }
   const items = selectionToExprList(opts as any, false);
 
-  return Expr(pli.concatString({items, sep}));
+  return (Expr as any)(pli.concatString({items, sep}));
 
 }
 
@@ -231,7 +231,7 @@ export function cov(a: ExprOrString, b: ExprOrString): Expr {
   a = exprToLitOrExpr(a, false)._expr;
   b = exprToLitOrExpr(b, false)._expr;
 
-  return Expr(pli.cov({a, b}));
+  return (Expr as any)(pli.cov({a, b}));
 }
 /**
  * Exclude certain columns from a wildcard expression.
@@ -382,7 +382,7 @@ export function pearsonCorr(a: ExprOrString, b: ExprOrString): Expr {
   a = exprToLitOrExpr(a, false)._expr;
   b = exprToLitOrExpr(b, false)._expr;
 
-  return Expr(pli.pearsonCorr({a, b}));
+  return (Expr as any)(pli.pearsonCorr({a, b}));
 }
 
 /** Get the quantile */
@@ -409,7 +409,7 @@ export function spearmanRankCorr(a: ExprOrString, b: ExprOrString): Expr {
   a = exprToLitOrExpr(a, false)._expr;
   b = exprToLitOrExpr(b, false)._expr;
 
-  return Expr(pli.spearmanRankCorr({a, b}));
+  return (Expr as any)(pli.spearmanRankCorr({a, b}));
 }
 
 

--- a/nodejs-polars/polars/lazy/whenthen.ts
+++ b/nodejs-polars/polars/lazy/whenthen.ts
@@ -27,14 +27,14 @@ function WhenThenThen(_when): WhenThenThen {
   return {
     when: ({_expr}: Expr): WhenThenThen => WhenThenThen(pli._whenthenthen.when({_when, _expr})),
     then: ({_expr}: Expr): WhenThenThen => WhenThenThen(pli._whenthenthen.then({_when, _expr})),
-    otherwise: ({_expr}: Expr): Expr => Expr(pli._whenthenthen.otherwise({_when, _expr}))
+    otherwise: ({_expr}: Expr): Expr => (Expr as any)(pli._whenthenthen.otherwise({_when, _expr}))
   };
 }
 
 function WhenThen(_when): WhenThen {
   return {
     when: ({_expr}: Expr): WhenThenThen => WhenThenThen(pli._whenthen.when({_when, _expr})),
-    otherwise: ({_expr}: Expr): Expr => Expr(pli._whenthen.otherwise({_when, _expr}))
+    otherwise: ({_expr}: Expr): Expr => (Expr as any)(pli._whenthen.otherwise({_when, _expr}))
   };
 }
 

--- a/nodejs-polars/polars/series/series.ts
+++ b/nodejs-polars/polars/series/series.ts
@@ -1462,6 +1462,13 @@ export const seriesWrapper = <T>(_s: JsSeries): Series<T> => {
       }
     },
     sample(opts?, frac?, withReplacement = false, seed?) {
+      if(arguments.length === 0) {
+        return wrap("sample_n", {
+          n: 1,
+          withReplacement,
+          seed
+        });
+      }
       if(opts?.n  !== undefined || opts?.frac  !== undefined) {
         return this.sample(opts.n, opts.frac, opts.withReplacement, seed);
       }

--- a/nodejs-polars/polars/series/string.ts
+++ b/nodejs-polars/polars/series/string.ts
@@ -145,7 +145,8 @@ export interface StringFunctions {
   toUpperCase(): Series<string>
   /** Remove trailing whitespace. */
   rstrip(): Series<string>
-
+  /** Remove leading and trailing whitespace. */
+  strip(): Series<string>
   /**
    * Create subslices of the string values of a Utf8 Series.
    * @param start - Start of the slice (negative indexing may be used).
@@ -172,6 +173,19 @@ export const StringFunctions = (_s: JsSeries): StringFunctions => {
   const wrap = (method, args?, _series = _s): any => {
     return seriesWrapper(pli.series.str[method]({_series, ...args }));
   };
+  const callExpr = (method) => (...args) => {
+    const s = seriesWrapper(_s);
+
+    return s
+      .toFrame()
+      .select(
+        col(s.name)
+          .lst[method](...args)
+          .as(s.name)
+      )
+      .getColumn(s.name);
+  };
+
   const handleDecode = (encoding, strict) => {
     switch (encoding) {
     case "hex":
@@ -256,6 +270,35 @@ export const StringFunctions = (_s: JsSeries): StringFunctions => {
         )
         .getColumn(s.name);
 
+
+    },
+    // splitExact(by: string, options?, inclusive?) {
+    //   const n = typeof options === "boolean" ? options : options?.n;
+    //   inclusive = typeof inclusive === "boolean" ? inclusive : options.inclusive;
+    //   const s = seriesWrapper(_s);
+
+    //   return s
+    //     .toFrame()
+    //     .select(
+    //       col(s.name)
+    //         .str
+    //         .splitExact(by, n, inclusive)
+    //         .as(s.name)
+    //     )
+    //     .getColumn(s.name);
+    // },
+    strip() {
+      const s = seriesWrapper(_s);
+
+      return s
+        .toFrame()
+        .select(
+          col(s.name)
+            .str
+            .strip()
+            .as(s.name)
+        )
+        .getColumn(s.name);
 
     },
     strftime(dtype, fmt?) {

--- a/nodejs-polars/polars/shared_traits.ts
+++ b/nodejs-polars/polars/shared_traits.ts
@@ -315,3 +315,8 @@ export interface Sample<T> {
   sample(opts?: {frac: number, withReplacement?: boolean, seed?: number | bigint}): T
   sample(n?: number, frac?: number, withReplacement?: boolean, seed?: number | bigint): T
 }
+
+export interface Bincode<T> {
+  (bincode: Uint8Array): T;
+  getState(T): Uint8Array;
+}

--- a/nodejs-polars/polars/shared_traits.ts
+++ b/nodejs-polars/polars/shared_traits.ts
@@ -310,7 +310,8 @@ export interface Sample<T> {
    * ╰─────┴─────┴─────╯
    * ```
    */
-  sample(opts: {n: number, withReplacement?: boolean, seed?: number | bigint}): T
-  sample(opts: {frac: number, withReplacement?: boolean, seed?: number | bigint}): T
+
+  sample(opts?: {n: number, withReplacement?: boolean, seed?: number | bigint}): T
+  sample(opts?: {frac: number, withReplacement?: boolean, seed?: number | bigint}): T
   sample(n?: number, frac?: number, withReplacement?: boolean, seed?: number | bigint): T
 }

--- a/nodejs-polars/polars/shared_traits.ts
+++ b/nodejs-polars/polars/shared_traits.ts
@@ -282,3 +282,35 @@ export interface Round<T> {
   clip(min: number, max: number): T
   clip(options: {min: number, max: number})
 }
+
+export interface Sample<T> {
+  /**
+   * Sample from this DataFrame by setting either `n` or `frac`.
+   * @param n - Number of samples < self.len() .
+   * @param frac - Fraction between 0.0 and 1.0 .
+   * @param withReplacement - Sample with replacement.
+   * @param seed - Seed initialization. If not provided, a random seed will be used
+   * @example
+   * ```
+   * >>> df = pl.DataFrame({
+   * >>>   "foo": [1, 2, 3],
+   * >>>   "bar": [6, 7, 8],
+   * >>>   "ham": ['a', 'b', 'c']
+   * >>> })
+   * >>> df.sample({n: 2})
+   * shape: (2, 3)
+   * ╭─────┬─────┬─────╮
+   * │ foo ┆ bar ┆ ham │
+   * │ --- ┆ --- ┆ --- │
+   * │ i64 ┆ i64 ┆ str │
+   * ╞═════╪═════╪═════╡
+   * │ 1   ┆ 6   ┆ "a" │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
+   * │ 3   ┆ 8   ┆ "c" │
+   * ╰─────┴─────┴─────╯
+   * ```
+   */
+  sample(opts: {n: number, withReplacement?: boolean, seed?: number | bigint}): T
+  sample(opts: {frac: number, withReplacement?: boolean, seed?: number | bigint}): T
+  sample(n?: number, frac?: number, withReplacement?: boolean, seed?: number | bigint): T
+}

--- a/nodejs-polars/polars/shared_traits.ts
+++ b/nodejs-polars/polars/shared_traits.ts
@@ -13,7 +13,6 @@ export interface Arithmetic<T> {
   div(rhs: any): T
   mul(rhs: any): T
   rem(rhs: any): T
-
   plus(rhs: any): T
   minus(rhs: any): T
   divideBy(rhs: any): T

--- a/nodejs-polars/rust-toolchain
+++ b/nodejs-polars/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-04-01
+nightly

--- a/nodejs-polars/src/conversion/from.rs
+++ b/nodejs-polars/src/conversion/from.rs
@@ -56,12 +56,12 @@ impl FromJsUnknown for RowCount {
     }
 }
 
-impl FromJsUnknown for DistinctKeepStrategy {
+impl FromJsUnknown for UniqueKeepStrategy {
     fn from_js(val: JsUnknown) -> Result<Self> {
         let s = String::from_js(val)?;
         match s.as_str() {
-            "first" => Ok(DistinctKeepStrategy::First),
-            "last" => Ok(DistinctKeepStrategy::Last),
+            "first" => Ok(UniqueKeepStrategy::First),
+            "last" => Ok(UniqueKeepStrategy::Last),
             s => panic!("keep strategy {} is not supported", s),
         }
     }

--- a/nodejs-polars/src/dataframe/frame.rs
+++ b/nodejs-polars/src/dataframe/frame.rs
@@ -16,6 +16,7 @@ impl IntoJs<JsExternal> for DataFrame {
     }
 }
 
+
 #[js_function(1)]
 pub(crate) fn add(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;

--- a/nodejs-polars/src/dataframe/frame.rs
+++ b/nodejs-polars/src/dataframe/frame.rs
@@ -16,7 +16,6 @@ impl IntoJs<JsExternal> for DataFrame {
     }
 }
 
-
 #[js_function(1)]
 pub(crate) fn add(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;

--- a/nodejs-polars/src/dataframe/frame.rs
+++ b/nodejs-polars/src/dataframe/frame.rs
@@ -594,17 +594,17 @@ pub fn extend(cx: CallContext) -> JsResult<JsUndefined> {
 }
 
 #[js_function(1)]
-pub fn distinct(cx: CallContext) -> JsResult<JsExternal> {
+pub fn unique(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let df = params.get_external::<DataFrame>(&cx, "_df")?;
     let maintain_order: bool = params.get_or("maintainOrder", false)?;
-    let keep: DistinctKeepStrategy = params.get_as("keep")?;
+    let keep: UniqueKeepStrategy = params.get_as("keep")?;
 
     let subset: Option<Vec<String>> = params.get_as("subset")?;
     let subset = subset.as_ref().map(|v| v.as_ref());
     let df = match maintain_order {
-        true => df.distinct_stable(subset, keep),
-        false => df.distinct(subset, keep),
+        true => df.unique_stable(subset, keep),
+        false => df.unique(subset, keep),
     }
     .map_err(JsPolarsEr::from)?;
 

--- a/nodejs-polars/src/dataframe/frame.rs
+++ b/nodejs-polars/src/dataframe/frame.rs
@@ -66,7 +66,8 @@ pub(crate) fn sample_n(cx: CallContext) -> JsResult<JsExternal> {
     let df = params.get_external::<DataFrame>(&cx, "_df")?;
     let n = params.get_as::<usize>("n")?;
     let with_replacement = params.get_as::<bool>("withReplacement")?;
-    df.sample_n(n, with_replacement, Some(0))
+    let seed = params.get_as::<Option<u64>>("seed")?;
+    df.sample_n(n, with_replacement, seed)
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }
@@ -77,7 +78,8 @@ pub(crate) fn sample_frac(cx: CallContext) -> JsResult<JsExternal> {
     let df = params.get_external::<DataFrame>(&cx, "_df")?;
     let frac = params.get_as::<f64>("frac")?;
     let with_replacement = params.get_as::<bool>("withReplacement")?;
-    df.sample_frac(frac, with_replacement, Some(0))
+    let seed = params.get_as::<Option<u64>>("seed")?;
+    df.sample_frac(frac, with_replacement, seed)
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }

--- a/nodejs-polars/src/dataframe/io.rs
+++ b/nodejs-polars/src/dataframe/io.rs
@@ -763,6 +763,27 @@ pub(crate) fn read_array_rows(cx: CallContext) -> JsResult<JsExternal> {
     finish_from_rows(rows)?.try_into_js(&cx)
 }
 
+#[js_function(1)]
+pub fn from_bincode(cx: CallContext) -> JsResult<JsExternal> {
+    let buff: napi::JsBuffer = cx.get::<napi::JsBuffer>(0)?;
+    let buffer_value = buff.into_value()?;
+    let df: DataFrame = bincode::deserialize(buffer_value.as_ref()).unwrap();
+
+    df.try_into_js(&cx)
+}
+
+#[js_function(1)]
+pub fn to_bincode(cx: CallContext) -> JsResult<napi::JsBuffer> {
+    let params = get_params(&cx)?;
+    let df = params.get_external::<DataFrame>(&cx, "_df")?;
+
+    let buf = bincode::serialize(df).unwrap();
+
+    let bytes = cx.env.create_buffer_with_data(buf).unwrap();
+    let js_buff = bytes.into_raw();
+    Ok(js_buff)
+}
+
 fn resolve_homedir(path: &Path) -> PathBuf {
     // replace "~" with home directory
     if path.starts_with("~") {

--- a/nodejs-polars/src/dataframe/mod.rs
+++ b/nodejs-polars/src/dataframe/mod.rs
@@ -22,7 +22,7 @@ impl JsDataFrame {
             napi::Property::new(env, "div")?.with_method(df::div),
             napi::Property::new(env, "drop_in_place")?.with_method(df::drop_in_place),
             napi::Property::new(env, "drop_nulls")?.with_method(df::drop_nulls),
-            napi::Property::new(env, "distinct")?.with_method(df::distinct),
+            napi::Property::new(env, "unique")?.with_method(df::unique),
             napi::Property::new(env, "drop")?.with_method(df::drop),
             napi::Property::new(env, "dtypes")?.with_method(df::dtypes),
             napi::Property::new(env, "extend")?.with_method(df::extend),

--- a/nodejs-polars/src/dataframe/mod.rs
+++ b/nodejs-polars/src/dataframe/mod.rs
@@ -83,6 +83,8 @@ impl JsDataFrame {
             napi::Property::new(env, "with_column")?.with_method(df::with_column),
             napi::Property::new(env, "with_row_count")?.with_method(df::with_row_count),
             // IO
+            napi::Property::new(env, "to_bincode")?.with_method(io::to_bincode),
+            napi::Property::new(env, "from_bincode")?.with_method(io::from_bincode),
             napi::Property::new(env, "to_js")?.with_method(io::to_js),
             // row
             napi::Property::new(env, "to_row")?.with_method(io::to_row),

--- a/nodejs-polars/src/lazy/dsl.rs
+++ b/nodejs-polars/src/lazy/dsl.rs
@@ -356,7 +356,6 @@ pub fn str_replace(cx: CallContext) -> JsResult<JsExternal> {
         .try_into_js(&cx)
 }
 
-
 #[js_function(1)]
 pub fn str_replace_all(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
@@ -399,7 +398,7 @@ pub fn str_rstrip(cx: CallContext) -> JsResult<JsExternal> {
     let expr = params.get_external::<Expr>(&cx, "_expr")?;
     let function = |s: Series| {
         let ca = s.utf8()?;
-  
+
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_end())).into_series())
     };
 
@@ -414,7 +413,7 @@ pub fn str_lstrip(cx: CallContext) -> JsResult<JsExternal> {
     let expr = params.get_external::<Expr>(&cx, "_expr")?;
     let function = |s: Series| {
         let ca = s.utf8()?;
-  
+
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_start())).into_series())
     };
 
@@ -423,7 +422,6 @@ pub fn str_lstrip(cx: CallContext) -> JsResult<JsExternal> {
         .with_fmt("str.lstrip")
         .try_into_js(&cx)
 }
-
 
 #[js_function(1)]
 pub fn str_contains(cx: CallContext) -> JsResult<JsExternal> {
@@ -651,7 +649,9 @@ pub fn sample_frac(cx: CallContext) -> JsResult<JsExternal> {
     let frac = params.get_as::<f64>("frac")?;
     let with_replacement = params.get_as::<bool>("withReplacement")?;
     let seed = params.get_as::<Option<u64>>("seed")?;
-    expr.clone().sample_frac(frac, with_replacement, seed).try_into_js(&cx)
+    expr.clone()
+        .sample_frac(frac, with_replacement, seed)
+        .try_into_js(&cx)
 }
 #[js_function(1)]
 pub fn sort_by(cx: CallContext) -> JsResult<JsExternal> {
@@ -1147,14 +1147,14 @@ pub fn when_then_then_otherwise(cx: CallContext) -> JsResult<JsExternal> {
 #[js_function(1)]
 pub fn from_bincode(cx: CallContext) -> JsResult<JsExternal> {
     let buff: napi::JsBuffer = cx.get::<napi::JsBuffer>(0)?;
-    
+
     let s = buff.into_value()?;
     let v: &[u8] = &s;
-    
+
     // Safety
     // this is safe because the buf was created from js-land
     // JS manages the lifecycle & we only are borrowing.
-    let v = unsafe { std::mem::transmute::<&'_  [u8], &'static [u8]>(v) };
+    let v = unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(v) };
     let expr: Expr = bincode::deserialize(v).unwrap();
 
     expr.try_into_js(&cx)

--- a/nodejs-polars/src/lazy/dsl.rs
+++ b/nodejs-polars/src/lazy/dsl.rs
@@ -8,6 +8,7 @@ use polars::lazy::dsl::Operator;
 use crate::error::JsPolarsEr;
 use polars::lazy::dsl;
 use polars::prelude::*;
+use std::borrow::Cow;
 
 pub struct JsExpr {}
 
@@ -355,6 +356,7 @@ pub fn str_replace(cx: CallContext) -> JsResult<JsExternal> {
         .try_into_js(&cx)
 }
 
+
 #[js_function(1)]
 pub fn str_replace_all(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
@@ -374,6 +376,54 @@ pub fn str_replace_all(cx: CallContext) -> JsResult<JsExternal> {
         .map(function, GetOutput::same_type())
         .try_into_js(&cx)
 }
+
+#[js_function(1)]
+pub fn str_strip(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let expr = params.get_external::<Expr>(&cx, "_expr")?;
+
+    let function = |s: Series| {
+        let ca = s.utf8()?;
+
+        Ok(ca.apply(|s| Cow::Borrowed(s.trim())).into_series())
+    };
+
+    expr.clone()
+        .map(function, GetOutput::same_type())
+        .with_fmt("str.strip")
+        .try_into_js(&cx)
+}
+#[js_function(1)]
+pub fn str_rstrip(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let expr = params.get_external::<Expr>(&cx, "_expr")?;
+    let function = |s: Series| {
+        let ca = s.utf8()?;
+  
+        Ok(ca.apply(|s| Cow::Borrowed(s.trim_end())).into_series())
+    };
+
+    expr.clone()
+        .map(function, GetOutput::same_type())
+        .with_fmt("str.rstrip")
+        .try_into_js(&cx)
+}
+#[js_function(1)]
+pub fn str_lstrip(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let expr = params.get_external::<Expr>(&cx, "_expr")?;
+    let function = |s: Series| {
+        let ca = s.utf8()?;
+  
+        Ok(ca.apply(|s| Cow::Borrowed(s.trim_start())).into_series())
+    };
+
+    expr.clone()
+        .map(function, GetOutput::same_type())
+        .with_fmt("str.lstrip")
+        .try_into_js(&cx)
+}
+
 
 #[js_function(1)]
 pub fn str_contains(cx: CallContext) -> JsResult<JsExternal> {
@@ -594,7 +644,15 @@ pub fn sort_with(cx: CallContext) -> JsResult<JsExternal> {
         })
         .try_into_js(&cx)
 }
-
+#[js_function(1)]
+pub fn sample_frac(cx: CallContext) -> JsResult<JsExternal> {
+    let params = get_params(&cx)?;
+    let expr = params.get_external::<Expr>(&cx, "_expr")?;
+    let frac = params.get_as::<f64>("frac")?;
+    let with_replacement = params.get_as::<bool>("withReplacement")?;
+    let seed = params.get_as::<Option<u64>>("seed")?;
+    expr.clone().sample_frac(frac, with_replacement, seed).try_into_js(&cx)
+}
 #[js_function(1)]
 pub fn sort_by(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;

--- a/nodejs-polars/src/lazy/dsl_object.rs
+++ b/nodejs-polars/src/lazy/dsl_object.rs
@@ -200,6 +200,8 @@ impl dsl::JsExpr {
             napi::Property::new(env, "upperBound")?.with_method(dsl::upper_bound),
             napi::Property::new(env, "var")?.with_method(dsl::var),
             napi::Property::new(env, "xor")?.with_method(dsl::xor),
+            napi::Property::new(env, "to_bincode")?.with_method(dsl::to_bincode),
+            napi::Property::new(env, "from_bincode")?.with_method(dsl::from_bincode),
         ])?;
 
         Ok(expr)

--- a/nodejs-polars/src/lazy/dsl_object.rs
+++ b/nodejs-polars/src/lazy/dsl_object.rs
@@ -70,6 +70,9 @@ impl dsl::JsExpr {
             napi::Property::new(env, "decodeHex")?.with_method(dsl::hex_decode),
             napi::Property::new(env, "encodeBase64")?.with_method(dsl::base64_encode),
             napi::Property::new(env, "decodeBase64")?.with_method(dsl::base64_decode),
+            napi::Property::new(env, "strip")?.with_method(dsl::str_strip),
+            napi::Property::new(env, "lstrip")?.with_method(dsl::str_lstrip),
+            napi::Property::new(env, "rstrip")?.with_method(dsl::str_rstrip),
         ])?;
         date_obj.define_properties(&[
             napi::Property::new(env, "day")?.with_method(dsl::day),
@@ -178,6 +181,7 @@ impl dsl::JsExpr {
             napi::Property::new(env, "rollingQuantile")?.with_method(dsl::rolling_quantile),
             napi::Property::new(env, "rollingSkew")?.with_method(dsl::rolling_skew),
             napi::Property::new(env, "round")?.with_method(dsl::round),
+            napi::Property::new(env, "sampleFrac")?.with_method(dsl::sample_frac),
             napi::Property::new(env, "shiftAndFill")?.with_method(dsl::shift_and_fill),
             napi::Property::new(env, "shift")?.with_method(dsl::shift),
             napi::Property::new(env, "skew")?.with_method(dsl::skew),

--- a/nodejs-polars/src/lazy/lazyframe.rs
+++ b/nodejs-polars/src/lazy/lazyframe.rs
@@ -423,16 +423,16 @@ pub fn explode(cx: CallContext) -> JsResult<JsExternal> {
 }
 
 #[js_function(1)]
-pub fn distinct(cx: CallContext) -> JsResult<JsExternal> {
+pub fn unique(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let ldf = params.get_external::<LazyFrame>(&cx, "_ldf")?.clone();
     let maintain_order: bool = params.get_or("maintainOrder", false)?;
-    let keep: DistinctKeepStrategy = params.get_as("keep")?;
+    let keep: UniqueKeepStrategy = params.get_as("keep")?;
 
     let subset: Option<Vec<String>> = params.get_as("subset")?;
     match maintain_order {
-        true => ldf.distinct_stable(subset, keep),
-        false => ldf.distinct(subset, keep),
+        true => ldf.unique_stable(subset, keep),
+        false => ldf.unique(subset, keep),
     }
     .try_into_js(&cx)
 }

--- a/nodejs-polars/src/lazy/lazyframe_object.rs
+++ b/nodejs-polars/src/lazy/lazyframe_object.rs
@@ -20,7 +20,7 @@ impl JsLazyFrame {
             napi::Property::new(env, "collectSync")?.with_method(lazyframe::collect_sync),
             napi::Property::new(env, "columns")?.with_method(lazyframe::columns),
             napi::Property::new(env, "dropColumns")?.with_method(lazyframe::drop_columns),
-            napi::Property::new(env, "distinct")?.with_method(lazyframe::distinct),
+            napi::Property::new(env, "unique")?.with_method(lazyframe::unique),
             napi::Property::new(env, "dropNulls")?.with_method(lazyframe::drop_nulls),
             napi::Property::new(env, "explode")?.with_method(lazyframe::explode),
             napi::Property::new(env, "fetch")?.with_method(lazyframe::fetch),

--- a/nodejs-polars/src/series.rs
+++ b/nodejs-polars/src/series.rs
@@ -1179,8 +1179,9 @@ pub(crate) fn sample_n(cx: CallContext) -> JsResult<JsExternal> {
     let series = params.get_external::<Series>(&cx, "_series")?;
     let n = params.get_as::<usize>("n")?;
     let with_replacement = params.get_as::<bool>("withReplacement")?;
+    let seed = params.get_as::<Option<u64>>("seed")?;
     series
-        .sample_n(n, with_replacement, Some(0))
+        .sample_n(n, with_replacement, seed)
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }
@@ -1191,8 +1192,9 @@ pub(crate) fn sample_frac(cx: CallContext) -> JsResult<JsExternal> {
     let series = params.get_external::<Series>(&cx, "_series")?;
     let frac = params.get_as::<f64>("frac")?;
     let with_replacement = params.get_as::<bool>("withReplacement")?;
+    let seed = params.get_as::<Option<u64>>("seed")?;
     series
-        .sample_frac(frac, with_replacement, Some(0))
+        .sample_frac(frac, with_replacement, seed)
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }

--- a/nodejs-polars/src/series.rs
+++ b/nodejs-polars/src/series.rs
@@ -440,7 +440,7 @@ pub fn value_counts(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let series = params.get_external::<Series>(&cx, "_series")?;
     series
-        .value_counts()
+        .value_counts(true)
         .map_err(JsPolarsEr::from)?
         .try_into_js(&cx)
 }

--- a/nodejs-polars/src/series.rs
+++ b/nodejs-polars/src/series.rs
@@ -24,6 +24,27 @@ impl IntoJs<JsExternal> for Series {
 }
 
 #[js_function(1)]
+pub fn from_bincode(cx: CallContext) -> JsResult<JsExternal> {
+    let buff: napi::JsBuffer = cx.get::<napi::JsBuffer>(0)?;
+    let buffer_value = buff.into_value()?;
+    let s: Series = bincode::deserialize(buffer_value.as_ref()).unwrap();
+
+    s.try_into_js(&cx)
+}
+
+#[js_function(1)]
+pub fn to_bincode(cx: CallContext) -> JsResult<napi::JsBuffer> {
+    let params = get_params(&cx)?;
+    let series = params.get_external::<Series>(&cx, "_series")?;
+
+    let buf = bincode::serialize(series).unwrap();
+
+    let bytes = cx.env.create_buffer_with_data(buf).unwrap();
+    let js_buff = bytes.into_raw();
+    Ok(js_buff)
+}
+
+#[js_function(1)]
 pub fn new_from_typed_array(cx: CallContext) -> JsResult<JsExternal> {
     let params = get_params(&cx)?;
     let name = params.get_as::<&str>("name")?;

--- a/nodejs-polars/src/series_object.rs
+++ b/nodejs-polars/src/series_object.rs
@@ -314,7 +314,7 @@ impl JsSeries {
             napi::Property::new(env, "rem_u8")?.with_method(rem_u8),
             napi::Property::new(env, "rem")?.with_method(rem),
             napi::Property::new(env, "rename")?.with_method(rename),
-            napi::Property::new(env, "repeat")?.with_method(repeat),
+            napi::Property::new(env, "repeat")?.with_method(crate::series::repeat),
             napi::Property::new(env, "rolling_max")?.with_method(rolling_max),
             napi::Property::new(env, "rolling_mean")?.with_method(rolling_mean),
             napi::Property::new(env, "rolling_min")?.with_method(rolling_min),

--- a/nodejs-polars/src/series_object.rs
+++ b/nodejs-polars/src/series_object.rs
@@ -42,7 +42,8 @@ impl JsSeries {
         ])?;
 
         series.define_properties(&[
-            napi::Property::new(env, "_not")?.with_method(crate::series::not),
+            napi::Property::new(env, "to_bincode")?.with_method(crate::series::to_bincode),
+            napi::Property::new(env, "from_bincode")?.with_method(crate::series::from_bincode),
             napi::Property::new(env, "abs")?.with_method(abs),
             napi::Property::new(env, "add_f32_rhs")?.with_method(add_f32_rhs),
             napi::Property::new(env, "add_f32")?.with_method(add_f32),


### PR DESCRIPTION
# Description
- [x] rename `distinct` -> `unique`
- [x] str namespace `strip, lstrip, rstrip` 
- [x] removes previously deprecated `dropDuplicates`
- [x] rename `df.to*` methods to `df.write*`
- [x] add expr serde
- [x] sample refactor

Still TODO:

-  add struct dtype
-  update `value_counts` & `unique_counts`
-  rechunk option for `ipc` 
-  add parseDates option for read_csv


@ritchie46 I think this is a comprehensive list of the recent updates to python apis.  please let me know if there were any other major updates in the past ~45 days. 