### PR TITLE
Fix polars.Expr.apply() Python API docs text

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1632,8 +1632,6 @@ class Expr:
 
         Depending on the context it has the following behavior:
 
-        ## Context
-
         * Select/Project
             expected type `f`: Callable[[Any], Any]
             Applies a python function over each individual value in the column.


### PR DESCRIPTION
I wasn't sure if 👇 works the way I'd intend for it to.

```py
"""
Context
---------
   ...
"""
```
