### PR TITLE
Fix mode for multiple modes

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -142,21 +142,16 @@ where
         .into_iter()
         .collect_trusted::<Vec<_>>();
     groups.sort_unstable_by_key(|k| k.1.len());
-    let first = &groups[0];
+    let last = &groups.last().unwrap();
 
-    let max_occur = first.1.len();
+    let max_occur = last.1.len();
 
     // collect until we don't take with trusted len anymore
     // TODO! take directly from iter, but first remove standard trusted-length collect.
-    let mut was_equal = true;
     let idx = groups
         .iter()
         .rev()
-        .take_while(|v| {
-            let current = was_equal;
-            was_equal = v.1.len() == max_occur;
-            current
-        })
+        .take_while(|v| v.1.len() == max_occur)
         .map(|v| v.0)
         .collect::<Vec<_>>();
     // Safety:
@@ -456,5 +451,23 @@ mod test {
                 Some(false)
             ]
         );
+    }
+
+    #[test]
+    #[cfg(feature = "mode")]
+    fn mode() {
+        let ca = Int32Chunked::from_slice("a", &[0, 1, 2, 3, 4, 4, 5, 6, 5, 0]);
+        let mut result = Vec::from(&ca.mode().unwrap());
+        dbg!(&result.sort_by(|a, b| a.unwrap().cmp(&b.unwrap())));
+        assert_eq!(&result, &[Some(0), Some(4), Some(5)]);
+
+        let ca2 = Int32Chunked::from_slice("b", &[1, 1]);
+        let mut result2 = Vec::from(&ca2.mode().unwrap());
+        dbg!(&result2.sort_by(|a, b| a.unwrap().cmp(&b.unwrap())));
+        assert_eq!(&result2, &[Some(1)]);
+
+        let ca3 = Int32Chunked::from_slice("c", &[]);
+        let result3 = Vec::from(&ca3.mode().unwrap());
+        assert_eq!(result3, &[]);
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -458,12 +458,10 @@ mod test {
     fn mode() {
         let ca = Int32Chunked::from_slice("a", &[0, 1, 2, 3, 4, 4, 5, 6, 5, 0]);
         let mut result = Vec::from(&ca.mode().unwrap());
-        dbg!(&result.sort_by(|a, b| a.unwrap().cmp(&b.unwrap())));
         assert_eq!(&result, &[Some(0), Some(4), Some(5)]);
 
         let ca2 = Int32Chunked::from_slice("b", &[1, 1]);
         let mut result2 = Vec::from(&ca2.mode().unwrap());
-        dbg!(&result2.sort_by(|a, b| a.unwrap().cmp(&b.unwrap())));
         assert_eq!(&result2, &[Some(1)]);
 
         let ca3 = Int32Chunked::from_slice("c", &[]);

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -458,10 +458,12 @@ mod test {
     fn mode() {
         let ca = Int32Chunked::from_slice("a", &[0, 1, 2, 3, 4, 4, 5, 6, 5, 0]);
         let mut result = Vec::from(&ca.mode().unwrap());
+        result.sort_by(|a, b| a.unwrap().cmp(&b.unwrap()));
         assert_eq!(&result, &[Some(0), Some(4), Some(5)]);
 
         let ca2 = Int32Chunked::from_slice("b", &[1, 1]);
         let mut result2 = Vec::from(&ca2.mode().unwrap());
+        result2.sort_by(|a, b| a.unwrap().cmp(&b.unwrap()));
         assert_eq!(&result2, &[Some(1)]);
 
         let ca3 = Int32Chunked::from_slice("c", &[]);


### PR DESCRIPTION
Hi - first PR so take it easy on me :)

Noticed that at least with int32 was not getting all the mode values.

Fix is:
1. First grab the size of the group that is the largest (last vs first)
2. Take based only on whether the length of the current iteration matches

I don't really understand the comment above it (with the TODO), so if you wanted to fix this a different way happy to do it that way.

I also added some tests.