### PR TITLE
Fix Series init (as pl.Object dtype) from mixed-type input and extend test coverage

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -180,7 +180,7 @@ def sequence_to_pyseries(
 
         elif dtype_ == list or dtype_ == tuple:
             nested_value = _get_first_non_none(value)
-            nested_dtype = type(nested_value) if value is not None else float
+            nested_dtype = type(nested_value) if nested_value is not None else float
 
             # recursively call Series constructor
             if nested_dtype == list:
@@ -225,7 +225,7 @@ def sequence_to_pyseries(
                 try:
                     arrow_values = pa.array(values, pa.large_list(nested_arrow_dtype))
                     return arrow_to_pyseries(name, arrow_values)
-                except pa.lib.ArrowInvalid:
+                except (pa.lib.ArrowInvalid, pa.lib.ArrowTypeError):
                     pass
 
             # Convert mixed sequences like `[[12], "foo", 9]`


### PR DESCRIPTION
Fixed Series init from mixed-type input (should treat as pl.Object), and added test coverage for the same.

**Before**

```python
import polars as pl
df = pl.DataFrame(
    data = {"x": [["abc", 12, 34.5]], "y": [1]}
)
ArrowTypeError: Expected bytes, got a 'int' object
```
**After**
```python
import polars as pl
df = pl.DataFrame(
    data = {"x": [["abc", 12, 34.5]], "y": [1]}
)
df.schema 
# {'x': pl.Object, 'y': pl.Int64}
df.rows()
# [(['abc', 12, 34.5], 1)]
```
(Rebased against latest code, as requested).