### PR TITLE
improve predicate combination and schema state

### DIFF
--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -531,9 +531,6 @@ mod test {
         );
         let root = *acc_predicates.get("foo").unwrap();
         let expr = node_to_expr(root, &expr_arena);
-        assert_eq!(
-            format!("{:?}", &expr),
-            format!("{:?}", predicate_expr.and(lit(true)))
-        );
+        assert_eq!(format!("{:?}", &expr), format!("{:?}", predicate_expr));
     }
 }

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -25,17 +25,17 @@ pub(super) fn insert_and_combine_predicate(
     predicate: Node,
     arena: &mut Arena<AExpr>,
 ) {
-    let existing_predicate = acc_predicates
+    acc_predicates
         .entry(name)
-        .or_insert_with(|| arena.add(AExpr::Literal(LiteralValue::Boolean(true))));
-
-    let node = arena.add(AExpr::BinaryExpr {
-        left: predicate,
-        op: Operator::And,
-        right: *existing_predicate,
-    });
-
-    *existing_predicate = node;
+        .and_modify(|existing_predicate| {
+            let node = arena.add(AExpr::BinaryExpr {
+                left: predicate,
+                op: Operator::And,
+                right: *existing_predicate,
+            });
+            *existing_predicate = node
+        })
+        .or_insert_with(|| predicate);
 }
 
 pub(super) fn combine_predicates<I>(iter: I, arena: &mut Arena<AExpr>) -> Node

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -51,7 +51,8 @@ impl Executor for JoinExec {
 
         let (df_left, df_right) = if self.parallel {
             let state_left = state.clone();
-            let state_right = state.clone();
+            let mut state_right = state.clone();
+            state_right.join_branch += 1;
             // propagate the fetch_rows static value to the spawning threads.
             let fetch_rows = FETCH_ROWS.with(|fetch_rows| fetch_rows.get());
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "base64",
  "bytemuck",
  "chrono",
+ "chrono-tz",
  "crc",
  "dyn-clone",
  "either",
@@ -248,6 +249,28 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1124,6 +1147,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1252,7 @@ dependencies = [
  "arrow2",
  "base64",
  "chrono",
+ "chrono-tz",
  "comfy-table",
  "hashbrown 0.12.1",
  "hex",
@@ -1579,6 +1651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1777,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -106,6 +106,7 @@ features = [
   "to_dummies",
   "string_justify",
   "arg_where",
+  "timezones",
 ]
 
 # [patch.crates-io]

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -458,6 +458,9 @@ def test_upsample() -> None:
     up = df.upsample(
         time_column="time", every="1mo", by="admin", maintain_order=True
     ).select(pl.all().forward_fill())
+    # this print will panic if timezones feature is not activated
+    # don't remove
+    print(up)
 
     expected = pl.DataFrame(
         {


### PR DESCRIPTION
fixes #3784 

// predicates
in predicate pushdown predicates were always combined with:

lit(true) && predicate

now, we simply insert the predicate.

// joins

joins branch the query executor, the schemas therefore need
to be split by join branch

// python

activate timezone feature