### PR TITLE
slice_pushdown projections

### DIFF
--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -117,6 +117,36 @@ impl AExpr {
             .map(|f| f.data_type().clone())
     }
 
+    pub(crate) fn replace_input(self, input: Node) -> Self {
+        use AExpr::*;
+        match self {
+            Alias(_, name) => Alias(input, name),
+            IsNotNull(_) => IsNotNull(input),
+            IsNull(_) => IsNull(input),
+            Cast {
+                expr: _,
+                data_type,
+                strict,
+            } => Cast {
+                expr: input,
+                data_type,
+                strict,
+            },
+            _ => todo!(),
+        }
+    }
+
+    pub(crate) fn get_input(&self) -> Node {
+        use AExpr::*;
+        match self {
+            Alias(input, _) => *input,
+            IsNotNull(input) => *input,
+            IsNull(input) => *input,
+            Cast { expr, .. } => *expr,
+            _ => todo!(),
+        }
+    }
+
     /// Get Field result of the expression. The schema is the input data.
     pub(crate) fn to_field(
         &self,

--- a/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
@@ -9,9 +9,14 @@ pub(crate) mod fast_projection;
 pub(crate) mod predicate_pushdown;
 pub(crate) mod projection_pushdown;
 pub(crate) mod simplify_expr;
-pub(crate) mod slice_pushdown;
+mod slice_pushdown_expr;
+pub mod slice_pushdown_lp;
 pub(crate) mod stack_opt;
 pub(crate) mod type_coercion;
+
+use crate::prelude::stack_opt::OptimizationRule;
+
+pub(crate) use slice_pushdown_lp::SlicePushDown;
 
 pub trait Optimize {
     fn optimize(&self, logical_plan: LogicalPlan) -> Result<LogicalPlan>;

--- a/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_expr.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+fn pushdown(input: Node, offset: Node, length: Node, arena: &mut Arena<AExpr>) -> Node {
+    arena.add(AExpr::Slice {
+        input,
+        offset,
+        length,
+    })
+}
+
+impl OptimizationRule for SlicePushDown {
+    fn optimize_expr(
+        &self,
+        expr_arena: &mut Arena<AExpr>,
+        expr_node: Node,
+        _lp_arena: &Arena<ALogicalPlan>,
+        _lp_node: Node,
+    ) -> Option<AExpr> {
+        if let AExpr::Slice {
+            input,
+            offset,
+            length,
+        } = expr_arena.get(expr_node)
+        {
+            let offset = *offset;
+            let length = *length;
+
+            use AExpr::*;
+            match expr_arena.get(*input) {
+                m @ Alias(..) | m @ IsNull(_) | m @ IsNotNull(_) | m @ Cast { .. } => {
+                    let m = m.clone();
+                    let input = m.get_input();
+                    let new_input = pushdown(input, offset, length, expr_arena);
+                    Some(m.replace_input(new_input))
+                }
+                Literal(lv) => {
+                    match lv {
+                        LiteralValue::Series(_) => None,
+                        LiteralValue::Range { .. } => None,
+                        // no need to slice a literal value of unit length
+                        lv => Some(Literal(lv.clone())),
+                    }
+                }
+                BinaryExpr { left, right, op } => {
+                    let left = *left;
+                    let right = *right;
+                    let op = *op;
+
+                    let left = pushdown(left, offset, length, expr_arena);
+                    let right = pushdown(right, offset, length, expr_arena);
+                    Some(BinaryExpr { left, op, right })
+                }
+                Ternary {
+                    truthy,
+                    falsy,
+                    predicate,
+                } => {
+                    let truthy = *truthy;
+                    let falsy = *falsy;
+                    let predicate = *predicate;
+
+                    let truthy = pushdown(truthy, offset, length, expr_arena);
+                    let falsy = pushdown(falsy, offset, length, expr_arena);
+                    let predicate = pushdown(predicate, offset, length, expr_arena);
+                    Some(Ternary {
+                        truthy,
+                        falsy,
+                        predicate,
+                    })
+                }
+                m @ Function { options, .. }
+                    if matches!(options.collect_groups, ApplyOptions::ApplyFlat) =>
+                {
+                    if let Function {
+                        input,
+                        function,
+                        output_type,
+                        options,
+                    } = m.clone()
+                    {
+                        let input = input
+                            .iter()
+                            .map(|n| pushdown(*n, offset, length, expr_arena))
+                            .collect();
+
+                        Some(Function {
+                            input,
+                            function,
+                            output_type,
+                            options,
+                        })
+                    } else {
+                        unreachable!()
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -290,21 +290,37 @@ impl SlicePushDown {
             }
             // [Pushdown]
             // these nodes will be pushed down.
-             m @(Udf{options: LogicalPlanUdfOptions{ predicate_pd: true, ..}, .. }, _)
-
+             m @(Udf{options: LogicalPlanUdfOptions{ predicate_pd: true, ..}, .. }, _) |
+             // State is None, we can continue
+             m @(Projection{..}, None)
             => {
                 let (lp, state) = m;
                 self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
             }
-            m @ (Projection {..}, _) => {
-                let (lp, state) = m;
+            // there is state, inspect the projection to determine how to deal with it
+            (Projection {input, mut expr, schema}, Some(State{offset, len})) => {
                 // The slice operation may only pass on simple projections. col("foo").alias("bar")
-                if lp.get_exprs().iter().all(|root|  {
+                if expr.iter().all(|root|  {
                     aexpr_is_simple_projection(*root, expr_arena)
                 }) {
+                    let lp = Projection {input, expr, schema};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
-                } else {
-                    self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)
+                }
+                // we add a slice node to the projections
+                else {
+                    let offset_node = to_aexpr(lit(offset), expr_arena);
+                    let length_node = to_aexpr(lit(len), expr_arena);
+                    expr.iter_mut().for_each(|node| {
+                        let aexpr = AExpr::Slice {
+                            input: *node,
+                            offset: offset_node,
+                            length: length_node
+                        };
+                        *node = expr_arena.add(aexpr)
+                    });
+                    let lp = Projection {input, expr, schema};
+
+                    self.pushdown_and_continue(lp, None, lp_arena, expr_arena)
                 }
             }
             (catch_all, state) => {

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -452,7 +452,7 @@ class LazyFrame(Generic[DF]):
                 If you already have set a global string cache, set this to `False` as this will reset the
                 global cache when the query is finished.
         no_optimization
-            Turn off optimizations.
+            Turn off (certain) optimizations.
         slice_pushdown
             Slice pushdown optimization.
 
@@ -463,7 +463,6 @@ class LazyFrame(Generic[DF]):
         if no_optimization:
             predicate_pushdown = False
             projection_pushdown = False
-            slice_pushdown = False
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,


### PR DESCRIPTION
closes #3135

A slow development build show these results

```python
n = int(1e6)
df = pl.DataFrame([
    pl.arange(0, n, eager=True).alias("a"),
    pl.arange(0, n, eager=True).alias("b"),
])
```

```python
%%time

df.lazy().select([
    pl.all().cast(str).suffix("foo"),
    (pl.col("a") * 10).alias("binary"),
    pl.when(pl.col("a") > 10).then(1).otherwise(2).alias("ternary")
]).limit(10).collect()

CPU times: user 7.94 ms, sys: 3.26 ms, total: 11.2 ms
Wall time: 2.32 ms
```

## without optimization
```python
%%time

df.lazy().select([
    pl.all().cast(str).suffix("foo"),
    (pl.col("a") * 10).alias("binary"),
    pl.when(pl.col("a") > 10).then(1).otherwise(2).alias("ternary")
]).limit(10).collect(slice_pushdown=False)

CPU times: user 833 ms, sys: 0 ns, total: 833 ms
Wall time: 339 ms

```

## Optimized logical plan

```
SELECT 4 COLUMNS: [col("a").slice(offset=0i64, length=10u32).cast(Utf8).alias("afoo"), col("b").slice(offset=0i64, length=10u32).cast(Utf8).alias("bfoo"), [(col("a").slice(offset=0i64, length=10u32)) * (10i64)].alias("binary"), 
WHEN [(col("a").slice(offset=0i64, length=10u32)) > (10i64)]
	1i32
OTHERWISE
	2i32.alias("ternary")]
FROM
DATAFRAME(in-memory): ["a", "b"];
	project 2/2 columns	|	details: Some([col("a"), col("b")]);
	selection: "None"



```