### PR TITLE
Update jemallocator.

### DIFF
--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -270,7 +270,7 @@
 //! A DataFrame library naturally does a lot of heap allocations. It is recommended to use a custom
 //! allocator.
 //! [Mimalloc](https://crates.io/crates/mimalloc) and
-//! [JeMalloc](https://crates.io/crates/tikv-jemallocator) for instance, show a significant
+//! [JeMalloc](https://crates.io/crates/jemallocator) for instance, show a significant
 //! performance gain in runtime as well as memory usage.
 //!
 //! #### Usage

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -648,6 +648,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.0+5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f655c3ecfa6b0d03634595b4b54551d4bd5ac208b9e0124873949a7ab168f70b"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1283,7 @@ version = "0.13.38"
 dependencies = [
  "ahash",
  "bincode",
+ "jemallocator",
  "libc",
  "mimalloc",
  "ndarray",
@@ -1273,7 +1295,6 @@ dependencies = [
  "pyo3",
  "serde_json",
  "thiserror",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1643,27 +1664,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -19,7 +19,7 @@ description = "Blazingly fast DataFrame library"
 mimalloc = { version = "*", default-features = false }
 
 [target.'cfg(target_os="linux")'.dependencies]
-tikv-jemallocator = { version = "0.4", features = ["disable_initial_exec_tls"] }
+jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
 
 [dependencies]
 ahash = "0.7"

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -42,6 +42,8 @@ use crate::error::{
 use crate::file::get_either_file;
 use crate::prelude::{ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs, PyDataType};
 use dsl::ToExprs;
+#[cfg(target_os = "linux")]
+use jemallocator::Jemalloc;
 #[cfg(not(target_os = "linux"))]
 use mimalloc::MiMalloc;
 use polars::functions::{diag_concat_df, hor_concat_df};
@@ -51,8 +53,6 @@ use polars_core::export::arrow::io::ipc::read::read_file_metadata;
 use polars_core::prelude::IntoSeries;
 use pyo3::panic::PanicException;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
-#[cfg(target_os = "linux")]
-use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Switch back from tikv-jemallocator to jemallocator as the latter
is now the same as tikv-jemallocator.

The update also brings jemalloc to version 5.3.0, which should
give multiple percent of system level metric improvements.