### PR TITLE
Improve parse_lines error message.

### DIFF
--- a/polars/polars-io/src/csv_core/parser.rs
+++ b/polars/polars-io/src/csv_core/parser.rs
@@ -486,11 +486,13 @@ pub(crate) fn parse_lines(
                                     let unparsable = String::from_utf8_lossy(field);
                                     PolarsError::ComputeError(
                                         format!(
-                                            r#"Could not parse {} as dtype {:?} at column {}.
-                                            The total offset in the file is {} bytes.
-
-                                            Consider running the parser `with_ignore_parser_errors=true`
-                                            or consider adding {} to the `null_values` list."#,
+                                            "Could not parse `{}` as dtype {:?} at column {}.\n\
+                                            The current offset in the file is {} bytes.\n\
+                                            \n\
+                                            Consider specifying the correct dtype, increasing\n\
+                                            the number of records used to infer the schema,\n\
+                                            running the parser with `ignore_parser_errors=true`\n\
+                                            or  adding `{}` to the `null_values` list.",
                                             &unparsable,
                                             buf.dtype(),
                                             idx,


### PR DESCRIPTION
Improve parse_lines error message:
  - Fix file offset at which the error was encountered
    (header and skipped lines were not included).
  - Remove leading spaces in error message due to use
    of raw string.
  - Add other ideas (specify correct dtype or increasing
    number of records used to infer the schema) to
    potentionaly avoid the error, as the error also show
    up quite frequently when an incorrect dtype was
    inferred.

Previous error message:

ComputeError: Could not parse 3.0 as dtype Int64 at column 3.
                                            The total offset in the file is 37 bytes.

                                            Consider running the parser `with_ignore_parser_errors=true`
                                            or consider adding 3.0 to the `null_values` list.

Current error message:

ComputeError: Could not parse `3.0` as dtype Int64 at column 3.
The current offset in the file is 69 bytes.

Consider specifying the correct dtype, increasing
the number of records used to infer the schema,
running the parser with `ignore_parser_errors=true`
or  adding `3.0` to the `null_values` list.