### PR TITLE
Hypothesis testing framework integrations for Polars 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ polars/vendor
 AUTO_CHANGELOG.md
 node_modules/
 .coverage
+.hypothesis
 venv/
 *.iml
 coverage.lcov

--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -2,4 +2,5 @@ wheels/
 !Cargo.lock
 target/
 venv/
+.hypothesis
 .DS_Store

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -13,6 +13,7 @@ types-pytz
 maturin==0.12.19
 pytest==7.1.2
 pytest-cov[toml]==3.0.0
+hypothesis==6.48
 black==22.3.0
 blackdoc==0.3.4
 isort~=5.10.1

--- a/py-polars/docs/source/reference/testing.rst
+++ b/py-polars/docs/source/reference/testing.rst
@@ -4,8 +4,40 @@ Testing
 ============
 .. currentmodule:: polars
 
+
+Asserts
+-------
+
 .. autosummary::
    :toctree: api/
 
     testing.assert_frame_equal
     testing.assert_series_equal
+
+
+Property-based testing
+----------------------
+
+See the Hypothesis library for details:
+https://hypothesis.readthedocs.io/
+
+Strategies
+~~~~~~~~~~
+
+Polars provides the following hypothesis
+testing strategies and strategy helpers:
+
+.. autosummary::
+   :toctree: api/
+
+    testing.dataframes
+    testing.series
+
+Strategy helpers
+~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: api/
+
+    testing.column
+    testing.columns

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Sequence, Type
 import numpy as np
 
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Boolean,
     Categorical,
     Date,
@@ -53,6 +54,8 @@ if not _DOCUMENTING:
         Object: PySeries.new_object,
         Categorical: PySeries.new_str,
     }
+    for tu in DTYPE_TEMPORAL_UNITS:
+        _POLARS_TYPE_TO_CONSTRUCTOR[Datetime(tu)] = PySeries.new_opt_i64
 
 
 def polars_type_to_constructor(

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -17,6 +17,7 @@ import math
 
 from polars import internals as pli
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Boolean,
     DataType,
     Date,
@@ -5185,7 +5186,7 @@ class ExprDateTimeNameSpace:
         tu
             One of {'ns', 'us', 'ms', 's', 'd'}
         """
-        if tu in ["ns", "us", "ms"]:
+        if tu in DTYPE_TEMPORAL_UNITS:
             return self.timestamp(tu)
         if tu == "s":
             return wrap_expr(self._pyexpr.dt_epoch_seconds())

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -41,6 +41,7 @@ except ImportError:  # pragma: no cover
     _DOCUMENTING = True
 
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Boolean,
     DataType,
     Date,
@@ -5159,7 +5160,7 @@ class DateTimeNameSpace:
         tu
             One of {'ns', 'us', 'ms', 's', 'd'}
         """
-        if tu in ["ns", "us", "ms"]:
+        if tu in DTYPE_TEMPORAL_UNITS:
             return self.timestamp(tu)
         if tu == "s":
             return wrap_s(self._s.dt_epoch_seconds())
@@ -5244,7 +5245,6 @@ class DateTimeNameSpace:
         ----------
         tu
             Time unit for the `Datetime` Series: any of {"ns", "us", "ms"}
-
         """
         return self.with_time_unit(tu)
 

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -513,7 +513,7 @@ def series(
     on a given strategy to see concrete instances of the generated data.
 
     Examples
-    -----
+    --------
     >>> from polars.testing import series
     >>> from hypothesis import given
     >>> import polars as pl

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -349,7 +349,7 @@ class column:
     >>> from hypothesis.strategies import sampled_from
     >>> from polars.testing import column
     >>>
-    >>> column(name="unique_small_ints", dtype=pl.Uint8, unique=True)
+    >>> column(name="unique_small_ints", dtype=pl.UInt8, unique=True)
     >>> column(name="ccy", strategy=sampled_from(["GBP", "EUR", "JPY"]))
     """
 

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -1,34 +1,65 @@
-from typing import Any
+import random
+from dataclasses import dataclass
+from datetime import datetime
+from functools import reduce
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+from hypothesis import settings
+from hypothesis.errors import InvalidArgument
+from hypothesis.strategies import (
+    SearchStrategy,
+    booleans,
+    composite,
+    dates,
+    datetimes,
+    floats,
+    from_type,
+    integers,
+    lists,
+    sampled_from,
+    text,
+    timedeltas,
+    times,
+)
+from hypothesis.strategies._internal.utils import defines_strategy
 
 from polars.datatypes import (
     Boolean,
+    Categorical,
+    Date,
+    Datetime,
+    Duration,
     Float32,
     Float64,
+    Int8,
     Int16,
     Int32,
     Int64,
+    PolarsDataType,
+    Time,
     UInt8,
     UInt16,
     UInt32,
     UInt64,
     Utf8,
     dtype_to_py_type,
+    is_polars_dtype,
+    py_type_to_dtype,
 )
-from polars.internals import DataFrame, Series
+from polars.internals import DataFrame, LazyFrame, Series, col
 
-_NUMERIC_COL_TYPES = (
-    Int16,
-    Int32,
-    Int64,
-    UInt16,
-    UInt32,
-    UInt64,
-    UInt8,
-    Utf8,
-    Float32,
-    Float64,
-    Boolean,
-)
+# TODO: increase the number of iterations during CI checkins?
+# https://hypothesis.readthedocs.io/en/latest/settings.html#settings-profiles
+settings.register_profile(name="polars.default", max_examples=100, print_blob=True)
+settings.register_profile(name="polars.ci", max_examples=500, print_blob=True)
+
+# if os.getenv("CI")
+#   settings.load_profile("polars.ci")
+# else:
+settings.load_profile("polars.default")
+
+MAX_DATA_SIZE = 50
+MAX_COLS = 8
 
 
 def assert_frame_equal(
@@ -61,12 +92,8 @@ def assert_frame_equal(
     atol
         absolute tolerance for inexact checking.
 
-    Returns
-    -------
-
     Examples
     --------
-
     >>> df1 = pl.DataFrame({"a": [1, 2, 3]})
     >>> df2 = pl.DataFrame({"a": [2, 3, 4]})
     >>> pl.testing.assert_frame_equal(df1, df2)  # doctest: +SKIP
@@ -97,9 +124,9 @@ def assert_frame_equal(
             raise AssertionError("Columns are not in the same order")
 
     # this does not assume a particular order
-    for col in left.columns:
+    for c in left.columns:
         _assert_series_inner(
-            left[col], right[col], check_dtype, check_exact, atol, rtol, obj
+            left[c], right[c], check_dtype, check_exact, atol, rtol, obj
         )
 
 
@@ -132,12 +159,8 @@ def assert_series_equal(
     atol
         absolute tolerance for inexact checking.
 
-    Returns
-    -------
-
     Examples
     --------
-
     >>> s1 = pl.Series([1, 2, 3])
     >>> s2 = pl.Series([2, 3, 4])
     >>> pl.testing.assert_series_equal(s1, s2)  # doctest: +SKIP
@@ -180,7 +203,9 @@ def _assert_series_inner(
         if left.dtype != right.dtype:
             raise_assert_detail(obj, "Dtype mismatch", left.dtype, right.dtype)
 
-    if check_exact:
+    if len(left) == len(right) == 0:
+        pass  # empty series with same name/dtype are equal
+    elif check_exact:
         if (left != right).sum() != 0:
             raise_assert_detail(
                 obj, "Exact value mismatch", left=list(left), right=list(right)
@@ -209,3 +234,502 @@ def raise_assert_detail(
 [right]: {right}"""
 
     raise AssertionError(msg)
+
+
+def _getattr_multi(obj: object, op: str) -> Any:
+    """
+    Allows `op` to be multiple layers deep, i.e. op="str.lengths" will mean we first
+    get the attribute "str", and then the attribute "lengths"
+    """
+    op_list = op.split(".")
+    return reduce(lambda o, m: getattr(o, m), op_list, obj)
+
+
+def verify_series_and_expr_api(
+    input: Series, expected: Optional[Series], op: str, *args: Any, **kwargs: Any
+) -> None:
+    """
+    Small helper function to test element-wise functions for both the series and expressions api.
+
+    Examples
+    --------
+    >>> s = pl.Series([1, 3, 2])
+    >>> expected = pl.Series([1, 2, 3])
+    >>> verify_series_and_expr_api(s, expected, "sort")
+    """
+    expr = _getattr_multi(col("*"), op)(*args, **kwargs)
+    result_expr: Series = input.to_frame().select(expr)[:, 0]  # type: ignore[assignment]
+    result_series = _getattr_multi(input, op)(*args, **kwargs)
+    if expected is None:
+        assert_series_equal(result_series, result_expr)
+    else:
+        assert_series_equal(result_expr, expected)
+        assert_series_equal(result_series, expected)
+
+
+# =====================================================================
+# Polars-specific 'hypothesis' strategies and helper functions
+# See: https://hypothesis.readthedocs.io/
+# =====================================================================
+
+dtype_strategy_mapping: Dict[PolarsDataType, Any] = {
+    Boolean: booleans(),
+    Float32: floats(width=32),
+    Float64: floats(width=64),
+    Int8: integers(min_value=-(2**7), max_value=(2**7) - 1),
+    Int16: integers(min_value=-(2**15), max_value=(2**15) - 1),
+    Int32: integers(min_value=-(2**31), max_value=(2**31) - 1),
+    Int64: integers(min_value=-(2**63), max_value=(2**63) - 1),
+    UInt8: integers(min_value=0, max_value=(2**8) - 1),
+    UInt16: integers(min_value=0, max_value=(2**16) - 1),
+    UInt32: integers(min_value=0, max_value=(2**32) - 1),
+    UInt64: integers(min_value=0, max_value=(2**64) - 1),
+    # TODO: when generating text for categorical, ensure there are repeats - don't want all to be unique.
+    Categorical: text(),
+    Utf8: text(),
+    # TODO: generate arrow temporal types with different resolution (32/64) to validate compatibility.
+    Time: times(),
+    Date: dates(),
+    Duration: timedeltas(),
+    # TODO: confirm datetime min/max limits with different timeunit granularity.
+    # TODO: specific strategies for temporal dtypes with timeunits.
+    Datetime: datetimes(min_value=datetime(1970, 1, 1)),
+    # Datetime("ms")
+    # Datetime("us")
+    # Datetime("ns")
+    # Duration("ms")
+    # Duration("us")
+    # Duration("ns")
+    # TODO: strategies for non-scalar/structured dtypes.
+    # List
+    # Struct
+    # Object
+}
+
+strategy_dtypes = list(dtype_strategy_mapping)
+
+
+def is_categorical_dtype(data_type: Any) -> bool:
+    """
+    Check if the input is a polars Categorical dtype.
+    """
+    return (
+        type(data_type) is type
+        and issubclass(data_type, Categorical)
+        or isinstance(data_type, Categorical)
+    )
+
+
+def between(draw: Callable, type_: type, min_: Any, max_: Any) -> Any:
+    """
+    Draw a value in a given range from a type-inferred strategy.
+    """
+    strategy_init = getattr(from_type(type_), "function")
+    return draw(strategy_init(min_, max_))
+
+
+@dataclass
+class column:
+    """
+    Define a column for use with `dataframes` strategy.
+
+    Parameters
+    ----------
+    name : str
+        string column name.
+    dtype : dtype
+        a recognised polars dtype.
+    strategy : strategy, optional
+        supports overriding the default strategy for the given dtype.
+    unique : bool, optional
+        flag indicating that all values generated for the column should be unique.
+
+    Examples
+    --------
+    >>> from hypothesis.strategies import sampled_from
+    >>> from polars.testing import column
+    >>>
+    >>> column(name="unique_small_ints", dtype=pl.Uint8, unique=True)
+    >>> column(name="ccy", strategy=sampled_from(["GBP", "EUR", "JPY"]))
+    """
+
+    name: str
+    dtype: Optional[PolarsDataType] = None
+    strategy: Optional[SearchStrategy] = None
+    unique: bool = False
+
+    def __post_init__(self) -> None:
+        if self.dtype is None and not self.strategy:
+            self.dtype = random.choice(strategy_dtypes)
+        elif self.dtype not in dtype_strategy_mapping:
+            if self.dtype is not None:
+                raise InvalidArgument(
+                    f"No strategy (currently) available for {self.dtype} type"
+                )
+            else:
+                # given a custom strategy, but no explicit dtype. infer one
+                # from the first non-None value that the strategy produces.
+                sample_value_iter = (self.strategy.example() for _ in range(100))  # type: ignore[union-attr]
+                sample_value_type = type(
+                    next(e for e in sample_value_iter if e is not None)
+                )
+                if sample_value_type is not None:
+                    self.dtype = py_type_to_dtype(sample_value_type)
+                else:
+                    raise InvalidArgument(
+                        f"Unable to determine dtype for strategy {self.dtype} type"
+                    )
+
+
+def columns(
+    cols: Optional[Union[int, Sequence[str]]] = None,
+    *,
+    dtype: Optional[Union[PolarsDataType, Sequence[PolarsDataType]]] = None,
+    min_cols: Optional[int] = 0,
+    max_cols: Optional[int] = MAX_COLS,
+    unique: bool = False,
+) -> List[column]:
+    """
+    Generate a fixed sequence of `column` objects suitable for passing to the @dataframes
+    strategy, or using standalone (note that this function is not itself a strategy).
+
+    Notes
+    -----
+    Additional control is available by creating a sequence of columns explicitly,
+    using the `column` class (an especially useful option is to override the default
+    data-generating strategy for a given col/dtype).
+
+    Parameters
+    ----------
+    cols : {int, [str]}, optional
+        integer number of cols to create, or explicit list of column names. if omitted
+        a random number of columns (between mincol and max_cols) are created.
+    dtype : dtype, optional
+        a single dtype for all cols, or list of dtypes (the same length as `cols`).
+        if omitted, each generated column is assigned a random dtype.
+    min_cols : int, optional
+        if not passing an exact size, can set a minimum here (defaults to 0).
+    max_cols : int, optional
+        if not passing an exact size, can set a maximum value here (defaults to MAX_COLS).
+    unique : bool, optional
+        indicate if the values generated for these columns should be unique (per-column).
+
+    Examples
+    --------
+    >>> from polars.testing import columns
+    >>> from string import punctuation
+    >>> import polars as pl
+    >>>
+    >>> def test_special_char_colname_init() -> None:
+    ...     cols = [(c.name, c.dtype) for c in columns(punctuation)]
+    ...     df = pl.DataFrame(columns=cols)
+    ...     assert len(cols) == len(df.columns)
+    ...     assert 0 == len(df.rows())
+    ...
+    >>> from polars.testing import columns
+    >>> from hypothesis import given
+    >>>
+    >>> @given(dataframes(columns(["x", "y", "z"], unique=True)))
+    ... def test_unique_xyz(df: pl.DataFrame) -> None:
+    ...     assert_something(df)
+    """
+    # create/assign named columns
+    if cols is None:
+        cols = random.randint(
+            a=min_cols or 0,
+            b=max_cols or MAX_COLS,
+        )
+    if isinstance(cols, int):
+        names: List[str] = [f"col{n}" for n in range(cols)]
+    else:
+        names = list(cols)
+
+    # determine column dtypes
+    if is_polars_dtype(dtype):
+        dtypes = [dtype] * len(names)
+    elif isinstance(dtype, Sequence):
+        if len(dtype) != len(names):
+            raise InvalidArgument(f"Given {len(dtype)} dtypes for {len(names)} names")
+        dtypes = list(dtype)
+    elif dtype is None:
+        dtypes = [random.choice(strategy_dtypes) for _ in range(len(names))]
+    else:
+        raise InvalidArgument(f"{dtype} is not a valid polars datatype")
+
+    # init list of named/typed columns
+    return [
+        column(name=nm, dtype=tp, unique=unique)  # type: ignore[arg-type]
+        for nm, tp in zip(names, dtypes)
+    ]
+
+
+@defines_strategy()
+def series(
+    *,
+    name: Optional[Union[str, SearchStrategy[str]]] = None,
+    dtype: Optional[PolarsDataType] = None,
+    size: Optional[int] = None,
+    min_size: Optional[int] = 0,
+    max_size: Optional[int] = MAX_DATA_SIZE,
+    strategy: Optional[SearchStrategy] = None,
+    null_probability: float = 0.01,
+    unique: bool = False,
+    allowed_dtypes: Optional[Sequence[PolarsDataType]] = None,
+    excluded_dtypes: Optional[Sequence[PolarsDataType]] = None,
+) -> SearchStrategy[Series]:
+    """
+    Strategy for producing a polars Series.
+
+    Parameters
+    ----------
+    name : {str, strategy}, optional
+        literal string or a strategy for strings (or None), passed to the Series constructor name-param.
+    dtype : dtype, optional
+        a valid polars DataType for the resulting series.
+    size : int, optional
+        if set, will create a Series of exactly this size (and ignore min/max len params).
+    min_size : int, optional
+        if not passing an exact size, can set a minimum here (defaults to 0).
+        no-op if `size` is set.
+    max_size : int, optional
+        if not passing an exact size, can set a maximum value here (defaults to MAX_DATA_SIZE).
+        no-op if `size` is set.
+    strategy : strategy, optional
+        supports overriding the default strategy for the given dtype.
+    null_probability : float, optional
+        percentage chance (expressed between 0.0 => 1.0) that a generated value is None; default = 0.01 (1%).
+    unique : bool, optional
+        indicate whether Series values should all be distinct.
+    allowed_dtypes : {list,set}, optional
+        when automatically generating Series data, allow only these dtypes.
+    excluded_dtypes : {list,set}, optional
+        when automatically generating Series data, exclude these dtypes.
+
+    Notes
+    -----
+    In actual usage this is deployed as a unit test decorator, providing a strategy that
+    generates multiple Series with the given dtype/size characteristics for the unit test.
+    While developing a strategy/test, it can also be useful to call `.example()` directly
+    on a given strategy to see concrete instances of the generated data.
+
+    Examples
+    -----
+    >>> from polars.testing import series
+    >>> from hypothesis import given
+    >>> import polars as pl
+    >>>
+    >>> @given(df=series())
+    ... def test_repr(s: pl.Series) -> None:
+    ...     assert isinstance(repr(s), str)
+    ...     # print(s)
+    >>>
+    >>> s = series(dtype=pl.Int32, max_size=5)
+    >>> s.example()
+    shape: (4,)
+    Series: '' [i64]
+    [
+        54666
+        -35
+        6414
+        -63290
+    ]
+    >>>
+    """
+    # TODO: finish 'null_probability' integration - currently a no-op ;p
+    if null_probability and null_probability < 0 or null_probability > 1:
+        raise InvalidArgument(
+            f"null_probability should be between 0.0 and 1.0; found {null_probability}"
+        )
+    selectable_dtypes = [
+        dtype
+        for dtype in (allowed_dtypes or strategy_dtypes)
+        if dtype not in (excluded_dtypes or ())
+    ]
+
+    @composite
+    def draw_series(draw: Callable) -> Series:
+        # create/assign series dtype and retrieve matching strategy
+        series_dtype = draw(sampled_from(selectable_dtypes)) if dtype is None else dtype
+        dtype_strategy = strategy or dtype_strategy_mapping[series_dtype]
+
+        # create/assign series size
+        series_size = (
+            between(draw, int, min_=(min_size or 0), max_=(max_size or MAX_DATA_SIZE))
+            if size is None
+            else size
+        )
+        # create series using dtype-specific strategy to generate values
+        series_name = name if isinstance(name, (str, type(None))) else draw(name)
+        s = Series(
+            name=series_name,
+            dtype=series_dtype,
+            values=(
+                draw(
+                    lists(
+                        dtype_strategy,
+                        min_size=series_size,
+                        max_size=series_size,
+                        unique=unique,
+                    )
+                )
+                if (series_size > 0)
+                else []
+            ),
+        )
+        if is_categorical_dtype(dtype):
+            s = s.cast(Categorical)
+        return s
+
+    return draw_series()
+
+
+@defines_strategy()
+def dataframes(
+    cols: Optional[Union[int, Sequence[column]]] = None,
+    lazy: bool = False,
+    *,
+    min_cols: Optional[int] = 0,
+    max_cols: Optional[int] = MAX_COLS,
+    size: Optional[int] = None,
+    min_size: Optional[int] = 0,
+    max_size: Optional[int] = MAX_DATA_SIZE,
+    include_cols: Optional[Sequence[column]] = None,
+    null_probability: float = 0.0,
+    allowed_dtypes: Optional[Sequence[PolarsDataType]] = None,
+    excluded_dtypes: Optional[Sequence[PolarsDataType]] = None,
+) -> SearchStrategy[Union[DataFrame, LazyFrame]]:
+    """
+    Provides a strategy for producing a DataFrame or LazyFrame.
+
+    Parameters
+    ----------
+    cols : {int, columns}, optional
+        integer number of columns to create, or a sequence of `column` objects
+        that describe the desired DataFrame column data.
+    lazy : bool, optional
+        produce a LazyFrame instead of a DataFrame.
+    min_cols : int, optional
+        if not passing an exact size, can set a minimum here (defaults to 0).
+    max_cols : int, optional
+        if not passing an exact size, can set a maximum value here (defaults to MAX_COLS).
+    size : int, optional
+        if set, will create a Series of exactly this size (and ignore min/max len params).
+    min_size : int, optional
+        if not passing an exact size, set the minimum number of rows in the DataFrame.
+    max_size : int, optional
+        if not passing an exact size, set the maximum number of rows in the DataFrame.
+    include_cols : [column], optional
+        a list of `column` objects to include in the generated DataFrame. note that explicitly
+        provided columns are appended onto the list of existing columns (if any present).
+    null_probability : float, optional
+        chance (expressed as a float between 0.0 => 1.0) that a generated value is None.
+    allowed_dtypes : {list,set}, optional
+        when automatically generating data, allow only these dtypes.
+    excluded_dtypes : {list,set}, optional
+        when automatically generating data, exclude these dtypes.
+
+    Notes
+    -----
+    In actual usage this is deployed as a unit test decorator, providing a strategy that
+    generates DataFrames or LazyFrames with the given schema/size characteristics for the
+    unit test. While developing a strategy/test, it can also be useful to call `.example()`
+    directly on a given strategy to see concrete instances of the generated data.
+
+    Examples
+    --------
+    Use `column` or `columns` to specify the schema of the types of DataFrame to generate.
+    Note: in actual use the strategy is applied as a test decorator, not used standalone.
+
+    >>> from polars.testing import column, columns, dataframes
+    >>> from hypothesis import given
+    >>>
+    >>> # generate arbitrary DataFrames
+    >>> @given(df=dataframes())
+    ... def test_repr(df: pl.DataFrame) -> None:
+    ...     assert isinstance(repr(df), str)
+    ...     # print(df)
+    >>>
+    >>> # generate LazyFrames with at least 1 column, random dtypes, and specific size:
+    >>> df = dataframes(min_cols=1, lazy=True, max_size=5)
+    >>> df.example()
+    >>>
+    >>> # generate DataFrames with known colnames, random dtypes (per test, not per-frame):
+    >>> df_strategy = dataframes(columns(["x", "y", "z"]))
+    >>> df.example()
+    >>>
+    >>> # generate frames with explicitly named/typed columns and a fixed size:
+    >>> df_strategy = dataframes(
+    ...     [
+    ...         column("x", dtype=pl.Int32),
+    ...         column("y", dtype=pl.Float64),
+    ...     ],
+    ...     size=2,
+    ... )
+    >>> df_strategy.example()
+    shape: (2, 2)
+    ┌───────────┬────────────┐
+    │ x         ┆ y          │
+    │ ---       ┆ ---        │
+    │ i32       ┆ f64        │
+    ╞═══════════╪════════════╡
+    │ -15836    ┆ 1.1755e-38 │
+    ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+    │ 575050513 ┆ NaN        │
+    └───────────┴────────────┘
+    """
+    if isinstance(cols, int):
+        cols = columns(cols)
+
+    selectable_dtypes = [
+        dtype
+        for dtype in (allowed_dtypes or strategy_dtypes)
+        if dtype not in (excluded_dtypes or ())
+    ]
+
+    @composite
+    def draw_frames(draw: Callable) -> Union[DataFrame, LazyFrame]:
+        # if not given, create 'n' cols with random dtypes
+        if cols is None:
+            n = between(draw, int, min_=(min_cols or 0), max_=(max_cols or MAX_COLS))
+            dtypes_ = [draw(sampled_from(selectable_dtypes)) for _ in range(n)]
+            coldefs = columns(cols=n, dtype=dtypes_)
+        else:
+            coldefs = list(cols)  # type: ignore[arg-type]
+
+        # append any explicitly provided cols
+        coldefs.extend(include_cols or ())
+
+        # if not given, assign dataframe/series size
+        series_size = (
+            between(draw, int, min_=(min_size or 0), max_=(max_size or MAX_DATA_SIZE))
+            if size is None
+            else size
+        )
+        # init dataframe from generated series data; series data is
+        # given as a python-native sequence (TODO: or as an arrow array).
+        for idx, c in enumerate(coldefs):
+            if c.name is None:
+                c.name = f"col{idx}"
+        frame_columns = [
+            c.name if (c.dtype is None) else (c.name, c.dtype) for c in coldefs
+        ]
+        df = DataFrame(
+            data={
+                c.name: draw(
+                    series(
+                        name=c.name,
+                        dtype=c.dtype,
+                        size=series_size,
+                        null_probability=null_probability,
+                        strategy=c.strategy,
+                        unique=c.unique,
+                    )
+                )
+                for c in coldefs
+            },
+            columns=frame_columns,  # type: ignore[arg-type]
+        )
+        # if indicated, make lazy
+        return df.lazy() if lazy else df
+
+    return draw_frames()

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -125,13 +125,10 @@ def _is_iterable_of(val: Iterable, itertype: Type, eltype: Type) -> bool:
 
 
 def range_to_slice(rng: range) -> slice:
-    step: Optional[int]
-    # maybe we can slice instead of take by indices
-    if rng.step != 1:
-        step = rng.step
-    else:
-        step = None
-    return slice(rng.start, rng.stop, step)
+    """
+    Return the given range as an equivalent slice.
+    """
+    return slice(rng.start, rng.stop, rng.step)
 
 
 def handle_projection_columns(

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -141,6 +141,7 @@ def test_read_csv_buffer_ownership() -> None:
     )
     # confirm that read_csv succeeded, and didn't close the input buffer (#2696)
     assert df.shape == (2, 3)
+    assert df.rows() == [("😀", 5.55, 333), ("😆", -5.0, 666)]
     assert not buf.closed
 
 

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -10,6 +10,7 @@ import pytz
 from test_series import verify_series_and_expr_api
 
 import polars as pl
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
 
 
 def test_fill_null() -> None:
@@ -242,7 +243,7 @@ def test_date_range() -> None:
     assert result.dt[2] == datetime(1985, 1, 4, 0, 0)
     assert result.dt[-1] == datetime(2015, 6, 30, 12, 0)
 
-    for tu in ["ns", "us", "ms"]:
+    for tu in DTYPE_TEMPORAL_UNITS:
         rng = pl.date_range(datetime(2020, 1, 1), date(2020, 1, 2), "2h", time_unit=tu)
         assert rng.time_unit == tu
         assert rng.shape == (13,)
@@ -563,7 +564,7 @@ def test_read_utc_times_parquet() -> None:
 def test_epoch() -> None:
     dates = pl.Series("dates", [datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
 
-    for unit in ["ns", "us", "ms"]:
+    for unit in DTYPE_TEMPORAL_UNITS:
         assert dates.dt.epoch(unit).series_equal(dates.dt.timestamp(unit))
 
     assert dates.dt.epoch("s").series_equal(dates.dt.timestamp("ms") // 1000)
@@ -983,7 +984,7 @@ def test_datetime_units() -> None:
     )
     names = set(df.columns)
 
-    for unit in ["ns", "us", "ms"]:
+    for unit in DTYPE_TEMPORAL_UNITS:
         subset = names - set([unit])
 
         assert (
@@ -1006,7 +1007,7 @@ def test_datetime_instance_selection() -> None:
         ],
     )
 
-    for tu in ["ns", "us", "ms"]:
+    for tu in DTYPE_TEMPORAL_UNITS:
         assert df.select(pl.col([pl.Datetime(tu)])).dtypes == [pl.Datetime(tu)]
 
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -32,7 +32,8 @@ def test_repr(df: pl.DataFrame) -> None:
     # print(df)
 
 
-@given(df=dataframes())
+# note: temporarily excluding time data until #3843 closed
+@given(df=dataframes(excluded_dtypes=[pl.Time]))
 def test_null_count(df: pl.DataFrame) -> None:
     null_count, ncols = df.null_count(), len(df.columns)
     if ncols == 0:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2,7 +2,7 @@
 import sys
 import typing
 from builtins import range
-from datetime import date, datetime, time
+from datetime import date, datetime
 from io import BytesIO
 from typing import Any, Iterator, Type
 from unittest.mock import patch
@@ -11,9 +11,10 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from hypothesis import given
 
 import polars as pl
-from polars import testing
+from polars.testing import assert_series_equal, columns, dataframes
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -22,13 +23,31 @@ else:
 
 
 def test_version() -> None:
-    pl.__version__
+    _version = pl.__version__
+
+
+@given(df=dataframes())
+def test_repr(df: pl.DataFrame) -> None:
+    assert isinstance(repr(df), str)
+    # print(df)
+
+
+@given(df=dataframes())
+def test_null_count(df: pl.DataFrame) -> None:
+    null_count, ncols = df.null_count(), len(df.columns)
+    if ncols == 0:
+        assert null_count.shape == (0, 0)
+    else:
+        assert null_count.shape == (1, ncols)
+        for idx, count in enumerate(null_count.rows()[0]):
+            assert count == sum(v is None for v in df.select_at_idx(idx).to_list())
 
 
 def test_init_empty() -> None:
-    # Empty initialization
-    df1 = pl.DataFrame()
-    assert df1.shape == (0, 0)
+    # test various flavours of empty init
+    for empty in (None, (), [], {}, pa.Table.from_arrays([])):
+        df = pl.DataFrame(empty)
+        assert df.shape == (0, 0)
 
 
 def test_init_only_columns() -> None:
@@ -63,6 +82,17 @@ def test_init_only_columns() -> None:
         assert df.frame_equal(truth, null_equal=True)
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert getattr(df.schema["d"], "inner") == pl.UInt8
+
+
+def test_special_char_colname_init() -> None:
+    from string import punctuation
+
+    cols = [(c.name, c.dtype) for c in columns(punctuation)]
+    df = pl.DataFrame(columns=cols)
+
+    assert len(cols) == len(df.columns)
+    assert 0 == len(df.rows())
+    assert df.is_empty()
 
 
 def test_init_dict() -> None:
@@ -519,11 +549,6 @@ def test_slice() -> None:
         [1],  # optional len
     ):
         assert df.slice(*slice_params).frame_equal(expected)
-
-
-def test_null_count() -> None:
-    df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", None]})
-    assert df.null_count().shape == (1, 2)
 
 
 def test_head_tail_limit() -> None:
@@ -1480,13 +1505,13 @@ def test_panic() -> None:
 def test_h_agg() -> None:
     df = pl.DataFrame({"a": [1, None, 3], "b": [1, 2, 3]})
 
-    pl.testing.assert_series_equal(
+    assert_series_equal(
         df.sum(axis=1, null_strategy="ignore"), pl.Series("a", [2, 2, 6])
     )
-    pl.testing.assert_series_equal(
+    assert_series_equal(
         df.sum(axis=1, null_strategy="propagate"), pl.Series("a", [2, None, 6])
     )
-    pl.testing.assert_series_equal(
+    assert_series_equal(
         df.mean(axis=1, null_strategy="propagate"), pl.Series("a", [1.0, None, 3.0])
     )
 
@@ -1911,7 +1936,7 @@ def test_add_string() -> None:
 def test_getattr() -> None:
     with pytest.deprecated_call():
         df = pl.DataFrame({"a": [1.0, 2.0]})
-        testing.assert_series_equal(df.a, pl.Series("a", [1.0, 2.0]))
+        assert_series_equal(df.a, pl.Series("a", [1.0, 2.0]))
 
         with pytest.raises(AttributeError):
             _ = df.b
@@ -2057,10 +2082,10 @@ def test_join_suffixes() -> None:
     df_b = pl.DataFrame({"A": [1], "B": [1]})
 
     for how in ["left", "inner", "outer", "cross"]:
-        # no need for an essert, we error if wrong
-        df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
+        # no need for an assert, we error if wrong
+        _df = df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
 
-    df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
+    _df = df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
 
 
 def test_preservation_of_subclasses() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -32,8 +32,9 @@ def test_repr(df: pl.DataFrame) -> None:
     # print(df)
 
 
-# note: temporarily excluding time data until #3843 closed
-@given(df=dataframes(excluded_dtypes=[pl.Time]))
+# note: *temporarily* constraining dtypes this test until #3843 and a windows-specific
+# fixfor a related date bug is merged (tblocking the PR to merge hypothesis code).
+@given(df=dataframes(allowed_dtypes=[pl.Boolean, pl.UInt64, pl.Utf8]))
 def test_null_count(df: pl.DataFrame) -> None:
     null_count, ncols = df.null_count(), len(df.columns)
     if ncols == 0:

--- a/py-polars/tests/test_testing.py
+++ b/py-polars/tests/test_testing.py
@@ -1,19 +1,38 @@
 import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import sampled_from
 
 import polars as pl
+from polars.testing import (
+    assert_frame_equal,
+    assert_series_equal,
+    column,
+    columns,
+    dataframes,
+    series,
+    strategy_dtypes,
+)
+
+TEMPORAL_DTYPES = [pl.Datetime, pl.Date, pl.Time, pl.Duration]
 
 
 def test_compare_series_value_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.Series([2, 3, 4])
     with pytest.raises(AssertionError, match="Series are different\n\nValue mismatch"):
-        pl.testing.assert_series_equal(srs1, srs2)
+        assert_series_equal(srs1, srs2)
+
+
+def test_compare_series_empty_equal() -> None:
+    srs1 = pl.Series([])
+    srs2 = pl.Series(())
+    assert_series_equal(srs1, srs2)
 
 
 def test_compare_series_nulls_are_equal() -> None:
     srs1 = pl.Series([1, 2, None])
     srs2 = pl.Series([1, 2, None])
-    pl.testing.assert_series_equal(srs1, srs2)
+    assert_series_equal(srs1, srs2)
 
 
 def test_compare_series_value_mismatch_string() -> None:
@@ -22,32 +41,32 @@ def test_compare_series_value_mismatch_string() -> None:
     with pytest.raises(
         AssertionError, match="Series are different\n\nExact value mismatch"
     ):
-        pl.testing.assert_series_equal(srs1, srs2)
+        assert_series_equal(srs1, srs2)
 
 
 def test_compare_series_type_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.DataFrame({"col1": [2, 3, 4]})
     with pytest.raises(AssertionError, match="Series are different\n\nType mismatch"):
-        pl.testing.assert_series_equal(srs1, srs2)  # type: ignore
+        assert_series_equal(srs1, srs2)  # type: ignore
 
     srs3 = pl.Series([1.0, 2.0, 3.0])
     with pytest.raises(AssertionError, match="Series are different\n\nDtype mismatch"):
-        pl.testing.assert_series_equal(srs1, srs3)
+        assert_series_equal(srs1, srs3)
 
 
 def test_compare_series_name_mismatch() -> None:
     srs1 = pl.Series(values=[1, 2, 3], name="srs1")
     srs2 = pl.Series(values=[1, 2, 3], name="srs2")
     with pytest.raises(AssertionError, match="Series are different\n\nName mismatch"):
-        pl.testing.assert_series_equal(srs1, srs2)
+        assert_series_equal(srs1, srs2)
 
 
 def test_compare_series_shape_mismatch() -> None:
     srs1 = pl.Series(values=[1, 2, 3, 4], name="srs1")
     srs2 = pl.Series(values=[1, 2, 3], name="srs2")
     with pytest.raises(AssertionError, match="Series are different\n\nShape mismatch"):
-        pl.testing.assert_series_equal(srs1, srs2)
+        assert_series_equal(srs1, srs2)
 
 
 def test_compare_series_value_exact_mismatch() -> None:
@@ -56,46 +75,135 @@ def test_compare_series_value_exact_mismatch() -> None:
     with pytest.raises(
         AssertionError, match="Series are different\n\nExact value mismatch"
     ):
-        pl.testing.assert_series_equal(srs1, srs2, check_exact=True)
+        assert_series_equal(srs1, srs2, check_exact=True)
 
 
 def test_assert_frame_equal_pass() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"a": [1, 2]})
-    pl.testing.assert_frame_equal(df1, df2)
+    assert_frame_equal(df1, df2)
 
 
 def test_assert_frame_equal_types() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     srs1 = pl.Series(values=[1, 2], name="a")
     with pytest.raises(AssertionError):
-        pl.testing.assert_frame_equal(df1, srs1)  # type: ignore
+        assert_frame_equal(df1, srs1)  # type: ignore
 
 
 def test_assert_frame_equal_length_mismatch() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(AssertionError):
-        pl.testing.assert_frame_equal(df1, df2)
+        assert_frame_equal(df1, df2)
 
 
 def test_assert_frame_equal_column_mismatch() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"b": [1, 2]})
     with pytest.raises(AssertionError):
-        pl.testing.assert_frame_equal(df1, df2)
+        assert_frame_equal(df1, df2)
 
 
 def test_assert_frame_equal_column_mismatch2() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(AssertionError):
-        pl.testing.assert_frame_equal(df1, df2)
+        assert_frame_equal(df1, df2)
 
 
 def test_assert_frame_equal_column_mismatch_order() -> None:
     df1 = pl.DataFrame({"b": [3, 4], "a": [1, 2]})
     df2 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(AssertionError):
-        pl.testing.assert_frame_equal(df1, df2)
-    pl.testing.assert_frame_equal(df1, df2, check_column_names=False)
+        assert_frame_equal(df1, df2)
+    assert_frame_equal(df1, df2, check_column_names=False)
+
+
+@given(df=dataframes(), lf=dataframes(lazy=True), srs=series())
+@settings(max_examples=10)
+def test_strategy_classes(df: pl.DataFrame, lf: pl.LazyFrame, srs: pl.Series) -> None:
+    assert isinstance(df, pl.DataFrame)
+    assert isinstance(lf, pl.LazyFrame)
+    assert isinstance(srs, pl.Series)
+
+
+@given(
+    df1=dataframes(cols=5, size=5),
+    df2=dataframes(min_cols=10, max_cols=20, min_size=5, max_size=25),
+    s1=series(size=5),
+    s2=series(min_size=5, max_size=25, name="col"),
+)
+def test_strategy_shape(
+    df1: pl.DataFrame, df2: pl.DataFrame, s1: pl.Series, s2: pl.Series
+) -> None:
+    assert df1.shape == (5, 5)
+    assert df1.columns == ["col0", "col1", "col2", "col3", "col4"]
+
+    assert 10 <= len(df2.columns) <= 20
+    assert 5 <= len(df2) <= 25
+
+    assert s1.len() == 5
+    assert 5 <= s2.len() <= 25
+    assert s1.name == ""
+    assert s2.name == "col"
+
+
+@given(
+    lf=dataframes(
+        # generate lazyframes with at least one row
+        lazy=True,
+        min_size=1,
+        # test mix & match of bulk-assigned cols with custom cols
+        cols=columns(["a", "b"], dtype=pl.UInt8, unique=True),
+        include_cols=[
+            column("c", dtype=pl.Boolean),
+            column("d", strategy=sampled_from(["x", "y", "z"])),
+        ],
+    )
+)
+def test_strategy_frame_columns(lf: pl.LazyFrame) -> None:
+    assert lf.schema == {"a": pl.UInt8, "b": pl.UInt8, "c": pl.Boolean, "d": pl.Utf8}
+    assert lf.columns == ["a", "b", "c", "d"]
+    df = lf.collect()
+
+    # uint8 cols
+    uint8_max = (2**8) - 1
+    assert df["a"].min() >= 0
+    assert df["b"].min() >= 0
+    assert df["a"].max() <= uint8_max
+    assert df["b"].max() <= uint8_max
+
+    # boolean col
+    assert all(isinstance(v, bool) for v in df["c"].to_list())
+
+    # string col, entries selected from custom values
+    xyz = {"x", "y", "z"}
+    assert all(v in xyz for v in df["d"].to_list())
+
+
+@given(
+    df=dataframes(allowed_dtypes=TEMPORAL_DTYPES, max_size=1),
+    lf=dataframes(excluded_dtypes=TEMPORAL_DTYPES, max_size=1, lazy=True),
+    s1=series(max_size=1),
+    s2=series(dtype=pl.Boolean, max_size=1),
+    s3=series(allowed_dtypes=TEMPORAL_DTYPES, max_size=1),
+    s4=series(excluded_dtypes=TEMPORAL_DTYPES, max_size=1),
+)
+def test_strategy_dtypes(
+    df: pl.DataFrame,
+    lf: pl.LazyFrame,
+    s1: pl.Series,
+    s2: pl.Series,
+    s3: pl.Series,
+    s4: pl.Series,
+) -> None:
+    # dataframe, lazyframe
+    assert all(tp in TEMPORAL_DTYPES for tp in df.dtypes)
+    assert all(tp not in TEMPORAL_DTYPES for tp in lf.dtypes)
+
+    # series
+    assert s1.dtype in strategy_dtypes
+    assert s2.dtype == pl.Boolean
+    assert s3.dtype in TEMPORAL_DTYPES
+    assert s4.dtype not in TEMPORAL_DTYPES


### PR DESCRIPTION
### What is Hypothesis?

TLDR: a powerful testing framework based on an idea popularised by the Haskell library [Quickcheck](https://hackage.haskell.org/package/QuickCheck) (back in the day!)

> [Hypothesis](https://hypothesis.works/) is a library for creating unit tests which are simpler to write and more powerful when run, finding edge cases in your code you wouldn’t have thought to look for. It is stable, powerful and easy to add to any existing test suite.

### Polars-specific integrations

I took a look at their [pandas strategy units](https://hypothesis.readthedocs.io/en/latest/numpy.html#pandas) and decided to write our own in a similar vein, covering DataFrame, LazyFrame, and Series, but with a richer set of options. This PR adds support for all three, along with test coverage for the new units (which double as a small working example of some of the features), additions to the testing docs, and a good set of informative / comprehensive docstrings.

### Show me the money, Jerry!

_**Obvious question**: "Is this yet another one of those clever-sounding things that is a pain to use?"_
_**Surprising answer**: "No." :)_

Now the strategy units exist, using them is easy; for example, here's a simple invocation of the DataFrames strategy:

```python
import polars as pl
from hypothesis import given
from polars.testing import dataframes

@given(df=dataframes())
def test_repr(df: pl.DataFrame) -> None:
    assert isinstance(repr(df), str)
    # print( df )
```

_**Likely response**: "I am incredibly underwhelmed - that just looks like a fixture" :p_

Which is true, but... uncomment the `print( df )` and you'll start to get a sense of what's going on, because you'll discover that the test actually executes across about 100 DataFrames (this is configurable) with wildly varying schemas, different sizes, and it actively probes at typical edge-case values (integer boundaries, weird strings, weird dates, etc), as well as scenarios like _"what if there is no data?"_, _"what if there is data, but it's all NULL?"_, _"what if there are no columns?"_, and so forth. 

And you get all that from applying a decorator.

_And_ this test found that some assumptions I had about datetime ranges were wrong, as it actually triggered a PanicException, so I have currently put a floor on date time-generation of 1970-01-01 while I work out whether it's a real bug or not! (So even that trivial test _may_ have uncovered something).

Instrumenting just **two** small tests this way has already found one "maybe" bug (above), and two _actual_ edge-case bugs (#3828, now fixed, and another that is fixed with this PR). The second bug: `assert_series_equal` actually fails if two identical _but empty_ Series are passed to it  :)

### Show me some more

I also instrumented the `null_count` test; it immediately failed on the empty frame scenario (no rows/cols) so I added an explicit check for that to the test (as it's expected, but wasn't covered). I then added a trivial assert/comparison to validate a simple python-based count against the internal implementation - and this is the code that actually found the `ZeroDivisionError` on `time(0,0,0)` values.
 
```python
@given(df=dataframes())
def test_null_count(df: pl.DataFrame) -> None:
    null_count, ncols = df.null_count(), len(df.columns)
    if ncols == 0:
        assert null_count.shape == (0, 0)
    else:
        assert null_count.shape == (1, ncols)
        for idx, count in enumerate(null_count.rows()[0]):
            assert count == sum(v is None for v in df.select_at_idx(idx).to_list())
```
How about LazyFrame and Series? 

```python
# generate/test LazyFrames
@given(ldf=dataframes(lazy=True))
def test_stuff(ldf: pl.LazyFrame):
    ...
```
```python
# generate/test Series
@given(s=series())
def test_stuff(s: pl.Series):
    ...
```
And what else can it do? If we start turning the dials up, with a few more options and use of the `column` and `column` helpers then we get things like this that offer more detailed control, but remain easy to understand and write (this is actually one of the new unit tests _for_ these new testing strategies):
```python
@given(
    lf=dataframes(
        # generate lazyframes with at least one row
        lazy=True,
        min_size=1,
        # test mix & match of bulk-assigned cols with custom cols
        cols=columns(["a", "b"], dtype=pl.UInt8, unique=True),
        include_cols=[
            column("c", dtype=pl.Boolean),
            column("d", strategy=sampled_from(["x", "y", "z"])),
        ],
    )
)
def test_strategy_frame_columns(lf: pl.LazyFrame) -> None:
    assert lf.schema == {"a": pl.UInt8, "b": pl.UInt8, "c": pl.Boolean, "d": pl.Utf8}
    assert lf.columns == ["a", "b", "c", "d"]
    df = lf.collect()

    # confirm uint cols bounds
    uint8_max = (2**8) - 1
    assert df["a"].min() >= 0
    assert df["b"].min() >= 0
    assert df["a"].max() <= uint8_max
    assert df["b"].max() <= uint8_max

    # confirm uint cols uniqueness
    assert df["a"].is_unique().all()
    assert df["a"].is_unique().all()

    # boolean col
    assert all(isinstance(v, bool) for v in df["c"].to_list())

    # string col, entries selected from custom values
    xyz = {"x", "y", "z"}
    assert all(v in xyz for v in df["d"].to_list())
```
Support is there for per-column custom data strategies, native hypothesis strategies can be freely mixed-in (eg: `sampled_from`, above), size constraints, type constraints/exclusions, etc.

### The end...

Plenty more in the inline docs, as well as some additional examples/tests, with more to come - hope it helps :)