### PR TITLE
describe plan for group by representation

### DIFF
--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -1238,6 +1238,11 @@ impl LazyGroupBy {
             .build();
         LazyFrame::from_logical_plan(lp, self.opt_state)
     }
+    
+    /// Describe the logical plan.
+    pub fn describe_plan(&self) -> String {
+        self.logical_plan.describe()
+    }
 }
 
 #[must_use]


### PR DESCRIPTION
To help with the representation of group by in Nushell, it helps to print the logical plan. This makes it consistent with the LazyFrame representation