### PR TITLE
fix partitoned and error don't ignore errors

### DIFF
--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -369,10 +369,11 @@ impl DefaultPlanner {
                                                 | AAggExpr::Count(_)
                                         )
                                     },
-                                    BinaryExpr {left, right, ..} => {
-                                        matches!(expr_arena.get(*left), Literal(_) | Column(_)) &&
-                                        matches!(expr_arena.get(*right), Literal(_) | Column(_))
-                                    }
+                                    // TODO: first fix make proper final implementation
+                                    // BinaryExpr {left, right, ..} => {
+                                    //     matches!(expr_arena.get(*left), Literal(_) | Column(_)) &&
+                                    //     matches!(expr_arena.get(*right), Literal(_) | Column(_))
+                                    // }
                                     Literal(_) | Not(_) | IsNotNull(_) | IsNull(_) | Column(_) | Count | Alias(_, _) => {
                                         true
                                     }


### PR DESCRIPTION
Turn off binary expressions for partitioned groupby. We must ensure to call `final` evaluation to all expressions first.