### PR TITLE
Groupby Optimization for sorted keys: `~15x` perf gain.

### DIFF
--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -7,6 +7,7 @@ pub mod float;
 pub mod list;
 pub mod rolling;
 pub mod set;
+pub mod sort_partition;
 #[cfg(feature = "strings")]
 pub mod string;
 pub mod take;

--- a/polars/polars-arrow/src/kernels/sort_partition.rs
+++ b/polars/polars-arrow/src/kernels/sort_partition.rs
@@ -1,0 +1,147 @@
+use crate::index::IdxSize;
+use arrow::types::NativeType;
+use std::fmt::Debug;
+
+/// Find partition indexes such that every partition contains unique groups.
+fn find_partition_points<T>(values: &[T], n: usize, reverse: bool) -> Vec<usize>
+where
+    T: Debug + NativeType + PartialOrd,
+{
+    let len = values.len();
+    if n > len {
+        return find_partition_points(values, len / 2, reverse);
+    }
+    if n < 2 {
+        return vec![];
+    }
+    let chunk_size = len / n;
+
+    let mut partition_points = Vec::with_capacity(n + 1);
+
+    let mut start_idx = 0;
+    loop {
+        let end_idx = start_idx + chunk_size;
+        if end_idx >= len {
+            break;
+        }
+        // first take that partition as a slice
+        // and then find the location where the group of the latest value starts
+        let part = &values[start_idx..end_idx];
+
+        let latest_val = values[end_idx];
+        let idx = if reverse {
+            part.partition_point(|v| *v > latest_val)
+        } else {
+            part.partition_point(|v| *v < latest_val)
+        };
+
+        if idx != 0 {
+            partition_points.push(idx + start_idx)
+        }
+
+        start_idx += chunk_size;
+    }
+    partition_points
+}
+
+pub fn create_clean_partitions<T>(values: &[T], n: usize, reverse: bool) -> Vec<&[T]>
+where
+    T: Debug + NativeType + PartialOrd,
+{
+    let part_idx = find_partition_points(values, n, reverse);
+    let mut out = Vec::with_capacity(n + 1);
+
+    let mut start_idx = 0_usize;
+    for end_idx in part_idx {
+        if end_idx != start_idx {
+            out.push(&values[start_idx..end_idx]);
+            start_idx = end_idx;
+        }
+    }
+    let latest = &values[start_idx..];
+    if !latest.is_empty() {
+        out.push(latest)
+    }
+
+    out
+}
+
+/// Take a clean-partitioned slice and return the groups slices
+/// With clean-partitioned we mean that the slice contains all groups and are not spilled to another partition.
+///
+/// `first_group_offset` can be used to add insert the `null` values group.
+pub fn partition_to_groups<T>(
+    values: &[T],
+    first_group_offset: IdxSize,
+    nulls_first: bool,
+    offset: IdxSize,
+) -> Vec<[IdxSize; 2]>
+where
+    T: Debug + NativeType + PartialOrd,
+{
+    if values.is_empty() {
+        return vec![];
+    }
+    let mut first = values.get(0).unwrap();
+    let mut out = Vec::with_capacity(values.len() / 10);
+
+    if nulls_first && first_group_offset > 0 {
+        out.push([0, first_group_offset])
+    }
+
+    let mut first_idx = if nulls_first { first_group_offset } else { 0 } + offset;
+
+    for val in values {
+        // new group reached
+        if val != first {
+            let val_ptr = val as *const T;
+            let first_ptr = first as *const T;
+
+            // Safety
+            // all pointers suffice the invariants
+            let len = unsafe { val_ptr.offset_from(first_ptr) } as IdxSize;
+            out.push([first_idx, len]);
+            first_idx += len;
+            first = val;
+        }
+    }
+    // add last group
+    if nulls_first {
+        out.push([
+            first_idx,
+            values.len() as IdxSize + first_group_offset - first_idx,
+        ]);
+    } else {
+        out.push([first_idx, values.len() as IdxSize - (first_idx - offset)]);
+    }
+
+    if !nulls_first && first_group_offset > 0 {
+        out.push([values.len() as IdxSize + offset, first_group_offset])
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_partition_points() {
+        let values = &[1, 3, 3, 3, 3, 5, 5, 5, 9, 9, 10];
+
+        assert_eq!(find_partition_points(values, 4, false), &[1, 5, 8, 10]);
+        assert_eq!(
+            partition_to_groups(values, 0, true, 0),
+            &[[0, 1], [1, 4], [5, 3], [8, 2], [10, 1]]
+        );
+        assert_eq!(
+            partition_to_groups(values, 5, true, 0),
+            &[[0, 5], [5, 1], [6, 4], [10, 3], [13, 2], [15, 1]]
+        );
+        assert_eq!(
+            partition_to_groups(values, 5, false, 0),
+            &[[0, 1], [1, 4], [5, 3], [8, 2], [10, 1], [11, 5]]
+        );
+    }
+}

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -40,7 +40,23 @@ where
             DataType::Categorical(_) => {
                 Ok(CategoricalChunked::full_null(self.name(), self.len()).into_series())
             }
-            _ => cast_impl(self.name(), &self.chunks, data_type),
+            _ => cast_impl(self.name(), &self.chunks, data_type).map(|mut s| {
+                // maintain sorted if data types remain signed
+                if self.is_sorted()
+                    || self.is_sorted_reverse() && (s.null_count() == self.null_count())
+                {
+                    // this may still fail with overflow?
+                    //
+                    if (self.dtype().is_signed() && data_type.is_signed())
+                        || (self.dtype().is_unsigned() && data_type.is_unsigned())
+                    {
+                        let reverse = self.is_sorted_reverse();
+                        let inner = s._get_inner_mut();
+                        inner._set_sorted(reverse)
+                    }
+                }
+                s
+            }),
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -163,7 +163,9 @@ where
             order_reverse,
         );
 
-        ChunkedArray::from_vec(ca.name(), vals)
+        let mut ca = ChunkedArray::from_vec(ca.name(), vals);
+        ca.set_sorted(options.descending);
+        ca
     } else {
         let null_count = ca.null_count();
         let len = ca.len();

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -52,11 +52,17 @@ pub(crate) fn is_unique_helper(
     duplicated_val: bool,
 ) -> BooleanChunked {
     debug_assert_ne!(unique_val, duplicated_val);
-    let idx = groups
-        .into_idx()
-        .into_iter()
-        .filter_map(|(first, g)| if g.len() == 1 { Some(first) } else { None })
-        .collect::<Vec<_>>();
+
+    let idx = match groups {
+        GroupsProxy::Idx(groups) => groups
+            .into_iter()
+            .filter_map(|(first, g)| if g.len() == 1 { Some(first) } else { None })
+            .collect::<Vec<_>>(),
+        GroupsProxy::Slice(groups) => groups
+            .into_iter()
+            .filter_map(|[first, len]| if len == 1 { Some(first) } else { None })
+            .collect(),
+    };
     finish_is_unique_helper(idx, len, unique_val, duplicated_val)
 }
 

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -84,7 +84,7 @@ impl DataFrame {
                     ))?;
                     *col = df[idx].clone();
                     let ca = col
-                        .get_inner_mut()
+                        ._get_inner_mut()
                         .as_any_mut()
                         .downcast_mut::<ListChunked>()
                         .unwrap();

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -262,10 +262,22 @@ impl GroupsProxy {
     /// # Panic
     ///
     /// panics if the groups are a slice.
-    pub fn idx_ref(&self) -> &GroupsIdx {
+    pub fn unwrap_idx(&self) -> &GroupsIdx {
         match self {
             GroupsProxy::Idx(groups) => groups,
             GroupsProxy::Slice(_) => panic!("groups are slices not index"),
+        }
+    }
+
+    /// Get a reference to the `GroupsSlice`.
+    ///
+    /// # Panic
+    ///
+    /// panics if the groups are an idx.
+    pub fn unwrap_slice(&self) -> &GroupsSlice {
+        match self {
+            GroupsProxy::Slice(groups) => groups,
+            GroupsProxy::Idx(_) => panic!("groups are index not slices"),
         }
     }
 

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -206,10 +206,15 @@ impl GroupsProxy {
     pub fn into_idx(self) -> GroupsIdx {
         match self {
             GroupsProxy::Idx(groups) => groups,
-            GroupsProxy::Slice(groups) => groups
-                .iter()
-                .map(|&[first, len]| (first, (first..first + len).collect_trusted::<Vec<_>>()))
-                .collect(),
+            GroupsProxy::Slice(groups) => {
+                if std::env::var("POLARS_VERBOSE").is_ok() {
+                    println!("had to reallocate groups, missed an optimization opportunity.")
+                }
+                groups
+                    .iter()
+                    .map(|&[first, len]| (first, (first..first + len).collect_trusted::<Vec<_>>()))
+                    .collect()
+            }
         }
     }
 
@@ -238,6 +243,13 @@ impl GroupsProxy {
         let mut ca = ca.into_inner();
         ca.rename(name);
         ca
+    }
+
+    pub fn take_group_firsts(self) -> Vec<IdxSize> {
+        match self {
+            GroupsProxy::Idx(mut groups) => std::mem::take(&mut groups.first),
+            GroupsProxy::Slice(groups) => groups.into_iter().map(|[first, _len]| first).collect(),
+        }
     }
 
     #[cfg(feature = "private")]

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -322,7 +322,7 @@ impl DataFrame {
         if left_join && join_tuples.len() == self.height() {
             self.clone()
         } else {
-            self.take_unchecked_slice(join_tuples, true)
+            self._take_unchecked_slice(join_tuples, true)
         }
     }
 
@@ -498,7 +498,7 @@ impl DataFrame {
                     || unsafe {
                         // remove join columns
                         remove_selected(other, &selected_right)
-                            .take_unchecked_slice(join_idx_right, true)
+                            ._take_unchecked_slice(join_idx_right, true)
                     },
                 );
                 self.finish_join(df_left, df_right, suffix)
@@ -683,7 +683,7 @@ impl DataFrame {
                 other
                     .drop(s_right.name())
                     .unwrap()
-                    .take_unchecked_slice(join_tuples_right, true)
+                    ._take_unchecked_slice(join_tuples_right, true)
             },
         );
         self.finish_join(df_left, df_right, suffix)
@@ -841,7 +841,7 @@ impl DataFrame {
         if let Some((offset, len)) = slice {
             idx = slice_slice(idx, offset, len);
         }
-        self.take_unchecked_slice(idx, true)
+        self._take_unchecked_slice(idx, true)
     }
 
     #[cfg(feature = "semi_anti_join")]

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -39,7 +39,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.explode_by_offsets(offsets)
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -73,7 +73,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         .into_series()
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.logical_mut().set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -57,7 +57,7 @@ macro_rules! impl_dyn_series {
                 self.0.cummin(reverse).$into_logical().into_series()
             }
 
-            fn set_sorted(&mut self, reverse: bool) {
+            fn _set_sorted(&mut self, reverse: bool) {
                 self.0.deref_mut().set_sorted(reverse)
             }
 

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -57,7 +57,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.deref_mut().set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -57,7 +57,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.deref_mut().set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -95,7 +95,7 @@ macro_rules! impl_dyn_series {
                 self.0.cummin(reverse).into_series()
             }
 
-            fn set_sorted(&mut self, reverse: bool) {
+            fn _set_sorted(&mut self, reverse: bool) {
                 self.0.set_sorted(reverse)
             }
 

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -29,7 +29,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         self.0.explode_by_offsets(offsets)
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -139,7 +139,7 @@ macro_rules! impl_dyn_series {
                 self.0.cummin(reverse).into_series()
             }
 
-            fn set_sorted(&mut self, reverse: bool) {
+            fn _set_sorted(&mut self, reverse: bool) {
                 self.0.set_sorted(reverse)
             }
 

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -298,7 +298,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
     /// Get first indexes of unique values.
     fn arg_unique(&self) -> Result<IdxCa> {
         let groups = self.group_tuples(true, false);
-        let first = std::mem::take(groups.into_idx().first_mut());
+        let first = groups.take_group_firsts();
         Ok(IdxCa::from_vec(self.name(), first))
     }
 

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -37,7 +37,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.explode_by_offsets(offsets)
     }
 
-    fn set_sorted(&mut self, reverse: bool) {
+    fn _set_sorted(&mut self, reverse: bool) {
         self.0.set_sorted(reverse)
     }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -159,11 +159,18 @@ impl Series {
         Series::full_null(name, 0, dtype)
     }
 
-    pub(crate) fn get_inner_mut(&mut self) -> &mut dyn SeriesTrait {
+    #[doc(hidden)]
+    #[cfg(feature = "private")]
+    pub(crate) fn _get_inner_mut(&mut self) -> &mut dyn SeriesTrait {
         if Arc::weak_count(&self.0) + Arc::strong_count(&self.0) != 1 {
             self.0 = self.0.clone_inner();
         }
         Arc::get_mut(&mut self.0).expect("implementation error")
+    }
+
+    pub fn set_sorted(&mut self, _reverse: bool) {
+        let inner = self._get_inner_mut();
+        inner._set_sorted(_reverse)
     }
 
     pub fn into_frame(self) -> DataFrame {
@@ -172,18 +179,18 @@ impl Series {
 
     /// Rename series.
     pub fn rename(&mut self, name: &str) -> &mut Series {
-        self.get_inner_mut().rename(name);
+        self._get_inner_mut().rename(name);
         self
     }
 
     /// Shrink the capacity of this array to fit it's length.
     pub fn shrink_to_fit(&mut self) {
-        self.get_inner_mut().shrink_to_fit()
+        self._get_inner_mut().shrink_to_fit()
     }
 
     /// Append arrow array of same datatype.
     pub fn append_array(&mut self, other: ArrayRef) -> Result<&mut Self> {
-        self.get_inner_mut().append_array(other)?;
+        self._get_inner_mut().append_array(other)?;
         Ok(self)
     }
 
@@ -191,7 +198,7 @@ impl Series {
     ///
     /// See [`ChunkedArray::append`] and [`ChunkedArray::extend`].
     pub fn append(&mut self, other: &Series) -> Result<&mut Self> {
-        self.get_inner_mut().append(other)?;
+        self._get_inner_mut().append(other)?;
         Ok(self)
     }
 
@@ -199,7 +206,7 @@ impl Series {
     ///
     /// See [`ChunkedArray::extend`] and [`ChunkedArray::append`].
     pub fn extend(&mut self, other: &Series) -> Result<&mut Self> {
-        self.get_inner_mut().extend(other)?;
+        self._get_inner_mut().extend(other)?;
         Ok(self)
     }
 
@@ -212,7 +219,7 @@ impl Series {
 
     /// Only implemented for numeric types
     pub fn as_single_ptr(&mut self) -> Result<usize> {
-        self.get_inner_mut().as_single_ptr()
+        self._get_inner_mut().as_single_ptr()
     }
 
     /// Cast `[Series]` to another `[DataType]`

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -142,7 +142,7 @@ pub(crate) mod private {
             panic!("operation cummin not supported for this dtype")
         }
 
-        fn set_sorted(&mut self, _reverse: bool) {
+        fn _set_sorted(&mut self, _reverse: bool) {
             invalid_operation_panic!(self)
         }
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -102,7 +102,7 @@ fn estimate_unique_count(keys: &[Series], mut sample_size: usize) -> usize {
         let ui = if groups.len() == sample_size {
             u
         } else {
-            groups.idx_ref().iter().filter(|g| g.1.len() == 1).count() as f32
+            groups.iter().filter(|g| g.len() == 1).count() as f32
         };
 
         (u + (ui / sample_size as f32) * (set_size - sample_size) as f32) as usize

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -305,17 +305,6 @@
 //!                               `T` in complex lazy expressions. However this does require `unsafe` code allow this.
 //! * `POLARS_NO_PARQUET_STATISTICS` -> if set, statistics in parquet files are ignored.
 //!
-//!
-//! ## Compile for WASM
-//! To be able to pretty print a `DataFrame` in `wasm32-wasi` you need to patch the `prettytable-rs`
-//! dependency. If you add this snippet to your `Cargo.toml` you can compile and pretty print when
-//! compiling to `wasm32-wasi` target.
-//!
-//! ```toml
-//! [patch.crates-io]
-//! prettytable-rs = { git = "https://github.com/phsym/prettytable-rs", branch = "master"}
-//! ```
-//!
 //! ## User Guide
 //! If you want to read more, [check the User Guide](https://pola-rs.github.io/polars-book/).
 pub mod docs;

--- a/polars/tests/it/core/groupby.rs
+++ b/polars/tests/it/core/groupby.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[test]
+fn test_sorted_groupby() -> Result<()> {
+    // nulls last
+    let mut s = Series::new("a", &[Some(1), Some(1), Some(1), Some(6), Some(6), None]);
+    s.set_sorted(false);
+    for mt in [true, false] {
+        let out = s.group_tuples(mt, false);
+        assert_eq!(out.unwrap_slice(), &[[0, 3], [3, 2], [5, 1]]);
+    }
+
+    // nulls first
+    let mut s = Series::new(
+        "a",
+        &[None, None, Some(1), Some(1), Some(1), Some(6), Some(6)],
+    );
+    s.set_sorted(false);
+    for mt in [true, false] {
+        let out = s.group_tuples(mt, false);
+        assert_eq!(out.unwrap_slice(), &[[0, 2], [2, 3], [5, 2]]);
+    }
+
+    // nulls last
+    let mut s = Series::new("a", &[Some(1), Some(1), Some(1), Some(6), Some(6), None]);
+    s.set_sorted(false);
+    for mt in [true, false] {
+        let out = s.group_tuples(mt, false);
+        assert_eq!(out.unwrap_slice(), &[[0, 3], [3, 2], [5, 1]]);
+    }
+
+    // nulls first reverse sorted
+    let mut s = Series::new(
+        "a",
+        &[
+            None,
+            None,
+            Some(3),
+            Some(3),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(-1),
+        ],
+    );
+    s.set_sorted(true);
+    for mt in [false, true] {
+        let out = s.group_tuples(mt, false);
+        assert_eq!(out.unwrap_slice(), &[[0, 2], [2, 2], [4, 3], [7, 1]]);
+    }
+
+    // nulls last reverse sorted
+    let mut s = Series::new(
+        "a",
+        &[
+            Some(15),
+            Some(15),
+            Some(15),
+            Some(15),
+            Some(14),
+            Some(13),
+            Some(11),
+            Some(11),
+            Some(3),
+            Some(3),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(-1),
+            None,
+            None,
+            None,
+        ],
+    );
+    s.set_sorted(true);
+    for mt in [false, true] {
+        let out = s.group_tuples(mt, false);
+        assert_eq!(
+            out.unwrap_slice(),
+            &[
+                [0, 4],
+                [4, 1],
+                [5, 1],
+                [6, 2],
+                [8, 2],
+                [10, 3],
+                [13, 1],
+                [14, 3]
+            ]
+        );
+    }
+
+    Ok(())
+}

--- a/polars/tests/it/core/mod.rs
+++ b/polars/tests/it/core/mod.rs
@@ -1,3 +1,4 @@
+mod groupby;
 mod joins;
 mod list;
 #[cfg(feature = "rows")]

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -248,6 +248,13 @@ Window
 
     Expr.over
 
+Various
+--------
+.. autosummary::
+   :toctree: api/
+
+    Expr.set_sorted
+
 TimeSeries
 ----------
 The following methods are available under the `expr.dt` attribute.

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -198,6 +198,7 @@ Various
     Series.str
     Series.reinterpret
     Series.to_physical
+    Series.set_sorted
 
 TimeSeries
 ----------

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2955,6 +2955,22 @@ class Expr:
             self._pyexpr.cumulative_eval(expr._pyexpr, min_periods, parallel)
         )
 
+    def set_sorted(self, reverse: bool = False) -> "Expr":
+        """
+        Set this `Series` as `sorted` so that downstream code can use
+        fast paths for sorted arrays.
+
+        .. warning::
+            This can lead to incorrect results if this `Series` is not sorted!!
+            Use with care!
+
+        Parameters
+        ----------
+        reverse
+            If the `Series` order is reversed, e.g. descending.
+        """
+        return self.map(lambda s: s.set_sorted(reverse))
+
     # Below are the namespaces defined. Keep these at the end of the definition of Expr, as to not confuse mypy with
     # the type annotation `str` with the namespace "str"
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3642,6 +3642,22 @@ class Series:
         """
         return wrap_s(self._s.extend_constant(value, n))
 
+    def set_sorted(self, reverse: bool = False) -> "Series":
+        """
+        Set this `Series` as `sorted` so that downstream code can use
+        fast paths for sorted arrays.
+
+        .. warning::
+            This can lead to incorrect results if this `Series` is not sorted!!
+            Use with care!
+
+        Parameters
+        ----------
+        reverse
+            If the `Series` order is reversed, e.g. descending.
+        """
+        return wrap_s(self._s.set_sorted(reverse))
+
     @property
     def time_unit(self) -> Optional[str]:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -394,6 +394,12 @@ impl PySeries {
             .map(|dt| Wrap(dt.clone()).to_object(py))
     }
 
+    fn set_sorted(&self, reverse: bool) -> Self {
+        let mut out = self.series.clone();
+        out.set_sorted(reverse);
+        out.into()
+    }
+
     pub fn mean(&self) -> Option<f64> {
         match self.series.dtype() {
             DataType::Boolean => {


### PR DESCRIPTION
This changes the grouping algorithm when we know the key is sorted. 

This has an approx. ~15x perf improvement on the default hash aggregation and ~37x on a pandas equivalent baseline.

![image](https://user-images.githubusercontent.com/3023000/170227110-8d5e14dc-7c4e-4242-ab1c-73db5ffa2617.png)
