### PR TITLE
add specialized rolling_std kernel

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -19,7 +19,7 @@ pub use mean::rolling_mean;
 pub use min_max::{rolling_max, rolling_min};
 pub use quantile::{rolling_median, rolling_quantile};
 pub use sum::rolling_sum;
-pub use variance::rolling_var;
+pub use variance::{rolling_std, rolling_var};
 
 pub(crate) trait RollingAggWindow<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;

--- a/polars/polars-arrow/src/kernels/rolling/nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/mod.rs
@@ -9,7 +9,7 @@ pub use mean::rolling_mean;
 pub use min_max::{rolling_max, rolling_min};
 pub use quantile::{rolling_median, rolling_quantile};
 pub use sum::rolling_sum;
-pub use variance::rolling_var;
+pub use variance::{rolling_std, rolling_var};
 
 pub(crate) trait RollingAggWindow<'a, T: NativeType> {
     unsafe fn new(


### PR DESCRIPTION
This doubles performance by doing the square root immediately.