### PR TITLE
improve `rolling_{min/max/sum/mean}` prerformance `~3.4x`

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/mean_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mean_no_nulls.rs
@@ -1,0 +1,72 @@
+use super::*;
+use crate::kernels::rolling::sum_min_max_no_nulls::SumWindow;
+use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
+
+struct MeanWindow<'a, T> {
+    sum: SumWindow<'a, T>,
+}
+
+impl<
+        'a,
+        T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Div<Output = T> + NumCast,
+    > RollingAggWindow<'a, T> for MeanWindow<'a, T>
+{
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        Self {
+            sum: SumWindow::new(slice, start, end),
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        let sum = self.sum.update(start, end);
+        sum / NumCast::from(end - start).unwrap()
+    }
+}
+
+pub fn rolling_mean<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + Float + std::iter::Sum<T> + SubAssign + AddAssign + IsFloat,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply_agg_window::<MeanWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => rolling_apply_agg_window::<MeanWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets,
+        ),
+        (true, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                no_nulls::compute_mean_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                no_nulls::compute_mean_weights,
+                &weights,
+            )
+        }
+    }
+}

--- a/polars/polars-arrow/src/kernels/rolling/min_max_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/min_max_no_nulls.rs
@@ -1,0 +1,380 @@
+use super::*;
+use no_nulls;
+
+pub(crate) trait RollingAggWindow<'a, T: NativeType + IsFloat + PartialOrd> {
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self;
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T;
+}
+
+struct MinWindow<'a, T: NativeType + PartialOrd + IsFloat> {
+    slice: &'a [T],
+    min: T,
+    last_start: usize,
+    last_end: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindow<'a, T> for MinWindow<'a, T> {
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        let min = *slice[start..end]
+            .iter()
+            .min_by(|a, b| compare_fn(*a, *b))
+            .unwrap();
+        Self {
+            slice,
+            min,
+            last_start: start,
+            last_end: end,
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        // remove elements that should leave the window
+        let mut recompute_min = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let leaving_value = self.slice.get_unchecked(idx);
+            // if the leaving value is the max value, we need to recompute the max.
+            if matches!(compare_fn(leaving_value, &self.min), Ordering::Equal) {
+                recompute_min = true;
+                break;
+            }
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if recompute_min {
+            self.min = *self
+                .slice
+                .get_unchecked(start..end)
+                .iter()
+                .min_by(|a, b| compare_fn(*a, *b))
+                .unwrap();
+        }
+        // the max has not left the window, so we only check
+        // if the entering values are larger
+        else if end > self.last_end {
+            let min_entering = self
+                .slice
+                .get_unchecked(self.last_end..end)
+                .iter()
+                .min_by(|a, b| compare_fn(*a, *b))
+                .unwrap_unchecked();
+            if matches!(compare_fn(min_entering, &self.min), Ordering::Less) {
+                self.min = *min_entering
+            }
+        }
+        self.last_end = end;
+        self.min
+    }
+}
+
+struct MaxWindow<'a, T: NativeType> {
+    slice: &'a [T],
+    max: T,
+    last_start: usize,
+    last_end: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindow<'a, T> for MaxWindow<'a, T> {
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        let max = *slice[start..end]
+            .iter()
+            .max_by(|a, b| compare_fn(*a, *b))
+            .unwrap();
+        Self {
+            slice,
+            max,
+            last_start: start,
+            last_end: end,
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        // remove elements that should leave the window
+        let mut recompute_max = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let leaving_value = self.slice.get_unchecked(idx);
+            // if the leaving value is the max value, we need to recompute the max.
+            if matches!(compare_fn(leaving_value, &self.max), Ordering::Equal) {
+                recompute_max = true;
+                break;
+            }
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if recompute_max {
+            self.max = *self
+                .slice
+                .get_unchecked(start..end)
+                .iter()
+                .max_by(|a, b| compare_fn(*a, *b))
+                .unwrap_unchecked();
+        }
+        // the max has not left the window, so we only check
+        // if the entering values are larger
+        else if end > self.last_end {
+            let max_entering = self
+                .slice
+                .get_unchecked(self.last_end..end)
+                .iter()
+                .max_by(|a, b| compare_fn(*a, *b))
+                .unwrap_unchecked();
+            if matches!(compare_fn(max_entering, &self.max), Ordering::Greater) {
+                self.max = *max_entering
+            }
+        }
+        self.last_end = end;
+        self.max
+    }
+}
+
+pub(super) fn rolling_apply<'a, Agg, T, Fo>(
+    values: &'a [T],
+    window_size: usize,
+    min_periods: usize,
+    det_offsets_fn: Fo,
+) -> ArrayRef
+where
+    Fo: Fn(Idx, WindowSize, Len) -> (Start, End),
+    Agg: RollingAggWindow<'a, T>,
+    T: Debug + PartialOrd + IsFloat + NativeType,
+{
+    let len = values.len();
+    let (start, end) = det_offsets_fn(0, window_size, len);
+    let mut agg_window = Agg::new(values, start, end);
+
+    let out = (0..len)
+        .map(|idx| {
+            let (start, end) = det_offsets_fn(idx, window_size, len);
+            // safety:
+            // we are in bounds
+            unsafe { agg_window.update(start, end) }
+        })
+        .collect_trusted::<Vec<_>>();
+
+    let validity = create_validity(min_periods, len as usize, window_size, det_offsets_fn);
+    Arc::new(PrimitiveArray::from_data(
+        T::PRIMITIVE.into(),
+        out.into(),
+        validity.map(|b| b.into()),
+    ))
+}
+
+pub(crate) fn compute_min<T>(values: &[T]) -> T
+where
+    T: NativeType + PartialOrd + IsFloat + Bounded,
+{
+    let mut min = T::max_value();
+
+    for &v in values {
+        if T::is_float() && v.is_nan() {
+            return v;
+        }
+        if v < min {
+            min = v
+        }
+    }
+    min
+}
+
+pub(crate) fn compute_min_weights<T>(values: &[T], weights: &[T]) -> T
+where
+    T: NativeType + PartialOrd + std::ops::Mul<Output = T>,
+{
+    values
+        .iter()
+        .zip(weights)
+        .map(|(v, w)| *v * *w)
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap()
+}
+
+pub(crate) fn compute_max<T>(values: &[T]) -> T
+where
+    T: NativeType + PartialOrd + IsFloat + Bounded,
+{
+    let mut max = T::min_value();
+
+    for &v in values {
+        if T::is_float() && v.is_nan() {
+            return v;
+        }
+        if v > max {
+            max = v
+        }
+    }
+    max
+}
+
+pub(crate) fn compute_max_weights<T>(values: &[T], weights: &[T]) -> T
+where
+    T: NativeType + PartialOrd + IsFloat + Bounded + Mul<Output = T>,
+{
+    let mut max = T::min_value();
+    for v in values.iter().zip(weights).map(|(v, w)| *v * *w) {
+        if T::is_float() && v.is_nan() {
+            return v;
+        }
+        if v > max {
+            max = v
+        }
+    }
+
+    max
+}
+
+pub fn rolling_max<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + PartialOrd + IsFloat + Bounded + NumCast + Mul<Output = T>,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply::<MaxWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => {
+            no_nulls::rolling_apply(values, window_size, min_periods, det_offsets, compute_max)
+        }
+        (true, Some(weights)) => {
+            assert!(
+                T::is_float(),
+                "implementation error, should only be reachable by float types"
+            );
+            let weights = weights
+                .iter()
+                .map(|v| NumCast::from(*v).unwrap())
+                .collect::<Vec<_>>();
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                compute_max_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            assert!(
+                T::is_float(),
+                "implementation error, should only be reachable by float types"
+            );
+            let weights = weights
+                .iter()
+                .map(|v| NumCast::from(*v).unwrap())
+                .collect::<Vec<_>>();
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                compute_max_weights,
+                &weights,
+            )
+        }
+    }
+}
+
+pub fn rolling_min<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + PartialOrd + NumCast + Mul<Output = T> + Bounded + IsFloat,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply::<MinWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => {
+            rolling_apply::<MinWindow<_>, _, _>(values, window_size, min_periods, det_offsets)
+        }
+        (true, Some(weights)) => {
+            assert!(
+                T::is_float(),
+                "implementation error, should only be reachable by float types"
+            );
+            let weights = weights
+                .iter()
+                .map(|v| NumCast::from(*v).unwrap())
+                .collect::<Vec<_>>();
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                compute_min_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            assert!(
+                T::is_float(),
+                "implementation error, should only be reachable by float types"
+            );
+            let weights = weights
+                .iter()
+                .map(|v| NumCast::from(*v).unwrap())
+                .collect::<Vec<_>>();
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                compute_min_weights,
+                &weights,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rolling_min_max() {
+        let values = &[1.0f64, 5.0, 3.0, 4.0];
+
+        let out = rolling_min(values, 2, 2, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, Some(1.0), Some(3.0), Some(3.0)]);
+        let out = rolling_max(values, 2, 2, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, Some(5.0), Some(5.0), Some(4.0)]);
+
+        let out = rolling_min(values, 2, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(1.0), Some(3.0), Some(3.0)]);
+        let out = rolling_max(values, 2, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(5.0), Some(5.0), Some(4.0)]);
+
+        let out = rolling_max(values, 3, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(5.0), Some(5.0), Some(5.0)]);
+    }
+}

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -27,7 +27,26 @@ type Idx = usize;
 type WindowSize = usize;
 type Len = usize;
 
-fn compare_fn<T>(a: &T, b: &T) -> Ordering
+fn compare_fn_nan_min<T>(a: &T, b: &T) -> Ordering
+where
+    T: PartialOrd + IsFloat + NativeType,
+{
+    if T::is_float() {
+        match (a.is_nan(), b.is_nan()) {
+            // safety: we checked nans
+            (false, false) => unsafe { a.partial_cmp(b).unwrap_unchecked() },
+            (true, true) => Ordering::Equal,
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+        }
+    } else {
+        // Safety:
+        // all integers are Ord
+        unsafe { a.partial_cmp(b).unwrap_unchecked() }
+    }
+}
+
+fn compare_fn_nan_max<T>(a: &T, b: &T) -> Ordering
 where
     T: PartialOrd + IsFloat + NativeType,
 {

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -1,8 +1,8 @@
-pub mod min_max_no_nulls;
 pub mod no_nulls;
 pub mod nulls;
 pub mod quantile_no_nulls;
 pub mod quantile_nulls;
+pub mod sum_min_max_no_nulls;
 mod window;
 
 use crate::data_types::IsFloat;

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -1,8 +1,9 @@
+mod mean_no_nulls;
 pub mod no_nulls;
 pub mod nulls;
-pub mod quantile_no_nulls;
-pub mod quantile_nulls;
-pub mod sum_min_max_no_nulls;
+mod quantile_no_nulls;
+mod quantile_nulls;
+mod sum_min_max_no_nulls;
 mod window;
 
 use crate::data_types::IsFloat;
@@ -12,12 +13,10 @@ use arrow::array::{ArrayRef, PrimitiveArray};
 use arrow::bitmap::utils::{count_zeros, get_bit_unchecked};
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::NativeType;
-use core::fmt::Debug;
 use num::ToPrimitive;
 use num::{Bounded, Float, NumCast, One, Zero};
 use std::cmp::Ordering;
-use std::ops::AddAssign;
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use std::sync::Arc;
 use window::*;
 

--- a/polars/polars-arrow/src/kernels/rolling/nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls.rs
@@ -153,7 +153,7 @@ where
 {
     let null_count = count_zeros(validity_bytes, offset, values.len());
     if null_count == 0 {
-        Some(no_nulls::compute_min(values))
+        Some(min_max_no_nulls::compute_min(values))
     } else if (values.len() - null_count) < min_periods {
         None
     } else {
@@ -189,7 +189,7 @@ where
 {
     let null_count = count_zeros(validity_bytes, offset, values.len());
     if null_count == 0 {
-        Some(no_nulls::compute_max(values))
+        Some(min_max_no_nulls::compute_max(values))
     } else if (values.len() - null_count) < min_periods {
         None
     } else {

--- a/polars/polars-arrow/src/kernels/rolling/nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls.rs
@@ -153,7 +153,7 @@ where
 {
     let null_count = count_zeros(validity_bytes, offset, values.len());
     if null_count == 0 {
-        Some(min_max_no_nulls::compute_min(values))
+        Some(sum_min_max_no_nulls::compute_min(values))
     } else if (values.len() - null_count) < min_periods {
         None
     } else {
@@ -189,7 +189,7 @@ where
 {
     let null_count = count_zeros(validity_bytes, offset, values.len());
     if null_count == 0 {
-        Some(min_max_no_nulls::compute_max(values))
+        Some(sum_min_max_no_nulls::compute_max(values))
     } else if (values.len() - null_count) < min_periods {
         None
     } else {

--- a/polars/polars-arrow/src/kernels/rolling/nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls.rs
@@ -1,4 +1,5 @@
 use super::*;
+pub use quantile_nulls::{rolling_median, rolling_quantile};
 
 fn rolling_apply<T, K, Fo, Fa>(
     values: &[T],

--- a/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
@@ -242,7 +242,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::kernels::rolling::min_max_no_nulls::{rolling_max, rolling_min};
+    use crate::kernels::rolling::sum_min_max_no_nulls::{rolling_max, rolling_min};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
 

--- a/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
@@ -242,7 +242,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::kernels::rolling::no_nulls::{rolling_max, rolling_min};
+    use crate::kernels::rolling::min_max_no_nulls::{rolling_max, rolling_min};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
 
@@ -318,7 +318,7 @@ mod test {
 
     #[test]
     fn test_rolling_quantile_limits() {
-        let values = &[1.0, 2.0, 3.0, 4.0];
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
 
         let interpol_options = vec![
             QuantileInterpolOptions::Lower,

--- a/polars/polars-arrow/src/kernels/rolling/sum_min_max_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/sum_min_max_no_nulls.rs
@@ -1,10 +1,69 @@
 use super::*;
 use no_nulls;
+use std::ops::SubAssign;
 
-pub(crate) trait RollingAggWindow<'a, T: NativeType + IsFloat + PartialOrd> {
+pub(crate) trait RollingAggWindow<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;
 
     unsafe fn update(&mut self, start: usize, end: usize) -> T;
+}
+
+struct SumWindow<'a, T: NativeType + IsFloat> {
+    slice: &'a [T],
+    sum: T,
+    last_start: usize,
+    last_end: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign> RollingAggWindow<'a, T>
+    for SumWindow<'a, T>
+{
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        let sum = slice[start..end].iter().copied().sum::<T>();
+        Self {
+            slice,
+            sum,
+            last_start: start,
+            last_end: end,
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        // remove elements that should leave the window
+        let mut recompute_sum = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let leaving_value = self.slice.get_unchecked(idx);
+
+            if T::is_float() && leaving_value.is_nan() {
+                recompute_sum = true;
+                break;
+            }
+
+            self.sum -= *leaving_value;
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if T::is_float() && recompute_sum {
+            self.sum = self
+                .slice
+                .get_unchecked(start..end)
+                .iter()
+                .copied()
+                .sum::<T>();
+        }
+        // the max has not left the window, so we only check
+        // if the entering values are larger
+        else {
+            for idx in self.last_end..end {
+                self.sum += *self.slice.get_unchecked(idx);
+            }
+        }
+        self.last_end = end;
+        self.sum
+    }
 }
 
 struct MinWindow<'a, T: NativeType + PartialOrd + IsFloat> {
@@ -153,7 +212,7 @@ pub(super) fn rolling_apply<'a, Agg, T, Fo>(
 where
     Fo: Fn(Idx, WindowSize, Len) -> (Start, End),
     Agg: RollingAggWindow<'a, T>,
-    T: Debug + PartialOrd + IsFloat + NativeType,
+    T: Debug + IsFloat + NativeType,
 {
     let len = values.len();
     let (start, end) = det_offsets_fn(0, window_size, len);
@@ -357,6 +416,51 @@ where
     }
 }
 
+pub fn rolling_sum<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + std::iter::Sum + NumCast + Mul<Output = T> + AddAssign + SubAssign + IsFloat,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply::<SumWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => {
+            rolling_apply::<SumWindow<_>, _, _>(values, window_size, min_periods, det_offsets)
+        }
+        (true, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                no_nulls::compute_sum_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                no_nulls::compute_sum_weights,
+                &weights,
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -425,6 +529,60 @@ mod test {
                     Some(f64::nan()),
                     Some(f64::nan()),
                     Some(7.0)
+                ]
+            )
+        );
+    }
+
+    use super::*;
+
+    #[test]
+    fn test_rolling_sum() {
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
+
+        let out = rolling_sum(values, 2, 2, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, Some(3.0), Some(5.0), Some(7.0)]);
+
+        let out = rolling_sum(values, 2, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(3.0), Some(5.0), Some(7.0)]);
+
+        let out = rolling_sum(values, 4, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(3.0), Some(6.0), Some(10.0)]);
+
+        let out = rolling_sum(values, 4, 1, true, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(3.0), Some(6.0), Some(10.0), Some(9.0)]);
+
+        let out = rolling_sum(values, 4, 4, true, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, Some(10.0), None]);
+
+        // test nan handling.
+        let values = &[1.0, 2.0, 3.0, f64::nan(), 5.0, 6.0, 7.0];
+        let out = rolling_sum(values, 3, 3, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+
+        assert_eq!(
+            format!("{:?}", out.as_slice()),
+            format!(
+                "{:?}",
+                &[
+                    None,
+                    None,
+                    Some(6.0),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(18.0)
                 ]
             )
         );

--- a/polars/polars-arrow/src/kernels/rolling/window.rs
+++ b/polars/polars-arrow/src/kernels/rolling/window.rs
@@ -35,7 +35,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> SortedBuf<'a, T> {
             // value is present in buf
             let remove_idx = self
                 .buf
-                .binary_search_by(|a| compare_fn(a, val))
+                .binary_search_by(|a| compare_fn_nan_max(a, val))
                 .unwrap_unchecked();
             // this is O(n) but we need a sorted window
             self.buf.remove(remove_idx);
@@ -49,7 +49,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> SortedBuf<'a, T> {
             let val = *self.slice.get_unchecked(idx);
             let insertion_idx = self
                 .buf
-                .binary_search_by(|a| compare_fn(a, &val))
+                .binary_search_by(|a| compare_fn_nan_max(a, &val))
                 .unwrap_or_else(|insertion_idx| insertion_idx);
 
             // this is O(n) but we need a sorted window

--- a/polars/polars-arrow/src/kernels/rolling/window.rs
+++ b/polars/polars-arrow/src/kernels/rolling/window.rs
@@ -1,24 +1,5 @@
 use super::*;
 
-fn compare_fn<T>(a: &T, b: &T) -> Ordering
-where
-    T: PartialOrd + IsFloat + NativeType,
-{
-    if T::is_float() {
-        match (a.is_nan(), b.is_nan()) {
-            // safety: we checked nans
-            (false, false) => unsafe { a.partial_cmp(b).unwrap_unchecked() },
-            (true, true) => Ordering::Equal,
-            (true, false) => Ordering::Greater,
-            (false, true) => Ordering::Less,
-        }
-    } else {
-        // Safety:
-        // all integers are Ord
-        unsafe { a.partial_cmp(b).unwrap_unchecked() }
-    }
-}
-
 pub(super) struct SortedBuf<'a, T: NativeType + IsFloat + PartialOrd> {
     // slice over which the window slides
     slice: &'a [T],

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod array;
 pub mod bit_util;
 mod bitmap;

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -33,6 +33,7 @@ mod inner_mod {
     use polars_arrow::prelude::QuantileInterpolOptions;
     use polars_arrow::{kernels::rolling, trusted_len::PushUnchecked};
     use std::convert::TryFrom;
+    use std::ops::SubAssign;
 
     fn rolling_agg<T, F1, F2>(
         ca: &ChunkedArray<T>,
@@ -92,7 +93,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::no_nulls::rolling_sum,
+                        rolling::sum_min_max_no_nulls::rolling_sum,
                         rolling::nulls::rolling_sum,
                     )
                 }
@@ -105,7 +106,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::min_max_no_nulls::rolling_min,
+                        rolling::sum_min_max_no_nulls::rolling_min,
                         rolling::nulls::rolling_min,
                     )
                 }
@@ -118,7 +119,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::min_max_no_nulls::rolling_max,
+                        rolling::sum_min_max_no_nulls::rolling_max,
                         rolling::nulls::rolling_max,
                     )
                 }
@@ -180,7 +181,7 @@ mod inner_mod {
     impl<T> ChunkedArray<T>
     where
         T: PolarsIntegerType,
-        T::Native: IsFloat,
+        T::Native: IsFloat + SubAssign,
     {
         /// Apply a rolling sum (moving sum) over the values in this array.
         /// A window of length `window_size` will traverse the array. The values that fill this window
@@ -193,7 +194,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::no_nulls::rolling_sum,
+                rolling::sum_min_max_no_nulls::rolling_sum,
                 rolling::nulls::rolling_sum,
             )
         }
@@ -229,7 +230,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::min_max_no_nulls::rolling_min,
+                rolling::sum_min_max_no_nulls::rolling_min,
                 rolling::nulls::rolling_min,
             )
         }
@@ -245,7 +246,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::min_max_no_nulls::rolling_max,
+                rolling::sum_min_max_no_nulls::rolling_max,
                 rolling::nulls::rolling_max,
             )
         }

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -105,7 +105,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::no_nulls::rolling_min,
+                        rolling::min_max_no_nulls::rolling_min,
                         rolling::nulls::rolling_min,
                     )
                 }
@@ -118,7 +118,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::no_nulls::rolling_max,
+                        rolling::min_max_no_nulls::rolling_max,
                         rolling::nulls::rolling_max,
                     )
                 }
@@ -229,7 +229,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::no_nulls::rolling_min,
+                rolling::min_max_no_nulls::rolling_min,
                 rolling::nulls::rolling_min,
             )
         }
@@ -245,7 +245,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::no_nulls::rolling_max,
+                rolling::min_max_no_nulls::rolling_max,
                 rolling::nulls::rolling_max,
             )
         }

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -93,7 +93,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::sum_min_max_no_nulls::rolling_sum,
+                        rolling::no_nulls::rolling_sum,
                         rolling::nulls::rolling_sum,
                     )
                 }
@@ -106,7 +106,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::sum_min_max_no_nulls::rolling_min,
+                        rolling::no_nulls::rolling_min,
                         rolling::nulls::rolling_min,
                     )
                 }
@@ -119,7 +119,7 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::sum_min_max_no_nulls::rolling_max,
+                        rolling::no_nulls::rolling_max,
                         rolling::nulls::rolling_max,
                     )
                 }
@@ -131,8 +131,8 @@ mod inner_mod {
                     rolling_agg(
                         self,
                         options,
-                        rolling::quantile_no_nulls::rolling_median,
-                        rolling::quantile_nulls::rolling_median,
+                        rolling::no_nulls::rolling_median,
+                        rolling::nulls::rolling_median,
                     )
                 }
 
@@ -150,7 +150,7 @@ mod inner_mod {
 
                     let arr = ca.downcast_iter().next().unwrap();
                     let arr = match self.has_validity() {
-                        false => rolling::quantile_no_nulls::rolling_quantile(
+                        false => rolling::no_nulls::rolling_quantile(
                             arr.values(),
                             quantile,
                             interpolation,
@@ -159,7 +159,7 @@ mod inner_mod {
                             options.center,
                             options.weights.as_deref(),
                         ),
-                        _ => rolling::quantile_nulls::rolling_quantile(
+                        _ => rolling::nulls::rolling_quantile(
                             arr,
                             quantile,
                             interpolation,
@@ -194,7 +194,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::sum_min_max_no_nulls::rolling_sum,
+                rolling::no_nulls::rolling_sum,
                 rolling::nulls::rolling_sum,
             )
         }
@@ -230,7 +230,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::sum_min_max_no_nulls::rolling_min,
+                rolling::no_nulls::rolling_min,
                 rolling::nulls::rolling_min,
             )
         }
@@ -246,7 +246,7 @@ mod inner_mod {
             rolling_agg(
                 self,
                 options,
-                rolling::sum_min_max_no_nulls::rolling_max,
+                rolling::no_nulls::rolling_max,
                 rolling::nulls::rolling_max,
             )
         }


### PR DESCRIPTION
Also improvements to `rolling_min`/ `rolling_max` kernels. They can maintain a rolling `min`/`max` state. No need to to do an `O(n)` operation at every new window.

We can do the same with `sum`. Will add that to this PR.

```rust
bench_1                 time:   [543.66 us 544.71 us 546.00 us]
                        change: [-70.677% -70.627% -70.585%] (p = 0.00 < 0.05)
                        Performance has improved.

```