### PR TITLE
Fix init of DataFrame with empty dataset (eg:"[]") and column/schema typedefs

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -463,7 +463,7 @@ def sequence_to_pydf(
     data_series: List["PySeries"]
 
     if len(data) == 0:
-        data_series = []
+        return dict_to_pydf({}, columns=columns)
 
     elif isinstance(data[0], pli.Series):
         series_names = [s.name for s in data]

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -506,7 +506,7 @@ def sequence_to_pydf(
         columns, dtypes = _unpack_columns(columns, n_expected=1)
         data_series = [pli.Series(columns[0], data, dtypes.get(columns[0])).inner()]
 
-    data_series = _handle_columns_arg(data_series, columns=columns)  # type: ignore[arg-type]
+    data_series = _handle_columns_arg(data_series, columns=columns)
     return PyDataFrame(data_series)
 
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -36,19 +36,22 @@ def test_init_only_columns() -> None:
     assert df.frame_equal(truth, null_equal=True)
     assert df.dtypes == [pl.Float32, pl.Float32, pl.Float32]
 
-    df = pl.DataFrame(
-        columns=[("a", pl.Date), ("b", pl.UInt64), ("c", pl.datatypes.Int8)]
-    )
-    truth = pl.DataFrame({"a": [], "b": [], "c": []}).with_columns(
-        [
-            pl.col("a").cast(pl.Date),
-            pl.col("b").cast(pl.UInt64),
-            pl.col("c").cast(pl.Int8),
-        ]
-    )
-    assert df.shape == (0, 3)
-    assert df.frame_equal(truth, null_equal=True)
-    assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8]
+    # Validate construction with various flavours of no/empty data
+    for no_data in ( None, {}, [] ):
+        df = pl.DataFrame(
+            data=no_data,
+            columns=[("a", pl.Date), ("b", pl.UInt64), ("c", pl.datatypes.Int8)]
+        )
+        truth = pl.DataFrame({"a": [], "b": [], "c": []}).with_columns(
+            [
+                pl.col("a").cast(pl.Date),
+                pl.col("b").cast(pl.UInt64),
+                pl.col("c").cast(pl.Int8),
+            ]
+        )
+        assert df.shape == (0, 3)
+        assert df.frame_equal(truth, null_equal=True)
+        assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8]
 
 
 def test_init_dict() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,5 +1,4 @@
 # flake8: noqa: W191,E101
-import io
 import sys
 import typing
 from builtins import range
@@ -15,8 +14,6 @@ import pytest
 
 import polars as pl
 from polars import testing
-from polars.datatypes import List
-from polars.internals.frame import DataFrame
 
 
 def test_version() -> None:
@@ -37,6 +34,7 @@ def test_init_only_columns() -> None:
     assert df.dtypes == [pl.Float32, pl.Float32, pl.Float32]
 
     # Validate construction with various flavours of no/empty data
+    no_data: Any
     for no_data in (None, {}, []):
         df = pl.DataFrame(
             data=no_data,

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -37,10 +37,10 @@ def test_init_only_columns() -> None:
     assert df.dtypes == [pl.Float32, pl.Float32, pl.Float32]
 
     # Validate construction with various flavours of no/empty data
-    for no_data in ( None, {}, [] ):
+    for no_data in (None, {}, []):
         df = pl.DataFrame(
             data=no_data,
-            columns=[("a", pl.Date), ("b", pl.UInt64), ("c", pl.datatypes.Int8)]
+            columns=[("a", pl.Date), ("b", pl.UInt64), ("c", pl.datatypes.Int8)],
         )
         truth = pl.DataFrame({"a": [], "b": [], "c": []}).with_columns(
             [


### PR DESCRIPTION
Fixes #3321; when input data is an empty sequence, construct the DataFrame using the same codepath as in the None case. Extended current test coverage to validate.


Example:
```python
import polars as pl
pl.DataFrame( data=[], columns=[("col1",pl.Float64),("col2",pl.Float64)] )
```
Without fix (error):
```python
RuntimeError: Duplicate("Column with name: '' has more than one occurrences")
```
With fix (empty dataframe with correct schema):
```
shape: (0, 2)
┌──────┬──────┐
│ col1 ┆ col2 │
│ ---  ┆ ---  │
│ f64  ┆ f64  │
╞══════╪══════╡
└──────┴──────┘
```
