### PR TITLE
improve agg_list performance of chunked numerical data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ coverage:
 		$(MAKE) -C py-polars venv; \
 		source py-polars/venv/bin/activate; \
 		$(MAKE) -C polars test; \
-		$(MAKE) -C polars integration-tests; \
 		$(MAKE) -C py-polars test-with-cov; \
 		cargo llvm-cov --no-run --lcov --output-path coverage.lcov; \
 		"

--- a/polars/polars-arrow/src/bitmap/mutable.rs
+++ b/polars/polars-arrow/src/bitmap/mutable.rs
@@ -1,12 +1,6 @@
 use arrow::bitmap::MutableBitmap;
 
 pub trait MutableBitmapExtension {
-    /// Initializes a [`MutableBitmap`] with all values set to valid/ true.
-    fn from_len_set(length: usize) -> MutableBitmap {
-        let values = vec![u8::MAX; length.saturating_add(7) / 8];
-        MutableBitmap::from_vec(values, length)
-    }
-
     fn as_slice_mut(&mut self) -> &mut [u8];
 
     /// # Safety

--- a/polars/polars-core/src/frame/groupby/aggregations.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations.rs
@@ -1,4 +1,5 @@
 use crate::POOL;
+use arrow::bitmap::MutableBitmap;
 use num::{Bounded, Num, NumCast, ToPrimitive, Zero};
 use rayon::prelude::*;
 
@@ -757,63 +758,67 @@ where
     ChunkedArray<T>: IntoSeries,
 {
     fn agg_list(&self, groups: &GroupsProxy) -> Series {
+        let ca = self.rechunk();
+
         match groups {
             GroupsProxy::Idx(groups) => {
                 let mut can_fast_explode = true;
-                let arr = match self.cont_slice() {
-                    Ok(values) => {
-                        let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
-                        let mut length_so_far = 0i64;
-                        offsets.push(length_so_far);
 
-                        let mut list_values = Vec::<T::Native>::with_capacity(self.len());
-                        groups.iter().for_each(|(_, idx)| {
-                            let idx_len = idx.len();
-                            if idx_len == 0 {
-                                can_fast_explode = false;
-                            }
+                let arr = ca.downcast_iter().next().unwrap();
+                let values = arr.values();
 
-                            length_so_far += idx_len as i64;
-                            // Safety:
-                            // group tuples are in bounds
-                            unsafe {
-                                list_values.extend(idx.iter().map(|idx| {
-                                    debug_assert!((*idx as usize) < values.len());
-                                    *values.get_unchecked(*idx as usize)
-                                }));
-                                // Safety:
-                                // we know that offsets has allocated enough slots
-                                offsets.push_unchecked(length_so_far);
-                            }
-                        });
-                        let array = PrimitiveArray::from_data(
-                            T::get_dtype().to_arrow(),
-                            list_values.into(),
-                            None,
-                        );
-                        let data_type =
-                            ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
-                        ListArray::<i64>::from_data(
-                            data_type,
-                            offsets.into(),
-                            Arc::new(array),
-                            None,
-                        )
+                let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
+                let mut length_so_far = 0i64;
+                offsets.push(length_so_far);
+
+                let mut list_values = Vec::<T::Native>::with_capacity(self.len());
+                groups.iter().for_each(|(_, idx)| {
+                    let idx_len = idx.len();
+                    if idx_len == 0 {
+                        can_fast_explode = false;
                     }
-                    _ => {
-                        let mut builder = ListPrimitiveChunkedBuilder::<T::Native>::new(
-                            self.name(),
-                            groups.len(),
-                            self.len(),
-                            self.dtype().clone(),
-                        );
-                        for idx in groups.all().iter() {
-                            let s = unsafe { self.take_unchecked(idx.into()).into_series() };
-                            builder.append_series(&s);
+
+                    length_so_far += idx_len as i64;
+                    // Safety:
+                    // group tuples are in bounds
+                    unsafe {
+                        list_values.extend(idx.iter().map(|idx| {
+                            debug_assert!((*idx as usize) < values.len());
+                            *values.get_unchecked(*idx as usize)
+                        }));
+                        // Safety:
+                        // we know that offsets has allocated enough slots
+                        offsets.push_unchecked(length_so_far);
+                    }
+                });
+
+                let validity = if arr.null_count() > 0 {
+                    let old_validity = arr.validity().unwrap();
+                    let mut validity = MutableBitmap::from_len_set(list_values.len());
+
+                    let mut count = 0;
+                    groups.iter().for_each(|(_, idx)| unsafe {
+                        for i in idx {
+                            if !old_validity.get_bit_unchecked(*i as usize) {
+                                validity.set_bit_unchecked(count, false)
+                            }
+                            count += 1;
                         }
-                        return builder.finish().into_series();
-                    }
+                    });
+                    Some(validity.into())
+                } else {
+                    None
                 };
+
+                let array = PrimitiveArray::from_data(
+                    T::get_dtype().to_arrow(),
+                    list_values.into(),
+                    validity,
+                );
+                let data_type = ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
+                let arr =
+                    ListArray::<i64>::from_data(data_type, offsets.into(), Arc::new(array), None);
+
                 let mut ca = ListChunked::from_chunks(self.name(), vec![Arc::new(arr)]);
                 if can_fast_explode {
                     ca.set_fast_explode()
@@ -822,55 +827,54 @@ where
             }
             GroupsProxy::Slice(groups) => {
                 let mut can_fast_explode = true;
-                let arr = match self.cont_slice() {
-                    Ok(values) => {
-                        let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
-                        let mut length_so_far = 0i64;
-                        offsets.push(length_so_far);
+                let arr = ca.downcast_iter().next().unwrap();
+                let values = arr.values();
 
-                        let mut list_values = Vec::<T::Native>::with_capacity(self.len());
-                        groups.iter().for_each(|&[first, len]| {
-                            if len == 0 {
-                                can_fast_explode = false;
-                            }
+                let mut offsets = Vec::<i64>::with_capacity(groups.len() + 1);
+                let mut length_so_far = 0i64;
+                offsets.push(length_so_far);
 
-                            length_so_far += len as i64;
-                            list_values
-                                .extend_from_slice(&values[first as usize..(first + len) as usize]);
-                            unsafe {
-                                // Safety:
-                                // we know that offsets has allocated enough slots
-                                offsets.push_unchecked(length_so_far);
-                            }
-                        });
-                        let array = PrimitiveArray::from_data(
-                            T::get_dtype().to_arrow(),
-                            list_values.into(),
-                            None,
-                        );
-                        let data_type =
-                            ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
-                        ListArray::<i64>::from_data(
-                            data_type,
-                            offsets.into(),
-                            Arc::new(array),
-                            None,
-                        )
+                let mut list_values = Vec::<T::Native>::with_capacity(self.len());
+                groups.iter().for_each(|&[first, len]| {
+                    if len == 0 {
+                        can_fast_explode = false;
                     }
-                    _ => {
-                        let mut builder = ListPrimitiveChunkedBuilder::<T::Native>::new(
-                            self.name(),
-                            groups.len(),
-                            self.len(),
-                            self.dtype().clone(),
-                        );
-                        for &[first, len] in groups {
-                            let s = self.slice(first as i64, len as usize).into_series();
-                            builder.append_series(&s);
+
+                    length_so_far += len as i64;
+                    list_values.extend_from_slice(&values[first as usize..(first + len) as usize]);
+                    unsafe {
+                        // Safety:
+                        // we know that offsets has allocated enough slots
+                        offsets.push_unchecked(length_so_far);
+                    }
+                });
+
+                let validity = if arr.null_count() > 0 {
+                    let old_validity = arr.validity().unwrap();
+                    let mut validity = MutableBitmap::from_len_set(list_values.len());
+
+                    let mut count = 0;
+                    groups.iter().for_each(|[first, len]| unsafe {
+                        for i in *first..(*first + *len) {
+                            if !old_validity.get_bit_unchecked(i as usize) {
+                                validity.set_bit_unchecked(count, false)
+                            }
+                            count += 1;
                         }
-                        return builder.finish().into_series();
-                    }
+                    });
+                    Some(validity.into())
+                } else {
+                    None
                 };
+
+                let array = PrimitiveArray::from_data(
+                    T::get_dtype().to_arrow(),
+                    list_values.into(),
+                    validity,
+                );
+                let data_type = ListArray::<i64>::default_datatype(T::get_dtype().to_arrow());
+                let arr =
+                    ListArray::<i64>::from_data(data_type, offsets.into(), Arc::new(array), None);
                 let mut ca = ListChunked::from_chunks(self.name(), vec![Arc::new(arr)]);
                 if can_fast_explode {
                     ca.set_fast_explode()


### PR DESCRIPTION
Delaying a full rechunk can improve performance of many query, but some are slower.

This improves the following query by `~3x`.

```rust
fn main() -> Result<()> {
    let q = LazyCsvReader::new("/home/ritchie46/code/db-benchmark/data/G1_1e7_1e2_0_0.csv".into())
        .with_rechunk(false)
        .finish()?;

    let out = q
        .groupby([col("id2"), col("id4")])
        .agg([(pearson_corr(col("v1"), col("v2")).pow(2.0)).alias("r2")])
        .collect()?;
    Ok(())
}
```

# before

```
          6.685,79 msec task-clock                #    2,124 CPUs utilized          
             4.747      context-switches          #  710,013 /sec                   
               218      cpu-migrations            #   32,606 /sec                   
           173.797      page-faults               #   25,995 K/sec                  
    21.435.123.551      cycles                    #    3,206 GHz                    
    38.153.190.822      instructions              #    1,78  insn per cycle         
     5.010.104.768      branches                  #  749,366 M/sec                  
        24.141.092      branch-misses             #    0,48% of all branches        

       3,148083894 seconds time elapsed

       6,231878000 seconds user
       0,469579000 seconds sys
```

# after

```
          5.024,99 msec task-clock                #    4,879 CPUs utilized          
             4.305      context-switches          #  856,718 /sec                   
               118      cpu-migrations            #   23,483 /sec                   
           212.864      page-faults               #   42,361 K/sec                  
    14.441.547.675      cycles                    #    2,874 GHz                    
    21.711.917.241      instructions              #    1,50  insn per cycle         
     4.031.158.541      branches                  #  802,222 M/sec                  
        21.774.943      branch-misses             #    0,54% of all branches        

       1,029876114 seconds time elapsed

       4,531616000 seconds user
       0,502194000 seconds sys
```
