### PR TITLE
Negative-indexing support for additional functions, and frame-level `take_every`

### DIFF
--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -125,6 +125,7 @@ Manipulation/ selection
     DataFrame.slice
     DataFrame.sort
     DataFrame.tail
+    DataFrame.take_every
     DataFrame.to_dummies
     DataFrame.to_series
     DataFrame.transpose

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -75,6 +75,7 @@ Manipulation/ selection
     LazyFrame.slice
     LazyFrame.sort
     LazyFrame.tail
+    LazyFrame.take_every
     LazyFrame.unique
     LazyFrame.unnest
     LazyFrame.with_column

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1882,6 +1882,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ]
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         return pli.wrap_s(self._df.select_at_idx(index))
 
     def reverse(self: DF) -> DF:
@@ -1974,6 +1976,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴─────┴─────┘
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         self._df.insert_at_idx(index, series._s)
 
     def filter(self: DF, predicate: pli.Expr) -> DF:
@@ -2275,6 +2279,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └───────┴─────┴─────┘
 
         """
+        if index < 0:
+            index = len(self.columns) + index
         self._df.replace_at_idx(index, series._s)
 
     @overload
@@ -4079,6 +4085,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ]
 
         """
+        if idx < 0:
+            idx = len(self.columns) + idx
         return pli.wrap_s(self._df.select_at_idx(idx))
 
     def cleared(self: DF) -> DF:
@@ -5461,6 +5469,27 @@ class DataFrame(metaclass=DataFrameMetaClass):
             df = self.clone()
             df._df.shrink_to_fit()
             return df
+
+    def take_every(self: DF, n: int) -> DF:
+        """
+        Take every nth row in the DataFrame and return as a new DataFrame.
+
+        Examples
+        --------
+        >>> s = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+        >>> s.take_every(2)
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 5   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+        """
+        return self.select(pli.col("*").take_every(n))
 
     def hash_rows(
         self, k0: int = 0, k1: int = 1, k2: int = 2, k3: int = 3

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1782,6 +1782,27 @@ class LazyFrame(Generic[DF]):
         """
         return self._from_pyldf(self._ldf.with_row_count(name, offset))
 
+    def take_every(self: LDF, n: int) -> LDF:
+        """
+        Take every nth row in the LazyFrame and return as a new LazyFrame.
+
+        Examples
+        --------
+        >>> s = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]}).lazy()
+        >>> s.take_every(2).collect()
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 5   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+        """
+        return self.select(pli.col("*").take_every(n))
+
     def fill_null(self: LDF, fill_value: int | str | pli.Expr) -> LDF:
         """
         Fill missing values with a literal or Expr.

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -4,6 +4,7 @@ from _pytest.capture import CaptureFixture
 
 import polars as pl
 from polars import col, lit, map_binary, when
+from polars.testing import assert_frame_equal
 
 
 def test_lazy() -> None:
@@ -48,6 +49,12 @@ def test_set_null() -> None:
     assert s[0] == 100
     assert s[1] is None
     assert s[2] is None
+
+
+def test_take_every() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}).lazy()
+    expected_df = pl.DataFrame({"a": [1, 3], "b": ["w", "y"]})
+    assert_frame_equal(expected_df, df.take_every(2).collect())
 
 
 def test_agg() -> None:


### PR DESCRIPTION
_(This is the rebased/squashed #3874, without all the noise)_

--------

A couple of small additions/tweaks, and associated new test coverage:

* Allow negative indexing for -
  * `select_at_idx`
  * `insert_at_idx`
  * `replace_at_idx`
  * `to_series`

* Expose frame-level `take_every` method to DataFrame and LazyFrame (consistent with Series).
