### PR TITLE
Add serde feature to field to fix serde feature

### DIFF
--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -880,7 +880,10 @@ impl PartialEq<ArrowDataType> for DataType {
 
 /// Characterizes the name and the [`DataType`] of a column.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(feature = "serde", feature = "serde-lazy"), derive(Serialize, Deserialize))]
+#[cfg_attr(
+    any(feature = "serde", feature = "serde-lazy"),
+    derive(Serialize, Deserialize)
+)]
 pub struct Field {
     name: String,
     dtype: DataType,

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -880,7 +880,7 @@ impl PartialEq<ArrowDataType> for DataType {
 
 /// Characterizes the name and the [`DataType`] of a column.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(any(feature = "serde", feature = "serde-lazy"), derive(Serialize, Deserialize))]
 pub struct Field {
     name: String,
     dtype: DataType,


### PR DESCRIPTION
1. Add `polars = { git = "https://github.com/pola-rs/polars", features = ["dtype-struct", "serde"] }` to Cargo.toml dependencies
2. Try and run `cargo build`
```
error[E0277]: the trait bound `datatypes::Field: Serialize` is not satisfied
   --> /Users/joshtaylor/.cargo/git/checkouts/polars-b0d90607192fd414/c217364/polars/polars-core/src/datatypes/_serde.rs:57:12
    |
57  |     Struct(Vec<Field>),
    |            ^^^^^^^^^^ the trait `Serialize` is not implemented for `datatypes::Field`
    |
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
              (T0, T1, T2, T3, T4, T5)
            and 142 others
    = note: required because of the requirements on the impl of `Serialize` for `Vec<datatypes::Field>`
note: required by a bound in `serialize_newtype_variant`
   --> /Users/joshtaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.137/src/ser/mod.rs:940:12
    |
940 |         T: Serialize;
    |            ^^^^^^^^^ required by this bound in `serialize_newtype_variant`
```

Fixes #3807 