### PR TITLE
Address deprecation warnings while running pytest

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -631,8 +631,9 @@ def test_groupby() -> None:
     # )
     assert df.groupby("a").apply(lambda df: df[["c"]].sum()).sort("c")["c"][0] == 1
 
-    df_groups = df.groupby("a").groups().sort("a")
-    assert df_groups["a"].series_equal(pl.Series("a", ["a", "b", "c"]))
+    with pytest.deprecated_call():
+        df_groups = df.groupby("a").groups().sort("a")
+        assert df_groups["a"].series_equal(pl.Series("a", ["a", "b", "c"]))
 
     with pytest.deprecated_call():
         # TODO: find a way to avoid indexing into GroupBy
@@ -641,9 +642,10 @@ def test_groupby() -> None:
             if subdf["a"][0] == "b":
                 assert subdf.shape == (3, 3)
 
-    assert df.groupby("a").get_group("c").shape == (1, 3)
-    assert df.groupby("a").get_group("b").shape == (3, 3)
-    assert df.groupby("a").get_group("a").shape == (2, 3)
+    with pytest.deprecated_call():
+        assert df.groupby("a").get_group("c").shape == (1, 3)
+        assert df.groupby("a").get_group("b").shape == (3, 3)
+        assert df.groupby("a").get_group("a").shape == (2, 3)
 
     # Use lazy API in eager groupby
     assert df.groupby("a").agg([pl.sum("b")]).shape == (3, 2)
@@ -1951,9 +1953,6 @@ def test_get_item() -> None:
     # expression
     assert df.select(pl.col("a")).frame_equal(pl.DataFrame({"a": [1.0, 2.0]}))
 
-    # numpy array
-    assert df[np.array([True, False])].frame_equal(pl.DataFrame({"a": [1.0], "b": [3]}))
-
     # tuple. The first element refers to the rows, the second element to columns
     assert df[:, :].frame_equal(df)
 
@@ -1970,12 +1969,16 @@ def test_get_item() -> None:
     assert df[::2].frame_equal(pl.DataFrame({"a": [1.0], "b": [3]}))
 
     # numpy array; assumed to be row indices if integers, or columns if strings
-    # TODO: add boolean mask support
     df[np.array([1])].frame_equal(pl.DataFrame({"a": [2.0], "b": [4]}))
     df[np.array(["a"])].frame_equal(pl.DataFrame({"a": [1.0, 2.0]}))
     # note that we cannot use floats (even if they could be casted to integer without loss)
     with pytest.raises(NotImplementedError):
         _ = df[np.array([1.0])]
+    # using boolean masks with numpy is deprecated
+    with pytest.deprecated_call():
+        assert df[np.array([True, False])].frame_equal(
+            pl.DataFrame({"a": [1.0], "b": [3]})
+        )
 
     # sequences (lists or tuples; tuple only if length != 2)
     # if strings or list of expressions, assumed to be column names

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1162,7 +1162,7 @@ def test_self_join() -> None:
     ).lazy()
 
     out = (
-        df.join(ldf=df, left_on="manager_id", right_on="employee_id", how="left")
+        df.join(other=df, left_on="manager_id", right_on="employee_id", how="left")
         .select(
             exprs=[
                 pl.col("employee_id"),


### PR DESCRIPTION
Changes:
* polars `join` argument `ldf` is deprecated in favor of `other` - updated this accordingly
* Added `with pytest.deprecated_call()` context handler to some test cases with polars functionality that has been deprecated.
* ~~Newest `pandas` versions deprecated the `closed` argument in favor of the `inclusive` argument for `date_range`.~~ Cannot fix `pandas` FutureWarning as the new argument `inclusive` is not available in Python 3.7.

There is still a `NonInteractiveExampleWarning` by the new `hypothesis` package - not sure how to address that one.