### PR TITLE
CI: Update used actions to v3

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -16,7 +16,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
@@ -21,7 +21,7 @@ jobs:
     name: Features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -39,7 +39,7 @@ jobs:
     name: Build and test Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -47,14 +47,14 @@ jobs:
           override: true
           components: rustfmt, clippy, miri
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: /github/home/.cargo
           key: cargo-cache-
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and arrow
           # and thus are specific for a particular OS, arch and rust version.

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,8 +17,8 @@ jobs:
         os: ["ubuntu"]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/create-js-release.yaml
+++ b/.github/workflows/create-js-release.yaml
@@ -122,12 +122,12 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.settings.target }}-cargo-registry
       - name: Cache cargo index
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ matrix.settings.target }}-cargo-index
@@ -155,7 +155,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bindings-${{ matrix.settings.target }}
           path: nodejs-polars/polars/*.node
@@ -168,11 +168,11 @@ jobs:
       - build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: yarn install
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: bindings-x86_64-apple-darwin
           path: nodejs-polars/polars
@@ -187,7 +187,7 @@ jobs:
         working-directory: nodejs-polars
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -199,7 +199,7 @@ jobs:
         run: yarn install
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: nodejs-polars/artifacts
 

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -15,7 +15,7 @@ jobs:
         os: ["macos-latest"]
         python-version: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -26,7 +26,7 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Prepare maturin publish

--- a/.github/workflows/create-py-release-manylinux.yaml
+++ b/.github/workflows/create-py-release-manylinux.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Create Release manylinux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: publish x86_64
         uses: docker://konstin2/maturin:latest
         env:

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -14,7 +14,7 @@ jobs:
         os: ["macos-latest", "windows-latest"]
         python-version: ["3.7"]
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Install latest Rust nightly
           uses: actions-rs/toolchain@v1
           with:
@@ -22,7 +22,7 @@ jobs:
             override: true
             components: rustfmt, clippy
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v3
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install dependencies

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -27,7 +27,7 @@ jobs:
           npm install
           npx typedoc
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -9,9 +9,9 @@ jobs:
     name: Docs check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/fmt_all.yaml
+++ b/.github/workflows/fmt_all.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Test global formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           curl -fsSLO https://github.com/dprint/dprint/releases/download/0.18.2/dprint-x86_64-unknown-linux-gnu.zip

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -15,7 +15,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         node: ["16", "17"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.10" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -21,7 +21,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Build and test Python
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -17,7 +17,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.9"
       - name: Install dependencies

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: nightly-2022-04-01
           override: true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |


### PR DESCRIPTION
Update the checkout, setup-python, cache and upload- and download-artifact actions to v3. 