### PR TITLE
allow concat/append expressions

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -177,6 +177,7 @@ Manipulation/ selection
 
     Expr.inspect
     Expr.slice
+    Expr.append
     Expr.explode
     Expr.flatten
     Expr.take_every
@@ -204,6 +205,7 @@ Manipulation/ selection
     Expr.reinterpret
     Expr.drop_nulls
     Expr.drop_nans
+    Expr.rechunk
     Expr.interpolate
     Expr.arg_sort
     Expr.clip

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -774,6 +774,26 @@ class Expr:
             length = pli.lit(length)
         return wrap_expr(self._pyexpr.slice(offset._pyexpr, length._pyexpr))
 
+    def append(self, other: "Expr", upcast: bool = True) -> "Expr":
+        """
+        Append expressions. This is done by adding the chunks of `other` to this `Series`.
+
+        Parameters
+        ----------
+        other
+            Expression to append
+        upcast
+            Cast both `Series` to the same supertype
+        """
+        other = expr_to_lit_or_expr(other)
+        return wrap_expr(self._pyexpr.append(other._pyexpr, upcast))
+
+    def rechunk(self) -> "Expr":
+        """
+        Create a single chunk of memory for this Series.
+        """
+        return wrap_expr(self._pyexpr.rechunk())
+
     def drop_nulls(self) -> "Expr":
         """
         Drop null values.

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -327,6 +327,17 @@ impl PyExpr {
         self.inner.clone().slice(offset.inner, length.inner).into()
     }
 
+    pub fn append(&self, other: PyExpr, upcast: bool) -> PyExpr {
+        self.inner.clone().append(other.inner, upcast).into()
+    }
+
+    pub fn rechunk(&self) -> PyExpr {
+        self.inner
+            .clone()
+            .map(|s| Ok(s.rechunk()), GetOutput::same_type())
+            .into()
+    }
+
     pub fn round(&self, decimals: u32) -> PyExpr {
         self.clone().inner.round(decimals).into()
     }

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -235,3 +235,16 @@ def test_power_by_expression() -> None:
         None,
         46656.0,
     ]
+
+
+def test_expression_appends() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2]})
+
+    assert df.select(pl.repeat(None, 3).append(pl.col("a"))).n_chunks() == 2
+
+    assert df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk()).n_chunks() == 1
+
+    out = df.select(pl.concat([pl.repeat(None, 3), pl.col("a")]))
+
+    assert out.n_chunks() == 1
+    assert out.to_series().to_list() == [None, None, None, 1, 1, 2]


### PR DESCRIPTION
I found it pretty hard to extend a `DataFrame` with nulls. So I have added `append`, `concat` and `rechunk` functionality to the expressions.

```python
df = pl.DataFrame({
    "a": [1, 1, 2]
})

assert df.select(
    pl.repeat(None, 3).append(pl.col("a"))
).n_chunks() == 2

assert df.select(
    pl.repeat(None, 3).append(pl.col("a")).rechunk()
).n_chunks() == 1


out = df.select(
    pl.concat([pl.repeat(None, 3), pl.col("a")])
)

assert out.n_chunks() == 1
assert out.to_series().to_list() == [None, None, None, 1, 1, 2]
```