### PR TITLE
Deprecate df/ldf argument to .join

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -67,6 +67,7 @@ from polars.datatypes import Boolean, DataType, UInt32, Utf8, py_type_to_dtype
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
+    deprecated_alias,
     format_path,
     handle_projection_columns,
     is_int_sequence,
@@ -3382,9 +3383,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
             self._df.upsample(by, time_column, every, offset, maintain_order)
         )
 
+    @deprecated_alias(df="other")
     def join_asof(
         self: DF,
-        df: "DataFrame",
+        other: "DataFrame",
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
         on: Optional[str] = None,
@@ -3415,7 +3417,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Parameters
         ----------
-        ldf
+        other
             Lazy DataFrame to join with.
         left_on
             Join column of the left DataFrame.
@@ -3506,7 +3508,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return (
             self.lazy()
             .join_asof(
-                df.lazy(),
+                other.lazy(),
                 left_on=left_on,
                 right_on=right_on,
                 on=on,
@@ -3522,9 +3524,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
             .collect(no_optimization=True)
         )
 
+    @deprecated_alias(df="other")
     def join(
         self: DF,
-        df: "DataFrame",
+        other: "DataFrame",
         left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
@@ -3539,7 +3542,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Parameters
         ----------
-        df
+        other
             DataFrame to join with.
         left_on
             Name(s) of the left join column(s).
@@ -3626,7 +3629,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 DeprecationWarning,
             )
         if how == "cross":
-            return self._from_pydf(self._df.join(df._df, [], [], how, suffix))
+            return self._from_pydf(self._df.join(other._df, [], [], how, suffix))
 
         left_on_: Optional[List[Union[str, pli.Expr]]]
         if isinstance(left_on, (str, pli.Expr)):
@@ -3660,7 +3663,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             return (
                 self.lazy()
                 .join(
-                    df.lazy(),
+                    other.lazy(),
                     left_on,
                     right_on,
                     on=on,
@@ -3674,7 +3677,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             )
         else:
             return self._from_pydf(
-                self._df.join(df._df, left_on_, right_on_, how, suffix)
+                self._df.join(other._df, left_on_, right_on_, how, suffix)
             )
 
     def apply(

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -43,6 +43,7 @@ from polars.utils import (
     _in_notebook,
     _prepare_row_count_args,
     _process_null_values,
+    deprecated_alias,
     format_path,
 )
 
@@ -1121,9 +1122,10 @@ class LazyFrame(Generic[DF]):
         )
         return LazyGroupBy(lgb, lazyframe_class=self.__class__)
 
+    @deprecated_alias(ldf="other")
     def join_asof(
         self: LDF,
-        ldf: "LazyFrame",
+        other: "LazyFrame",
         left_on: Optional[str] = None,
         right_on: Optional[str] = None,
         on: Optional[str] = None,
@@ -1154,7 +1156,7 @@ class LazyFrame(Generic[DF]):
 
         Parameters
         ----------
-        ldf
+        other
             Lazy DataFrame to join with.
         left_on
             Join column of the left DataFrame.
@@ -1197,8 +1199,8 @@ class LazyFrame(Generic[DF]):
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel.
         """
-        if not isinstance(ldf, LazyFrame):
-            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(ldf)}")
+        if not isinstance(other, LazyFrame):
+            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(other)}")
 
         if isinstance(on, str):
             left_on = on
@@ -1235,7 +1237,7 @@ class LazyFrame(Generic[DF]):
 
         return self._from_pyldf(
             self._ldf.join_asof(
-                ldf._ldf,
+                other._ldf,
                 pli.col(left_on)._pyexpr,
                 pli.col(right_on)._pyexpr,
                 by_left_,
@@ -1249,9 +1251,10 @@ class LazyFrame(Generic[DF]):
             )
         )
 
+    @deprecated_alias(ldf="other")
     def join(
         self: LDF,
-        ldf: "LazyFrame",
+        other: "LazyFrame",
         left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
         on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
@@ -1268,7 +1271,7 @@ class LazyFrame(Generic[DF]):
 
         Parameters
         ----------
-        ldf
+        other
             Lazy DataFrame to join with.
         left_on
             Join column of the left DataFrame.
@@ -1346,8 +1349,8 @@ class LazyFrame(Generic[DF]):
         └──────┴──────┴─────┴───────┘
 
         """
-        if not isinstance(ldf, LazyFrame):
-            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(ldf)}")
+        if not isinstance(other, LazyFrame):
+            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(other)}")
 
         if how == "asof":
             warnings.warn(
@@ -1357,7 +1360,7 @@ class LazyFrame(Generic[DF]):
         if how == "cross":
             return self._from_pyldf(
                 self._ldf.join(
-                    ldf._ldf,
+                    other._ldf,
                     [],
                     [],
                     allow_parallel,
@@ -1430,7 +1433,7 @@ class LazyFrame(Generic[DF]):
 
         return self._from_pyldf(
             self._ldf.join(
-                ldf._ldf,
+                other._ldf,
                 new_left_on,
                 new_right_on,
                 allow_parallel,

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -270,9 +270,9 @@ def deprecated_alias(**aliases: str) -> Callable:
         ...
     """
 
-    def deco(f: Callable):
+    def deco(f: Callable) -> Callable:
         @functools.wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Callable:
             rename_kwargs(f.__name__, kwargs, aliases)
             return f(*args, **kwargs)
 
@@ -281,7 +281,9 @@ def deprecated_alias(**aliases: str) -> Callable:
     return deco
 
 
-def rename_kwargs(func_name: str, kwargs: Dict[str, str], aliases: Dict[str, str]):
+def rename_kwargs(
+    func_name: str, kwargs: Dict[str, str], aliases: Dict[str, str]
+) -> None:
     """Helper function for deprecating function and method arguments."""
     for alias, new in aliases.items():
         if alias in kwargs:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,9 +1,22 @@
 import ctypes
+import functools
 import os
 import sys
+import warnings
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 
@@ -245,3 +258,44 @@ def threadpool_size() -> int:
     Get the size of polars; thread pool
     """
     return _pool_size()
+
+
+def deprecated_alias(**aliases: str) -> Callable:
+    """Decorator for deprecated function and method arguments.
+
+    Use as follows:
+
+    @deprecated_alias(old_arg='new_arg')
+    def myfunc(new_arg):
+        ...
+    """
+
+    def deco(f: Callable):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            rename_kwargs(f.__name__, kwargs, aliases)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
+def rename_kwargs(func_name: str, kwargs: Dict[str, str], aliases: Dict[str, str]):
+    """Helper function for deprecating function and method arguments."""
+    for alias, new in aliases.items():
+        if alias in kwargs:
+            if new in kwargs:
+                raise TypeError(
+                    f"{func_name} received both {alias} and {new} as arguments!"
+                    f" {alias} is deprecated, use {new} instead."
+                )
+            warnings.warn(
+                message=(
+                    f"`{alias}` is deprecated as an argument to `{func_name}`; use"
+                    f" `{new}` instead."
+                ),
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
+            kwargs[new] = kwargs.pop(alias)

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import numpy as np
+import pytest
 
 import polars as pl
 
@@ -180,3 +181,17 @@ def test_join_asof_tolerance() -> None:
         "trade": [101, 299, 301, 500],
         "quote": [100, None, 300, None],
     }
+
+
+def test_deprecated():
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    other = pl.DataFrame({"a": [1, 2], "c": [3, 4]})
+    result = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [3, 4]})
+
+    with pytest.deprecated_call():
+        df.join(df=other, on="a")
+    with pytest.deprecated_call():
+        df.lazy().join(ldf=other.lazy(), on="a")
+
+    assert df.join(other=other, on="a") == result
+    assert df.lazy().join(other=other.lazy(), on="a").collect() == result

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -183,7 +183,7 @@ def test_join_asof_tolerance() -> None:
     }
 
 
-def test_deprecated():
+def test_deprecated() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     other = pl.DataFrame({"a": [1, 2], "c": [3, 4]})
     result = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [3, 4]})

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -193,7 +193,8 @@ def test_deprecated():
     with pytest.deprecated_call():
         df.lazy().join(ldf=other.lazy(), on="a").collect()
 
-    assert np.testing.assert_equal(df.join(other=other, on="a"), result)
-    assert np.testing.assert_equal(
-        df.lazy().join(other=other.lazy(), on="a").collect(), result
+    np.testing.assert_equal(df.join(other=other, on="a").to_numpy(), result.to_numpy())
+    np.testing.assert_equal(
+        df.lazy().join(other=other.lazy(), on="a").collect().to_numpy(),
+        result.to_numpy(),
     )

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -191,7 +191,9 @@ def test_deprecated():
     with pytest.deprecated_call():
         df.join(df=other, on="a")
     with pytest.deprecated_call():
-        df.lazy().join(ldf=other.lazy(), on="a")
+        df.lazy().join(ldf=other.lazy(), on="a").collect()
 
-    assert df.join(other=other, on="a") == result
-    assert df.lazy().join(other=other.lazy(), on="a").collect() == result
+    assert np.testing.assert_equal(df.join(other=other, on="a"), result)
+    assert np.testing.assert_equal(
+        df.lazy().join(other=other.lazy(), on="a").collect(), result
+    )


### PR DESCRIPTION
Deprecated the first argument to `.join`, replaced with `other`.

[I found a nice way ](https://stackoverflow.com/questions/49802412/how-to-implement-deprecation-in-python-with-argument-alias/49802489#49802489)of deprecating old variable names via a decorator. 

I wasn't able to run `make test` in py-polars locally (due to a compilation error in arrow2), but ran isort and black 


Error from make:
```
   Compiling parquet2 v0.14.0
   Compiling arrow2 v0.12.0 (https://github.com/jorgecarleitao/arrow2?rev=f57dbd5dbc61b940a71decd5f81d0fd4c93b158d#f57dbd5d)
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /Users/thomas/.cargo/git/checkouts/arrow2-8a2ad61d97265680/f57dbd5/src/lib.rs:10:39
   |
10 | #![cfg_attr(feature = "simd", feature(portable_simd))]
   |                                       ^^^^^^^^^^^^^


error: aborting due to previous error> ] 272/281: arrow2


For more information about this error, try `rustc --explain E0554`.

error: could not compile `arrow2` due to 2 previous errors
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `cargo rustc --manifest-path Cargo.toml --message-format json --lib -- -C link-arg=-undefined -C link-arg=dynamic_lookup -C link-args=-Wl,-install_name,@rpath/polars.cpython-310-darwin.so`
make: *** [test] Error 1
```