### PR TITLE
improve ternary in groupby context

### DIFF
--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -234,8 +234,8 @@ fn test_binary_agg_context_0() -> Result<()> {
         .lazy()
         .groupby_stable([col("groups")])
         .agg([when(col("vals").first().neq(lit(1)))
-            .then(lit("a"))
-            .otherwise(lit("b"))
+            .then(repeat("a", count()))
+            .otherwise(repeat("b", count()))
             .alias("foo")])
         .collect()
         .unwrap();


### PR DESCRIPTION
`with -> then -> otherwise` now is more intuitive in the groupby context. It allows for branching on single literal values.

Below is an example how we can implement null propagating aggregations with the new rules.

```python

df = pl.DataFrame({
    "key": ["a", "b", "b", "a"],
    "val": [1, 2, None, 1]
})

(df
 .groupby("key")
    .agg([
        pl.when(pl.col("val").null_count() > 0).then(None).otherwise(pl.sum("val"))
    ])
)
```

```
shape: (2, 2)
┌─────┬─────────┐
│ key ┆ literal │
│ --- ┆ ---     │
│ str ┆ i64     │
╞═════╪═════════╡
│ a   ┆ 2       │
├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ b   ┆ null    │
└─────┴─────────┘

```