### PR TITLE
ndjson reader complex types support

### DIFF
--- a/nodejs-polars/src/lazy/dataframe.rs
+++ b/nodejs-polars/src/lazy/dataframe.rs
@@ -663,18 +663,15 @@ struct JsonScan {
 
 impl AnonymousScan for JsonScan {
     fn scan(&self, scan_opts: AnonymousScanOptions) -> polars::prelude::Result<DataFrame> {
-        if let Some(s) = scan_opts.output_schema {
-            JsonLineReader::from_path(&self.path)
-                .expect("unable to read file")
-                .with_schema(&s)
-                .with_chunk_size(self.batch_size)
-                .finish()
-        } else {
-            JsonLineReader::from_path(&self.path)
-                .expect("unable to read file")
-                .with_chunk_size(self.batch_size)
-                .finish()
-        }
+        println!("scan_opts={:#?}", scan_opts);
+        let schema = scan_opts.output_schema.unwrap_or(scan_opts.schema);
+        JsonLineReader::from_path(&self.path)
+            .expect("unable to read file")
+            .with_schema(&schema)
+            .with_chunk_size(self.batch_size)
+            .with_n_rows(scan_opts.n_rows)
+            .finish()
+
     }
 
     fn schema(&self, infer_schema_length: Option<usize>) -> polars::prelude::Result<Schema> {

--- a/nodejs-polars/src/lazy/dataframe.rs
+++ b/nodejs-polars/src/lazy/dataframe.rs
@@ -663,7 +663,6 @@ struct JsonScan {
 
 impl AnonymousScan for JsonScan {
     fn scan(&self, scan_opts: AnonymousScanOptions) -> polars::prelude::Result<DataFrame> {
-        println!("scan_opts={:#?}", scan_opts);
         let schema = scan_opts.output_schema.unwrap_or(scan_opts.schema);
         JsonLineReader::from_path(&self.path)
             .expect("unable to read file")

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -1,11 +1,11 @@
+use arrow::types::NativeType;
 use num::traits::NumCast;
 use polars_core::prelude::*;
+use polars_core::utils::Wrap;
 use polars_time::prelude::utf8::infer::infer_pattern_single;
 use polars_time::prelude::utf8::infer::DatetimeInfer;
 use polars_time::prelude::utf8::Pattern;
 use serde_json::Value;
-use polars_core::utils::Wrap;
-use arrow::types::NativeType;
 use std::collections::BTreeMap;
 pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<BTreeMap<String, Buffer>> {
     schema
@@ -52,7 +52,7 @@ pub(crate) enum Buffer<'a> {
     All((Vec<AnyValue<'a>>, &'a str)),
 }
 
-impl <'a> Buffer<'a> {
+impl<'a> Buffer<'a> {
     pub(crate) fn into_series(self) -> Result<Series> {
         let s = match self {
             Buffer::Boolean(v) => v.finish().into_series(),
@@ -227,7 +227,7 @@ fn value_to_dtype(val: &Value) -> DataType {
             } else {
                 DataType::Float64
             }
-        },
+        }
         Value::String(_) => DataType::Utf8,
         Value::Array(arr) => {
             let dtype = value_to_dtype(&arr[0]);
@@ -242,7 +242,6 @@ fn value_to_dtype(val: &Value) -> DataType {
             DataType::Struct(fields.collect()).into()
         }
     }
-
 }
 
 fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -232,6 +232,7 @@ fn value_to_dtype(val: &Value) -> DataType {
 
             DataType::List(Box::new(dtype))
         }
+        #[cfg(feature = "dtype-struct")]
         Value::Object(doc) => {
             let fields = doc.iter().map(|(key, value)| {
                 let dtype = value_to_dtype(value);
@@ -239,6 +240,8 @@ fn value_to_dtype(val: &Value) -> DataType {
             });
             DataType::Struct(fields.collect())
         }
+        #[cfg(not(feature = "dtype-struct"))]
+        Value::Object(doc) => DataType::Utf8
     }
 }
 
@@ -262,7 +265,7 @@ fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {
             AnyValue::List(s)
         }
         Value::Null => AnyValue::Null,
-
+        #[cfg(feature = "dtype-struct")]
         Value::Object(doc) => {
             let vals: (Vec<AnyValue>, Vec<Field>) = doc
                 .into_iter()
@@ -275,6 +278,8 @@ fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {
                 .unzip();
 
             AnyValue::StructOwned(Box::new(vals))
-        }
+        },
+        #[cfg(not(feature = "dtype-struct"))]
+        Value::Object(doc) => AnyValue::Utf8Owned(format!("{:#?}", doc)),
     }
 }

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -1,7 +1,6 @@
 use arrow::types::NativeType;
 use num::traits::NumCast;
 use polars_core::prelude::*;
-use polars_core::utils::Wrap;
 use polars_time::prelude::utf8::infer::infer_pattern_single;
 use polars_time::prelude::utf8::infer::DatetimeInfer;
 use polars_time::prelude::utf8::Pattern;
@@ -218,7 +217,7 @@ where
 fn value_to_dtype(val: &Value) -> DataType {
     match val {
         Value::Null => DataType::Null,
-        Value::Bool(b) => DataType::Boolean,
+        Value::Bool(_) => DataType::Boolean,
         Value::Number(n) => {
             if n.is_i64() {
                 DataType::Int64
@@ -239,7 +238,7 @@ fn value_to_dtype(val: &Value) -> DataType {
                 let dtype = value_to_dtype(value);
                 Field::new(key, dtype)
             });
-            DataType::Struct(fields.collect()).into()
+            DataType::Struct(fields.collect())
         }
     }
 }

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -244,7 +244,6 @@ fn value_to_dtype(val: &Value) -> DataType {
             }
         }
         _ => DataType::Utf8,
-
     }
 }
 

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -4,9 +4,10 @@ use polars_time::prelude::utf8::infer::infer_pattern_single;
 use polars_time::prelude::utf8::infer::DatetimeInfer;
 use polars_time::prelude::utf8::Pattern;
 use serde_json::Value;
-
+use polars_core::utils::Wrap;
 use arrow::types::NativeType;
-pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<PlHashMap<String, Buffer>> {
+use std::collections::BTreeMap;
+pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<BTreeMap<String, Buffer>> {
     schema
         .iter()
         .map(|(name, dtype)| {
@@ -27,11 +28,7 @@ pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<PlHashMap
                 }
                 #[cfg(feature = "dtype-date")]
                 &DataType::Date => Buffer::Date(PrimitiveChunkedBuilder::new(name, capacity)),
-                other => {
-                    return Err(PolarsError::ComputeError(
-                        format!("Unsupported data type {:?} when reading a csv", other).into(),
-                    ))
-                }
+                _ => Buffer::All((Vec::with_capacity(capacity), name)),
             };
             Ok((name.clone(), builder))
         })
@@ -39,7 +36,7 @@ pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<PlHashMap
 }
 
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum Buffer {
+pub(crate) enum Buffer<'a> {
     Boolean(BooleanChunkedBuilder),
     Int32(PrimitiveChunkedBuilder<Int32Type>),
     Int64(PrimitiveChunkedBuilder<Int64Type>),
@@ -52,9 +49,10 @@ pub(crate) enum Buffer {
     Datetime(PrimitiveChunkedBuilder<Int64Type>),
     #[cfg(feature = "dtype-date")]
     Date(PrimitiveChunkedBuilder<Int32Type>),
+    All((Vec<AnyValue<'a>>, &'a str)),
 }
 
-impl Buffer {
+impl <'a> Buffer<'a> {
     pub(crate) fn into_series(self) -> Result<Series> {
         let s = match self {
             Buffer::Boolean(v) => v.finish().into_series(),
@@ -73,6 +71,7 @@ impl Buffer {
             #[cfg(feature = "dtype-date")]
             Buffer::Date(v) => v.finish().into_series().cast(&DataType::Date).unwrap(),
             Buffer::Utf8(v) => v.finish().into_series(),
+            Buffer::All((vals, name)) => Series::new(name, vals),
         };
         Ok(s)
     }
@@ -91,6 +90,7 @@ impl Buffer {
             Buffer::Datetime(v) => v.append_null(),
             #[cfg(feature = "dtype-date")]
             Buffer::Date(v) => v.append_null(),
+            Buffer::All((v, _)) => v.push(AnyValue::Null),
         };
     }
 
@@ -173,6 +173,11 @@ impl Buffer {
                 buf.append_option(v);
                 Ok(())
             }
+            All((buf, _)) => {
+                let av = deserialize_all(value);
+                buf.push(av);
+                Ok(())
+            }
         }
     }
 }
@@ -208,5 +213,71 @@ where
             Ok(mut infer) => infer.parse(val),
             Err(_) => None,
         },
+    }
+}
+fn value_to_dtype(val: &Value) -> DataType {
+    match val {
+        Value::Null => DataType::Null,
+        Value::Bool(b) => DataType::Boolean,
+        Value::Number(n) => {
+            if n.is_i64() {
+                DataType::Int64
+            } else if n.is_u64() {
+                DataType::UInt64
+            } else {
+                DataType::Float64
+            }
+        },
+        Value::String(_) => DataType::Utf8,
+        Value::Array(arr) => {
+            let dtype = value_to_dtype(&arr[0]);
+
+            DataType::List(Box::new(dtype))
+        }
+        Value::Object(doc) => {
+            let fields = doc.iter().map(|(key, value)| {
+                let dtype = value_to_dtype(value);
+                Field::new(key, dtype)
+            });
+            DataType::Struct(fields.collect()).into()
+        }
+    }
+
+}
+
+fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {
+    match json {
+        Value::Bool(b) => AnyValue::Boolean(*b),
+        Value::Number(n) => {
+            if n.is_i64() {
+                AnyValue::Int64(n.as_i64().unwrap())
+            } else if n.is_u64() {
+                AnyValue::UInt64(n.as_u64().unwrap())
+            } else {
+                AnyValue::Float64(n.as_f64().unwrap())
+            }
+        }
+        Value::String(v) => AnyValue::Utf8Owned(v.clone()),
+        Value::Array(arr) => {
+            let vals: Vec<AnyValue> = arr.iter().map(deserialize_all).collect();
+
+            let s = Series::new("", vals);
+            AnyValue::List(s)
+        }
+        Value::Null => AnyValue::Null,
+
+        Value::Object(doc) => {
+            let vals: (Vec<AnyValue>, Vec<Field>) = doc
+                .into_iter()
+                .map(|(key, value)| {
+                    let dt = value_to_dtype(value);
+                    let fld = Field::new(key, dt);
+                    let av: AnyValue<'a> = deserialize_all(value);
+                    (av, fld)
+                })
+                .unzip();
+
+            AnyValue::StructOwned(Box::new(vals))
+        }
     }
 }

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -213,6 +213,8 @@ where
         },
     }
 }
+
+#[cfg(feature = "dtype-struct")]
 fn value_to_dtype(val: &Value) -> DataType {
     match val {
         Value::Null => DataType::Null,
@@ -233,15 +235,11 @@ fn value_to_dtype(val: &Value) -> DataType {
         }
         #[cfg(feature = "dtype-struct")]
         Value::Object(doc) => {
-            if cfg!(feature = "dtype-struct") {
-                let fields = doc.iter().map(|(key, value)| {
-                    let dtype = value_to_dtype(value);
-                    Field::new(key, dtype)
-                });
-                DataType::Struct(fields.collect())
-            } else {
-                DataType::Utf8
-            }
+            let fields = doc.iter().map(|(key, value)| {
+                let dtype = value_to_dtype(value);
+                Field::new(key, dtype)
+            });
+            DataType::Struct(fields.collect())
         }
         _ => DataType::Utf8,
     }

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -5,8 +5,7 @@ use polars_time::prelude::utf8::infer::infer_pattern_single;
 use polars_time::prelude::utf8::infer::DatetimeInfer;
 use polars_time::prelude::utf8::Pattern;
 use serde_json::Value;
-use std::collections::BTreeMap;
-pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<BTreeMap<String, Buffer>> {
+pub(crate) fn init_buffers(schema: &Schema, capacity: usize) -> Result<PlIndexMap<String, Buffer>> {
     schema
         .iter()
         .map(|(name, dtype)| {

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -237,7 +237,6 @@ impl<'a> CoreJsonReader<'a> {
                 })
                 .collect::<Result<Vec<_>>>()
         })?;
-        println!("dfs={:#?}", dfs);
         accumulate_dataframes_vertical(dfs)
     }
     pub fn as_df(&mut self) -> Result<DataFrame> {

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -11,7 +11,6 @@ use polars_core::{prelude::*, utils::accumulate_dataframes_vertical, POOL};
 use rayon::prelude::*;
 use serde_json::{Deserializer, Value};
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Cursor;
 use std::path::PathBuf;
@@ -256,7 +255,7 @@ impl<'a> CoreJsonReader<'a> {
     }
 }
 
-fn parse_lines<'a>(bytes: &[u8], buffers: &mut BTreeMap<String, Buffer<'a>>) -> Result<usize> {
+fn parse_lines<'a>(bytes: &[u8], buffers: &mut PlIndexMap<String, Buffer<'a>>) -> Result<usize> {
     let mut stream = Deserializer::from_slice(bytes).into_iter::<Value>();
     for value in stream.by_ref() {
         let v = value.unwrap_or(Value::Null);

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -227,13 +227,12 @@ impl<'a> CoreJsonReader<'a> {
                         last_read = read;
                         read += parse_lines(local_bytes, &mut buffers)?;
                     }
-                    let df = DataFrame::new(
+                    DataFrame::new(
                         buffers
                             .into_values()
                             .map(|buf| buf.into_series())
                             .collect::<Result<_>>()?,
-                    )?;
-                    Ok(df)
+                    )?
                 })
                 .collect::<Result<Vec<_>>>()
         })?;

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -232,7 +232,7 @@ impl<'a> CoreJsonReader<'a> {
                             .into_values()
                             .map(|buf| buf.into_series())
                             .collect::<Result<_>>()?,
-                    )?
+                    )
                 })
                 .collect::<Result<Vec<_>>>()
         })?;


### PR DESCRIPTION
ndjson reader wasn't handling slice pushdowns or complex types. added some fallbacks for list/struct similar to the `row` implementation. 

The `PlHashMap` (hashbrown::Hashmap) was causing some issues because it does not maintain order of the keys. BTreeMap maintains the key order, so you can vstack the dfs created in the pool. 