### PR TITLE
Enable creating struct fields from list-of-dicts

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -164,13 +164,21 @@ def from_dicts(dicts: Sequence[Dict[str, Any]]) -> DataFrame:
     struct_cols = []
     for col_name, value in dicts[0].items():
         if isinstance(value, dict):
-            struct_series = from_dicts([row[col_name] for row in dicts]).to_struct(col_name)
+            struct_series = from_dicts([row[col_name] for row in dicts]).to_struct(
+                col_name
+            )
             struct_cols.append(struct_series)
     df_struct = DataFrame(struct_cols)
-    dicts_without_structs = [{col_name: row[col_name] for col_name in row if col_name not in df_struct.columns} for row in dicts]
+    dicts_without_structs = [
+        {
+            col_name: row[col_name]
+            for col_name in row
+            if col_name not in df_struct.columns
+        }
+        for row in dicts
+    ]
     df = DataFrame._from_dicts(dicts_without_structs)
     return DataFrame([*df, *struct_cols])
-
 
 
 # Note that we cannot overload because pyarrow has no stubs :(

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -202,12 +202,14 @@ def test_from_dicts_struct() -> None:
     assert df["a"][0] == {"b": 1, "c": 2}
     assert df["a"][1] == {"b": 3, "c": 4}
 
+
 def test_from_dicts_nested_struct() -> None:
     data = [{"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}]
     df = pl.from_dicts(data)
     assert df.shape == (2, 1)
     assert df["a"][0] == {"b": {"c": 1}}
     assert df["a"][1] == {"b": {"c": 2}}
+
 
 @pytest.mark.skip("not implemented yet")
 def test_from_dicts_list_of_struct() -> None:
@@ -216,6 +218,7 @@ def test_from_dicts_list_of_struct() -> None:
     assert df.shape == (2, 1)
     assert df["a"][0] == [{"b": 1}, {"b": 2}]
     assert df["a"][1] == [{"b": 3}, {"b": 4}]
+
 
 def test_from_records() -> None:
     data = [[1, 2, 3], [4, 5, 6]]

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -195,14 +195,27 @@ def test_from_dicts() -> None:
     assert df.shape == (3, 2)
 
 
-@pytest.mark.skip("not implemented yet")
 def test_from_dicts_struct() -> None:
     data = [{"a": {"b": 1, "c": 2}, "d": 5}, {"a": {"b": 3, "c": 4}, "d": 6}]
     df = pl.from_dicts(data)
     assert df.shape == (2, 2)
-    assert df["a"][0] == (1, 2)
-    assert df["a"][1] == (3, 4)
+    assert df["a"][0] == {"b": 1, "c": 2}
+    assert df["a"][1] == {"b": 3, "c": 4}
 
+def test_from_dicts_nested_struct() -> None:
+    data = [{"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}]
+    df = pl.from_dicts(data)
+    assert df.shape == (2, 1)
+    assert df["a"][0] == {"b": {"c": 1}}
+    assert df["a"][1] == {"b": {"c": 2}}
+
+@pytest.mark.skip("not implemented yet")
+def test_from_dicts_list_of_struct() -> None:
+    data = [{"a": [{"b": 1}, {"b": 2}]}, {"a": [{"b": 3}, {"b": 4}]}]
+    df = pl.from_dicts(data)
+    assert df.shape == (2, 1)
+    assert df["a"][0] == [{"b": 1}, {"b": 2}]
+    assert df["a"][1] == [{"b": 3}, {"b": 4}]
 
 def test_from_records() -> None:
     data = [[1, 2, 3], [4, 5, 6]]


### PR DESCRIPTION
Partially addresses #3145. This is definitely not an optimal solution, but it provides some basic coverage for users wishing to create a `DataFrame` involving struct fields from a list of python dictionaries. Lists of structs are not yet supported.