### PR TITLE
Fixing Linux ARM builds

### DIFF
--- a/.github/deploy_manylinux.sh
+++ b/.github/deploy_manylinux.sh
@@ -23,3 +23,6 @@ sed '/s/"dynamic_groupby",/"dynamic_groupby",\n"bigidx",/' Cargo.toml
 maturin publish \
   --skip-existing \
   --username ritchie46
+
+# Clean up after bigidx changes
+git checkout .


### PR DESCRIPTION
This is intended to resolve #3163. I don't have a good way to test it. The issue appears to be that sed modifications during the manylinux build are not cleaned up, and persist into the aarch64 build.