### PR TITLE
Lazy: Don't materialize whole table in JOIN followed by SLICE

### DIFF
--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -109,6 +109,7 @@ where
 }
 
 // prefer this one over split_ca, as this can push the null_count into the thread pool
+#[doc(hidden)]
 pub fn split_offsets(len: usize, n: usize) -> Vec<(usize, usize)> {
     if n == 1 {
         vec![(0, len)]
@@ -130,11 +131,13 @@ pub fn split_offsets(len: usize, n: usize) -> Vec<(usize, usize)> {
 }
 
 #[cfg(feature = "private")]
+#[doc(hidden)]
 pub fn split_series(s: &Series, n: usize) -> Result<Vec<Series>> {
     split_array!(s, n, i64)
 }
 
 #[cfg(feature = "private")]
+#[doc(hidden)]
 pub fn split_df(df: &DataFrame, n: usize) -> Result<Vec<DataFrame>> {
     trait Len {
         fn len(&self) -> usize;
@@ -147,8 +150,14 @@ pub fn split_df(df: &DataFrame, n: usize) -> Result<Vec<DataFrame>> {
     split_array!(df, n, i64)
 }
 
+pub(crate) fn slice_slice<T>(vals: &[T], offset: i64, len: usize) -> &[T] {
+    let (raw_offset, slice_len) = slice_offsets(offset, len, vals.len());
+    &vals[raw_offset..raw_offset + slice_len]
+}
+
 #[inline]
 #[cfg(feature = "private")]
+#[doc(hidden)]
 pub fn slice_offsets(offset: i64, length: usize, array_len: usize) -> (usize, usize) {
     let abs_offset = offset.abs() as usize;
 

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -273,7 +273,7 @@ impl<'a> LazyCsvReader<'a> {
                 .map_err(|_| PolarsError::ComputeError("no matching files found".into()))
                 .map(|lf| {
                     if self.skip_rows != 0 || self.n_rows.is_some() {
-                        lf.slice(self.skip_rows as i64, self.n_rows.unwrap() as u32)
+                        lf.slice(self.skip_rows as i64, self.n_rows.unwrap() as IdxSize)
                     } else {
                         lf
                     }

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -54,7 +54,7 @@ impl LazyFrame {
                 .map_err(|_| PolarsError::ComputeError("no matching files found".into()))
                 .map(|mut lf| {
                     if let Some(n_rows) = args.n_rows {
-                        lf = lf.slice(0, n_rows as u32);
+                        lf = lf.slice(0, n_rows as IdxSize);
                     };
 
                     if let Some(rc) = args.row_count {

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -50,6 +50,7 @@ pub struct JoinOptions {
     pub force_parallel: bool,
     pub how: JoinType,
     pub suffix: Cow<'static, str>,
+    pub slice: Option<(i64, usize)>,
 }
 
 impl Default for JoinOptions {
@@ -59,6 +60,7 @@ impl Default for JoinOptions {
             force_parallel: false,
             how: JoinType::Left,
             suffix: "_right".into(),
+            slice: None,
         }
     }
 }
@@ -989,7 +991,7 @@ impl LazyFrame {
     }
 
     /// Slice the DataFrame.
-    pub fn slice(self, offset: i64, len: u32) -> LazyFrame {
+    pub fn slice(self, offset: i64, len: IdxSize) -> LazyFrame {
         let opt_state = self.get_opt_state();
         let lp = self.get_plan_builder().slice(offset, len).build();
         Self::from_logical_plan(lp, opt_state)
@@ -1006,7 +1008,7 @@ impl LazyFrame {
     }
 
     /// Get the last `n` rows
-    pub fn tail(self, n: u32) -> LazyFrame {
+    pub fn tail(self, n: IdxSize) -> LazyFrame {
         let neg_tail = -(n as i64);
         self.slice(neg_tail, n)
     }
@@ -1023,7 +1025,7 @@ impl LazyFrame {
 
     /// Limit the DataFrame to the first `n` rows. Note if you don't want the rows to be scanned,
     /// use [fetch](LazyFrame::fetch).
-    pub fn limit(self, n: u32) -> LazyFrame {
+    pub fn limit(self, n: IdxSize) -> LazyFrame {
         self.slice(0, n)
     }
 
@@ -1327,6 +1329,7 @@ impl JoinBuilder {
                     force_parallel: self.force_parallel,
                     how: self.how,
                     suffix,
+                    slice: None,
                 },
             )
             .build();

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -57,7 +57,7 @@ impl LazyFrame {
                 .map_err(|_| PolarsError::ComputeError("no matching files found".into()))
                 .map(|mut lf| {
                     if let Some(n_rows) = args.n_rows {
-                        lf = lf.slice(0, n_rows as u32)
+                        lf = lf.slice(0, n_rows as IdxSize)
                     };
 
                     if let Some(rc) = args.row_count {

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -23,7 +23,7 @@ pub enum ALogicalPlan {
     Slice {
         input: Node,
         offset: i64,
-        len: u32,
+        len: IdxSize,
     },
     Selection {
         input: Node,

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -421,7 +421,7 @@ impl LogicalPlanBuilder {
         .into()
     }
 
-    pub fn slice(self, offset: i64, len: u32) -> Self {
+    pub fn slice(self, offset: i64, len: IdxSize) -> Self {
         LogicalPlan::Slice {
             input: Box::new(self.0),
             offset,

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -143,7 +143,7 @@ pub enum LogicalPlan {
     Slice {
         input: Box<LogicalPlan>,
         offset: i64,
-        len: u32,
+        len: IdxSize,
     },
     /// A Melt operation
     Melt {

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -45,7 +45,7 @@ pub struct IpcScanOptions {
 pub struct UnionOptions {
     pub(crate) slice: bool,
     pub(crate) slice_offset: i64,
-    pub(crate) slice_len: u32,
+    pub(crate) slice_len: IdxSize,
 }
 
 #[derive(Clone, Debug)]

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -5,7 +5,7 @@ use polars_core::prelude::*;
 pub struct SliceExec {
     pub input: Box<dyn Executor>,
     pub offset: i64,
-    pub len: u32,
+    pub len: IdxSize,
 }
 
 impl Executor for SliceExec {

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -433,7 +433,7 @@ impl DefaultPlanner {
                     right_on,
                     parallel,
                     options.suffix,
-                    None,
+                    options.slice,
                 )))
             }
             HStack { input, exprs, .. } => {

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -433,6 +433,7 @@ impl DefaultPlanner {
                     right_on,
                     parallel,
                     options.suffix,
+                    None,
                 )))
             }
             HStack { input, exprs, .. } => {


### PR DESCRIPTION
This optimization may save a lot of unneeded work in queries that join and follow by a slicing operation like limit/ tail/ slice.