### PR TITLE
Improve performance of categorical casting

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -91,7 +91,7 @@ dtype-i8 = []
 dtype-i16 = []
 dtype-u8 = []
 dtype-u16 = []
-dtype-categorical = []
+dtype-categorical = ["smartstring"]
 dtype-struct = []
 
 parquet = ["arrow/io_parquet"]
@@ -167,6 +167,7 @@ regex = { version = "1.5", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+smartstring = { version = "1", optional = true }
 thiserror = "^1.0"
 
 [dependencies.arrow]

--- a/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -1,6 +1,10 @@
+use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
 use crate::prelude::*;
 use crate::{datatypes::PlHashMap, use_string_cache};
+use ahash::CallHasher;
 use arrow::array::*;
+use hashbrown::hash_map::RawEntryMut;
+use std::hash::{Hash, Hasher};
 
 pub enum RevMappingBuilder {
     /// Hashmap: maps the indexes from the global cache/categorical array to indexes in the local Utf8Array
@@ -121,6 +125,32 @@ impl RevMapping {
     }
 }
 
+#[derive(Eq, Copy, Clone)]
+pub struct StrHashLocal<'a> {
+    str: &'a str,
+    hash: u64,
+}
+
+impl<'a> Hash for StrHashLocal<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash)
+    }
+}
+
+impl<'a> StrHashLocal<'a> {
+    pub(crate) fn new(s: &'a str, hash: u64) -> Self {
+        Self { str: s, hash }
+    }
+}
+
+impl<'a> PartialEq for StrHashLocal<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        // can be collisions in the hashtable even though the hashes are equal
+        // e.g. hashtable hash = hash % n_slots
+        (self.hash == other.hash) && (self.str == other.str)
+    }
+}
+
 pub struct CategoricalChunkedBuilder {
     array_builder: UInt32Vec,
     name: String,
@@ -160,7 +190,7 @@ impl CategoricalChunkedBuilder {
                             Some(idx) => *idx,
                             None => {
                                 let idx = cache.map.len() as u32;
-                                cache.map.insert(s.to_string(), idx);
+                                cache.map.insert(s.into(), idx);
                                 idx
                             }
                         };
@@ -174,17 +204,22 @@ impl CategoricalChunkedBuilder {
                 }
             }
         } else {
-            let mut mapping = PlHashMap::new();
+            let mut mapping = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+            let hb = mapping.hasher().clone();
             for opt_s in i {
                 match opt_s {
                     Some(s) => {
-                        let idx = match mapping.get(s) {
-                            Some(idx) => *idx,
-                            None => {
-                                let idx = mapping.len() as u32;
+                        let h = str::get_hash(s, &hb);
+                        let key = StrHashLocal::new(s, h);
+                        let mut idx = mapping.len() as u32;
+
+                        let entry = mapping.raw_entry_mut().from_key_hashed_nocheck(h, &key);
+
+                        match entry {
+                            RawEntryMut::Occupied(entry) => idx = *entry.get(),
+                            RawEntryMut::Vacant(entry) => {
+                                entry.insert_with_hasher(h, key, idx, |s| s.hash);
                                 self.reverse_mapping.insert(idx, s);
-                                mapping.insert(s, idx);
-                                idx
                             }
                         };
                         self.array_builder.push(Some(idx));

--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -2,6 +2,7 @@ mod builder;
 mod from;
 mod merge;
 mod ops;
+pub mod stringcache;
 
 use super::*;
 use crate::prelude::*;

--- a/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -1,0 +1,79 @@
+use ahash::AHashMap;
+use once_cell::sync::Lazy;
+use smartstring::{LazyCompact, SmartString};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) static USE_STRING_CACHE: AtomicBool = AtomicBool::new(false);
+
+pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
+    toggle_string_cache(true);
+    let out = func();
+    toggle_string_cache(false);
+    out
+}
+
+/// Use a global string cache for the Categorical Types.
+///
+/// This is used to cache the string categories locally.
+/// This allows join operations on categorical types.
+pub fn toggle_string_cache(toggle: bool) {
+    USE_STRING_CACHE.store(toggle, Ordering::Release);
+
+    if !toggle {
+        STRING_CACHE.clear()
+    }
+}
+
+/// Reset the global string cache used for the Categorical Types.
+pub fn reset_string_cache() {
+    STRING_CACHE.clear()
+}
+
+/// Check if string cache is set.
+pub(crate) fn use_string_cache() -> bool {
+    USE_STRING_CACHE.load(Ordering::Acquire)
+}
+
+pub(crate) struct SCacheInner {
+    pub(crate) map: AHashMap<SmartString<LazyCompact>, u32>,
+    pub(crate) uuid: u128,
+}
+
+impl Default for SCacheInner {
+    fn default() -> Self {
+        Self {
+            map: Default::default(),
+            uuid: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        }
+    }
+}
+
+/// Used by categorical data that need to share global categories.
+/// In *eager* you need to specifically toggle global string cache to have a global effect.
+/// In *lazy* it is toggled on at the start of a computation run and turned of (deleted) when a
+/// result is produced.
+pub(crate) struct StringCache(pub(crate) Mutex<SCacheInner>);
+
+impl StringCache {
+    pub(crate) fn lock_map(&self) -> MutexGuard<SCacheInner> {
+        self.0.lock().unwrap()
+    }
+
+    pub(crate) fn clear(&self) {
+        let mut lock = self.lock_map();
+        *lock = Default::default();
+    }
+}
+
+impl Default for StringCache {
+    fn default() -> Self {
+        StringCache(Mutex::new(Default::default()))
+    }
+}
+
+pub(crate) static STRING_CACHE: Lazy<StringCache> = Lazy::new(Default::default);

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -36,6 +36,9 @@ use std::sync::Mutex;
 #[cfg(feature = "dtype-categorical")]
 use std::sync::MutexGuard;
 
+#[cfg(feature = "dtype-categorical")]
+use smartstring::{LazyCompact, SmartString};
+
 #[cfg(feature = "object")]
 pub(crate) static PROCESS_ID: Lazy<u128> = Lazy::new(|| {
     SystemTime::now()
@@ -62,7 +65,7 @@ pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
 
 #[cfg(feature = "dtype-categorical")]
 struct SCacheInner {
-    map: AHashMap<String, u32>,
+    map: AHashMap<SmartString<LazyCompact>, u32>,
     uuid: u128,
 }
 

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -24,20 +24,14 @@ mod tests;
 pub(crate) mod vector_hasher;
 use once_cell::sync::Lazy;
 
-#[cfg(any(feature = "dtype-categorical", feature = "object"))]
+#[cfg(feature = "object")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(feature = "dtype-categorical")]
-use ahash::AHashMap;
 use rayon::{ThreadPool, ThreadPoolBuilder};
-#[cfg(feature = "dtype-categorical")]
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-#[cfg(feature = "dtype-categorical")]
-use std::sync::MutexGuard;
 
 #[cfg(feature = "dtype-categorical")]
-use smartstring::{LazyCompact, SmartString};
+pub use crate::chunked_array::logical::categorical::stringcache::*;
 
 #[cfg(feature = "object")]
 pub(crate) static PROCESS_ID: Lazy<u128> = Lazy::new(|| {
@@ -63,89 +57,5 @@ pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
         .expect("could not spawn threads")
 });
 
-#[cfg(feature = "dtype-categorical")]
-struct SCacheInner {
-    map: AHashMap<SmartString<LazyCompact>, u32>,
-    uuid: u128,
-}
-
-#[cfg(feature = "dtype-categorical")]
-impl Default for SCacheInner {
-    fn default() -> Self {
-        Self {
-            map: Default::default(),
-            uuid: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos(),
-        }
-    }
-}
-
-/// Used by categorical data that need to share global categories.
-/// In *eager* you need to specifically toggle global string cache to have a global effect.
-/// In *lazy* it is toggled on at the start of a computation run and turned of (deleted) when a
-/// result is produced.
-#[cfg(feature = "dtype-categorical")]
-pub(crate) struct StringCache(pub(crate) Mutex<SCacheInner>);
-
-#[cfg(feature = "dtype-categorical")]
-impl StringCache {
-    pub(crate) fn lock_map(&self) -> MutexGuard<SCacheInner> {
-        self.0.lock().unwrap()
-    }
-
-    pub(crate) fn clear(&self) {
-        let mut lock = self.lock_map();
-        *lock = Default::default();
-    }
-}
-
-#[cfg(feature = "dtype-categorical")]
-impl Default for StringCache {
-    fn default() -> Self {
-        StringCache(Mutex::new(Default::default()))
-    }
-}
-
-#[cfg(feature = "dtype-categorical")]
-pub(crate) static USE_STRING_CACHE: AtomicBool = AtomicBool::new(false);
-
-#[cfg(feature = "dtype-categorical")]
-pub(crate) static STRING_CACHE: Lazy<StringCache> = Lazy::new(Default::default);
-
 // utility for the tests to ensure a single thread can execute
 pub static SINGLE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
-
-#[cfg(feature = "dtype-categorical")]
-pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
-    toggle_string_cache(true);
-    let out = func();
-    toggle_string_cache(false);
-    out
-}
-
-/// Use a global string cache for the Categorical Types.
-///
-/// This is used to cache the string categories locally.
-/// This allows join operations on categorical types.
-#[cfg(feature = "dtype-categorical")]
-pub fn toggle_string_cache(toggle: bool) {
-    USE_STRING_CACHE.store(toggle, Ordering::Release);
-
-    if !toggle {
-        STRING_CACHE.clear()
-    }
-}
-
-/// Reset the global string cache used for the Categorical Types.
-#[cfg(feature = "dtype-categorical")]
-pub fn reset_string_cache() {
-    STRING_CACHE.clear()
-}
-
-/// Check if string cache is set.
-#[cfg(feature = "dtype-categorical")]
-pub(crate) fn use_string_cache() -> bool {
-    USE_STRING_CACHE.load(Ordering::Acquire)
-}

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -384,7 +384,7 @@ impl<'a> StrHash<'a> {
 
 impl<'a> PartialEq for StrHash<'a> {
     fn eq(&self, other: &Self) -> bool {
-        self.str == other.str
+        (self.hash == other.hash) && (self.str == other.str)
     }
 }
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smartstring",
  "thiserror",
 ]
 
@@ -1588,6 +1589,17 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "snap"


### PR DESCRIPTION
Creating local cached categoricals is ~35% faster.

Creating global cached categorical is ~20% faster. For this latest one we can still improve by parallellizing the hashing and delaying locking the mutex until the hashing is done.