### PR TITLE
Add extension_module in python example 

### DIFF
--- a/examples/python_rust_compiled_function/Cargo.toml
+++ b/examples/python_rust_compiled_function/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 polars = { path = "../../polars" }
 polars-arrow = { path = "../../polars/polars-arrow" }
-pyo3 = "0.16"
+pyo3 = { version = "0.16.4", features = ["extension-module"] }


### PR DESCRIPTION
Using `cargo build` was breaking because of relocation errors like this:

> relocation R_X86_64_32S against symbol `_Py_ctype_table' can not be used when making a shared object; recompile with -fPIC

Adding `features = ["extension-module"]` will now skip linking against libpython.so and fix the errors above when running `cargo build`

More information: https://pyo3.rs/main/features.html#extension-module.
