### PR TITLE
deprecate `df[[col(foo)]]` syntax

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1599,6 +1599,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Does quite a lot. Read the comments.
         """
         if isinstance(item, pli.Expr):
+            warnings.warn(
+                "'using expressions in []' is deprecated. please use 'select'",
+                DeprecationWarning,
+            )
             return self.select(item)
         # select rows and columns at once
         # every 2d selection, i.e. tuple is row column order, just like numpy


### PR DESCRIPTION
I don't like having multiple ways to do things. And a `select` is objectively more clear than an indexing operation as it is an english word.