### PR TITLE
improve when then otherwise for lists

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -733,6 +733,11 @@ impl PartialEq for DataType {
                 #[cfg(feature = "dtype-categorical")]
                 (Categorical(_), Categorical(_)) => true,
                 (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r)) => tu_l == tu_r && tz_l == tz_r,
+                (List(left_inner), List(right_inner)) => left_inner == right_inner,
+                #[cfg(feature = "dtype-duration")]
+                (Duration(tu_l), Duration(tu_r)) => tu_l == tu_r,
+                #[cfg(feature = "object")]
+                (Object(lhs), Object(rhs)) => lhs == rhs,
                 _ => std::mem::discriminant(self) == std::mem::discriminant(other),
             }
         }

--- a/polars/polars-lazy/src/tests/projection_queries.rs
+++ b/polars/polars-lazy/src/tests/projection_queries.rs
@@ -107,6 +107,7 @@ fn scan_join_same_file() -> Result<()> {
 }
 
 #[test]
+#[cfg(all(feature = "regex", feature = "concat_str"))]
 fn concat_str_regex_expansion() -> Result<()> {
     let df = df![
         "a"=> [1, 1, 1],

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5286,7 +5286,23 @@ class ExprDateTimeNameSpace:
 
 
 def expr_to_lit_or_expr(
-    expr: Union[Expr, bool, int, float, str, "pli.Series", None],
+    expr: Union[
+        Expr,
+        bool,
+        int,
+        float,
+        str,
+        "pli.Series",
+        None,
+        Sequence[
+            Union[
+                int,
+                float,
+                str,
+                None,
+            ]
+        ],
+    ],
     str_to_lit: bool = True,
 ) -> Expr:
     """
@@ -5312,6 +5328,8 @@ def expr_to_lit_or_expr(
         return pli.lit(expr)
     elif isinstance(expr, Expr):
         return expr
+    elif isinstance(expr, list):
+        return pli.lit(pli.Series("", [expr]))
     else:
         raise ValueError(
             f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with pl.lit or pl.col"

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Sequence, Union
 
 try:
     from polars.polars import when as pywhen
@@ -24,7 +24,24 @@ class WhenThenThen:
         """
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
-    def then(self, expr: Union[pli.Expr, int, float, str, None]) -> "WhenThenThen":
+    def then(
+        self,
+        expr: Union[
+            pli.Expr,
+            int,
+            float,
+            str,
+            None,
+            Sequence[
+                Union[
+                    int,
+                    float,
+                    str,
+                    None,
+                ]
+            ],
+        ],
+    ) -> "WhenThenThen":
         """
         Values to return in case of the predicate being `True`.
 
@@ -33,7 +50,24 @@ class WhenThenThen:
         expr_ = pli.expr_to_lit_or_expr(expr)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
-    def otherwise(self, expr: Union[pli.Expr, int, float, str, None]) -> pli.Expr:
+    def otherwise(
+        self,
+        expr: Union[
+            pli.Expr,
+            int,
+            float,
+            str,
+            None,
+            Sequence[
+                Union[
+                    int,
+                    float,
+                    str,
+                    None,
+                ]
+            ],
+        ],
+    ) -> pli.Expr:
         """
         Values to return in case of the predicate being `False`.
 
@@ -75,7 +109,12 @@ class When:
     def __init__(self, pywhen: "pywhen"):
         self._pywhen = pywhen
 
-    def then(self, expr: Union[pli.Expr, int, float, str, None]) -> WhenThen:
+    def then(
+        self,
+        expr: Union[
+            pli.Expr, int, float, str, None, Sequence[Union[None, int, float, str]]
+        ],
+    ) -> WhenThen:
         """
         Values to return in case of the predicate being `True`.
 

--- a/py-polars/tests/test_lists.py
+++ b/py-polars/tests/test_lists.py
@@ -252,3 +252,14 @@ def test_list_fill_null() -> None:
             .alias("C")
         ]
     ).to_series().to_list() == [["a", "b", "c"], None, None, ["d", "e"]]
+
+
+def test_list_fill_list() -> None:
+    assert pl.DataFrame({"a": [[1, 2, 3], []]}).select(
+        [
+            pl.when(pl.col("a").arr.lengths() == 0)
+            .then([5])
+            .otherwise(pl.col("a"))
+            .alias("filled")
+        ]
+    ).to_dict(False) == {"filled": [[1, 2, 3], [5]]}

--- a/py-polars/tests/test_queries.py
+++ b/py-polars/tests/test_queries.py
@@ -49,7 +49,7 @@ def test_repeat_expansion_in_groupby() -> None:
         pl.DataFrame({"g": [1, 2, 2, 3, 3, 3]})
         .groupby("g", maintain_order=True)
         .agg(pl.repeat(1, pl.count()).cumsum())
-        .to_dict()
+        .to_dict(False)
     )
     assert out == {"g": [1, 2, 3], "literal": [[1], [1, 2], [1, 2, 3]]}
 


### PR DESCRIPTION
closes #3596

Can now use list literals in `when then otherwise`.

This only does not work for empty lists. This is because of the way we implemented. We ternary mask on the inner array. However, there is not 'empty' type, so we cannot express the empty branch that way. 

```python
pl.DataFrame({
    "a": [[1, 2, 3], []]
}).select([
    pl.when(pl.col("a").arr.lengths() == 0).then([5]).otherwise(pl.col("a")).alias("filled")
])
```

```
shape: (2, 1)
┌───────────┐
│ filled    │
│ ---       │
│ list[i64] │
╞═══════════╡
│ [1, 2, 3] │
├╌╌╌╌╌╌╌╌╌╌╌┤
│ [5]       │
└───────────┘

```