### PR TITLE
Select multiple columns with list or multiple arguments

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4373,7 +4373,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def select(
         self: DF,
-        exprs: Union[
+        *exprs: Union[
             str,
             "pli.Expr",
             Sequence[Union[str, "pli.Expr", bool, int, float, "pli.Series"]],
@@ -4412,9 +4412,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┘
 
         """
+        expr_list = exprs[0] if len(exprs) == 1 else exprs
         return (
             self.lazy()
-            .select(exprs)  # type: ignore
+            .select(expr_list)  # type: ignore
             .collect(no_optimization=True, string_cache=False)
         )
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1933,7 +1933,10 @@ def test_first_last_expression(fruits_cars: pl.DataFrame) -> None:
 def test_empty_is_in() -> None:
     assert pl.DataFrame({"foo": ["a", "b", "c", "d"]}).filter(
         pl.col("foo").is_in([])
-    ).shape == (0, 1)
+    ).shape == (
+        0,
+        1,
+    )
 
 
 def test_groupby_slice_expression_args() -> None:
@@ -2090,3 +2093,22 @@ def test_list_of_list_of_struct() -> None:
     df = pl.from_arrow(pa_df)
     assert df.rows() == [([[{"a": 1}, {"a": 2}]],)]
     assert df.to_dicts() == expected
+
+
+def test_select() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": [1, 2, 3],
+            "bar": [6, 7, 8],
+            "ham": ["a", "b", "c"],
+        }
+    )
+    assert df.select("foo").columns == ["foo"]
+    assert df.select(["foo", "bar"]).columns == ["foo", "bar"]
+    assert df.select("foo", "ham").columns == ["foo", "ham"]
+    s = pl.Series("baz", ["d", "e", "f"])
+    assert df.select(s).columns == ["baz"]
+    assert df.select([s]).columns == ["baz"]
+    e = pl.col("foo").alias("qux")
+    assert df.select(e).columns == ["qux"]
+    assert df.select([e]).columns == ["qux"]

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1933,10 +1933,7 @@ def test_first_last_expression(fruits_cars: pl.DataFrame) -> None:
 def test_empty_is_in() -> None:
     assert pl.DataFrame({"foo": ["a", "b", "c", "d"]}).filter(
         pl.col("foo").is_in([])
-    ).shape == (
-        0,
-        1,
-    )
+    ).shape == (0, 1)
 
 
 def test_groupby_slice_expression_args() -> None:


### PR DESCRIPTION
This PR enables two equivalent syntaxes for selecting multiple columns:
```python
df.select("a", "b")
df.select(["a", "b"])
```
Addresses a basic case raised in #3283