### PR TITLE
Add `Series` to `DataFrame.with_columns()` argument annotation

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4680,7 +4680,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
             .collect(no_optimization=True, string_cache=False)
         )
 
-    def with_columns(self: DF, exprs: Union["pli.Expr", List["pli.Expr"]]) -> DF:
+    def with_columns(
+        self: DF,
+        exprs: Union["pli.Expr", "pli.Series", List[Union["pli.Expr", "pli.Series"]]],
+    ) -> DF:
         """
         Add or overwrite multiple columns in a DataFrame.
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1430,7 +1430,10 @@ class LazyFrame(Generic[DF]):
             )
         )
 
-    def with_columns(self: LDF, exprs: Union[List["pli.Expr"], "pli.Expr"]) -> LDF:
+    def with_columns(
+        self: LDF,
+        exprs: Union["pli.Expr", "pli.Series", List[Union["pli.Expr", "pli.Series"]]],
+    ) -> LDF:
         """
         Add or overwrite multiple columns in a DataFrame.
 


### PR DESCRIPTION
`DataFrame.with_columns()` will accept a `Series` or list of `Series` as the argument. This PR just updates the type annotation to reflect this.