### PR TITLE
python: jemalloc

### DIFF
--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -261,8 +261,8 @@
 //!
 //! ### Custom allocator
 //! A DataFrame library naturally does a lot of heap allocations. It is recommended to use a custom
-//! allocator. [Mimalloc](https://docs.rs/mimalloc/0.1.25/mimalloc/) for instance, shows a significant
-//! performance gain in runtime as well as memory usage. Especially with `MIMALLOC_LARGE_OS_PAGES=1`.
+//! allocator. [Mimalloc](https://docs.rs/mimalloc/0.1.25/mimalloc/) and [JeMalloc](https://crates.io/crates/jemallocator) for instance, show a significant
+//! performance gain in runtime as well as memory usage.
 //!
 //! #### Usage
 //! ```ignore

--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -3,5 +3,5 @@
 max-line-length = 180
 # E203, W503: due to black fmt
 ignore = E203,W503
-exclude = legacy, docs, venv
+exclude = legacy, docs, venv, target
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -397,12 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +440,12 @@ dependencies = [
  "libz-sys",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
@@ -656,6 +656,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,16 +807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7705fc40f6ed493f73584abbb324e74f96b358ff60dfe5659a0f8fc12c590a69"
-dependencies = [
- "cc",
- "cty",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,15 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dfa131390c2f6bdb3242f65ff271fcdaca5ff7b6c08f28398be7f2280e3926"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1290,9 +1292,8 @@ version = "0.13.19"
 dependencies = [
  "ahash",
  "bincode",
+ "jemallocator",
  "libc",
- "libmimalloc-sys",
- "mimalloc",
  "ndarray",
  "numpy",
  "polars",
@@ -1364,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -18,9 +18,8 @@ description = "Blazingly fast DataFrame library"
 [dependencies]
 ahash = "0.7"
 bincode = "1.3"
+jemallocator = { version = "0.3", features = ["disable_initial_exec_tls"] }
 libc = "0.2"
-libmimalloc-sys = { version = "*", features = ["extended"] }
-mimalloc = { version = "*", default-features = false }
 ndarray = "0.15"
 numpy = "0.16"
 polars-core = { path = "../polars/polars-core", default-features = false }

--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -14,7 +14,5 @@ Config
     Config.set_tbl_cols
     Config.set_global_string_cache
     Config.unset_global_string_cache
-    Config.set_large_os_pages
-    Config.unset_large_os_pages
     toggle_string_cache
     StringCache

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -3,8 +3,6 @@ import warnings
 
 try:
     from polars.polars import version
-
-    _DOCUMENTING = False
 except ImportError as e:  # pragma: no cover
 
     def version() -> str:
@@ -12,7 +10,6 @@ except ImportError as e:  # pragma: no cover
 
     # this is only useful for documentation
     warnings.warn("polars binary missing!")
-    _DOCUMENTING = True
 
 import polars.testing as testing
 from polars.cfg import (  # flake8: noqa. We do not export in __all__
@@ -233,6 +230,3 @@ __version__ = version()
 import os
 
 os.environ["POLARS_ALLOW_EXTENSION"] = "true"
-
-if not _DOCUMENTING:
-    Config.set_large_os_pages()

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -3,13 +3,6 @@ from typing import Type
 
 from polars.string_cache import toggle_string_cache
 
-try:
-    from polars.polars import enable_large_os_pages as _enable_large_os_pages
-
-    _DOCUMENTING = False
-except ImportError:  # pragma: no cover
-    _DOCUMENTING = True
-
 
 class Config:
     """
@@ -105,24 +98,4 @@ class Config:
         Turn off the global string cache
         """
         toggle_string_cache(False)
-        return cls
-
-    @classmethod
-    def unset_large_os_pages(cls) -> "Type[Config]":
-        """
-        Turn off large OS pages in `mimalloc` allocator.
-
-        This can be slower depending on your use case. It is on by default in polars.
-        """
-        _enable_large_os_pages(False)
-        return cls
-
-    @classmethod
-    def set_large_os_pages(cls) -> "Type[Config]":
-        """
-        Turn on large OS pages in `mimalloc` allocator.
-
-        It is on by default in polars.
-        """
-        _enable_large_os_pages(True)
         return cls

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -39,7 +39,7 @@ use crate::error::{
 use crate::file::get_either_file;
 use crate::prelude::{ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs, PyDataType};
 use dsl::ToExprs;
-use mimalloc::MiMalloc;
+use jemallocator::Jemalloc;
 use polars::functions::{diag_concat_df, hor_concat_df};
 use polars::prelude::Null;
 use polars_core::datatypes::TimeUnit;
@@ -48,16 +48,7 @@ use polars_core::prelude::IntoSeries;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
 
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
-#[pyfunction]
-fn enable_large_os_pages(_py: Python, toggle: bool) {
-    // Safety
-    // holding the python gil makes this thread safe
-    unsafe {
-        libmimalloc_sys::mi_option_set_enabled(libmimalloc_sys::mi_option_large_os_pages, toggle)
-    }
-}
+static ALLOC: Jemalloc = Jemalloc;
 
 #[pyfunction]
 fn col(name: &str) -> dsl::PyExpr {
@@ -477,7 +468,5 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(max_exprs)).unwrap();
     m.add_wrapped(wrap_pyfunction!(as_struct)).unwrap();
     m.add_wrapped(wrap_pyfunction!(repeat)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(enable_large_os_pages))
-        .unwrap();
     Ok(())
 }


### PR DESCRIPTION
swap mimalloc for jemalloc. I did some local benchmarks and on all tasks it seemed to perform better.

Things I tried:

* db benchmark groupby
* read_csv taxi dataset
* write csv
* write ipc