### PR TITLE
improve rolling_min/max for columns with null values

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/mean_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mean_no_nulls.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::kernels::rolling::sum_min_max_no_nulls::SumWindow;
+use crate::kernels::rolling::sum_no_nulls::SumWindow;
 use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
 
 struct MeanWindow<'a, T> {

--- a/polars/polars-arrow/src/kernels/rolling/min_max_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/min_max_nulls.rs
@@ -1,0 +1,309 @@
+use super::*;
+use nulls;
+use nulls::{rolling_apply_agg_window, RollingAggWindow};
+
+struct MinWindow<'a, T: NativeType + PartialOrd + IsFloat> {
+    slice: &'a [T],
+    validity: &'a Bitmap,
+    min: Option<T>,
+    last_start: usize,
+    last_end: usize,
+    null_count: usize,
+    min_periods: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> MinWindow<'a, T> {
+    // compute min from the entire window
+    unsafe fn compute_min_and_null_count(&mut self, start: usize, end: usize) -> Option<T> {
+        let mut min = None;
+        let mut idx = start;
+        self.null_count = 0;
+        for value in (&self.slice[start..end]).iter() {
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                match min {
+                    None => min = Some(*value),
+                    Some(current) => {
+                        min = Some(std::cmp::min_by(*value, current, compare_fn_nan_min))
+                    }
+                }
+            } else {
+                self.null_count += 1;
+            }
+            idx += 1;
+        }
+        self.min = min;
+        min
+    }
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindow<'a, T> for MinWindow<'a, T> {
+    unsafe fn new(
+        slice: &'a [T],
+        validity: &'a Bitmap,
+        start: usize,
+        end: usize,
+        min_periods: usize,
+    ) -> Self {
+        let mut out = Self {
+            slice,
+            validity,
+            min: None,
+            last_start: start,
+            last_end: end,
+            null_count: 0,
+            min_periods,
+        };
+        out.compute_min_and_null_count(start, end);
+        out
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
+        // remove elements that should leave the window
+        let mut recompute_min = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                let leaving_value = self.slice.get_unchecked(idx);
+
+                // if the leaving value is the
+                // max value, we need to recompute the max.
+                if matches!(
+                    compare_fn_nan_min(leaving_value, &self.min.unwrap()),
+                    Ordering::Equal
+                ) {
+                    recompute_min = true;
+                    break;
+                }
+            } else {
+                // null value leaving the window
+                self.null_count -= 1;
+
+                // self.min is None and the leaving value is None
+                // if the entering value is valid, we might get a new min.
+                if self.min.is_none() {
+                    recompute_min = true;
+                    break;
+                }
+            }
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if recompute_min {
+            self.compute_min_and_null_count(start, end);
+        } else {
+            // the max has not left the window, so we only check
+            // if the entering values are larger
+            for idx in self.last_end..end {
+                let valid = self.validity.get_bit_unchecked(idx);
+
+                if valid {
+                    let value = *self.slice.get_unchecked(idx);
+                    match self.min {
+                        None => self.min = Some(value),
+                        Some(current) => {
+                            self.min = Some(std::cmp::min_by(value, current, compare_fn_nan_min))
+                        }
+                    }
+                } else {
+                    // null value entering the window
+                    self.null_count += 1;
+                }
+            }
+        }
+        self.last_end = end;
+        if ((end - start) - self.null_count) < self.min_periods {
+            None
+        } else {
+            self.min
+        }
+    }
+}
+
+pub fn rolling_min<T>(
+    arr: &PrimitiveArray<T>,
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,
+{
+    if weights.is_some() {
+        panic!("weights not yet supported on array with null values")
+    }
+    if center {
+        rolling_apply_agg_window::<MinWindow<_>, _, _>(
+            arr.values().as_slice(),
+            arr.validity().as_ref().unwrap(),
+            window_size,
+            min_periods,
+            det_offsets_center,
+        )
+    } else {
+        rolling_apply_agg_window::<MinWindow<_>, _, _>(
+            arr.values().as_slice(),
+            arr.validity().as_ref().unwrap(),
+            window_size,
+            min_periods,
+            det_offsets,
+        )
+    }
+}
+
+struct MaxWindow<'a, T: NativeType + PartialOrd + IsFloat> {
+    slice: &'a [T],
+    validity: &'a Bitmap,
+    max: Option<T>,
+    last_start: usize,
+    last_end: usize,
+    null_count: usize,
+    min_periods: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> MaxWindow<'a, T> {
+    // compute max from the entire window
+    unsafe fn compute_max_and_null_count(&mut self, start: usize, end: usize) -> Option<T> {
+        let mut max = None;
+        let mut idx = start;
+        self.null_count = 0;
+        for value in (&self.slice[start..end]).iter() {
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                match max {
+                    None => max = Some(*value),
+                    Some(current) => {
+                        max = Some(std::cmp::max_by(*value, current, compare_fn_nan_max))
+                    }
+                }
+            } else {
+                self.null_count += 1;
+            }
+            idx += 1;
+        }
+        self.max = max;
+        max
+    }
+}
+
+impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindow<'a, T> for MaxWindow<'a, T> {
+    unsafe fn new(
+        slice: &'a [T],
+        validity: &'a Bitmap,
+        start: usize,
+        end: usize,
+        min_periods: usize,
+    ) -> Self {
+        let mut out = Self {
+            slice,
+            validity,
+            max: None,
+            last_start: start,
+            last_end: end,
+            null_count: 0,
+            min_periods,
+        };
+        out.compute_max_and_null_count(start, end);
+        out
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
+        // remove elements that should leave the window
+        let mut recompute_max = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                let leaving_value = self.slice.get_unchecked(idx);
+
+                // if the leaving value is the
+                // max value, we need to recompute the max.
+                if matches!(
+                    compare_fn_nan_max(leaving_value, &self.max.unwrap()),
+                    Ordering::Equal
+                ) {
+                    recompute_max = true;
+                    break;
+                }
+            } else {
+                // null value leaving the window
+                self.null_count -= 1;
+
+                // self.max is None and the leaving value is None
+                // if the entering value is valid, we might get a new max.
+                if self.max.is_none() {
+                    recompute_max = true;
+                    break;
+                }
+            }
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if recompute_max {
+            self.compute_max_and_null_count(start, end);
+        } else {
+            // the max has not left the window, so we only check
+            // if the entering values are larger
+            for idx in self.last_end..end {
+                let valid = self.validity.get_bit_unchecked(idx);
+
+                if valid {
+                    let value = *self.slice.get_unchecked(idx);
+                    match self.max {
+                        None => self.max = Some(value),
+                        Some(current) => {
+                            self.max = Some(std::cmp::max_by(value, current, compare_fn_nan_max))
+                        }
+                    }
+                } else {
+                    // null value entering the window
+                    self.null_count += 1;
+                }
+            }
+        }
+        self.last_end = end;
+        if ((end - start) - self.null_count) < self.min_periods {
+            None
+        } else {
+            self.max
+        }
+    }
+}
+
+pub fn rolling_max<T>(
+    arr: &PrimitiveArray<T>,
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,
+{
+    if weights.is_some() {
+        panic!("weights not yet supported on array with null values")
+    }
+    if center {
+        rolling_apply_agg_window::<MaxWindow<_>, _, _>(
+            arr.values().as_slice(),
+            arr.validity().as_ref().unwrap(),
+            window_size,
+            min_periods,
+            det_offsets_center,
+        )
+    } else {
+        rolling_apply_agg_window::<MaxWindow<_>, _, _>(
+            arr.values().as_slice(),
+            arr.validity().as_ref().unwrap(),
+            window_size,
+            min_periods,
+            det_offsets,
+        )
+    }
+}

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -1,9 +1,11 @@
 mod mean_no_nulls;
+mod min_max_no_nulls;
+mod min_max_nulls;
 pub mod no_nulls;
 pub mod nulls;
 mod quantile_no_nulls;
 mod quantile_nulls;
-mod sum_min_max_no_nulls;
+mod sum_no_nulls;
 mod window;
 
 use crate::data_types::IsFloat;

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls.rs
@@ -10,6 +10,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 pub use mean_no_nulls::rolling_mean;
+pub use min_max_no_nulls::{rolling_max, rolling_min};
+pub use quantile_no_nulls::{rolling_median, rolling_quantile};
+pub use sum_no_nulls::rolling_sum;
 
 pub(crate) trait RollingAggWindow<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;
@@ -49,9 +52,6 @@ where
         validity.map(|b| b.into()),
     ))
 }
-
-pub use quantile_no_nulls::{rolling_median, rolling_quantile};
-pub use sum_min_max_no_nulls::{rolling_max, rolling_min, rolling_sum};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/quantile_no_nulls.rs
@@ -242,7 +242,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::kernels::rolling::sum_min_max_no_nulls::{rolling_max, rolling_min};
+    use crate::kernels::rolling::min_max_no_nulls::{rolling_max, rolling_min};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
 

--- a/polars/polars-arrow/src/kernels/rolling/sum_no_nulls.rs
+++ b/polars/polars-arrow/src/kernels/rolling/sum_no_nulls.rs
@@ -1,0 +1,165 @@
+use super::*;
+use no_nulls;
+use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
+
+pub(super) struct SumWindow<'a, T> {
+    slice: &'a [T],
+    sum: T,
+    last_start: usize,
+    last_end: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign> RollingAggWindow<'a, T>
+    for SumWindow<'a, T>
+{
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        let sum = slice[start..end].iter().copied().sum::<T>();
+        Self {
+            slice,
+            sum,
+            last_start: start,
+            last_end: end,
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        // remove elements that should leave the window
+        let mut recompute_sum = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let leaving_value = self.slice.get_unchecked(idx);
+
+            if T::is_float() && leaving_value.is_nan() {
+                recompute_sum = true;
+                break;
+            }
+
+            self.sum -= *leaving_value;
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if T::is_float() && recompute_sum {
+            self.sum = self
+                .slice
+                .get_unchecked(start..end)
+                .iter()
+                .copied()
+                .sum::<T>();
+        }
+        // the max has not left the window, so we only check
+        // if the entering values are larger
+        else {
+            for idx in self.last_end..end {
+                self.sum += *self.slice.get_unchecked(idx);
+            }
+        }
+        self.last_end = end;
+        self.sum
+    }
+}
+
+pub fn rolling_sum<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType + std::iter::Sum + NumCast + Mul<Output = T> + AddAssign + SubAssign + IsFloat,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply_agg_window::<SumWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => rolling_apply_agg_window::<SumWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets,
+        ),
+        (true, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                no_nulls::compute_sum_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            let weights = no_nulls::coerce_weights(weights);
+            no_nulls::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                no_nulls::compute_sum_weights,
+                &weights,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_rolling_sum() {
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
+
+        let out = rolling_sum(values, 2, 2, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, Some(3.0), Some(5.0), Some(7.0)]);
+
+        let out = rolling_sum(values, 2, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(3.0), Some(5.0), Some(7.0)]);
+
+        let out = rolling_sum(values, 4, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(1.0), Some(3.0), Some(6.0), Some(10.0)]);
+
+        let out = rolling_sum(values, 4, 1, true, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(3.0), Some(6.0), Some(10.0), Some(9.0)]);
+
+        let out = rolling_sum(values, 4, 4, true, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, Some(10.0), None]);
+
+        // test nan handling.
+        let values = &[1.0, 2.0, 3.0, f64::nan(), 5.0, 6.0, 7.0];
+        let out = rolling_sum(values, 3, 3, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+
+        assert_eq!(
+            format!("{:?}", out.as_slice()),
+            format!(
+                "{:?}",
+                &[
+                    None,
+                    None,
+                    Some(6.0),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(18.0)
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
Same optimizations as previous PR's. We keep a state with the rolling aggregate and only check the incoming and outgoing values and determine if state needs to be updated.