### PR TITLE
Address distinction between DataType and DataType()

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -21,7 +21,16 @@ except ImportError:  # pragma: no cover
 
 
 class DataType:
-    """Base class for all Polars data types"""
+    """
+    Base class for all Polars data types.
+    """
+
+    def __new__(cls, *args, **kwargs) -> "PolarsDataType":  # type: ignore
+        # this formulation allows for equivalent use of "pl.Type" and "pl.Type()", while
+        # still respecting types that take initialisation params (eg: Duration/Datetime)
+        if args or kwargs:
+            return super().__new__(cls)
+        return cls
 
     @classmethod
     def string_repr(cls) -> str:
@@ -182,7 +191,7 @@ class Datetime(DataType):
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Datetime):
             return True
-        if isinstance(other, Datetime):
+        elif isinstance(other, Datetime):
             return self.tu == other.tu and self.tz == other.tz
         else:
             return False
@@ -209,7 +218,7 @@ class Duration(DataType):
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Duration):
             return True
-        if isinstance(other, Duration):
+        elif isinstance(other, Duration):
             return self.tu == other.tu
         else:
             return False

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -709,6 +709,8 @@ if HYPOTHESIS_INSTALLED:
                 )
                 dtypes_ = [draw(sampled_from(selectable_dtypes)) for _ in range(n)]
                 coldefs = columns(cols=n, dtype=dtypes_)
+            elif isinstance(cols, column):
+                coldefs = [cols]
             else:
                 coldefs = list(cols)  # type: ignore[arg-type]
 

--- a/py-polars/tests/test_datatypes.py
+++ b/py-polars/tests/test_datatypes.py
@@ -3,16 +3,15 @@ import inspect
 import polars as pl
 import polars.datatypes as datatypes
 
-ALL_DATATYPES = set(
-    dtype
-    for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
-    if inspect.isclass(dtype) and issubclass(dtype, datatypes.DataType)
-)
-
 
 def test_dtype_init_equivalence() -> None:
-    # check "DataType.__new__" behaviour
-    for dtype in ALL_DATATYPES:
+    # check "DataType.__new__" behaviour for all datatypes
+    all_datatypes = set(
+        dtype
+        for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
+        if inspect.isclass(dtype) and issubclass(dtype, datatypes.DataType)
+    )
+    for dtype in all_datatypes:
         assert dtype == dtype()
 
 

--- a/py-polars/tests/test_datatypes.py
+++ b/py-polars/tests/test_datatypes.py
@@ -1,0 +1,29 @@
+import inspect
+
+import polars as pl
+import polars.datatypes as datatypes
+
+ALL_DATATYPES = set(
+    dtype
+    for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
+    if inspect.isclass(dtype) and issubclass(dtype, datatypes.DataType)
+)
+
+
+def test_dtype_init_equivalence() -> None:
+    # check "DataType.__new__" behaviour
+    for dtype in ALL_DATATYPES:
+        assert dtype == dtype()
+
+
+def test_dtype_temporal_units() -> None:
+    # check (in)equality behaviour of temporal types that take units
+    for tu in datatypes.DTYPE_TEMPORAL_UNITS:
+        assert pl.Datetime == pl.Datetime(tu)
+        assert pl.Duration == pl.Duration(tu)
+
+        assert pl.Datetime(tu) == pl.Datetime()  # type: ignore[operator]
+        assert pl.Duration(tu) == pl.Duration()  # type: ignore[operator]
+
+    assert pl.Datetime("ms") != pl.Datetime("ns")
+    assert pl.Duration("ns") != pl.Duration("us")


### PR DESCRIPTION
In some ways it's a slightly odd solution, making `Type` and `Type()` equivalent (for DataTypes that don't take init params). However, it has the advantage of making it impossible to pass the wrong form of the typedef into any downstream functions (as raised in #3819) without requiring any changes/awareness on the user-side, and it allows typedefs that do/don't take init params to be used/called in the same way for consistency.

With the change:
```python
# ----------------------------------------------------
# what looks like an init (that would cause issues if 
# passed into, for example, a cast op) now... isn't 
# ----------------------------------------------------
pl.Int64() is pl.Int64       => True  # "surprise" ;)

# ----------------------------------------------------
# but... no change if the type takes init params 
# ----------------------------------------------------
pl.Int32()                   => pl.Int32
pl.Datetime()                => pl.Datetime
pl.Datetime("ns")            => pl.Datetime("ns")
pl.Duration(time_unit="ms")  => pl.Duration("ms")
```
Also added test coverage for the same; as the datatypes module could do with some more unit testing I started a new file for it; related tests can be added there in the future (indeed, I'll probably write some more shortly).
