### PR TITLE
ternary literal predicates

### DIFF
--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -221,7 +221,31 @@ impl OptimizationRule for SimplifyBooleanRule {
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(false)))
             }
-
+            AExpr::Ternary {
+                truthy, predicate, ..
+            } if matches!(
+                expr_arena.get(*predicate),
+                AExpr::Literal(LiteralValue::Boolean(true))
+            ) =>
+            {
+                Some(expr_arena.get(*truthy).clone())
+            }
+            AExpr::Ternary {
+                truthy,
+                falsy,
+                predicate,
+            } if matches!(
+                expr_arena.get(*predicate),
+                AExpr::Literal(LiteralValue::Boolean(false))
+            ) =>
+            {
+                let names = aexpr_to_root_names(*truthy, expr_arena);
+                if names.is_empty() {
+                    None
+                } else {
+                    Some(AExpr::Alias(*falsy, names[0].clone()))
+                }
+            }
             AExpr::Not(x) => {
                 let y = expr_arena.get(*x);
 

--- a/polars/polars-lazy/src/tests/optimization_checks.rs
+++ b/polars/polars-lazy/src/tests/optimization_checks.rs
@@ -378,3 +378,50 @@ fn test_with_row_count_opts() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_groupby_ternary_literal_predicate() -> Result<()> {
+    let df = df![
+        "a" => [1, 2, 3],
+        "b" => [1, 2, 3]
+    ]?;
+
+    for predicate in [true, false] {
+        let q = df
+            .clone()
+            .lazy()
+            .groupby(["a"])
+            .agg([when(lit(predicate))
+                .then(col("b").sum())
+                .otherwise(NULL.lit())])
+            .sort("a", Default::default());
+
+        let (mut expr_arena, mut lp_arena) = get_arenas();
+        let lp = q.clone().optimize(&mut lp_arena, &mut expr_arena).unwrap();
+
+        (&lp_arena).iter(lp).any(|(_, lp)| {
+            use ALogicalPlan::*;
+            match lp {
+                Aggregate { aggs, .. } => {
+                    for node in aggs {
+                        // we should not have a ternary expression anymore
+                        assert!(!matches!(expr_arena.get(*node), AExpr::Ternary { .. }));
+                    }
+                    false
+                }
+                _ => false,
+            }
+        });
+
+        let out = q.collect()?;
+        let b = out.column("b")?;
+        let b = b.i32()?;
+        if predicate {
+            assert_eq!(Vec::from(b), &[Some(1), Some(2), Some(3)]);
+        } else {
+            assert_eq!(b.null_count(), 3);
+        };
+    }
+
+    Ok(())
+}

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1958,7 +1958,7 @@ fn test_is_in() -> Result<()> {
 }
 
 #[test]
-fn test_partitioned_gb() -> Result<()> {
+fn test_partitioned_gb_1() -> Result<()> {
     // don't move these to integration tests
     // keep these dtypes
     let out = df![


### PR DESCRIPTION
Fix lengths in the ternary operator and add an optimization that removes branches on literals in when then otherwise.

E.g.

```
when(true)
    then ( some_work)
    otherwise (other_work)
```

is replaced with

```
some_work.cast(supertype_both_branches)
```