### PR TITLE
fix typo for null_count in expr.py

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1349,7 +1349,7 @@ class Expr:
         return wrap_expr(self._pyexpr.n_unique())
 
     def null_count(self) -> "Expr":
-        """Count unique values."""
+        """Count null values."""
         return wrap_expr(self._pyexpr.null_count())
 
     def arg_unique(self) -> "Expr":


### PR DESCRIPTION
minor typo fix for null_count in polars-python code docs.

Signed-off-by: chitralverma <chitralverma@gmail.com>