### PR TITLE
docs: Improve expr.string documentation

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4764,6 +4764,32 @@ class ExprStringNameSpace:
         literal
             Treat pattern as a literal string.
 
+        Examples
+        --------
+
+        >>> df = pl.DataFrame({"a": ["Crab", "cat and dog", "rab$bit", None]})
+        >>> df.select(
+        ...     [
+        ...         pl.col("a"),
+        ...         pl.col("a").str.contains("cat|bit").alias("regex"),
+        ...         pl.col("a").str.contains("rab$", literal=True).alias("literal"),
+        ...     ]
+        ... )
+        shape: (4, 3)
+        ┌─────────────┬───────┬─────────┐
+        │ a           ┆ regex ┆ literal │
+        │ ---         ┆ ---   ┆ ---     │
+        │ str         ┆ bool  ┆ bool    │
+        ╞═════════════╪═══════╪═════════╡
+        │ Crab        ┆ false ┆ false   │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ cat and dog ┆ true  ┆ false   │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ rab$bit     ┆ true  ┆ true    │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ null        ┆ null  ┆ null    │
+        └─────────────┴───────┴─────────┘
+
         """
         return wrap_expr(self._pyexpr.str_contains(pattern, literal))
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4615,6 +4615,25 @@ class ExprStringNameSpace:
     def lengths(self) -> Expr:
         """
         Get the length of the Strings as UInt32.
+
+        Examples
+        --------
+
+        >>> df = pl.DataFrame({"s": [None, "bears", "110"]})
+        >>> df.select(["s", pl.col("s").str.lengths().alias("len")])
+        shape: (3, 2)
+        ┌───────┬──────┐
+        │ s     ┆ len  │
+        │ ---   ┆ ---  │
+        │ str   ┆ u32  │
+        ╞═══════╪══════╡
+        │ null  ┆ null │
+        ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+        │ bears ┆ 5    │
+        ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+        │ 110   ┆ 3    │
+        └───────┴──────┘
+
         """
         return wrap_expr(self._pyexpr.str_lengths())
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4539,19 +4539,19 @@ class ExprStringNameSpace:
         exact: bool = True,
     ) -> Expr:
         """
-        Parse a UTF8 expression to a Date/Datetime/Time type.
+        Parse a Utf8 expression to a Date/Datetime/Time type.
 
         Parameters
         ----------
         datatype
             Date | Datetime | Time.
         fmt
-            format to use, see the following link for examples:
+            Format to use, see the following link for examples:
             https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 
             example: "%y-%m-%d".
         strict
-            raise an error if any conversion fails
+            Raise an error if any conversion fails.
         exact
             - If True, require an exact format match.
             - If False, allow the format to match anywhere in the target string.
@@ -4702,7 +4702,7 @@ class ExprStringNameSpace:
         Return a copy of the string left filled with ASCII '0' digits to make a string of length width.
         A leading sign prefix ('+'/'-') is handled by inserting the padding after the sign character
         rather than before.
-        The original string is returned if width is less than or equal to `len(s)`.
+        The original string is returned if width is less than or equal to ``len(s)``.
 
         Parameters
         ----------
@@ -4749,30 +4749,30 @@ class ExprStringNameSpace:
     def ljust(self, width: int, fillchar: str = " ") -> Expr:
         """
         Return the string left justified in a string of length width.
-        Padding is done using the specified `fillchar`,
-        The original string is returned if width is less than or equal to `len(s)`.
+        Padding is done using the specified ``fillchar``,
+        The original string is returned if width is less than or equal to ``len(s)``.
 
         Parameters
         ----------
         width
-            justify left to this length
+            Justify left to this length.
         fillchar
-            fill with this ASCII character
+            Fill with this ASCII character.
         """
         return wrap_expr(self._pyexpr.str_ljust(width, fillchar))
 
     def rjust(self, width: int, fillchar: str = " ") -> Expr:
         """
         Return the string right justified in a string of length width.
-        Padding is done using the specified `fillchar`,
-        The original string is returned if width is less than or equal to `len(s)`.
+        Padding is done using the specified ``fillchar``,
+        The original string is returned if ``width`` is less than or equal to ``len(s)``.
 
         Parameters
         ----------
         width
-            justify right to this length
+            Justify right to this length.
         fillchar
-            fill with this ASCII character
+            Fill with this ASCII character.
         """
         return wrap_expr(self._pyexpr.str_rjust(width, fillchar))
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5055,14 +5055,13 @@ class ExprStringNameSpace:
     def split(self, by: str, inclusive: bool = False) -> Expr:
         """
         Split the string by a substring.
-        The return type will by of type List<Utf8>
 
         Parameters
         ----------
         by
-            substring
+            Substring to split by.
         inclusive
-            Include the split character/string in the results
+            If True, include the split character/string in the results.
 
         Examples
         --------
@@ -5082,6 +5081,10 @@ class ExprStringNameSpace:
         │ ["foo", "bar", "baz"] │
         └───────────────────────┘
 
+        Returns
+        -------
+        List of Utf8 type
+
         """
         if inclusive:
             return wrap_expr(self._pyexpr.str_split_inclusive(by))
@@ -5089,19 +5092,18 @@ class ExprStringNameSpace:
 
     def split_exact(self, by: str, n: int, inclusive: bool = False) -> Expr:
         """
-        Split the string by a substring into a struct of `n` fields.
-        The return type will by of type Struct<Utf8>
+        Split the string by a substring into a struct of ``n`` fields.
 
-        If it cannot make `n` splits, the remaiming field elements will be null
+        If it cannot make ``n`` splits, the remaining field elements will be null.
 
         Parameters
         ----------
         by
-            substring
+            Substring to split by.
         n
-            Number of splits to make
+            Number of splits to make.
         inclusive
-            Include the split character/string in the results
+            If True, include the split character/string in the results.
 
         Examples
         --------
@@ -5127,6 +5129,10 @@ class ExprStringNameSpace:
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
         │ {"d","4"}                                 │
         └───────────────────────────────────────────┘
+
+        Returns
+        -------
+        Struct of Utf8 type
 
         """
         if inclusive:

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4641,6 +4641,11 @@ class ExprStringNameSpace:
         """
         Vertically concat the values in the Series to a single string value.
 
+        Parameters
+        ----------
+        delimiter
+            The delimiter to insert between consecutive string values.
+
         Returns
         -------
         Series of dtype Utf8
@@ -4649,8 +4654,7 @@ class ExprStringNameSpace:
         --------
 
         >>> df = pl.DataFrame({"foo": [1, None, 2]})
-        >>> df = df.select(pl.col("foo").str.concat("-"))
-        >>> df
+        >>> df.select(pl.col("foo").str.concat("-"))
         shape: (1, 1)
         ┌──────────┐
         │ foo      │

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5212,7 +5212,8 @@ class ExprStringNameSpace:
         Parameters
         ----------
         start
-            Start of the slice (negative indexing may be used).
+            Starting index of the slice (zero-indexed). Negative indexing
+            may be used.
         length
             Optional length of the slice.
 


### PR DESCRIPTION
I'm only just starting to get to know `polars` a bit better (really impressed so far!), and would like to contribute back to the community in any small way I can. This PR proposes improvements to the `expr.str` section in the py-polars documentation.

I've tried to keep the PR small and contained, and the changes are grouped logically on a commit-level. Feel free to let me know if there are any (documentation) styles I'm violating.

ps. I intend to read through the other sections in the documentation over the next couple weeks to understand better what is possible in polars, so I'll probably be contributing further documentation changes as and when. :)