### PR TITLE
improve and simplify ternary aggregation

### DIFF
--- a/polars/polars-core/src/series/unstable.rs
+++ b/polars/polars-core/src/series/unstable.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use std::ptr::NonNull;
 
 /// A wrapper type that should make it a bit more clear that we should not clone Series
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[cfg(feature = "private")]
 pub struct UnstableSeries<'a> {
     // A series containing a single chunk ArrayRef
@@ -40,10 +40,6 @@ impl<'a> UnstableSeries<'a> {
             container: series,
             inner: NonNull::new(inner_chunk as *const ArrayRef as *mut ArrayRef).unwrap(),
         }
-    }
-
-    pub fn clone(&self) {
-        panic!("don't clone this type, use deep_clone")
     }
 
     pub fn deep_clone(&self) -> Series {

--- a/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
@@ -1,0 +1,103 @@
+use super::*;
+use polars_arrow::export::arrow::array::ArrayRef;
+use polars_core::series::unstable::UnstableSeries;
+use std::pin::Pin;
+
+impl<'a> AggregationContext<'a> {
+    pub(super) fn iter_groups(
+        &mut self,
+    ) -> Box<dyn Iterator<Item = Option<UnstableSeries<'_>>> + '_> {
+        match self.agg_state() {
+            AggState::Literal(_) => {
+                let s = self.series();
+                let s = UnstableSeries::new(s);
+                Box::new(LitIter::new(s, self.groups.len()))
+            }
+            AggState::AggregatedFlat(_) => {
+                let s = self.series();
+                Box::new(FlatIter::new(s.array_ref(0).clone(), self.groups.len()))
+            }
+            AggState::AggregatedList(_) => {
+                let s = self.series();
+                let list = s.list().unwrap();
+                Box::new(list.amortized_iter())
+            }
+            AggState::NotAggregated(_) => {
+                // we don't take the owned series as we want a reference
+                let _ = self.aggregated();
+                let s = self.series();
+                let list = s.list().unwrap();
+                Box::new(list.amortized_iter())
+            }
+        }
+    }
+}
+
+struct LitIter<'a> {
+    len: usize,
+    offset: usize,
+    item: UnstableSeries<'a>,
+}
+
+impl<'a> LitIter<'a> {
+    fn new(s: UnstableSeries<'a>, len: usize) -> Self {
+        Self {
+            len,
+            offset: 0,
+            item: s,
+        }
+    }
+}
+
+impl<'a> Iterator for LitIter<'a> {
+    type Item = Option<UnstableSeries<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len == self.offset {
+            None
+        } else {
+            self.offset += 1;
+            Some(Some(self.item))
+        }
+    }
+}
+
+struct FlatIter<'a> {
+    array: ArrayRef,
+    offset: usize,
+    len: usize,
+    // UnstableSeries referenced that series
+    #[allow(dead_code)]
+    series_container: Pin<Box<Series>>,
+    item: UnstableSeries<'a>,
+}
+
+impl<'a> FlatIter<'a> {
+    fn new(array: ArrayRef, len: usize) -> Self {
+        let series_container = Box::pin(Series::try_from(("", array.clone())).unwrap());
+        let ref_s = &*series_container as *const Series;
+        Self {
+            array,
+            offset: 0,
+            len,
+            series_container,
+            // Safety: we pinned the series so the location is still valid
+            item: UnstableSeries::new(unsafe { &*ref_s }),
+        }
+    }
+}
+
+impl<'a> Iterator for FlatIter<'a> {
+    type Item = Option<UnstableSeries<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len == self.offset {
+            None
+        } else {
+            let arr = unsafe { Arc::from(self.array.slice_unchecked(self.offset, 1)) };
+            self.offset += 1;
+            self.item.swap(arr);
+            Some(Some(self.item))
+        }
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -2,9 +2,7 @@ use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use polars_core::series::unstable::UnstableSeries;
 use polars_core::POOL;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 pub struct TernaryExpr {
@@ -45,6 +43,45 @@ fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChu
     }
 }
 
+fn finish_as_iters<'a>(
+    mut ac_truthy: AggregationContext<'a>,
+    mut ac_falsy: AggregationContext<'a>,
+    mut ac_mask: AggregationContext<'a>,
+) -> Result<AggregationContext<'a>> {
+    let mut ca: ListChunked = ac_truthy
+        .iter_groups()
+        .zip(ac_falsy.iter_groups())
+        .zip(ac_mask.iter_groups())
+        .map(|((truthy, falsy), mask)| {
+            match (truthy, falsy, mask) {
+                (Some(truthy), Some(falsy), Some(mask)) => Some(
+                    truthy
+                        .as_ref()
+                        .zip_with(mask.as_ref().bool()?, falsy.as_ref()),
+                ),
+                _ => None,
+            }
+            .transpose()
+        })
+        .collect::<Result<_>>()?;
+
+    ca.rename(ac_truthy.series().name());
+    // aggregation leaves only a single chunks
+    let arr = ca.downcast_iter().next().unwrap();
+    let list_vals_len = arr.values().len();
+    let mut out = ca.into_series();
+
+    if ac_truthy.arity_should_explode() && ac_falsy.arity_should_explode() && ac_mask.arity_should_explode() &&
+        // exploded list should be equal to groups length
+        list_vals_len == ac_truthy.groups.len()
+    {
+        out = out.explode()?
+    }
+
+    ac_truthy.with_series(out, true);
+    Ok(ac_truthy)
+}
+
 impl PhysicalExpr for TernaryExpr {
     fn as_expression(&self) -> &Expr {
         &self.expr
@@ -82,9 +119,9 @@ impl PhysicalExpr for TernaryExpr {
 
         let (ac_mask, (ac_truthy, ac_falsy)) =
             POOL.install(|| rayon::join(op_mask, || rayon::join(op_truthy, op_falsy)));
-        let mut ac_mask = ac_mask?;
+        let ac_mask = ac_mask?;
         let mut ac_truthy = ac_truthy?;
-        let mut ac_falsy = ac_falsy?;
+        let ac_falsy = ac_falsy?;
 
         let mask_s = ac_mask.flat_naive();
 
@@ -98,60 +135,7 @@ impl PhysicalExpr for TernaryExpr {
             (AggState::AggregatedFlat(s), AggState::NotAggregated(_) | AggState::Literal(_))
                 if s.len() != df.height() =>
             {
-                // this is a flat series of len eq to group tuples
-                let truthy = ac_truthy.aggregated_arity_operation();
-                let truthy = truthy.as_ref();
-                let arr_truthy = &truthy.chunks()[0];
-                assert_eq!(truthy.len(), groups.len());
-
-                // we create a dummy Series that is not cloned nor moved
-                // so we can swap the ArrayRef during the hot loop
-                // this prevents a series Arc alloc and a vec alloc per iteration
-                let dummy = Series::try_from(("dummy", vec![arr_truthy.clone()])).unwrap();
-                let mut us = UnstableSeries::new(&dummy);
-
-                // this is now a list
-                let falsy = ac_falsy.aggregated_arity_operation();
-                let falsy = falsy.as_ref();
-                let falsy = falsy.list().unwrap();
-
-                let mask = ac_mask.aggregated_arity_operation();
-                let mask = mask.as_ref();
-                let mask = mask.list()?;
-                if !matches!(mask.inner_dtype(), DataType::Boolean) {
-                    return Err(PolarsError::ComputeError(
-                        format!("expected mask of type bool, got {:?}", mask.inner_dtype()).into(),
-                    ));
-                }
-
-                let mut ca: ListChunked = falsy
-                    .amortized_iter()
-                    .zip(mask.amortized_iter())
-                    .enumerate()
-                    .map(|(idx, (opt_falsy, opt_mask))| {
-                        match (opt_falsy, opt_mask) {
-                            (Some(falsy), Some(mask)) => {
-                                let falsy = falsy.as_ref();
-                                let mask = mask.as_ref();
-                                let mask = mask.bool()?;
-
-                                // Safety:
-                                // we are in bounds
-                                let arr = unsafe { Arc::from(arr_truthy.slice_unchecked(idx, 1)) };
-                                us.swap(arr);
-                                let truthy = us.as_ref();
-
-                                Some(truthy.zip_with(mask, falsy))
-                            }
-                            _ => None,
-                        }
-                        .transpose()
-                    })
-                    .collect::<Result<_>>()?;
-                ca.rename(truthy.name());
-
-                ac_truthy.with_series(ca.into_series(), true);
-                Ok(ac_truthy)
+                finish_as_iters(ac_truthy, ac_falsy, ac_mask)
             }
             // all aggregated or literal
             // simply align lengths and zip
@@ -175,60 +159,7 @@ impl PhysicalExpr for TernaryExpr {
             (AggState::NotAggregated(_) | AggState::Literal(_), AggState::AggregatedFlat(s))
                 if s.len() != df.height() =>
             {
-                // this is now a list
-                let truthy = ac_truthy.aggregated_arity_operation();
-                let truthy = truthy.as_ref();
-                let truthy = truthy.list().unwrap();
-
-                // this is a flat series of len eq to group tuples
-                let falsy = ac_falsy.aggregated_arity_operation();
-                assert_eq!(falsy.len(), groups.len());
-                let falsy = falsy.as_ref();
-                let arr_falsy = &falsy.chunks()[0];
-
-                // we create a dummy Series that is not cloned nor moved
-                // so we can swap the ArrayRef during the hot loop
-                // this prevents a series Arc alloc and a vec alloc per iteration
-                let dummy = Series::try_from(("dummy", vec![arr_falsy.clone()])).unwrap();
-                let mut us = UnstableSeries::new(&dummy);
-
-                let mask = ac_mask.aggregated_arity_operation();
-                let mask = mask.as_ref();
-                let mask = mask.list()?;
-                if !matches!(mask.inner_dtype(), DataType::Boolean) {
-                    return Err(PolarsError::ComputeError(
-                        format!("expected mask of type bool, got {:?}", mask.inner_dtype()).into(),
-                    ));
-                }
-
-                let mut ca: ListChunked = truthy
-                    .amortized_iter()
-                    .zip(mask.amortized_iter())
-                    .enumerate()
-                    .map(|(idx, (opt_truthy, opt_mask))| {
-                        match (opt_truthy, opt_mask) {
-                            (Some(truthy), Some(mask)) => {
-                                let truthy = truthy.as_ref();
-                                let mask = mask.as_ref();
-                                let mask = mask.bool()?;
-
-                                // Safety:
-                                // we are in bounds
-                                let arr = unsafe { Arc::from(arr_falsy.slice_unchecked(idx, 1)) };
-                                us.swap(arr);
-                                let falsy = us.as_ref();
-
-                                Some(truthy.zip_with(mask, falsy))
-                            }
-                            _ => None,
-                        }
-                        .transpose()
-                    })
-                    .collect::<Result<_>>()?;
-                ca.rename(truthy.name());
-
-                ac_truthy.with_series(ca.into_series(), true);
-                Ok(ac_truthy)
+                finish_as_iters(ac_truthy, ac_falsy, ac_mask)
             }
 
             // Both are or a flat series or aggregated into a list

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -300,6 +300,7 @@ fn test_binary_agg_context_1() -> Result<()> {
             .otherwise(lit(90))
             .alias("vals")])
         .collect()?;
+    dbg!(&out);
 
     // if vals == 1 then sum(vals) else vals
     // [14, 90]


### PR DESCRIPTION
Greatly simplifies evaluation of ternary expressions in aggregation context. We can remove more code in the future with this.

closes #3393