### PR TITLE
Tag unsafe

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -278,7 +278,7 @@ mod test {
         ));
 
         let groups = s.group_tuples(false, true);
-        let aggregated = s.agg_list(&groups);
+        let aggregated = unsafe { s.agg_list(&groups) };
         match aggregated.get(0) {
             AnyValue::List(s) => {
                 assert!(matches!(s.dtype(), DataType::Categorical(_)));

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -35,14 +35,15 @@ impl CategoricalChunked {
 
     pub fn value_counts(&self) -> Result<DataFrame> {
         let groups = self.logical().group_tuples(true, false);
-        let logical_values = self
-            .logical()
-            .clone()
-            .into_series()
-            .agg_first(&groups)
-            .u32()
-            .unwrap()
-            .clone();
+        let logical_values = unsafe {
+            self.logical()
+                .clone()
+                .into_series()
+                .agg_first(&groups)
+                .u32()
+                .unwrap()
+                .clone()
+        };
 
         let mut values = self.clone();
         *values.logical_mut() = logical_values;

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -191,7 +191,7 @@ mod test {
         let ca = ObjectChunked::new("", values);
 
         let groups = GroupsProxy::Idx(vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into());
-        let out = ca.agg_list(&groups);
+        let out = unsafe { ca.agg_list(&groups) };
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());
     }
@@ -214,7 +214,7 @@ mod test {
         let ca = ObjectChunked::new("", values);
 
         let groups = vec![(0, vec![0, 1]), (2, vec![2]), (3, vec![3])].into();
-        let out = ca.agg_list(&GroupsProxy::Idx(groups));
+        let out = unsafe { ca.agg_list(&GroupsProxy::Idx(groups)) };
         let a = out.explode().unwrap();
 
         let ca_foo = a.as_any().downcast_ref::<ObjectChunked<Foo>>().unwrap();

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -251,7 +251,7 @@ pub struct GroupBy<'df> {
     df: &'df DataFrame,
     pub(crate) selected_keys: Vec<Series>,
     // [first idx, [other idx]]
-    pub(crate) groups: GroupsProxy,
+    groups: GroupsProxy,
     // columns selected for aggregation
     pub(crate) selected_agg: Option<Vec<String>>,
 }
@@ -299,7 +299,11 @@ impl<'df> GroupBy<'df> {
     /// The Vec returned contains:
     ///     (first_idx, Vec<indexes>)
     ///     Where second value in the tuple is a vector with all matching indexes.
-    pub fn get_groups_mut(&mut self) -> &mut GroupsProxy {
+    ///
+    /// # Safety
+    /// Groups should always be in bounds of the `DataFrame` hold by this `[GroupBy]`.
+    /// If you mutate it, you must hold that invariant.
+    pub unsafe fn get_groups_mut(&mut self) -> &mut GroupsProxy {
         &mut self.groups
     }
 
@@ -405,7 +409,7 @@ impl<'df> GroupBy<'df> {
 
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Mean);
-            let mut agg = agg_col.agg_mean(&self.groups);
+            let mut agg = unsafe { agg_col.agg_mean(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -442,7 +446,7 @@ impl<'df> GroupBy<'df> {
 
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Sum);
-            let mut agg = agg_col.agg_sum(&self.groups);
+            let mut agg = unsafe { agg_col.agg_sum(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -478,7 +482,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Min);
-            let mut agg = agg_col.agg_min(&self.groups);
+            let mut agg = unsafe { agg_col.agg_min(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -514,7 +518,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Max);
-            let mut agg = agg_col.agg_max(&self.groups);
+            let mut agg = unsafe { agg_col.agg_max(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -550,7 +554,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::First);
-            let mut agg = agg_col.agg_first(&self.groups);
+            let mut agg = unsafe { agg_col.agg_first(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -586,7 +590,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Last);
-            let mut agg = agg_col.agg_last(&self.groups);
+            let mut agg = unsafe { agg_col.agg_last(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }
@@ -622,7 +626,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::NUnique);
-            let mut agg = agg_col.agg_n_unique(&self.groups);
+            let mut agg = unsafe { agg_col.agg_n_unique(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg.into_series());
         }
@@ -651,7 +655,7 @@ impl<'df> GroupBy<'df> {
         for agg_col in agg_cols {
             let new_name =
                 fmt_groupby_column(agg_col.name(), GroupByMethod::Quantile(quantile, interpol));
-            let mut agg = agg_col.agg_quantile(&self.groups, quantile, interpol);
+            let mut agg = unsafe { agg_col.agg_quantile(&self.groups, quantile, interpol) };
             agg.rename(&new_name);
             cols.push(agg.into_series());
         }
@@ -672,7 +676,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Median);
-            let mut agg = agg_col.agg_median(&self.groups);
+            let mut agg = unsafe { agg_col.agg_median(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg.into_series());
         }
@@ -684,7 +688,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Var);
-            let mut agg = agg_col.agg_var(&self.groups);
+            let mut agg = unsafe { agg_col.agg_var(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg.into_series());
         }
@@ -696,7 +700,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::Std);
-            let mut agg = agg_col.agg_std(&self.groups);
+            let mut agg = unsafe { agg_col.agg_std(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg.into_series());
         }
@@ -827,7 +831,7 @@ impl<'df> GroupBy<'df> {
         macro_rules! finish_agg_opt {
             ($self:ident, $name_fmt:expr, $agg_fn:ident, $agg_col:ident, $cols:ident) => {{
                 let new_name = format!($name_fmt, $agg_col.name());
-                let mut agg = $agg_col.$agg_fn(&$self.groups);
+                let mut agg = unsafe { $agg_col.$agg_fn(&$self.groups) };
                 agg.rename(&new_name);
                 $cols.push(agg.into_series());
             }};
@@ -835,7 +839,7 @@ impl<'df> GroupBy<'df> {
         macro_rules! finish_agg {
             ($self:ident, $name_fmt:expr, $agg_fn:ident, $agg_col:ident, $cols:ident) => {{
                 let new_name = format!($name_fmt, $agg_col.name());
-                let mut agg = $agg_col.$agg_fn(&$self.groups);
+                let mut agg = unsafe { $agg_col.$agg_fn(&$self.groups) };
                 agg.rename(&new_name);
                 $cols.push(agg.into_series());
             }};
@@ -902,7 +906,7 @@ impl<'df> GroupBy<'df> {
         let (mut cols, agg_cols) = self.prepare_agg()?;
         for agg_col in agg_cols {
             let new_name = fmt_groupby_column(agg_col.name(), GroupByMethod::List);
-            let mut agg = agg_col.agg_list(&self.groups);
+            let mut agg = unsafe { agg_col.agg_list(&self.groups) };
             agg.rename(&new_name);
             cols.push(agg);
         }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2937,8 +2937,8 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn is_unique(&self) -> Result<BooleanChunked> {
-        let mut gb = self.groupby(self.get_column_names())?;
-        let groups = std::mem::take(&mut gb.groups);
+        let gb = self.groupby(self.get_column_names())?;
+        let groups = gb.take_groups();
         Ok(is_unique_helper(
             groups,
             self.height() as IdxSize,
@@ -2961,8 +2961,8 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn is_duplicated(&self) -> Result<BooleanChunked> {
-        let mut gb = self.groupby(self.get_column_names())?;
-        let groups = std::mem::take(&mut gb.groups);
+        let gb = self.groupby(self.get_column_names())?;
+        let groups = gb.take_groups();
         Ok(is_unique_helper(
             groups,
             self.height() as IdxSize,
@@ -3068,9 +3068,9 @@ impl DataFrame {
     #[doc(hidden)]
     pub fn _partition_by_impl(&self, cols: &[String], stable: bool) -> Result<Vec<DataFrame>> {
         let groups = if stable {
-            self.groupby_stable(cols)?.groups
+            self.groupby_stable(cols)?.take_groups()
         } else {
-            self.groupby(cols)?.groups
+            self.groupby(cols)?.take_groups()
         };
 
         // don't parallelize this

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -66,19 +66,19 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_min(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_min(groups)
     }
 
-    fn agg_max(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_max(groups)
     }
 
-    fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_sum(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_sum(groups)
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_list(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -99,7 +99,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.logical().vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0
             .logical()

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -77,15 +77,15 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_min(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_min(groups).$into_logical().into_series()
             }
 
-            fn agg_max(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_max(groups).$into_logical().into_series()
             }
 
-            fn agg_list(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
                 // we cannot cast and dispatch as the inner type of the list would be incorrect
                 self.0
                     .agg_list(groups)
@@ -93,7 +93,7 @@ macro_rules! impl_dyn_series {
                     .unwrap()
             }
 
-            fn agg_quantile(
+            unsafe fn agg_quantile(
                 &self,
                 groups: &GroupsProxy,
                 quantile: f64,
@@ -105,7 +105,7 @@ macro_rules! impl_dyn_series {
                     .into_series()
             }
 
-            fn agg_median(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_median(groups).$into_logical().into_series()
             }
 
@@ -597,7 +597,7 @@ mod test {
         let s = Series::new("foo", &[1, 2, 3]);
         let s = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
 
-        let l = s.agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])].into()));
+        let l = unsafe { s.agg_list(&GroupsProxy::Idx(vec![(0, vec![0, 1, 2])].into())) };
 
         match l.dtype() {
             DataType::List(inner) => {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -78,20 +78,20 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_min(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_min(groups)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }
 
-    fn agg_max(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_max(groups)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0
             .agg_list(groups)
@@ -99,7 +99,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             .unwrap()
     }
 
-    fn agg_quantile(
+    unsafe fn agg_quantile(
         &self,
         groups: &GroupsProxy,
         quantile: f64,
@@ -111,7 +111,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
-    fn agg_median(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_median(groups)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -81,28 +81,28 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_min(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_min(groups)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn agg_max(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_max(groups)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_sum(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_sum(groups)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn agg_std(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_std(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_std(groups)
             // cast f64 back to physical type
@@ -112,7 +112,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn agg_var(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_var(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_var(groups)
             // cast f64 back to physical type
@@ -122,7 +122,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         // we cannot cast and dispatch as the inner type of the list would be incorrect
         self.0
             .agg_list(groups)
@@ -130,7 +130,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .unwrap()
     }
 
-    fn agg_quantile(
+    unsafe fn agg_quantile(
         &self,
         groups: &GroupsProxy,
         quantile: f64,
@@ -145,7 +145,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn agg_median(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
         self.0
             .agg_median(groups)
             // cast f64 back to physical type

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -87,31 +87,31 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_min(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_min(groups)
             }
 
-            fn agg_max(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_max(groups)
             }
 
-            fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_sum(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_sum(groups)
             }
 
-            fn agg_std(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_std(&self, groups: &GroupsProxy) -> Series {
                 self.agg_std(groups)
             }
 
-            fn agg_var(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_var(&self, groups: &GroupsProxy) -> Series {
                 self.agg_var(groups)
             }
 
-            fn agg_list(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_list(groups)
             }
 
-            fn agg_quantile(
+            unsafe fn agg_quantile(
                 &self,
                 groups: &GroupsProxy,
                 quantile: f64,
@@ -120,7 +120,7 @@ macro_rules! impl_dyn_series {
                 self.agg_quantile(groups, quantile, interpol)
             }
 
-            fn agg_median(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
                 self.agg_median(groups)
             }
             fn zip_outer_join_column(

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -44,7 +44,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
         ChunkZip::zip_with(&self.0, mask, other.as_ref().as_ref()).map(|ca| ca.into_series())
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_list(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -142,15 +142,15 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash_combine(build_hasher, hashes)
             }
 
-            fn agg_min(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_min(groups)
             }
 
-            fn agg_max(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_max(groups)
             }
 
-            fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_sum(&self, groups: &GroupsProxy) -> Series {
                 use DataType::*;
                 match self.dtype() {
                     Int8 | UInt8 | Int16 | UInt16 => self.cast(&Int64).unwrap().agg_sum(groups),
@@ -158,19 +158,19 @@ macro_rules! impl_dyn_series {
                 }
             }
 
-            fn agg_std(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_std(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_std(groups)
             }
 
-            fn agg_var(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_var(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_var(groups)
             }
 
-            fn agg_list(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_list(groups)
             }
 
-            fn agg_quantile(
+            unsafe fn agg_quantile(
                 &self,
                 groups: &GroupsProxy,
                 quantile: f64,
@@ -179,7 +179,7 @@ macro_rules! impl_dyn_series {
                 self.0.agg_quantile(groups, quantile, interpol)
             }
 
-            fn agg_median(&self, groups: &GroupsProxy) -> Series {
+            unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_median(groups)
             }
             fn zip_outer_join_column(

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -39,7 +39,7 @@ where
         Cow::Borrowed(self.0.ref_field())
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_list(groups)
     }
 

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -64,7 +64,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.vec_hash_combine(build_hasher, hashes)
     }
 
-    fn agg_list(&self, groups: &GroupsProxy) -> Series {
+    unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_list(groups)
     }
 

--- a/polars/polars-core/src/series/ops/unique.rs
+++ b/polars/polars-core/src/series/ops/unique.rs
@@ -30,7 +30,7 @@ impl Series {
     /// with dtype [`IdxType`]
     pub fn value_counts(&self, multithreaded: bool) -> Result<DataFrame> {
         let groups = self.group_tuples(multithreaded, false);
-        let values = self.agg_first(&groups);
+        let values = unsafe { self.agg_first(&groups) };
         let counts = groups.group_lengths("counts");
         let cols = vec![values.into_series(), counts.into_series()];
         let df = DataFrame::new_no_checks(cols);

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -118,27 +118,27 @@ pub(crate) mod private {
         fn vec_hash_combine(&self, _build_hasher: RandomState, _hashes: &mut [u64]) {
             invalid_operation_panic!(self)
         }
-        fn agg_min(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_max(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
         /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16}` the `Series` is
         /// first cast to `Int64` to prevent overflow issues.
-        fn agg_sum(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_sum(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_std(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_std(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_var(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_var(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_list(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_quantile(
+        unsafe fn agg_quantile(
             &self,
             groups: &GroupsProxy,
             _quantile: f64,
@@ -146,7 +146,7 @@ pub(crate) mod private {
         ) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
-        fn agg_median(&self, groups: &GroupsProxy) -> Series {
+        unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
             Series::full_null(self._field().name(), groups.len(), self._dtype())
         }
         fn zip_outer_join_column(

--- a/polars/polars-lazy/src/physical_plan/expressions/count.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/count.rs
@@ -80,7 +80,9 @@ impl PartitionedAggregation for CountExpr {
         groups: &GroupsProxy,
         _state: &ExecutionState,
     ) -> Result<Series> {
-        let mut agg = partitioned.agg_sum(groups);
+        // safety:
+        // groups are in bounds
+        let mut agg = unsafe { partitioned.agg_sum(groups) };
         agg.rename(COUNT_NAME);
         Ok(agg)
     }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -323,7 +323,9 @@ impl<'a> AggregationContext<'a> {
             AggState::NotAggregated(s) => {
                 // We should not aggregate literals!!
                 if self.state.safe_to_agg(&self.groups) {
-                    let agg = s.agg_list(&self.groups);
+                    // safety:
+                    // groups are in bounds
+                    let agg = unsafe { s.agg_list(&self.groups) };
                     self.update_groups = UpdateGroups::WithGroupsLen;
                     self.state = AggState::AggregatedList(agg);
                 }
@@ -390,7 +392,9 @@ impl<'a> AggregationContext<'a> {
                     }
                 }
 
-                let out = s.agg_list(&self.groups);
+                // safety:
+                // groups are in bounds
+                let out = unsafe { s.agg_list(&self.groups) };
                 self.state = AggState::AggregatedList(out.clone());
 
                 if !self.sorted {
@@ -424,7 +428,9 @@ impl<'a> AggregationContext<'a> {
             let s = s.clone();
             // // todo! optimize this, we don't have to call agg_list, create the list directly.
             let s = s.expand_at_index(0, self.groups.iter().map(|g| g.len()).sum());
-            s.agg_list(&self.groups)
+            // safety:
+            // groups are in bounds
+            unsafe { s.agg_list(&self.groups) }
         } else {
             self.aggregated()
         }

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -239,8 +239,8 @@ impl PhysicalExpr for WindowExpr {
             // and keys are sorted
             //  we may optimize with explode call
             (!self.is_simple_column_expr() && !explicit_list_agg && sorted_keys && !self.is_aggregation());
-            let mut gb = df.groupby_with_series(groupby_columns.clone(), true, sorted)?;
-            let out: Result<GroupsProxy> = Ok(std::mem::take(gb.get_groups_mut()));
+            let gb = df.groupby_with_series(groupby_columns.clone(), true, sorted)?;
+            let out: Result<GroupsProxy> = Ok(gb.take_groups());
             out
         };
 
@@ -274,9 +274,9 @@ impl PhysicalExpr for WindowExpr {
 
         let mut ac = self.run_aggregation(df, state, &gb)?;
 
-        let cache_gb = |mut gb: GroupBy| {
+        let cache_gb = |gb: GroupBy| {
             if state.cache_window {
-                let groups = std::mem::take(gb.get_groups_mut());
+                let groups = gb.take_groups();
                 let mut gt_map = state.group_tuples.lock();
                 gt_map.insert(cache_key.clone(), groups);
             } else {

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -288,10 +288,10 @@ impl Wrap<&DataFrame> {
             }
         };
 
-        let dt = dt.clone().into_series().agg_first(&groups);
+        let dt = unsafe { dt.clone().into_series().agg_first(&groups) };
         let mut dt = dt.datetime().unwrap().as_ref().clone();
         for key in by.iter_mut() {
-            *key = key.agg_first(&groups)
+            *key = unsafe { key.agg_first(&groups) };
         }
 
         if options.truncate {
@@ -379,7 +379,7 @@ impl Wrap<&DataFrame> {
 
         if !by.is_empty() {
             for key in by.iter_mut() {
-                *key = key.agg_first(&groups)
+                *key = unsafe { key.agg_first(&groups) };
             }
         }
         dt.cast(time_type).map(|s| (s, by, groups))
@@ -449,7 +449,7 @@ mod test {
                 )
                 .unwrap();
 
-            let sum = a.agg_sum(&groups);
+            let sum = unsafe { a.agg_sum(&groups) };
             let expected = Series::new("", [3, 10, 15, 24, 11, 1]);
             assert_eq!(sum, expected);
         }
@@ -489,37 +489,37 @@ mod test {
 
         let nulls = Series::new("", [Some(3), Some(7), None, Some(9), Some(2), Some(1)]);
 
-        let min = a.agg_min(&groups);
+        let min = unsafe { a.agg_min(&groups) };
         let expected = Series::new("", [3, 3, 3, 3, 2, 1]);
         assert_eq!(min, expected);
 
         // expected for nulls is equal
-        let min = nulls.agg_min(&groups);
+        let min = unsafe { nulls.agg_min(&groups) };
         assert_eq!(min, expected);
 
-        let max = a.agg_max(&groups);
+        let max = unsafe { a.agg_max(&groups) };
         let expected = Series::new("", [3, 7, 7, 9, 9, 1]);
         assert_eq!(max, expected);
 
-        let max = nulls.agg_max(&groups);
+        let max = unsafe { nulls.agg_max(&groups) };
         assert_eq!(max, expected);
 
-        let var = a.agg_var(&groups);
+        let var = unsafe { a.agg_var(&groups) };
         let expected = Series::new(
             "",
             [0.0, 8.0, 4.000000000000002, 6.666666666666667, 24.5, 0.0],
         );
         assert_eq!(var, expected);
 
-        let var = nulls.agg_var(&groups);
+        let var = unsafe { nulls.agg_var(&groups) };
         let expected = Series::new("", [0.0, 8.0, 8.0, 9.333333333333343, 24.5, 0.0]);
         assert_eq!(var, expected);
 
-        let quantile = a.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear);
+        let quantile = unsafe { a.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear) };
         let expected = Series::new("", [3.0, 5.0, 5.0, 6.0, 5.5, 1.0]);
         assert_eq!(quantile, expected);
 
-        let quantile = nulls.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear);
+        let quantile = unsafe { nulls.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear) };
         let expected = Series::new("", [3.0, 5.0, 5.0, 7.0, 5.5, 1.0]);
         assert_eq!(quantile, expected);
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.13.41"
+version = "0.13.42"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.13.41"
+version = "0.13.42"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"


### PR DESCRIPTION
Correctly tag inner API methods that don't do bound checks as `unsafe`.