### PR TITLE
docs: use quotes in pip install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ See the results in [h2oai's db-benchmark](https://h2oai.github.io/db-benchmark/)
 Install the latest polars version with:
 
 ```
-$ pip3 install -U polars[pyarrow]
+$ pip3 install -U 'polars[pyarrow]'
 ```
 
 Releases happen quite often (weekly / every few days) at the moment, so updating polars regularly to get the latest bugfixes / features might not be a bad idea.


### PR DESCRIPTION
A small PR to encourage the use of quotes around the package name during pip install. (`README.md`)

Under zsh,
```shell
$ pip3 install -U polars[pyarrow]
```
will throw an error
```
zsh: no matches found: polars[pyarrow]
```
which might throw some beginners off.

The more robust solution is to put quotes around the package name so globbing doesn't happen. And this is compatible with bash as well.