### PR TITLE
Code coverage for Rust/Python

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "py-polars/build.requirements.txt"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-04-01

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,39 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  coverage:
+    name: Coverage for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu"]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: coverage-cargo-${{ matrix.os }}
+        continue-on-error: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-04-01
+          override: true
+          profile: minimal
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run coverage
+        run: make coverage
+      - uses: codecov/codecov-action@v3
+        with:
+          files: coverage.lcov,coverage.xml
+          name: ${{ matrix.os }}
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,10 +18,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: coverage-cargo-${{ matrix.os }}
-        continue-on-error: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-04-01
@@ -30,6 +26,10 @@ jobs:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: coverage-cargo-${{ matrix.os }}
+        continue-on-error: true
       - name: Run coverage
         run: make coverage
       - uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules/
 .coverage
 venv/
 *.iml
+coverage.lcov
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ coverage:
 		rustup override set nightly-2022-04-01; \
 		source <(cargo llvm-cov show-env --export-prefix); \
 		export CARGO_TARGET_DIR=\$$CARGO_LLVM_COV_TARGET_DIR; \
+		export CARGO_INCREMENTAL=1; \
 		cargo llvm-cov clean --workspace; \
 		$(MAKE) -C py-polars venv; \
 		source py-polars/venv/bin/activate; \

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,16 @@ changelog-rust:
 
 fmt_toml:
 	dprint fmt
+
+coverage:
+	@bash -c "\
+		rustup override set nightly-2022-04-01; \
+		source <(cargo llvm-cov show-env --export-prefix); \
+		export CARGO_TARGET_DIR=\$$CARGO_LLVM_COV_TARGET_DIR; \
+		cargo llvm-cov clean --workspace; \
+		$(MAKE) -C py-polars venv; \
+		source py-polars/venv/bin/activate; \
+		$(MAKE) -C polars test; \
+		$(MAKE) -C py-polars test-with-cov; \
+		cargo llvm-cov --no-run --lcov --output-path coverage.lcov; \
+		"

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -28,7 +28,11 @@ test: venv
 	$(PYTHON) -m pytest tests
 
 test-with-cov: venv
-	@cd tests && ../$(PYTHON) -m pytest --cov=polars --cov-fail-under=90 --import-mode=importlib
+	@cd tests && ../$(PYTHON) -m pytest \
+		--cov=polars \
+		--cov-report xml \
+		--cov-fail-under=90 \
+		--import-mode=importlib
 
 doctest:
 	cd tests && ../$(PYTHON) run_doc_examples.py


### PR DESCRIPTION
This resolves #3241 by introducing a new `make coverage` target that produces coverage for both the Rust and Python sections. This includes coverage of Rust code that called from Python tests (inspired by PyO3 coverage CI, and demoed in [cjermain/rust-python-coverage](https://github.com/cjermain/rust-python-coverage).

Example runs demoed in https://github.com/cjermain/polars/pull/1 have coverage of 77.21%:
https://codecov.io/gh/cjermain/polars/tree/e6e225779a974407ced2421ff8d32701423725e3

This requires CodeCov to be added to the polars repository/organization.

Follow up items:
- [ ] Add the CodeCov badge to the README.md