### PR TITLE
Support for struct columns in DataFrame.to_pandas

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -556,8 +556,7 @@ impl DataFrame {
             .ok_or_else(|| {
                 PolarsError::NoData("Can not determine number of chunks if there is no data".into())
             })?
-            .chunks()
-            .len())
+            .n_chunks())
     }
 
     /// Get a reference to the schema fields of the `DataFrame`.

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -87,6 +87,11 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0.name()
     }
 
+    fn chunk_lengths(&self) -> ChunkIdIter {
+        let s = self.0.fields().first().unwrap();
+        s.chunk_lengths()
+    }
+
     /// Number of chunks in this Series
     fn n_chunks(&self) -> usize {
         let s = self.0.fields().first().unwrap();

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 import polars as pl
 
 
@@ -141,3 +143,12 @@ def test_nested_struct() -> None:
 def test_eager_struct() -> None:
     s = pl.struct([pl.Series([1, 2, 3]), pl.Series(["a", "b", "c"])], eager=True)
     assert s.dtype == pl.Struct
+
+
+def test_struct_to_pandas() -> None:
+    df = pd.DataFrame([{"a": {"b": {"c": 2}}}])
+    pl_df = pl.from_pandas(df)
+
+    assert isinstance(pl_df.dtypes[0], pl.datatypes.Struct)
+
+    assert pl_df.to_pandas().equals(df)


### PR DESCRIPTION
This PR resolves #3176 by adding a `chunked_lengths` method to `SeriesWrap<StructChunked>`, and fixing the reference to `n_chunks` in the `DataFrame::n_chunks` method. The `chunked_lengths` follows `n_chunks` for a struct by looking only at the first field, assuming all fields are consistent. The PR adds a test to demonstrate that nested structs are correctly translated to and from pandas.