### PR TITLE
polars-ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "polars/polars-lazy",
   "polars/polars-time",
   "polars/polars-utils",
+  "polars/polars-ops",
   "examples/read_csv",
   "examples/read_parquet",
   "examples/python_rust_compiled_function",

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -106,6 +106,7 @@ partition_by = ["polars-core/partition_by"]
 semi_anti_join = ["polars-core/semi_anti_join"]
 list_eval = ["polars-lazy/list_eval"]
 chunked_ids = ["polars-core/chunked_ids", "polars-lazy/chunked_ids"]
+to_dummies = ["polars-ops/to_dummies"]
 
 test = [
   "lazy",
@@ -149,21 +150,38 @@ dtype-slim = [
 ]
 
 # opt-in datatypes for Series
-dtype-date = ["polars-core/dtype-date", "polars-lazy/dtype-date", "polars-io/dtype-date", "polars-time/dtype-date"]
+dtype-date = [
+  "polars-core/dtype-date",
+  "polars-lazy/dtype-date",
+  "polars-io/dtype-date",
+  "polars-time/dtype-date",
+  "polars-core/dtype-date",
+]
 dtype-datetime = [
   "polars-core/dtype-datetime",
   "polars-lazy/dtype-datetime",
   "polars-io/dtype-datetime",
   "polars-time/dtype-datetime",
+  "polars-ops/dtype-datetime",
 ]
-dtype-duration = ["polars-core/dtype-duration", "polars-lazy/dtype-duration", "polars-time/dtype-duration"]
-dtype-time = ["polars-core/dtype-time", "polars-io/dtype-time", "polars-time/dtype-time"]
+dtype-duration = [
+  "polars-core/dtype-duration",
+  "polars-lazy/dtype-duration",
+  "polars-time/dtype-duration",
+  "polars-core/dtype-duration",
+]
+dtype-time = ["polars-core/dtype-time", "polars-io/dtype-time", "polars-time/dtype-time", "polars-ops/dtype-time"]
 dtype-i8 = ["polars-core/dtype-i8", "polars-lazy/dtype-i8"]
 dtype-i16 = ["polars-core/dtype-i16", "polars-lazy/dtype-i16"]
-dtype-u8 = ["polars-core/dtype-u8", "polars-lazy/dtype-u8"]
+dtype-u8 = ["polars-core/dtype-u8", "polars-lazy/dtype-u8", "polars-ops/dtype-u8"]
 dtype-u16 = ["polars-core/dtype-u16", "polars-lazy/dtype-u16"]
-dtype-categorical = ["polars-core/dtype-categorical", "polars-io/dtype-categorical", "polars-lazy/dtype-categorical"]
-dtype-struct = ["polars-core/dtype-struct", "polars-lazy/dtype-struct"]
+dtype-categorical = [
+  "polars-core/dtype-categorical",
+  "polars-io/dtype-categorical",
+  "polars-lazy/dtype-categorical",
+  "polars-ops/dtype-categorical",
+]
+dtype-struct = ["polars-core/dtype-struct", "polars-lazy/dtype-struct", "polars-ops/dtype-struct"]
 
 docs-selection = [
   "csv-file",
@@ -207,6 +225,7 @@ docs-selection = [
   "dot_diagram",
   "string_encoding",
   "product",
+  "to_dummies",
 ]
 
 bench = [
@@ -217,6 +236,7 @@ bench = [
 polars-core = { version = "0.20.0", path = "./polars-core", features = ["docs", "private"], default-features = false }
 polars-io = { version = "0.20.0", path = "./polars-io", features = ["private"], default-features = false, optional = true }
 polars-lazy = { version = "0.20.0", path = "./polars-lazy", features = ["private"], default-features = false, optional = true }
+polars-ops = { version = "0.20.0", path = "./polars-ops" }
 polars-time = { version = "0.20.0", path = "./polars-time", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -12,7 +12,8 @@ check:
 	    -p polars-io \
 	    -p polars-lazy \
 	    -p polars-arrow \
-	    -p polars-time
+	    -p polars-time \
+	    -p polars-ops
 
 clippy:
 	cargo clippy --all-features \
@@ -21,6 +22,7 @@ clippy:
 	    -p polars-lazy \
 	    -p polars-arrow \
 	    -p polars-utils \
+	    -p polars-ops \
 	    -p polars-time
 
 clippy-default:

--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -31,12 +31,12 @@ impl CategoricalChunked {
         self.logical.len()
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         self.logical.name()
     }
 
     /// Get a reference to the logical array (the categories).
-    pub(crate) fn logical(&self) -> &UInt32Chunked {
+    pub fn logical(&self) -> &UInt32Chunked {
         &self.logical
     }
 

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -499,14 +499,6 @@ pub trait ChunkUnique<T> {
     }
 }
 
-pub trait ToDummies<T>: ChunkUnique<T> {
-    fn to_dummies(&self) -> Result<DataFrame> {
-        Err(PolarsError::InvalidOperation(
-            "is_duplicated is not implemented for this dtype".into(),
-        ))
-    }
-}
-
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortOptions {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -392,10 +392,6 @@ macro_rules! impl_dyn_series {
                 }
             }
 
-            fn to_dummies(&self) -> Result<DataFrame> {
-                self.0.to_dummies()
-            }
-
             fn get(&self, index: usize) -> AnyValue {
                 self.0.get_any_value(index)
             }

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -393,10 +393,6 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         }
     }
 
-    fn to_dummies(&self) -> Result<DataFrame> {
-        self.0.to_dummies()
-    }
-
     fn get(&self, index: usize) -> AnyValue {
         self.0.get_any_value(index)
     }

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -377,10 +377,6 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         self.0.cast(data_type)
     }
 
-    fn to_dummies(&self) -> Result<DataFrame> {
-        self.0.to_dummies()
-    }
-
     fn get(&self, index: usize) -> AnyValue {
         self.0.get_any_value(index)
     }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -406,10 +406,6 @@ macro_rules! impl_dyn_series {
                 self.0.cast(data_type)
             }
 
-            fn to_dummies(&self) -> Result<DataFrame> {
-                ToDummies::to_dummies(&self.0)
-            }
-
             fn get(&self, index: usize) -> AnyValue {
                 self.0.get_any_value(index)
             }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -575,10 +575,6 @@ macro_rules! impl_dyn_series {
                 self.0.cast(data_type)
             }
 
-            fn to_dummies(&self) -> Result<DataFrame> {
-                ToDummies::to_dummies(&self.0)
-            }
-
             fn get(&self, index: usize) -> AnyValue {
                 self.0.get_any_value(index)
             }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -249,10 +249,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.cast(data_type)
     }
 
-    fn to_dummies(&self) -> Result<DataFrame> {
-        ToDummies::to_dummies(&self.0)
-    }
-
     fn get(&self, index: usize) -> AnyValue {
         self.0.get_any_value(index)
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -583,11 +583,6 @@ pub trait SeriesTrait:
         invalid_operation_panic!(self)
     }
 
-    /// Create dummy variables. See [DataFrame](DataFrame::to_dummies)
-    fn to_dummies(&self) -> Result<DataFrame> {
-        invalid_operation_panic!(self)
-    }
-
     /// Get a single value by index. Don't use this operation for loops as a runtime cast is
     /// needed for every iteration.
     fn get(&self, _index: usize) -> AnyValue {

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "polars-ops"
+version = "0.20.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+polars-core = { version = "0.20.0", path = "../polars-core", features = ["private"], default-features = false }
+
+[features]
+dtype-categorical = ["polars-core/dtype-categorical"]
+dtype-date = ["polars-core/dtype-date"]
+dtype-datetime = ["polars-core/dtype-datetime"]
+dtype-time = ["polars-core/dtype-time"]
+dtype-duration = ["polars-core/dtype-duration"]
+dtype-struct = ["polars-core/dtype-struct"]
+dtype-u8 = ["polars-core/dtype-u8"]
+object = ["polars-core/object"]
+to_dummies = []

--- a/polars/polars-ops/src/chunked_array/mod.rs
+++ b/polars/polars-ops/src/chunked_array/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "to_dummies")]
+mod to_dummies;
+
+#[allow(unused_imports)]
+use crate::prelude::*;
+#[allow(unused_imports)]
+use polars_core::prelude::*;
+
+#[cfg(feature = "to_dummies")]
+pub use to_dummies::*;

--- a/polars/polars-ops/src/chunked_array/to_dummies.rs
+++ b/polars/polars-ops/src/chunked_array/to_dummies.rs
@@ -1,0 +1,126 @@
+use super::*;
+use polars_core::frame::groupby::IntoGroupsProxy;
+use polars_core::utils::Wrap;
+
+pub trait ToDummies<T> {
+    fn to_dummies(&self) -> Result<DataFrame> {
+        Err(PolarsError::InvalidOperation(
+            "to_dummies is not implemented for this dtype".into(),
+        ))
+    }
+}
+
+#[cfg(feature = "dtype-u8")]
+type DummyType = u8;
+#[cfg(feature = "dtype-u8")]
+type DummyCa = UInt8Chunked;
+
+#[cfg(not(feature = "dtype-u8"))]
+type DummyType = i32;
+#[cfg(not(feature = "dtype-u8"))]
+type DummyCa = Int32Chunked;
+
+fn dummies_helper(mut groups: Vec<IdxSize>, len: usize, name: &str) -> DummyCa {
+    groups.sort_unstable();
+
+    // let mut group_member_iter = groups.into_iter();
+    let mut av = vec![0 as DummyType; len];
+
+    for idx in groups {
+        let elem = unsafe { av.get_unchecked_mut(idx as usize) };
+        *elem = 1;
+    }
+
+    ChunkedArray::from_vec(name, av)
+}
+
+fn sort_columns(mut columns: Vec<Series>) -> Vec<Series> {
+    columns.sort_by(|a, b| a.name().partial_cmp(b.name()).unwrap());
+    columns
+}
+
+impl ToDummies<Utf8Type> for Wrap<Utf8Chunked> {
+    fn to_dummies(&self) -> Result<DataFrame> {
+        let ca = &self.0;
+        let groups = ca.group_tuples(true, false).into_idx();
+        let col_name = ca.name();
+        let taker = ca.take_rand();
+
+        let columns = groups
+            .into_par_iter()
+            .map(|(first, groups)| {
+                let name = match unsafe { taker.get_unchecked(first as usize) } {
+                    Some(val) => format!("{}_{}", col_name, val),
+                    None => format!("{}_null", col_name),
+                };
+                let ca = dummies_helper(groups, self.len(), &name);
+                ca.into_series()
+            })
+            .collect();
+
+        Ok(DataFrame::new_no_checks(sort_columns(columns)))
+    }
+}
+
+#[cfg(feature = "dtype-categorical")]
+impl ToDummies<Utf8Type> for Wrap<CategoricalChunked> {
+    fn to_dummies(&self) -> Result<DataFrame> {
+        let rev_map = self.get_rev_map();
+
+        let groups = self.logical().group_tuples(true, false).into_idx();
+        let col_name = self.name();
+        let taker = self.logical().take_rand();
+
+        let columns = groups
+            .into_par_iter()
+            .map(|(first, groups)| {
+                let name = match unsafe { taker.get_unchecked(first as usize) } {
+                    Some(val) => {
+                        let name = rev_map.get(val);
+                        format!("{}_{}", col_name, name)
+                    }
+                    None => format!("{}_null", col_name),
+                };
+                let ca = dummies_helper(groups, self.len(), &name);
+                ca.into_series()
+            })
+            .collect();
+
+        Ok(DataFrame::new_no_checks(sort_columns(columns)))
+    }
+}
+
+impl<T> ToDummies<T> for ChunkedArray<T>
+where
+    T: PolarsIntegerType + Sync,
+    T::Native: NumericNative,
+{
+    fn to_dummies(&self) -> Result<DataFrame> {
+        let groups = self.group_tuples(true, false).into_idx();
+        let col_name = self.name();
+        let taker = self.take_rand();
+
+        let columns = groups
+            .into_par_iter()
+            .map(|(first, groups)| {
+                let name = match unsafe { taker.get_unchecked(first as usize) } {
+                    Some(val) => format!("{}_{}", col_name, val),
+                    None => format!("{}_null", col_name),
+                };
+
+                let ca = dummies_helper(groups, self.len(), &name);
+                ca.into_series()
+            })
+            .collect();
+
+        Ok(DataFrame::new_no_checks(sort_columns(columns)))
+    }
+}
+
+impl<T: PolarsFloatType> ToDummies<Float32Type> for WrapFloat<ChunkedArray<T>> {}
+impl ToDummies<Wrap<BooleanType>> for Wrap<BooleanChunked> {
+    fn to_dummies(&self) -> Result<DataFrame> {
+        let ca = self.cast(&DataType::Int8)?;
+        ca.to_ops().to_dummies()
+    }
+}

--- a/polars/polars-ops/src/frame.rs
+++ b/polars/polars-ops/src/frame.rs
@@ -1,0 +1,83 @@
+#[cfg(feature = "to_dummies")]
+use polars_core::export::rayon::prelude::*;
+use polars_core::prelude::*;
+#[cfg(feature = "to_dummies")]
+use polars_core::utils::accumulate_dataframes_horizontal;
+#[cfg(feature = "to_dummies")]
+use polars_core::POOL;
+
+#[allow(unused_imports)]
+use crate::prelude::*;
+
+pub trait IntoDf {
+    fn to_df(&self) -> &DataFrame;
+}
+
+impl IntoDf for DataFrame {
+    fn to_df(&self) -> &DataFrame {
+        self
+    }
+}
+
+impl<T: IntoDf> DataFrameOps for T {}
+
+pub trait DataFrameOps: IntoDf {
+    /// Create dummy variables.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    ///
+    /// # #[macro_use] extern crate polars_core;
+    /// # fn main() {
+    ///
+    ///  use polars_core::prelude::*;
+    ///
+    ///  let df = df! {
+    ///       "id" => &[1, 2, 3, 1, 2, 3, 1, 1],
+    ///       "type" => &["A", "B", "B", "B", "C", "C", "C", "B"],
+    ///       "code" => &["X1", "X2", "X3", "X3", "X2", "X2", "X1", "X1"]
+    ///   }.unwrap();
+    ///
+    ///   let dummies = df.to_dummies().unwrap();
+    ///   dbg!(dummies);
+    /// # }
+    /// ```
+    /// Outputs:
+    /// ```text
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | id_1 | id_3 | id_2 | type_A | type_B | type_C | code_X1 | code_X2 | code_X3 |
+    ///  | ---  | ---  | ---  | ---    | ---    | ---    | ---     | ---     | ---     |
+    ///  | u8   | u8   | u8   | u8     | u8     | u8     | u8      | u8      | u8      |
+    ///  +======+======+======+========+========+========+=========+=========+=========+
+    ///  | 1    | 0    | 0    | 1      | 0      | 0      | 1       | 0       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 0    | 0    | 1    | 0      | 1      | 0      | 0       | 1       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 0    | 1    | 0    | 0      | 1      | 0      | 0       | 0       | 1       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 1    | 0    | 0    | 0      | 1      | 0      | 0       | 0       | 1       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 0    | 0    | 1    | 0      | 0      | 1      | 0       | 1       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 0    | 1    | 0    | 0      | 0      | 1      | 0       | 1       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 1    | 0    | 0    | 0      | 0      | 1      | 1       | 0       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    ///  | 1    | 0    | 0    | 0      | 1      | 0      | 1       | 0       | 0       |
+    ///  +------+------+------+--------+--------+--------+---------+---------+---------+
+    /// ```
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        let df = self.to_df();
+
+        let cols = POOL.install(|| {
+            df.get_columns()
+                .par_iter()
+                .map(|s| s.to_ops().to_dummies())
+                .collect::<Result<Vec<_>>>()
+        })?;
+
+        accumulate_dataframes_horizontal(cols)
+    }
+}

--- a/polars/polars-ops/src/lib.rs
+++ b/polars/polars-ops/src/lib.rs
@@ -1,0 +1,4 @@
+mod chunked_array;
+mod frame;
+pub mod prelude;
+mod series;

--- a/polars/polars-ops/src/prelude.rs
+++ b/polars/polars-ops/src/prelude.rs
@@ -1,0 +1,4 @@
+#[allow(unused_imports)]
+pub(crate) use {crate::series::*, polars_core::export::rayon::prelude::*};
+
+pub use crate::{chunked_array::*, frame::DataFrameOps, series::*};

--- a/polars/polars-ops/src/series/_trait.rs
+++ b/polars/polars-ops/src/series/_trait.rs
@@ -1,0 +1,34 @@
+use super::*;
+use std::ops::Deref;
+
+#[cfg(feature = "to_dummies")]
+macro_rules! invalid_operation {
+    ($s:expr) => {
+        Err(PolarsError::InvalidOperation(
+            format!(
+                "this operation is not implemented/valid for this dtype: {:?}",
+                $s.dtype()
+            )
+            .into(),
+        ))
+    };
+}
+
+pub trait SeriesOps {
+    fn dtype(&self) -> &DataType;
+
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        invalid_operation!(self)
+    }
+}
+
+impl SeriesOps for Series {
+    fn dtype(&self) -> &DataType {
+        self.deref().dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        self.to_ops().to_dummies()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/boolean.rs
+++ b/polars/polars-ops/src/series/implementations/boolean.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+impl SeriesOps for Wrap<BooleanChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(self)
+    }
+}

--- a/polars/polars-ops/src/series/implementations/categoricals.rs
+++ b/polars/polars-ops/src/series/implementations/categoricals.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+impl SeriesOps for Wrap<CategoricalChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(self)
+    }
+}

--- a/polars/polars-ops/src/series/implementations/date.rs
+++ b/polars/polars-ops/src/series/implementations/date.rs
@@ -1,0 +1,12 @@
+use super::*;
+use std::ops::Deref;
+
+impl SeriesOps for Wrap<DateChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(self.0.deref())
+    }
+}

--- a/polars/polars-ops/src/series/implementations/datetime.rs
+++ b/polars/polars-ops/src/series/implementations/datetime.rs
@@ -1,0 +1,13 @@
+use super::*;
+#[cfg(feature = "to_dummies")]
+use std::ops::Deref;
+
+impl SeriesOps for Wrap<DatetimeChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        self.0.deref().to_ops().to_dummies()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/duration.rs
+++ b/polars/polars-ops/src/series/implementations/duration.rs
@@ -1,0 +1,12 @@
+use super::*;
+use std::ops::Deref;
+
+impl SeriesOps for Wrap<DurationChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        self.0.deref().to_ops().to_dummies()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/floats.rs
+++ b/polars/polars-ops/src/series/implementations/floats.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+impl<T: PolarsFloatType> SeriesOps for WrapFloat<ChunkedArray<T>> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(self)
+    }
+}

--- a/polars/polars-ops/src/series/implementations/integers.rs
+++ b/polars/polars-ops/src/series/implementations/integers.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+impl<T: PolarsIntegerType> SeriesOps for WrapInt<ChunkedArray<T>>
+where
+    T::Native: NumericNative,
+{
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(&self.0)
+    }
+}

--- a/polars/polars-ops/src/series/implementations/list.rs
+++ b/polars/polars-ops/src/series/implementations/list.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+impl SeriesOps for Wrap<ListChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/mod.rs
+++ b/polars/polars-ops/src/series/implementations/mod.rs
@@ -1,0 +1,23 @@
+mod boolean;
+#[cfg(feature = "dtype-categorical")]
+mod categoricals;
+#[cfg(feature = "dtype-date")]
+mod date;
+#[cfg(feature = "dtype-datetime")]
+mod datetime;
+#[cfg(feature = "dtype-duration")]
+mod duration;
+mod floats;
+mod integers;
+mod list;
+#[cfg(feature = "object")]
+mod object;
+#[cfg(feature = "dtype-struct")]
+mod struct_;
+#[cfg(feature = "dtype-time")]
+mod time;
+mod utf8;
+
+use crate::prelude::*;
+use polars_core::prelude::*;
+use polars_core::utils::Wrap;

--- a/polars/polars-ops/src/series/implementations/object.rs
+++ b/polars/polars-ops/src/series/implementations/object.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+impl<T: PolarsObject> SeriesOps for Wrap<ObjectChunked<T>> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/struct_.rs
+++ b/polars/polars-ops/src/series/implementations/struct_.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+impl SeriesOps for Wrap<StructChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/time.rs
+++ b/polars/polars-ops/src/series/implementations/time.rs
@@ -1,0 +1,12 @@
+use super::*;
+use std::ops::Deref;
+
+impl SeriesOps for Wrap<TimeChunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        self.0.deref().to_ops().to_dummies()
+    }
+}

--- a/polars/polars-ops/src/series/implementations/utf8.rs
+++ b/polars/polars-ops/src/series/implementations/utf8.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+impl SeriesOps for Wrap<Utf8Chunked> {
+    fn dtype(&self) -> &DataType {
+        self.0.dtype()
+    }
+    #[cfg(feature = "to_dummies")]
+    fn to_dummies(&self) -> Result<DataFrame> {
+        ToDummies::to_dummies(self)
+    }
+}

--- a/polars/polars-ops/src/series/mod.rs
+++ b/polars/polars-ops/src/series/mod.rs
@@ -1,0 +1,106 @@
+mod _trait;
+mod implementations;
+pub use self::_trait::*;
+use polars_core::prelude::*;
+use polars_core::utils::Wrap;
+use std::sync::Arc;
+
+type SeriesOpsRef = Arc<dyn SeriesOps>;
+
+pub trait IntoSeriesOps {
+    fn to_ops(&self) -> SeriesOpsRef;
+}
+
+impl IntoSeriesOps for Series {
+    fn to_ops(&self) -> SeriesOpsRef {
+        match self.dtype() {
+            DataType::Int8 => self.i8().unwrap().to_ops(),
+            DataType::Int16 => self.i16().unwrap().to_ops(),
+            DataType::Int32 => self.i32().unwrap().to_ops(),
+            DataType::Int64 => self.i64().unwrap().to_ops(),
+            DataType::UInt8 => self.u8().unwrap().to_ops(),
+            DataType::UInt16 => self.u16().unwrap().to_ops(),
+            DataType::UInt32 => self.u32().unwrap().to_ops(),
+            DataType::UInt64 => self.u64().unwrap().to_ops(),
+            DataType::Float32 => self.f32().unwrap().to_ops(),
+            DataType::Float64 => self.f64().unwrap().to_ops(),
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Categorical(_) => self.categorical().unwrap().to_ops(),
+            DataType::Boolean => self.bool().unwrap().to_ops(),
+            DataType::Utf8 => self.utf8().unwrap().to_ops(),
+            #[cfg(feature = "dtype-date")]
+            DataType::Date => self.date().unwrap().to_ops(),
+            #[cfg(feature = "dtype-datetime")]
+            DataType::Datetime(_, _) => self.datetime().unwrap().to_ops(),
+            #[cfg(feature = "dtype-duration")]
+            DataType::Duration(_) => self.duration().unwrap().to_ops(),
+            #[cfg(feature = "dtype-time")]
+            DataType::Time => self.time().unwrap().to_ops(),
+            DataType::List(_) => self.list().unwrap().to_ops(),
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(_) => self.struct_().unwrap().to_ops(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl<T: PolarsIntegerType> IntoSeriesOps for &ChunkedArray<T>
+where
+    T::Native: NumericNative,
+{
+    fn to_ops(&self) -> SeriesOpsRef {
+        Arc::new(WrapInt((*self).clone()))
+    }
+}
+
+#[repr(transparent)]
+pub(crate) struct WrapFloat<T>(pub T);
+
+#[repr(transparent)]
+pub(crate) struct WrapInt<T>(pub T);
+
+impl IntoSeriesOps for Float32Chunked {
+    fn to_ops(&self) -> SeriesOpsRef {
+        Arc::new(WrapFloat(self.clone()))
+    }
+}
+
+impl IntoSeriesOps for Float64Chunked {
+    fn to_ops(&self) -> SeriesOpsRef {
+        Arc::new(WrapFloat(self.clone()))
+    }
+}
+
+macro_rules! into_ops_impl_wrapped {
+    ($tp:ty) => {
+        impl IntoSeriesOps for $tp {
+            fn to_ops(&self) -> SeriesOpsRef {
+                Arc::new(Wrap(self.clone()))
+            }
+        }
+    };
+}
+
+into_ops_impl_wrapped!(Utf8Chunked);
+into_ops_impl_wrapped!(BooleanChunked);
+#[cfg(feature = "dtype-date")]
+into_ops_impl_wrapped!(DateChunked);
+#[cfg(feature = "dtype-time")]
+into_ops_impl_wrapped!(TimeChunked);
+#[cfg(feature = "dtype-duration")]
+into_ops_impl_wrapped!(DurationChunked);
+#[cfg(feature = "dtype-datetime")]
+into_ops_impl_wrapped!(DatetimeChunked);
+#[cfg(feature = "dtype-struct")]
+into_ops_impl_wrapped!(StructChunked);
+into_ops_impl_wrapped!(ListChunked);
+
+#[cfg(feature = "dtype-categorical")]
+into_ops_impl_wrapped!(CategoricalChunked);
+
+#[cfg(feature = "object")]
+impl<T: PolarsObject> IntoSeriesOps for ObjectChunked<T> {
+    fn to_ops(&self) -> SeriesOpsRef {
+        Arc::new(Wrap(self.clone()))
+    }
+}

--- a/polars/src/prelude.rs
+++ b/polars/src/prelude.rs
@@ -8,3 +8,5 @@ pub use polars_lazy::prelude::*;
 
 #[cfg(feature = "temporal")]
 pub use polars_time::prelude::*;
+
+pub use polars_ops::prelude::*;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "polars-core",
  "polars-io",
  "polars-lazy",
+ "polars-ops",
  "polars-time",
 ]
 
@@ -1248,6 +1249,13 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+]
+
+[[package]]
+name = "polars-ops"
+version = "0.20.0"
+dependencies = [
+ "polars-core",
 ]
 
 [[package]]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -99,6 +99,7 @@ features = [
   "partition_by",
   "semi_anti_join",
   "list_eval",
+  "to_dummies",
 ]
 
 # [patch.crates-io]

--- a/py-polars/tests/test_categorical.py
+++ b/py-polars/tests/test_categorical.py
@@ -105,3 +105,17 @@ def test_categorical_lexical_ordering_after_concat() -> None:
         )
 
         df.sort(["key1", "key2"])
+
+
+def test_cat_to_dummies() -> None:
+    df = pl.DataFrame({"foo": [1, 2, 3, 4], "bar": ["a", "b", "a", "c"]})
+    df = df.with_column(pl.col("bar").cast(pl.Categorical))
+    assert pl.get_dummies(df).to_dict(False) == {
+        "foo_1": [1, 0, 0, 0],
+        "foo_2": [0, 1, 0, 0],
+        "foo_3": [0, 0, 1, 0],
+        "foo_4": [0, 0, 0, 1],
+        "bar_a": [1, 0, 1, 0],
+        "bar_b": [0, 1, 0, 0],
+        "bar_c": [0, 0, 0, 1],
+    }


### PR DESCRIPTION
Adds a new crate where we can host operations that don't have to be in core.

This may reduce compile times are make IDE's more responsive.

Also fixes #3204