### PR TITLE
Fixing small typos in docs

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1407,8 +1407,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         use_pyarrow
             Use C++ parquet implementation vs rust parquet implementation.
             At the moment C++ supports more features.
-
-        **kwargs are passed to pyarrow.parquet.write_table
+        kwargs
+            Arguments are passed to pyarrow.parquet.write_table.
         """
         if compression is None:
             compression = "uncompressed"
@@ -4453,11 +4453,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Parameters
         ----------
         groups
-            Groups to partition by
+            Groups to partition by.
         maintain_order
-            Keep predictable output order. This is slower as it requires and extra sort operation.
+            Keep predictable output order. This is slower as it requires an extra sort operation.
         as_dict
-            Return as dictionary
+            If True, return the partitions in a dictionary keyed by the distinct group values instead
+            of a list.
 
         Examples
         --------

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -213,7 +213,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Int64'>]
 
     In order to specify dtypes for your columns, initialize the DataFrame with a list
-    of typed Series, or set the columns parameter with a list of (name,dtype) pairs:
+    of typed Series:
 
     >>> data = [
     ...     pl.Series("col1", [1, 2], dtype=pl.Float32),
@@ -232,9 +232,13 @@ class DataFrame(metaclass=DataFrameMetaClass):
     │ 2.0  ┆ 4    │
     └──────┴──────┘
 
-    # or, equivalent... (and also compatible with all of the other valid data parameter types):
+    Or set the `columns` parameter with a list of (name,dtype) pairs (compatible with
+    all of the other valid data parameter types):
+
+    >>> data = {"col1": [1, 2], "col2": [3, 4]}
     >>> df3 = pl.DataFrame(data, columns=[("col1", pl.Float32), ("col2", pl.Int64)])
     >>> df3
+    shape: (2, 2)
     ┌──────┬──────┐
     │ col1 ┆ col2 │
     │ ---  ┆ ---  │


### PR DESCRIPTION
Fixing small typos & formatting issues in the py-polars documentation.

Mainly to fix this:

<img src="https://user-images.githubusercontent.com/30731072/175783796-7e8f1996-5b96-4a98-9544-303eda1c5be3.png" width=500>
