### PR TITLE
Fast/cheap empty `clone` ops

### DIFF
--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -81,6 +81,7 @@ Manipulation/ selection
 .. autosummary::
    :toctree: api/
 
+    DataFrame.cleared
     DataFrame.clone
     DataFrame.distinct
     DataFrame.drop

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -46,6 +46,7 @@ Manipulation/ selection
 .. autosummary::
    :toctree: api/
 
+    LazyFrame.cleared
     LazyFrame.clone
     LazyFrame.distinct
     LazyFrame.drop

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -155,6 +155,7 @@ Manipulation/ selection
     Series.argsort
     Series.cast
     Series.ceil
+    Series.cleared
     Series.clip
     Series.clone
     Series.drop_nans

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4081,10 +4081,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.select_at_idx(idx))
 
-    def clone(self: DF) -> DF:
+    def clone(self: DF, empty: bool = False) -> DF:
         """
-        Cheap deepcopy/clone.
+        Very cheap deepcopy/clone.
+
+        Parameters
+        ----------
+        empty
+            Create a clone of the DataFrame with matching schema, but no data.
         """
+        if empty and len(self) > 0:
+            return self.head(0)
         return self._from_pydf(self._df.clone())
 
     def __copy__(self: DF) -> DF:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4081,17 +4081,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return pli.wrap_s(self._df.select_at_idx(idx))
 
-    def clone(self: DF, empty: bool = False) -> DF:
+    def cleared(self: DF) -> DF:
+        """
+        Create an empty copy of the current DataFrame, with identical schema but no data.
+        """
+        return self.head(0) if len(self) > 0 else self.clone()
+
+    def clone(self: DF) -> DF:
         """
         Very cheap deepcopy/clone.
-
-        Parameters
-        ----------
-        empty
-            Create a clone of the DataFrame with matching schema, but no data.
         """
-        if empty and len(self) > 0:
-            return self.head(0)
         return self._from_pydf(self._df.clone())
 
     def __copy__(self: DF) -> DF:

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -746,10 +746,17 @@ class LazyFrame(Generic[DF]):
         """
         return self._from_pyldf(self._ldf.cache())
 
-    def clone(self: LDF) -> LDF:
+    def clone(self: LDF, empty: bool = False) -> LDF:
         """
-        Cheap deepcopy/clone.
+        Very cheap deepcopy/clone.
+
+        Parameters
+        ----------
+        empty
+            Create a clone of the LazyFrame with matching schema, but no data or query plan.
         """
+        if empty:
+            return self._dataframe_class(columns=self.schema).lazy()
         return self._from_pyldf(self._ldf.clone())
 
     def __copy__(self: LDF) -> LDF:

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -746,17 +746,16 @@ class LazyFrame(Generic[DF]):
         """
         return self._from_pyldf(self._ldf.cache())
 
-    def clone(self: LDF, empty: bool = False) -> LDF:
+    def cleared(self: LDF) -> LDF:
+        """
+        Create an empty copy of the current LazyFrame, with identical schema but no data.
+        """
+        return self._dataframe_class(columns=self.schema).lazy()
+
+    def clone(self: LDF) -> LDF:
         """
         Very cheap deepcopy/clone.
-
-        Parameters
-        ----------
-        empty
-            Create a clone of the LazyFrame with matching schema, but no data or query plan.
         """
-        if empty:
-            return self._dataframe_class(columns=self.schema).lazy()
         return self._from_pyldf(self._ldf.clone())
 
     def __copy__(self: LDF) -> LDF:

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2352,10 +2352,17 @@ class Series:
 
         return wrap_s(f(idx_array, value))
 
-    def clone(self) -> Series:
+    def clone(self, empty: bool = False) -> "Series":
         """
-        Cheap deep clones.
+        Very cheap deepcopy/clone.
+
+        Parameters
+        ----------
+        empty
+            Create a clone of the Series with matching dtype/name, but no data.
         """
+        if empty and len(self) > 0:
+            return self.limit(0)
         return wrap_s(self._s.clone())
 
     def __copy__(self) -> Series:

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2352,17 +2352,16 @@ class Series:
 
         return wrap_s(f(idx_array, value))
 
-    def clone(self, empty: bool = False) -> "Series":
+    def cleared(self) -> "Series":
+        """
+        Create an empty copy of the current Series, with identical name/dtype but no data.
+        """
+        return self.limit(0) if len(self) > 0 else self.clone()
+
+    def clone(self) -> "Series":
         """
         Very cheap deepcopy/clone.
-
-        Parameters
-        ----------
-        empty
-            Create a clone of the Series with matching dtype/name, but no data.
         """
-        if empty and len(self) > 0:
-            return self.limit(0)
         return wrap_s(self._s.clone())
 
     def __copy__(self) -> Series:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -85,6 +85,9 @@ def test_init_only_columns() -> None:
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert getattr(df.schema["d"], "inner") == pl.UInt8
 
+        dfe = df.clone(empty=True)
+        assert (df.schema == dfe.schema) and (dfe.shape == df.shape)
+
 
 def test_special_char_colname_init() -> None:
     from string import punctuation
@@ -172,6 +175,9 @@ def test_init_dict() -> None:
         {"a": [1, 2, 3], "b": [4, 5, 6]}, columns=[("c", pl.Int8), ("d", pl.Int16)]
     )
     assert df.schema == {"c": pl.Int8, "d": pl.Int16}
+
+    dfe = df.clone(empty=True)
+    assert (df.schema == dfe.schema) and (len(dfe) == 0)
 
 
 def test_init_ndarray() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -85,7 +85,7 @@ def test_init_only_columns() -> None:
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert getattr(df.schema["d"], "inner") == pl.UInt8
 
-        dfe = df.clone(empty=True)
+        dfe = df.cleared()
         assert (df.schema == dfe.schema) and (dfe.shape == df.shape)
 
 
@@ -176,7 +176,7 @@ def test_init_dict() -> None:
     )
     assert df.schema == {"c": pl.Int8, "d": pl.Int16}
 
-    dfe = df.clone(empty=True)
+    dfe = df.cleared()
     assert (df.schema == dfe.schema) and (len(dfe) == 0)
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1258,7 +1258,7 @@ def test_lazy_schema() -> None:
     ).lazy()
     assert lf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
 
-    lfe = lf.clone(empty=True)
+    lfe = lf.cleared()
     assert lfe.schema == lf.schema
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1258,6 +1258,9 @@ def test_lazy_schema() -> None:
     ).lazy()
     assert lf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
 
+    lfe = lf.clone(empty=True)
+    assert lfe.schema == lf.schema
+
 
 def test_deadlocks_3409() -> None:
     assert (

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -631,7 +631,7 @@ def test_empty() -> None:
     )
 
     a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
-    empty_a = a.clone(empty=True)
+    empty_a = a.cleared()
     assert a.dtype == empty_a.dtype
     assert len(empty_a) == 0
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -630,6 +630,11 @@ def test_empty() -> None:
         pl.Series(dtype=pl.Int32), pl.Series(dtype=pl.Int64), check_dtype=False
     )
 
+    a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
+    empty_a = a.clone(empty=True)
+    assert a.dtype == empty_a.dtype
+    assert len(empty_a) == 0
+
 
 def test_describe() -> None:
     num_s = pl.Series([1, 2, 3])


### PR DESCRIPTION
Sometimes it's useful to get an empty clone of a Frame/Series (eg: identical schema) without trying to recreate all the init params (dtypes/names/etc) from scratch. This patch adds an option to pass `empty=True` into the existing `clone()` method to achieve this.

Observationally, it is ~2x faster to call `head` or `limit` with `length=0` for DataFrame/Series than to init a fresh object explicitly (and simpler, as the returned object is already guaranteed to have identical schema).

eg:
```python
empty_df = df.clone( empty=True ) 
empty_series = series.clone( empty=True ) 
```
**Update**:
Proposed syntax now updated to use `.cleared()` instead of `.clone(empty=True)`