### PR TITLE
Allow negative column-indexing for additional functions, and expose frame-level `take_every`

### DIFF
--- a/polars/polars-io/src/parquet/read.rs
+++ b/polars/polars-io/src/parquet/read.rs
@@ -24,7 +24,7 @@ pub struct ParquetReader<R: Read + Seek> {
 impl<R: MmapBytesReader> ParquetReader<R> {
     #[cfg(feature = "lazy")]
     // todo! hoist to lazy crate
-    pub fn finish_with_scan_ops(
+    pub fn _finish_with_scan_ops(
         mut self,
         predicate: Option<Arc<dyn PhysicalIoExpr>>,
         aggregate: Option<&[ScanAggregation]>,

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -152,7 +152,8 @@ pub fn read_parquet<R: MmapBytesReader>(
                 .collect::<Result<Vec<_>>>()?
         };
 
-        remaining_rows = file_metadata.row_groups[rg].num_rows() as usize;
+        remaining_rows =
+            remaining_rows.saturating_sub(file_metadata.row_groups[rg].num_rows() as usize);
 
         let mut df = DataFrame::new_no_checks(columns);
         if let Some(rc) = &row_count {

--- a/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
@@ -26,6 +26,6 @@ pub trait Optimize {
 // arbitrary constant to reduce reallocation.
 const HASHMAP_SIZE: usize = 16;
 
-pub(crate) fn init_hashmap<K, V>() -> PlHashMap<K, V> {
-    PlHashMap::with_capacity(HASHMAP_SIZE)
+pub(crate) fn init_hashmap<K, V>(max_len: Option<usize>) -> PlHashMap<K, V> {
+    PlHashMap::with_capacity(std::cmp::min(max_len.unwrap_or(HASHMAP_SIZE), HASHMAP_SIZE))
 }

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -50,7 +50,7 @@ impl Executor for JoinExec {
         let mut input_right = self.input_right.take().unwrap();
 
         let (df_left, df_right) = if self.parallel {
-            let state_left = state.clone();
+            let state_left = state;
             let mut state_right = state.clone();
             state_right.join_branch += 1;
             // propagate the fetch_rows static value to the spawning threads.
@@ -59,7 +59,7 @@ impl Executor for JoinExec {
             POOL.join(
                 move || {
                     FETCH_ROWS.with(|fr| fr.set(fetch_rows));
-                    input_left.execute(&state_left)
+                    input_left.execute(state_left)
                 },
                 move || {
                     FETCH_ROWS.with(|fr| fr.set(fetch_rows));

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -41,7 +41,7 @@ impl ParquetExec {
             .read_parallel(self.options.parallel)
             .with_row_count(std::mem::take(&mut self.options.row_count))
             .set_rechunk(self.options.rechunk)
-            .finish_with_scan_ops(
+            ._finish_with_scan_ops(
                 predicate,
                 aggregate,
                 projection.as_ref().map(|v| v.as_ref()),

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -96,7 +96,6 @@ impl PhysicalExpr for TakeExpr {
                         };
                     let taken = ac.flat_naive().take(&idx)?;
                     ac.with_series(taken, true);
-                    ac.with_update_groups(UpdateGroups::WithSeriesLen);
                     return Ok(ac);
                 }
                 AggState::AggregatedList(s) => s.list().unwrap().clone(),

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -10,6 +10,7 @@ use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::POOL;
 use polars_utils::sort::perfect_sort;
+use std::fmt::Write;
 use std::sync::Arc;
 
 pub struct WindowExpr {
@@ -247,6 +248,7 @@ impl PhysicalExpr for WindowExpr {
         // Try to get cached grouptuples
         let (groups, _, cache_key) = if state.cache_window {
             let mut cache_key = String::with_capacity(32 * groupby_columns.len());
+            write!(&mut cache_key, "{}", state.join_branch).unwrap();
             for s in &groupby_columns {
                 cache_key.push_str(s.name());
             }

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -25,7 +25,7 @@ pub struct ExecutionState {
     pub(crate) join_tuples: JoinTuplesCache,
     pub(crate) verbose: bool,
     pub(crate) cache_window: bool,
-    // every join split gets an increment to distinguish between schema state
+    // every join/union split gets an increment to distinguish between schema state
     pub(crate) join_branch: usize,
 }
 

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -81,6 +81,7 @@ Manipulation/ selection
 .. autosummary::
    :toctree: api/
 
+    DataFrame.cleared
     DataFrame.clone
     DataFrame.distinct
     DataFrame.drop

--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -124,6 +124,7 @@ Manipulation/ selection
     DataFrame.slice
     DataFrame.sort
     DataFrame.tail
+    DataFrame.take_every
     DataFrame.to_dummies
     DataFrame.to_series
     DataFrame.transpose

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -46,6 +46,7 @@ Manipulation/ selection
 .. autosummary::
    :toctree: api/
 
+    LazyFrame.cleared
     LazyFrame.clone
     LazyFrame.distinct
     LazyFrame.drop

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -74,6 +74,7 @@ Manipulation/ selection
     LazyFrame.slice
     LazyFrame.sort
     LazyFrame.tail
+    LazyFrame.take_every
     LazyFrame.unique
     LazyFrame.unnest
     LazyFrame.with_column

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -155,6 +155,7 @@ Manipulation/ selection
     Series.argsort
     Series.cast
     Series.ceil
+    Series.cleared
     Series.clip
     Series.clone
     Series.drop_nans

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -1,9 +1,11 @@
 """
 Module for formatting output data in HTML.
 """
+from __future__ import annotations
+
 from textwrap import dedent
 from types import TracebackType
-from typing import Dict, Iterable, List, Optional, Type
+from typing import Iterable
 
 from polars.datatypes import Object
 
@@ -11,9 +13,9 @@ from polars.datatypes import Object
 class Tag:
     def __init__(
         self,
-        elements: List[str],
+        elements: list[str],
         tag: str,
-        attributes: Optional[Dict[str, str]] = None,
+        attributes: dict[str, str] | None = None,
     ):
         self.tag = tag
         self.elements = elements
@@ -31,17 +33,17 @@ class Tag:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         self.elements.append(f"</{self.tag}>")
 
 
 class HTMLFormatter:
-    def __init__(self, df: "DataFrame", max_cols: int = 75, max_rows: int = 40):  # type: ignore  # noqa
+    def __init__(self, df: DataFrame, max_cols: int = 75, max_rows: int = 40):  # type: ignore  # noqa
         self.df = df
-        self.elements: List[str] = []
+        self.elements: list[str] = []
         self.max_cols = max_cols
         self.max_rows = max_rows
         self.row_idx: Iterable[int]
@@ -109,7 +111,7 @@ class HTMLFormatter:
     def write(self, inner: str) -> None:
         self.elements.append(inner)
 
-    def render(self) -> List[str]:
+    def render(self) -> list[str]:
         with Tag(self.elements, "table", {"border": "1", "class": "dataframe"}):
             self.write_header()
             self.write_body()
@@ -150,7 +152,7 @@ class NotebookFormatter(HTMLFormatter):
         template = dedent("\n".join((template_first, template_mid, template_last)))
         self.write(template)
 
-    def render(self) -> List[str]:
+    def render(self) -> list[str]:
         """
         Return the lines needed to render a HTML table.
         """

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import Type
 
 from polars.string_cache import toggle_string_cache
 
@@ -10,7 +11,7 @@ class Config:
     """
 
     @classmethod
-    def set_utf8_tables(cls) -> "Type[Config]":
+    def set_utf8_tables(cls) -> type[Config]:
         """
         Use utf8 characters to print tables
         """
@@ -21,7 +22,7 @@ class Config:
         return cls
 
     @classmethod
-    def set_ascii_tables(cls) -> "Type[Config]":
+    def set_ascii_tables(cls) -> type[Config]:
         """
         Use ascii characters to print tables
         """
@@ -29,7 +30,7 @@ class Config:
         return cls
 
     @classmethod
-    def set_tbl_width_chars(cls, width: int) -> "Type[Config]":
+    def set_tbl_width_chars(cls, width: int) -> type[Config]:
         """
         Set the number of character used to draw the table
 
@@ -42,7 +43,7 @@ class Config:
         return cls
 
     @classmethod
-    def set_tbl_rows(cls, n: int) -> "Type[Config]":
+    def set_tbl_rows(cls, n: int) -> type[Config]:
         """
         Set the number of rows used to print tables
 
@@ -56,7 +57,7 @@ class Config:
         return cls
 
     @classmethod
-    def set_tbl_cols(cls, n: int) -> "Type[Config]":
+    def set_tbl_cols(cls, n: int) -> type[Config]:
         """
         Set the number of columns used to print tables
 
@@ -85,7 +86,7 @@ class Config:
         return cls
 
     @classmethod
-    def set_global_string_cache(cls) -> "Type[Config]":
+    def set_global_string_cache(cls) -> type[Config]:
         """
         Turn on the global string cache
         """
@@ -93,7 +94,7 @@ class Config:
         return cls
 
     @classmethod
-    def unset_global_string_cache(cls) -> "Type[Config]":
+    def unset_global_string_cache(cls) -> type[Config]:
         """
         Turn off the global string cache
         """

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,13 +1,6 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-    overload,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
 
 import numpy as np
 
@@ -28,8 +21,8 @@ else:
 
 
 def from_dict(
-    data: Mapping[str, Union[Sequence, Mapping]],
-    columns: Optional[Sequence[str]] = None,
+    data: Mapping[str, Sequence | Mapping],
+    columns: Sequence[str] | None = None,
 ) -> DataFrame:
     """
     Construct a DataFrame from a dictionary of sequences.
@@ -69,9 +62,9 @@ def from_dict(
 
 
 def from_records(
-    data: Union[np.ndarray, Sequence[Sequence[Any]]],
-    columns: Optional[Sequence[str]] = None,
-    orient: Optional[str] = None,
+    data: np.ndarray | Sequence[Sequence[Any]],
+    columns: Sequence[str] | None = None,
+    orient: str | None = None,
 ) -> DataFrame:
     """
     Construct a DataFrame from a numpy ndarray or sequence of sequences.
@@ -118,8 +111,8 @@ def from_records(
 
 
 def from_dicts(
-    dicts: Sequence[Dict[str, Any]],
-    infer_schema_length: Optional[int] = 50,
+    dicts: Sequence[dict[str, Any]],
+    infer_schema_length: int | None = 50,
 ) -> DataFrame:
     """
     Construct a DataFrame from a sequence of dictionaries.
@@ -161,8 +154,8 @@ def from_dicts(
 
 # Note that we cannot overload because pyarrow has no stubs :(
 def from_arrow(
-    a: Union["pa.Table", "pa.Array", "pa.ChunkedArray"], rechunk: bool = True
-) -> Union[DataFrame, Series]:
+    a: pa.Table | pa.Array | pa.ChunkedArray, rechunk: bool = True
+) -> DataFrame | Series:
     """
     Create a DataFrame or Series from an Arrow Table or Array.
 
@@ -230,7 +223,7 @@ def from_arrow(
 
 @overload
 def from_pandas(
-    df: "pd.DataFrame",
+    df: pd.DataFrame,
     rechunk: bool = True,
     nan_to_none: bool = True,
 ) -> DataFrame:
@@ -239,7 +232,7 @@ def from_pandas(
 
 @overload
 def from_pandas(
-    df: Union["pd.Series", "pd.DatetimeIndex"],
+    df: pd.Series | pd.DatetimeIndex,
     rechunk: bool = True,
     nan_to_none: bool = True,
 ) -> Series:
@@ -247,10 +240,10 @@ def from_pandas(
 
 
 def from_pandas(
-    df: Union["pd.DataFrame", "pd.Series", "pd.DatetimeIndex"],
+    df: pd.DataFrame | pd.Series | pd.DatetimeIndex,
     rechunk: bool = True,
     nan_to_none: bool = True,
-) -> Union[DataFrame, Series]:
+) -> DataFrame | Series:
     """
     Construct a Polars DataFrame or Series from a pandas DataFrame or Series.
 

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -54,79 +54,53 @@ ColumnsType = Union[
 class Int8(DataType):
     """8-bit signed integer type"""
 
-    pass
-
 
 class Int16(DataType):
     """16-bit signed integer type"""
-
-    pass
 
 
 class Int32(DataType):
     """32-bit signed integer type"""
 
-    pass
-
 
 class Int64(DataType):
     """64-bit signed integer type"""
-
-    pass
 
 
 class UInt8(DataType):
     """8-bit unsigned integer type"""
 
-    pass
-
 
 class UInt16(DataType):
     """16-bit unsigned integer type"""
-
-    pass
 
 
 class UInt32(DataType):
     """32-bit unsigned integer type"""
 
-    pass
-
 
 class UInt64(DataType):
     """64-bit unsigned integer type"""
-
-    pass
 
 
 class Float32(DataType):
     """32-bit floating point type"""
 
-    pass
-
 
 class Float64(DataType):
     """64-bit floating point type"""
-
-    pass
 
 
 class Boolean(DataType):
     """Boolean type"""
 
-    pass
-
 
 class Utf8(DataType):
     """UTF-8 encoded string type"""
 
-    pass
-
 
 class Null(DataType):
     """Type representing Null / None values"""
-
-    pass
 
 
 class List(DataType):
@@ -168,8 +142,6 @@ class List(DataType):
 
 class Date(DataType):
     """Calendar date type"""
-
-    pass
 
 
 class Datetime(DataType):
@@ -232,19 +204,13 @@ class Duration(DataType):
 class Time(DataType):
     """Time of day type"""
 
-    pass
-
 
 class Object(DataType):
     """Type for wrapping arbitrary Python objects"""
 
-    pass
-
 
 class Categorical(DataType):
     """A categorical encoding of a set of strings"""
-
-    pass
 
 
 class Field:

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import sys
 from datetime import date, datetime, time, timedelta
@@ -25,7 +27,7 @@ class DataType:
     Base class for all Polars data types.
     """
 
-    def __new__(cls, *args, **kwargs) -> "PolarsDataType":  # type: ignore
+    def __new__(cls, *args, **kwargs) -> PolarsDataType:  # type: ignore
         # this formulation allows for equivalent use of "pl.Type" and "pl.Type()", while
         # still respecting types that take initialisation params (eg: Duration/Datetime)
         if args or kwargs:
@@ -128,7 +130,7 @@ class Null(DataType):
 
 
 class List(DataType):
-    def __init__(self, inner: Type[DataType]):
+    def __init__(self, inner: type[DataType]):
         """
         Nested list/array type
 
@@ -139,7 +141,7 @@ class List(DataType):
         """
         self.inner = py_type_to_dtype(inner)
 
-    def __eq__(self, other: Type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
         # The comparison allows comparing objects to classes
         # and specific inner types to none specific.
         # if one of the arguments is not specific about its inner type
@@ -173,7 +175,7 @@ class Date(DataType):
 class Datetime(DataType):
     """Calendar date and time type"""
 
-    def __init__(self, time_unit: str = "us", time_zone: Optional[str] = None):
+    def __init__(self, time_unit: str = "us", time_zone: str | None = None):
         """
         Calendar date and time type
 
@@ -187,7 +189,7 @@ class Datetime(DataType):
         self.tu = time_unit
         self.tz = time_zone
 
-    def __eq__(self, other: Type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Datetime):
             return True
@@ -214,7 +216,7 @@ class Duration(DataType):
         """
         self.tu = time_unit
 
-    def __eq__(self, other: Type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Duration):
             return True
@@ -246,7 +248,7 @@ class Categorical(DataType):
 
 
 class Field:
-    def __init__(self, name: str, dtype: Type[DataType]):
+    def __init__(self, name: str, dtype: type[DataType]):
         """
         Definition of a single field within a `Struct` DataType
 
@@ -260,7 +262,7 @@ class Field:
         self.name = name
         self.dtype = py_type_to_dtype(dtype)
 
-    def __eq__(self, other: "Field") -> bool:  # type: ignore
+    def __eq__(self, other: Field) -> bool:  # type: ignore
         return (self.name == other.name) & (self.dtype == other.dtype)
 
     def __repr__(self) -> str:
@@ -283,7 +285,7 @@ class Struct(DataType):
         """
         self.fields = fields
 
-    def __eq__(self, other: Type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
         # The comparison allows comparing objects to classes
         # and specific inner types to none specific.
         # if one of the arguments is not specific about its inner type
@@ -306,7 +308,7 @@ class Struct(DataType):
 DTYPE_TEMPORAL_UNITS = frozenset(["ms", "us", "ns"])
 
 
-_DTYPE_TO_FFINAME: Dict[PolarsDataType, str] = {
+_DTYPE_TO_FFINAME: dict[PolarsDataType, str] = {
     Int8: "i8",
     Int16: "i16",
     Int32: "i32",
@@ -332,7 +334,7 @@ for tu in DTYPE_TEMPORAL_UNITS:
     _DTYPE_TO_FFINAME[Datetime(tu)] = "datetime"
     _DTYPE_TO_FFINAME[Duration(tu)] = "duration"
 
-_DTYPE_TO_CTYPE: Dict[PolarsDataType, Any] = {
+_DTYPE_TO_CTYPE: dict[PolarsDataType, Any] = {
     UInt8: ctypes.c_uint8,
     UInt16: ctypes.c_uint16,
     UInt32: ctypes.c_uint32,
@@ -353,7 +355,7 @@ for tu in DTYPE_TEMPORAL_UNITS:
     _DTYPE_TO_CTYPE[Duration(tu)] = ctypes.c_int64
 
 
-_PY_TYPE_TO_DTYPE: Dict[type, Type[DataType]] = {
+_PY_TYPE_TO_DTYPE: dict[type, type[DataType]] = {
     float: Float64,
     int: Int64,
     str: Utf8,
@@ -367,7 +369,7 @@ _PY_TYPE_TO_DTYPE: Dict[type, Type[DataType]] = {
 }
 
 
-_DTYPE_TO_PY_TYPE: Dict[PolarsDataType, type] = {
+_DTYPE_TO_PY_TYPE: dict[PolarsDataType, type] = {
     Float64: float,
     Float32: float,
     Int64: int,
@@ -409,7 +411,7 @@ _NUMPY_CHAR_CODE_TO_DTYPE = {
 }
 
 if _PYARROW_AVAILABLE:
-    _PY_TYPE_TO_ARROW_TYPE: Dict[type, "pa.lib.DataType"] = {
+    _PY_TYPE_TO_ARROW_TYPE: dict[type, pa.lib.DataType] = {
         float: pa.float64(),
         int: pa.int64(),
         str: pa.large_utf8(),
@@ -449,7 +451,7 @@ if _PYARROW_AVAILABLE:
     }
 
 
-def dtype_to_ctype(dtype: PolarsDataType) -> Type[_SimpleCData]:
+def dtype_to_ctype(dtype: PolarsDataType) -> type[_SimpleCData]:
     try:
         return _DTYPE_TO_CTYPE[dtype]
     except KeyError:  # pragma: no cover
@@ -463,7 +465,7 @@ def dtype_to_ffiname(dtype: PolarsDataType) -> str:
         raise NotImplementedError
 
 
-def dtype_to_py_type(dtype: PolarsDataType) -> Type:
+def dtype_to_py_type(dtype: PolarsDataType) -> type:
     try:
         return _DTYPE_TO_PY_TYPE[dtype]
     except KeyError:  # pragma: no cover
@@ -478,7 +480,7 @@ def is_polars_dtype(data_type: Any) -> bool:
     )
 
 
-def py_type_to_dtype(data_type: Any) -> Type[DataType]:
+def py_type_to_dtype(data_type: Any) -> type[DataType]:
     # when the passed in is already a Polars datatype, return that
     if is_polars_dtype(data_type):
         return data_type
@@ -488,7 +490,7 @@ def py_type_to_dtype(data_type: Any) -> Type[DataType]:
         raise NotImplementedError
 
 
-def py_type_to_arrow_type(dtype: Type[Any]) -> "pa.lib.DataType":
+def py_type_to_arrow_type(dtype: type[Any]) -> pa.lib.DataType:
     """
     Convert a Python dtype to an Arrow dtype.
     """
@@ -498,7 +500,7 @@ def py_type_to_arrow_type(dtype: Type[Any]) -> "pa.lib.DataType":
         raise ValueError(f"Cannot parse dtype {dtype} into Arrow dtype.")
 
 
-def dtype_to_arrow_type(dtype: PolarsDataType) -> "pa.lib.DataType":
+def dtype_to_arrow_type(dtype: PolarsDataType) -> pa.lib.DataType:
     """
     Convert a Polars dtype to an Arrow dtype.
     """
@@ -512,7 +514,7 @@ def supported_numpy_char_code(dtype: str) -> bool:
     return dtype in _NUMPY_CHAR_CODE_TO_DTYPE
 
 
-def numpy_char_code_to_dtype(dtype: str) -> Type[DataType]:
+def numpy_char_code_to_dtype(dtype: str) -> type[DataType]:
     try:
         return _NUMPY_CHAR_CODE_TO_DTYPE[dtype]
     except KeyError:  # pragma: no cover
@@ -520,8 +522,8 @@ def numpy_char_code_to_dtype(dtype: str) -> Type[DataType]:
 
 
 def maybe_cast(
-    el: Type[DataType], dtype: Type, time_unit: Optional[str] = None
-) -> Type[DataType]:
+    el: type[DataType], dtype: type, time_unit: str | None = None
+) -> type[DataType]:
     # cast el if it doesn't match
     from polars.utils import _datetime_to_pl_timestamp, _timedelta_to_pl_timedelta
 

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, Dict, Sequence, Type
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
 
 import numpy as np
 
@@ -34,7 +36,7 @@ except ImportError:  # pragma: no cover
 
 
 if not _DOCUMENTING:
-    _POLARS_TYPE_TO_CONSTRUCTOR: Dict[PolarsDataType, Callable] = {
+    _POLARS_TYPE_TO_CONSTRUCTOR: dict[PolarsDataType, Callable] = {
         Float32: PySeries.new_opt_f32,
         Float64: PySeries.new_opt_f64,
         Int8: PySeries.new_opt_i8,
@@ -60,7 +62,7 @@ if not _DOCUMENTING:
 
 def polars_type_to_constructor(
     dtype: PolarsDataType,
-) -> Callable[[str, Sequence[Any], bool], "PySeries"]:
+) -> Callable[[str, Sequence[Any], bool], PySeries]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
@@ -87,7 +89,7 @@ if not _DOCUMENTING:
     }
 
 
-def numpy_type_to_constructor(dtype: Type[np.dtype]) -> Callable[..., "PySeries"]:
+def numpy_type_to_constructor(dtype: type[np.dtype]) -> Callable[..., PySeries]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """
@@ -106,7 +108,7 @@ if not _DOCUMENTING:
     }
 
 
-def py_type_to_constructor(dtype: Type[Any]) -> Callable[..., "PySeries"]:
+def py_type_to_constructor(dtype: type[Any]) -> Callable[..., PySeries]:
     """
     Get the right PySeries constructor for the given Python dtype.
     """

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -13,45 +13,29 @@ except ImportError:  # pragma: no cover
     # They are only redefined for documentation purposes
     # when there is no binary yet
 
-    class ArrowError(Exception):  # type: ignore
+    class ArrowError(Exception):  # type: ignore[no-redef]
         """Exception raised the underlying Arrow library encounters an error"""
 
-        pass
-
-    class ComputeError(Exception):  # type: ignore
+    class ComputeError(Exception):  # type: ignore[no-redef]
         """Exception raised when we couldn't finish the computation"""
 
-        pass
-
-    class NoDataError(Exception):  # type: ignore
+    class NoDataError(Exception):  # type: ignore[no-redef]
         """Exception raised when an operation can not be performed on an empty data structure"""
 
-        pass
-
-    class NotFoundError(Exception):  # type: ignore
+    class NotFoundError(Exception):  # type: ignore[no-redef]
         """Exception raised when a specified column is not found"""
 
-        pass
-
-    class SchemaError(Exception):  # type: ignore
+    class SchemaError(Exception):  # type: ignore[no-redef]
         """Exception raised when trying to combine data structures with mismatched schemas"""
 
-        pass
-
-    class ShapeError(Exception):  # type: ignore
+    class ShapeError(Exception):  # type: ignore[no-redef]
         """Exception raised when trying to combine data structures with incompatible shapes"""
 
-        pass
-
-    class DuplicateError(Exception):  # type: ignore
+    class DuplicateError(Exception):  # type: ignore[no-redef]
         """Exception raised when a column name is duplicated"""
 
-        pass
-
-    class PanicException(Exception):  # type: ignore
+    class PanicException(Exception):  # type: ignore[no-redef]
         """Exception raised when an unexpected state causes a panic in the underlying Rust library"""
-
-        pass
 
 
 __all__ = [

--- a/py-polars/polars/internals/datatypes.py
+++ b/py-polars/polars/internals/datatypes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union
 
 from polars import internals as pli

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4089,9 +4089,15 @@ class DataFrame(metaclass=DataFrameMetaClass):
             idx = len(self.columns) + idx
         return pli.wrap_s(self._df.select_at_idx(idx))
 
+    def cleared(self: DF) -> DF:
+        """
+        Create an empty copy of the current DataFrame, with identical schema but no data.
+        """
+        return self.head(0) if len(self) > 0 else self.clone()
+
     def clone(self: DF) -> DF:
         """
-        Cheap deepcopy/clone.
+        Very cheap deepcopy/clone.
         """
         return self._from_pydf(self._df.clone())
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1897,6 +1897,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ]
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         return pli.wrap_s(self._df.select_at_idx(index))
 
     def reverse(self: DF) -> DF:
@@ -1989,6 +1991,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴─────┴─────┘
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         self._df.insert_at_idx(index, series._s)
 
     def filter(self: DF, predicate: "pli.Expr") -> DF:
@@ -2290,6 +2294,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └───────┴─────┴─────┘
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         self._df.replace_at_idx(index, series._s)
 
     @overload
@@ -4094,6 +4100,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ]
 
         """
+        if idx < 0:
+            idx = len(self.columns) + idx
         return pli.wrap_s(self._df.select_at_idx(idx))
 
     def clone(self: DF) -> DF:
@@ -5474,6 +5482,27 @@ class DataFrame(metaclass=DataFrameMetaClass):
             df = self.clone()
             df._df.shrink_to_fit()
             return df
+
+    def take_every(self: DF, n: int) -> DF:
+        """
+        Take every nth row in the DataFrame and return as a new DataFrame.
+
+        Examples
+        --------
+        >>> s = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+        >>> s.take_every(2)
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 5   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+        """
+        return self.select(pli.col("*").take_every(n))
 
     def hash_rows(
         self, k0: int = 0, k1: int = 1, k2: int = 2, k3: int = 3

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1,6 +1,8 @@
 """
 Module containing logic related to eager DataFrames
 """
+from __future__ import annotations
+
 import os
 import sys
 import warnings
@@ -10,19 +12,13 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
-    Dict,
     Generic,
     Iterable,
     Iterator,
-    List,
     Mapping,
-    Optional,
     Sequence,
     TextIO,
-    Tuple,
-    Type,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -88,11 +84,11 @@ except ImportError:  # pragma: no cover
 DF = TypeVar("DF", bound="DataFrame")
 
 
-def wrap_df(df: "PyDataFrame") -> "DataFrame":
+def wrap_df(df: PyDataFrame) -> DataFrame:
     return DataFrame._from_pydf(df)
 
 
-def _prepare_other_arg(other: Any) -> "pli.Series":
+def _prepare_other_arg(other: Any) -> pli.Series:
     # if not a series create singleton series such that it will broadcast
     if not isinstance(other, pli.Series):
         if isinstance(other, str):
@@ -287,18 +283,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def __init__(
         self,
-        data: Optional[
-            Union[
-                Dict[str, Sequence[Any]],
-                Sequence[Any],
-                np.ndarray,
-                "pa.Table",
-                "pd.DataFrame",
-                "pli.Series",
-            ]
-        ] = None,
-        columns: Optional[ColumnsType] = None,
-        orient: Optional[str] = None,
+        data: None
+        | (
+            dict[str, Sequence[Any]]
+            | Sequence[Any]
+            | np.ndarray
+            | pa.Table
+            | pd.DataFrame
+            | pli.Series
+        ) = None,
+        columns: ColumnsType | None = None,
+        orient: str | None = None,
     ):
         if data is None:
             self._df = dict_to_pydf({}, columns=columns)
@@ -345,7 +340,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self._df.estimated_size()
 
     @classmethod
-    def _from_pydf(cls: Type[DF], py_df: "PyDataFrame") -> DF:
+    def _from_pydf(cls: type[DF], py_df: PyDataFrame) -> DF:
         """
         Construct Polars DataFrame from FFI PyDataFrame object.
         """
@@ -355,18 +350,18 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _from_dicts(
-        cls: Type[DF],
-        data: Sequence[Dict[str, Any]],
-        infer_schema_length: Optional[int] = 100,
+        cls: type[DF],
+        data: Sequence[dict[str, Any]],
+        infer_schema_length: int | None = 100,
     ) -> DF:
         pydf = PyDataFrame.read_dicts(data, infer_schema_length)
         return cls._from_pydf(pydf)
 
     @classmethod
     def _from_dict(
-        cls: Type[DF],
-        data: Dict[str, Sequence[Any]],
-        columns: Optional[Sequence[str]] = None,
+        cls: type[DF],
+        data: dict[str, Sequence[Any]],
+        columns: Sequence[str] | None = None,
     ) -> DF:
         """
         Construct a DataFrame from a dictionary of sequences.
@@ -388,10 +383,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _from_records(
-        cls: Type[DF],
-        data: Union[np.ndarray, Sequence[Sequence[Any]]],
-        columns: Optional[Sequence[str]] = None,
-        orient: Optional[str] = None,
+        cls: type[DF],
+        data: np.ndarray | Sequence[Sequence[Any]],
+        columns: Sequence[str] | None = None,
+        orient: str | None = None,
     ) -> DF:
         """
         Construct a DataFrame from a numpy ndarray or sequence of sequences.
@@ -420,9 +415,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _from_arrow(
-        cls: Type[DF],
-        data: "pa.Table",
-        columns: Optional[Sequence[str]] = None,
+        cls: type[DF],
+        data: pa.Table,
+        columns: Sequence[str] | None = None,
         rechunk: bool = True,
     ) -> DF:
         """
@@ -450,9 +445,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _from_pandas(
-        cls: Type[DF],
-        data: "pd.DataFrame",
-        columns: Optional[Sequence[str]] = None,
+        cls: type[DF],
+        data: pd.DataFrame,
+        columns: Sequence[str] | None = None,
         rechunk: bool = True,
         nan_to_none: bool = True,
     ) -> DF:
@@ -495,29 +490,27 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _read_csv(
-        cls: Type[DF],
-        file: Union[str, Path, BinaryIO, bytes],
+        cls: type[DF],
+        file: str | Path | BinaryIO | bytes,
         has_header: bool = True,
-        columns: Optional[Union[List[int], List[str]]] = None,
+        columns: list[int] | list[str] | None = None,
         sep: str = ",",
-        comment_char: Optional[str] = None,
-        quote_char: Optional[str] = r'"',
+        comment_char: str | None = None,
+        quote_char: str | None = r'"',
         skip_rows: int = 0,
-        dtypes: Optional[
-            Union[Mapping[str, Type[DataType]], List[Type[DataType]]]
-        ] = None,
-        null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
+        dtypes: None | (Mapping[str, type[DataType]] | list[type[DataType]]) = None,
+        null_values: str | list[str] | dict[str, str] | None = None,
         ignore_errors: bool = False,
         parse_dates: bool = False,
-        n_threads: Optional[int] = None,
-        infer_schema_length: Optional[int] = 100,
+        n_threads: int | None = None,
+        infer_schema_length: int | None = 100,
         batch_size: int = 8192,
-        n_rows: Optional[int] = None,
+        n_rows: int | None = None,
         encoding: str = "utf8",
         low_memory: bool = False,
         rechunk: bool = True,
         skip_rows_after_header: int = 0,
-        row_count_name: Optional[str] = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
         sample_size: int = 1024,
     ) -> DF:
@@ -526,7 +519,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         self = cls.__new__(cls)
 
-        path: Optional[str]
+        path: str | None
         if isinstance(file, (str, Path)):
             path = format_path(file)
         else:
@@ -536,8 +529,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             if isinstance(file, StringIO):
                 file = file.getvalue().encode()
 
-        dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
-        dtype_slice: Optional[List[Type[DataType]]] = None
+        dtype_list: list[tuple[str, type[DataType]]] | None = None
+        dtype_slice: list[type[DataType]] | None = None
         if dtypes is not None:
             if isinstance(dtypes, dict):
                 dtype_list = []
@@ -619,12 +612,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _read_parquet(
-        cls: Type[DF],
-        file: Union[str, Path, BinaryIO],
-        columns: Optional[Union[List[int], List[str]]] = None,
-        n_rows: Optional[int] = None,
+        cls: type[DF],
+        file: str | Path | BinaryIO,
+        columns: list[int] | list[str] | None = None,
+        n_rows: int | None = None,
         parallel: bool = True,
-        row_count_name: Optional[str] = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
     ) -> DF:
         """
@@ -679,10 +672,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _read_avro(
-        cls: Type[DF],
-        file: Union[str, Path, BinaryIO],
-        columns: Optional[Union[List[int], List[str]]] = None,
-        n_rows: Optional[int] = None,
+        cls: type[DF],
+        file: str | Path | BinaryIO,
+        columns: list[int] | list[str] | None = None,
+        n_rows: int | None = None,
     ) -> DF:
         """
         Read into a DataFrame from Apache Avro format.
@@ -707,11 +700,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _read_ipc(
-        cls: Type[DF],
-        file: Union[str, Path, BinaryIO],
-        columns: Optional[Union[List[int], List[str]]] = None,
-        n_rows: Optional[int] = None,
-        row_count_name: Optional[str] = None,
+        cls: type[DF],
+        file: str | Path | BinaryIO,
+        columns: list[int] | list[str] | None = None,
+        n_rows: int | None = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
         rechunk: bool = True,
     ) -> DF:
@@ -769,8 +762,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     @classmethod
     def _read_json(
-        cls: Type[DF],
-        file: Union[str, Path, IOBase],
+        cls: type[DF],
+        file: str | Path | IOBase,
         json_lines: bool = False,
     ) -> DF:
         """
@@ -785,7 +778,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self._df = PyDataFrame.read_json(file, json_lines)
         return self
 
-    def to_arrow(self) -> "pa.Table":
+    def to_arrow(self) -> pa.Table:
         """
         Collect the underlying arrow arrays in an Arrow Table.
         This operation is mostly zero copy.
@@ -801,22 +794,22 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return pa.Table.from_batches(record_batches)
 
     @overload
-    def to_dict(self, as_series: Literal[True] = ...) -> Dict[str, "pli.Series"]:
+    def to_dict(self, as_series: Literal[True] = ...) -> dict[str, pli.Series]:
         ...
 
     @overload
-    def to_dict(self, as_series: Literal[False]) -> Dict[str, List[Any]]:
+    def to_dict(self, as_series: Literal[False]) -> dict[str, list[Any]]:
         ...
 
     @overload
     def to_dict(
         self, as_series: bool = True
-    ) -> Union[Dict[str, "pli.Series"], Dict[str, List[Any]]]:
+    ) -> dict[str, pli.Series] | dict[str, list[Any]]:
         ...
 
     def to_dict(
         self, as_series: bool = True
-    ) -> Union[Dict[str, "pli.Series"], Dict[str, List[Any]]]:
+    ) -> dict[str, pli.Series] | dict[str, list[Any]]:
         """
         Convert DataFrame to a dictionary mapping column name to values.
 
@@ -913,7 +906,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def to_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
@@ -925,7 +918,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def to_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
@@ -937,24 +930,24 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def to_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
         *,
         to_string: bool = ...,
-    ) -> Optional[str]:
+    ) -> str | None:
         ...
 
     def to_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = None,
+        file: IOBase | str | Path | None = None,
         pretty: bool = False,
         row_oriented: bool = False,
         json_lines: bool = False,
         *,
         to_string: bool = False,
-    ) -> Optional[str]:  # pragma: no cover
+    ) -> str | None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
             Please use `write_json`
@@ -969,7 +962,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
@@ -981,7 +974,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
@@ -993,24 +986,24 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
         json_lines: bool = ...,
         *,
         to_string: bool = ...,
-    ) -> Optional[str]:
+    ) -> str | None:
         ...
 
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = None,
+        file: IOBase | str | Path | None = None,
         pretty: bool = False,
         row_oriented: bool = False,
         json_lines: bool = False,
         *,
         to_string: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Serialize to JSON representation.
 
@@ -1046,7 +1039,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_pandas(
         self, *args: Any, date_as_object: bool = False, **kwargs: Any
-    ) -> "pd.DataFrame":  # noqa: F821
+    ) -> pd.DataFrame:  # noqa: F821
         """
         Cast to a pandas DataFrame.
         This requires that pandas and pyarrow are installed.
@@ -1087,12 +1080,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def write_csv(
         self,
-        file: Optional[Union[TextIO, BytesIO, str, Path]] = None,
+        file: TextIO | BytesIO | str | Path | None = None,
         has_header: bool = True,
         sep: str = ",",
         quote: str = '"',
         batch_size: int = 1024,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Write Dataframe to comma-separated values file (csv).
 
@@ -1139,10 +1132,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_csv(
         self,
-        file: Optional[Union[TextIO, BytesIO, str, Path]] = None,
+        file: TextIO | BytesIO | str | Path | None = None,
         has_header: bool = True,
         sep: str = ",",
-    ) -> Optional[str]:  # pragma: no cover
+    ) -> str | None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
             Please use `write_csv`
@@ -1154,7 +1147,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def write_avro(
         self,
-        file: Union[BinaryIO, BytesIO, str, Path],
+        file: BinaryIO | BytesIO | str | Path,
         compression: Literal["uncompressed", "snappy", "deflate"] = "uncompressed",
     ) -> None:
         """
@@ -1177,7 +1170,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_avro(
         self,
-        file: Union[BinaryIO, BytesIO, str, Path],
+        file: BinaryIO | BytesIO | str | Path,
         compression: Literal["uncompressed", "snappy", "deflate"] = "uncompressed",
     ) -> None:  # pragma: no cover
         """
@@ -1191,8 +1184,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def write_ipc(
         self,
-        file: Union[BinaryIO, BytesIO, str, Path],
-        compression: Optional[Literal["uncompressed", "lz4", "zstd"]] = "uncompressed",
+        file: BinaryIO | BytesIO | str | Path,
+        compression: Literal["uncompressed", "lz4", "zstd"] | None = "uncompressed",
     ) -> None:
         """
         Write to Arrow IPC binary stream, or a feather file.
@@ -1216,8 +1209,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_ipc(
         self,
-        file: Union[BinaryIO, BytesIO, str, Path],
-        compression: Optional[Literal["uncompressed", "lz4", "zstd"]] = "uncompressed",
+        file: BinaryIO | BytesIO | str | Path,
+        compression: Literal["uncompressed", "lz4", "zstd"] | None = "uncompressed",
     ) -> None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
@@ -1228,7 +1221,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         )
         return self.write_ipc(file, compression)
 
-    def to_dicts(self) -> List[Dict[str, Any]]:
+    def to_dicts(self) -> list[dict[str, Any]]:
         """
         Convert every row to a dictionary.
 
@@ -1255,7 +1248,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self: DF,
         include_header: bool = False,
         header_name: str = "column",
-        column_names: Optional[Union[Iterator[str], Sequence[str]]] = None,
+        column_names: Iterator[str] | Sequence[str] | None = None,
     ) -> DF:
         """
         Transpose a DataFrame over the diagonal.
@@ -1361,19 +1354,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def write_parquet(
         self,
-        file: Union[str, Path, BytesIO],
+        file: str | Path | BytesIO,
         *,
-        compression: Optional[
-            Union[
-                Literal[
-                    "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
-                ],
-                str,
-            ]
-        ] = "lz4",
-        compression_level: Optional[int] = None,
+        compression: None
+        | (
+            Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
+            | str
+        ) = "lz4",
+        compression_level: int | None = None,
         statistics: bool = False,
-        row_group_size: Optional[int] = None,
+        row_group_size: int | None = None,
         use_pyarrow: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -1455,15 +1445,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_parquet(
         self,
-        file: Union[str, Path, BytesIO],
-        compression: Optional[
-            Union[
-                Literal[
-                    "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
-                ],
-                str,
-            ]
-        ] = "snappy",
+        file: str | Path | BytesIO,
+        compression: None
+        | (
+            Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
+            | str
+        ) = "snappy",
         statistics: bool = False,
         use_pyarrow: bool = False,
         **kwargs: Any,
@@ -1517,18 +1504,14 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def __setstate__(self, state):  # type: ignore
         self._df = DataFrame(state)._df
 
-    def __mul__(
-        self: DF, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> DF:
+    def __mul__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.mul_df(other._df))
 
         other = _prepare_other_arg(other)
         return self._from_pydf(self._df.mul(other._s))
 
-    def __truediv__(
-        self: DF, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> DF:
+    def __truediv__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.div_df(other._df))
 
@@ -1537,24 +1520,20 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def __add__(
         self: DF,
-        other: Union["DataFrame", "pli.Series", int, float, bool, str],
+        other: DataFrame | pli.Series | int | float | bool | str,
     ) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.add_df(other._df))
         other = _prepare_other_arg(other)
         return self._from_pydf(self._df.add(other._s))
 
-    def __sub__(
-        self: DF, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> DF:
+    def __sub__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.sub_df(other._df))
         other = _prepare_other_arg(other)
         return self._from_pydf(self._df.sub(other._s))
 
-    def __mod__(
-        self: DF, other: Union["DataFrame", "pli.Series", int, float, bool]
-    ) -> DF:
+    def __mod__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.rem_df(other._df))
         other = _prepare_other_arg(other)
@@ -1566,7 +1545,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __getattr__(self, item: Any) -> "PySeries":
+    def __getattr__(self, item: Any) -> PySeries:
         """
         Access columns as attribute.
         """
@@ -1619,24 +1598,30 @@ class DataFrame(metaclass=DataFrameMetaClass):
     # __getitem__() mostly returns a dataframe. The major exception is when a string is passed in. Note that there are
     # more subtle cases possible where a non-string value leads to a Series.
     @overload
-    def __getitem__(self, item: str) -> "pli.Series":
+    def __getitem__(self, item: str) -> pli.Series:
         ...
 
     @overload
     def __getitem__(
         self: DF,
-        item: Union[
-            int, range, slice, np.ndarray, "pli.Expr", "pli.Series", List, tuple
-        ],
+        item: int | range | slice | np.ndarray | pli.Expr | pli.Series | list | tuple,
     ) -> DF:
         ...
 
     def __getitem__(
         self: DF,
-        item: Union[
-            str, int, range, slice, np.ndarray, "pli.Expr", "pli.Series", List, tuple
-        ],
-    ) -> Union[DF, "pli.Series"]:
+        item: (
+            str
+            | int
+            | range
+            | slice
+            | np.ndarray
+            | pli.Expr
+            | pli.Series
+            | list
+            | tuple
+        ),
+    ) -> DF | pli.Series:
         """
         Does quite a lot. Read the comments.
         """
@@ -1804,7 +1789,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         raise NotImplementedError
 
     def __setitem__(
-        self, key: Union[str, List, Tuple[Any, Union[str, int]]], value: Any
+        self, key: str | list | tuple[Any, str | int], value: Any
     ) -> None:  # pragma: no cover
         warnings.warn(
             "setting a DataFrame by indexing is deprecated; Consider using DataFrame.with_column",
@@ -1869,7 +1854,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=25))
         return "\n".join(NotebookFormatter(self, max_cols, max_rows).render())
 
-    def to_series(self, index: int = 0) -> "pli.Series":
+    def to_series(self, index: int = 0) -> pli.Series:
         """
         Select column as Series at index location.
 
@@ -1927,7 +1912,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self.select(pli.col("*").reverse())
 
-    def rename(self: DF, mapping: Dict[str, str]) -> DF:
+    def rename(self: DF, mapping: dict[str, str]) -> DF:
         """
         Rename column names.
 
@@ -1959,7 +1944,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self.lazy().rename(mapping).collect(no_optimization=True)
 
-    def insert_at_idx(self, index: int, series: "pli.Series") -> None:
+    def insert_at_idx(self, index: int, series: pli.Series) -> None:
         """
         Insert a Series at a certain column index. This operation is in place.
 
@@ -1995,7 +1980,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             index = len(self.columns) + index
         self._df.insert_at_idx(index, series._s)
 
-    def filter(self: DF, predicate: "pli.Expr") -> DF:
+    def filter(self: DF, predicate: pli.Expr) -> DF:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -2049,7 +2034,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         )
 
     @property
-    def shape(self) -> Tuple[int, int]:
+    def shape(self) -> tuple[int, int]:
         """
         Get the shape of the DataFrame.
 
@@ -2093,7 +2078,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self._df.width()
 
     @property
-    def columns(self) -> List[str]:
+    def columns(self) -> list[str]:
         """
         Get or set column names.
 
@@ -2144,7 +2129,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self._df.set_column_names(columns)
 
     @property
-    def dtypes(self) -> List[Type[DataType]]:
+    def dtypes(self) -> list[type[DataType]]:
         """
         Get dtypes of columns in DataFrame. Dtypes can also be found in column headers when printing the DataFrame.
 
@@ -2180,7 +2165,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self._df.dtypes()
 
     @property
-    def schema(self) -> Dict[str, Type[DataType]]:
+    def schema(self) -> dict[str, type[DataType]]:
         """
         Get a dict[column name, DataType]
 
@@ -2257,7 +2242,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         )
         return summary
 
-    def replace_at_idx(self, index: int, series: "pli.Series") -> None:
+    def replace_at_idx(self, index: int, series: pli.Series) -> None:
         """
         Replace a column at an index location.
 
@@ -2301,8 +2286,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def sort(
         self: DF,
-        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
-        reverse: Union[bool, List[bool]] = ...,
+        by: str | pli.Expr | list[str] | list[pli.Expr],
+        reverse: bool | list[bool] = ...,
         nulls_last: bool = ...,
         *,
         in_place: Literal[False] = ...,
@@ -2312,8 +2297,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def sort(
         self,
-        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
-        reverse: Union[bool, List[bool]] = ...,
+        by: str | pli.Expr | list[str] | list[pli.Expr],
+        reverse: bool | list[bool] = ...,
         nulls_last: bool = ...,
         *,
         in_place: Literal[True],
@@ -2323,22 +2308,22 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def sort(
         self: DF,
-        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
-        reverse: Union[bool, List[bool]] = ...,
+        by: str | pli.Expr | list[str] | list[pli.Expr],
+        reverse: bool | list[bool] = ...,
         nulls_last: bool = ...,
         *,
         in_place: bool,
-    ) -> Optional[DF]:
+    ) -> DF | None:
         ...
 
     def sort(
         self: DF,
-        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
-        reverse: Union[bool, List[bool]] = False,
+        by: str | pli.Expr | list[str] | list[pli.Expr],
+        reverse: bool | list[bool] = False,
         nulls_last: bool = False,
         *,
         in_place: bool = False,
-    ) -> Optional[DF]:
+    ) -> DF | None:
         """
         Sort the DataFrame by column.
 
@@ -2422,7 +2407,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         else:
             return self._from_pydf(self._df.sort(by, reverse, nulls_last))
 
-    def frame_equal(self, other: "DataFrame", null_equal: bool = True) -> bool:
+    def frame_equal(self, other: DataFrame, null_equal: bool = True) -> bool:
         """
         Check if DataFrame is equal to other.
 
@@ -2457,7 +2442,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self._df.frame_equal(other._df, null_equal)
 
-    def replace(self, column: str, new_col: "pli.Series") -> None:
+    def replace(self, column: str, new_col: pli.Series) -> None:
         """
         Replace a column by a new Series.
 
@@ -2491,7 +2476,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         self._df.replace(column, new_col.inner())
 
-    def slice(self: DF, offset: int, length: Optional[int] = None) -> DF:
+    def slice(self: DF, offset: int, length: int | None = None) -> DF:
         """
         Slice this DataFrame over the rows direction.
 
@@ -2634,7 +2619,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self._from_pydf(self._df.tail(length))
 
-    def drop_nulls(self: DF, subset: Optional[Union[str, List[str]]] = None) -> DF:
+    def drop_nulls(self: DF, subset: str | list[str] | None = None) -> DF:
         """
         Return a new DataFrame where the null values are dropped.
 
@@ -2810,9 +2795,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def groupby(
         self: DF,
-        by: Union[str, "pli.Expr", Sequence[str], Sequence["pli.Expr"]],
+        by: str | pli.Expr | Sequence[str] | Sequence[pli.Expr],
         maintain_order: bool = False,
-    ) -> "GroupBy[DF]":
+    ) -> GroupBy[DF]:
         """
         Start a groupby operation.
 
@@ -2889,10 +2874,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self: DF,
         index_column: str,
         period: str,
-        offset: Optional[str] = None,
+        offset: str | None = None,
         closed: str = "right",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
-    ) -> "RollingGroupBy[DF]":
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+    ) -> RollingGroupBy[DF]:
         """
         Create rolling groups based on a time column (or index value of type Int32, Int64).
 
@@ -2998,13 +2983,13 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self,
         index_column: str,
         every: str,
-        period: Optional[str] = None,
-        offset: Optional[str] = None,
+        period: str | None = None,
+        offset: str | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: str = "right",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
-    ) -> "DynamicGroupBy":
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+    ) -> DynamicGroupBy:
         """
         Groups based on a time value (or index value of type Int32, Int64). Time windows are calculated and rows are assigned to windows.
         Different from a normal groupby is that a row can be member of multiple groups. The time/index window could
@@ -3301,8 +3286,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self: DF,
         time_column: str,
         every: str,
-        offset: Optional[str] = None,
-        by: Optional[Union[str, Sequence[str]]] = None,
+        offset: str | None = None,
+        by: str | Sequence[str] | None = None,
         maintain_order: bool = False,
     ) -> DF:
         """
@@ -3399,16 +3384,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @deprecated_alias(df="other")
     def join_asof(
         self: DF,
-        other: "DataFrame",
-        left_on: Optional[str] = None,
-        right_on: Optional[str] = None,
-        on: Optional[str] = None,
-        by_left: Optional[Union[str, List[str]]] = None,
-        by_right: Optional[Union[str, List[str]]] = None,
-        by: Optional[Union[str, List[str]]] = None,
+        other: DataFrame,
+        left_on: str | None = None,
+        right_on: str | None = None,
+        on: str | None = None,
+        by_left: str | list[str] | None = None,
+        by_right: str | list[str] | None = None,
+        by: str | list[str] | None = None,
         strategy: str = "backward",
         suffix: str = "_right",
-        tolerance: Optional[Union[str, int, float]] = None,
+        tolerance: str | int | float | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> DF:
@@ -3540,15 +3525,15 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @deprecated_alias(df="other")
     def join(
         self: DF,
-        other: "DataFrame",
-        left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
-        right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
-        on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        other: DataFrame,
+        left_on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        right_on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        on: str | pli.Expr | list[str | pli.Expr] | None = None,
         how: str = "inner",
         suffix: str = "_right",
-        asof_by: Optional[Union[str, List[str]]] = None,
-        asof_by_left: Optional[Union[str, List[str]]] = None,
-        asof_by_right: Optional[Union[str, List[str]]] = None,
+        asof_by: str | list[str] | None = None,
+        asof_by_left: str | list[str] | None = None,
+        asof_by_right: str | list[str] | None = None,
     ) -> DF:
         """
         SQL like joins.
@@ -3644,13 +3629,13 @@ class DataFrame(metaclass=DataFrameMetaClass):
         if how == "cross":
             return self._from_pydf(self._df.join(other._df, [], [], how, suffix))
 
-        left_on_: Optional[List[Union[str, pli.Expr]]]
+        left_on_: list[str | pli.Expr] | None
         if isinstance(left_on, (str, pli.Expr)):
             left_on_ = [left_on]
         else:
             left_on_ = left_on
 
-        right_on_: Optional[List[Union[str, pli.Expr]]]
+        right_on_: list[str | pli.Expr] | None
         if isinstance(right_on, (str, pli.Expr)):
             right_on_ = [right_on]
         else:
@@ -3695,8 +3680,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def apply(
         self: DF,
-        f: Callable[[Tuple[Any, ...]], Any],
-        return_dtype: Optional[Type[DataType]] = None,
+        f: Callable[[tuple[Any, ...]], Any],
+        return_dtype: type[DataType] | None = None,
         inference_size: int = 256,
     ) -> DF:
         """
@@ -3764,7 +3749,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         else:
             return self._from_pydf(pli.wrap_s(out).to_frame()._df)
 
-    def with_column(self: DF, column: Union["pli.Series", "pli.Expr"]) -> DF:
+    def with_column(self: DF, column: pli.Series | pli.Expr) -> DF:
         """
         Return a new DataFrame with the column added or replaced.
 
@@ -3822,7 +3807,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def hstack(
         self: DF,
-        columns: Union[List["pli.Series"], "DataFrame"],
+        columns: list[pli.Series] | DataFrame,
         in_place: Literal[False] = False,
     ) -> DF:
         ...
@@ -3830,16 +3815,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def hstack(
         self: DF,
-        columns: Union[List["pli.Series"], "DataFrame"],
+        columns: list[pli.Series] | DataFrame,
         in_place: Literal[True],
     ) -> None:
         ...
 
     def hstack(
         self: DF,
-        columns: Union[List["pli.Series"], "DataFrame"],
+        columns: list[pli.Series] | DataFrame,
         in_place: bool = False,
-    ) -> Optional[DF]:
+    ) -> DF | None:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
 
@@ -3884,18 +3869,18 @@ class DataFrame(metaclass=DataFrameMetaClass):
             return self._from_pydf(self._df.hstack([s.inner() for s in columns]))
 
     @overload
-    def vstack(self, df: "DataFrame", in_place: Literal[True]) -> None:
+    def vstack(self, df: DataFrame, in_place: Literal[True]) -> None:
         ...
 
     @overload
-    def vstack(self: DF, df: "DataFrame", in_place: Literal[False] = ...) -> DF:
+    def vstack(self: DF, df: DataFrame, in_place: Literal[False] = ...) -> DF:
         ...
 
     @overload
-    def vstack(self: DF, df: "DataFrame", in_place: bool) -> Optional[DF]:
+    def vstack(self: DF, df: DataFrame, in_place: bool) -> DF | None:
         ...
 
-    def vstack(self: DF, df: "DataFrame", in_place: bool = False) -> Optional[DF]:
+    def vstack(self: DF, df: DataFrame, in_place: bool = False) -> DF | None:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
 
@@ -3946,7 +3931,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         else:
             return self._from_pydf(self._df.vstack(df._df))
 
-    def extend(self, other: "DataFrame") -> None:
+    def extend(self, other: DataFrame) -> None:
         """
         Extend the memory backed by this `DataFrame` with the values from `other`.
 
@@ -3997,7 +3982,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         self._df.extend(other._df)
 
-    def drop(self: DF, name: Union[str, List[str]]) -> DF:
+    def drop(self: DF, name: str | list[str]) -> DF:
         """
         Remove column from DataFrame and return as new.
 
@@ -4040,7 +4025,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         return self._from_pydf(self._df.drop(name))
 
-    def drop_in_place(self, name: str) -> "pli.Series":
+    def drop_in_place(self, name: str) -> pli.Series:
         """
         Drop in place.
 
@@ -4070,7 +4055,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.drop_in_place(name))
 
-    def select_at_idx(self, idx: int) -> "pli.Series":
+    def select_at_idx(self, idx: int) -> pli.Series:
         """
         Select column at index location.
 
@@ -4116,7 +4101,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def __deepcopy__(self: DF, memodict={}) -> DF:  # type: ignore
         return self.clone()
 
-    def get_columns(self) -> List["pli.Series"]:
+    def get_columns(self) -> list[pli.Series]:
         """
         Get the DataFrame as a List of Series.
 
@@ -4142,7 +4127,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return list(map(lambda s: pli.wrap_s(s), self._df.get_columns()))
 
-    def get_column(self, name: str) -> "pli.Series":
+    def get_column(self, name: str) -> pli.Series:
         """
         Get a single column as Series by name.
 
@@ -4163,7 +4148,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self[name]
 
     def fill_null(
-        self: DF, strategy: Union[str, "pli.Expr", Any], limit: Optional[int] = None
+        self: DF, strategy: str | pli.Expr | Any, limit: int | None = None
     ) -> DF:
         """
         Fill null values using a filling strategy, literal, or Expr.
@@ -4197,7 +4182,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             return self.fill_null(pli.lit(strategy))
         return self._from_pydf(self._df.fill_null(strategy, limit))
 
-    def fill_nan(self: DF, fill_value: Union["pli.Expr", int, float]) -> DF:
+    def fill_nan(self: DF, fill_value: pli.Expr | int | float) -> DF:
         """
         Fill floating point NaN values by an Expression evaluation.
 
@@ -4223,7 +4208,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def explode(
         self: DF,
-        columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
+        columns: str | list[str] | pli.Expr | list[pli.Expr],
     ) -> DF:
         """
         Explode `DataFrame` to long format by exploding a column with Lists.
@@ -4295,9 +4280,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def pivot(
         self: DF,
-        values: Union[List[str], str],
-        index: Union[List[str], str],
-        columns: Union[List[str], str],
+        values: list[str] | str,
+        index: list[str] | str,
+        columns: list[str] | str,
         aggregate_fn: str = "first",
         maintain_order: bool = True,
         sort_columns: bool = False,
@@ -4370,10 +4355,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def melt(
         self: DF,
-        id_vars: Optional[Union[List[str], str]] = None,
-        value_vars: Optional[Union[List[str], str]] = None,
-        variable_name: Optional[str] = None,
-        value_name: Optional[str] = None,
+        id_vars: list[str] | str | None = None,
+        value_vars: list[str] | str | None = None,
+        variable_name: str | None = None,
+        value_name: str | None = None,
     ) -> DF:
         """
         Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
@@ -4441,40 +4426,40 @@ class DataFrame(metaclass=DataFrameMetaClass):
     @overload
     def partition_by(
         self: DF,
-        groups: Union[str, List[str]],
+        groups: str | list[str],
         maintain_order: bool,
         *,
         as_dict: Literal[False] = ...,
-    ) -> List[DF]:
+    ) -> list[DF]:
         ...
 
     @overload
     def partition_by(
         self: DF,
-        groups: Union[str, List[str]],
+        groups: str | list[str],
         maintain_order: bool,
         *,
         as_dict: Literal[True],
-    ) -> Dict[Any, DF]:
+    ) -> dict[Any, DF]:
         ...
 
     @overload
     def partition_by(
         self: DF,
-        groups: Union[str, List[str]],
+        groups: str | list[str],
         maintain_order: bool,
         *,
         as_dict: bool,
-    ) -> Union[List[DF], Dict[Any, DF]]:
+    ) -> list[DF] | dict[Any, DF]:
         ...
 
     def partition_by(
         self: DF,
-        groups: Union[str, List[str]],
+        groups: str | list[str],
         maintain_order: bool = True,
         *,
         as_dict: bool = False,
-    ) -> Union[List[DF], Dict[Any, DF]]:
+    ) -> list[DF] | dict[Any, DF]:
         """
         Split into multiple DataFrames partitioned by groups.
 
@@ -4533,7 +4518,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             groups = [groups]
 
         if as_dict:
-            out: Dict[Any, DF] = dict()
+            out: dict[Any, DF] = dict()
             if len(groups) == 1:
                 for _df in self._df.partition_by(groups, maintain_order):
                     df = self._from_pydf(_df)
@@ -4600,9 +4585,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self._from_pydf(self._df.shift(periods))
 
-    def shift_and_fill(
-        self: DF, periods: int, fill_value: Union[int, str, float]
-    ) -> DF:
+    def shift_and_fill(self: DF, periods: int, fill_value: int | str | float) -> DF:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
         with the result of the `fill_value` expression.
@@ -4644,7 +4627,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             .collect(no_optimization=True, string_cache=False)
         )
 
-    def is_duplicated(self) -> "pli.Series":
+    def is_duplicated(self) -> pli.Series:
         """
         Get a mask of all duplicated rows in this DataFrame.
 
@@ -4670,7 +4653,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.is_duplicated())
 
-    def is_unique(self) -> "pli.Series":
+    def is_unique(self) -> pli.Series:
         """
         Get a mask of all unique rows in this DataFrame.
 
@@ -4696,7 +4679,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.is_unique())
 
-    def lazy(self: DF) -> "pli.LazyFrame[DF]":
+    def lazy(self: DF) -> pli.LazyFrame[DF]:
         """
         Start a lazy query from this point. This returns a `LazyFrame` object.
 
@@ -4714,12 +4697,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def select(
         self: DF,
-        exprs: Union[
-            str,
-            "pli.Expr",
-            Sequence[Union[str, "pli.Expr", bool, int, float, "pli.Series"]],
-            "pli.Series",
-        ],
+        exprs: (
+            str
+            | pli.Expr
+            | Sequence[str | pli.Expr | bool | int | float | pli.Series]
+            | pli.Series
+        ),
     ) -> DF:
         """
         Select columns from this DataFrame.
@@ -4761,7 +4744,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def with_columns(
         self: DF,
-        exprs: Union["pli.Expr", "pli.Series", List[Union["pli.Expr", "pli.Series"]]],
+        exprs: pli.Expr | pli.Series | list[pli.Expr | pli.Series],
     ) -> DF:
         """
         Add or overwrite multiple columns in a DataFrame.
@@ -4790,14 +4773,14 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...
 
     @overload
-    def max(self, axis: Literal[1]) -> "pli.Series":
+    def max(self, axis: Literal[1]) -> pli.Series:
         ...
 
     @overload
-    def max(self: DF, axis: int = 0) -> Union[DF, "pli.Series"]:
+    def max(self: DF, axis: int = 0) -> DF | pli.Series:
         ...
 
-    def max(self: DF, axis: int = 0) -> Union[DF, "pli.Series"]:
+    def max(self: DF, axis: int = 0) -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their maximum value.
 
@@ -4832,14 +4815,14 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...
 
     @overload
-    def min(self, axis: Literal[1]) -> "pli.Series":
+    def min(self, axis: Literal[1]) -> pli.Series:
         ...
 
     @overload
-    def min(self: DF, axis: int = 0) -> Union[DF, "pli.Series"]:
+    def min(self: DF, axis: int = 0) -> DF | pli.Series:
         ...
 
-    def min(self: DF, axis: int = 0) -> Union[DF, "pli.Series"]:
+    def min(self: DF, axis: int = 0) -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their minimum value.
 
@@ -4874,18 +4857,18 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...
 
     @overload
-    def sum(self, *, axis: Literal[1], null_strategy: str = "ignore") -> "pli.Series":
+    def sum(self, *, axis: Literal[1], null_strategy: str = "ignore") -> pli.Series:
         ...
 
     @overload
     def sum(
         self: DF, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union[DF, "pli.Series"]:
+    ) -> DF | pli.Series:
         ...
 
     def sum(
         self: DF, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union[DF, "pli.Series"]:
+    ) -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their sum value.
 
@@ -4928,18 +4911,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...
 
     @overload
-    def mean(self, *, axis: Literal[1], null_strategy: str = "ignore") -> "pli.Series":
+    def mean(self, *, axis: Literal[1], null_strategy: str = "ignore") -> pli.Series:
         ...
 
     @overload
     def mean(
         self: DF, *, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union[DF, "pli.Series"]:
+    ) -> DF | pli.Series:
         ...
 
-    def mean(
-        self: DF, axis: int = 0, null_strategy: str = "ignore"
-    ) -> Union[DF, "pli.Series"]:
+    def mean(self: DF, axis: int = 0, null_strategy: str = "ignore") -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their mean value.
 
@@ -5172,7 +5153,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def distinct(
         self: DF,
         maintain_order: bool = True,
-        subset: Optional[Union[str, List[str]]] = None,
+        subset: str | list[str] | None = None,
         keep: str = "first",
     ) -> DF:
         """
@@ -5184,7 +5165,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def unique(
         self: DF,
         maintain_order: bool = True,
-        subset: Optional[Union[str, List[str]]] = None,
+        subset: str | list[str] | None = None,
         keep: str = "first",
     ) -> DF:
         """
@@ -5266,11 +5247,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def sample(
         self: DF,
-        n: Optional[int] = None,
-        frac: Optional[float] = None,
+        n: int | None = None,
+        frac: float | None = None,
         with_replacement: bool = False,
         shuffle: bool = False,
-        seed: Optional[int] = None,
+        seed: int | None = None,
     ) -> DF:
         """
         Sample from this DataFrame by setting either `n` or `frac`.
@@ -5324,8 +5305,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self._from_pydf(self._df.sample_n(n, with_replacement, shuffle, seed))
 
     def fold(
-        self, operation: Callable[["pli.Series", "pli.Series"], "pli.Series"]
-    ) -> "pli.Series":
+        self, operation: Callable[[pli.Series, pli.Series], pli.Series]
+    ) -> pli.Series:
         """
         Apply a horizontal reduction on a DataFrame. This can be used to effectively
         determine aggregations on a row level, and can be applied to any DataType that
@@ -5416,7 +5397,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             acc = operation(acc, self.to_series(i))
         return acc
 
-    def row(self, index: int) -> Tuple[Any]:
+    def row(self, index: int) -> tuple[Any]:
         """
         Get a row as tuple.
 
@@ -5440,7 +5421,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self._df.row_tuple(index)
 
-    def rows(self) -> List[Tuple]:
+    def rows(self) -> list[tuple]:
         """
         Convert columnar data to rows as python tuples.
 
@@ -5468,10 +5449,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...
 
     @overload
-    def shrink_to_fit(self: DF, in_place: bool) -> Optional[DF]:
+    def shrink_to_fit(self: DF, in_place: bool) -> DF | None:
         ...
 
-    def shrink_to_fit(self: DF, in_place: bool = False) -> Optional[DF]:
+    def shrink_to_fit(self: DF, in_place: bool = False) -> DF | None:
         """
         Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
         """
@@ -5506,7 +5487,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def hash_rows(
         self, k0: int = 0, k1: int = 1, k2: int = 2, k3: int = 3
-    ) -> "pli.Series":
+    ) -> pli.Series:
         """
         Hash and combine the rows in this DataFrame.
         Hash value is UInt64.
@@ -5589,7 +5570,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self.height == 0
 
-    def to_struct(self, name: str) -> "pli.Series":
+    def to_struct(self, name: str) -> pli.Series:
         """
         Convert a ``DataFrame`` to a ``Series`` of type ``Struct``
 
@@ -5621,7 +5602,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.to_struct(name))
 
-    def unnest(self: DF, names: Union[str, List[str]]) -> DF:
+    def unnest(self: DF, names: str | list[str]) -> DF:
         """
         Decompose a struct into its fields. The fields will be inserted in to the `DataFrame` on the
         location of the `struct` type.
@@ -5686,9 +5667,9 @@ class RollingGroupBy(Generic[DF]):
         df: DF,
         index_column: str,
         period: str,
-        offset: Optional[str],
+        offset: str | None,
         closed: str = "none",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ):
         self.df = df
         self.time_column = index_column
@@ -5699,12 +5680,12 @@ class RollingGroupBy(Generic[DF]):
 
     def agg(
         self,
-        column_to_agg: Union[
-            List[Tuple[str, List[str]]],
-            Dict[str, Union[str, List[str]]],
-            List["pli.Expr"],
-            "pli.Expr",
-        ],
+        column_to_agg: (
+            list[tuple[str, list[str]]]
+            | dict[str, str | list[str]]
+            | list[pli.Expr]
+            | pli.Expr
+        ),
     ) -> DF:
         return (
             self.df.lazy()
@@ -5727,12 +5708,12 @@ class DynamicGroupBy(Generic[DF]):
         df: DF,
         index_column: str,
         every: str,
-        period: Optional[str],
-        offset: Optional[str],
+        period: str | None,
+        offset: str | None,
         truncate: bool = True,
         include_boundaries: bool = True,
         closed: str = "none",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ):
         self.df = df
         self.time_column = index_column
@@ -5746,12 +5727,12 @@ class DynamicGroupBy(Generic[DF]):
 
     def agg(
         self,
-        column_to_agg: Union[
-            List[Tuple[str, List[str]]],
-            Dict[str, Union[str, List[str]]],
-            List["pli.Expr"],
-            "pli.Expr",
-        ],
+        column_to_agg: (
+            list[tuple[str, list[str]]]
+            | dict[str, str | list[str]]
+            | list[pli.Expr]
+            | pli.Expr
+        ),
     ) -> DF:
         return (
             self.df.lazy()
@@ -5807,9 +5788,9 @@ class GroupBy(Generic[DF]):
 
     def __init__(
         self,
-        df: "PyDataFrame",
-        by: Union[str, List[str]],
-        dataframe_class: Type[DF],
+        df: PyDataFrame,
+        by: str | list[str],
+        dataframe_class: type[DF],
         maintain_order: bool = False,
     ):
         """
@@ -5834,15 +5815,13 @@ class GroupBy(Generic[DF]):
         self.by = by
         self.maintain_order = maintain_order
 
-    def __getitem__(self, item: Any) -> "GBSelection[DF]":
+    def __getitem__(self, item: Any) -> GBSelection[DF]:
         print(
             "accessing GroupBy by index is deprecated, consider using the `.agg` method"
         )
         return self._select(item)
 
-    def _select(
-        self, columns: Union[str, List[str]]
-    ) -> "GBSelection[DF]":  # pragma: no cover
+    def _select(self, columns: str | list[str]) -> GBSelection[DF]:  # pragma: no cover
         """
         Select the columns that will be aggregated.
 
@@ -5871,7 +5850,7 @@ class GroupBy(Generic[DF]):
         for i in range(groups_df.height):
             yield df[groups[i]]
 
-    def get_group(self, group_value: Union[Any, Tuple[Any]]) -> DF:
+    def get_group(self, group_value: Any | tuple[Any]) -> DF:
         """
         Select a single group as a new DataFrame.
 
@@ -6009,12 +5988,12 @@ class GroupBy(Generic[DF]):
 
     def agg(
         self,
-        column_to_agg: Union[
-            List[Tuple[str, List[str]]],
-            Dict[str, Union[str, List[str]]],
-            List["pli.Expr"],
-            "pli.Expr",
-        ],
+        column_to_agg: (
+            list[tuple[str, list[str]]]
+            | dict[str, str | list[str]]
+            | list[pli.Expr]
+            | pli.Expr
+        ),
     ) -> DF:
         """
         Use multiple aggregations on columns. This can be combined with complete lazy API
@@ -6224,7 +6203,7 @@ class GroupBy(Generic[DF]):
             .collect(no_optimization=True, string_cache=False)
         )
 
-    def _select_all(self) -> "GBSelection[DF]":
+    def _select_all(self) -> GBSelection[DF]:
         """
         Select all columns for aggregation.
         """
@@ -6236,8 +6215,8 @@ class GroupBy(Generic[DF]):
         )
 
     def pivot(
-        self, pivot_column: Union[str, List[str]], values_column: Union[str, List[str]]
-    ) -> "PivotOps[DF]":
+        self, pivot_column: str | list[str], values_column: str | list[str]
+    ) -> PivotOps[DF]:
         """
         Do a pivot operation based on the group key, a pivot column and an aggregation function on the values column.
 
@@ -6388,10 +6367,10 @@ class PivotOps(Generic[DF]):
     def __init__(
         self,
         df: DataFrame,
-        by: Union[str, List[str]],
-        pivot_column: Union[str, List[str]],
-        values_column: Union[str, List[str]],
-        dataframe_class: Type[DF],
+        by: str | list[str],
+        pivot_column: str | list[str],
+        values_column: str | list[str],
+        dataframe_class: type[DF],
     ):
         self._df = df
         self.by = by
@@ -6471,10 +6450,10 @@ class GBSelection(Generic[DF]):
 
     def __init__(
         self,
-        df: "PyDataFrame",
-        by: Union[str, List[str]],
-        selection: Optional[List[str]],
-        dataframe_class: Type[DF],
+        df: PyDataFrame,
+        by: str | list[str],
+        selection: list[str] | None,
+        dataframe_class: type[DF],
     ):
         self._df = df
         self.by = by
@@ -6605,7 +6584,7 @@ class GBSelection(Generic[DF]):
     def apply(
         self,
         func: Callable[[Any], Any],
-        return_dtype: Optional[Type[DataType]] = None,
+        return_dtype: type[DataType] | None = None,
     ) -> DF:
         """
         Apply a function over the groups.

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
-from typing import Optional, Sequence, Tuple, Union, overload
+from typing import Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Date
@@ -22,7 +24,7 @@ except ImportError:  # pragma: no cover
     _DOCUMENTING = True
 
 
-def get_dummies(df: "pli.DataFrame") -> "pli.DataFrame":
+def get_dummies(df: pli.DataFrame) -> pli.DataFrame:
     """
     Convert categorical variables into dummy/indicator variables.
 
@@ -36,50 +38,50 @@ def get_dummies(df: "pli.DataFrame") -> "pli.DataFrame":
 
 @overload
 def concat(
-    items: Sequence["pli.DataFrame"],
+    items: Sequence[pli.DataFrame],
     rechunk: bool = True,
     how: str = "vertical",
-) -> "pli.DataFrame":
+) -> pli.DataFrame:
     ...
 
 
 @overload
 def concat(
-    items: Sequence["pli.Series"],
+    items: Sequence[pli.Series],
     rechunk: bool = True,
     how: str = "vertical",
-) -> "pli.Series":
+) -> pli.Series:
     ...
 
 
 @overload
 def concat(
-    items: Sequence["pli.LazyFrame"],
+    items: Sequence[pli.LazyFrame],
     rechunk: bool = True,
     how: str = "vertical",
-) -> "pli.LazyFrame":
+) -> pli.LazyFrame:
     ...
 
 
 @overload
 def concat(
-    items: Sequence["pli.Expr"],
+    items: Sequence[pli.Expr],
     rechunk: bool = True,
     how: str = "vertical",
-) -> "pli.Expr":
+) -> pli.Expr:
     ...
 
 
 def concat(
-    items: Union[
-        Sequence["pli.DataFrame"],
-        Sequence["pli.Series"],
-        Sequence["pli.LazyFrame"],
-        Sequence["pli.Expr"],
-    ],
+    items: (
+        Sequence[pli.DataFrame]
+        | Sequence[pli.Series]
+        | Sequence[pli.LazyFrame]
+        | Sequence[pli.Expr]
+    ),
     rechunk: bool = True,
     how: str = "vertical",
-) -> Union["pli.DataFrame", "pli.Series", "pli.LazyFrame", "pli.Expr"]:
+) -> pli.DataFrame | pli.Series | pli.LazyFrame | pli.Expr:
     """
     Aggregate all the Dataframes/Series in a List of DataFrames/Series to a single DataFrame/Series.
 
@@ -118,7 +120,7 @@ def concat(
     if not len(items) > 0:
         raise ValueError("cannot concat empty list")
 
-    out: Union["pli.Series", "pli.DataFrame", "pli.LazyFrame", "pli.Expr"]
+    out: pli.Series | pli.DataFrame | pli.LazyFrame | pli.Expr
     first = items[0]
     if isinstance(first, pli.DataFrame):
         if how == "vertical":
@@ -147,7 +149,7 @@ def concat(
     return out
 
 
-def _ensure_datetime(value: Union[date, datetime]) -> Tuple[datetime, bool]:
+def _ensure_datetime(value: date | datetime) -> tuple[datetime, bool]:
     is_date_type = False
     if isinstance(value, date) and not isinstance(value, datetime):
         value = datetime(value.year, value.month, value.day)
@@ -160,13 +162,13 @@ def _interval_granularity(interval: str) -> str:
 
 
 def date_range(
-    low: Union[date, datetime],
-    high: Union[date, datetime],
-    interval: Union[str, timedelta],
-    closed: Optional[str] = "both",
-    name: Optional[str] = None,
-    time_unit: Optional[str] = None,
-) -> "pli.Series":
+    low: date | datetime,
+    high: date | datetime,
+    interval: str | timedelta,
+    closed: str | None = "both",
+    name: str | None = None,
+    time_unit: str | None = None,
+) -> pli.Series:
     """
     Create a range of type `Datetime` (or `Date`).
 

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -1,19 +1,10 @@
+from __future__ import annotations
+
 import glob
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import (
-    Any,
-    BinaryIO,
-    ContextManager,
-    Dict,
-    Iterator,
-    List,
-    TextIO,
-    Type,
-    Union,
-    overload,
-)
+from typing import Any, BinaryIO, ContextManager, Iterator, TextIO, overload
 from urllib.request import urlopen
 
 from polars.datatypes import DataType
@@ -41,28 +32,28 @@ def _process_http_file(path: str) -> BytesIO:
 
 @overload
 def _prepare_file_arg(
-    file: Union[str, List[str], Path, BinaryIO, bytes], **kwargs: Any
-) -> ContextManager[Union[str, BinaryIO]]:
+    file: str | list[str] | Path | BinaryIO | bytes, **kwargs: Any
+) -> ContextManager[str | BinaryIO]:
     ...
 
 
 @overload
 def _prepare_file_arg(
-    file: Union[str, TextIO, Path, BinaryIO, bytes], **kwargs: Any
-) -> ContextManager[Union[str, BinaryIO]]:
+    file: str | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+) -> ContextManager[str | BinaryIO]:
     ...
 
 
 @overload
 def _prepare_file_arg(
-    file: Union[str, List[str], TextIO, Path, BinaryIO, bytes], **kwargs: Any
-) -> ContextManager[Union[str, List[str], BinaryIO, List[BinaryIO]]]:
+    file: str | list[str] | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+) -> ContextManager[str | list[str] | BinaryIO | list[BinaryIO]]:
     ...
 
 
 def _prepare_file_arg(
-    file: Union[str, List[str], TextIO, Path, BinaryIO, bytes], **kwargs: Any
-) -> ContextManager[Union[str, BinaryIO, List[str], List[BinaryIO]]]:
+    file: str | list[str] | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+) -> ContextManager[str | BinaryIO | list[str] | list[BinaryIO]]:
     """
     Utility for read_[csv, parquet]. (not to be used by scan_[csv, parquet]).
     Returned value is always usable as a context.
@@ -106,9 +97,7 @@ def _prepare_file_arg(
     return managed_file(file)
 
 
-def read_ipc_schema(
-    file: Union[str, BinaryIO, Path, bytes]
-) -> Dict[str, Type[DataType]]:
+def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, type[DataType]]:
     """
     Get a schema of the IPC file without reading data.
 
@@ -128,8 +117,8 @@ def read_ipc_schema(
 
 
 def read_parquet_schema(
-    file: Union[str, BinaryIO, Path, bytes]
-) -> Dict[str, Type[DataType]]:
+    file: str | BinaryIO | Path | bytes,
+) -> dict[str, type[DataType]]:
     """
     Get a schema of the Parquet file without reading data.
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -746,9 +746,15 @@ class LazyFrame(Generic[DF]):
         """
         return self._from_pyldf(self._ldf.cache())
 
+    def cleared(self: LDF) -> LDF:
+        """
+        Create an empty copy of the current LazyFrame, with identical schema but no data.
+        """
+        return self._dataframe_class(columns=self.schema).lazy()
+
     def clone(self: LDF) -> LDF:
         """
-        Cheap deepcopy/clone.
+        Very cheap deepcopy/clone.
         """
         return self._from_pyldf(self._ldf.clone())
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1,6 +1,8 @@
 """
 This module contains all expressions and classes needed for lazy computation/ query execution.
 """
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
@@ -9,20 +11,7 @@ import tempfile
 import warnings
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Generic, Sequence, TypeVar, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -65,13 +54,13 @@ LDF = TypeVar("LDF", bound="LazyFrame")
 DF = TypeVar("DF", bound="pli.DataFrame")
 
 
-def wrap_ldf(ldf: "PyLazyFrame") -> "LazyFrame":
+def wrap_ldf(ldf: PyLazyFrame) -> LazyFrame:
     return LazyFrame._from_pyldf(ldf)
 
 
 def _prepare_groupby_inputs(
-    by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]],
-) -> List["PyExpr"]:
+    by: str | list[str] | pli.Expr | list[pli.Expr] | None,
+) -> list[PyExpr]:
     if isinstance(by, list):
         new_by = []
         for e in by:
@@ -96,13 +85,13 @@ class LazyFrame(Generic[DF]):
         self._ldf: PyLazyFrame
 
     @classmethod
-    def _from_pyldf(cls: Type[LDF], ldf: "PyLazyFrame") -> LDF:
+    def _from_pyldf(cls: type[LDF], ldf: PyLazyFrame) -> LDF:
         self = cls.__new__(cls)
         self._ldf = ldf
         return self
 
     @property
-    def _dataframe_class(self) -> Type[DF]:
+    def _dataframe_class(self) -> type[DF]:
         """
         Return the associated DataFrame which is the equivalent of this LazyFrame object.
 
@@ -120,32 +109,32 @@ class LazyFrame(Generic[DF]):
 
     @classmethod
     def scan_csv(
-        cls: Type[LDF],
+        cls: type[LDF],
         file: str,
         has_header: bool = True,
         sep: str = ",",
-        comment_char: Optional[str] = None,
-        quote_char: Optional[str] = r'"',
+        comment_char: str | None = None,
+        quote_char: str | None = r'"',
         skip_rows: int = 0,
-        dtypes: Optional[Dict[str, Type[DataType]]] = None,
-        null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
+        dtypes: dict[str, type[DataType]] | None = None,
+        null_values: str | list[str] | dict[str, str] | None = None,
         ignore_errors: bool = False,
         cache: bool = True,
-        with_column_names: Optional[Callable[[List[str]], List[str]]] = None,
-        infer_schema_length: Optional[int] = 100,
-        n_rows: Optional[int] = None,
+        with_column_names: Callable[[list[str]], list[str]] | None = None,
+        infer_schema_length: int | None = 100,
+        n_rows: int | None = None,
         encoding: str = "utf8",
         low_memory: bool = False,
         rechunk: bool = True,
         skip_rows_after_header: int = 0,
-        row_count_name: Optional[str] = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
         parse_dates: bool = False,
     ) -> LDF:
         """
         See Also: `pl.scan_csv`
         """
-        dtype_list: Optional[List[Tuple[str, Type[DataType]]]] = None
+        dtype_list: list[tuple[str, type[DataType]]] | None = None
         if dtypes is not None:
             dtype_list = []
             for k, v in dtypes.items():
@@ -178,15 +167,15 @@ class LazyFrame(Generic[DF]):
 
     @classmethod
     def scan_parquet(
-        cls: Type[LDF],
+        cls: type[LDF],
         file: str,
-        n_rows: Optional[int] = None,
+        n_rows: int | None = None,
         cache: bool = True,
         parallel: bool = True,
         rechunk: bool = True,
-        row_count_name: Optional[str] = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
-        storage_options: Optional[Dict] = None,
+        storage_options: dict | None = None,
     ) -> LDF:
         """
         See Also: `pl.scan_parquet`
@@ -214,14 +203,14 @@ class LazyFrame(Generic[DF]):
 
     @classmethod
     def scan_ipc(
-        cls: Type[LDF],
-        file: Union[str, Path],
-        n_rows: Optional[int] = None,
+        cls: type[LDF],
+        file: str | Path,
+        n_rows: int | None = None,
         cache: bool = True,
         rechunk: bool = True,
-        row_count_name: Optional[str] = None,
+        row_count_name: str | None = None,
         row_count_offset: int = 0,
-        storage_options: Optional[Dict] = None,
+        storage_options: dict | None = None,
     ) -> LDF:
         """
         See Also: `pl.scan_ipc`
@@ -249,7 +238,7 @@ class LazyFrame(Generic[DF]):
         return self
 
     @classmethod
-    def from_json(cls, json: str) -> "LazyFrame":
+    def from_json(cls, json: str) -> LazyFrame:
         """
         See Also pl.read_json
         """
@@ -259,8 +248,8 @@ class LazyFrame(Generic[DF]):
     @classmethod
     def read_json(
         cls,
-        file: Union[str, Path, IOBase],
-    ) -> "LazyFrame":
+        file: str | Path | IOBase,
+    ) -> LazyFrame:
         """
         See Also pl.read_json
         """
@@ -274,7 +263,7 @@ class LazyFrame(Generic[DF]):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         *,
         to_string: Literal[True],
     ) -> str:
@@ -283,7 +272,7 @@ class LazyFrame(Generic[DF]):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         *,
         to_string: Literal[False] = ...,
     ) -> None:
@@ -292,18 +281,18 @@ class LazyFrame(Generic[DF]):
     @overload
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = ...,
+        file: IOBase | str | Path | None = ...,
         *,
         to_string: bool = ...,
-    ) -> Optional[str]:
+    ) -> str | None:
         ...
 
     def write_json(
         self,
-        file: Optional[Union[IOBase, str, Path]] = None,
+        file: IOBase | str | Path | None = None,
         *,
         to_string: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Serialize LogicalPlan to JSON representation.
 
@@ -333,8 +322,8 @@ class LazyFrame(Generic[DF]):
 
     @classmethod
     def _scan_python_function(
-        cls, schema: Union["pa.schema", Dict[str, Type[DataType]]], scan_fn: bytes
-    ) -> "LazyFrame":
+        cls, schema: pa.schema | dict[str, type[DataType]], scan_fn: bytes
+    ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, dict):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
@@ -346,7 +335,7 @@ class LazyFrame(Generic[DF]):
             )
         return self
 
-    def __getitem__(self, item: Union[int, range, slice]) -> None:
+    def __getitem__(self, item: int | range | slice) -> None:
         raise TypeError(
             "'LazyFrame' object is not subscriptable. Use 'select()' or 'filter()' instead."
         )
@@ -442,10 +431,10 @@ class LazyFrame(Generic[DF]):
         self,
         optimized: bool = True,
         show: bool = True,
-        output_path: Optional[str] = None,
+        output_path: str | None = None,
         raw_output: bool = False,
-        figsize: Tuple[float, float] = (16.0, 12.0),
-    ) -> Optional[str]:
+        figsize: tuple[float, float] = (16.0, 12.0),
+    ) -> str | None:
         """
         Show a plot of the query plan. Note that you should have graphviz installed.
 
@@ -532,8 +521,8 @@ class LazyFrame(Generic[DF]):
 
     def sort(
         self: LDF,
-        by: Union[str, "pli.Expr", List[str], List["pli.Expr"]],
-        reverse: Union[bool, List[bool]] = False,
+        by: str | pli.Expr | list[str] | list[pli.Expr],
+        reverse: bool | list[bool] = False,
         nulls_last: bool = False,
     ) -> LDF:
         """
@@ -683,7 +672,7 @@ class LazyFrame(Generic[DF]):
         return self._dataframe_class._from_pydf(ldf.fetch(n_rows))
 
     @property
-    def columns(self) -> List[str]:
+    def columns(self) -> list[str]:
         """
         Get or set column names.
 
@@ -709,7 +698,7 @@ class LazyFrame(Generic[DF]):
         return self._ldf.columns()
 
     @property
-    def dtypes(self) -> List[Type[DataType]]:
+    def dtypes(self) -> list[type[DataType]]:
         """
         Get dtypes of columns in LazyFrame.
 
@@ -732,7 +721,7 @@ class LazyFrame(Generic[DF]):
         return self._ldf.dtypes()
 
     @property
-    def schema(self) -> Dict[str, Type[DataType]]:
+    def schema(self) -> dict[str, type[DataType]]:
         """
         Get a dict[column name, DataType]
 
@@ -769,7 +758,7 @@ class LazyFrame(Generic[DF]):
     def __deepcopy__(self: LDF, memodict={}) -> LDF:  # type: ignore
         return self.clone()
 
-    def filter(self: LDF, predicate: Union["pli.Expr", str]) -> LDF:
+    def filter(self: LDF, predicate: pli.Expr | str) -> LDF:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -822,9 +811,7 @@ class LazyFrame(Generic[DF]):
 
     def select(
         self: LDF,
-        exprs: Union[
-            str, "pli.Expr", Sequence[str], Sequence["pli.Expr"], "pli.Series"
-        ],
+        exprs: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | pli.Series,
     ) -> LDF:
         """
         Select columns from this DataFrame.
@@ -864,9 +851,9 @@ class LazyFrame(Generic[DF]):
 
     def groupby(
         self: LDF,
-        by: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
+        by: str | list[str] | pli.Expr | list[pli.Expr],
         maintain_order: bool = False,
-    ) -> "LazyGroupBy[LDF]":
+    ) -> LazyGroupBy[LDF]:
         """
         Start a groupby operation.
 
@@ -914,10 +901,10 @@ class LazyFrame(Generic[DF]):
         self: LDF,
         index_column: str,
         period: str,
-        offset: Optional[str] = None,
+        offset: str | None = None,
         closed: str = "right",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
-    ) -> "LazyGroupBy[LDF]":
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+    ) -> LazyGroupBy[LDF]:
         """
         Create rolling groups based on a time column (or index value of type Int32, Int64).
 
@@ -1029,13 +1016,13 @@ class LazyFrame(Generic[DF]):
         self: LDF,
         index_column: str,
         every: str,
-        period: Optional[str] = None,
-        offset: Optional[str] = None,
+        period: str | None = None,
+        offset: str | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: str = "right",
-        by: Optional[Union[str, List[str], "pli.Expr", List["pli.Expr"]]] = None,
-    ) -> "LazyGroupBy[LDF]":
+        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+    ) -> LazyGroupBy[LDF]:
         """
         Groups based on a time value (or index value of type Int32, Int64). Time windows are calculated and rows are assigned to windows.
         Different from a normal groupby is that a row can be member of multiple groups. The time/index window could
@@ -1125,16 +1112,16 @@ class LazyFrame(Generic[DF]):
     @deprecated_alias(ldf="other")
     def join_asof(
         self: LDF,
-        other: "LazyFrame",
-        left_on: Optional[str] = None,
-        right_on: Optional[str] = None,
-        on: Optional[str] = None,
-        by_left: Optional[Union[str, List[str]]] = None,
-        by_right: Optional[Union[str, List[str]]] = None,
-        by: Optional[Union[str, List[str]]] = None,
+        other: LazyFrame,
+        left_on: str | None = None,
+        right_on: str | None = None,
+        on: str | None = None,
+        by_left: str | list[str] | None = None,
+        by_right: str | list[str] | None = None,
+        by: str | list[str] | None = None,
         strategy: str = "backward",
         suffix: str = "_right",
-        tolerance: Optional[Union[str, int, float]] = None,
+        tolerance: str | int | float | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> LDF:
@@ -1209,13 +1196,13 @@ class LazyFrame(Generic[DF]):
         if left_on is None or right_on is None:
             raise ValueError("You should pass the column to join on as an argument.")
 
-        by_left_: Union[List[str], None]
+        by_left_: list[str] | None
         if isinstance(by_left, str):
             by_left_ = [by_left]
         else:
             by_left_ = by_left
 
-        by_right_: Union[List[str], None]
+        by_right_: list[str] | None
         if isinstance(by_right, (str, pli.Expr)):
             by_right_ = [by_right]
         else:
@@ -1228,8 +1215,8 @@ class LazyFrame(Generic[DF]):
             by_left_ = by
             by_right_ = by
 
-        tolerance_str: Optional[str] = None
-        tolerance_num: Optional[Union[float, int]] = None
+        tolerance_str: str | None = None
+        tolerance_num: float | int | None = None
         if isinstance(tolerance, str):
             tolerance_str = tolerance
         else:
@@ -1254,17 +1241,17 @@ class LazyFrame(Generic[DF]):
     @deprecated_alias(ldf="other")
     def join(
         self: LDF,
-        other: "LazyFrame",
-        left_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
-        right_on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
-        on: Optional[Union[str, "pli.Expr", List[Union[str, "pli.Expr"]]]] = None,
+        other: LazyFrame,
+        left_on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        right_on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        on: str | pli.Expr | list[str | pli.Expr] | None = None,
         how: str = "inner",
         suffix: str = "_right",
         allow_parallel: bool = True,
         force_parallel: bool = False,
-        asof_by: Optional[Union[str, List[str]]] = None,
-        asof_by_left: Optional[Union[str, List[str]]] = None,
-        asof_by_right: Optional[Union[str, List[str]]] = None,
+        asof_by: str | list[str] | None = None,
+        asof_by_left: str | list[str] | None = None,
+        asof_by_right: str | list[str] | None = None,
     ) -> LDF:
         """
         Add a join operation to the Logical Plan.
@@ -1372,13 +1359,13 @@ class LazyFrame(Generic[DF]):
                 )
             )
 
-        left_on_: Optional[List[Union[str, pli.Expr]]]
+        left_on_: list[str | pli.Expr] | None
         if isinstance(left_on, (str, pli.Expr)):
             left_on_ = [left_on]
         else:
             left_on_ = left_on
 
-        right_on_: Optional[List[Union[str, pli.Expr]]]
+        right_on_: list[str | pli.Expr] | None
         if isinstance(right_on, (str, pli.Expr)):
             right_on_ = [right_on]
         else:
@@ -1407,13 +1394,13 @@ class LazyFrame(Generic[DF]):
 
         # set asof_by
 
-        left_asof_by_: Union[List[str], None]
+        left_asof_by_: list[str] | None
         if isinstance(asof_by_left, str):
             left_asof_by_ = [asof_by_left]
         else:
             left_asof_by_ = asof_by_left
 
-        right_asof_by_: Union[List[str], None]
+        right_asof_by_: list[str] | None
         if isinstance(asof_by_right, (str, pli.Expr)):
             right_asof_by_ = [asof_by_right]
         else:
@@ -1447,7 +1434,7 @@ class LazyFrame(Generic[DF]):
 
     def with_columns(
         self: LDF,
-        exprs: Union["pli.Expr", "pli.Series", List[Union["pli.Expr", "pli.Series"]]],
+        exprs: pli.Expr | pli.Series | list[pli.Expr | pli.Series],
     ) -> LDF:
         """
         Add or overwrite multiple columns in a DataFrame.
@@ -1472,7 +1459,7 @@ class LazyFrame(Generic[DF]):
 
         return self._from_pyldf(self._ldf.with_columns(pyexprs))
 
-    def with_column(self: LDF, expr: "pli.Expr") -> LDF:
+    def with_column(self: LDF, expr: pli.Expr) -> LDF:
         """
         Add or overwrite column in a DataFrame.
 
@@ -1520,7 +1507,7 @@ class LazyFrame(Generic[DF]):
         """
         return self.with_columns([expr])
 
-    def drop(self: LDF, columns: Union[str, List[str]]) -> LDF:
+    def drop(self: LDF, columns: str | list[str]) -> LDF:
         """
         Remove one or multiple columns from a DataFrame.
 
@@ -1535,7 +1522,7 @@ class LazyFrame(Generic[DF]):
             columns = [columns]
         return self._from_pyldf(self._ldf.drop_columns(columns))
 
-    def rename(self: LDF, mapping: Dict[str, str]) -> LDF:
+    def rename(self: LDF, mapping: dict[str, str]) -> LDF:
         """
         Rename column names.
 
@@ -1606,7 +1593,7 @@ class LazyFrame(Generic[DF]):
     def shift_and_fill(
         self: LDF,
         periods: int,
-        fill_value: Union["pli.Expr", int, str, float],
+        fill_value: pli.Expr | int | str | float,
     ) -> LDF:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
@@ -1660,7 +1647,7 @@ class LazyFrame(Generic[DF]):
             fill_value = pli.lit(fill_value)
         return self._from_pyldf(self._ldf.shift_and_fill(periods, fill_value._pyexpr))
 
-    def slice(self: LDF, offset: int, length: Optional[int] = None) -> LDF:
+    def slice(self: LDF, offset: int, length: int | None = None) -> LDF:
         """
         Slice the DataFrame.
 
@@ -1810,7 +1797,7 @@ class LazyFrame(Generic[DF]):
         """
         return self.select(pli.col("*").take_every(n))
 
-    def fill_null(self: LDF, fill_value: Union[int, str, "pli.Expr"]) -> LDF:
+    def fill_null(self: LDF, fill_value: int | str | pli.Expr) -> LDF:
         """
         Fill missing values with a literal or Expr.
 
@@ -1823,7 +1810,7 @@ class LazyFrame(Generic[DF]):
             fill_value = pli.lit(fill_value)
         return self._from_pyldf(self._ldf.fill_null(fill_value._pyexpr))
 
-    def fill_nan(self: LDF, fill_value: Union[int, str, float, "pli.Expr"]) -> LDF:
+    def fill_nan(self: LDF, fill_value: int | str | float | pli.Expr) -> LDF:
         """
         Fill floating point NaN values.
 
@@ -1892,7 +1879,7 @@ class LazyFrame(Generic[DF]):
 
     def explode(
         self: LDF,
-        columns: Union[str, List[str], "pli.Expr", List["pli.Expr"]],
+        columns: str | list[str] | pli.Expr | list[pli.Expr],
     ) -> LDF:
         """
         Explode lists to long format.
@@ -1958,7 +1945,7 @@ class LazyFrame(Generic[DF]):
     def distinct(
         self: LDF,
         maintain_order: bool = True,
-        subset: Optional[Union[str, List[str]]] = None,
+        subset: str | list[str] | None = None,
         keep: str = "first",
     ) -> LDF:
         """
@@ -1970,7 +1957,7 @@ class LazyFrame(Generic[DF]):
     def unique(
         self: LDF,
         maintain_order: bool = True,
-        subset: Optional[Union[str, List[str]]] = None,
+        subset: str | list[str] | None = None,
         keep: str = "first",
     ) -> LDF:
         """
@@ -1994,7 +1981,7 @@ class LazyFrame(Generic[DF]):
             subset = [subset]
         return self._from_pyldf(self._ldf.unique(maintain_order, subset, keep))
 
-    def drop_nulls(self: LDF, subset: Optional[Union[List[str], str]] = None) -> LDF:
+    def drop_nulls(self: LDF, subset: list[str] | str | None = None) -> LDF:
         """
         Drop rows with null values from this DataFrame.
 
@@ -2076,10 +2063,10 @@ class LazyFrame(Generic[DF]):
 
     def melt(
         self: LDF,
-        id_vars: Optional[Union[str, List[str]]] = None,
-        value_vars: Optional[Union[str, List[str]]] = None,
-        variable_name: Optional[str] = None,
-        value_name: Optional[str] = None,
+        id_vars: str | list[str] | None = None,
+        value_vars: str | list[str] | None = None,
+        variable_name: str | None = None,
+        value_name: str | None = None,
     ) -> LDF:
         """
         Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
@@ -2145,7 +2132,7 @@ class LazyFrame(Generic[DF]):
 
     def map(
         self: LDF,
-        f: Callable[["pli.DataFrame"], "pli.DataFrame"],
+        f: Callable[[pli.DataFrame], pli.DataFrame],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         no_optimizations: bool = False,
@@ -2204,7 +2191,7 @@ class LazyFrame(Generic[DF]):
         """
         return self.select(pli.col("*").interpolate())
 
-    def unnest(self: LDF, names: Union[str, List[str]]) -> LDF:
+    def unnest(self: LDF, names: str | list[str]) -> LDF:
         """
         Decompose a struct into its fields. The fields will be inserted in to the `DataFrame` on the
         location of the `struct` type.
@@ -2224,11 +2211,11 @@ class LazyGroupBy(Generic[LDF]):
     Created by `df.lazy().groupby("foo)"`
     """
 
-    def __init__(self, lgb: "PyLazyGroupBy", lazyframe_class: Type[LDF]) -> None:
+    def __init__(self, lgb: PyLazyGroupBy, lazyframe_class: type[LDF]) -> None:
         self.lgb = lgb
         self._lazyframe_class = lazyframe_class
 
-    def agg(self, aggs: Union[List["pli.Expr"], "pli.Expr"]) -> LDF:
+    def agg(self, aggs: list[pli.Expr] | pli.Expr) -> LDF:
         """
         Describe the aggregation that need to be done on a group.
 
@@ -2371,7 +2358,7 @@ class LazyGroupBy(Generic[LDF]):
         """
         return self._lazyframe_class._from_pyldf(self.lgb.tail(n))
 
-    def apply(self, f: Callable[["pli.DataFrame"], "pli.DataFrame"]) -> LDF:
+    def apply(self, f: Callable[[pli.DataFrame], pli.DataFrame]) -> LDF:
         """
         Apply a function over the groups as a new `DataFrame`.
         Implementing logic using this .apply method is generally slower and more memory intensive

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1789,6 +1789,27 @@ class LazyFrame(Generic[DF]):
         """
         return self._from_pyldf(self._ldf.with_row_count(name, offset))
 
+    def take_every(self: LDF, n: int) -> LDF:
+        """
+        Take every nth row in the LazyFrame and return as a new LazyFrame.
+
+        Examples
+        --------
+        >>> s = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]}).lazy()
+        >>> s.take_every(2).collect()
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 5   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+        """
+        return self.select(pli.col("*").take_every(n))
+
     def fill_null(self: LDF, fill_value: Union[int, str, "pli.Expr"]) -> LDF:
         """
         Fill missing values with a literal or Expr.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sys
 from datetime import date, datetime, timedelta
 from inspect import isclass
-from typing import Any, Callable, List, Optional, Sequence, Type, Union, cast, overload
+from typing import Any, Callable, Sequence, cast, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -58,14 +60,8 @@ except ImportError:  # pragma: no cover
 
 
 def col(
-    name: Union[
-        str,
-        List[str],
-        Sequence[PolarsDataType],
-        "pli.Series",
-        PolarsDataType,
-    ]
-) -> "pli.Expr":
+    name: (str | list[str] | Sequence[PolarsDataType] | pli.Series | PolarsDataType),
+) -> pli.Expr:
     """
     A column in a DataFrame.
     Can be used to select:
@@ -182,7 +178,7 @@ def col(
     return pli.wrap_expr(pycol(name))
 
 
-def element() -> "pli.Expr":
+def element() -> pli.Expr:
     """
     Alias for an element in evaluated in an `eval` expression
 
@@ -233,21 +229,21 @@ def element() -> "pli.Expr":
 
 
 @overload
-def count(column: str) -> "pli.Expr":
+def count(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def count(column: "pli.Series") -> int:
+def count(column: pli.Series) -> int:
     ...
 
 
 @overload
-def count(column: None = None) -> "pli.Expr":
+def count(column: None = None) -> pli.Expr:
     ...
 
 
-def count(column: Optional[Union[str, "pli.Series"]] = None) -> Union["pli.Expr", int]:
+def count(column: str | pli.Series | None = None) -> pli.Expr | int:
     """
     Count the number of values in this column/context.
 
@@ -267,7 +263,7 @@ def count(column: Optional[Union[str, "pli.Series"]] = None) -> Union["pli.Expr"
     return col(column).count()
 
 
-def to_list(name: str) -> "pli.Expr":
+def to_list(name: str) -> pli.Expr:
     """
     Aggregate to list.
 
@@ -277,16 +273,16 @@ def to_list(name: str) -> "pli.Expr":
 
 
 @overload
-def std(column: str) -> "pli.Expr":
+def std(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def std(column: "pli.Series") -> Optional[float]:
+def std(column: pli.Series) -> float | None:
     ...
 
 
-def std(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
+def std(column: str | pli.Series) -> pli.Expr | float | None:
     """
     Get the standard deviation.
     """
@@ -296,16 +292,16 @@ def std(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
 
 
 @overload
-def var(column: str) -> "pli.Expr":
+def var(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def var(column: "pli.Series") -> Optional[float]:
+def var(column: pli.Series) -> float | None:
     ...
 
 
-def var(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
+def var(column: str | pli.Series) -> pli.Expr | float | None:
     """
     Get the variance.
     """
@@ -315,18 +311,16 @@ def var(column: Union[str, "pli.Series"]) -> Union["pli.Expr", Optional[float]]:
 
 
 @overload
-def max(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
+def max(column: str | list[pli.Expr | str]) -> pli.Expr:
     ...
 
 
 @overload
-def max(column: "pli.Series") -> Union[int, float]:
+def max(column: pli.Series) -> int | float:
     ...
 
 
-def max(
-    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
-) -> Union["pli.Expr", Any]:
+def max(column: str | list[pli.Expr | str] | pli.Series) -> pli.Expr | Any:
     """
     Get the maximum value. Can be used horizontally or vertically.
 
@@ -348,18 +342,16 @@ def max(
 
 
 @overload
-def min(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
+def min(column: str | list[pli.Expr | str]) -> pli.Expr:
     ...
 
 
 @overload
-def min(column: "pli.Series") -> Union[int, float]:
+def min(column: pli.Series) -> int | float:
     ...
 
 
-def min(
-    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
-) -> Union["pli.Expr", Any]:
+def min(column: str | list[pli.Expr | str] | pli.Series) -> pli.Expr | Any:
     """
     Get the minimum value.
 
@@ -379,18 +371,16 @@ def min(
 
 
 @overload
-def sum(column: Union[str, List[Union["pli.Expr", str]]]) -> "pli.Expr":
+def sum(column: str | list[pli.Expr | str]) -> pli.Expr:
     ...
 
 
 @overload
-def sum(column: "pli.Series") -> Union[int, float]:
+def sum(column: pli.Series) -> int | float:
     ...
 
 
-def sum(
-    column: Union[str, List[Union["pli.Expr", str]], "pli.Series"]
-) -> Union["pli.Expr", Any]:
+def sum(column: str | list[pli.Expr | str] | pli.Series) -> pli.Expr | Any:
     """
     Get the sum value.
 
@@ -412,16 +402,16 @@ def sum(
 
 
 @overload
-def mean(column: str) -> "pli.Expr":
+def mean(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def mean(column: "pli.Series") -> float:
+def mean(column: pli.Series) -> float:
     ...
 
 
-def mean(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
+def mean(column: str | pli.Series) -> pli.Expr | float:
     """
     Get the mean value.
     """
@@ -431,16 +421,16 @@ def mean(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
 
 
 @overload
-def avg(column: str) -> "pli.Expr":
+def avg(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def avg(column: "pli.Series") -> float:
+def avg(column: pli.Series) -> float:
     ...
 
 
-def avg(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
+def avg(column: str | pli.Series) -> pli.Expr | float:
     """
     Alias for mean.
     """
@@ -448,16 +438,16 @@ def avg(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float]:
 
 
 @overload
-def median(column: str) -> "pli.Expr":
+def median(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def median(column: "pli.Series") -> Union[float, int]:
+def median(column: pli.Series) -> float | int:
     ...
 
 
-def median(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float, int]:
+def median(column: str | pli.Series) -> pli.Expr | float | int:
     """
     Get the median value.
     """
@@ -467,16 +457,16 @@ def median(column: Union[str, "pli.Series"]) -> Union["pli.Expr", float, int]:
 
 
 @overload
-def n_unique(column: str) -> "pli.Expr":
+def n_unique(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def n_unique(column: "pli.Series") -> int:
+def n_unique(column: pli.Series) -> int:
     ...
 
 
-def n_unique(column: Union[str, "pli.Series"]) -> Union["pli.Expr", int]:
+def n_unique(column: str | pli.Series) -> pli.Expr | int:
     """Count unique values."""
     if isinstance(column, pli.Series):
         return column.n_unique()
@@ -484,21 +474,21 @@ def n_unique(column: Union[str, "pli.Series"]) -> Union["pli.Expr", int]:
 
 
 @overload
-def first(column: str) -> "pli.Expr":
+def first(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def first(column: "pli.Series") -> Any:
+def first(column: pli.Series) -> Any:
     ...
 
 
 @overload
-def first(column: None = None) -> "pli.Expr":
+def first(column: None = None) -> pli.Expr:
     ...
 
 
-def first(column: Optional[Union[str, "pli.Series"]] = None) -> Union["pli.Expr", Any]:
+def first(column: str | pli.Series | None = None) -> pli.Expr | Any:
     """
     Get the first value.
 
@@ -524,21 +514,21 @@ def first(column: Optional[Union[str, "pli.Series"]] = None) -> Union["pli.Expr"
 
 
 @overload
-def last(column: str) -> "pli.Expr":
+def last(column: str) -> pli.Expr:
     ...
 
 
 @overload
-def last(column: "pli.Series") -> Any:
+def last(column: pli.Series) -> Any:
     ...
 
 
 @overload
-def last(column: None = None) -> "pli.Expr":
+def last(column: None = None) -> pli.Expr:
     ...
 
 
-def last(column: Optional[Union[str, "pli.Series"]] = None) -> "pli.Expr":
+def last(column: str | pli.Series | None = None) -> pli.Expr:
     """
     Get the last value.
 
@@ -563,18 +553,16 @@ def last(column: Optional[Union[str, "pli.Series"]] = None) -> "pli.Expr":
 
 
 @overload
-def head(column: str, n: Optional[int]) -> "pli.Expr":
+def head(column: str, n: int | None) -> pli.Expr:
     ...
 
 
 @overload
-def head(column: "pli.Series", n: Optional[int]) -> "pli.Series":
+def head(column: pli.Series, n: int | None) -> pli.Series:
     ...
 
 
-def head(
-    column: Union[str, "pli.Series"], n: Optional[int] = None
-) -> Union["pli.Expr", "pli.Series"]:
+def head(column: str | pli.Series, n: int | None = None) -> pli.Expr | pli.Series:
     """
     Get the first n rows of an Expression.
 
@@ -591,18 +579,16 @@ def head(
 
 
 @overload
-def tail(column: str, n: Optional[int]) -> "pli.Expr":
+def tail(column: str, n: int | None) -> pli.Expr:
     ...
 
 
 @overload
-def tail(column: "pli.Series", n: Optional[int]) -> "pli.Series":
+def tail(column: pli.Series, n: int | None) -> pli.Series:
     ...
 
 
-def tail(
-    column: Union[str, "pli.Series"], n: Optional[int] = None
-) -> Union["pli.Expr", "pli.Series"]:
+def tail(column: str | pli.Series, n: int | None = None) -> pli.Expr | pli.Series:
     """
     Get the last n rows of an Expression.
 
@@ -619,11 +605,9 @@ def tail(
 
 
 def lit(
-    value: Optional[
-        Union[float, int, str, date, datetime, "pli.Series", np.ndarray, Any]
-    ],
-    dtype: Optional[Type[DataType]] = None,
-) -> "pli.Expr":
+    value: None | (float | int | str | date | datetime | pli.Series | np.ndarray | Any),
+    dtype: type[DataType] | None = None,
+) -> pli.Expr:
     """
     A literal value.
 
@@ -704,9 +688,9 @@ def lit(
 
 
 def spearman_rank_corr(
-    a: Union[str, "pli.Expr"],
-    b: Union[str, "pli.Expr"],
-) -> "pli.Expr":
+    a: str | pli.Expr,
+    b: str | pli.Expr,
+) -> pli.Expr:
     """
     Compute the spearman rank correlation between two columns.
 
@@ -725,9 +709,9 @@ def spearman_rank_corr(
 
 
 def pearson_corr(
-    a: Union[str, "pli.Expr"],
-    b: Union[str, "pli.Expr"],
-) -> "pli.Expr":
+    a: str | pli.Expr,
+    b: str | pli.Expr,
+) -> pli.Expr:
     """
     Compute the pearson's correlation between two columns.
 
@@ -746,9 +730,9 @@ def pearson_corr(
 
 
 def cov(
-    a: Union[str, "pli.Expr"],
-    b: Union[str, "pli.Expr"],
-) -> "pli.Expr":
+    a: str | pli.Expr,
+    b: str | pli.Expr,
+) -> pli.Expr:
     """
     Compute the covariance between two columns/ expressions.
 
@@ -767,10 +751,10 @@ def cov(
 
 
 def map(
-    exprs: Union[List[str], List["pli.Expr"]],
-    f: Callable[[List["pli.Series"]], "pli.Series"],
-    return_dtype: Optional[Type[DataType]] = None,
-) -> "pli.Expr":
+    exprs: list[str] | list[pli.Expr],
+    f: Callable[[list[pli.Series]], pli.Series],
+    return_dtype: type[DataType] | None = None,
+) -> pli.Expr:
     """
     Map a custom function over multiple columns/expressions and produce a single Series result.
 
@@ -792,10 +776,10 @@ def map(
 
 
 def apply(
-    exprs: List[Union[str, "pli.Expr"]],
-    f: Callable[[List["pli.Series"]], Union["pli.Series", Any]],
-    return_dtype: Optional[Type[DataType]] = None,
-) -> "pli.Expr":
+    exprs: list[str | pli.Expr],
+    f: Callable[[list[pli.Series]], pli.Series | Any],
+    return_dtype: type[DataType] | None = None,
+) -> pli.Expr:
     """
     Apply a custom function in a GroupBy context.
 
@@ -825,11 +809,11 @@ def apply(
 
 
 def map_binary(
-    a: Union[str, "pli.Expr"],
-    b: Union[str, "pli.Expr"],
-    f: Callable[["pli.Series", "pli.Series"], "pli.Series"],
-    return_dtype: Optional[Type[DataType]] = None,
-) -> "pli.Expr":
+    a: str | pli.Expr,
+    b: str | pli.Expr,
+    f: Callable[[pli.Series, pli.Series], pli.Series],
+    return_dtype: type[DataType] | None = None,
+) -> pli.Expr:
     """
      .. deprecated:: 0.10.4
        use `map` or `apply`
@@ -854,10 +838,10 @@ def map_binary(
 
 
 def fold(
-    acc: "pli.IntoExpr",
-    f: Callable[["pli.Series", "pli.Series"], "pli.Series"],
-    exprs: Union[Sequence[Union["pli.Expr", str]], "pli.Expr"],
-) -> "pli.Expr":
+    acc: pli.IntoExpr,
+    f: Callable[[pli.Series, pli.Series], pli.Series],
+    exprs: Sequence[pli.Expr | str] | pli.Expr,
+) -> pli.Expr:
     """
     Accumulate over multiple columns horizontally/ row wise with a left fold.
 
@@ -882,7 +866,7 @@ def fold(
     return pli.wrap_expr(pyfold(acc._pyexpr, f, exprs))
 
 
-def any(name: Union[str, List["pli.Expr"]]) -> "pli.Expr":
+def any(name: str | list[pli.Expr]) -> pli.Expr:
     """
     Evaluate columnwise or elementwise with a bitwise OR operation.
     """
@@ -893,7 +877,7 @@ def any(name: Union[str, List["pli.Expr"]]) -> "pli.Expr":
     return col(name).any()
 
 
-def exclude(columns: Union[str, List[str]]) -> "pli.Expr":
+def exclude(columns: str | list[str]) -> pli.Expr:
     """
     Exclude certain columns from a wildcard expression.
 
@@ -949,7 +933,7 @@ def exclude(columns: Union[str, List[str]]) -> "pli.Expr":
     return col("*").exclude(columns)
 
 
-def all(name: Optional[Union[str, List["pli.Expr"]]] = None) -> "pli.Expr":
+def all(name: str | list[pli.Expr] | None = None) -> pli.Expr:
     """
     This function is two things
 
@@ -990,16 +974,14 @@ def all(name: Optional[Union[str, List["pli.Expr"]]] = None) -> "pli.Expr":
     return col(name).all()
 
 
-def groups(column: str) -> "pli.Expr":
+def groups(column: str) -> pli.Expr:
     """
     Syntactic sugar for `pl.col("foo").agg_groups()`.
     """
     return col(column).agg_groups()
 
 
-def quantile(
-    column: str, quantile: float, interpolation: str = "nearest"
-) -> "pli.Expr":
+def quantile(column: str, quantile: float, interpolation: str = "nearest") -> pli.Expr:
     """
     Syntactic sugar for `pl.col("foo").quantile(..)`.
     """
@@ -1008,44 +990,44 @@ def quantile(
 
 @overload
 def arange(
-    low: Union[int, "pli.Expr", "pli.Series"],
-    high: Union[int, "pli.Expr", "pli.Series"],
+    low: int | pli.Expr | pli.Series,
+    high: int | pli.Expr | pli.Series,
     step: int = ...,
     *,
     eager: Literal[False],
-) -> "pli.Expr":
+) -> pli.Expr:
     ...
 
 
 @overload
 def arange(
-    low: Union[int, "pli.Expr", "pli.Series"],
-    high: Union[int, "pli.Expr", "pli.Series"],
+    low: int | pli.Expr | pli.Series,
+    high: int | pli.Expr | pli.Series,
     step: int = ...,
     *,
     eager: Literal[True],
-) -> "pli.Series":
+) -> pli.Series:
     ...
 
 
 @overload
 def arange(
-    low: Union[int, "pli.Expr", "pli.Series"],
-    high: Union[int, "pli.Expr", "pli.Series"],
+    low: int | pli.Expr | pli.Series,
+    high: int | pli.Expr | pli.Series,
     step: int = ...,
     *,
     eager: bool = False,
-) -> Union["pli.Expr", "pli.Series"]:
+) -> pli.Expr | pli.Series:
     ...
 
 
 def arange(
-    low: Union[int, "pli.Expr", "pli.Series"],
-    high: Union[int, "pli.Expr", "pli.Series"],
+    low: int | pli.Expr | pli.Series,
+    high: int | pli.Expr | pli.Series,
     step: int = 1,
     *,
     eager: bool = False,
-) -> Union["pli.Expr", "pli.Series"]:
+) -> pli.Expr | pli.Series:
     """
     Create a range expression. This can be used in a `select`, `with_column` etc.
     Be sure that the range size is equal to the DataFrame you are collecting.
@@ -1076,9 +1058,9 @@ def arange(
 
 
 def argsort_by(
-    exprs: Union[Union["pli.Expr", str], Sequence[Union["pli.Expr", str]]],
-    reverse: Union[List[bool], bool] = False,
-) -> "pli.Expr":
+    exprs: pli.Expr | str | Sequence[pli.Expr | str],
+    reverse: list[bool] | bool = False,
+) -> pli.Expr:
     """
     Find the indexes that would sort the columns.
 
@@ -1103,14 +1085,14 @@ def argsort_by(
 
 def duration(
     *,
-    days: Optional[Union["pli.Expr", str]] = None,
-    seconds: Optional[Union["pli.Expr", str]] = None,
-    nanoseconds: Optional[Union["pli.Expr", str]] = None,
-    milliseconds: Optional[Union["pli.Expr", str]] = None,
-    minutes: Optional[Union["pli.Expr", str]] = None,
-    hours: Optional[Union["pli.Expr", str]] = None,
-    weeks: Optional[Union["pli.Expr", str]] = None,
-) -> "pli.Expr":
+    days: pli.Expr | str | None = None,
+    seconds: pli.Expr | str | None = None,
+    nanoseconds: pli.Expr | str | None = None,
+    milliseconds: pli.Expr | str | None = None,
+    minutes: pli.Expr | str | None = None,
+    hours: pli.Expr | str | None = None,
+    weeks: pli.Expr | str | None = None,
+) -> pli.Expr:
     """
     Create polars `Duration` from distinct time components.
 
@@ -1173,14 +1155,14 @@ def duration(
 
 
 def _datetime(
-    year: Union["pli.Expr", str],
-    month: Union["pli.Expr", str],
-    day: Union["pli.Expr", str],
-    hour: Optional[Union["pli.Expr", str]] = None,
-    minute: Optional[Union["pli.Expr", str]] = None,
-    second: Optional[Union["pli.Expr", str]] = None,
-    millisecond: Optional[Union["pli.Expr", str]] = None,
-) -> "pli.Expr":
+    year: pli.Expr | str,
+    month: pli.Expr | str,
+    day: pli.Expr | str,
+    hour: pli.Expr | str | None = None,
+    minute: pli.Expr | str | None = None,
+    second: pli.Expr | str | None = None,
+    millisecond: pli.Expr | str | None = None,
+) -> pli.Expr:
     """
     Create polars `Datetime` from distinct time components.
 
@@ -1232,10 +1214,10 @@ def _datetime(
 
 
 def _date(
-    year: Union["pli.Expr", str],
-    month: Union["pli.Expr", str],
-    day: Union["pli.Expr", str],
-) -> "pli.Expr":
+    year: pli.Expr | str,
+    month: pli.Expr | str,
+    day: pli.Expr | str,
+) -> pli.Expr:
     """
     Create polars Date from distinct time components.
 
@@ -1255,9 +1237,7 @@ def _date(
     return _datetime(year, month, day).cast(Date).alias("date")
 
 
-def concat_str(
-    exprs: Union[Sequence[Union["pli.Expr", str]], "pli.Expr"], sep: str = ""
-) -> "pli.Expr":
+def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli.Expr:
     """
     Horizontally Concat Utf8 Series in linear time. Non utf8 columns are cast to utf8.
 
@@ -1272,7 +1252,7 @@ def concat_str(
     return pli.wrap_expr(_concat_str(exprs, sep))
 
 
-def format(fstring: str, *args: Union["pli.Expr", str]) -> "pli.Expr":
+def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
     """
     String format utility for expressions
 
@@ -1329,9 +1309,7 @@ def format(fstring: str, *args: Union["pli.Expr", str]) -> "pli.Expr":
     return concat_str(exprs, sep="")
 
 
-def concat_list(
-    exprs: Union[Sequence[Union[str, "pli.Expr", "pli.Series"]], "pli.Expr"]
-) -> "pli.Expr":
+def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.Expr:
     """
     Concat the arrays in a Series dtype List in linear time.
 
@@ -1384,7 +1362,7 @@ def concat_list(
 
 
 def collect_all(
-    lazy_frames: "List[pli.LazyFrame]",
+    lazy_frames: list[pli.LazyFrame],
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
@@ -1392,7 +1370,7 @@ def collect_all(
     string_cache: bool = False,
     no_optimization: bool = False,
     slice_pushdown: bool = False,
-) -> "List[pli.DataFrame]":
+) -> list[pli.DataFrame]:
     """
     Collect multiple LazyFrames at the same time. This runs all the computation graphs in parallel on
     Polars threadpool.
@@ -1450,8 +1428,8 @@ def collect_all(
 
 
 def select(
-    exprs: Union[str, "pli.Expr", Sequence[str], Sequence["pli.Expr"], "pli.Series"]
-) -> "pli.DataFrame":
+    exprs: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | pli.Series,
+) -> pli.DataFrame:
     """
     Run polars expressions without a context.
 
@@ -1494,40 +1472,32 @@ def select(
 
 @overload
 def struct(
-    exprs: Union[
-        Sequence[Union["pli.Expr", str, "pli.Series"]], "pli.Expr", "pli.Series"
-    ],
+    exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: Literal[True],
-) -> "pli.Series":
+) -> pli.Series:
     ...
 
 
 @overload
 def struct(
-    exprs: Union[
-        Sequence[Union["pli.Expr", str, "pli.Series"]], "pli.Expr", "pli.Series"
-    ],
+    exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: Literal[False],
-) -> "pli.Expr":
+) -> pli.Expr:
     ...
 
 
 @overload
 def struct(
-    exprs: Union[
-        Sequence[Union["pli.Expr", str, "pli.Series"]], "pli.Expr", "pli.Series"
-    ],
+    exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: bool = False,
-) -> Union["pli.Expr", "pli.Series"]:
+) -> pli.Expr | pli.Series:
     ...
 
 
 def struct(
-    exprs: Union[
-        Sequence[Union["pli.Expr", str, "pli.Series"]], "pli.Expr", "pli.Series"
-    ],
+    exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: bool = False,
-) -> Union["pli.Expr", "pli.Series"]:
+) -> pli.Expr | pli.Series:
     """
     Collect several columns into a Series of dtype Struct
 
@@ -1591,44 +1561,44 @@ def struct(
 
 @overload
 def repeat(
-    value: Optional[Union[float, int, str, bool]],
-    n: Union["pli.Expr", int],
+    value: float | int | str | bool | None,
+    n: pli.Expr | int,
     *,
     eager: Literal[False] = ...,
-    name: Optional[str] = ...,
-) -> "pli.Expr":
+    name: str | None = ...,
+) -> pli.Expr:
     ...
 
 
 @overload
 def repeat(
-    value: Optional[Union[float, int, str, bool]],
-    n: Union["pli.Expr", int],
+    value: float | int | str | bool | None,
+    n: pli.Expr | int,
     *,
     eager: Literal[True],
-    name: Optional[str] = ...,
-) -> "pli.Series":
+    name: str | None = ...,
+) -> pli.Series:
     ...
 
 
 @overload
 def repeat(
-    value: Optional[Union[float, int, str, bool]],
-    n: Union["pli.Expr", int],
+    value: float | int | str | bool | None,
+    n: pli.Expr | int,
     *,
     eager: bool,
-    name: Optional[str],
-) -> Union["pli.Expr", "pli.Series"]:
+    name: str | None,
+) -> pli.Expr | pli.Series:
     ...
 
 
 def repeat(
-    value: Optional[Union[float, int, str, bool]],
-    n: Union["pli.Expr", int],
+    value: float | int | str | bool | None,
+    n: pli.Expr | int,
     *,
     eager: bool = False,
-    name: Optional[str] = None,
-) -> Union["pli.Expr", "pli.Series"]:
+    name: str | None = None,
+) -> pli.Expr | pli.Series:
     """
     Repeat a single value n times.
 
@@ -1657,29 +1627,25 @@ def repeat(
 
 @overload
 def arg_where(
-    condition: Union["pli.Expr", "pli.Series"],
+    condition: pli.Expr | pli.Series,
     eager: Literal[False] = ...,
-) -> "pli.Expr":
+) -> pli.Expr:
     ...
 
 
 @overload
-def arg_where(
-    condition: Union["pli.Expr", "pli.Series"], eager: Literal[True]
-) -> "pli.Series":
+def arg_where(condition: pli.Expr | pli.Series, eager: Literal[True]) -> pli.Series:
     ...
 
 
 @overload
-def arg_where(
-    condition: Union["pli.Expr", "pli.Series"], eager: bool
-) -> Union["pli.Expr", "pli.Series"]:
+def arg_where(condition: pli.Expr | pli.Series, eager: bool) -> pli.Expr | pli.Series:
     ...
 
 
 def arg_where(
-    condition: Union["pli.Expr", "pli.Series"], eager: bool = False
-) -> Union["pli.Expr", "pli.Series"]:
+    condition: pli.Expr | pli.Series, eager: bool = False
+) -> pli.Expr | pli.Series:
     """
     Return indices where `condition` evaluates `True`.
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2352,9 +2352,15 @@ class Series:
 
         return wrap_s(f(idx_array, value))
 
-    def clone(self) -> Series:
+    def cleared(self) -> "Series":
         """
-        Cheap deep clones.
+        Create an empty copy of the current Series, with identical name/dtype but no data.
+        """
+        return self.limit(0) if len(self) > 0 else self.clone()
+
+    def clone(self) -> "Series":
+        """
+        Very cheap deepcopy/clone.
         """
         return wrap_s(self._s.clone())
 

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -1,4 +1,6 @@
-from typing import Any, Sequence, Union
+from __future__ import annotations
+
+from typing import Any, Sequence
 
 try:
     from polars.polars import when as pywhen
@@ -18,7 +20,7 @@ class WhenThenThen:
     def __init__(self, pywhenthenthen: Any):
         self.pywhenthenthen = pywhenthenthen
 
-    def when(self, predicate: Union[pli.Expr, bool]) -> "WhenThenThen":
+    def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
         """
         Start another when, then, otherwise layer.
         """
@@ -27,23 +29,16 @@ class WhenThenThen:
 
     def then(
         self,
-        expr: Union[
-            pli.Expr,
-            int,
-            float,
-            str,
-            None,
-            pli.Series,
-            Sequence[
-                Union[
-                    int,
-                    float,
-                    str,
-                    None,
-                ]
-            ],
-        ],
-    ) -> "WhenThenThen":
+        expr: (
+            pli.Expr
+            | int
+            | float
+            | str
+            | None
+            | pli.Series
+            | Sequence[(int | float | str | None)]
+        ),
+    ) -> WhenThenThen:
         """
         Values to return in case of the predicate being `True`.
 
@@ -54,21 +49,9 @@ class WhenThenThen:
 
     def otherwise(
         self,
-        expr: Union[
-            pli.Expr,
-            int,
-            float,
-            str,
-            None,
-            Sequence[
-                Union[
-                    int,
-                    float,
-                    str,
-                    None,
-                ]
-            ],
-        ],
+        expr: (
+            pli.Expr | int | float | str | None | Sequence[(int | float | str | None)]
+        ),
     ) -> pli.Expr:
         """
         Values to return in case of the predicate being `False`.
@@ -87,14 +70,14 @@ class WhenThen:
     def __init__(self, pywhenthen: Any):
         self._pywhenthen = pywhenthen
 
-    def when(self, predicate: Union[pli.Expr, bool]) -> WhenThenThen:
+    def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
         """
         Start another when, then, otherwise layer.
         """
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
 
-    def otherwise(self, expr: Union[pli.Expr, int, float, str, None]) -> pli.Expr:
+    def otherwise(self, expr: pli.Expr | int | float | str | None) -> pli.Expr:
         """
         Values to return in case of the predicate being `False`.
 
@@ -109,20 +92,20 @@ class When:
     Utility class. See the `when` function.
     """
 
-    def __init__(self, pywhen: "pywhen"):
+    def __init__(self, pywhen: pywhen):
         self._pywhen = pywhen
 
     def then(
         self,
-        expr: Union[
-            pli.Expr,
-            pli.Series,
-            int,
-            float,
-            str,
-            None,
-            Sequence[Union[None, int, float, str]],
-        ],
+        expr: (
+            pli.Expr
+            | pli.Series
+            | int
+            | float
+            | str
+            | None
+            | Sequence[None | int | float | str]
+        ),
     ) -> WhenThen:
         """
         Values to return in case of the predicate being `True`.
@@ -134,7 +117,7 @@ class When:
         return WhenThen(pywhenthen)
 
 
-def when(expr: Union[pli.Expr, bool]) -> When:
+def when(expr: pli.Expr | bool) -> When:
     """
     Start a when, then, otherwise expression.
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,19 +1,8 @@
+from __future__ import annotations
+
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    TextIO,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, BinaryIO, Callable, Mapping, TextIO, cast
 
 from polars.utils import format_path, handle_projection_columns
 
@@ -41,7 +30,7 @@ except ImportError:
 
 
 def _check_arg_is_1byte(
-    arg_name: str, arg: Optional[str], can_be_empty: bool = False
+    arg_name: str, arg: str | None, can_be_empty: bool = False
 ) -> None:
     if isinstance(arg, str):
         arg_byte_length = len(arg.encode("utf-8"))
@@ -56,7 +45,7 @@ def _check_arg_is_1byte(
             )
 
 
-def update_columns(df: DataFrame, new_columns: List[str]) -> DataFrame:
+def update_columns(df: DataFrame, new_columns: list[str]) -> DataFrame:
     if df.width > len(new_columns):
         cols = df.columns
         for i, name in enumerate(new_columns):
@@ -67,29 +56,29 @@ def update_columns(df: DataFrame, new_columns: List[str]) -> DataFrame:
 
 
 def read_csv(
-    file: Union[str, TextIO, BytesIO, Path, BinaryIO, bytes],
+    file: str | TextIO | BytesIO | Path | BinaryIO | bytes,
     has_header: bool = True,
-    columns: Optional[Union[List[int], List[str]]] = None,
-    new_columns: Optional[List[str]] = None,
+    columns: list[int] | list[str] | None = None,
+    new_columns: list[str] | None = None,
     sep: str = ",",
-    comment_char: Optional[str] = None,
-    quote_char: Optional[str] = r'"',
+    comment_char: str | None = None,
+    quote_char: str | None = r'"',
     skip_rows: int = 0,
-    dtypes: Optional[Union[Mapping[str, Type[DataType]], List[Type[DataType]]]] = None,
-    null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
+    dtypes: Mapping[str, type[DataType]] | list[type[DataType]] | None = None,
+    null_values: str | list[str] | dict[str, str] | None = None,
     ignore_errors: bool = False,
     parse_dates: bool = False,
-    n_threads: Optional[int] = None,
-    infer_schema_length: Optional[int] = 100,
+    n_threads: int | None = None,
+    infer_schema_length: int | None = 100,
     batch_size: int = 8192,
-    n_rows: Optional[int] = None,
+    n_rows: int | None = None,
     encoding: str = "utf8",
     low_memory: bool = False,
     rechunk: bool = True,
     use_pyarrow: bool = False,
-    storage_options: Optional[Dict] = None,
+    storage_options: dict | None = None,
     skip_rows_after_header: int = 0,
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
     sample_size: int = 1024,
     **kwargs: Any,
@@ -361,24 +350,24 @@ def read_csv(
 
 
 def scan_csv(
-    file: Union[str, Path],
+    file: str | Path,
     has_header: bool = True,
     sep: str = ",",
-    comment_char: Optional[str] = None,
-    quote_char: Optional[str] = r'"',
+    comment_char: str | None = None,
+    quote_char: str | None = r'"',
     skip_rows: int = 0,
-    dtypes: Optional[Dict[str, Type[DataType]]] = None,
-    null_values: Optional[Union[str, List[str], Dict[str, str]]] = None,
+    dtypes: dict[str, type[DataType]] | None = None,
+    null_values: str | list[str] | dict[str, str] | None = None,
     ignore_errors: bool = False,
     cache: bool = True,
-    with_column_names: Optional[Callable[[List[str]], List[str]]] = None,
-    infer_schema_length: Optional[int] = 100,
-    n_rows: Optional[int] = None,
+    with_column_names: Callable[[list[str]], list[str]] | None = None,
+    infer_schema_length: int | None = 100,
+    n_rows: int | None = None,
     encoding: str = "utf8",
     low_memory: bool = False,
     rechunk: bool = True,
     skip_rows_after_header: int = 0,
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
     parse_dates: bool = False,
     **kwargs: Any,
@@ -528,13 +517,13 @@ def scan_csv(
 
 
 def scan_ipc(
-    file: Union[str, Path],
-    n_rows: Optional[int] = None,
+    file: str | Path,
+    n_rows: int | None = None,
     cache: bool = True,
     rechunk: bool = True,
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
-    storage_options: Optional[Dict] = None,
+    storage_options: dict | None = None,
     **kwargs: Any,
 ) -> LazyFrame:
     """
@@ -578,14 +567,14 @@ def scan_ipc(
 
 
 def scan_parquet(
-    file: Union[str, Path],
-    n_rows: Optional[int] = None,
+    file: str | Path,
+    n_rows: int | None = None,
     cache: bool = True,
     parallel: bool = True,
     rechunk: bool = True,
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
-    storage_options: Optional[Dict] = None,
+    storage_options: dict | None = None,
     **kwargs: Any,
 ) -> LazyFrame:
     """
@@ -635,9 +624,9 @@ def scan_parquet(
 
 
 def read_avro(
-    file: Union[str, Path, BytesIO, BinaryIO],
-    columns: Optional[Union[List[int], List[str]]] = None,
-    n_rows: Optional[int] = None,
+    file: str | Path | BytesIO | BinaryIO,
+    columns: list[int] | list[str] | None = None,
+    n_rows: int | None = None,
     **kwargs: Any,
 ) -> DataFrame:
     """
@@ -665,13 +654,13 @@ def read_avro(
 
 
 def read_ipc(
-    file: Union[str, BinaryIO, BytesIO, Path, bytes],
-    columns: Optional[Union[List[int], List[str]]] = None,
-    n_rows: Optional[int] = None,
+    file: str | BinaryIO | BytesIO | Path | bytes,
+    columns: list[int] | list[str] | None = None,
+    n_rows: int | None = None,
     use_pyarrow: bool = False,
     memory_map: bool = True,
-    storage_options: Optional[Dict] = None,
-    row_count_name: Optional[str] = None,
+    storage_options: dict | None = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
     rechunk: bool = True,
     **kwargs: Any,
@@ -744,14 +733,14 @@ def read_ipc(
 
 
 def read_parquet(
-    source: Union[str, Path, BinaryIO, BytesIO, bytes],
-    columns: Optional[Union[List[int], List[str]]] = None,
-    n_rows: Optional[int] = None,
+    source: str | Path | BinaryIO | BytesIO | bytes,
+    columns: list[int] | list[str] | None = None,
+    n_rows: int | None = None,
     use_pyarrow: bool = False,
     memory_map: bool = True,
-    storage_options: Optional[Dict] = None,
+    storage_options: dict | None = None,
     parallel: bool = True,
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
     **kwargs: Any,
 ) -> DataFrame:
@@ -827,7 +816,7 @@ def read_parquet(
         )
 
 
-def read_json(source: Union[str, IOBase], json_lines: bool = False) -> DataFrame:
+def read_json(source: str | IOBase, json_lines: bool = False) -> DataFrame:
     """
     Read into a DataFrame from JSON format.
 
@@ -842,12 +831,12 @@ def read_json(source: Union[str, IOBase], json_lines: bool = False) -> DataFrame
 
 
 def read_sql(
-    sql: Union[List[str], str],
+    sql: list[str] | str,
     connection_uri: str,
-    partition_on: Optional[str] = None,
-    partition_range: Optional[Tuple[int, int]] = None,
-    partition_num: Optional[int] = None,
-    protocol: Optional[str] = None,
+    partition_on: str | None = None,
+    partition_range: tuple[int, int] | None = None,
+    partition_num: int | None = None,
+    protocol: str | None = None,
 ) -> DataFrame:
     """
     Read a SQL query into a DataFrame.
@@ -932,11 +921,11 @@ def read_sql(
 
 
 def read_excel(
-    file: Union[str, BytesIO, Path, BinaryIO, bytes],
-    sheet_id: Optional[int] = 1,
-    sheet_name: Optional[str] = None,
-    xlsx2csv_options: Optional[dict] = None,
-    read_csv_options: Optional[dict] = None,
+    file: str | BytesIO | Path | BinaryIO | bytes,
+    sheet_id: int | None = 1,
+    sheet_name: str | None = None,
+    xlsx2csv_options: dict | None = None,
+    read_csv_options: dict | None = None,
 ) -> DataFrame:
     """
     Read Excel (XLSX) sheet into a DataFrame by converting an Excel
@@ -1059,7 +1048,7 @@ def read_excel(
     return read_csv(csv_buffer, **read_csv_options)
 
 
-def scan_ds(ds: "pa.dataset.dataset") -> "LazyFrame":
+def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
     """
     .. warning::
         This API is experimental and may change without it being considered a breaking change.

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from types import TracebackType
-from typing import Optional, Type
 
 try:
     from polars.polars import toggle_string_cache as pytoggle_string_cache
@@ -56,15 +57,15 @@ class StringCache:
     def __init__(self) -> None:
         pass
 
-    def __enter__(self) -> "StringCache":
+    def __enter__(self) -> StringCache:
         pytoggle_string_cache(True)
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         pytoggle_string_cache(False)
 

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import random
 from dataclasses import dataclass
 from datetime import datetime
 from functools import reduce
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Sequence
 
 try:
     from hypothesis import settings
@@ -257,7 +259,7 @@ def _getattr_multi(obj: object, op: str) -> Any:
 
 
 def verify_series_and_expr_api(
-    input: Series, expected: Optional[Series], op: str, *args: Any, **kwargs: Any
+    input: Series, expected: Series | None, op: str, *args: Any, **kwargs: Any
 ) -> None:
     """
     Small helper function to test element-wise functions for both the series and expressions api.
@@ -295,7 +297,7 @@ if HYPOTHESIS_INSTALLED:
     # See: https://hypothesis.readthedocs.io/
     # =====================================================================
 
-    dtype_strategy_mapping: Dict[PolarsDataType, Any] = {
+    dtype_strategy_mapping: dict[PolarsDataType, Any] = {
         Boolean: booleans(),
         Float32: floats(width=32),
         Float64: floats(width=64),
@@ -368,9 +370,9 @@ if HYPOTHESIS_INSTALLED:
         """
 
         name: str
-        dtype: Optional[PolarsDataType] = None
-        strategy: Optional["SearchStrategy"] = None
-        null_probability: Optional[float] = None
+        dtype: PolarsDataType | None = None
+        strategy: SearchStrategy | None = None
+        null_probability: float | None = None
         unique: bool = False
 
         def __post_init__(self) -> None:
@@ -402,13 +404,13 @@ if HYPOTHESIS_INSTALLED:
                         )
 
     def columns(
-        cols: Optional[Union[int, Sequence[str]]] = None,
+        cols: int | Sequence[str] | None = None,
         *,
-        dtype: Optional[Union[PolarsDataType, Sequence[PolarsDataType]]] = None,
-        min_cols: Optional[int] = 0,
-        max_cols: Optional[int] = MAX_COLS,
+        dtype: PolarsDataType | Sequence[PolarsDataType] | None = None,
+        min_cols: int | None = 0,
+        max_cols: int | None = MAX_COLS,
         unique: bool = False,
-    ) -> List[column]:
+    ) -> list[column]:
         """
         Generate a fixed sequence of `column` objects suitable for passing to the @dataframes
         strategy, or using standalone (note that this function is not itself a strategy).
@@ -460,7 +462,7 @@ if HYPOTHESIS_INSTALLED:
                 b=max_cols or MAX_COLS,
             )
         if isinstance(cols, int):
-            names: List[str] = [f"col{n}" for n in range(cols)]
+            names: list[str] = [f"col{n}" for n in range(cols)]
         else:
             names = list(cols)
 
@@ -487,17 +489,17 @@ if HYPOTHESIS_INSTALLED:
     @defines_strategy()
     def series(
         *,
-        name: Optional[Union[str, "SearchStrategy[str]"]] = None,
-        dtype: Optional[PolarsDataType] = None,
-        size: Optional[int] = None,
-        min_size: Optional[int] = 0,
-        max_size: Optional[int] = MAX_DATA_SIZE,
-        strategy: Optional["SearchStrategy"] = None,
+        name: str | SearchStrategy[str] | None = None,
+        dtype: PolarsDataType | None = None,
+        size: int | None = None,
+        min_size: int | None = 0,
+        max_size: int | None = MAX_DATA_SIZE,
+        strategy: SearchStrategy | None = None,
         null_probability: float = 0.0,
         unique: bool = False,
-        allowed_dtypes: Optional[Sequence[PolarsDataType]] = None,
-        excluded_dtypes: Optional[Sequence[PolarsDataType]] = None,
-    ) -> "SearchStrategy[Series]":
+        allowed_dtypes: Sequence[PolarsDataType] | None = None,
+        excluded_dtypes: Sequence[PolarsDataType] | None = None,
+    ) -> SearchStrategy[Series]:
         """
         Strategy for producing a polars Series.
 
@@ -625,19 +627,19 @@ if HYPOTHESIS_INSTALLED:
 
     @defines_strategy()
     def dataframes(
-        cols: Optional[Union[int, Sequence[column]]] = None,
+        cols: int | Sequence[column] | None = None,
         lazy: bool = False,
         *,
-        min_cols: Optional[int] = 0,
-        max_cols: Optional[int] = MAX_COLS,
-        size: Optional[int] = None,
-        min_size: Optional[int] = 0,
-        max_size: Optional[int] = MAX_DATA_SIZE,
-        include_cols: Optional[Sequence[column]] = None,
-        null_probability: Union[float, dict] = 0.0,
-        allowed_dtypes: Optional[Sequence[PolarsDataType]] = None,
-        excluded_dtypes: Optional[Sequence[PolarsDataType]] = None,
-    ) -> "SearchStrategy[Union[DataFrame, LazyFrame]]":
+        min_cols: int | None = 0,
+        max_cols: int | None = MAX_COLS,
+        size: int | None = None,
+        min_size: int | None = 0,
+        max_size: int | None = MAX_DATA_SIZE,
+        include_cols: Sequence[column] | None = None,
+        null_probability: float | dict[str, float] = 0.0,
+        allowed_dtypes: Sequence[PolarsDataType] | None = None,
+        excluded_dtypes: Sequence[PolarsDataType] | None = None,
+    ) -> SearchStrategy[DataFrame | LazyFrame]:
         """
         Provides a strategy for producing a DataFrame or LazyFrame.
 
@@ -730,7 +732,7 @@ if HYPOTHESIS_INSTALLED:
         ]
 
         @composite
-        def draw_frames(draw: Callable) -> Union[DataFrame, LazyFrame]:
+        def draw_frames(draw: Callable) -> DataFrame | LazyFrame:
             # if not given, create 'n' cols with random dtypes
             if cols is None:
                 n = between(

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import functools
 import os
@@ -5,18 +7,7 @@ import sys
 import warnings
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Iterable, Sequence
 
 import numpy as np
 
@@ -36,8 +27,8 @@ else:
 
 
 def _process_null_values(
-    null_values: Union[None, str, List[str], Dict[str, str]] = None,
-) -> Union[None, str, List[str], List[Tuple[str, str]]]:
+    null_values: None | str | list[str] | dict[str, str] = None,
+) -> None | str | list[str] | list[tuple[str, str]]:
     if isinstance(null_values, dict):
         return list(null_values.items())
     else:
@@ -79,7 +70,7 @@ def timedelta_in_nanoseconds_window(td: timedelta) -> bool:
     return in_nanoseconds_window(datetime(1970, 1, 1) + td)
 
 
-def _datetime_to_pl_timestamp(dt: datetime, tu: Optional[str]) -> int:
+def _datetime_to_pl_timestamp(dt: datetime, tu: str | None) -> int:
     """
     Converts a python datetime to a timestamp in nanoseconds
     """
@@ -96,7 +87,7 @@ def _datetime_to_pl_timestamp(dt: datetime, tu: Optional[str]) -> int:
         raise ValueError("expected on of {'ns', 'us', 'ms'}")
 
 
-def _timedelta_to_pl_timedelta(td: timedelta, tu: Optional[str] = None) -> int:
+def _timedelta_to_pl_timedelta(td: timedelta, tu: str | None = None) -> int:
     if tu == "ns":
         return int(td.total_seconds() * 1e9)
     elif tu == "us":
@@ -133,7 +124,7 @@ def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
     return _is_iterable_of(val, Sequence, int)
 
 
-def _is_iterable_of(val: Iterable, itertype: Type, eltype: Type) -> bool:
+def _is_iterable_of(val: Iterable, itertype: type, eltype: type) -> bool:
     return isinstance(val, itertype) and all(isinstance(x, eltype) for x in val)
 
 
@@ -145,9 +136,9 @@ def range_to_slice(rng: range) -> slice:
 
 
 def handle_projection_columns(
-    columns: Optional[Union[List[str], List[int]]]
-) -> Tuple[Optional[List[int]], Optional[List[str]]]:
-    projection: Optional[List[int]] = None
+    columns: list[str] | list[int] | None,
+) -> tuple[list[int] | None, list[str] | None]:
+    projection: list[int] | None = None
     if columns:
         if is_int_sequence(columns):
             projection = columns  # type: ignore
@@ -172,9 +163,7 @@ def _to_python_time(value: int) -> time:
     return time(hour=hours, minute=minutes, second=seconds, microsecond=microsecond)
 
 
-def _to_python_timedelta(
-    value: Union[int, float], tu: Optional[str] = "ns"
-) -> timedelta:
+def _to_python_timedelta(value: int | float, tu: str | None = "ns") -> timedelta:
     if tu == "ns":
         return timedelta(microseconds=value // 1e3)
     elif tu == "us":
@@ -186,9 +175,9 @@ def _to_python_timedelta(
 
 
 def _prepare_row_count_args(
-    row_count_name: Optional[str] = None,
+    row_count_name: str | None = None,
     row_count_offset: int = 0,
-) -> Optional[Tuple[str, int]]:
+) -> tuple[str, int] | None:
 
     if row_count_name is not None:
         return (row_count_name, row_count_offset)
@@ -200,11 +189,11 @@ EPOCH = datetime(1970, 1, 1).replace(tzinfo=None)
 
 
 def _to_python_datetime(
-    value: Union[int, float],
-    dtype: Type[DataType],
-    tu: Optional[str] = "ns",
-    tz: Optional["str"] = None,
-) -> Union[date, datetime]:
+    value: int | float,
+    dtype: type[DataType],
+    tu: str | None = "ns",
+    tz: str | None = None,
+) -> date | datetime:
     if dtype == Date:
         # days to seconds
         # important to create from utc. Not doing this leads
@@ -245,7 +234,7 @@ def _in_notebook() -> bool:
     return True
 
 
-def format_path(path: Union[str, Path]) -> str:
+def format_path(path: str | Path) -> str:
     """
     Returns a string path, expanding the home directory if present.
     """
@@ -281,7 +270,7 @@ def deprecated_alias(**aliases: str) -> Callable:
 
 
 def rename_kwargs(
-    func_name: str, kwargs: Dict[str, str], aliases: Dict[str, str]
+    func_name: str, kwargs: dict[str, str], aliases: dict[str, str]
 ) -> None:
     """Helper function for deprecating function and method arguments."""
     for alias, new in aliases.items():

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -32,9 +32,8 @@ def test_repr(df: pl.DataFrame) -> None:
     # print(df)
 
 
-# note: *temporarily* constraining dtypes this test until #3843 and a windows-specific
-# fixfor a related date bug is merged (tblocking the PR to merge hypothesis code).
-@given(df=dataframes(allowed_dtypes=[pl.Boolean, pl.UInt64, pl.Utf8]))
+# note: temporarily constraining dtypes for this test (possible windows-specific date bug)
+@given(df=dataframes(allowed_dtypes=[pl.Boolean, pl.UInt64, pl.Utf8, pl.Time]))
 def test_null_count(df: pl.DataFrame) -> None:
     null_count, ncols = df.null_count(), len(df.columns)
     if ncols == 0:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -84,6 +84,9 @@ def test_init_only_columns() -> None:
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert getattr(df.schema["d"], "inner") == pl.UInt8
 
+        dfe = df.cleared()
+        assert (df.schema == dfe.schema) and (dfe.shape == df.shape)
+
 
 def test_special_char_colname_init() -> None:
     from string import punctuation
@@ -171,6 +174,9 @@ def test_init_dict() -> None:
         {"a": [1, 2, 3], "b": [4, 5, 6]}, columns=[("c", pl.Int8), ("d", pl.Int16)]
     )
     assert df.schema == {"c": pl.Int8, "d": pl.Int16}
+
+    dfe = df.cleared()
+    assert (df.schema == dfe.schema) and (len(dfe) == 0)
 
 
 def test_init_ndarray() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -14,7 +14,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.testing import assert_series_equal, columns, dataframes
+from polars.testing import assert_frame_equal, assert_series_equal, columns, dataframes
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -539,6 +539,54 @@ def test_assignment() -> None:
         pl.when(pl.col("foo") > 1).then(9).otherwise(pl.col("foo")).alias("foo")
     )
     assert df["foo"].to_list() == [1, 9, 9]
+
+
+def test_select_at_idx() -> None:
+    df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
+    for idx in range(len(df.columns)):
+        assert_series_equal(
+            df.select_at_idx(idx),  # regular positive indexing
+            df.select_at_idx(idx - len(df.columns)),  # equivalent negative index
+        )
+
+
+def test_insert_at_idx() -> None:
+    df = pl.DataFrame({"z": [3, 4, 5]})
+    df.insert_at_idx(0, pl.Series("x", [1, 2, 3]))
+    df.insert_at_idx(-1, pl.Series("y", [2, 3, 4]))
+
+    expected_df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
+    assert_frame_equal(expected_df, df)
+
+
+def test_replace_at_idx() -> None:
+    df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
+    df.replace_at_idx(0, pl.Series("a", [4, 5, 6]))
+    df.replace_at_idx(-2, pl.Series("b", [5, 6, 7]))
+    df.replace_at_idx(-1, pl.Series("c", [6, 7, 8]))
+
+    expected_df = pl.DataFrame({"a": [4, 5, 6], "b": [5, 6, 7], "c": [6, 7, 8]})
+    assert_frame_equal(expected_df, df)
+
+
+def test_to_series() -> None:
+    df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
+
+    assert_series_equal(df.to_series(), df["x"])
+    assert_series_equal(df.to_series(0), df["x"])
+    assert_series_equal(df.to_series(-3), df["x"])
+
+    assert_series_equal(df.to_series(1), df["y"])
+    assert_series_equal(df.to_series(-2), df["y"])
+
+    assert_series_equal(df.to_series(2), df["z"])
+    assert_series_equal(df.to_series(-1), df["z"])
+
+
+def test_take_every() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]})
+    expected_df = pl.DataFrame({"a": [1, 3], "b": ["w", "y"]})
+    assert_frame_equal(expected_df, df.take_every(2))
 
 
 def test_slice() -> None:
@@ -1209,9 +1257,6 @@ def test_lazy_functions() -> None:
     expected = 1
     assert np.isclose(out.select_at_idx(8), expected)
     assert np.isclose(pl.first(df["b"]), expected)
-    expected = 3
-    assert np.isclose(out.select_at_idx(9), expected)
-    assert np.isclose(pl.last(df["b"]), expected)
     expected = 3
     assert np.isclose(out.select_at_idx(9), expected)
     assert np.isclose(pl.last(df["b"]), expected)

--- a/py-polars/tests/test_groupby.py
+++ b/py-polars/tests/test_groupby.py
@@ -35,3 +35,19 @@ def test_groupby_custom_agg_empty_list() -> None:
             ]
         )
     ).dtypes == [pl.Categorical, pl.Float64, pl.Float64, pl.Float64, pl.Float64]
+
+
+def test_apply_after_take_in_groupby_3869() -> None:
+    assert (
+        pl.DataFrame(
+            {
+                "k": list("aaabbb"),
+                "t": [1, 2, 3, 4, 5, 6],
+                "v": [3, 1, 2, 5, 6, 4],
+            }
+        )
+        .groupby("k", maintain_order=True)
+        .agg(
+            pl.col("v").take(pl.col("t").arg_max()).sqrt()
+        )  # <- fails for sqrt, exp, log, pow, etc.
+    ).to_dict(False) == {"k": ["a", "b"], "v": [1.4142135623730951, 2.0]}

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -4,6 +4,7 @@ from _pytest.capture import CaptureFixture
 
 import polars as pl
 from polars import col, lit, map_binary, when
+from polars.testing import assert_frame_equal
 
 
 def test_lazy() -> None:
@@ -48,6 +49,12 @@ def test_set_null() -> None:
     assert s[0] == 100
     assert s[1] is None
     assert s[2] is None
+
+
+def test_take_every() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}).lazy()
+    expected_df = pl.DataFrame({"a": [1, 3], "b": ["w", "y"]})
+    assert_frame_equal(expected_df, df.take_every(2).collect())
 
 
 def test_agg() -> None:

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1286,3 +1286,21 @@ def test_deadlocks_3409() -> None:
         .with_columns([pl.col("col1").cumulative_eval(pl.element().map(lambda x: 0))])
         .to_dict(False)
     ) == {"col1": [0, 0, 0]}
+
+
+def test_predicate_count_vstack() -> None:
+    l1 = pl.DataFrame(
+        {
+            "k": ["x", "y"],
+            "v": [3, 2],
+        }
+    ).lazy()
+    l2 = pl.DataFrame(
+        {
+            "k": ["x", "y"],
+            "v": [5, 7],
+        }
+    ).lazy()
+    assert pl.concat([l1, l2]).filter(pl.count().over("k") == 2).collect()[
+        "v"
+    ].to_list() == [3, 2, 5, 7]

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1265,6 +1265,9 @@ def test_lazy_schema() -> None:
     ).lazy()
     assert lf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
 
+    lfe = lf.cleared()
+    assert lfe.schema == lf.schema
+
 
 def test_deadlocks_3409() -> None:
     assert (

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -630,6 +630,11 @@ def test_empty() -> None:
         pl.Series(dtype=pl.Int32), pl.Series(dtype=pl.Int64), check_dtype=False
     )
 
+    a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
+    empty_a = a.cleared()
+    assert a.dtype == empty_a.dtype
+    assert len(empty_a) == 0
+
 
 def test_describe() -> None:
     num_s = pl.Series([1, 2, 3])


### PR DESCRIPTION
A couple of small additions/tweaks, and associated new test coverage:

* Allow negative indexing for -
  * `select_at_idx`
  * `insert_at_idx`
  * `replace_at_idx`
  * `to_series`

* Expose frame-level `take_every` method to DataFrame and LazyFrame (consistent with Series).

