### PR TITLE
Make numpy an optional requirement

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
 
-import numpy as np
-
 from polars.internals import DataFrame, Series
 
 if TYPE_CHECKING:  # pragma: no cover
+    import numpy as np
     import pandas as pd
     import pyarrow as pa
 

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Callable, Sequence
 
-import numpy as np
-
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     Boolean,
@@ -34,6 +32,12 @@ try:
 except ImportError:  # pragma: no cover
     _DOCUMENTING = True
 
+try:
+    import numpy as np
+
+    _NUMPY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NUMPY_AVAILABLE = False
 
 if not _DOCUMENTING:
     _POLARS_TYPE_TO_CONSTRUCTOR: dict[PolarsDataType, Callable] = {
@@ -72,7 +76,7 @@ def polars_type_to_constructor(
         raise ValueError(f"Cannot construct PySeries for type {dtype}.")
 
 
-if not _DOCUMENTING:
+if _NUMPY_AVAILABLE and not _DOCUMENTING:
     _NUMPY_TYPE_TO_CONSTRUCTOR = {
         np.float32: PySeries.new_f32,
         np.float64: PySeries.new_f64,
@@ -97,6 +101,10 @@ def numpy_type_to_constructor(dtype: type[np.dtype]) -> Callable[..., PySeries]:
         return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:
         return PySeries.new_object
+    except NameError:
+        raise ImportError(
+            "'numpy' is required for this functionality."
+        )  # pragma: no cover
 
 
 if not _DOCUMENTING:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -94,9 +94,6 @@ def numpy_to_pyseries(
     """
     Construct a PySeries from a numpy array.
     """
-    if not _NUMPY_AVAILABLE:
-        raise ImportError("'numpy' is required for this functionality.")
-
     if not values.flags["C_CONTIGUOUS"]:
         values = np.array(values)
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -29,6 +29,9 @@ from polars.datatypes_constructor import (
 )
 from polars.utils import threadpool_size
 
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
+
 try:
     from polars.polars import PyDataFrame, PySeries
 
@@ -36,25 +39,19 @@ try:
 except ImportError:  # pragma: no cover
     _DOCUMENTING = True
 
-if TYPE_CHECKING:  # pragma: no cover
-    import pandas as pd
-    import pyarrow as pa
-
-    _PYARROW_AVAILABLE = True
-else:
-    try:
-        import pyarrow as pa
-
-        _PYARROW_AVAILABLE = True
-    except ImportError:  # pragma: no cover
-        _PYARROW_AVAILABLE = False
-
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _NUMPY_AVAILABLE = False
+
+try:
+    import pyarrow as pa
+
+    _PYARROW_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PYARROW_AVAILABLE = False
 
 
 ################################

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4,8 +4,6 @@ import copy
 from datetime import date, datetime, timedelta
 from typing import Any, Callable, List, Sequence
 
-import numpy as np
-
 from polars.utils import _timedelta_to_pl_duration
 
 try:
@@ -31,6 +29,13 @@ from polars.datatypes import (
     UInt32,
     py_type_to_dtype,
 )
+
+try:
+    import numpy as np
+
+    _NUMPY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NUMPY_AVAILABLE = False
 
 
 def selection_to_pyexpr_list(
@@ -188,6 +193,8 @@ class Expr:
         """
         Numpy universal functions.
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         out_type = ufunc(np.array([1])).dtype
         dtype: type[DataType] | None
         if "float" in str(out_type):
@@ -1284,7 +1291,9 @@ class Expr:
         └───────┴───────┘
 
         """
-        if isinstance(index, (list, np.ndarray)):
+        if isinstance(index, list):
+            index_lit = pli.lit(pli.Series("", index, dtype=UInt32))
+        elif _NUMPY_AVAILABLE and isinstance(index, np.ndarray):
             index_lit = pli.lit(pli.Series("", index, dtype=UInt32))
         else:
             index_lit = pli.expr_to_lit_or_expr(index, str_to_lit=False)
@@ -3321,6 +3330,8 @@ class Expr:
         └─────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.sign(self)  # type: ignore
 
     def sin(self) -> Expr:
@@ -3346,6 +3357,8 @@ class Expr:
         └─────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.sin(self)  # type: ignore
 
     def cos(self) -> Expr:
@@ -3371,6 +3384,8 @@ class Expr:
         └─────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.cos(self)  # type: ignore
 
     def tan(self) -> Expr:
@@ -3396,6 +3411,8 @@ class Expr:
         └──────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.tan(self)  # type: ignore
 
     def arcsin(self) -> Expr:
@@ -3420,6 +3437,8 @@ class Expr:
         └────────────────────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.arcsin(self)  # type: ignore
 
     def arccos(self) -> Expr:
@@ -3444,6 +3463,8 @@ class Expr:
         └────────────────────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.arccos(self)  # type: ignore
 
     def arctan(self) -> Expr:
@@ -3468,6 +3489,8 @@ class Expr:
         └────────────────────┘
 
         """
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         return np.arctan(self)  # type: ignore
 
     def reshape(self, dims: tuple[int, ...]) -> Expr:
@@ -3517,6 +3540,8 @@ class Expr:
             Seed initialization. If None given numpy is used.
         """
         if seed is None:
+            if not _NUMPY_AVAILABLE:
+                raise ImportError("'numpy' is required for this functionality.")
             seed = int(np.random.randint(0, 10000))
         return wrap_expr(self._pyexpr.shuffle(seed))
 
@@ -5876,6 +5901,8 @@ def _prepare_alpha(
         alpha = 2.0 / (span + 1.0)
     if half_life is not None and alpha is None:
         assert half_life > 0.0
+        if not _NUMPY_AVAILABLE:
+            raise ImportError("'numpy' is required for this functionality.")
         alpha = 1.0 - np.exp(-np.log(2.0) / half_life)
     if alpha is None:
         raise ValueError("at least one of {com, span, half_life, alpha} should be set")

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -6,15 +6,6 @@ import random
 from datetime import date, datetime, timedelta
 from typing import Any, Callable, List, Sequence
 
-from polars.utils import _timedelta_to_pl_duration
-
-try:
-    from polars.polars import PyExpr
-
-    _DOCUMENTING = False
-except ImportError:  # pragma: no cover
-    _DOCUMENTING = True
-
 from polars import internals as pli
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
@@ -29,6 +20,14 @@ from polars.datatypes import (
     UInt32,
     py_type_to_dtype,
 )
+from polars.utils import _timedelta_to_pl_duration
+
+try:
+    from polars.polars import PyExpr
+
+    _DOCUMENTING = False
+except ImportError:  # pragma: no cover
+    _DOCUMENTING = True
 
 try:
     import numpy as np

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import math
+import random
 from datetime import date, datetime, timedelta
 from typing import Any, Callable, List, Sequence
 
@@ -12,8 +14,6 @@ try:
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover
     _DOCUMENTING = True
-
-import math
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -3543,9 +3543,7 @@ class Expr:
             Seed initialization. If None given numpy is used.
         """
         if seed is None:
-            if not _NUMPY_AVAILABLE:
-                raise ImportError("'numpy' is required for this functionality.")
-            seed = int(np.random.randint(0, 10000))
+            seed = random.randint(0, 10000)
         return wrap_expr(self._pyexpr.shuffle(seed))
 
     def sample(
@@ -5904,9 +5902,7 @@ def _prepare_alpha(
         alpha = 2.0 / (span + 1.0)
     if half_life is not None and alpha is None:
         assert half_life > 0.0
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        alpha = 1.0 - np.exp(-np.log(2.0) / half_life)
+        alpha = 1.0 - math.exp(-math.log(2.0) / half_life)
     if alpha is None:
         raise ValueError("at least one of {com, span, half_life, alpha} should be set")
     return alpha

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3539,7 +3539,8 @@ class Expr:
         Parameters
         ----------
         seed
-            Seed initialization. If None given numpy is used.
+            Seed initialization. If None given, the `random` module is used to generate
+            a random seed.
         """
         if seed is None:
             seed = random.randint(0, 10000)

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1296,7 +1296,10 @@ class Expr:
         elif _NUMPY_AVAILABLE and isinstance(index, np.ndarray):
             index_lit = pli.lit(pli.Series("", index, dtype=UInt32))
         else:
-            index_lit = pli.expr_to_lit_or_expr(index, str_to_lit=False)
+            index_lit = pli.expr_to_lit_or_expr(
+                index,  # type: ignore[arg-type]
+                str_to_lit=False,
+            )
         return pli.wrap_expr(self._pyexpr.take(index_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Expr:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -415,7 +415,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
         if _NUMPY_AVAILABLE and isinstance(data, np.ndarray):
             pydf = numpy_to_pydf(data, columns=columns, orient=orient)
         else:
-            pydf = sequence_to_pydf(data, columns=columns, orient=orient)
+            pydf = sequence_to_pydf(
+                data,  # type: ignore[arg-type]
+                columns=columns,
+                orient=orient,
+            )
         return cls._from_pydf(pydf)
 
     @classmethod

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1814,6 +1814,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 self.hstack([pli.Series(key, value)], in_place=True)
         # df[["C", "D"]]
         elif isinstance(key, list):
+            # TODO: Use python sequence constructors
             if not _NUMPY_AVAILABLE:
                 raise ImportError("'numpy' is required for this functionality.")
             value = np.array(value)

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -22,22 +22,9 @@ from typing import (
     overload,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
-
-try:
-    import pyarrow as pa
-    import pyarrow.compute
-    import pyarrow.parquet
-
-    _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    _PYARROW_AVAILABLE = False
-
 from polars import internals as pli
+from polars._html import NotebookFormatter
+from polars.datatypes import Boolean, DataType, UInt32, Utf8, py_type_to_dtype
 from polars.internals.construction import (
     ColumnsType,
     arrow_to_pydf,
@@ -47,18 +34,6 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-
-from .lazy_frame import LazyFrame, wrap_ldf  # noqa: F401
-
-try:
-    from polars.polars import PyDataFrame, PySeries
-
-    _DOCUMENTING = False
-except ImportError:  # pragma: no cover
-    _DOCUMENTING = True
-
-from polars._html import NotebookFormatter
-from polars.datatypes import Boolean, DataType, UInt32, Utf8, py_type_to_dtype
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
@@ -70,6 +45,15 @@ from polars.utils import (
     range_to_slice,
 )
 
+from .lazy_frame import LazyFrame, wrap_ldf  # noqa: F401
+
+try:
+    from polars.polars import PyDataFrame, PySeries
+
+    _DOCUMENTING = False
+except ImportError:  # pragma: no cover
+    _DOCUMENTING = True
+
 try:
     import numpy as np
 
@@ -78,11 +62,25 @@ except ImportError:  # pragma: no cover
     _NUMPY_AVAILABLE = False
 
 try:
+    import pyarrow as pa
+    import pyarrow.compute
+    import pyarrow.parquet
+
+    _PYARROW_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PYARROW_AVAILABLE = False
+
+try:
     import pandas as pd
 
     _PANDAS_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PANDAS_AVAILABLE = False
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
 
 # A type variable used to refer to a polars.DataFrame or any subclass of it.
 # Used to annotate DataFrame methods which returns the same type as self.

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1477,7 +1477,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             **kwargs,
         )
 
-    def to_numpy(self) -> "np.ndarray":
+    def to_numpy(self) -> np.ndarray:
         """
         Convert DataFrame to a 2d numpy array.
         This operation clones data.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -10,8 +10,6 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal  # pragma: no cover
 
-import numpy as np
-
 from polars import internals as pli
 from polars.datatypes import (
     DataType,
@@ -27,6 +25,13 @@ from polars.utils import (
     in_nanoseconds_window,
     timedelta_in_nanoseconds_window,
 )
+
+try:
+    import numpy as np
+
+    _NUMPY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NUMPY_AVAILABLE = False
 
 try:
     from polars.polars import arange as pyarange
@@ -675,7 +680,7 @@ def lit(
             return e
         return e.alias(name)
 
-    if isinstance(value, np.ndarray):
+    if _NUMPY_AVAILABLE and isinstance(value, np.ndarray):
         return lit(pli.Series("", value))
 
     if dtype:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -5,11 +5,6 @@ from datetime import date, datetime, timedelta
 from inspect import isclass
 from typing import Any, Callable, Sequence, cast, overload
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
 from polars import internals as pli
 from polars.datatypes import (
     DataType,
@@ -25,13 +20,6 @@ from polars.utils import (
     in_nanoseconds_window,
     timedelta_in_nanoseconds_window,
 )
-
-try:
-    import numpy as np
-
-    _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    _NUMPY_AVAILABLE = False
 
 try:
     from polars.polars import arange as pyarange
@@ -62,6 +50,18 @@ try:
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover
     _DOCUMENTING = True
+
+try:
+    import numpy as np
+
+    _NUMPY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NUMPY_AVAILABLE = False
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
 
 
 def col(

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2119,7 +2119,7 @@ class Series:
         """
         return self.dtype is Utf8
 
-    def view(self, ignore_nulls: bool = False) -> "np.ndarray":
+    def view(self, ignore_nulls: bool = False) -> np.ndarray:
         """
         Get a view into this Series data with a numpy array. This operation doesn't clone data, but does not include
         missing values. Don't use this unless you know what you are doing.
@@ -2146,7 +2146,7 @@ class Series:
         array.setflags(write=False)
         return array
 
-    def __array__(self, dtype: Any = None) -> "np.ndarray":
+    def __array__(self, dtype: Any = None) -> np.ndarray:
         if dtype:
             return self.to_numpy().__array__(dtype)
         else:
@@ -2154,7 +2154,7 @@ class Series:
 
     def __array_ufunc__(
         self,
-        ufunc: "np.ufunc",
+        ufunc: np.ufunc,
         method: str,
         *inputs: Any,
         **kwargs: Any,
@@ -2235,7 +2235,7 @@ class Series:
 
     def to_numpy(
         self, *args: Any, zero_copy_only: bool = False, **kwargs: Any
-    ) -> "np.ndarray":
+    ) -> np.ndarray:
         """
         Convert this Series to numpy. This operation clones data but is completely safe.
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -823,6 +823,8 @@ class Series:
         """
         if not self.is_numeric():
             return None
+        if ddof == 1:
+            return self.to_frame().select(pli.col(self.name).std()).to_series()[0]
         if not _NUMPY_AVAILABLE:
             raise ImportError("'numpy' is required for this functionality.")
         return np.std(self.drop_nulls().view(), ddof=ddof)
@@ -847,6 +849,8 @@ class Series:
         """
         if not self.is_numeric():
             return None
+        if ddof == 1:
+            return self.to_frame().select(pli.col(self.name).var()).to_series()[0]
         if not _NUMPY_AVAILABLE:
             raise ImportError("'numpy' is required for this functionality.")
         return np.var(self.drop_nulls().view(), ddof=ddof)

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1,35 +1,11 @@
 from __future__ import annotations
 
+import math
 import sys
 from datetime import date, datetime, timedelta
 from typing import Any, Callable, Sequence, Union, overload
 
-try:
-    import pyarrow as pa
-
-    _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    _PYARROW_AVAILABLE = False
-
-
-import math
-
 from polars import internals as pli
-from polars.internals.construction import (
-    arrow_to_pyseries,
-    numpy_to_pyseries,
-    pandas_to_pyseries,
-    sequence_to_pyseries,
-    series_to_pyseries,
-)
-
-try:
-    from polars.polars import PyDataFrame, PySeries
-
-    _DOCUMENTING = False
-except ImportError:  # pragma: no cover
-    _DOCUMENTING = True
-
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     Boolean,
@@ -58,6 +34,13 @@ from polars.datatypes import (
     py_type_to_dtype,
     supported_numpy_char_code,
 )
+from polars.internals.construction import (
+    arrow_to_pyseries,
+    numpy_to_pyseries,
+    pandas_to_pyseries,
+    sequence_to_pyseries,
+    series_to_pyseries,
+)
 from polars.utils import (
     _date_to_pl_date,
     _datetime_to_pl_timestamp,
@@ -67,11 +50,25 @@ from polars.utils import (
 )
 
 try:
+    from polars.polars import PyDataFrame, PySeries
+
+    _DOCUMENTING = False
+except ImportError:  # pragma: no cover
+    _DOCUMENTING = True
+
+try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _NUMPY_AVAILABLE = False
+
+try:
+    import pyarrow as pa
+
+    _PYARROW_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PYARROW_AVAILABLE = False
 
 try:
     import pandas as pd

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -578,9 +578,7 @@ class Series:
         """
         Return the base 10 logarithm of the input array, element-wise.
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.log10(self)  # type: ignore
+        return self.log(10.0)
 
     def exp(self) -> Series:
         """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -9,14 +9,14 @@ from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
+from polars.datatypes import DataType, Date, Datetime
+
 try:
     from polars.polars import pool_size as _pool_size
 
     _DOCUMENTING = False
 except ImportError:  # pragma: no cover
     _DOCUMENTING = True
-
-from polars.datatypes import DataType, Date, Datetime
 
 try:
     import numpy as np

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -41,7 +41,7 @@ def _process_null_values(
 
 
 # https://stackoverflow.com/questions/4355524/getting-data-from-ctypes-array-into-numpy
-def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> "np.ndarray":
+def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
     """
 
     Parameters

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -9,8 +9,6 @@ from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
-import numpy as np
-
 try:
     from polars.polars import pool_size as _pool_size
 
@@ -19,6 +17,13 @@ except ImportError:  # pragma: no cover
     _DOCUMENTING = True
 
 from polars.datatypes import DataType, Date, Datetime
+
+try:
+    import numpy as np
+
+    _NUMPY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NUMPY_AVAILABLE = False
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -36,7 +41,7 @@ def _process_null_values(
 
 
 # https://stackoverflow.com/questions/4355524/getting-data-from-ctypes-array-into-numpy
-def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
+def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> "np.ndarray":
     """
 
     Parameters
@@ -54,6 +59,8 @@ def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
     View of memory block as numpy array.
 
     """
+    if not _NUMPY_AVAILABLE:
+        raise ImportError("'numpy' is required for this functionality.")
     ptr_ctype = ctypes.cast(ptr, ctypes.POINTER(ptr_type))
     return np.ctypeslib.as_array(ptr_ctype, (len,))
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "maturin"
 [project]
 name = "polars"
 dependencies = [
-  "numpy >= 1.16.0",
   "typing_extensions >= 4.0.0; python_version < '3.10'",
 ]
 requires-python = ">=3.7"
@@ -15,6 +14,7 @@ requires-python = ">=3.7"
 # (which the Rust libraries use to take advantage of Rust API changes).
 pyarrow = ["pyarrow>=4.0.*"]
 pandas = ["pyarrow>=4.0.*", "pandas"]
+numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv"]

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -237,6 +237,11 @@ def test_init_ndarray() -> None:
     with pytest.raises(ValueError):
         _ = pl.DataFrame(np.random.randn(2, 2, 2))
 
+    # numpy not available
+    with patch("polars.internals.frame._NUMPY_AVAILABLE", False):
+        with pytest.raises(ValueError):
+            pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
+
 
 # TODO: Remove this test case when removing deprecated behaviour
 def test_init_ndarray_deprecated() -> None:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from typing import Any, Union
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -65,6 +66,11 @@ def test_init_inputs(monkeypatch: Any) -> None:
 
     # pandas
     assert pl.Series(pd.Series([1, 2])).dtype == pl.Int64
+
+    # numpy not available
+    with patch("polars.internals.series._NUMPY_AVAILABLE", False):
+        with pytest.raises(ValueError):
+            pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
 
     # Bad inputs
     with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #3571 

Changes:
* Update `pyproject.toml` by making `numpy` optional.
* Wrap `numpy` imports by a `try` block and set the `_NUMPY_AVAILABLE` boolean (similar to `pandas` and `pyarrow`).
* Check for `numpy` availability wherever `numpy` is used. Raise an `ImportError` when `numpy` is integral to a function.
* Replaced some `numpy` functionality with Python built-ins:
    * Replaced `np.random.randint` with Python's built-in `random.randint` for generating a seed for the `Expr.shuffle` method.
    * Replaced `np.exp` and `np.log` with Python's built-in `math.exp` and `math.log` for generating a seed for the `_prepare_alpha` function.
    * Replaced `np.log10` with polars' `log` functionality.
* Add tests for the case that numpy is not available (`DataFrame`/`Series` constructor)

To do (future):
* Implement some of the `numpy`-only functionality natively (I will open a new issue with a list of these).
* (?) Update docs to include more examples without `numpy`.