### PR TITLE
CI: Fix windows tests disk space failure

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -4,16 +4,19 @@ on:
   pull_request:
     paths:
       - 'polars/**'
+      - '.github/workflows/test-windows.yaml'
 jobs:
   test-rust:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-04-01
           override: true
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
+          set RUSTFLAGS="-C debuginfo=0"
           cd polars && make test && make integration-tests


### PR DESCRIPTION
Fixes: #2783

## Problem

The windows tests were failing due to insufficient disk space because of cargo management on the `D:` drive. Unlike other OS options, the windows GHA option uses the `D:` drive which has less capacity than the `C:` drive. 

## Solution

Use [`Swatinem/rust-cache@v1`](https://github.com/Swatinem/rust-cache) or similar logic to manage caching deps

**NOTE: I modified the `on` to trigger this GHA in order to demonstrate the passing test. Before merging I can pull this out.** 

## Other

While looking into this I noticed:
- `windows-2019` is often associated with random issues (changed to `windows-latest` in this PR)
- The first pass I submitted used a hacky workaround based on info from the issue I linked [here](https://github.com/pola-rs/polars/issues/2783#issuecomment-1095112700)

I'm curious how well this will hold up over time since nightly is used here. In case there's a need to fallback to the workaround, something along these lines (+ some cleaning logic) could probably be used:

```yaml
jobs:
  test-rust:
    runs-on: windows-latest
    steps:
      - name: Install latest Rust nightly
        uses: actions-rs/toolchain@v1
        with:
          toolchain: nightly-2022-04-01
          override: true
      - name: Checkout branch
        run: |
          git clone ${{ github.event.pull_request.head.repo.full_name }} C:/polars --depth 1
      - uses: Swatinem/rust-cache@v1
        with:
          working-directory: C:/polars
      - name: Run tests
        working-directory: C:/polars
        run: |
          rustup override set nightly-2022-04-01
          git checkout ${{ github.event.pull_request.head.sha }}
          set RUSTFLAGS="-C debuginfo=0"
          cd polars && make test && make integration-tests
```

Note the cloning and `checkout` need to be further validated.

### Other Resources:
- https://github.com/rust-lang/cargo/issues/7150