### PR TITLE
Anonymous scan enhancements & cleanup

### DIFF
--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -187,7 +187,7 @@ pub fn infer_schema(
     infer_schema_length: usize,
 ) -> Schema {
     let mut values: Tracker = Tracker::new();
-    let len = iter.size_hint().1.unwrap();
+    let len = iter.size_hint().1.unwrap_or(infer_schema_length);
 
     let max_infer = std::cmp::min(len, infer_schema_length);
     for inner in iter.take(max_infer) {
@@ -223,7 +223,8 @@ fn resolve_fields(spec: Tracker) -> Vec<Field> {
         .collect()
 }
 
-fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType {
+/// Coerces a slice of datatypes into a single supertype.
+pub fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType {
     use DataType::*;
 
     let are_all_equal = datatypes.windows(2).all(|w| w[0].borrow() == w[1].borrow());

--- a/polars/polars-lazy/src/frame/anonymous_scan.rs
+++ b/polars/polars-lazy/src/frame/anonymous_scan.rs
@@ -6,6 +6,8 @@ use polars_io::RowCount;
 pub struct ScanArgsAnonymous {
     pub infer_schema_length: Option<usize>,
     pub schema: Option<Schema>,
+    pub skip_rows: Option<usize>,
+    pub n_rows: Option<usize>,
     pub row_count: Option<RowCount>,
     pub name: &'static str,
 }
@@ -14,6 +16,8 @@ impl Default for ScanArgsAnonymous {
     fn default() -> Self {
         Self {
             infer_schema_length: None,
+            skip_rows: None,
+            n_rows: None,
             schema: None,
             row_count: None,
             name: "ANONYMOUS SCAN",
@@ -29,6 +33,8 @@ impl LazyFrame {
             function,
             args.schema,
             args.infer_schema_length,
+            args.skip_rows,
+            args.n_rows,
             args.name,
         )?
         .build()

--- a/polars/polars-lazy/src/frame/anonymous_scan.rs
+++ b/polars/polars-lazy/src/frame/anonymous_scan.rs
@@ -26,7 +26,7 @@ impl Default for ScanArgsAnonymous {
 }
 impl LazyFrame {
     pub fn anonymous_scan(
-        function: Arc<dyn AnonymousScan>,
+        function: Arc<dyn ScanProvider>,
         args: ScanArgsAnonymous,
     ) -> Result<Self> {
         let mut lf: LazyFrame = LogicalPlanBuilder::anonymous_scan(

--- a/polars/polars-lazy/src/frame/anonymous_scan.rs
+++ b/polars/polars-lazy/src/frame/anonymous_scan.rs
@@ -4,8 +4,6 @@ use polars_io::RowCount;
 
 #[derive(Clone)]
 pub struct ScanArgsAnonymous {
-    pub skip_rows: Option<usize>,
-    pub n_rows: Option<usize>,
     pub infer_schema_length: Option<usize>,
     pub schema: Option<Schema>,
     pub row_count: Option<RowCount>,
@@ -15,8 +13,6 @@ pub struct ScanArgsAnonymous {
 impl Default for ScanArgsAnonymous {
     fn default() -> Self {
         Self {
-            skip_rows: None,
-            n_rows: None,
             infer_schema_length: None,
             schema: None,
             row_count: None,
@@ -26,23 +22,17 @@ impl Default for ScanArgsAnonymous {
 }
 impl LazyFrame {
     pub fn anonymous_scan(
-        function: Arc<dyn ScanProvider>,
+        function: Arc<dyn AnonymousScan>,
         args: ScanArgsAnonymous,
     ) -> Result<Self> {
         let mut lf: LazyFrame = LogicalPlanBuilder::anonymous_scan(
             function,
             args.schema,
             args.infer_schema_length,
-            args.skip_rows,
-            args.n_rows,
             args.name,
         )?
         .build()
         .into();
-
-        if let Some(n_rows) = args.n_rows {
-            lf = lf.slice(0, n_rows as IdxSize);
-        };
 
         if let Some(rc) = args.row_count {
             lf = lf.with_row_count(&rc.name, Some(rc.offset))

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub enum ALogicalPlan {
     AnonymousScan {
-        function: Arc<dyn ScanProvider>,
+        function: Arc<dyn AnonymousScan>,
         schema: SchemaRef,
         output_schema: Option<SchemaRef>,
         predicate: Option<Node>,

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -12,14 +12,15 @@ use polars_utils::arena::{Arena, Node};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-// ALogicalPlan is a representation of LogicalPlan with Nodes which are allocated in an Arena
+/// ALogicalPlan is a representation of LogicalPlan with Nodes which are allocated in an Arena
 #[derive(Clone, Debug)]
 pub enum ALogicalPlan {
     AnonymousScan {
-        function: Arc<dyn AnonymousScan>,
+        function: Arc<dyn ScanProvider>,
         schema: SchemaRef,
         output_schema: Option<SchemaRef>,
         predicate: Option<Node>,
+        aggregate: Vec<Node>,
         options: AnonymousScanOptions,
     },
     #[cfg(feature = "python")]
@@ -173,7 +174,11 @@ impl ALogicalPlan {
                 ..
             } => output_schema.as_ref().unwrap_or(schema),
             DataFrameScan { schema, .. } => schema,
-            AnonymousScan { schema, .. } => schema,
+            AnonymousScan {
+                schema,
+                output_schema,
+                ..
+            } => output_schema.as_ref().unwrap_or(schema),
             Selection { input, .. } => arena.get(*input).schema(arena),
             #[cfg(feature = "csv-file")]
             CsvScan {
@@ -384,15 +389,18 @@ impl ALogicalPlan {
                 schema,
                 output_schema,
                 predicate,
+                aggregate: _,
                 options,
             } => {
                 let mut new_predicate = None;
                 if predicate.is_some() {
                     new_predicate = exprs.pop()
                 }
+
                 AnonymousScan {
                     function: function.clone(),
                     schema: schema.clone(),
+                    aggregate: exprs,
                     output_schema: output_schema.clone(),
                     predicate: new_predicate,
                     options: options.clone(),

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -1,26 +1,50 @@
-use crate::prelude::AnonymousScanOptions;
+use crate::prelude::{AnonymousScanOptions, PhysicalExpr};
 use polars_core::prelude::*;
 use std::fmt::{Debug, Formatter};
 
-pub trait AnonymousScan: Send + Sync {
-    fn scan(&self, scan_opts: AnonymousScanOptions) -> Result<DataFrame>;
+pub trait ScanProvider: Send + Sync {
+    /// Creates a dataframe from the supplied function & scan options. 
+    fn scan(&self, scan_opts: AnonymousScanOptions,  predicate: Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame>;
+
+    #[must_use]
+    /// function to supply the schema. 
+    /// Allows for an optional infer schema argument for data sources with flexible schemas
     fn schema(&self, _infer_schema_length: Option<usize>) -> Result<Schema> {
         Err(PolarsError::ComputeError(
             "Must supply either a schema or a schema function".into(),
         ))
     }
-}
-
-impl<F> AnonymousScan for F
-where
-    F: Fn(AnonymousScanOptions) -> Result<DataFrame> + Send + Sync,
-{
-    fn scan(&self, scan_opts: AnonymousScanOptions) -> Result<DataFrame> {
-        self(scan_opts)
+    /// specify if the scan provider should allow predicate pushdowns
+    /// 
+    /// Defaults to `false`
+    fn allows_predicate_pushdown(&self) -> Result<bool> {
+        Ok(false)
+    }
+    /// specify if the scan provider should allow projection pushdowns
+    /// 
+    /// Defaults to `false`
+    fn allows_projection_pushdown(&self) -> Result<bool> {
+        Ok(false)
+    }
+    /// specify if the scan provider should allow slice pushdowns
+    /// 
+    /// Defaults to `false`
+    fn allows_slice_pushdown(&self) -> Result<bool> {
+        // defaults to no pushdowns
+        Ok(false)
     }
 }
 
-impl Debug for dyn AnonymousScan {
+impl<F> ScanProvider for F
+where
+    F: Fn(AnonymousScanOptions, Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame> + Send + Sync,
+{
+    fn scan(&self, scan_opts: AnonymousScanOptions, predicate: Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame> {
+        self(scan_opts, predicate)
+    }
+}
+
+impl Debug for dyn ScanProvider {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "anonymous_scan")
     }

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -1,15 +1,13 @@
-use crate::prelude::{AnonymousScanOptions, PhysicalExpr};
+use crate::prelude::AnonymousScanOptions;
 use polars_core::prelude::*;
 use std::fmt::{Debug, Formatter};
 
 pub trait AnonymousScan: Send + Sync {
     /// Creates a dataframe from the supplied function & scan options.
-    #[must_use]
     fn scan(&self, scan_opts: AnonymousScanOptions) -> Result<DataFrame>;
 
     /// function to supply the schema.
     /// Allows for an optional infer schema argument for data sources with dynamic schemas
-    #[must_use]
     fn schema(&self, _infer_schema_length: Option<usize>) -> Result<Schema> {
         Err(PolarsError::ComputeError(
             "Must supply either a schema or a schema function".into(),

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -5,11 +5,7 @@ use std::fmt::{Debug, Formatter};
 pub trait AnonymousScan: Send + Sync {
     /// Creates a dataframe from the supplied function & scan options.
     #[must_use]
-    fn scan(
-        &self,
-        scan_opts: AnonymousScanOptions,
-        predicate: Option<Arc<dyn PhysicalExpr>>,
-    ) -> Result<DataFrame>;
+    fn scan(&self, scan_opts: AnonymousScanOptions) -> Result<DataFrame>;
 
     /// function to supply the schema.
     /// Allows for an optional infer schema argument for data sources with dynamic schemas
@@ -42,14 +38,10 @@ pub trait AnonymousScan: Send + Sync {
 
 impl<F> AnonymousScan for F
 where
-    F: Fn(AnonymousScanOptions, Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame> + Send + Sync,
+    F: Fn(AnonymousScanOptions) -> Result<DataFrame> + Send + Sync,
 {
-    fn scan(
-        &self,
-        scan_opts: AnonymousScanOptions,
-        predicate: Option<Arc<dyn PhysicalExpr>>,
-    ) -> Result<DataFrame> {
-        self(scan_opts, predicate)
+    fn scan(&self, scan_opts: AnonymousScanOptions) -> Result<DataFrame> {
+        self(scan_opts)
     }
 }
 

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -16,21 +16,20 @@ pub trait AnonymousScan: Send + Sync {
     /// specify if the scan provider should allow predicate pushdowns
     ///
     /// Defaults to `false`
-    fn allows_predicate_pushdown(&self) -> Result<bool> {
-        Ok(false)
+    fn allows_predicate_pushdown(&self) -> bool {
+        false
     }
     /// specify if the scan provider should allow projection pushdowns
     ///
     /// Defaults to `false`
-    fn allows_projection_pushdown(&self) -> Result<bool> {
-        Ok(false)
+    fn allows_projection_pushdown(&self) -> bool {
+        false
     }
     /// specify if the scan provider should allow slice pushdowns
     ///
     /// Defaults to `false`
-    fn allows_slice_pushdown(&self) -> Result<bool> {
-        // defaults to no pushdowns
-        Ok(false)
+    fn allows_slice_pushdown(&self) -> bool {
+        false
     }
 }
 

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -2,32 +2,37 @@ use crate::prelude::{AnonymousScanOptions, PhysicalExpr};
 use polars_core::prelude::*;
 use std::fmt::{Debug, Formatter};
 
-pub trait ScanProvider: Send + Sync {
-    /// Creates a dataframe from the supplied function & scan options. 
-    fn scan(&self, scan_opts: AnonymousScanOptions,  predicate: Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame>;
-
+pub trait AnonymousScan: Send + Sync {
+    /// Creates a dataframe from the supplied function & scan options.
     #[must_use]
-    /// function to supply the schema. 
-    /// Allows for an optional infer schema argument for data sources with flexible schemas
+    fn scan(
+        &self,
+        scan_opts: AnonymousScanOptions,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+    ) -> Result<DataFrame>;
+
+    /// function to supply the schema.
+    /// Allows for an optional infer schema argument for data sources with dynamic schemas
+    #[must_use]
     fn schema(&self, _infer_schema_length: Option<usize>) -> Result<Schema> {
         Err(PolarsError::ComputeError(
             "Must supply either a schema or a schema function".into(),
         ))
     }
     /// specify if the scan provider should allow predicate pushdowns
-    /// 
+    ///
     /// Defaults to `false`
     fn allows_predicate_pushdown(&self) -> Result<bool> {
         Ok(false)
     }
     /// specify if the scan provider should allow projection pushdowns
-    /// 
+    ///
     /// Defaults to `false`
     fn allows_projection_pushdown(&self) -> Result<bool> {
         Ok(false)
     }
     /// specify if the scan provider should allow slice pushdowns
-    /// 
+    ///
     /// Defaults to `false`
     fn allows_slice_pushdown(&self) -> Result<bool> {
         // defaults to no pushdowns
@@ -35,16 +40,20 @@ pub trait ScanProvider: Send + Sync {
     }
 }
 
-impl<F> ScanProvider for F
+impl<F> AnonymousScan for F
 where
     F: Fn(AnonymousScanOptions, Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame> + Send + Sync,
 {
-    fn scan(&self, scan_opts: AnonymousScanOptions, predicate: Option<Arc<dyn PhysicalExpr>>) -> Result<DataFrame> {
+    fn scan(
+        &self,
+        scan_opts: AnonymousScanOptions,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+    ) -> Result<DataFrame> {
         self(scan_opts, predicate)
     }
 }
 
-impl Debug for dyn ScanProvider {
+impl Debug for dyn AnonymousScan {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "anonymous_scan")
     }

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -53,11 +53,9 @@ macro_rules! try_delayed {
 
 impl LogicalPlanBuilder {
     pub fn anonymous_scan(
-        function: Arc<dyn ScanProvider>,
+        function: Arc<dyn AnonymousScan>,
         schema: Option<Schema>,
         infer_schema_length: Option<usize>,
-        skip_rows: Option<usize>,
-        n_rows: Option<usize>,
         name: &'static str,
     ) -> Result<Self> {
         let schema = Arc::new(match schema {
@@ -73,8 +71,8 @@ impl LogicalPlanBuilder {
             options: AnonymousScanOptions {
                 fmt_str: name,
                 schema,
-                skip_rows,
-                n_rows,
+                skip_rows: None,
+                n_rows: None,
                 output_schema: None,
                 with_columns: None,
             },

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -53,7 +53,7 @@ macro_rules! try_delayed {
 
 impl LogicalPlanBuilder {
     pub fn anonymous_scan(
-        function: Arc<dyn AnonymousScan>,
+        function: Arc<dyn ScanProvider>,
         schema: Option<Schema>,
         infer_schema_length: Option<usize>,
         skip_rows: Option<usize>,
@@ -69,6 +69,7 @@ impl LogicalPlanBuilder {
             function,
             schema: schema.clone(),
             predicate: None,
+            aggregate: vec![],
             options: AnonymousScanOptions {
                 fmt_str: name,
                 schema,

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -56,6 +56,8 @@ impl LogicalPlanBuilder {
         function: Arc<dyn AnonymousScan>,
         schema: Option<Schema>,
         infer_schema_length: Option<usize>,
+        skip_rows: Option<usize>,
+        n_rows: Option<usize>,
         name: &'static str,
     ) -> Result<Self> {
         let schema = Arc::new(match schema {
@@ -71,8 +73,8 @@ impl LogicalPlanBuilder {
             options: AnonymousScanOptions {
                 fmt_str: name,
                 schema,
-                skip_rows: None,
-                n_rows: None,
+                skip_rows,
+                n_rows,
                 output_schema: None,
                 with_columns: None,
             },

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -53,9 +53,10 @@ pub enum Context {
 pub enum LogicalPlan {
     #[cfg_attr(feature = "serde", serde(skip))]
     AnonymousScan {
-        function: Arc<dyn AnonymousScan>,
+        function: Arc<dyn ScanProvider>,
         schema: SchemaRef,
         predicate: Option<Expr>,
+        aggregate: Vec<Expr>,
         options: AnonymousScanOptions,
     },
     #[cfg(feature = "python")]

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -53,7 +53,7 @@ pub enum Context {
 pub enum LogicalPlan {
     #[cfg_attr(feature = "serde", serde(skip))]
     AnonymousScan {
-        function: Arc<dyn ScanProvider>,
+        function: Arc<dyn AnonymousScan>,
         schema: SchemaRef,
         predicate: Option<Expr>,
         aggregate: Vec<Expr>,

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -310,7 +310,7 @@ impl PredicatePushDown {
                 predicate,
                 aggregate
             } => {
-                if function.allows_predicate_pushdown()? {
+                if function.allows_predicate_pushdown() {
                     let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
                     let lp = AnonymousScan {
                         function,

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -302,6 +302,37 @@ impl PredicatePushDown {
                 };
                 Ok(lp)
             }
+            AnonymousScan {
+                function,
+                schema,
+                output_schema,
+                options,
+                predicate,
+                aggregate
+            } => {
+                if function.allows_predicate_pushdown()? {
+                    let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
+                    let lp = AnonymousScan {
+                        function,
+                        schema,
+                        output_schema,
+                        options,
+                        predicate,
+                        aggregate
+                    };
+                    Ok(lp)
+                } else {
+                    let lp = AnonymousScan {
+                        function,
+                        schema,
+                        output_schema,
+                        options,
+                        predicate,
+                        aggregate
+                    };
+                    self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
+                }
+            }
 
             Explode { input, columns, schema } => {
                 let condition = |name: Arc<str>| columns.iter().any(|s| s.as_str() == &*name);
@@ -466,10 +497,7 @@ impl PredicatePushDown {
              lp @ PythonScan {..} => {
                 self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
             }
-            lp @ AnonymousScan {..} => {
-                // TODO: add predicate pushdowns.
-                self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
-            }
+
         }
     }
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -343,10 +343,8 @@ impl ProjectionPushDown {
                 predicate,
                 mut options,
                 output_schema,
-                aggregate
-                
+                aggregate,
             } => {
-
                 if function.allows_projection_pushdown()? {
                     options.with_columns = get_scan_columns(&mut acc_projections, expr_arena);
 
@@ -368,10 +366,9 @@ impl ProjectionPushDown {
                         output_schema,
                         options,
                         predicate,
-                        aggregate
+                        aggregate,
                     };
                     Ok(lp)
-
                 } else {
                     let lp = AnonymousScan {
                         function,
@@ -379,11 +376,10 @@ impl ProjectionPushDown {
                         predicate,
                         options,
                         output_schema,
-                        aggregate
+                        aggregate,
                     };
                     Ok(lp)
                 }
-              
             }
             DataFrameScan {
                 df,

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -342,29 +342,48 @@ impl ProjectionPushDown {
                 schema,
                 predicate,
                 mut options,
-                ..
+                output_schema,
+                aggregate
+                
             } => {
-                options.with_columns = get_scan_columns(&mut acc_projections, expr_arena);
-                let output_schema = if options.with_columns.is_none() {
-                    None
-                } else {
-                    Some(Arc::new(update_scan_schema(
-                        &acc_projections,
-                        expr_arena,
-                        &*schema,
-                        true,
-                    )))
-                };
-                options.output_schema = output_schema.clone();
 
-                let lp = AnonymousScan {
-                    function,
-                    schema,
-                    output_schema,
-                    options,
-                    predicate,
-                };
-                Ok(lp)
+                if function.allows_projection_pushdown()? {
+                    options.with_columns = get_scan_columns(&mut acc_projections, expr_arena);
+
+                    let output_schema = if options.with_columns.is_none() {
+                        None
+                    } else {
+                        Some(Arc::new(update_scan_schema(
+                            &acc_projections,
+                            expr_arena,
+                            &*schema,
+                            true,
+                        )))
+                    };
+                    options.output_schema = output_schema.clone();
+
+                    let lp = AnonymousScan {
+                        function,
+                        schema,
+                        output_schema,
+                        options,
+                        predicate,
+                        aggregate
+                    };
+                    Ok(lp)
+
+                } else {
+                    let lp = AnonymousScan {
+                        function,
+                        schema,
+                        predicate,
+                        options,
+                        output_schema,
+                        aggregate
+                    };
+                    Ok(lp)
+                }
+              
             }
             DataFrameScan {
                 df,

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -345,7 +345,7 @@ impl ProjectionPushDown {
                 output_schema,
                 aggregate,
             } => {
-                if function.allows_projection_pushdown()? {
+                if function.allows_projection_pushdown() {
                     options.with_columns = get_scan_columns(&mut acc_projections, expr_arena);
 
                     let output_schema = if options.with_columns.is_none() {

--- a/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -100,7 +100,7 @@ impl SlicePushDown {
                 output_schema,
                 predicate,
                 options,
-
+                aggregate,
             },
                 // TODO! we currently skip slice pushdown if there is a predicate.
                 // we can modify the readers to only limit after predicates have been applied
@@ -112,7 +112,8 @@ impl SlicePushDown {
                     schema,
                     output_schema,
                     predicate,
-                    options
+                    options,
+                    aggregate,
                 };
 
                 Ok(lp)

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -292,9 +292,7 @@ pub(crate) struct AnonymousScanExec {
 
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
-        let mut df = self
-            .function
-            .scan(self.options.clone(), self.predicate.clone())?;
+        let mut df = self.function.scan(self.options.clone())?;
         if let Some(predicate) = &self.predicate {
             let s = predicate.evaluate(&df, state)?;
             let mask = s.bool().map_err(|_| {

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -285,14 +285,16 @@ impl Executor for DataFrameExec {
 }
 
 pub(crate) struct AnonymousScanExec {
-    pub(crate) function: Arc<dyn ScanProvider>,
+    pub(crate) function: Arc<dyn AnonymousScan>,
     pub(crate) options: AnonymousScanOptions,
     pub(crate) predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
-        let mut df = self.function.scan(self.options.clone(), self.predicate.clone())?;
+        let mut df = self
+            .function
+            .scan(self.options.clone(), self.predicate.clone())?;
         if let Some(predicate) = &self.predicate {
             let s = predicate.evaluate(&df, state)?;
             let mask = s.bool().map_err(|_| {

--- a/polars/polars-lazy/src/physical_plan/executors/scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan.rs
@@ -285,14 +285,14 @@ impl Executor for DataFrameExec {
 }
 
 pub(crate) struct AnonymousScanExec {
-    pub(crate) function: Arc<dyn AnonymousScan>,
+    pub(crate) function: Arc<dyn ScanProvider>,
     pub(crate) options: AnonymousScanOptions,
     pub(crate) predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
-        let mut df = self.function.scan(self.options.clone())?;
+        let mut df = self.function.scan(self.options.clone(), self.predicate.clone())?;
         if let Some(predicate) = &self.predicate {
             let s = predicate.evaluate(&df, state)?;
             let mask = s.bool().map_err(|_| {


### PR DESCRIPTION
general cleanup on the anonymousscan trait. 

i removed the `skip_rows` and `n_rows` from the scan_args because they can be pushed down through the lazyframe, so they are unnecessary. 

also added a few methods to the trait to allow the implementor to specify what should be pushed down. (predicate, pushdown, slice) being the supported pushdowns. 

added a few comments to the logical & physical plans explaining what they do, as I had some trouble initially understanding them. 

also small cleanup in the row infer so anonymousscan implementors can leverage `infer_schema` and `coerce_data_type` easier. 