### PR TITLE
use specialize kernels in rolling_groupby aggregation `~10x` perf gain (window of 100 elements)

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -234,6 +234,7 @@ docs-selection = [
   "describe",
   "list_eval",
   "cumulative_eval",
+  "timezones",
 ]
 
 bench = [
@@ -281,4 +282,4 @@ harness = false
 # all-features = true
 features = ["docs-selection"]
 # defines the configuration attribute `docsrs`
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "polars-core/docsrs"]

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
@@ -1,6 +1,6 @@
 use super::sum::SumWindow;
 use super::*;
-use no_nulls::{rolling_apply_agg_window, RollingAggWindow};
+use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
 
 pub struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,
@@ -9,7 +9,7 @@ pub struct MeanWindow<'a, T> {
 impl<
         'a,
         T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Div<Output = T> + NumCast,
-    > RollingAggWindow<'a, T> for MeanWindow<'a, T>
+    > RollingAggWindowNoNulls<'a, T> for MeanWindow<'a, T>
 {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self {
         Self {

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 
 pub use mean::*;
 pub use min_max::*;
-pub use quantile::{rolling_median, rolling_quantile};
+pub use quantile::*;
 pub use sum::*;
 pub use variance::*;
 
-pub trait RollingAggWindow<'a, T: NativeType> {
+pub trait RollingAggWindowNoNulls<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;
 
     /// Update and recompute the window
@@ -39,7 +39,7 @@ pub(super) fn rolling_apply_agg_window<'a, Agg, T, Fo>(
 ) -> ArrayRef
 where
     Fo: Fn(Idx, WindowSize, Len) -> (Start, End),
-    Agg: RollingAggWindow<'a, T>,
+    Agg: RollingAggWindowNoNulls<'a, T>,
     T: Debug + IsFloat + NativeType,
 {
     let len = values.len();

--- a/polars/polars-arrow/src/kernels/rolling/nulls/mean.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/mean.rs
@@ -1,15 +1,15 @@
 use super::sum::SumWindow;
 use super::*;
-use super::{rolling_apply_agg_window, RollingAggWindow};
+use super::{rolling_apply_agg_window, RollingAggWindowNulls};
 
-pub(super) struct MeanWindow<'a, T> {
+pub struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,
 }
 
 impl<
         'a,
         T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + NumCast + Div<Output = T>,
-    > RollingAggWindow<'a, T> for MeanWindow<'a, T>
+    > RollingAggWindowNulls<'a, T> for MeanWindow<'a, T>
 {
     unsafe fn new(
         slice: &'a [T],

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -1,12 +1,12 @@
 use super::*;
-use polars_arrow::kernels::rolling::no_nulls::{self, RollingAggWindow};
+use polars_arrow::kernels::rolling::no_nulls::{self, RollingAggWindowNoNulls};
 use polars_core::export::num;
 
 // Use an aggregation window that maintains the state
 pub(crate) fn rolling_apply_agg_window<'a, Agg, T, O>(values: &'a [T], offsets: O) -> ArrayRef
 where
     // items (offset, len) -> so offsets are offset, offset + len
-    Agg: RollingAggWindow<'a, T>,
+    Agg: RollingAggWindowNoNulls<'a, T>,
     O: Iterator<Item = (IdxSize, IdxSize)> + TrustedLen,
     T: Debug + IsFloat + NativeType,
 {

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -408,7 +408,8 @@ mod test {
     use chrono::prelude::*;
 
     #[test]
-    fn test_rolling_groupby() -> Result<()> {
+    fn test_rolling_groupby_tu() -> Result<()> {
+        // test multiple time units
         for tu in [
             TimeUnit::Nanoseconds,
             TimeUnit::Microseconds,
@@ -441,10 +442,80 @@ mod test {
                     },
                 )
                 .unwrap();
+
             let sum = a.agg_sum(&groups);
             let expected = Series::new("", [3, 10, 15, 24, 11, 1]);
             assert_eq!(sum, expected);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rolling_groupby_aggs() -> Result<()> {
+        let date = Utf8Chunked::new(
+            "dt",
+            [
+                "2020-01-01 13:45:48",
+                "2020-01-01 16:42:13",
+                "2020-01-01 16:45:09",
+                "2020-01-02 18:12:48",
+                "2020-01-03 19:45:32",
+                "2020-01-08 23:16:43",
+            ],
+        )
+        .as_datetime(None, TimeUnit::Milliseconds)?
+        .into_series();
+        let a = Series::new("a", [3, 7, 5, 9, 2, 1]);
+        let df = DataFrame::new(vec![date, a.clone()])?;
+
+        let (_, _, groups) = df
+            .groupby_rolling(
+                vec![],
+                &RollingGroupOptions {
+                    index_column: "dt".into(),
+                    period: Duration::parse("2d"),
+                    offset: Duration::parse("-2d"),
+                    closed_window: ClosedWindow::Right,
+                },
+            )
+            .unwrap();
+
+        let nulls = Series::new("", [Some(3), Some(7), None, Some(9), Some(2), Some(1)]);
+
+        let min = a.agg_min(&groups);
+        let expected = Series::new("", [3, 3, 3, 3, 2, 1]);
+        assert_eq!(min, expected);
+
+        // expected for nulls is equal
+        let min = nulls.agg_min(&groups);
+        assert_eq!(min, expected);
+
+        let max = a.agg_max(&groups);
+        let expected = Series::new("", [3, 7, 7, 9, 9, 1]);
+        assert_eq!(max, expected);
+
+        let max = nulls.agg_max(&groups);
+        assert_eq!(max, expected);
+
+        let var = a.agg_var(&groups);
+        let expected = Series::new(
+            "",
+            [0.0, 8.0, 4.000000000000002, 6.666666666666667, 24.5, 0.0],
+        );
+        assert_eq!(var, expected);
+
+        let var = nulls.agg_var(&groups);
+        let expected = Series::new("", [0.0, 8.0, 8.0, 9.333333333333343, 24.5, 0.0]);
+        assert_eq!(var, expected);
+
+        let quantile = a.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear);
+        let expected = Series::new("", [3.0, 5.0, 5.0, 6.0, 5.5, 1.0]);
+        assert_eq!(quantile, expected);
+
+        let quantile = nulls.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear);
+        let expected = Series::new("", [3.0, 5.0, 5.0, 7.0, 5.5, 1.0]);
+        assert_eq!(quantile, expected);
 
         Ok(())
     }

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -307,6 +307,7 @@
 //!
 //! ## User Guide
 //! If you want to read more, [check the User Guide](https://pola-rs.github.io/polars-book/).
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod docs;
 pub mod export;
 pub mod prelude;


### PR DESCRIPTION
If we have group slices and they overlap, we can use the fast `rolling_<agg>` kernels.

Benchmark on a rolling window with `10_000` elements and a window size of `100`:

```
Gnuplot not found, using plotters backend
bench_1                 time:   [107.76 us 108.04 us 108.33 us]                    
                        change: [-91.314% -91.244% -91.167%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

```