### PR TITLE
improve `rolling_var` performance

### DIFF
--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           toolchain: nightly-2022-05-20
           override: true
-          components: rustfmt, clippy
+          components: rustfmt
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
@@ -29,7 +29,6 @@ jobs:
         run: |
           export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-05-01 && make build-and-test-no-venv
-          cargo clippy
       # test if we can import polars without any requirements
       - name: Import polars
         run: |

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -6,7 +6,6 @@ use crate::data_types::IsFloat;
 use crate::prelude::QuantileInterpolOptions;
 use crate::utils::CustomIterTools;
 use arrow::array::{ArrayRef, PrimitiveArray};
-use arrow::bitmap::utils::{count_zeros, get_bit_unchecked};
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::NativeType;
 use num::ToPrimitive;

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
@@ -2,7 +2,7 @@ use super::sum::SumWindow;
 use super::*;
 use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
 
-struct MeanWindow<'a, T> {
+pub(super) struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,
 }
 

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -108,24 +108,6 @@ where
     ))
 }
 
-pub(crate) fn compute_var<T>(vals: &[T]) -> T
-where
-    T: Float + std::ops::AddAssign + std::fmt::Debug,
-{
-    let mut sum = T::zero();
-    let mut sum_of_squares = T::zero();
-
-    for &val in vals {
-        sum += val;
-        sum_of_squares += val * val;
-    }
-    let count = NumCast::from(vals.len()).unwrap();
-
-    let mean = sum / count;
-    // apply Bessel's correction
-    ((sum_of_squares / count) - mean * mean) / (count - T::one()) * count
-}
-
 fn compute_var_weights<T>(vals: &[T], weights: &[T]) -> T
 where
     T: Float + std::ops::AddAssign,
@@ -144,13 +126,6 @@ where
     let mean = sum / count;
     // apply Bessel's correction
     ((sum_of_squares / count) - mean * mean) / (count - T::one()) * count
-}
-
-pub(crate) fn compute_mean<T>(values: &[T]) -> T
-where
-    T: Float + std::iter::Sum<T>,
-{
-    values.iter().copied().sum::<T>() / T::from(values.len()).unwrap()
 }
 
 pub(crate) fn compute_mean_weights<T>(values: &[T], weights: &[T]) -> T

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -2,6 +2,7 @@ mod mean;
 mod min_max;
 mod quantile;
 mod sum;
+mod variance;
 
 use super::*;
 use crate::utils::CustomIterTools;
@@ -18,6 +19,7 @@ pub use mean::rolling_mean;
 pub use min_max::{rolling_max, rolling_min};
 pub use quantile::{rolling_median, rolling_quantile};
 pub use sum::rolling_sum;
+pub use variance::rolling_var;
 
 pub(crate) trait RollingAggWindow<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;
@@ -106,49 +108,18 @@ where
     ))
 }
 
-pub(super) fn rolling_apply<T, K, Fo, Fa>(
-    values: &[T],
-    window_size: usize,
-    min_periods: usize,
-    det_offsets_fn: Fo,
-    aggregator: Fa,
-) -> ArrayRef
-where
-    Fo: Fn(Idx, WindowSize, Len) -> (Start, End),
-    Fa: Fn(&[T]) -> K,
-    K: NativeType,
-    T: Debug,
-{
-    let len = values.len();
-    let out = (0..len)
-        .map(|idx| {
-            let (start, end) = det_offsets_fn(idx, window_size, len);
-            let vals = unsafe { values.get_unchecked(start..end) };
-            aggregator(vals)
-        })
-        .collect_trusted::<Vec<K>>();
-
-    let validity = create_validity(min_periods, len as usize, window_size, det_offsets_fn);
-    Arc::new(PrimitiveArray::from_data(
-        K::PRIMITIVE.into(),
-        out.into(),
-        validity.map(|b| b.into()),
-    ))
-}
-
 pub(crate) fn compute_var<T>(vals: &[T]) -> T
 where
     T: Float + std::ops::AddAssign + std::fmt::Debug,
 {
-    let mut count = T::zero();
     let mut sum = T::zero();
     let mut sum_of_squares = T::zero();
 
     for &val in vals {
         sum += val;
         sum_of_squares += val * val;
-        count += T::one();
     }
+    let count = NumCast::from(vals.len()).unwrap();
 
     let mean = sum / count;
     // apply Bessel's correction
@@ -161,15 +132,14 @@ where
 {
     let weighted_iter = vals.iter().zip(weights).map(|(x, y)| *x * *y);
 
-    let mut count = T::zero();
     let mut sum = T::zero();
     let mut sum_of_squares = T::zero();
 
     for val in weighted_iter {
         sum += val;
         sum_of_squares += val * val;
-        count += T::one();
     }
+    let count = NumCast::from(vals.len()).unwrap();
 
     let mean = sum / count;
     // apply Bessel's correction
@@ -204,48 +174,4 @@ where
         .iter()
         .map(|v| NumCast::from(*v).unwrap())
         .collect::<Vec<_>>()
-}
-
-pub fn rolling_var<T>(
-    values: &[T],
-    window_size: usize,
-    min_periods: usize,
-    center: bool,
-    weights: Option<&[f64]>,
-) -> ArrayRef
-where
-    T: NativeType + Float + std::ops::AddAssign,
-{
-    match (center, weights) {
-        (true, None) => rolling_apply(
-            values,
-            window_size,
-            min_periods,
-            det_offsets_center,
-            compute_var,
-        ),
-        (false, None) => rolling_apply(values, window_size, min_periods, det_offsets, compute_var),
-        (true, Some(weights)) => {
-            let weights = coerce_weights(weights);
-            rolling_apply_weights(
-                values,
-                window_size,
-                min_periods,
-                det_offsets_center,
-                compute_var_weights,
-                &weights,
-            )
-        }
-        (false, Some(weights)) => {
-            let weights = coerce_weights(weights);
-            rolling_apply_weights(
-                values,
-                window_size,
-                min_periods,
-                det_offsets,
-                compute_var_weights,
-                &weights,
-            )
-        }
-    }
 }

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -1,0 +1,206 @@
+use super::mean::MeanWindow;
+use super::*;
+use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
+
+pub(super) struct SumSquaredWindow<'a, T> {
+    slice: &'a [T],
+    sum_of_squares: T,
+    last_start: usize,
+    last_end: usize,
+}
+
+impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Mul<Output = T>>
+    RollingAggWindow<'a, T> for SumSquaredWindow<'a, T>
+{
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        let sum = slice[start..end].iter().map(|v| *v * *v).sum::<T>();
+        Self {
+            slice,
+            sum_of_squares: sum,
+            last_start: start,
+            last_end: end,
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        // remove elements that should leave the window
+        let mut recompute_sum = false;
+        for idx in self.last_start..start {
+            // safety
+            // we are in bounds
+            let leaving_value = self.slice.get_unchecked(idx);
+
+            if T::is_float() && leaving_value.is_nan() {
+                recompute_sum = true;
+                break;
+            }
+
+            self.sum_of_squares -= *leaving_value * *leaving_value;
+        }
+        self.last_start = start;
+
+        // we traverese all values and compute
+        if T::is_float() && recompute_sum {
+            self.sum_of_squares = self
+                .slice
+                .get_unchecked(start..end)
+                .iter()
+                .map(|v| *v * *v)
+                .sum::<T>();
+        }
+        // the max has not left the window, so we only check
+        // if the entering values are larger
+        else {
+            for idx in self.last_end..end {
+                let entering_value = *self.slice.get_unchecked(idx);
+                self.sum_of_squares += entering_value * entering_value;
+            }
+        }
+        self.last_end = end;
+        self.sum_of_squares
+    }
+}
+
+// E[(xi - E[x])^2]
+// can be expanded to
+// E[x^2] - E[x]^2
+struct VarWindow<'a, T> {
+    mean: MeanWindow<'a, T>,
+    sum_of_squares: SumSquaredWindow<'a, T>,
+}
+
+impl<
+        'a,
+        T: NativeType
+            + IsFloat
+            + std::iter::Sum
+            + AddAssign
+            + SubAssign
+            + Div<Output = T>
+            + NumCast
+            + One
+            + Sub<Output = T>,
+    > RollingAggWindow<'a, T> for VarWindow<'a, T>
+{
+    fn new(slice: &'a [T], start: usize, end: usize) -> Self {
+        Self {
+            mean: MeanWindow::new(slice, start, end),
+            sum_of_squares: SumSquaredWindow::new(slice, start, end),
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> T {
+        let count = NumCast::from(end - start).unwrap();
+        let sum_of_squares = self.sum_of_squares.update(start, end);
+        let mean_of_squares = sum_of_squares / count;
+        let mean = self.mean.update(start, end);
+        let var = mean_of_squares - mean * mean;
+        // apply Bessel's correction
+        var / (count - T::one()) * count
+    }
+}
+
+pub fn rolling_var<T>(
+    values: &[T],
+    window_size: usize,
+    min_periods: usize,
+    center: bool,
+    weights: Option<&[f64]>,
+) -> ArrayRef
+where
+    T: NativeType
+        + Float
+        + IsFloat
+        + std::iter::Sum
+        + AddAssign
+        + SubAssign
+        + Div<Output = T>
+        + NumCast
+        + One
+        + Sub<Output = T>,
+{
+    match (center, weights) {
+        (true, None) => rolling_apply_agg_window::<VarWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets_center,
+        ),
+        (false, None) => rolling_apply_agg_window::<VarWindow<_>, _, _>(
+            values,
+            window_size,
+            min_periods,
+            det_offsets,
+        ),
+        (true, Some(weights)) => {
+            let weights = coerce_weights(weights);
+            super::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets_center,
+                compute_var_weights,
+                &weights,
+            )
+        }
+        (false, Some(weights)) => {
+            let weights = coerce_weights(weights);
+            super::rolling_apply_weights(
+                values,
+                window_size,
+                min_periods,
+                det_offsets,
+                compute_var_weights,
+                &weights,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rolling_var() {
+        let values = &[1.0f64, 5.0, 3.0, 4.0];
+
+        let out = rolling_var(values, 2, 2, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, Some(8.0), Some(2.0), Some(0.5)]);
+
+        let out = rolling_var(values, 2, 1, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out
+            .into_iter()
+            .map(|v| v.copied().unwrap())
+            .collect::<Vec<_>>();
+        // we cannot compare nans, so we compare the string values
+        assert_eq!(
+            format!("{:?}", out.as_slice()),
+            format!("{:?}", &[f64::nan(), 8.0, 2.0, 0.5])
+        );
+        // test nan handling.
+        let values = &[-10.0, 2.0, 3.0, f64::nan(), 5.0, 6.0, 7.0];
+        let out = rolling_var(values, 3, 3, false, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        // we cannot compare nans, so we compare the string values
+        assert_eq!(
+            format!("{:?}", out.as_slice()),
+            format!(
+                "{:?}",
+                &[
+                    None,
+                    None,
+                    Some(52.33333333333333),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(f64::nan()),
+                    Some(0.9999999999999964)
+                ]
+            )
+        );
+    }
+}

--- a/polars/polars-arrow/src/kernels/rolling/nulls/mean.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/mean.rs
@@ -2,19 +2,13 @@ use super::sum::SumWindow;
 use super::*;
 use super::{rolling_apply_agg_window, RollingAggWindow};
 
-struct MeanWindow<'a, T> {
+pub(super) struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,
 }
 
 impl<
         'a,
-        T: NativeType
-            + IsFloat
-            + PartialOrd
-            + Add<Output = T>
-            + Sub<Output = T>
-            + NumCast
-            + Div<Output = T>,
+        T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + NumCast + Div<Output = T>,
     > RollingAggWindow<'a, T> for MeanWindow<'a, T>
 {
     unsafe fn new(
@@ -31,7 +25,6 @@ impl<
 
     unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
         let sum = self.sum.update(start, end);
-        dbg!(sum);
         sum.map(|sum| sum / NumCast::from(end - start - self.sum.null_count).unwrap())
     }
 }

--- a/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
@@ -1,42 +1,45 @@
 use super::*;
+use mean::MeanWindow;
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindow};
 
-pub(super) struct SumWindow<'a, T> {
+pub struct SumSquaredWindow<'a, T> {
     slice: &'a [T],
     validity: &'a Bitmap,
-    sum: Option<T>,
+    sum_of_squares: Option<T>,
     last_start: usize,
     last_end: usize,
-    pub(super) null_count: usize,
+    null_count: usize,
     min_periods: usize,
 }
 
-impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> SumWindow<'a, T> {
+impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Output = T>>
+    SumSquaredWindow<'a, T>
+{
     // compute sum from the entire window
     unsafe fn compute_sum_and_null_count(&mut self, start: usize, end: usize) -> Option<T> {
-        let mut sum = None;
+        let mut sum_of_squares = None;
         let mut idx = start;
         self.null_count = 0;
         for value in (&self.slice[start..end]).iter() {
             let valid = self.validity.get_bit_unchecked(idx);
             if valid {
-                match sum {
-                    None => sum = Some(*value),
-                    Some(current) => sum = Some(*value + current),
+                match sum_of_squares {
+                    None => sum_of_squares = Some(*value * *value),
+                    Some(current) => sum_of_squares = Some(*value * *value + current),
                 }
             } else {
                 self.null_count += 1;
             }
             idx += 1;
         }
-        self.sum = sum;
-        sum
+        self.sum_of_squares = sum_of_squares;
+        sum_of_squares
     }
 }
 
-impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAggWindow<'a, T>
-    for SumWindow<'a, T>
+impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Output = T>>
+    RollingAggWindow<'a, T> for SumSquaredWindow<'a, T>
 {
     unsafe fn new(
         slice: &'a [T],
@@ -48,7 +51,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
         let mut out = Self {
             slice,
             validity,
-            sum: None,
+            sum_of_squares: None,
             last_start: start,
             last_end: end,
             null_count: 0,
@@ -66,21 +69,23 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
             // we are in bounds
             let valid = self.validity.get_bit_unchecked(idx);
             if valid {
-                let leaving_value = self.slice.get_unchecked(idx);
+                let leaving_value = *self.slice.get_unchecked(idx);
 
                 // if the leaving value is nan we need to recompute the window
                 if T::is_float() && leaving_value.is_nan() {
                     recompute_sum = true;
                     break;
                 }
-                self.sum = self.sum.map(|v| v - *leaving_value)
+                self.sum_of_squares = self
+                    .sum_of_squares
+                    .map(|v| v - leaving_value * leaving_value)
             } else {
                 // null value leaving the window
                 self.null_count -= 1;
 
                 // self.sum is None and the leaving value is None
                 // if the entering value is valid, we might get a new sum.
-                if self.sum.is_none() {
+                if self.sum_of_squares.is_none() {
                     recompute_sum = true;
                     break;
                 }
@@ -97,9 +102,10 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
 
                 if valid {
                     let value = *self.slice.get_unchecked(idx);
-                    match self.sum {
-                        None => self.sum = Some(value),
-                        Some(current) => self.sum = Some(current + value),
+                    let value = value * value;
+                    match self.sum_of_squares {
+                        None => self.sum_of_squares = Some(value),
+                        Some(current) => self.sum_of_squares = Some(current + value),
                     }
                 } else {
                     // null value entering the window
@@ -111,12 +117,60 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
         if ((end - start) - self.null_count) < self.min_periods {
             None
         } else {
-            self.sum
+            self.sum_of_squares
         }
     }
 }
 
-pub fn rolling_sum<T>(
+// E[(xi - E[x])^2]
+// can be expanded to
+// E[x^2] - E[x]^2
+struct VarWindow<'a, T> {
+    mean: MeanWindow<'a, T>,
+    sum_of_squares: SumSquaredWindow<'a, T>,
+}
+
+impl<
+        'a,
+        T: NativeType
+            + IsFloat
+            + std::iter::Sum
+            + AddAssign
+            + SubAssign
+            + Div<Output = T>
+            + NumCast
+            + One
+            + Add<Output = T>
+            + Sub<Output = T>,
+    > RollingAggWindow<'a, T> for VarWindow<'a, T>
+{
+    unsafe fn new(
+        slice: &'a [T],
+        validity: &'a Bitmap,
+        start: usize,
+        end: usize,
+        min_periods: usize,
+    ) -> Self {
+        Self {
+            mean: MeanWindow::new(slice, validity, start, end, min_periods),
+            sum_of_squares: SumSquaredWindow::new(slice, validity, start, end, min_periods),
+        }
+    }
+
+    unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
+        let sum_of_squares = self.sum_of_squares.update(start, end)?;
+        let null_count = self.sum_of_squares.null_count;
+        let count = NumCast::from(end - start - null_count).unwrap();
+
+        let mean_of_squares = sum_of_squares / count;
+        let mean = self.mean.update(start, end)?;
+        let var = mean_of_squares - mean * mean;
+        // apply Bessel's correction
+        Some(var / (count - T::one()) * count)
+    }
+}
+
+pub fn rolling_var<T>(
     arr: &PrimitiveArray<T>,
     window_size: usize,
     min_periods: usize,
@@ -124,13 +178,13 @@ pub fn rolling_sum<T>(
     weights: Option<&[f64]>,
 ) -> ArrayRef
 where
-    T: NativeType + IsFloat + PartialOrd + Add<Output = T> + Sub<Output = T>,
+    T: NativeType + std::iter::Sum<T> + Zero + AddAssign + SubAssign + IsFloat + Float,
 {
     if weights.is_some() {
         panic!("weights not yet supported on array with null values")
     }
     if center {
-        rolling_apply_agg_window::<SumWindow<_>, _, _>(
+        rolling_apply_agg_window::<VarWindow<_>, _, _>(
             arr.values().as_slice(),
             arr.validity().as_ref().unwrap(),
             window_size,
@@ -138,7 +192,7 @@ where
             det_offsets_center,
         )
     } else {
-        rolling_apply_agg_window::<SumWindow<_>, _, _>(
+        rolling_apply_agg_window::<VarWindow<_>, _, _>(
             arr.values().as_slice(),
             arr.validity().as_ref().unwrap(),
             window_size,

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -390,7 +390,7 @@ mod inner_mod {
     where
         ChunkedArray<T>: IntoSeries,
         T: PolarsFloatType,
-        T::Native: Float + IsFloat,
+        T::Native: Float + IsFloat + SubAssign,
     {
         /// Apply a rolling custom function. This is pretty slow because of dynamic dispatch.
         pub fn rolling_apply_float<F>(&self, window_size: usize, f: F) -> Result<Self>

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -1,3 +1,4 @@
+import typing
 from datetime import datetime
 
 import pandas as pd
@@ -499,13 +500,17 @@ def test_struct_arr_eval() -> None:
     }
 
 
+@typing.no_type_check
 def test_arr_unique() -> None:
     df = pl.DataFrame(
         {"col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]]}
     )
-    assert df.with_column(pl.col("col_struct").arr.unique().alias("unique")).to_dict(
-        False
-    ) == {
-        "col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]],
-        "unique": [[{"a": 2, "b": 12}, {"a": 1, "b": 11}]],
-    }
+    # the order is unpredictable
+    unique = df.with_column(pl.col("col_struct").arr.unique().alias("unique"))[
+        "unique"
+    ].to_list()
+    assert len(unique) == 1
+    unique_el = unique[0]
+    assert len(unique_el) == 2
+    assert {"a": 2, "b": 12} in unique_el
+    assert {"a": 1, "b": 11} in unique_el


### PR DESCRIPTION
This wraps the performance improvements of the `rolling_window` kernels. 

All kernels now maintain a state and will do a lot less work than previously.