### PR TITLE
improve explode of empty lists

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2117,7 +2117,7 @@ def test_explode_empty() -> None:
 
     df = pl.DataFrame(dict(x=["1", "2", "4"], y=[["a", "b", "c"], ["d"], []]))
     assert df.explode("y").frame_equal(
-        pl.DataFrame({"x": ["1", "1", "1", "2"], "y": ["a", "b", "c", "d"]})
+        pl.DataFrame({"x": ["1", "1", "1", "2", "4"], "y": ["a", "b", "c", "d", None]})
     )
 
 


### PR DESCRIPTION
Exploding dataframes with empty lists did not yield the same result as exploding a Series with empty lists. 

Now it does. The empty list will become a `null` upon explosion. Happy side effect, it is also faster.

closes #3574