### PR TITLE
Update cummax documentation

### DIFF
--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1109,14 +1109,14 @@ class Series:
 
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s = pl.Series("a", [3, 5, 1])
         >>> s.cummax()
         shape: (3,)
         Series: 'a' [i64]
         [
-            1
-            2
             3
+            5
+            5
         ]
 
         """


### PR DESCRIPTION
Right now, the `Series.cummax()` documentation uses `[1, 2, 3]` as its example series. This series isn't the best short example because its cummax is also `[1, 2, 3]`. It's not immediately clear why passing `[1, 2, 3]` as input gets you identical output. The reason the output is identical to the input is that `[1, 2, 3]` just happens to be a monotonically increasing sequence. That means any monotonically increasing input to cummax will have an output identical to its input. And, when the output is identical to the input I think it's harder to see what the function is actually doing.

The slight change I'm introducing here is [3, 5, 1]—an example Series that's *not* monotonically increasing. I think this example might help users better understand what cummax actually does, because it's sort of humped in the middle. The first cummax output is the first element (3), the second is the new cumulative maximum 5, and the third is also 5 because 1 < (the current cummax).

I know this change might seem insignificant, but I really think it might help people. I also think it's a case where, while 1-2-3 is often our go-to for examples and mock data, it's not always the best input for showing what our functions do.