### PR TITLE
Adding 'line-height' at 95% to df _html.py print

### DIFF
--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -142,6 +142,7 @@ class NotebookFormatter(HTMLFormatter):
             ("tbody tr th", "vertical-align", "top"),
             ("thead th", "text-align", "right"),
             ("td", "white-space", "pre"),
+            ("td", "line-height", "95%"),
             ("td", "padding-top", "0"),
             ("td", "padding-bottom", "0"),
         ]


### PR DESCRIPTION
The reason for this PR is to decrease slightly the line heights of the Polars dataframe HTML table in Jupyter/JupyterLab. 
Here is a quick before and after:
__before the change__
![image](https://user-images.githubusercontent.com/16968156/173445923-415d0b52-594c-490e-b9bd-40d50b8b7eb8.png)

__after the change__
![image](https://user-images.githubusercontent.com/16968156/173445975-7e7bf861-df96-462d-bfed-799cdaafaa1c.png)

I personally prefer the more compact view as this is helping me fit longer dataframes on my screen. However, I understand that this is quite subjective, so please let me know if you disagree.

Best regards,
LG