### PR TITLE
chore: `chunked_array` readability improvements

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -827,7 +827,7 @@ mod test {
     #[test]
     fn test_var() {
         // validated with numpy
-        // Note that numpy as an argument ddof wich influences results. The default is ddof=0
+        // Note that numpy as an argument ddof which influences results. The default is ddof=0
         // we chose ddof=1, which is standard in statistics
         let ca1 = Int32Chunked::new("", &[5, 8, 9, 5, 0]);
         let ca2 = Int32Chunked::new(

--- a/polars/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/polars/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -23,13 +23,13 @@ where
                     let offset = buf.offset();
                     let ptr = buf.as_slice().as_ptr() as usize;
                     #[allow(clippy::transmute_undefined_repr)]
-                    let reinterpretted_buf = unsafe { std::mem::transmute::<_, Buffer<u64>>(buf) };
-                    assert_eq!(reinterpretted_buf.len(), len);
-                    assert_eq!(reinterpretted_buf.offset(), offset);
-                    assert_eq!(reinterpretted_buf.as_slice().as_ptr() as usize, ptr);
+                    let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u64>>(buf) };
+                    assert_eq!(reinterpreted_buf.len(), len);
+                    assert_eq!(reinterpreted_buf.offset(), offset);
+                    assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
                     Box::new(PrimitiveArray::from_data(
                         ArrowDataType::UInt64,
-                        reinterpretted_buf,
+                        reinterpreted_buf,
                         array.validity().cloned(),
                     )) as ArrayRef
                 })
@@ -54,13 +54,13 @@ where
                     let offset = buf.offset();
                     let ptr = buf.as_slice().as_ptr() as usize;
                     #[allow(clippy::transmute_undefined_repr)]
-                    let reinterpretted_buf = unsafe { std::mem::transmute::<_, Buffer<u32>>(buf) };
-                    assert_eq!(reinterpretted_buf.len(), len);
-                    assert_eq!(reinterpretted_buf.offset(), offset);
-                    assert_eq!(reinterpretted_buf.as_slice().as_ptr() as usize, ptr);
+                    let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u32>>(buf) };
+                    assert_eq!(reinterpreted_buf.len(), len);
+                    assert_eq!(reinterpreted_buf.offset(), offset);
+                    assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
                     Box::new(PrimitiveArray::from_data(
                         ArrowDataType::UInt32,
-                        reinterpretted_buf,
+                        reinterpreted_buf,
                         array.validity().cloned(),
                     )) as ArrayRef
                 })
@@ -91,13 +91,13 @@ impl Reinterpret for UInt64Chunked {
                 let offset = buf.offset();
                 let ptr = buf.as_slice().as_ptr() as usize;
                 #[allow(clippy::transmute_undefined_repr)]
-                let reinterpretted_buf = unsafe { std::mem::transmute::<_, Buffer<i64>>(buf) };
-                assert_eq!(reinterpretted_buf.len(), len);
-                assert_eq!(reinterpretted_buf.offset(), offset);
-                assert_eq!(reinterpretted_buf.as_slice().as_ptr() as usize, ptr);
+                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<i64>>(buf) };
+                assert_eq!(reinterpreted_buf.len(), len);
+                assert_eq!(reinterpreted_buf.offset(), offset);
+                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
                 Box::new(PrimitiveArray::new(
                     ArrowDataType::Int64,
-                    reinterpretted_buf,
+                    reinterpreted_buf,
                     array.validity().cloned(),
                 )) as ArrayRef
             })
@@ -134,13 +134,13 @@ impl UInt64Chunked {
                 let offset = buf.offset();
                 let ptr = buf.as_slice().as_ptr() as usize;
                 #[allow(clippy::transmute_undefined_repr)]
-                let reinterpretted_buf = unsafe { std::mem::transmute::<_, Buffer<f64>>(buf) };
-                assert_eq!(reinterpretted_buf.len(), len);
-                assert_eq!(reinterpretted_buf.offset(), offset);
-                assert_eq!(reinterpretted_buf.as_slice().as_ptr() as usize, ptr);
+                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<f64>>(buf) };
+                assert_eq!(reinterpreted_buf.len(), len);
+                assert_eq!(reinterpreted_buf.offset(), offset);
+                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
                 Box::new(PrimitiveArray::from_data(
                     ArrowDataType::Float64,
-                    reinterpretted_buf,
+                    reinterpreted_buf,
                     array.validity().cloned(),
                 )) as ArrayRef
             })
@@ -162,13 +162,13 @@ impl UInt32Chunked {
                 let offset = buf.offset();
                 let ptr = buf.as_slice().as_ptr() as usize;
                 #[allow(clippy::transmute_undefined_repr)]
-                let reinterpretted_buf = unsafe { std::mem::transmute::<_, Buffer<f32>>(buf) };
-                assert_eq!(reinterpretted_buf.len(), len);
-                assert_eq!(reinterpretted_buf.offset(), offset);
-                assert_eq!(reinterpretted_buf.as_slice().as_ptr() as usize, ptr);
+                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<f32>>(buf) };
+                assert_eq!(reinterpreted_buf.len(), len);
+                assert_eq!(reinterpreted_buf.offset(), offset);
+                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
                 Box::new(PrimitiveArray::from_data(
                     ArrowDataType::Float32,
-                    reinterpretted_buf,
+                    reinterpreted_buf,
                     array.validity().cloned(),
                 )) as ArrayRef
             })

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -50,7 +50,7 @@ where
 
         // in the case that the value array has got null values, we need to check every validity
         // value and collect the indices.
-        // because the length of the array is not known, we first collect the null indexes, offsetted
+        // because the length of the array is not known, we first collect the null indexes, offset
         // with the insertion of empty rows (as None) and later create a validity bitmap
         if arr.has_validity() {
             let validity_values = arr.validity().unwrap();

--- a/polars/polars-core/src/chunked_array/ops/take/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_single.rs
@@ -112,7 +112,7 @@ impl<'a> TakeRandomUtf8 for &'a Utf8Chunked {
     #[inline]
     fn get(self, index: usize) -> Option<Self::Item> {
         // Safety:
-        // Out of bounds is checkedn and downcast is of correct type
+        // Out of bounds is checked and downcast is of correct type
         unsafe { impl_take_random_get!(self, index, LargeStringArray) }
     }
 


### PR DESCRIPTION
Readability improvements in the `/polars/polars-core/src/chunked_array` path

- `reinterpretted_buf` -> `reinterpreted_buf`
- Small comment fixes