### PR TITLE
feat(python,rust): Implement `pl.unnest` Expr

### DIFF
--- a/polars/polars-lazy/src/dsl/expr.rs
+++ b/polars/polars-lazy/src/dsl/expr.rs
@@ -253,6 +253,8 @@ pub enum Expr {
     Column(Arc<str>),
     Columns(Vec<String>),
     DtypeColumn(Vec<DataType>),
+    #[cfg(feature = "dtype-struct")]
+    Unnest(Arc<str>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Box<Expr>,

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -595,6 +595,12 @@ pub fn dtype_cols<DT: AsRef<[DataType]>>(dtype: DT) -> Expr {
     Expr::DtypeColumn(dtypes)
 }
 
+#[cfg(feature = "dtype-struct")]
+/// Select one or more nested columns within a struct.
+pub fn unnest(path: &str) -> Expr {
+    Expr::Unnest(Arc::from(path))
+}
+
 /// Sum all the values in this Expression.
 pub fn sum(name: &str) -> Expr {
     col(name).sum()

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -37,6 +37,7 @@ pub enum AExpr {
     Explode(Node),
     Alias(Node, Arc<str>),
     Column(Arc<str>),
+    Unnest(Arc<str>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Node,
@@ -186,6 +187,11 @@ impl AExpr {
             Column(name) => schema
                 .get_field(name)
                 .ok_or_else(|| PolarsError::NotFound(name.to_string())),
+            Unnest(path) => {
+                let struct_schema = schema.get_field(path);
+                // TODO: Return Field object for nested column
+                panic!("not implemented")
+            }
             Literal(sv) => Ok(Field::new("literal", sv.get_datatype())),
             BinaryExpr { left, right, op } => {
                 use DataType::*;

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -138,6 +138,7 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         Expr::RenameAlias { .. } => panic!("no `rename_alias` expected at this point"),
         Expr::Columns { .. } => panic!("no `columns` expected at this point"),
         Expr::DtypeColumn { .. } => panic!("no `dtype-columns` expected at this point"),
+        Expr::Unnest(_) => panic!("not implemented?"),
     };
     arena.add(v)
 }

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -15,8 +15,7 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         Expr::Alias(e, name) => AExpr::Alias(to_aexpr(*e, arena), name),
         Expr::Literal(value) => AExpr::Literal(value),
         Expr::Column(s) => AExpr::Column(s),
-        // TODO: Implement
-        Expr::Unnest(_) => panic!("need to implemented"),
+        Expr::Unnest(s) => AExpr::Unnest(s),
         Expr::BinaryExpr { left, op, right } => {
             let l = to_aexpr(*left, arena);
             let r = to_aexpr(*right, arena);
@@ -414,6 +413,7 @@ pub(crate) fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             Expr::Alias(Box::new(exp), name)
         }
         AExpr::Column(a) => Expr::Column(a),
+        AExpr::Unnest(s) => Expr::Unnest(s),
         AExpr::Literal(s) => Expr::Literal(s),
         AExpr::BinaryExpr { left, op, right } => {
             let l = node_to_expr(left, expr_arena);

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -15,6 +15,8 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         Expr::Alias(e, name) => AExpr::Alias(to_aexpr(*e, arena), name),
         Expr::Literal(value) => AExpr::Literal(value),
         Expr::Column(s) => AExpr::Column(s),
+        // TODO: Implement
+        Expr::Unnest(_) => panic!("need to implemented"),
         Expr::BinaryExpr { left, op, right } => {
             let l = to_aexpr(*left, arena);
             let r = to_aexpr(*right, arena);
@@ -138,7 +140,6 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
         Expr::RenameAlias { .. } => panic!("no `rename_alias` expected at this point"),
         Expr::Columns { .. } => panic!("no `columns` expected at this point"),
         Expr::DtypeColumn { .. } => panic!("no `dtype-columns` expected at this point"),
-        Expr::Unnest(_) => panic!("not implemented?"),
     };
     arena.add(v)
 }

--- a/polars/polars-lazy/src/logical_plan/format.rs
+++ b/polars/polars-lazy/src/logical_plan/format.rs
@@ -263,6 +263,7 @@ impl fmt::Debug for Expr {
             RenameAlias { expr, .. } => write!(f, "RENAME_ALIAS {:?}", expr),
             Columns(names) => write!(f, "COLUMNS({:?})", names),
             DtypeColumn(dt) => write!(f, "COLUMN OF DTYPE: {:?}", dt),
+            Unnest(path) => write!(f, "unnest(\"{}\")", path),
         }
     }
 }

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -5,6 +5,7 @@ macro_rules! push_expr {
         use Expr::*;
         match $current_expr {
             Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_) | Count => {}
+            Unnest(_) => {},
             Alias(e, _) => $push(e),
             Not(e) => $push(e),
             BinaryExpr { left, op: _, right } => {

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -5,7 +5,7 @@ macro_rules! push_expr {
         use Expr::*;
         match $current_expr {
             Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_) | Count => {}
-            Unnest(_) => {},
+            Unnest(_) => {}
             Alias(e, _) => $push(e),
             Not(e) => $push(e),
             BinaryExpr { left, op: _, right } => {

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -165,6 +165,7 @@ impl AExpr {
 
         match self {
             Nth(_) | Column(_) | Literal(_) | Wildcard | Count => {}
+            Unnest(_) => {}
             Alias(e, _) => push(e),
             Not(e) => push(e),
             BinaryExpr { left, op: _, right } => {

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -16,13 +16,14 @@ mod sort;
 mod sortby;
 mod take;
 mod ternary;
+mod unnest;
 mod utils;
 mod window;
 
 pub(crate) use {
     aggregation::*, alias::*, apply::*, binary::*, cast::*, column::*, count::*, filter::*,
     is_not_null::*, is_null::*, literal::*, not::*, shift::*, slice::*, sort::*, sortby::*,
-    take::*, ternary::*, utils::*, window::*,
+    take::*, ternary::*, unnest::*, utils::*, window::*,
 };
 
 use crate::physical_plan::state::ExecutionState;

--- a/polars/polars-lazy/src/physical_plan/expressions/unnest.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/unnest.rs
@@ -1,0 +1,102 @@
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+use polars_core::frame::groupby::GroupsProxy;
+use polars_core::prelude::*;
+use std::borrow::Cow;
+use std::sync::Arc;
+
+pub struct UnnestExpr(Arc<str>, Expr);
+
+impl UnnestExpr {
+    pub fn new(path: Arc<str>, expr: Expr) -> Self {
+        Self(path, expr)
+    }
+}
+
+impl PhysicalExpr for UnnestExpr {
+    fn as_expression(&self) -> &Expr {
+        &self.1
+    }
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
+        // TODO: Implement physical plan
+        panic!("need to implement!");
+        match state.get_schema() {
+            None => df.column(&self.0).map(|s| s.clone()),
+            Some(schema) => {
+                match schema.get_full(&self.0) {
+                    Some((idx, _, _)) => {
+                        // check if the schema was correct
+                        // if not do O(n) search
+                        let out = match df.get_columns().get(idx) {
+                            Some(out) => out,
+                            None => {
+                                // this path should not happen
+                                #[cfg(feature = "panic_on_schema")]
+                                {
+                                    panic!("invalid schema")
+                                }
+                                // in release we fallback to linear search
+                                #[allow(unreachable_code)]
+                                {
+                                    return df.column(&self.0).map(|s| s.clone());
+                                }
+                            }
+                        };
+
+                        if out.name() != &*self.0 {
+                            // this path should not happen
+                            #[cfg(feature = "panic_on_schema")]
+                            {
+                                panic!(
+                                    "got {} expected: {} from schema: {:?} and DataFrame: {:?}",
+                                    out.name(),
+                                    &*self.0,
+                                    &schema,
+                                    &df
+                                )
+                            }
+                            // in release we fallback to linear search
+                            #[allow(unreachable_code)]
+                            {
+                                df.column(&self.0).map(|s| s.clone())
+                            }
+                        } else {
+                            Ok(out.clone())
+                        }
+                    }
+                    // in the future we will throw an error here
+                    // now we do a linear search first as the lazy reported schema may still be incorrect
+                    // in debug builds we panic so that it can be fixed when occurring
+                    None => {
+                        #[cfg(feature = "panic_on_schema")]
+                        {
+                            panic!("invalid schema")
+                        }
+                        // in release we fallback to linear search
+                        #[allow(unreachable_code)]
+                        df.column(&self.0).map(|s| s.clone())
+                    }
+                }
+            }
+        }
+    }
+    #[allow(clippy::ptr_arg)]
+    fn evaluate_on_groups<'a>(
+        &self,
+        df: &DataFrame,
+        groups: &'a GroupsProxy,
+        state: &ExecutionState,
+    ) -> Result<AggregationContext<'a>> {
+        let s = self.evaluate(df, state)?;
+        Ok(AggregationContext::new(s, Cow::Borrowed(groups), false))
+    }
+    fn to_field(&self, input_schema: &Schema) -> Result<Field> {
+        let field = input_schema.get_field(&self.0).ok_or_else(|| {
+            PolarsError::NotFound(format!(
+                "could not find column: {} in schema: {:?}",
+                self.0, &input_schema
+            ))
+        })?;
+        Ok(field)
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -82,6 +82,10 @@ impl DefaultPlanner {
                 column,
                 node_to_expr(expression, expr_arena),
             ))),
+            Unnest(path) => Ok(Arc::new(UnnestExpr::new(
+                path,
+                node_to_expr(expression, expr_arena),
+            ))),
             Sort { expr, options } => {
                 let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
                 Ok(Arc::new(SortExpr::new(

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -66,7 +66,6 @@ from polars.internals.lazy_functions import (
     argsort_by,
     avg,
     col,
-    unnest,
     collect_all,
     concat_list,
     concat_str,
@@ -99,7 +98,7 @@ from polars.internals.lazy_functions import (
     tail,
 )
 from polars.internals.lazy_functions import to_list as list
-from polars.internals.lazy_functions import var
+from polars.internals.lazy_functions import unnest, var
 from polars.internals.series import (  # flake8: noqa # TODO: remove need for wrap_s
     Series,
     wrap_s,

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -66,6 +66,7 @@ from polars.internals.lazy_functions import (
     argsort_by,
     avg,
     col,
+    unnest,
     collect_all,
     concat_list,
     concat_str,
@@ -177,6 +178,7 @@ __all__ = [
     "repeat",
     # polars.internal.lazy_functions
     "col",
+    "unnest",
     "count",
     "std",
     "var",

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -6,6 +6,6 @@ via this __init__ file using `import polars.internals as pli`. The imports below
 from .expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
 from .frame import DataFrame, LazyFrame, wrap_df, wrap_ldf
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
-from .lazy_functions import all, argsort_by, col, concat_list, lit, select
+from .lazy_functions import all, argsort_by, col, unnest, concat_list, lit, select
 from .series import Series, wrap_s
 from .whenthen import when  # used in expr.clip()

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -6,6 +6,6 @@ via this __init__ file using `import polars.internals as pli`. The imports below
 from .expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
 from .frame import DataFrame, LazyFrame, wrap_df, wrap_ldf
 from .functions import concat, date_range  # DataFrame.describe() & DataFrame.upsample()
-from .lazy_functions import all, argsort_by, col, unnest, concat_list, lit, select
+from .lazy_functions import all, argsort_by, col, concat_list, lit, select, unnest
 from .series import Series, wrap_s
 from .whenthen import when  # used in expr.clip()

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -162,6 +162,27 @@ def col(
     return pli.wrap_expr(pycol(name))
 
 
+def unnest(path: str) -> "pli.Expr":
+    """
+    Unnest a struct column in a DataFrame.
+    Can be used to select:
+
+    - a single column by name
+    - all columns by using a wildcard `"*"`
+
+    Parameters
+    ----------
+    path
+        A string that holds the path to column
+
+    Examples
+    --------
+
+    """
+    # TODO: Add examples
+    return pli.wrap_expr(pyunnest(path))
+
+
 @overload
 def count(column: str) -> "pli.Expr":
     ...

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -25,6 +25,7 @@ try:
     from polars.polars import as_struct as _as_struct
     from polars.polars import binary_function as pybinary_function
     from polars.polars import col as pycol
+    from polars.polars import unnest as pyunnest
     from polars.polars import collect_all as _collect_all
     from polars.polars import cols as pycols
     from polars.polars import concat_lst as _concat_lst

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -25,7 +25,6 @@ try:
     from polars.polars import as_struct as _as_struct
     from polars.polars import binary_function as pybinary_function
     from polars.polars import col as pycol
-    from polars.polars import unnest as pyunnest
     from polars.polars import collect_all as _collect_all
     from polars.polars import cols as pycols
     from polars.polars import concat_lst as _concat_lst
@@ -44,6 +43,7 @@ try:
     from polars.polars import py_datetime, py_duration
     from polars.polars import repeat as _repeat
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
+    from polars.polars import unnest as pyunnest
 
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1399,6 +1399,10 @@ pub fn col(name: &str) -> PyExpr {
     dsl::col(name).into()
 }
 
+pub fn unnest(path: &str) -> PyExpr {
+    dsl::unnest(path).into()
+}
+
 pub fn count() -> PyExpr {
     dsl::count().into()
 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -64,6 +64,11 @@ fn col(name: &str) -> dsl::PyExpr {
 }
 
 #[pyfunction]
+fn unnest(path: &str) -> dsl::PyExpr {
+    dsl::unnest(path)
+}
+
+#[pyfunction]
 fn count() -> dsl::PyExpr {
     dsl::count()
 }
@@ -441,6 +446,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<dsl::PyExpr>().unwrap();
     m.add_wrapped(wrap_pyfunction!(col)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(unnest)).unwrap();
     m.add_wrapped(wrap_pyfunction!(count)).unwrap();
     m.add_wrapped(wrap_pyfunction!(first)).unwrap();
     m.add_wrapped(wrap_pyfunction!(last)).unwrap();

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -141,3 +141,20 @@ def test_nested_struct() -> None:
 def test_eager_struct() -> None:
     s = pl.struct([pl.Series([1, 2, 3]), pl.Series(["a", "b", "c"])], eager=True)
     assert s.dtype == pl.Struct
+
+
+def test_unnest_by_path() -> None:
+    df = pl.DataFrame({"b": [1, 2, 3], "c": [0, 0, 0]})
+    nested_df = df.to_struct("a").to_frame()
+
+    selection = nested_df.select(pl.unnest("a.b"))
+    assert selection.columns == ["a.b"]
+
+    assert nested_df.select(pl.unnest("a.b"))["a.b"] == df["b"]
+    assert nested_df.select(pl.unnest("a.c"))["a.c"] == df["c"]
+
+    # Test 2 level nesting
+    nested_l2 = nested_df.to_struct("top").to_frame()
+    selection = nested_l2.select(pl.unnest("top.a.b"))
+    assert selection.columns == ["top.a.b"]
+    assert selection["top.a.b"] == df["b"]


### PR DESCRIPTION
This PR introduces a `pl.unnest` function for accessing nested struct columns, based on conversations in #3123. The goal is to allow a JSONPath-like string to index single or multiple columns that are nested at arbitrary depth.

- [ ] Implement the actual path and unnesting logic
- [ ] Add examples to the docs
- [ ] Add tests