### PR TITLE
Rust Readability Improvements

### DIFF
--- a/polars-sql/src/context.rs
+++ b/polars-sql/src/context.rs
@@ -121,7 +121,7 @@ impl SQLContext {
             }
             // Default polars group by will have group by columns at the front
             // need some container to contain position of group by columns and its position
-            // at the final agg projection, check the schema for the existant of group by column
+            // at the final agg projection, check the schema for the existence of group by column
             // and its projections columns, keeping the original index
             let (exclude_expr, groupby_pos): (Vec<_>, Vec<_>) = group_by
                 .iter()

--- a/polars-sql/src/sql_expr.rs
+++ b/polars-sql/src/sql_expr.rs
@@ -135,7 +135,7 @@ pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> Result<Expr> {
 fn apply_window_spec(expr: Expr, window_spec: &Option<WindowSpec>) -> Result<Expr> {
     Ok(match &window_spec {
         Some(window_spec) => {
-            // Process for simple window specification, partitionn by first
+            // Process for simple window specification, partition by first
             let partition_by = window_spec
                 .partition_by
                 .iter()

--- a/polars/polars-arrow/src/array/get.rs
+++ b/polars/polars-arrow/src/array/get.rs
@@ -10,7 +10,7 @@ pub trait ArrowGetItem {
     fn get(&self, item: usize) -> Option<Self::Item>;
 
     /// # Safety
-    /// Get item. It is the callers resposibility that the `item < self.len()`
+    /// Get item. It is the callers responsibility that the `item < self.len()`
     unsafe fn get_unchecked(&self, item: usize) -> Option<Self::Item>;
 }
 

--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -21,7 +21,7 @@ enum State {
     Bits(u64),
     // it is iterating over chunks (steps of size of 64 slots)
     Chunks,
-    // it is iterating over the remainding bits (steps of size of 1 slot)
+    // it is iterating over the remaining bits (steps of size of 1 slot)
     Remainder,
     // nothing more to iterate.
     Finish,

--- a/polars/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -85,7 +85,7 @@ impl<'a, T: NativeType> RollingAggWindowNulls<'a, T> for SortedMinMax<'a, T> {
 }
 
 /// Generic `Min` / `Max` kernel. It is written in terms of `Min` aggregation,
-/// but applys to `max` as well, just mentally `:s/min/max/g`.
+/// but applies to `max` as well, just mentally `:s/min/max/g`.
 pub struct MinMaxWindow<'a, T: NativeType + PartialOrd + IsFloat> {
     slice: &'a [T],
     validity: &'a Bitmap,

--- a/polars/polars-arrow/src/kernels/sorted_join/left.rs
+++ b/polars/polars-arrow/src/kernels/sorted_join/left.rs
@@ -23,7 +23,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
     // left array could start lower than right;
     // left: [-1, 0, 1, 2],
     // right: [1, 2, 3]
-    // first values should be None, until left has catched up
+    // first values should be None, until left has caught up
 
     let first_right = right[right_idx as usize];
     let mut left_idx = left.partition_point(|v| v < &first_right) as IdxSize;

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -37,7 +37,7 @@ impl Drop for ExtensionSentinel {
 }
 
 // https://stackoverflow.com/questions/28127165/how-to-convert-struct-to-u8d
-// not entirely sure if padding bytes in T are intialized or not.
+// not entirely sure if padding bytes in T are initialized or not.
 unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     std::slice::from_raw_parts((p as *const T) as *const u8, std::mem::size_of::<T>())
 }

--- a/polars/polars-core/src/frame/asof_join/asof.rs
+++ b/polars/polars-core/src/frame/asof_join/asof.rs
@@ -60,7 +60,7 @@ where
     // left array could start lower than right;
     // left: [-1, 0, 1, 2],
     // right: [1, 2, 3]
-    // first values should be None, until left has catched up
+    // first values should be None, until left has caught up
     let mut left_catched_up = false;
 
     // init with left so that the distance starts at 0
@@ -132,7 +132,7 @@ pub(super) fn join_asof_backward<T: PartialOrd + Copy + Debug>(
     // left array could start lower than right;
     // left: [-1, 0, 1, 2],
     // right: [1, 2, 3]
-    // first values should be None, until left has catched up
+    // first values should be None, until left has caught up
     let mut left_catched_up = false;
 
     for &val_l in left {

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -16,13 +16,13 @@ class WhenThenThen:
     """
 
     def __init__(self, pywhenthenthen: Any):
-        self.pywenthenthen = pywhenthenthen
+        self.pywhenthenthen = pywhenthenthen
 
     def when(self, predicate: pli.Expr) -> "WhenThenThen":
         """
         Start another when, then, otherwise layer.
         """
-        return WhenThenThen(self.pywenthenthen.when(predicate._pyexpr))
+        return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
     def then(self, expr: Union[pli.Expr, int, float, str]) -> "WhenThenThen":
         """
@@ -31,7 +31,7 @@ class WhenThenThen:
         See Also: the `when` function.
         """
         expr_ = pli.expr_to_lit_or_expr(expr)
-        return WhenThenThen(self.pywenthenthen.then(expr_._pyexpr))
+        return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
     def otherwise(self, expr: Union[pli.Expr, int, float, str]) -> pli.Expr:
         """
@@ -40,7 +40,7 @@ class WhenThenThen:
         See Also: the `when` function.
         """
         expr = pli.expr_to_lit_or_expr(expr)
-        return pli.wrap_expr(self.pywenthenthen.otherwise(expr._pyexpr))
+        return pli.wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
 
 class WhenThen:


### PR DESCRIPTION
Mostly rust readability; also included a single rename `pywenthenthen` -> `pywhenthenthen` from `.py` files.