### PR TITLE
Docs: sort entries within subsections

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -7,12 +7,12 @@ Config
 .. autosummary::
    :toctree: api/
 
-    Config.set_utf8_tables
     Config.set_ascii_tables
-    Config.set_tbl_width_chars
-    Config.set_tbl_rows
-    Config.set_tbl_cols
     Config.set_global_string_cache
+    Config.set_tbl_cols
+    Config.set_tbl_rows
+    Config.set_tbl_width_chars
+    Config.set_utf8_tables
     Config.unset_global_string_cache
     toggle_string_cache
     StringCache

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -16,12 +16,12 @@ Attributes
 .. autosummary::
    :toctree: api/
 
-    DataFrame.shape
-    DataFrame.height
-    DataFrame.width
     DataFrame.columns
     DataFrame.dtypes
+    DataFrame.height
     DataFrame.schema
+    DataFrame.shape
+    DataFrame.width
 
 Conversion
 ----------
@@ -30,14 +30,14 @@ Conversion
 
     DataFrame.to_arrow
     DataFrame.to_avro
-    DataFrame.to_json
-    DataFrame.to_pandas
     DataFrame.to_csv
-    DataFrame.to_ipc
-    DataFrame.to_parquet
-    DataFrame.to_numpy
     DataFrame.to_dict
     DataFrame.to_dicts
+    DataFrame.to_ipc
+    DataFrame.to_json
+    DataFrame.to_numpy
+    DataFrame.to_pandas
+    DataFrame.to_parquet
     DataFrame.to_struct
 
 Aggregation
@@ -46,14 +46,14 @@ Aggregation
    :toctree: api/
 
     DataFrame.max
-    DataFrame.min
-    DataFrame.sum
     DataFrame.mean
-    DataFrame.std
-    DataFrame.var
     DataFrame.median
-    DataFrame.quantile
+    DataFrame.min
     DataFrame.product
+    DataFrame.quantile
+    DataFrame.std
+    DataFrame.sum
+    DataFrame.var
 
 Descriptive stats
 -----------------
@@ -63,77 +63,77 @@ Descriptive stats
     DataFrame.describe
     DataFrame.estimated_size
     DataFrame.is_duplicated
+    DataFrame.is_empty
     DataFrame.is_unique
     DataFrame.n_chunks
     DataFrame.null_count
-    DataFrame.is_empty
 
 Computations
 ------------
 .. autosummary::
    :toctree: api/
 
-    DataFrame.hash_rows
     DataFrame.fold
+    DataFrame.hash_rows
 
 Manipulation/ selection
 -----------------------
 .. autosummary::
    :toctree: api/
 
-    DataFrame.rename
-    DataFrame.with_row_count
-    DataFrame.insert_at_idx
-    DataFrame.filter
-    DataFrame.find_idx_by_name
-    DataFrame.select_at_idx
-    DataFrame.replace_at_idx
-    DataFrame.sort
-    DataFrame.reverse
-    DataFrame.replace
-    DataFrame.slice
-    DataFrame.limit
-    DataFrame.head
-    DataFrame.tail
-    DataFrame.drop_nulls
+    DataFrame.clone
+    DataFrame.distinct
     DataFrame.drop
     DataFrame.drop_in_place
-    DataFrame.to_series
-    DataFrame.clone
-    DataFrame.get_columns
-    DataFrame.get_column
-    DataFrame.fill_null
-    DataFrame.fill_nan
+    DataFrame.drop_nulls
     DataFrame.explode
-    DataFrame.pivot
-    DataFrame.melt
-    DataFrame.shift
-    DataFrame.shift_and_fill
-    DataFrame.with_column
-    DataFrame.hstack
-    DataFrame.vstack
     DataFrame.extend
+    DataFrame.fill_nan
+    DataFrame.fill_null
+    DataFrame.filter
+    DataFrame.find_idx_by_name
+    DataFrame.get_column
+    DataFrame.get_columns
     DataFrame.groupby
     DataFrame.groupby_dynamic
     DataFrame.groupby_rolling
-    DataFrame.select
-    DataFrame.with_columns
-    DataFrame.sample
-    DataFrame.row
-    DataFrame.rows
-    DataFrame.to_dummies
-    DataFrame.distinct
-    DataFrame.unique
-    DataFrame.shrink_to_fit
-    DataFrame.rechunk
-    DataFrame.pipe
+    DataFrame.head
+    DataFrame.hstack
+    DataFrame.insert_at_idx
+    DataFrame.interpolate
     DataFrame.join
     DataFrame.join_asof
-    DataFrame.interpolate
-    DataFrame.transpose
+    DataFrame.limit
+    DataFrame.melt
     DataFrame.partition_by
-    DataFrame.upsample
+    DataFrame.pipe
+    DataFrame.pivot
+    DataFrame.rechunk
+    DataFrame.rename
+    DataFrame.replace
+    DataFrame.replace_at_idx
+    DataFrame.reverse
+    DataFrame.row
+    DataFrame.rows
+    DataFrame.sample
+    DataFrame.select
+    DataFrame.select_at_idx
+    DataFrame.shift
+    DataFrame.shift_and_fill
+    DataFrame.shrink_to_fit
+    DataFrame.slice
+    DataFrame.sort
+    DataFrame.tail
+    DataFrame.to_dummies
+    DataFrame.to_series
+    DataFrame.transpose
+    DataFrame.unique
     DataFrame.unnest
+    DataFrame.upsample
+    DataFrame.vstack
+    DataFrame.with_column
+    DataFrame.with_columns
+    DataFrame.with_row_count
 
 Apply
 -----
@@ -160,23 +160,23 @@ This namespace comes available by calling `DataFrame.groupby(..)`.
    :toctree: api/
 
     GroupBy.agg
+    GroupBy.agg_list
     GroupBy.apply
-    GroupBy.head
-    GroupBy.tail
+    GroupBy.count
+    GroupBy.first
     GroupBy.get_group
     GroupBy.groups
-    GroupBy.pivot
-    GroupBy.first
+    GroupBy.head
     GroupBy.last
-    GroupBy.sum
-    GroupBy.min
     GroupBy.max
-    GroupBy.count
     GroupBy.mean
-    GroupBy.n_unique
-    GroupBy.quantile
     GroupBy.median
-    GroupBy.agg_list
+    GroupBy.min
+    GroupBy.n_unique
+    GroupBy.pivot
+    GroupBy.quantile
+    GroupBy.sum
+    GroupBy.tail
 
 Pivot
 -----
@@ -189,11 +189,11 @@ This namespace comes available by calling `DataFrame.groupby(..).pivot`
 .. autosummary::
    :toctree: api/
 
+    PivotOps.count
     PivotOps.first
     PivotOps.last
-    PivotOps.sum
-    PivotOps.min
     PivotOps.max
     PivotOps.mean
-    PivotOps.count
     PivotOps.median
+    PivotOps.min
+    PivotOps.sum

--- a/py-polars/docs/source/reference/exceptions.rst
+++ b/py-polars/docs/source/reference/exceptions.rst
@@ -9,9 +9,9 @@ Exceptions
     
     ArrowError
     ComputeError
+    DuplicateError
     NoDataError
     NotFoundError
+    PanicException
     SchemaError
     ShapeError
-    DuplicateError
-    PanicException

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -11,46 +11,46 @@ These functions can be used as expression and sometimes also in eager contexts.
 .. autosummary::
    :toctree: api/
 
-   select
-   col
-   element
-   count
-   list
-   std
-   var
-   max
-   min
-   sum
-   mean
-   avg
-   median
-   n_unique
-   first
-   head
-   tail
-   lit
-   pearson_corr
-   spearman_rank_corr
-   cov
-   map
-   apply
-   fold
-   any
    all
-   groups
-   quantile
+   any
+   apply
    arange
-   repeat
    argsort_by
-   concat_str
+   avg
+   col
    concat_list
-   format
-   when
-   exclude
+   concat_str
+   count
+   cov
+   date
    datetime
    duration
-   date
+   element
+   exclude
+   first
+   fold
+   format
+   groups
+   head
+   list
+   lit
+   map
+   max
+   mean
+   median
+   min
+   n_unique
+   pearson_corr
+   quantile
+   repeat
+   select
+   spearman_rank_corr
+   std
    struct
+   sum
+   tail
+   var
+   when
 
 Constructor
 -----------
@@ -66,9 +66,9 @@ Attributes
    :toctree: api/
 
    Expr.arr
+   Expr.cat
    Expr.dt
    Expr.str
-   Expr.cat
 
 
 Aggregation
@@ -76,44 +76,44 @@ Aggregation
 .. autosummary::
    :toctree: api/
 
-    Expr.std
-    Expr.var
+    Expr.agg_groups
+    Expr.arg_max
+    Expr.arg_min
+    Expr.count
+    Expr.first
+    Expr.last
+    Expr.len
+    Expr.list
     Expr.max
-    Expr.min
-    Expr.sum
     Expr.mean
     Expr.mean
     Expr.median
-    Expr.first
-    Expr.last
+    Expr.min
     Expr.product
-    Expr.list
-    Expr.agg_groups
-    Expr.count
-    Expr.len
     Expr.quantile
-    Expr.arg_min
-    Expr.arg_max
+    Expr.std
+    Expr.sum
+    Expr.var
 
 Boolean
 -------
 .. autosummary::
    :toctree: api/
 
-    Expr.is_not
-    Expr.is_null
-    Expr.is_not_null
+    Expr.all
+    Expr.any
+    Expr.is_between
+    Expr.is_duplicated
     Expr.is_finite
+    Expr.is_first
+    Expr.is_in
     Expr.is_infinite
     Expr.is_nan
+    Expr.is_not
     Expr.is_not_nan
+    Expr.is_not_null
+    Expr.is_null
     Expr.is_unique
-    Expr.is_first
-    Expr.is_duplicated
-    Expr.is_between
-    Expr.is_in
-    Expr.any
-    Expr.all
 
 
 Computations
@@ -121,100 +121,100 @@ Computations
 .. autosummary::
    :toctree: api/
 
-    Expr.cumsum
-    Expr.cummin
-    Expr.cummax
-    Expr.cumprod
-    Expr.cumcount
-    Expr.cumulative_eval
-    Expr.dot
-    Expr.mode
-    Expr.n_unique
+    Expr.abs
+    Expr.arccos
+    Expr.arcsin
+    Expr.arctan
     Expr.arg_unique
-    Expr.unique
-    Expr.pow
-    Expr.rolling_min
-    Expr.rolling_max
-    Expr.rolling_mean
-    Expr.rolling_sum
-    Expr.rolling_apply
-    Expr.rolling_std
-    Expr.rolling_var
-    Expr.rolling_median
-    Expr.rolling_quantile
-    Expr.rolling_skew
+    Expr.cos
+    Expr.cumcount
+    Expr.cummax
+    Expr.cummin
+    Expr.cumprod
+    Expr.cumsum
+    Expr.cumulative_eval
+    Expr.diff
+    Expr.dot
+    Expr.entropy
     Expr.ewm_mean
     Expr.ewm_std
     Expr.ewm_var
+    Expr.exp
     Expr.hash
-    Expr.abs
-    Expr.rank
-    Expr.diff
-    Expr.pct_change
-    Expr.skew
     Expr.kurtosis
-    Expr.entropy
-    Expr.sqrt
-    Expr.sin
-    Expr.cos
-    Expr.tan
-    Expr.arcsin
-    Expr.arccos
-    Expr.arctan
     Expr.log
     Expr.log10
-    Expr.exp
+    Expr.mode
+    Expr.n_unique
+    Expr.null_count
+    Expr.pct_change
+    Expr.pow
+    Expr.rank
+    Expr.rolling_apply
+    Expr.rolling_max
+    Expr.rolling_mean
+    Expr.rolling_median
+    Expr.rolling_min
+    Expr.rolling_quantile
+    Expr.rolling_skew
+    Expr.rolling_std
+    Expr.rolling_sum
+    Expr.rolling_var
     Expr.sign
+    Expr.sin
+    Expr.skew
+    Expr.sqrt
+    Expr.tan
+    Expr.unique
     Expr.unique_counts
     Expr.value_counts
-    Expr.null_count
 
 Manipulation/ selection
 -----------------------
 .. autosummary::
    :toctree: api/
 
-    Expr.inspect
-    Expr.slice
     Expr.append
-    Expr.explode
-    Expr.flatten
-    Expr.take_every
-    Expr.repeat_by
-    Expr.round
-    Expr.floor
-    Expr.ceil
-    Expr.cast
-    Expr.sort
+    Expr.arg_sort
     Expr.arg_sort
     Expr.argsort
-    Expr.sort_by
-    Expr.take
+    Expr.backward_fill
+    Expr.cast
+    Expr.ceil
+    Expr.clip
+    Expr.drop_nans
+    Expr.drop_nulls
+    Expr.explode
+    Expr.extend_constant
+    Expr.fill_nan
+    Expr.fill_null
+    Expr.filter
+    Expr.flatten
+    Expr.floor
+    Expr.forward_fill
+    Expr.head
+    Expr.inspect
+    Expr.interpolate
+    Expr.lower_bound
+    Expr.rechunk
+    Expr.reinterpret
+    Expr.repeat_by
+    Expr.reshape
+    Expr.reverse
+    Expr.round
+    Expr.sample
     Expr.shift
     Expr.shift_and_fill
-    Expr.fill_null
-    Expr.fill_nan
-    Expr.forward_fill
-    Expr.backward_fill
-    Expr.reverse
-    Expr.filter
-    Expr.where
-    Expr.head
-    Expr.tail
-    Expr.reinterpret
-    Expr.drop_nulls
-    Expr.drop_nans
-    Expr.rechunk
-    Expr.interpolate
-    Expr.arg_sort
-    Expr.clip
-    Expr.lower_bound
-    Expr.upper_bound
-    Expr.reshape
-    Expr.to_physical
     Expr.shuffle
-    Expr.sample
-    Expr.extend_constant
+    Expr.slice
+    Expr.sort
+    Expr.sort_by
+    Expr.tail
+    Expr.take
+    Expr.take_every
+    Expr.to_physical
+    Expr.upper_bound
+    Expr.where
 
 Column names
 ------------
@@ -228,19 +228,19 @@ Column names
    :toctree: api/
 
     Expr.alias
+    Expr.exclude
     Expr.keep_name
+    Expr.map_alias
     Expr.prefix
     Expr.suffix
-    Expr.map_alias
-    Expr.exclude
 
 Apply
 -----
 .. autosummary::
    :toctree: api/
 
-    Expr.map
     Expr.apply
+    Expr.map
 
 Window
 ------
@@ -265,34 +265,34 @@ The following methods are available under the `expr.dt` attribute.
 .. autosummary::
    :toctree: api/
 
-    ExprDateTimeNameSpace.strftime
-    ExprDateTimeNameSpace.year
-    ExprDateTimeNameSpace.month
-    ExprDateTimeNameSpace.week
-    ExprDateTimeNameSpace.weekday
+    ExprDateTimeNameSpace.and_time_unit
+    ExprDateTimeNameSpace.and_time_zone
+    ExprDateTimeNameSpace.cast_time_unit
     ExprDateTimeNameSpace.day
-    ExprDateTimeNameSpace.ordinal_day
-    ExprDateTimeNameSpace.hour
-    ExprDateTimeNameSpace.minute
-    ExprDateTimeNameSpace.second
-    ExprDateTimeNameSpace.nanosecond
-    ExprDateTimeNameSpace.to_python_datetime
-    ExprDateTimeNameSpace.timestamp
-    ExprDateTimeNameSpace.truncate
+    ExprDateTimeNameSpace.days
     ExprDateTimeNameSpace.epoch
     ExprDateTimeNameSpace.epoch_days
     ExprDateTimeNameSpace.epoch_milliseconds
     ExprDateTimeNameSpace.epoch_seconds
-    ExprDateTimeNameSpace.and_time_unit
-    ExprDateTimeNameSpace.and_time_zone
-    ExprDateTimeNameSpace.with_time_unit
-    ExprDateTimeNameSpace.cast_time_unit
-    ExprDateTimeNameSpace.days
+    ExprDateTimeNameSpace.hour
     ExprDateTimeNameSpace.hours
-    ExprDateTimeNameSpace.minutes
-    ExprDateTimeNameSpace.seconds
     ExprDateTimeNameSpace.milliseconds
+    ExprDateTimeNameSpace.minute
+    ExprDateTimeNameSpace.minutes
+    ExprDateTimeNameSpace.month
+    ExprDateTimeNameSpace.nanosecond
     ExprDateTimeNameSpace.nanoseconds
+    ExprDateTimeNameSpace.ordinal_day
+    ExprDateTimeNameSpace.second
+    ExprDateTimeNameSpace.seconds
+    ExprDateTimeNameSpace.strftime
+    ExprDateTimeNameSpace.timestamp
+    ExprDateTimeNameSpace.to_python_datetime
+    ExprDateTimeNameSpace.truncate
+    ExprDateTimeNameSpace.week
+    ExprDateTimeNameSpace.weekday
+    ExprDateTimeNameSpace.with_time_unit
+    ExprDateTimeNameSpace.year
 
 Strings
 -------
@@ -304,31 +304,31 @@ The following methods are available under the `Expr.str` attribute.
 .. autosummary::
    :toctree: api/
 
-    ExprStringNameSpace.strptime
-    ExprStringNameSpace.lengths
-    ExprStringNameSpace.to_uppercase
-    ExprStringNameSpace.to_lowercase
     ExprStringNameSpace.concat
-    ExprStringNameSpace.strip
-    ExprStringNameSpace.lstrip
-    ExprStringNameSpace.rstrip
-    ExprStringNameSpace.zfill
-    ExprStringNameSpace.ljust
-    ExprStringNameSpace.rjust
     ExprStringNameSpace.contains
-    ExprStringNameSpace.starts_with
+    ExprStringNameSpace.count_match
+    ExprStringNameSpace.decode
+    ExprStringNameSpace.encode
     ExprStringNameSpace.ends_with
-    ExprStringNameSpace.json_path_match
     ExprStringNameSpace.extract
     ExprStringNameSpace.extract_all
-    ExprStringNameSpace.count_match
-    ExprStringNameSpace.split
-    ExprStringNameSpace.split_exact
+    ExprStringNameSpace.json_path_match
+    ExprStringNameSpace.lengths
+    ExprStringNameSpace.ljust
+    ExprStringNameSpace.lstrip
     ExprStringNameSpace.replace
     ExprStringNameSpace.replace_all
+    ExprStringNameSpace.rjust
+    ExprStringNameSpace.rstrip
     ExprStringNameSpace.slice
-    ExprStringNameSpace.encode
-    ExprStringNameSpace.decode
+    ExprStringNameSpace.split
+    ExprStringNameSpace.split_exact
+    ExprStringNameSpace.starts_with
+    ExprStringNameSpace.strip
+    ExprStringNameSpace.strptime
+    ExprStringNameSpace.to_lowercase
+    ExprStringNameSpace.to_uppercase
+    ExprStringNameSpace.zfill
 
 Lists
 -----
@@ -339,29 +339,29 @@ The following methods are available under the `expr.arr` attribute.
 .. autosummary::
    :toctree: api/
 
+    ExprListNameSpace.arg_max
+    ExprListNameSpace.arg_min
     ExprListNameSpace.concat
+    ExprListNameSpace.contains
+    ExprListNameSpace.diff
+    ExprListNameSpace.eval
+    ExprListNameSpace.first
+    ExprListNameSpace.get
+    ExprListNameSpace.head
+    ExprListNameSpace.join
+    ExprListNameSpace.last
     ExprListNameSpace.lengths
-    ExprListNameSpace.sum
-    ExprListNameSpace.min
     ExprListNameSpace.max
     ExprListNameSpace.mean
-    ExprListNameSpace.sort
+    ExprListNameSpace.min
     ExprListNameSpace.reverse
-    ExprListNameSpace.unique
-    ExprListNameSpace.get
-    ExprListNameSpace.first
-    ExprListNameSpace.last
-    ExprListNameSpace.contains
-    ExprListNameSpace.join
-    ExprListNameSpace.arg_min
-    ExprListNameSpace.arg_max
-    ExprListNameSpace.diff
     ExprListNameSpace.shift
     ExprListNameSpace.slice
-    ExprListNameSpace.head
+    ExprListNameSpace.sort
+    ExprListNameSpace.sum
     ExprListNameSpace.tail
     ExprListNameSpace.to_struct
-    ExprListNameSpace.eval
+    ExprListNameSpace.unique
 
 Categories
 ----------

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -16,22 +16,22 @@ Conversion
 .. autosummary::
    :toctree: api/
 
+    from_arrow
     from_dict
     from_dicts
-    from_records
-    from_arrow
     from_pandas
+    from_records
 
 Eager/Lazy functions
 ~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: api/
 
-   get_dummies
-   concat
-   repeat
    arg_where
+   concat
    date_range
+   get_dummies
+   repeat
 
 Parallelization
 ~~~~~~~~~~~~~~~

--- a/py-polars/docs/source/reference/index.rst
+++ b/py-polars/docs/source/reference/index.rst
@@ -9,13 +9,13 @@ methods. All classes and functions exposed in ``polars.*`` namespace are public.
 .. toctree::
    :maxdepth: 2
 
-   io
-   functions
-   series
-   dataframe
-   expression
-   lazyframe
-   testing
    config
+   dataframe
    datatypes
    exceptions
+   expression
+   functions
+   io
+   lazyframe
+   series
+   testing

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -23,14 +23,14 @@ Aggregation
 .. autosummary::
    :toctree: api/
 
-    LazyFrame.std
-    LazyFrame.var
     LazyFrame.max
-    LazyFrame.min
-    LazyFrame.sum
     LazyFrame.mean
     LazyFrame.median
+    LazyFrame.min
     LazyFrame.quantile
+    LazyFrame.std
+    LazyFrame.sum
+    LazyFrame.var
 
 Descriptive stats
 -----------------
@@ -46,48 +46,48 @@ Manipulation/ selection
 .. autosummary::
    :toctree: api/
 
-    LazyFrame.with_row_count
     LazyFrame.clone
-    LazyFrame.inspect
+    LazyFrame.distinct
+    LazyFrame.drop
+    LazyFrame.drop_nulls
+    LazyFrame.explode
+    LazyFrame.fill_nan
+    LazyFrame.fill_null
     LazyFrame.filter
-    LazyFrame.select
+    LazyFrame.first
     LazyFrame.groupby
     LazyFrame.groupby_dynamic
     LazyFrame.groupby_rolling
+    LazyFrame.head
+    LazyFrame.inspect
+    LazyFrame.interpolate
     LazyFrame.join
     LazyFrame.join_asof
-    LazyFrame.with_columns
-    LazyFrame.with_column
-    LazyFrame.drop
+    LazyFrame.last
+    LazyFrame.limit
+    LazyFrame.melt
     LazyFrame.rename
     LazyFrame.reverse
+    LazyFrame.select
     LazyFrame.shift
     LazyFrame.shift_and_fill
     LazyFrame.slice
-    LazyFrame.limit
-    LazyFrame.head
-    LazyFrame.tail
-    LazyFrame.last
-    LazyFrame.first
-    LazyFrame.fill_null
-    LazyFrame.fill_nan
-    LazyFrame.explode
-    LazyFrame.distinct
-    LazyFrame.unique
-    LazyFrame.drop_nulls
     LazyFrame.sort
-    LazyFrame.melt
-    LazyFrame.interpolate
+    LazyFrame.tail
+    LazyFrame.unique
     LazyFrame.unnest
+    LazyFrame.with_column
+    LazyFrame.with_columns
+    LazyFrame.with_row_count
 
 Conversion
 ----------
 .. autosummary::
    :toctree: api/
 
-    LazyFrame.write_json
-    LazyFrame.read_json
     LazyFrame.from_json
+    LazyFrame.read_json
+    LazyFrame.write_json
 
 Apply
 -----
@@ -101,10 +101,10 @@ Various
 .. autosummary::
    :toctree: api/
 
-    LazyFrame.pipe
+    LazyFrame.cache
     LazyFrame.collect
     LazyFrame.fetch
-    LazyFrame.cache
+    LazyFrame.pipe
 
 GroupBy
 -------

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -16,14 +16,14 @@ Attributes
 .. autosummary::
    :toctree: api/
 
+   Series.arr
+   Series.cat
+   Series.dt
    Series.dtype
    Series.inner_dtype
    Series.name
    Series.shape
-   Series.arr
-   Series.dt
    Series.str
-   Series.cat
    Series.time_unit
 
 Conversion
@@ -31,10 +31,10 @@ Conversion
 .. autosummary::
    :toctree: api/
 
+   Series.to_arrow
    Series.to_frame
    Series.to_list
    Series.to_numpy
-   Series.to_arrow
    Series.to_pandas
 
 
@@ -43,107 +43,107 @@ Aggregation
 .. autosummary::
    :toctree: api/
 
-    Series.sum
-    Series.mean
-    Series.min
-    Series.max
-    Series.std
-    Series.var
-    Series.median
-    Series.quantile
-    Series.product
-    Series.mode
-    Series.arg_min
     Series.arg_max
+    Series.arg_min
+    Series.max
+    Series.mean
+    Series.median
+    Series.min
+    Series.mode
+    Series.product
+    Series.quantile
+    Series.std
+    Series.sum
+    Series.var
 
 Descriptive stats
 -----------------
 .. autosummary::
    :toctree: api/
 
+    Series.chunk_lengths
     Series.describe
     Series.estimated_size
-    Series.unique_counts
-    Series.value_counts
-    Series.chunk_lengths
-    Series.n_chunks
-    Series.null_count
+    Series.has_validity
+    Series.is_boolean
+    Series.is_datelike
+    Series.is_duplicated
     Series.is_empty
-    Series.is_null
-    Series.is_not_null
     Series.is_finite
+    Series.is_first
+    Series.is_float
+    Series.is_in
     Series.is_infinite
     Series.is_nan
     Series.is_not_nan
-    Series.is_in
-    Series.is_unique
-    Series.is_first
-    Series.is_duplicated
+    Series.is_not_null
+    Series.is_null
     Series.is_numeric
-    Series.is_float
-    Series.is_boolean
+    Series.is_unique
     Series.is_utf8
-    Series.is_datelike
     Series.len
+    Series.n_chunks
     Series.n_unique
-    Series.has_validity
+    Series.null_count
+    Series.unique_counts
+    Series.value_counts
 
 Boolean
 -------
 .. autosummary::
    :toctree: api/
 
-    Series.any
     Series.all
+    Series.any
 
 Computations
 ------------
 .. autosummary::
    :toctree: api/
 
-    Series.cumsum
-    Series.cummin
-    Series.cummax
-    Series.cumprod
-    Series.cumulative_eval
+    Series.abs
+    Series.arccos
+    Series.arcsin
+    Series.arctan
     Series.arg_true
     Series.arg_unique
-    Series.unique
-    Series.rolling_min
-    Series.rolling_max
-    Series.rolling_mean
-    Series.rolling_sum
-    Series.rolling_apply
-    Series.rolling_std
-    Series.rolling_var
-    Series.rolling_median
-    Series.rolling_quantile
-    Series.rolling_skew
+    Series.cos
+    Series.cummax
+    Series.cummin
+    Series.cumprod
+    Series.cumsum
+    Series.cumulative_eval
+    Series.diff
+    Series.dot
+    Series.entropy
     Series.ewm_mean
     Series.ewm_std
     Series.ewm_var
+    Series.exp
     Series.hash
-    Series.peak_max
-    Series.peak_min
-    Series.dot
-    Series.abs
-    Series.rank
-    Series.diff
-    Series.pct_change
-    Series.skew
     Series.kurtosis
-    Series.entropy
-    Series.sqrt
-    Series.sin
-    Series.cos
-    Series.tan
-    Series.arcsin
-    Series.arccos
-    Series.arctan
     Series.log
     Series.log10
-    Series.exp
+    Series.pct_change
+    Series.peak_max
+    Series.peak_min
+    Series.rank
+    Series.rolling_apply
+    Series.rolling_max
+    Series.rolling_mean
+    Series.rolling_median
+    Series.rolling_min
+    Series.rolling_quantile
+    Series.rolling_skew
+    Series.rolling_std
+    Series.rolling_sum
+    Series.rolling_var
     Series.sign
+    Series.sin
+    Series.skew
+    Series.sqrt
+    Series.tan
+    Series.unique
 
 Manipulation/ selection
 -----------------------
@@ -151,56 +151,56 @@ Manipulation/ selection
    :toctree: api/
 
     Series.alias
-    Series.rename
-    Series.limit
-    Series.slice
     Series.append
-    Series.filter
-    Series.head
-    Series.tail
-    Series.take_every
-    Series.sort
     Series.argsort
-    Series.reverse
-    Series.take
-    Series.shrink_to_fit
-    Series.explode
-    Series.sample
-    Series.view
-    Series.set
+    Series.cast
+    Series.ceil
+    Series.clip
     Series.clone
+    Series.drop_nans
+    Series.drop_nulls
+    Series.explode
+    Series.extend_constant
+    Series.fill_nan
+    Series.fill_null
+    Series.filter
+    Series.floor
+    Series.head
+    Series.interpolate
+    Series.limit
+    Series.rechunk
+    Series.rename
+    Series.reshape
+    Series.reverse
+    Series.round
+    Series.sample
+    Series.set
+    Series.set_at_idx
     Series.shift
     Series.shift_and_fill
-    Series.drop_nulls
-    Series.drop_nans
-    Series.rechunk
-    Series.cast
-    Series.round
-    Series.floor
-    Series.ceil
-    Series.set_at_idx
-    Series.fill_null
-    Series.fill_nan
-    Series.zip_with
-    Series.interpolate
-    Series.clip
-    Series.reshape
-    Series.to_dummies
+    Series.shrink_to_fit
     Series.shuffle
-    Series.extend_constant
+    Series.slice
+    Series.sort
+    Series.tail
+    Series.take
+    Series.take_every
+    Series.to_dummies
+    Series.view
+    Series.zip_with
 
 Various
 --------
 .. autosummary::
    :toctree: api/
 
-    Series.series_equal
     Series.apply
     Series.dt
-    Series.str
     Series.reinterpret
-    Series.to_physical
+    Series.series_equal
     Series.set_sorted
+    Series.str
+    Series.to_physical
 
 TimeSeries
 ----------
@@ -211,38 +211,38 @@ The following methods are available under the `Series.dt` attribute.
 .. autosummary::
    :toctree: api/
 
-    DateTimeNameSpace.strftime
-    DateTimeNameSpace.year
-    DateTimeNameSpace.month
-    DateTimeNameSpace.week
-    DateTimeNameSpace.weekday
+    DateTimeNameSpace.and_time_unit
+    DateTimeNameSpace.and_time_zone
+    DateTimeNameSpace.cast_time_unit
     DateTimeNameSpace.day
-    DateTimeNameSpace.ordinal_day
-    DateTimeNameSpace.hour
-    DateTimeNameSpace.minute
-    DateTimeNameSpace.second
-    DateTimeNameSpace.nanosecond
-    DateTimeNameSpace.timestamp
-    DateTimeNameSpace.to_python_datetime
-    DateTimeNameSpace.min
-    DateTimeNameSpace.max
-    DateTimeNameSpace.median
-    DateTimeNameSpace.mean
-    DateTimeNameSpace.truncate
+    DateTimeNameSpace.days
     DateTimeNameSpace.epoch
     DateTimeNameSpace.epoch_days
     DateTimeNameSpace.epoch_milliseconds
     DateTimeNameSpace.epoch_seconds
-    DateTimeNameSpace.and_time_unit
-    DateTimeNameSpace.and_time_zone
-    DateTimeNameSpace.with_time_unit
-    DateTimeNameSpace.cast_time_unit
-    DateTimeNameSpace.days
+    DateTimeNameSpace.hour
     DateTimeNameSpace.hours
-    DateTimeNameSpace.minutes
-    DateTimeNameSpace.seconds
+    DateTimeNameSpace.max
+    DateTimeNameSpace.mean
+    DateTimeNameSpace.median
     DateTimeNameSpace.milliseconds
+    DateTimeNameSpace.min
+    DateTimeNameSpace.minute
+    DateTimeNameSpace.minutes
+    DateTimeNameSpace.month
+    DateTimeNameSpace.nanosecond
     DateTimeNameSpace.nanoseconds
+    DateTimeNameSpace.ordinal_day
+    DateTimeNameSpace.second
+    DateTimeNameSpace.seconds
+    DateTimeNameSpace.strftime
+    DateTimeNameSpace.timestamp
+    DateTimeNameSpace.to_python_datetime
+    DateTimeNameSpace.truncate
+    DateTimeNameSpace.week
+    DateTimeNameSpace.weekday
+    DateTimeNameSpace.with_time_unit
+    DateTimeNameSpace.year
 
 
 Strings
@@ -255,31 +255,31 @@ The following methods are available under the `Series.str` attribute.
 .. autosummary::
    :toctree: api/
 
-    StringNameSpace.strptime
-    StringNameSpace.lengths
     StringNameSpace.concat
     StringNameSpace.contains
-    StringNameSpace.starts_with
+    StringNameSpace.count_match
+    StringNameSpace.decode
+    StringNameSpace.encode
     StringNameSpace.ends_with
-    StringNameSpace.json_path_match
     StringNameSpace.extract
     StringNameSpace.extract_all
-    StringNameSpace.count_match
-    StringNameSpace.split
-    StringNameSpace.split_exact
+    StringNameSpace.json_path_match
+    StringNameSpace.lengths
+    StringNameSpace.ljust
+    StringNameSpace.lstrip
     StringNameSpace.replace
     StringNameSpace.replace_all
+    StringNameSpace.rjust
+    StringNameSpace.rstrip
+    StringNameSpace.slice
+    StringNameSpace.split
+    StringNameSpace.split_exact
+    StringNameSpace.starts_with
+    StringNameSpace.strip
+    StringNameSpace.strptime
     StringNameSpace.to_lowercase
     StringNameSpace.to_uppercase
-    StringNameSpace.strip
-    StringNameSpace.rstrip
-    StringNameSpace.lstrip
     StringNameSpace.zfill
-    StringNameSpace.ljust
-    StringNameSpace.rjust
-    StringNameSpace.slice
-    StringNameSpace.encode
-    StringNameSpace.decode
 
 Lists
 -----
@@ -291,28 +291,28 @@ The following methods are available under the `Series.arr` attribute.
 .. autosummary::
    :toctree: api/
 
+    ListNameSpace.arg_max
+    ListNameSpace.arg_min
     ListNameSpace.concat
+    ListNameSpace.contains
+    ListNameSpace.diff
+    ListNameSpace.eval
+    ListNameSpace.first
+    ListNameSpace.get
+    ListNameSpace.head
+    ListNameSpace.join
+    ListNameSpace.last
     ListNameSpace.lengths
-    ListNameSpace.sum
-    ListNameSpace.min
     ListNameSpace.max
     ListNameSpace.mean
-    ListNameSpace.sort
+    ListNameSpace.min
     ListNameSpace.reverse
-    ListNameSpace.unique
-    ListNameSpace.get
-    ListNameSpace.first
-    ListNameSpace.last
-    ListNameSpace.contains
-    ListNameSpace.join
-    ListNameSpace.arg_min
-    ListNameSpace.arg_max
-    ListNameSpace.diff
     ListNameSpace.shift
     ListNameSpace.slice
-    ListNameSpace.head
+    ListNameSpace.sort
+    ListNameSpace.sum
     ListNameSpace.tail
-    ListNameSpace.eval
+    ListNameSpace.unique
 
 Categories
 ----------
@@ -334,7 +334,7 @@ The following methods are available under the `Series.struct` attribute.
 .. autosummary::
    :toctree: api/
 
-    StructNameSpace.to_frame
     StructNameSpace.field
     StructNameSpace.fields
     StructNameSpace.rename_fields
+    StructNameSpace.to_frame

--- a/py-polars/docs/source/reference/testing.rst
+++ b/py-polars/docs/source/reference/testing.rst
@@ -7,5 +7,5 @@ Testing
 .. autosummary::
    :toctree: api/
 
-    testing.assert_series_equal
     testing.assert_frame_equal
+    testing.assert_series_equal


### PR DESCRIPTION
Only `.rst` updates. No code changes, no modification as to which entries are present - just standardises the sort order.