### PR TITLE
Replace OOB slice indexing with spare_capacity_mut

### DIFF
--- a/polars/polars-io/src/csv_core/buffer.rs
+++ b/polars/polars-io/src/csv_core/buffer.rs
@@ -183,7 +183,7 @@ impl ParsedBuffer for Utf8Field {
         let n_written = if needs_escaping {
             // Safety:
             // we just allocated enough capacity and data_len is correct.
-            unsafe { escape_field(bytes, self.quote_char, &mut self.data[data_len..]) }
+            unsafe { escape_field(bytes, self.quote_char, self.data.spare_capacity_mut()) }
         } else {
             self.data.extend_from_slice(bytes);
             bytes.len()


### PR DESCRIPTION
Previously, this code attempted to access the uninitialized region in a
Vec between len and capacity by doing unchecked indexing into a
zero-length slice. It is always UB to do this, and this can be detected
by running the tests with -Zbuild-std to turn on the standard library's
debug assertions, which add bounds checking to get_unchecked.
Vec::spare_capacity_mut is the right API for doing this sort of
operation.