### PR TITLE
allow more aggregations on dtype duration

### DIFF
--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -95,6 +95,33 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
+    fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+        self.0
+            .agg_sum(groups)
+            .into_duration(self.0.time_unit())
+            .into_series()
+    }
+
+    fn agg_std(&self, groups: &GroupsProxy) -> Series {
+        self.0
+            .agg_std(groups)
+            // cast f64 back to physical type
+            .cast(&DataType::Int64)
+            .unwrap()
+            .into_duration(self.0.time_unit())
+            .into_series()
+    }
+
+    fn agg_var(&self, groups: &GroupsProxy) -> Series {
+        self.0
+            .agg_var(groups)
+            // cast f64 back to physical type
+            .cast(&DataType::Int64)
+            .unwrap()
+            .into_duration(self.0.time_unit())
+            .into_series()
+    }
+
     fn agg_list(&self, groups: &GroupsProxy) -> Series {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0
@@ -111,6 +138,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     ) -> Series {
         self.0
             .agg_quantile(groups, quantile, interpol)
+            // cast f64 back to physical type
+            .cast(&DataType::Int64)
+            .unwrap()
             .into_duration(self.0.time_unit())
             .into_series()
     }
@@ -118,6 +148,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     fn agg_median(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_median(groups)
+            // cast f64 back to physical type
+            .cast(&DataType::Int64)
+            .unwrap()
             .into_duration(self.0.time_unit())
             .into_series()
     }

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -769,7 +769,7 @@ def read_ipc(
     file: Union[str, BinaryIO, BytesIO, Path, bytes],
     columns: Optional[Union[List[int], List[str]]] = None,
     n_rows: Optional[int] = None,
-    use_pyarrow: bool = _PYARROW_AVAILABLE,
+    use_pyarrow: bool = False,
     memory_map: bool = True,
     storage_options: Optional[Dict] = None,
     row_count_name: Optional[str] = None,

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -315,7 +315,22 @@ impl PySeries {
     }
 
     pub fn get_fmt(&self, index: usize) -> String {
-        format!("{}", self.series.get(index))
+        let val = format!("{}", self.series.get(index));
+        if let DataType::Utf8 | DataType::Categorical(_) = self.series.dtype() {
+            let v_trunc = &val[..val
+                .char_indices()
+                .take(15)
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(0)];
+            if val == v_trunc {
+                val
+            } else {
+                format!("{}...", v_trunc)
+            }
+        } else {
+            val
+        }
     }
 
     pub fn rechunk(&mut self, in_place: bool) -> Option<Self> {


### PR DESCRIPTION
closes #3544
closes #3543

And make arrow2 default ipc reader in python.