### PR TITLE
Added `PartitionedWriter` for disk partitioning.

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -57,6 +57,9 @@ serde_json = { version = "1", optional = true }
 simdutf8 = "0.1"
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
 
+[dev-dependencies]
+tempdir = "0.3.7"
+
 [package.metadata.docs.rs]
 all-features = true
 # defines the configuration attribute `docsrs`

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -28,6 +28,7 @@ fmt = ["polars-core/fmt"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng-compat"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
+partition = ["uuid"]
 # don't use this
 private = ["polars-time/private"]
 
@@ -54,6 +55,7 @@ regex = "1.5"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 simdutf8 = "0.1"
+uuid = { version = "1.0.0", features = ["v4"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -28,7 +28,7 @@ fmt = ["polars-core/fmt"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng-compat"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
-partition = []
+partition = ["polars-core/partition_by"]
 # don't use this
 private = ["polars-time/private"]
 

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -28,7 +28,7 @@ fmt = ["polars-core/fmt"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng-compat"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
-partition = ["uuid"]
+partition = []
 # don't use this
 private = ["polars-time/private"]
 
@@ -55,7 +55,6 @@ regex = "1.5"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 simdutf8 = "0.1"
-uuid = { version = "1.0.0", features = ["v4"], optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/polars/polars-io/src/avro.rs
+++ b/polars/polars-io/src/avro.rs
@@ -181,7 +181,7 @@ where
         }
     }
 
-    fn finish(mut self, df: &mut DataFrame) -> Result<()> {
+    fn finish(&mut self, df: &mut DataFrame) -> Result<()> {
         let schema = df.schema().to_arrow();
         let avro_fields = write::to_avro_schema(&schema)?;
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -89,7 +89,7 @@ where
         }
     }
 
-    fn finish(mut self, df: &mut DataFrame) -> Result<()> {
+    fn finish(&mut self, df: &mut DataFrame) -> Result<()> {
         df.rechunk();
         let names = df.get_column_names();
         let iter = df.iter_chunks();

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -283,15 +283,12 @@ where
 /// use polars_core::df;
 /// use polars_io::ipc::PartitionIpcWriter;
 ///
-/// let df = df!("a" => [1, 1, 2, 3], "b" => [2, 2, 3, 4], "c" => [2, 3, 4, 5]).unwrap();
-/// let by = ["a", "b"];
 /// fn example(df: &DataFrame) -> Result<()> {
-///     let mut file = File::create("file.ipc").expect("could not create file");
-///
+///     let df = df!("a" => [1, 1, 2, 3], "b" => [2, 2, 3, 4], "c" => [2, 3, 4, 5]).unwrap();
+///     let by = ["a", "b"];
 ///     PartitionIpcWriter::new("./tmp_dir", by)
 ///         .finish(&df)
 /// }
-///
 /// ```
 pub struct PartitionIpcWriter<P, I, S> {
     rootdir: P,
@@ -492,6 +489,7 @@ mod test {
     #[cfg(feature = "partition")]
     fn test_partition() -> Result<()> {
         use std::{io::BufReader, path::PathBuf};
+
         use tempdir::TempDir;
 
         let tempdir = TempDir::new("ipc-partition")?;

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -38,8 +38,6 @@ use crate::prelude::*;
 use arrow::io::ipc::write::WriteOptions;
 use arrow::io::ipc::{read, write};
 use polars_core::prelude::*;
-use polars_core::POOL;
-use rayon::iter::IntoParallelIterator;
 use std::io::{BufWriter, Read, Seek, Write};
 use std::marker::PhantomData;
 use std::path::PathBuf;
@@ -333,8 +331,11 @@ where
     }
 
     pub fn finish(self, df: &DataFrame) -> Result<()> {
+        use polars_core::POOL;
+        use rayon::iter::IntoParallelIterator;
         use rayon::iter::ParallelIterator;
         use uuid::Uuid;
+
         let rootdir: PathBuf = self.rootdir.into();
         let by: Vec<String> = self.by.into_iter().map(|x| x.as_ref().to_owned()).collect();
         let group = df.groupby(&by)?;

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -349,7 +349,7 @@ where
                         let mut path = resolve_partition_dir(&rootdir, &by, &partition_df);
                         std::fs::create_dir_all(&path)?;
 
-                        path.push(format!("part-{}.ipc", Uuid::new_v4().to_string()));
+                        path.push(format!("part-{}.ipc", Uuid::new_v4()));
 
                         let mut file = std::fs::File::create(path)?;
                         let writer = BufWriter::new(&mut file);
@@ -367,7 +367,7 @@ where
                 let mut path = resolve_partition_dir(&rootdir, &by, &partition_df);
                 std::fs::create_dir_all(&path)?;
 
-                path.push(format!("part-{}.ipc", Uuid::new_v4().to_string()));
+                path.push(format!("part-{}.ipc", Uuid::new_v4()));
 
                 let mut file = std::fs::File::create(path)?;
                 let writer = BufWriter::new(&mut file);

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -493,9 +493,13 @@ mod test {
     fn test_partition() -> Result<()> {
         use std::{io::BufReader, path::PathBuf};
 
+        use tempdir::TempDir;
+
+        let tempdir = TempDir::new("ipc-partition")?;
+
         let df = df!("a" => [1, 1, 2, 3], "b" => [2, 2, 3, 4], "c" => [2, 3, 4, 5]).unwrap();
         let by = ["a", "b"];
-        let rootdir = format!("tmp-{}", uuid::Uuid::new_v4().to_string());
+        let rootdir = tempdir.path();
         PartitionIpcWriter::new(&rootdir, by).finish(&df)?;
 
         let expected_dfs = [
@@ -507,7 +511,7 @@ mod test {
         let expected: Vec<(PathBuf, DataFrame)> = ["a=1/b=2", "a=2/b=3", "a=3/b=4"]
             .into_iter()
             .zip(expected_dfs.into_iter())
-            .map(|(p, df)| (PathBuf::from(format!("{}/{}", &rootdir, p)), df))
+            .map(|(p, df)| (PathBuf::from(rootdir.join(p)), df))
             .collect();
 
         for (expected_dir, expected_df) in expected.iter() {

--- a/polars/polars-io/src/ipc.rs
+++ b/polars/polars-io/src/ipc.rs
@@ -492,7 +492,6 @@ mod test {
     #[cfg(feature = "partition")]
     fn test_partition() -> Result<()> {
         use std::{io::BufReader, path::PathBuf};
-
         use tempdir::TempDir;
 
         let tempdir = TempDir::new("ipc-partition")?;
@@ -529,8 +528,6 @@ mod test {
             let df = IpcReader::new(reader).finish()?;
             assert!(expected_df.frame_equal(&df));
         }
-
-        std::fs::remove_dir_all(&rootdir)?;
 
         Ok(())
     }

--- a/polars/polars-io/src/json.rs
+++ b/polars/polars-io/src/json.rs
@@ -105,7 +105,7 @@ where
         }
     }
 
-    fn finish(mut self, df: &mut DataFrame) -> Result<()> {
+    fn finish(&mut self, df: &mut DataFrame) -> Result<()> {
         df.rechunk();
         let fields = df.iter().map(|s| s.field().to_arrow()).collect::<Vec<_>>();
         let batches = df

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -36,6 +36,9 @@ pub mod prelude;
 mod tests;
 pub(crate) mod utils;
 
+#[cfg(feature = "partition")]
+pub mod partition;
+
 pub use options::*;
 
 #[cfg(any(feature = "ipc", feature = "json", feature = "avro"))]
@@ -48,6 +51,7 @@ use arrow::error::Result as ArrowResult;
 use polars_core::frame::ArrowChunk;
 use polars_core::prelude::*;
 use std::io::{Read, Seek, Write};
+use std::path::PathBuf;
 
 pub trait SerReader<R>
 where
@@ -59,7 +63,7 @@ where
     #[must_use]
     fn set_rechunk(self, _rechunk: bool) -> Self
     where
-        Self: std::marker::Sized,
+        Self: Sized,
     {
         self
     }
@@ -72,8 +76,15 @@ pub trait SerWriter<W>
 where
     W: Write,
 {
-    fn new(writer: W) -> Self;
-    fn finish(self, df: &mut DataFrame) -> Result<()>;
+    fn new(writer: W) -> Self
+    where
+        Self: Sized;
+    fn finish(&mut self, df: &mut DataFrame) -> Result<()>;
+}
+
+pub trait WriterFactory {
+    fn create_writer<W: Write + 'static>(&self, writer: W) -> Box<dyn SerWriter<W>>;
+    fn extension(&self) -> PathBuf;
 }
 
 pub trait ArrowReader {

--- a/polars/polars-io/src/partition.rs
+++ b/polars/polars-io/src/partition.rs
@@ -36,6 +36,7 @@ where
 ///     PartitionedWriter::new(option, "./rootdir", ["a", "b"])
 ///         .finish(df)
 /// }
+/// ```
 ///
 pub struct PartitionedWriter<F> {
     option: F,

--- a/polars/polars-io/src/partition.rs
+++ b/polars/polars-io/src/partition.rs
@@ -23,6 +23,20 @@ where
     path
 }
 
+/// Write a DataFrame with disk partitioning
+///
+/// # Example
+/// ```
+/// use polars_core::prelude::*;
+/// use polars_io::ipc::IpcWriterOption;
+/// use polars_io::partition::PartitionedWriter;
+///
+/// fn example(df: &mut DataFrame) -> Result<()> {
+///     let option = IpcWriterOption::default();
+///     PartitionedWriter::new(option, "./rootdir", ["a", "b"])
+///         .finish(df)
+/// }
+///
 pub struct PartitionedWriter<F> {
     option: F,
     rootdir: PathBuf,

--- a/polars/polars-io/src/partition.rs
+++ b/polars/polars-io/src/partition.rs
@@ -1,0 +1,170 @@
+use crate::{utils::resolve_homedir, WriterFactory};
+use polars_core::prelude::*;
+use rayon::iter::IndexedParallelIterator;
+use std::{
+    fs::File,
+    io::BufWriter,
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+/// partition_df must be created by the same way of partition_by
+fn resolve_partition_dir<I, S>(rootdir: &Path, by: I, partition_df: &DataFrame) -> PathBuf
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut path = PathBuf::new();
+    path.push(resolve_homedir(rootdir));
+
+    for key in by.into_iter() {
+        let value = partition_df[key.as_ref()].get(0).to_string();
+        path.push(format!("{}={}", key.as_ref(), value))
+    }
+    path
+}
+
+pub struct PartitionedWriter<F, P, I, S> {
+    option: F,
+    rootdir: P,
+    by: I,
+    parallel: bool,
+    phantom: PhantomData<S>,
+}
+
+impl<F, P, I, S> PartitionedWriter<F, P, I, S>
+where
+    F: WriterFactory + Send + Sync,
+    P: Into<PathBuf>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    pub fn new(option: F, rootdir: P, by: I) -> Self {
+        Self {
+            option,
+            rootdir,
+            by,
+            parallel: true,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn finish(self, df: &DataFrame) -> Result<()> {
+        use polars_core::POOL;
+        use rayon::iter::IntoParallelIterator;
+        use rayon::iter::ParallelIterator;
+
+        let rootdir: PathBuf = self.rootdir.into();
+        let by: Vec<String> = self.by.into_iter().map(|x| x.as_ref().to_owned()).collect();
+        let group = df.groupby(&by)?;
+
+        if self.parallel {
+            POOL.install(|| {
+                group
+                    .get_groups()
+                    .idx_ref()
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(i, t)| {
+                        let mut partition_df =
+                            unsafe { df.take_iter_unchecked(t.1.iter().map(|i| *i as usize)) };
+                        let mut path = resolve_partition_dir(&rootdir, &by, &partition_df);
+                        std::fs::create_dir_all(&path)?;
+
+                        path.push(format!(
+                            "data-{:04}.{}",
+                            i,
+                            self.option.extension().display()
+                        ));
+
+                        let file = std::fs::File::create(path)?;
+                        let writer = BufWriter::new(file);
+
+                        self.option
+                            .create_writer::<BufWriter<File>>(writer)
+                            .finish(&mut partition_df)
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })?;
+        } else {
+            for (i, t) in group.get_groups().idx_ref().iter().enumerate() {
+                let mut partition_df =
+                    unsafe { df.take_iter_unchecked(t.1.iter().map(|i| *i as usize)) };
+                let mut path = resolve_partition_dir(&rootdir, &by, &partition_df);
+                std::fs::create_dir_all(&path)?;
+
+                path.push(format!(
+                    "data-{:04}.{}",
+                    i,
+                    self.option.extension().display()
+                ));
+
+                let file = std::fs::File::create(path)?;
+                let writer = BufWriter::new(file);
+
+                self.option
+                    .create_writer::<BufWriter<File>>(writer)
+                    .finish(&mut partition_df)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "ipc")]
+    fn test_ipc_partition() -> Result<()> {
+        use crate::ipc::IpcReader;
+        use crate::SerReader;
+        use std::{io::BufReader, path::PathBuf};
+
+        use tempdir::TempDir;
+
+        use crate::prelude::IpcWriterOption;
+
+        let tempdir = TempDir::new("ipc-partition")?;
+
+        let df = df!("a" => [1, 1, 2, 3], "b" => [2, 2, 3, 4], "c" => [2, 3, 4, 5]).unwrap();
+        let by = ["a", "b"];
+        let rootdir = tempdir.path();
+
+        let option = IpcWriterOption::new();
+
+        PartitionedWriter::new(option, &rootdir, by).finish(&df)?;
+
+        let expected_dfs = [
+            df!("a" => [1, 1], "b" => [2, 2], "c" => [2, 3])?,
+            df!("a" => [2], "b" => [3], "c" => [4])?,
+            df!("a" => [3], "b" => [4], "c" => [5])?,
+        ];
+
+        let expected: Vec<(PathBuf, DataFrame)> = ["a=1/b=2", "a=2/b=3", "a=3/b=4"]
+            .into_iter()
+            .zip(expected_dfs.into_iter())
+            .map(|(p, df)| (PathBuf::from(rootdir.join(p)), df))
+            .collect();
+
+        for (expected_dir, expected_df) in expected.iter() {
+            assert!(expected_dir.exists());
+
+            let ipc_paths = std::fs::read_dir(&expected_dir)?
+                .map(|e| {
+                    let entry = e?;
+                    Ok(entry.path())
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            assert_eq!(ipc_paths.len(), 1);
+            let reader = BufReader::new(std::fs::File::open(&ipc_paths[0])?);
+            let df = IpcReader::new(reader).finish()?;
+            assert!(expected_df.frame_equal(&df));
+        }
+
+        Ok(())
+    }
+}

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -81,6 +81,7 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
 }
 
 #[cfg(feature = "partition")]
+/// partition_df must be created by the same way of partition_by
 pub(crate) fn resolve_partition_dir<I, S>(
     rootdir: &Path,
     by: I,

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -80,6 +80,26 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
     }
 }
 
+#[cfg(feature = "partition")]
+pub(crate) fn resolve_partition_dir<I, S>(
+    rootdir: &Path,
+    by: I,
+    partition_df: &DataFrame,
+) -> PathBuf
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut path = PathBuf::new();
+    path.push(resolve_homedir(rootdir));
+
+    for key in by.into_iter() {
+        let value = partition_df[key.as_ref()].get(0).to_string();
+        path.push(format!("{}={}", key.as_ref(), value))
+    }
+    path
+}
+
 #[cfg(test)]
 mod tests {
     use super::resolve_homedir;

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -81,7 +81,7 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
 }
 
 #[cfg(feature = "partition")]
-/// partition_df must be created by the same way of partition_by 
+/// partition_df must be created by the same way of partition_by
 pub(crate) fn resolve_partition_dir<I, S>(
     rootdir: &Path,
     by: I,

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -81,7 +81,7 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
 }
 
 #[cfg(feature = "partition")]
-/// partition_df must be created by the same way of partition_by
+/// partition_df must be created by the same way of partition_by 
 pub(crate) fn resolve_partition_dir<I, S>(
     rootdir: &Path,
     by: I,

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -80,27 +80,6 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
     }
 }
 
-#[cfg(feature = "partition")]
-/// partition_df must be created by the same way of partition_by
-pub(crate) fn resolve_partition_dir<I, S>(
-    rootdir: &Path,
-    by: I,
-    partition_df: &DataFrame,
-) -> PathBuf
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-{
-    let mut path = PathBuf::new();
-    path.push(resolve_homedir(rootdir));
-
-    for key in by.into_iter() {
-        let value = partition_df[key.as_ref()].get(0).to_string();
-        path.push(format!("{}={}", key.as_ref(), value))
-    }
-    path
-}
-
 #[cfg(test)]
 mod tests {
     use super::resolve_homedir;


### PR DESCRIPTION
related #2257

It seems difficult to customize IpcWriter to archive disk partitioning because disk partitioning needs to create directories and write IPC to files multiple times.
Therefore, I added a new struct for this purpose.

Usage is like the following.

```rust
use polars_core::prelude::*;
use polars_core::df;
use polars_io::ipc::PartitionIpcWriter;
let df = df!("a" => [1, 1, 2, 3], "b" => [2, 2, 3, 4], "c" => [2, 3, 4, 5]).unwrap();
let by = ["a", "b"];
PartitionIpcWriter::new("./root_dir", by)
    .finish(&df)
```

and result like below

```
root_dir/
  a=1/
    b=2/
      part-cf737804-90ea-4c37-94f8-9aa016f6953a.ipc
  a=2/
    b=3/
      part-cf737804-90ea-4c37-94f8-9aa016f6953a.ipc
  a=3/
    b=4/
      part-cf737804-90ea-4c37-94f8-9aa016f6953a.ipc
```

I'm not sure which style (e.g., hive) is best for disk partitioning, so any opinions would be appreciated.