### PR TITLE
Fix LazyFrame.join_asof documentation reference

### DIFF
--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -49,7 +49,7 @@ Manipulation/ selection
     LazyFrame.groupby_dynamic
     LazyFrame.groupby_rolling
     LazyFrame.join
-    DataFrame.join_asof
+    LazyFrame.join_asof
     LazyFrame.with_columns
     LazyFrame.with_column
     LazyFrame.drop


### PR DESCRIPTION
Fixes a typo in `lazyframe.rst`