### PR TITLE
Improving array refs for to_list

### DIFF
--- a/polars/polars-core/src/chunked_array/list/iterator.rs
+++ b/polars/polars-core/src/chunked_array/list/iterator.rs
@@ -77,7 +77,14 @@ impl ListChunked {
             ))
         };
 
-        let ptr = &series_container.chunks()[0] as *const ArrayRef as *mut ArrayRef;
+        let ptr = match &series_container.dtype() {
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(_) => {
+                let ca = &series_container.struct_().unwrap();
+                ca.arrow_array() as *const ArrayRef as *mut ArrayRef
+            }
+            _ => &series_container.chunks()[0] as *const ArrayRef as *mut ArrayRef,
+        };
 
         AmortizedListIter {
             len: self.len(),

--- a/polars/polars-core/src/chunked_array/list/iterator.rs
+++ b/polars/polars-core/src/chunked_array/list/iterator.rs
@@ -77,14 +77,7 @@ impl ListChunked {
             ))
         };
 
-        let ptr = match &series_container.dtype() {
-            #[cfg(feature = "dtype-struct")]
-            DataType::Struct(_) => {
-                let ca = &series_container.struct_().unwrap();
-                ca.arrow_array() as *const ArrayRef as *mut ArrayRef
-            }
-            _ => &series_container.chunks()[0] as *const ArrayRef as *mut ArrayRef,
-        };
+        let ptr = series_container.array_ref(0) as *const ArrayRef as *mut ArrayRef;
 
         AmortizedListIter {
             len: self.len(),

--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -18,23 +18,11 @@ pub struct StructChunked {
     arrow_array: ArrayRef,
 }
 
-/// Returns an ['ArrayRef'](arrow::array::ArrayRef) for a given
-/// [`Series`], handling nested Struct-type series separately.
-fn array_ref_for_series(series: &Series) -> ArrayRef {
-    match series.dtype() {
-        DataType::Struct(_) => {
-            let s = series.struct_().unwrap();
-            s.arrow_array.clone()
-        }
-        _ => series.to_arrow(0),
-    }
-}
-
 fn fields_to_struct_array(fields: &[Series]) -> (ArrayRef, Vec<Series>) {
     let fields = fields.iter().map(|s| s.rechunk()).collect::<Vec<_>>();
 
     let new_fields = fields.iter().map(|s| s.field().to_arrow()).collect();
-    let field_arrays = fields.iter().map(array_ref_for_series).collect::<Vec<_>>();
+    let field_arrays = fields.iter().map(|s| s.to_arrow(0)).collect::<Vec<_>>();
     let arr = StructArray::new(ArrowDataType::Struct(new_fields), field_arrays, None);
     (Arc::new(arr), fields)
 }

--- a/polars/polars-core/src/series/into.rs
+++ b/polars/polars-core/src/series/into.rs
@@ -8,6 +8,18 @@ use crate::prelude::*;
 use polars_arrow::compute::cast::cast;
 
 impl Series {
+    /// Returns a reference to the Arrow ArrayRef
+    pub fn array_ref(&self, chunk_idx: usize) -> &ArrayRef {
+        match self.dtype() {
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(_) => {
+                let ca = self.struct_().unwrap();
+                ca.arrow_array()
+            }
+            _ => &self.chunks()[chunk_idx] as &ArrayRef
+        }
+    }
+
     /// Convert a chunk in the Series to the correct Arrow type.
     /// This conversion is needed because polars doesn't use a
     /// 1 on 1 mapping for logical/ categoricals, etc.
@@ -45,11 +57,8 @@ impl Series {
                 Arc::from(arr)
             }
             #[cfg(feature = "dtype-struct")]
-            DataType::Struct(_) => {
-                let ca = self.struct_().unwrap();
-                ca.arrow_array().clone()
-            }
-            _ => self.chunks()[chunk_idx].clone(),
+            DataType::Struct(_) => self.array_ref(chunk_idx).clone(),
+            _ => self.array_ref(chunk_idx).clone(),
         }
     }
 }

--- a/polars/polars-core/src/series/into.rs
+++ b/polars/polars-core/src/series/into.rs
@@ -16,7 +16,7 @@ impl Series {
                 let ca = self.struct_().unwrap();
                 ca.arrow_array()
             }
-            _ => &self.chunks()[chunk_idx] as &ArrayRef
+            _ => &self.chunks()[chunk_idx] as &ArrayRef,
         }
     }
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -740,8 +740,7 @@ impl PySeries {
             pylist.to_object(python)
         }
 
-        let pylist = to_list_recursive(python, series);
-        pylist.to_object(python)
+        to_list_recursive(python, series)
     }
 
     pub fn median(&self) -> Option<f64> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -740,7 +740,8 @@ impl PySeries {
             pylist.to_object(python)
         }
 
-        to_list_recursive(python, series)
+        let pylist = to_list_recursive(python, series);
+        pylist.to_object(python)
     }
 
     pub fn median(&self) -> Option<f64> {

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2083,9 +2083,10 @@ def test_partition_by() -> None:
     ]
 
 
+@typing.no_type_check
 def test_list_of_list_of_struct() -> None:
     expected = [{"list_of_list_of_struct": [[{"a": 1}, {"a": 2}]]}]
     pa_df = pa.Table.from_pylist(expected)
     df = pl.from_arrow(pa_df)
-    assert df.rows() == [([[{'a': 1}, {'a': 2}]],)]
+    assert df.rows() == [([[{"a": 1}, {"a": 2}]],)]
     assert df.to_dicts() == expected

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2081,3 +2081,11 @@ def test_partition_by() -> None:
         {"foo": ["B", "B"], "N": [2, 4], "bar": ["m", "m"]},
         {"foo": ["C"], "N": [2], "bar": ["l"]},
     ]
+
+
+def test_list_of_list_of_struct() -> None:
+    expected = [{"list_of_list_of_struct": [[{"a": 1}, {"a": 2}]]}]
+    pa_df = pa.Table.from_pylist(expected)
+    df = pl.from_arrow(pa_df)
+    assert df.rows() == [([[{'a': 1}, {'a': 2}]],)]
+    assert df.to_dicts() == expected


### PR DESCRIPTION
This partially resolves #3229 by fixing a call to `chunks()[0]`. I tried to get this working with `to_arrow(0)`, but ran into issues with reference/copy. The `series.rs:to_list` method still has issues that need to be resolved for this to fully work. There are also a number of `chunks()[0]` references in the code. I'll circle back as I have time.