### PR TITLE
python parquet: default to lz4 compression

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1335,7 +1335,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 ],
                 str,
             ]
-        ] = "snappy",
+        ] = "lz4",
         statistics: bool = False,
         use_pyarrow: bool = False,
         **kwargs: Any,


### PR DESCRIPTION
#3120 