### PR TITLE
Add `semi` and `anti` joins.

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -105,6 +105,7 @@ product = ["polars-core/product"]
 unique_counts = ["polars-core/unique_counts", "polars-lazy/unique_counts"]
 log = ["polars-core/log", "polars-lazy/log"]
 partition_by = ["polars-core/partition_by"]
+semi_anti_join = ["polars-core/semi_anti_join"]
 
 series_from_anyvalue = ["polars-core/series_from_anyvalue"]
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -78,8 +78,7 @@ product = []
 unique_counts = []
 log = []
 partition_by = []
-anti_join = []
-semi_join = []
+semi_anti_join = []
 
 dynamic_groupby = ["dtype-datetime", "dtype-date"]
 

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -78,6 +78,8 @@ product = []
 unique_counts = []
 log = []
 partition_by = []
+anti_join = []
+semi_join = []
 
 dynamic_groupby = ["dtype-datetime", "dtype-date"]
 

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -7,6 +7,10 @@ use polars_arrow::utils::CustomIterTools;
 use crate::frame::hash_join::multiple_keys::{
     inner_join_multiple_keys, left_join_multiple_keys, outer_join_multiple_keys,
 };
+
+#[cfg(feature = "semi_anti_join")]
+use crate::frame::hash_join::multiple_keys::{left_anti_multiple_keys, left_semi_multiple_keys};
+
 use crate::prelude::*;
 use crate::utils::{set_partition_size, slice_slice, split_ca};
 use crate::vector_hasher::{
@@ -467,7 +471,17 @@ impl DataFrame {
             )),
             #[cfg(feature = "semi_anti_join")]
             JoinType::Anti | JoinType::Semi => {
-                panic!("not yet supported on multiple keys")
+                let left = DataFrame::new_no_checks(selected_left_physical);
+                let right = DataFrame::new_no_checks(selected_right_physical);
+
+                let idx = if matches!(how, JoinType::Anti) {
+                    left_anti_multiple_keys(&left, &right)
+                } else {
+                    left_semi_multiple_keys(&left, &right)
+                };
+                // Safety:
+                // indices are in bounds
+                Ok(unsafe { self.finish_anti_semi_join(&idx, slice) })
             }
             JoinType::Cross => {
                 unreachable!()
@@ -651,6 +665,20 @@ impl DataFrame {
     }
 
     #[cfg(feature = "semi_anti_join")]
+    /// # Safety:
+    /// `idx` must be in bounds
+    unsafe fn finish_anti_semi_join(
+        &self,
+        mut idx: &[IdxSize],
+        slice: Option<(i64, usize)>,
+    ) -> DataFrame {
+        if let Some((offset, len)) = slice {
+            idx = slice_slice(idx, offset, len);
+        }
+        self.take_unchecked_slice(idx)
+    }
+
+    #[cfg(feature = "semi_anti_join")]
     pub(crate) fn semi_anti_join_from_series(
         &self,
         s_left: &Series,
@@ -662,12 +690,9 @@ impl DataFrame {
         check_categorical_src(s_left.dtype(), s_right.dtype())?;
 
         let idx = s_left.hash_join_semi_anti(s_right, anti);
-        let mut idx = &*idx;
-
-        if let Some((offset, len)) = slice {
-            idx = slice_slice(idx, offset, len);
-        }
-        Ok(unsafe { self.take_unchecked_slice(idx) })
+        // Safety:
+        // indices are in bounds
+        Ok(unsafe { self.finish_anti_semi_join(&idx, slice) })
     }
 
     /// Perform an outer join on two DataFrames

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -73,6 +73,8 @@ pub enum JoinType {
     #[cfg(feature = "asof_join")]
     AsOf(AsOfOptions),
     Cross,
+    Semi,
+    Anti
 }
 
 pub(crate) unsafe fn get_hash_tbl_threaded_join_partitioned<T, H>(
@@ -307,6 +309,12 @@ impl DataFrame {
                 JoinType::Outer => {
                     self.outer_join_from_series(other, s_left, s_right, suffix, slice)
                 }
+                JoinType::Anti => {
+                    self.anti_join_from_series(other, s_left, s_right, slice)
+                }
+                JoinType::Semi => {
+                    todo!()
+                }
                 #[cfg(feature = "asof_join")]
                 JoinType::AsOf(options) => {
                     let left_on = selected_left[0].name();
@@ -457,6 +465,9 @@ impl DataFrame {
             JoinType::AsOf(_) => Err(PolarsError::ComputeError(
                 "asof join not supported for join on multiple keys".into(),
             )),
+            JoinType::Anti | JoinType::Semi => {
+                panic!("not yet supported on multiple keys")
+            }
             JoinType::Cross => {
                 unreachable!()
             }
@@ -636,6 +647,38 @@ impl DataFrame {
             },
         );
         self.finish_join(df_left, df_right, suffix)
+    }
+
+
+    pub(crate) fn anti_join_from_series(
+        &self,
+        other: &DataFrame,
+        s_left: &Series,
+        s_right: &Series,
+        slice: Option<(i64, usize)>,
+    ) -> Result<DataFrame> {
+        todo!()
+        // #[cfg(feature = "dtype-categorical")]
+        // check_categorical_src(s_left.dtype(), s_right.dtype())?;
+        //
+        // let opt_join_tuples = s_left.hash_join_left(s_right);
+        // let mut opt_join_tuples = &*opt_join_tuples;
+        //
+        // if let Some((offset, len)) = slice {
+        //     opt_join_tuples = slice_slice(opt_join_tuples, offset, len);
+        // }
+        //
+        // let (df_left, df_right) = POOL.join(
+        //     || self.create_left_df(opt_join_tuples, true),
+        //     || unsafe {
+        //         other.drop(s_right.name()).unwrap().take_opt_iter_unchecked(
+        //             opt_join_tuples
+        //                 .iter()
+        //                 .map(|(_left, right)| right.map(|i| i as usize)),
+        //         )
+        //     },
+        // );
+        // self.finish_join(df_left, df_right, suffix)
     }
 
     /// Perform an outer join on two DataFrames

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -83,11 +83,11 @@ pub enum JoinType {
     Anti,
 }
 
-pub(crate) unsafe fn get_hash_tbl_threaded_join_partitioned<T, H>(
+pub(crate) unsafe fn get_hash_tbl_threaded_join_partitioned<Item>(
     h: u64,
-    hash_tables: &[HashMap<T, Vec<IdxSize>, H>],
+    hash_tables: &[Item],
     len: u64,
-) -> &HashMap<T, Vec<IdxSize>, H> {
+) -> &Item {
     let mut idx = 0;
     for i in 0..len {
         // can only be done for powers of two.

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -249,18 +249,7 @@ pub fn private_left_join_multiple_keys(
     left_join_multiple_keys(&a, &b)
 }
 
-pub(crate) fn left_join_multiple_keys_impl<'a, OnMatchFn: 'a>(
-    a: &'a DataFrame,
-    b: &'a DataFrame,
-    // Function that determines what we insert on a matching key
-    // This differs per join type:
-    // - for left join we extend with all matches
-    // - for semi and anti join we extend only with one match
-    on_match: OnMatchFn,
-) -> impl ParallelIterator<Item = LeftJoinTuples> + 'a
-where
-    OnMatchFn: Fn(&mut Vec<LeftJoinTuples>, &[IdxSize], IdxSize) + Sync + Send,
-{
+pub(crate) fn left_join_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<LeftJoinTuples> {
     // we should not join on logical types
     debug_assert!(!a.iter().any(|s| s.is_logical()));
     debug_assert!(!b.iter().any(|s| s.is_logical()));
@@ -310,7 +299,7 @@ where
                         match entry {
                             // left and right matches
                             Some((_, indexes_b)) => {
-                                on_match(&mut results, indexes_b, idx_a);
+                                on_match_left_join_extend(&mut results, indexes_b, idx_a);
                             }
                             // only left values, right = null
                             None => results.push((idx_a, None)),
@@ -322,38 +311,139 @@ where
                 results
             })
             .flatten()
+            .collect()
     })
 }
 
-pub(crate) fn left_join_multiple_keys(
-    a: &DataFrame,
-    b: &DataFrame,
-) -> Vec<(IdxSize, Option<IdxSize>)> {
-    left_join_multiple_keys_impl(a, b, on_match_left_join_extend).collect()
+#[cfg(feature = "semi_anti_join")]
+pub(crate) fn create_build_table_semi_anti(
+    hashes: &[UInt64Chunked],
+    keys: &DataFrame,
+) -> Vec<HashMap<IdxHash, (), IdBuildHasher>> {
+    let n_partitions = set_partition_size();
+
+    // We will create a hashtable in every thread.
+    // We use the hash to partition the keys to the matching hashtable.
+    // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
+    POOL.install(|| {
+        (0..n_partitions).into_par_iter().map(|part_no| {
+            let part_no = part_no as u64;
+            let mut hash_tbl: HashMap<IdxHash, (), IdBuildHasher> =
+                HashMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
+
+            let n_partitions = n_partitions as u64;
+            let mut offset = 0;
+            for hashes in hashes {
+                for hashes in hashes.data_views() {
+                    let len = hashes.len();
+                    let mut idx = 0;
+                    hashes.iter().for_each(|h| {
+                        // partition hashes by thread no.
+                        // So only a part of the hashes go to this hashmap
+                        if this_partition(*h, part_no, n_partitions) {
+                            let idx = idx + offset;
+                            populate_multiple_key_hashmap(
+                                &mut hash_tbl,
+                                idx,
+                                *h,
+                                keys,
+                                || (),
+                                |_| (),
+                            )
+                        }
+                        idx += 1;
+                    });
+
+                    offset += len as IdxSize;
+                }
+            }
+            hash_tbl
+        })
+    })
+    .collect()
+}
+
+#[cfg(feature = "semi_anti_join")]
+pub(crate) fn semi_anti_join_multiple_keys_impl<'a>(
+    a: &'a DataFrame,
+    b: &'a DataFrame,
+) -> impl ParallelIterator<Item = (IdxSize, bool)> + 'a {
+    // we should not join on logical types
+    debug_assert!(!a.iter().any(|s| s.is_logical()));
+    debug_assert!(!b.iter().any(|s| s.is_logical()));
+
+    let n_threads = POOL.current_num_threads();
+    let dfs_a = split_df(a, n_threads).unwrap();
+    let dfs_b = split_df(b, n_threads).unwrap();
+
+    let (build_hashes, random_state) = df_rows_to_hashes_threaded(&dfs_b, None);
+    let (probe_hashes, _) = df_rows_to_hashes_threaded(&dfs_a, Some(random_state));
+
+    let hash_tbls = create_build_table_semi_anti(&build_hashes, b);
+    // early drop to reduce memory pressure
+    drop(build_hashes);
+
+    let n_tables = hash_tbls.len() as u64;
+    let offsets = get_offsets(&probe_hashes);
+
+    // next we probe the other relation
+    // code duplication is because we want to only do the swap check once
+    POOL.install(move || {
+        probe_hashes
+            .into_par_iter()
+            .zip(offsets)
+            .map(move |(probe_hashes, offset)| {
+                // local reference
+                let hash_tbls = &hash_tbls;
+                let mut results =
+                    Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
+                let local_offset = offset;
+
+                let mut idx_a = local_offset as IdxSize;
+                for probe_hashes in probe_hashes.data_views() {
+                    for &h in probe_hashes {
+                        // probe table that contains the hashed value
+                        let current_probe_table = unsafe {
+                            get_hash_tbl_threaded_join_partitioned(h, hash_tbls, n_tables)
+                        };
+
+                        let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
+                            let idx_b = idx_hash.idx;
+                            // Safety:
+                            // indices in a join operation are always in bounds.
+                            unsafe { compare_df_rows2(a, b, idx_a as usize, idx_b as usize) }
+                        });
+
+                        match entry {
+                            // left and right matches
+                            Some((_, _)) => results.push((idx_a, true)),
+                            // only left values, right = null
+                            None => results.push((idx_a, false)),
+                        }
+                        idx_a += 1;
+                    }
+                }
+
+                results
+            })
+            .flatten()
+    })
 }
 
 #[cfg(feature = "semi_anti_join")]
 pub(super) fn left_anti_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<IdxSize> {
-    left_join_multiple_keys_impl(a, b, |results, _indexes_b, idx_a| {
-        // simply add a Some(0) to indicate that the row exists on the right.
-        // next we filter out all rhs Some values
-        results.push((idx_a, Some(0 as IdxSize)));
-    })
-    .filter(|tpls| tpls.1.is_none())
-    .map(|tpls| tpls.0)
-    .collect()
+    semi_anti_join_multiple_keys_impl(a, b)
+        .filter(|tpls| !tpls.1)
+        .map(|tpls| tpls.0)
+        .collect()
 }
 
 #[cfg(feature = "semi_anti_join")]
 pub(super) fn left_semi_multiple_keys(a: &DataFrame, b: &DataFrame) -> Vec<IdxSize> {
-    left_join_multiple_keys_impl(a, b, |results, _indexes_b, idx_a| {
-        // simply add a Some(0) to indicate that the row exists on the right.
-        // next we filter out all rhs None values
-        results.push((idx_a, Some(0 as IdxSize)));
-    })
-    .filter(|tpls| tpls.1.is_some())
-    .map(|tpls| tpls.0)
-    .collect()
+    semi_anti_join_multiple_keys_impl(a, b)
+        .filter(|tpls| tpls.1)
+        .map(|tpls| tpls.0)
+        .collect()
 }
 
 /// Probe the build table and add tuples to the results (inner join)

--- a/polars/polars-core/src/frame/hash_join/single_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys.rs
@@ -156,7 +156,7 @@ where
     })
 }
 
-type LeftJoinTuples = (IdxSize, Option<IdxSize>);
+pub(super) type LeftJoinTuples = (IdxSize, Option<IdxSize>);
 pub(super) fn hash_join_tuples_left_impl<T, IntoSlice, OnMatchFn>(
     probe: Vec<IntoSlice>,
     build: Vec<IntoSlice>,
@@ -220,6 +220,15 @@ where
     })
 }
 
+#[inline]
+pub(super) fn on_match_left_join_extend(
+    results: &mut Vec<LeftJoinTuples>,
+    indexes_b: &[IdxSize],
+    idx_a: IdxSize,
+) {
+    results.extend(indexes_b.iter().map(|&idx_b| (idx_a, Some(idx_b))))
+}
+
 pub(super) fn hash_join_tuples_left<T, IntoSlice>(
     probe: Vec<IntoSlice>,
     build: Vec<IntoSlice>,
@@ -228,10 +237,7 @@ where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
 {
-    hash_join_tuples_left_impl(probe, build, |results, indexes_b, idx_a| {
-        results.extend(indexes_b.iter().map(|&idx_b| (idx_a, Some(idx_b))))
-    })
-    .collect()
+    hash_join_tuples_left_impl(probe, build, on_match_left_join_extend).collect()
 }
 
 #[cfg(feature = "semi_anti_join")]

--- a/polars/polars-core/src/frame/hash_join/single_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys.rs
@@ -80,6 +80,39 @@ where
     .collect()
 }
 
+#[cfg(feature = "semi_anti_join")]
+/// Only keeps track of membership in right table
+pub(crate) fn create_probe_table_semi_anti<T, IntoSlice>(keys: Vec<IntoSlice>) -> Vec<PlHashSet<T>>
+where
+    T: Send + Hash + Eq + Sync + Copy + AsU64,
+    IntoSlice: AsRef<[T]> + Send + Sync,
+{
+    let n_partitions = set_partition_size();
+
+    // We will create a hashtable in every thread.
+    // We use the hash to partition the keys to the matching hashtable.
+    // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
+    POOL.install(|| {
+        (0..n_partitions).into_par_iter().map(|partition_no| {
+            let partition_no = partition_no as u64;
+
+            let mut hash_tbl: PlHashSet<T> = PlHashSet::with_capacity(HASHMAP_INIT_SIZE);
+
+            let n_partitions = n_partitions as u64;
+            for keys in &keys {
+                let keys = keys.as_ref();
+                keys.iter().for_each(|k| {
+                    if this_partition(k.as_u64(), partition_no, n_partitions) {
+                        hash_tbl.insert(*k);
+                    }
+                });
+            }
+            hash_tbl
+        })
+    })
+    .collect()
+}
+
 // we determine the offset so that we later know which index to store in the join tuples
 fn probe_to_offsets<T, IntoSlice>(probe: &[IntoSlice]) -> Vec<usize>
 where
@@ -157,19 +190,78 @@ where
 }
 
 pub(super) type LeftJoinTuples = (IdxSize, Option<IdxSize>);
-pub(super) fn hash_join_tuples_left_impl<T, IntoSlice, OnMatchFn>(
+#[cfg(feature = "semi_anti_join")]
+pub(super) fn semi_anti_impl<T, IntoSlice>(
     probe: Vec<IntoSlice>,
     build: Vec<IntoSlice>,
-    // Function that determines what we insert on a matching key
-    // This differs per join type:
-    // - for left join we extend with all matches
-    // - for semi and anti join we extend only with one match
-    on_match: OnMatchFn,
-) -> impl ParallelIterator<Item = LeftJoinTuples>
+) -> impl ParallelIterator<Item = (IdxSize, bool)>
 where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
-    OnMatchFn: Fn(&mut Vec<LeftJoinTuples>, &[IdxSize], IdxSize) + Sync + Send,
+{
+    // first we hash one relation
+    let hash_sets = create_probe_table_semi_anti(build);
+
+    // we determine the offset so that we later know which index to store in the join tuples
+    let offsets = probe_to_offsets(&probe);
+
+    let n_tables = hash_sets.len() as u64;
+    debug_assert!(n_tables.is_power_of_two());
+
+    // next we probe the other relation
+    POOL.install(move || {
+        probe
+            .into_par_iter()
+            .zip(offsets)
+            // probes_hashes: Vec<u64> processed by this thread
+            // offset: offset index
+            .map(move |(probe, offset)| {
+                // local reference
+                let hash_sets = &hash_sets;
+                let probe = probe.as_ref();
+
+                // assume the result tuples equal length of the no. of hashes processed by this thread.
+                let mut results = Vec::with_capacity(probe.len());
+
+                probe.iter().enumerate().for_each(|(idx_a, k)| {
+                    let idx_a = (idx_a + offset) as IdxSize;
+                    // probe table that contains the hashed value
+                    let current_probe_table = unsafe {
+                        get_hash_tbl_threaded_join_partitioned(k.as_u64(), hash_sets, n_tables)
+                    };
+
+                    // we already hashed, so we don't have to hash again.
+                    let value = current_probe_table.get(k);
+
+                    match value {
+                        // left and right matches
+                        Some(_) => results.push((idx_a, true)),
+                        // only left values, right = null
+                        None => results.push((idx_a, false)),
+                    }
+                });
+                results
+            })
+            .flatten()
+    })
+}
+
+#[inline]
+pub(super) fn on_match_left_join_extend(
+    results: &mut Vec<LeftJoinTuples>,
+    indexes_b: &[IdxSize],
+    idx_a: IdxSize,
+) {
+    results.extend(indexes_b.iter().map(|&idx_b| (idx_a, Some(idx_b))))
+}
+
+pub(super) fn hash_join_tuples_left<T, IntoSlice>(
+    probe: Vec<IntoSlice>,
+    build: Vec<IntoSlice>,
+) -> Vec<LeftJoinTuples>
+where
+    IntoSlice: AsRef<[T]> + Send + Sync,
+    T: Send + Hash + Eq + Sync + Copy + AsU64,
 {
     // first we hash one relation
     let hash_tbls = create_probe_table(build);
@@ -208,7 +300,7 @@ where
                     match value {
                         // left and right matches
                         Some(indexes_b) => {
-                            on_match(&mut results, indexes_b, idx_a);
+                            on_match_left_join_extend(&mut results, indexes_b, idx_a);
                         }
                         // only left values, right = null
                         None => results.push((idx_a, None)),
@@ -217,27 +309,8 @@ where
                 results
             })
             .flatten()
+            .collect()
     })
-}
-
-#[inline]
-pub(super) fn on_match_left_join_extend(
-    results: &mut Vec<LeftJoinTuples>,
-    indexes_b: &[IdxSize],
-    idx_a: IdxSize,
-) {
-    results.extend(indexes_b.iter().map(|&idx_b| (idx_a, Some(idx_b))))
-}
-
-pub(super) fn hash_join_tuples_left<T, IntoSlice>(
-    probe: Vec<IntoSlice>,
-    build: Vec<IntoSlice>,
-) -> Vec<LeftJoinTuples>
-where
-    IntoSlice: AsRef<[T]> + Send + Sync,
-    T: Send + Hash + Eq + Sync + Copy + AsU64,
-{
-    hash_join_tuples_left_impl(probe, build, on_match_left_join_extend).collect()
 }
 
 #[cfg(feature = "semi_anti_join")]
@@ -249,14 +322,10 @@ where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
 {
-    hash_join_tuples_left_impl(probe, build, |results, _indexes_b, idx_a| {
-        // simply add a Some(0) to indicate that the row exists on the right.
-        // next we filter out all rhs Some values
-        results.push((idx_a, Some(0 as IdxSize)));
-    })
-    .filter(|tpls| tpls.1.is_none())
-    .map(|tpls| tpls.0)
-    .collect()
+    semi_anti_impl(probe, build)
+        .filter(|tpls| !tpls.1)
+        .map(|tpls| tpls.0)
+        .collect()
 }
 
 #[cfg(feature = "semi_anti_join")]
@@ -268,14 +337,10 @@ where
     IntoSlice: AsRef<[T]> + Send + Sync,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
 {
-    hash_join_tuples_left_impl(probe, build, |results, _indexes_b, idx_a| {
-        // simply add a Some(0) to indicate that the row exists on the right.
-        // next we filter out all rhs None values
-        results.push((idx_a, Some(0 as IdxSize)));
-    })
-    .filter(|tpls| tpls.1.is_some())
-    .map(|tpls| tpls.0)
-    .collect()
+    semi_anti_impl(probe, build)
+        .filter(|tpls| tpls.1)
+        .map(|tpls| tpls.0)
+        .collect()
 }
 
 /// Probe the build table and add tuples to the results (inner join)

--- a/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
@@ -1,3 +1,4 @@
+use arrow::chunk::Chunk;
 use super::*;
 use crate::frame::hash_join::single_keys::{hash_join_tuples_inner, hash_join_tuples_left, hash_join_tuples_left_anti, hash_join_tuples_left_semi, hash_join_tuples_outer};
 
@@ -16,13 +17,37 @@ impl Series {
             }
             _ => {
                 if self.bit_repr_is_large() {
-                    let lhs = self.bit_repr_large();
-                    let rhs = other.bit_repr_large();
+                    let lhs = lhs.bit_repr_large();
+                    let rhs = rhs.bit_repr_large();
                     num_group_join_left(&lhs, &rhs)
                 } else {
-                    let lhs = self.bit_repr_small();
-                    let rhs = other.bit_repr_small();
+                    let lhs = lhs.bit_repr_small();
+                    let rhs = rhs.bit_repr_small();
                     num_group_join_left(&lhs, &rhs)
+                }
+            }
+        }
+    }
+
+    pub(super) fn hash_join_semi_anti(&self, other: &Series, anti: bool) -> Vec<IdxSize> {
+        let (lhs, rhs) = (self.to_physical_repr(), other.to_physical_repr());
+
+        use DataType::*;
+        match lhs.dtype() {
+            Utf8 => {
+                let lhs = lhs.utf8().unwrap();
+                let rhs = rhs.utf8().unwrap();
+                lhs.hash_join_semi_anti(rhs, anti)
+            }
+            _ => {
+                if self.bit_repr_is_large() {
+                    let lhs = lhs.bit_repr_large();
+                    let rhs = rhs.bit_repr_large();
+                    num_group_join_anti_semi(&lhs, &rhs, anti)
+                } else {
+                    let lhs = lhs.bit_repr_large();
+                    let rhs = rhs.bit_repr_large();
+                    num_group_join_anti_semi(&lhs, &rhs, anti)
                 }
             }
         }
@@ -80,34 +105,6 @@ impl Series {
     }
 }
 
-pub(crate) trait HashJoin<T> {
-    fn hash_join_inner(&self, _other: &ChunkedArray<T>) -> Vec<(IdxSize, IdxSize)> {
-        unimplemented!()
-    }
-    fn hash_join_left(&self, _other: &ChunkedArray<T>) -> Vec<(IdxSize, Option<IdxSize>)> {
-        unimplemented!()
-    }
-    fn hash_join_outer(&self, _other: &ChunkedArray<T>) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
-        unimplemented!()
-    }
-}
-
-impl HashJoin<Float32Type> for Float32Chunked {
-    fn hash_join_outer(&self, other: &Float32Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
-        let ca = self.bit_repr_small();
-        let other = other.bit_repr_small();
-        ca.hash_join_outer(&other)
-    }
-}
-
-impl HashJoin<Float64Type> for Float64Chunked {
-    fn hash_join_outer(&self, other: &Float64Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
-        let ca = self.bit_repr_large();
-        let other = other.bit_repr_large();
-        ca.hash_join_outer(&other)
-    }
-}
-
 fn splitted_to_slice<T>(splitted: &[ChunkedArray<T>]) -> Vec<&[T::Native]>
 where T: PolarsNumericType
 {
@@ -115,6 +112,26 @@ where T: PolarsNumericType
     .iter()
     .map(|ca| ca.cont_slice().unwrap())
     .collect()
+}
+
+fn splitted_by_chunks<T>(splitted: &[ChunkedArray<T>]) -> Vec<&[T::Native]>
+    where T: PolarsNumericType
+{
+    splitted
+        .iter()
+        .map(|ca| {
+            ca.downcast_iter().map(|arr| arr.values().as_slice())
+        })
+        .flatten()
+        .collect()
+}
+
+fn splitted_to_opt_vec<T>(splitted: &[ChunkedArray<T>]) -> Vec<Vec<Option<T::Native>>>
+    where T: PolarsNumericType {
+    splitted
+        .iter()
+        .map(|ca| ca.into_iter().collect_trusted::<Vec<_>>())
+        .collect()
 }
 
 fn num_group_join_inner<T>(
@@ -138,52 +155,17 @@ where
     ) {
         (true, true, 1, 1) => {
             let keys_a = splitted_to_slice(&splitted_a);
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.cont_slice().unwrap())
-                .collect::<Vec<_>>();
+            let keys_b = splitted_to_slice(&splitted_b);
             hash_join_tuples_inner(keys_a, keys_b, swap)
         }
         (true, true, _, _) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            hash_join_tuples_inner(keys_a, keys_b, swap)
-        }
-        (_, _, 1, 1) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| {
-                    ca.downcast_iter()
-                        .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                        .collect::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
-
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| {
-                    ca.downcast_iter()
-                        .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                        .collect::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
+            let keys_a = splitted_by_chunks(&splitted_a);
+            let keys_b = splitted_by_chunks(&splitted_b);
             hash_join_tuples_inner(keys_a, keys_b, swap)
         }
         _ => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.into_iter().map(|v| v.as_u64()).collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.into_iter().map(|v| v.as_u64()).collect::<Vec<_>>())
-                .collect::<Vec<_>>();
+            let keys_a = splitted_to_opt_vec(&splitted_a);
+            let keys_b = splitted_to_opt_vec(&splitted_b);
             hash_join_tuples_inner(keys_a, keys_b, swap)
         }
     }
@@ -209,78 +191,24 @@ where
         right.chunks.len(),
     ) {
         (0, 0, 1, 1) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.cont_slice().unwrap())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.cont_slice().unwrap())
-                .collect::<Vec<_>>();
+            let keys_a = splitted_to_slice(&splitted_a);
+            let keys_b = splitted_to_slice(&splitted_b);
             hash_join_tuples_left(keys_a, keys_b)
         }
         (0, 0, _, _) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect_trusted::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect_trusted::<Vec<_>>())
-                .collect::<Vec<_>>();
-            hash_join_tuples_left(keys_a, keys_b)
-        }
-        (_, _, 1, 1) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| {
-                    // we know that we only iterate over length == self.len()
-                    unsafe {
-                        ca.downcast_iter()
-                            .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                            .trust_my_length(ca.len())
-                            .collect_trusted::<Vec<_>>()
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| {
-                    // we know that we only iterate over length == self.len()
-                    unsafe {
-                        ca.downcast_iter()
-                            .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                            .trust_my_length(ca.len())
-                            .collect_trusted::<Vec<_>>()
-                    }
-                })
-                .collect::<Vec<_>>();
+            let keys_a = splitted_by_chunks(&splitted_a);
+            let keys_b = splitted_by_chunks(&splitted_b);
             hash_join_tuples_left(keys_a, keys_b)
         }
         _ => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| {
-                    ca.into_iter()
-                        .map(|v| v.as_u64())
-                        .collect_trusted::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| {
-                    ca.into_iter()
-                        .map(|v| v.as_u64())
-                        .collect_trusted::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
+            let keys_a = splitted_to_opt_vec(&splitted_a);
+            let keys_b = splitted_to_opt_vec(&splitted_b);
             hash_join_tuples_left(keys_a, keys_b)
         }
     }
 }
 
-impl<T> HashJoin<T> for ChunkedArray<T>
+impl<T> ChunkedArray<T>
 where
     T: PolarsIntegerType + Sync,
     T::Native: Eq + Hash + num::NumCast,
@@ -319,40 +247,6 @@ where
     }
 }
 
-impl HashJoin<BooleanType> for BooleanChunked {
-    fn hash_join_outer(&self, other: &BooleanChunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
-        let (a, b, swap) = det_hash_prone_order!(self, other);
-
-        let n_partitions = set_partition_size();
-        let splitted_a = split_ca(a, n_partitions).unwrap();
-        let splitted_b = split_ca(b, n_partitions).unwrap();
-
-        match (a.null_count(), b.null_count()) {
-            (0, 0) => {
-                let iters_a = splitted_a
-                    .iter()
-                    .map(|ca| ca.into_no_null_iter())
-                    .collect::<Vec<_>>();
-                let iters_b = splitted_b
-                    .iter()
-                    .map(|ca| ca.into_no_null_iter())
-                    .collect::<Vec<_>>();
-                hash_join_tuples_outer(iters_a, iters_b, swap)
-            }
-            _ => {
-                let iters_a = splitted_a
-                    .iter()
-                    .map(|ca| ca.into_iter())
-                    .collect::<Vec<_>>();
-                let iters_b = splitted_b
-                    .iter()
-                    .map(|ca| ca.into_iter())
-                    .collect::<Vec<_>>();
-                hash_join_tuples_outer(iters_a, iters_b, swap)
-            }
-        }
-    }
-}
 
 pub(crate) fn prepare_strs<'a>(
     been_split: &'a [Utf8Chunked],
@@ -375,31 +269,52 @@ pub(crate) fn prepare_strs<'a>(
     })
 }
 
-impl HashJoin<Utf8Type> for Utf8Chunked {
-    fn hash_join_inner(&self, other: &Utf8Chunked) -> Vec<(IdxSize, IdxSize)> {
+impl Utf8Chunked {
+    fn prepare(&self, other: &Utf8Chunked, swapped: bool) -> (
+        Vec<Self>,
+        Vec<Self>,
+         bool,
+        RandomState
+    ) {
         let n_threads = POOL.current_num_threads();
 
-        let (a, b, swap) = det_hash_prone_order!(self, other);
+        let (a, b, swap) = if swapped {
+            det_hash_prone_order!(self, other)
+        } else {
+            (self, other, false)
+        };
 
         let hb = RandomState::default();
         let splitted_a = split_ca(a, n_threads).unwrap();
         let splitted_b = split_ca(b, n_threads).unwrap();
 
+        (splitted_a, splitted_b,
+         swap, hb)
+    }
+
+    fn hash_join_inner(&self, other: &Utf8Chunked) -> Vec<(IdxSize, IdxSize)> {
+        let (splitted_a, splitted_b,  swap, hb) = self.prepare(other, true);
         let str_hashes_a = prepare_strs(&splitted_a, &hb);
         let str_hashes_b = prepare_strs(&splitted_b, &hb);
         hash_join_tuples_inner(str_hashes_a, str_hashes_b, swap)
     }
 
     fn hash_join_left(&self, other: &Utf8Chunked) -> Vec<(IdxSize, Option<IdxSize>)> {
-        let n_threads = POOL.current_num_threads();
-
-        let hb = RandomState::default();
-        let splitted_a = split_ca(self, n_threads).unwrap();
-        let splitted_b = split_ca(other, n_threads).unwrap();
-
+        let (splitted_a, splitted_b,  _, hb) = self.prepare(other, false);
         let str_hashes_a = prepare_strs(&splitted_a, &hb);
         let str_hashes_b = prepare_strs(&splitted_b, &hb);
         hash_join_tuples_left(str_hashes_a, str_hashes_b)
+    }
+
+    fn hash_join_semi_anti(&self, other: &Utf8Chunked, anti: bool) -> Vec<IdxSize> {
+        let (splitted_a, splitted_b,  _, hb) = self.prepare(other, false);
+        let str_hashes_a = prepare_strs(&splitted_a, &hb);
+        let str_hashes_b = prepare_strs(&splitted_b, &hb);
+        if anti {
+            hash_join_tuples_left_anti(str_hashes_a, str_hashes_b)
+        } else {
+            hash_join_tuples_left_semi(str_hashes_a, str_hashes_b)
+        }
     }
 
     fn hash_join_outer(&self, other: &Utf8Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
@@ -456,14 +371,8 @@ fn num_group_join_anti_semi<T>(
         right.chunks.len(),
     ) {
         (0, 0, 1, 1) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.cont_slice().unwrap())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.cont_slice().unwrap())
-                .collect::<Vec<_>>();
+            let keys_a = splitted_to_slice(&splitted_a);
+            let keys_b = splitted_to_slice(&splitted_b);
             if anti {
                 hash_join_tuples_left_anti(keys_a, keys_b)
             } else {
@@ -471,46 +380,8 @@ fn num_group_join_anti_semi<T>(
             }
         }
         (0, 0, _, _) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect_trusted::<Vec<_>>())
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| ca.into_no_null_iter().collect_trusted::<Vec<_>>())
-                .collect::<Vec<_>>();
-            if anti {
-                hash_join_tuples_left_anti(keys_a, keys_b)
-            } else {
-                hash_join_tuples_left_semi(keys_a, keys_b)
-            }
-        }
-        (_, _, 1, 1) => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| {
-                    // we know that we only iterate over length == self.len()
-                    unsafe {
-                        ca.downcast_iter()
-                            .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                            .trust_my_length(ca.len())
-                            .collect_trusted::<Vec<_>>()
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| {
-                    // we know that we only iterate over length == self.len()
-                    unsafe {
-                        ca.downcast_iter()
-                            .flat_map(|v| v.into_iter().map(|v| v.copied().as_u64()))
-                            .trust_my_length(ca.len())
-                            .collect_trusted::<Vec<_>>()
-                    }
-                })
-                .collect::<Vec<_>>();
+            let keys_a = splitted_by_chunks(&splitted_a);
+            let keys_b = splitted_by_chunks(&splitted_b);
             if anti {
                 hash_join_tuples_left_anti(keys_a, keys_b)
             } else {
@@ -518,22 +389,8 @@ fn num_group_join_anti_semi<T>(
             }
         }
         _ => {
-            let keys_a = splitted_a
-                .iter()
-                .map(|ca| {
-                    ca.into_iter()
-                        .map(|v| v.as_u64())
-                        .collect_trusted::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
-            let keys_b = splitted_b
-                .iter()
-                .map(|ca| {
-                    ca.into_iter()
-                        .map(|v| v.as_u64())
-                        .collect_trusted::<Vec<_>>()
-                })
-                .collect::<Vec<_>>();
+            let keys_a = splitted_to_opt_vec(&splitted_a);
+            let keys_b = splitted_to_opt_vec(&splitted_b);
             if anti {
                 hash_join_tuples_left_anti(keys_a, keys_b)
             } else {

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2944,7 +2944,7 @@ impl DataFrame {
             .reduce(|acc, b| get_supertype(&acc?, &b.unwrap()))
     }
 
-    #[cfg(feature = "partition_by")]
+    #[cfg(any(feature = "partition_by", feature = "semi_anti_join"))]
     pub(crate) unsafe fn take_unchecked_slice(&self, idx: &[IdxSize]) -> Self {
         self.take_iter_unchecked(idx.iter().map(|i| *i as usize))
     }

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -223,7 +223,6 @@ where
     }
 }
 
-
 // Used to to get a u64 from the hashing keys
 // We need to modify the hashing algorithm to use the hash for this and only compute the hash once.
 pub(crate) trait AsU64 {

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -223,6 +223,7 @@ where
     }
 }
 
+
 // Used to to get a u64 from the hashing keys
 // We need to modify the hashing algorithm to use the hash for this and only compute the hash once.
 pub(crate) trait AsU64 {

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -187,8 +187,9 @@
 //!     - `sort_multiple` - Allow sorting a `DataFrame` on multiple columns
 //!     - `rows` - Create `DataFrame` from rows and extract rows from `DataFrames`.
 //!                And activates `pivot` and `transpose` operations
-//!     - `asof_join` - Join as of, to join on nearest keys instead of exact equality match.
+//!     - `asof_join` - Join ASOF, to join on nearest keys instead of exact equality match.
 //!     - `cross_join` - Create the cartesian product of two DataFrames.
+//!     - `semi_anti_join` - SEMI and ANTI joins.
 //!     - `groupby_list` - Allow groupby operation on keys of type List.
 //!     - `row_hash` - Utility to hash DataFrame rows to UInt64Chunked
 //!     - `diagonal_concat` - Concat diagonally thereby combining different schemas.

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -98,6 +98,7 @@ features = [
   "log",
   "serde-lazy",
   "partition_by",
+  "semi_anti_join",
 ]
 
 # [patch.crates-io]

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3371,6 +3371,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 - "outer"
                 - "asof"
                 - "cross"
+                - "semi"
+                - "anti"
         suffix
             Suffix to append to columns with a duplicate name.
         asof_by

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1080,6 +1080,8 @@ class LazyFrame(Generic[DF]):
                 "outer"
                 "asof",
                 "cross"
+                "semi"
+                "anti"
         suffix
             Suffix to append to columns with a duplicate name.
         allow_parallel

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -720,6 +720,8 @@ impl PyDataFrame {
             "left" => JoinType::Left,
             "inner" => JoinType::Inner,
             "outer" => JoinType::Outer,
+            "semi" => JoinType::Semi,
+            "anti" => JoinType::Anti,
             "asof" => JoinType::AsOf(AsOfOptions {
                 strategy: AsofStrategy::Backward,
                 left_by: None,

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -443,6 +443,8 @@ impl PyLazyFrame {
             "left" => JoinType::Left,
             "inner" => JoinType::Inner,
             "outer" => JoinType::Outer,
+            "semi" => JoinType::Semi,
+            "anti" => JoinType::Anti,
             "asof" => JoinType::AsOf(AsOfOptions {
                 strategy: AsofStrategy::Backward,
                 left_by: if asof_by_left.is_empty() {

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -1,0 +1,30 @@
+import polars as pl
+
+
+def test_semi_anti_join() -> None:
+    df_a = pl.DataFrame({"key": [1, 2, 3], "payload": ["f", "i", None]})
+
+    df_b = pl.DataFrame({"key": [3, 4, 5, None]})
+
+    assert df_a.join(df_b, on="key", how="anti").to_dict(False) == {
+        "key": [1, 2],
+        "payload": ["f", "i"],
+    }
+    assert df_a.join(df_b, on="key", how="semi").to_dict(False) == {
+        "key": [3],
+        "payload": [None],
+    }
+
+    # lazy
+    assert df_a.lazy().join(df_b.lazy(), on="key", how="anti").collect().to_dict(
+        False
+    ) == {
+        "key": [1, 2],
+        "payload": ["f", "i"],
+    }
+    assert df_a.lazy().join(df_b.lazy(), on="key", how="semi").collect().to_dict(
+        False
+    ) == {
+        "key": [3],
+        "payload": [None],
+    }

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -28,3 +28,20 @@ def test_semi_anti_join() -> None:
         "key": [3],
         "payload": [None],
     }
+
+    df_a = pl.DataFrame(
+        {"a": [1, 2, 3, 1], "b": ["a", "b", "c", "a"], "payload": [10, 20, 30, 40]}
+    )
+
+    df_b = pl.DataFrame({"a": [3, 3, 4, 5], "b": ["c", "c", "d", "e"]})
+
+    assert df_a.join(df_b, on=["a", "b"], how="anti").to_dict(False) == {
+        "a": [1, 2, 1],
+        "b": ["a", "b", "a"],
+        "payload": [10, 20, 40],
+    }
+    assert df_a.join(df_b, on=["a", "b"], how="semi").to_dict(False) == {
+        "a": [3],
+        "b": ["c"],
+        "payload": [30],
+    }


### PR DESCRIPTION
Closes #3131. 

~First iteration adds semi + anti joins for joins on a single key.~

Should be fast and memory efficient.