### PR TITLE
Option to check column order when comparing polars dataframes

### DIFF
--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -36,7 +36,7 @@ def assert_frame_equal(
     right: DataFrame,
     check_dtype: bool = True,
     check_exact: bool = False,
-    check_column_order: bool = True,
+    check_column_names: bool = True,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
 ) -> None:
@@ -54,8 +54,8 @@ def assert_frame_equal(
         if True, data types need to match exactly
     check_exact
         if False, test if values are within tolerance of each other (see `rtol` & `atol`)
-    check_column_order
-        if False, ignore the order of columns
+    check_column_names
+        if True, dataframes must have the same column names in the same order
     rtol
         relative tolerance for inexact checking. Fraction of values in `right`
     atol
@@ -92,9 +92,9 @@ def assert_frame_equal(
                 f"column {c} in right dataframe, but not in left dataframe"
             )
 
-    if check_column_order:
+    if check_column_names:
         if left.columns != right.columns:
-            raise AssertionError("Columns are not in same order")
+            raise AssertionError("Columns are not in the same order")
 
     # this does not assume a particular order
     for col in left.columns:

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -36,6 +36,7 @@ def assert_frame_equal(
     right: DataFrame,
     check_dtype: bool = True,
     check_exact: bool = False,
+    check_column_order: bool = True,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
 ) -> None:
@@ -53,6 +54,8 @@ def assert_frame_equal(
         if True, data types need to match exactly
     check_exact
         if False, test if values are within tolerance of each other (see `rtol` & `atol`)
+    check_column_order
+        if False, ignore the order of columns
     rtol
         relative tolerance for inexact checking. Fraction of values in `right`
     atol
@@ -70,7 +73,6 @@ def assert_frame_equal(
     """
 
     obj = "DataFrame"
-    check_column_order = True
 
     if not (isinstance(left, DataFrame) and isinstance(right, DataFrame)):
         raise_assert_detail(obj, "Type mismatch", type(left), type(right))

--- a/py-polars/tests/test_testing.py
+++ b/py-polars/tests/test_testing.py
@@ -98,3 +98,4 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     df2 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(AssertionError):
         pl.testing.assert_frame_equal(df1, df2)
+    pl.testing.assert_frame_equal(df1, df2, check_column_order=False)

--- a/py-polars/tests/test_testing.py
+++ b/py-polars/tests/test_testing.py
@@ -98,4 +98,4 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     df2 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(AssertionError):
         pl.testing.assert_frame_equal(df1, df2)
-    pl.testing.assert_frame_equal(df1, df2, check_column_order=False)
+    pl.testing.assert_frame_equal(df1, df2, check_column_names=False)


### PR DESCRIPTION
This adds `check_column_order` as a keyword argument to `pl.testing.assert_frame_equal` to allow comparison of `DataFrame`s with columns in an arbitrary order.