### PR TITLE
Improve parquet reading performance `~35-40%`

### DIFF
--- a/polars/polars-io/src/parquet/mmap.rs
+++ b/polars/polars-io/src/parquet/mmap.rs
@@ -1,0 +1,66 @@
+use super::*;
+use arrow::datatypes::Field;
+use arrow::io::parquet::read::{
+    column_iter_to_arrays, ArrayIter, BasicDecompressor, ColumnChunkMetaData, PageReader,
+};
+
+// TODO! make public in arrow2?
+pub(super) fn get_field_columns<'a>(
+    columns: &'a [ColumnChunkMetaData],
+    field_name: &str,
+) -> Vec<&'a ColumnChunkMetaData> {
+    columns
+        .iter()
+        .filter(|x| x.descriptor().path_in_schema[0] == field_name)
+        .collect()
+}
+
+/// memory maps all columns that are part of the parquet field `field_name`
+pub(super) fn mmap_columns<'a>(
+    file: &'a [u8],
+    columns: &'a [ColumnChunkMetaData],
+    field_name: &str,
+) -> Vec<(&'a ColumnChunkMetaData, &'a [u8])> {
+    get_field_columns(columns, field_name)
+        .into_iter()
+        .map(|meta| _mmap_single_column(file, meta))
+        .collect()
+}
+
+fn _mmap_single_column<'a>(
+    file: &'a [u8],
+    meta: &'a ColumnChunkMetaData,
+) -> (&'a ColumnChunkMetaData, &'a [u8]) {
+    let (start, len) = meta.byte_range();
+    let chunk = &file[start as usize..(start + len) as usize];
+    (meta, chunk)
+}
+
+// similar to arrow2 serializer, except this accepts a slice instead of a vec.
+// this allows use to memory map
+pub(super) fn to_deserializer<'a>(
+    columns: Vec<(&ColumnChunkMetaData, &'a [u8])>,
+    field: Field,
+    num_rows: usize,
+    chunk_size: Option<usize>,
+) -> ArrowResult<ArrayIter<'a>> {
+    let chunk_size = chunk_size.unwrap_or(usize::MAX).min(num_rows);
+
+    let (columns, types): (Vec<_>, Vec<_>) = columns
+        .into_iter()
+        .map(|(column_meta, chunk)| {
+            let pages = PageReader::new(
+                std::io::Cursor::new(chunk),
+                column_meta,
+                std::sync::Arc::new(|_, _| true),
+                vec![],
+            );
+            (
+                BasicDecompressor::new(pages, vec![]),
+                &column_meta.descriptor().descriptor.primitive_type,
+            )
+        })
+        .unzip();
+
+    column_iter_to_arrays(columns, types, field, Some(chunk_size))
+}

--- a/polars/polars-io/src/parquet/mod.rs
+++ b/polars/polars-io/src/parquet/mod.rs
@@ -14,6 +14,7 @@
 //! }
 //! ```
 //!
+pub(super) mod mmap;
 pub mod predicates;
 mod read;
 mod read_impl;

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -36,7 +36,7 @@ impl ParquetExec {
             &self.aggregate,
         );
 
-        ParquetReader::from_path(self.path.as_path())?
+        ParquetReader::new(file)
             .with_n_rows(n_rows)
             .read_parallel(self.options.parallel)
             .with_row_count(std::mem::take(&mut self.options.row_count))

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -36,7 +36,7 @@ impl ParquetExec {
             &self.aggregate,
         );
 
-        ParquetReader::new(file)
+        ParquetReader::from_path(self.path.as_path())?
             .with_n_rows(n_rows)
             .read_parallel(self.options.parallel)
             .with_row_count(std::mem::take(&mut self.options.row_count))


### PR DESCRIPTION
Previous implementation we use memmap and read to a vector. This is not very smart, as we pay double IO. Removing memmap and reading directly to the buffers improved performance by `~30%`. 

But that data still needs to be zeroed before written, so if we use memmap directly we could skip that step. That improved performance by yet another `~8%` compared to master.

Reading the yellowtrip dataset benchmarks:

# master 
```
Performance counter stats for './target/release/memcheck':

         22.978,03 msec task-clock                #    6,296 CPUs utilized          
           465.290      context-switches          #   20,249 K/sec                  
            10.129      cpu-migrations            #  440,812 /sec                   
         2.323.129      page-faults               #  101,102 K/sec                  
    75.015.799.667      cycles                    #    3,265 GHz                    
    73.372.673.203      instructions              #    0,98  insn per cycle         
    13.989.811.069      branches                  #  608,834 M/sec                  
        71.684.372      branch-misses             #    0,51% of all branches        

       3,649539611 seconds time elapsed

      10,707208000 seconds user
      13,337545000 seconds sys
```


# read with zeroed
```
 Performance counter stats for './target/release/memcheck':

         17.159,57 msec task-clock                #    6,073 CPUs utilized          
           393.657      context-switches          #   22,941 K/sec                  
             7.877      cpu-migrations            #  459,044 /sec                   
         1.995.815      page-faults               #  116,309 K/sec                  
    59.192.854.862      cycles                    #    3,450 GHz                    
    52.386.441.413      instructions              #    0,89  insn per cycle         
    10.072.386.163      branches                  #  586,983 M/sec                  
        69.491.528      branch-misses             #    0,69% of all branches        

       2,825714164 seconds time elapsed

       5,988224000 seconds user
      12,028295000 seconds sys
```


# memory map
```
 Performance counter stats for './target/release/memcheck':

         16.007,82 msec task-clock                #    6,071 CPUs utilized          
           352.604      context-switches          #   22,027 K/sec                  
             6.504      cpu-migrations            #  406,301 /sec                   
         1.747.134      page-faults               #  109,143 K/sec                  
    55.113.085.851      cycles                    #    3,443 GHz                    
    51.144.360.047      instructions              #    0,93  insn per cycle         
     9.883.151.274      branches                  #  617,395 M/sec                  
        67.085.974      branch-misses             #    0,68% of all branches        

       2,636863878 seconds time elapsed

       6,678761000 seconds user
      10,102559000 seconds sys
```

@jorgecarleitao FYI