### PR TITLE
Fix Series init from list containing another empty list (#3608)

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -180,7 +180,7 @@ def sequence_to_pyseries(
 
         elif dtype_ == list or dtype_ == tuple:
             nested_value = _get_first_non_none(value)
-            nested_dtype = type(nested_value) if value is not None else float
+            nested_dtype = type(nested_value) if nested_value is not None else float
 
             # recursively call Series constructor
             if nested_dtype == list:


### PR DESCRIPTION
Small fix; use the standard default (float) as the inferred nested-type of an empty list (this was the intent, but the none-check was accidentally being made against `value` instead of `nested_value`).

*Before*
```python
pl.DataFrame( {'x':[[]],'y':[123]} )
ShapeError: Could not create a new DataFrame from Series. The Series have different lengths
```

*After*
```python
pl.DataFrame( {'x':[[]],'y':[123]} )
Out[4]: 
shape: (1, 2)
┌───────────┬─────┐
│ x         ┆ y   │
│ ---       ┆ --- │
│ list[f64] ┆ i64 │
╞═══════════╪═════╡
│ []        ┆ 123 │
└───────────┴─────┘
```