### PR TITLE
docs: `polars-lazy` readability improvements

### DIFF
--- a/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/aggregate_pushdown.rs
@@ -83,7 +83,7 @@ impl OptimizationRule for AggregatePushdown {
                 input,
                 schema,
             } => self.pushdown_projection(node, expr, input, schema, lp_arena, expr_arena),
-            // todo! hstack should pushown not dependent columns
+            // todo! hstack should pushdown not dependent columns
             Join { .. } | Aggregate { .. } | HStack { .. } | DataFrameScan { .. } => {
                 if self.accumulated_projections.is_empty() {
                     lp_arena.replace(node, lp);

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::utils::has_nth;
 use polars_arrow::index::IndexToUsize;
 
-/// This replace the wilcard Expr with a Column Expr. It also removes the Exclude Expr from the
+/// This replace the wildcard Expr with a Column Expr. It also removes the Exclude Expr from the
 /// expression chain.
 pub(super) fn replace_wildcard_with_column(mut expr: Expr, column_name: Arc<str>) -> Expr {
     expr.mutate().apply(|e| {
@@ -51,7 +51,7 @@ fn rewrite_special_aliases(expr: Expr) -> Expr {
 /// Take an expression with a root: col("*") and copies that expression for all columns in the schema,
 /// with the exclusion of the `names` in the exclude expression.
 /// The resulting expressions are written to result.
-fn replace_wilcard(expr: &Expr, result: &mut Vec<Expr>, exclude: &[Arc<str>], schema: &Schema) {
+fn replace_wildcard(expr: &Expr, result: &mut Vec<Expr>, exclude: &[Arc<str>], schema: &Schema) {
     for name in schema.iter_names() {
         if !exclude.iter().any(|exluded| &**exluded == name) {
             let new_expr = replace_wildcard_with_column(expr.clone(), Arc::from(name.as_str()));
@@ -306,7 +306,7 @@ fn function_wildcard_expansion(mut expr: Expr, schema: &Schema, exclude: &[Arc<s
                         }
                         _ => {
                             if has_wildcard(e) {
-                                replace_wilcard(e, &mut new_inputs, exclude, schema)
+                                replace_wildcard(e, &mut new_inputs, exclude, schema)
                             } else {
                                 #[cfg(feature = "regex")]
                                 {
@@ -371,7 +371,7 @@ pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema, keys: &[Exp
                 result.push(expr);
                 continue;
             }
-            replace_wilcard(&expr, &mut result, &exclude, schema);
+            replace_wildcard(&expr, &mut result, &exclude, schema);
         } else {
             #[allow(clippy::collapsible_else_if)]
             #[cfg(feature = "regex")]

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -53,7 +53,7 @@ fn rewrite_special_aliases(expr: Expr) -> Expr {
 /// The resulting expressions are written to result.
 fn replace_wildcard(expr: &Expr, result: &mut Vec<Expr>, exclude: &[Arc<str>], schema: &Schema) {
     for name in schema.iter_names() {
-        if !exclude.iter().any(|exluded| &**exluded == name) {
+        if !exclude.iter().any(|excluded| &**excluded == name) {
             let new_expr = replace_wildcard_with_column(expr.clone(), Arc::from(name.as_str()));
             let new_expr = rewrite_special_aliases(new_expr);
             result.push(new_expr)

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -55,7 +55,7 @@ fn execute_projection_cached_window_fns(
     // the partitioning messes with column order, so we also store the idx
     // and use those to restore the original projection order
     #[allow(clippy::type_complexity)]
-    // String: partion_name,
+    // String: partition_name,
     // u32: index,
     // bool: flatten (we must run those first because they need a sorted group tuples.
     //       if we cache the group tuples we must ensure we cast the sorted onces.

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -316,7 +316,7 @@ impl<'a> AggregationContext<'a> {
 
     /// In a binary expression one state can be aggregated and the other not.
     /// If both would be flattened naively one would be sorted and the other not.
-    /// Calling this function will ensure both are sortened. This will be a no-op
+    /// Calling this function will ensure both are sorted. This will be a no-op
     /// if already aggregated.
     pub(crate) fn sort_by_groups(&mut self) {
         // make sure that the groups are updated before we use them to sort.

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1300,7 +1300,7 @@ fn test_regex_selection() -> Result<()> {
 
 #[test]
 fn test_filter_in_groupby_agg() -> Result<()> {
-    // This tests if the fitler is correctly handled by the binary expression.
+    // This tests if the filter is correctly handled by the binary expression.
     // This could lead to UB if it were not the case. The filter creates an empty column.
     // but the group tuples could still be untouched leading to out of bounds aggregation.
     let df = df![

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -193,7 +193,7 @@ pub(crate) fn rename_aexpr_root_names(node: Node, arena: &mut Arena<AExpr>, new_
 }
 
 /// Rename the root of the expression from `current` to `new` and assign to new node in arena.
-/// Returns `Node` on first sucessful rename.
+/// Returns `Node` on first successful rename.
 pub(crate) fn aexpr_assign_renamed_root(
     node: Node,
     arena: &mut Arena<AExpr>,

--- a/py-polars/CHANGELOG.md
+++ b/py-polars/CHANGELOG.md
@@ -10,7 +10,7 @@ The Rust crate `polars` has its own changelog.
 **Merged pull requests:**
 
 - python collect\_all function [\#1503](https://github.com/pola-rs/polars/pull/1503) ([ritchie46](https://github.com/ritchie46))
-- python: remove deprecated code/funcitonallity [\#1502](https://github.com/pola-rs/polars/pull/1502) ([ritchie46](https://github.com/ritchie46))
+- python: remove deprecated code/functionallity [\#1502](https://github.com/pola-rs/polars/pull/1502) ([ritchie46](https://github.com/ritchie46))
 - Refactor Date/Datetime dtypes [\#1501](https://github.com/pola-rs/polars/pull/1501) ([ritchie46](https://github.com/ritchie46))
 - add vertical string concat; closes \#1490 [\#1500](https://github.com/pola-rs/polars/pull/1500) ([ritchie46](https://github.com/ritchie46))
 - fix bug in outer\_join functions, add tests [\#1498](https://github.com/pola-rs/polars/pull/1498) ([marcvanheerden](https://github.com/marcvanheerden))
@@ -345,7 +345,7 @@ The Rust crate `polars` has its own changelog.
 - Only first gzip stream of gzipped CSV/TSV files with multiple gzip streams is read. [\#1126](https://github.com/pola-rs/polars/issues/1126)
 - implement `__copy__, __deepcopy__` [\#1120](https://github.com/pola-rs/polars/issues/1120)
 - pretty print failure output of `frame_equal` assertions [\#1112](https://github.com/pola-rs/polars/issues/1112)
-- PanicException when converting non-Utf8 column to Catergorical. [\#1107](https://github.com/pola-rs/polars/issues/1107)
+- PanicException when converting non-Utf8 column to Categorical. [\#1107](https://github.com/pola-rs/polars/issues/1107)
 - read\_csv of a compressed file fails when selecting a subset of columns [\#1026](https://github.com/pola-rs/polars/issues/1026)
 - csv-parser: remove dependency on csv crate. [\#956](https://github.com/pola-rs/polars/issues/956)
 
@@ -553,7 +553,7 @@ patch release to fix panic #1077
 ### polars 0.7.16
 * feature
   - Series literal may have any length
-  - change globaly string cache behavior
+  - change globally string cache behavior
   - Add Expr.arg_sort
   - Make literals typed
 
@@ -643,7 +643,7 @@ patch release to fix panic #1077
 * feature
   - cast categorical in csv parser: #533
   - add many groupby-context aware operations: #534
-  - dowcast by month: #537
+  - downcast by month: #537
 
 * performance
   - improve iterator in no null case: #538

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1086,7 +1086,7 @@ impl PyDataFrame {
         // We don't use `py.allow_threads(|| gb.par_apply(..)` because that segfaulted
         // due to code related to Pyo3 or rayon, cannot reproduce it in native polars
         // so we lose parallelism, but it doesn't really matter because we are GIL bound anyways
-        // and this function should not be used in ideomatic polars anyway.
+        // and this function should not be used in idiomatic polars anyway.
         let df = gb.apply(function).map_err(PyPolarsErr::from)?;
 
         Ok(df.into())

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1881,7 +1881,7 @@ pub(crate) fn to_series_collection(ps: Vec<PySeries>) -> Vec<Series> {
     let len = ps.len();
     let cap = ps.capacity();
 
-    // The pointer ownership will be transferred to Vec and this will be responsible for dealoc
+    // The pointer ownership will be transferred to Vec and this will be responsible for dealloc
     unsafe { Vec::from_raw_parts(p, len, cap) }
 }
 


### PR DESCRIPTION
Separated out the two code re-wordingsto make them easier to read:
- `replace_wildcard`
- `excluded` 

Rest of the changes are mostly comments.

Best,
Ryan