### PR TITLE
Fix Node installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Want to know about all the features Polars supports? Read the docs!
 
 #### Node
 
-  * Installation guide: `$ yarn install nodejs-polars`
+  * Installation guide: `$ yarn add nodejs-polars`
   * [Node documentation](https://pola-rs.github.io/polars/nodejs-polars/html/index.html)
   * [User guide](https://pola-rs.github.io/polars-book/)
 


### PR DESCRIPTION
`yarn install <package>` no longer works to add a package:

```
$ yarn install nodejs-polars
yarn install v1.22.10
info No lockfile found.
error `install` has been replaced with `add` to add new dependencies. Run "yarn add nodejs-polars" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This changes the installation instructions to use the replacement, `yarn add` instead.