### PR TITLE
Broaden manylinux tag for Linux ARM build

### DIFF
--- a/.github/workflows/create-py-release-manylinux.yaml
+++ b/.github/workflows/create-py-release-manylinux.yaml
@@ -25,7 +25,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
           rust-toolchain: nightly-2022-04-01
-          manylinux: '2_24'
+          manylinux: '2_17'
           target: aarch64-unknown-linux-gnu
           maturin-version: 0.12.1
           command: publish


### PR DESCRIPTION
When looking at the logs for the Linux ARM build, I noticed that it suggested broadening the support of the wheel.
```
📦 Wheel is eligible for a higher priority tag. You requested manylinux_2_24 but this wheel is eligible for manylinux_2_17(aka manylinux2014)
```
https://github.com/pola-rs/polars/runs/6039255346?check_suite_focus=true#step:5:278

This PR changes the manylinux tag from `2_24` to `2_17` to match the suggestion. I expect this will broaden the install base for the wheel based on this specification:
https://github.com/pypa/manylinux#manylinux