### PR TITLE
Added StringCache Python API example

### DIFF
--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -13,6 +13,21 @@ class StringCache:
     """
     Context manager that allows data sources to share the same categorical features.
     This will temporarily cache the string categories until the context manager is finished.
+
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a_col": ["red", "green", "blue"],
+    ...         "b_col": ["yellow", "orange", "black"],
+    ...     }
+    ... )
+    >>> with pl.StringCache():
+    ...     df = df.with_columns(
+    ...         [
+    ...             pl.col("a_col").cast(pl.Categorical).alias("a_col"),
+    ...             pl.col("b_col").cast(pl.Categorical).alias("b_col"),
+    ...         ]
+    ...     )
+    ...
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Adds simple example using context manager (`with pl.StringCache()`).

Noticed a few files are being reformatted by `blackdoc`. I'll give it another look.
```
modified:   polars/internals/expr.py
modified:   polars/internals/series.py
modified:   tests/test_series.py
```

Let me know if there's a better place to put this. Going huntin'. 🙂 

Edit: I think updating `blackdoc` resolves the extra formatting? no longer seeing it.
