### PR TITLE
Assign dtypes to expected columns when dtypes is a list and column se…

### DIFF
--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -103,6 +103,32 @@ a,b,c
     assert df.dtypes == [pl.Utf8, pl.Int64, pl.Int64]
 
 
+def test_dtype_overwrite_with_column_name_selection() -> None:
+    csv = """
+a,b,c,d
+1,2,3,4
+1,2,3,4
+"""
+    f = io.StringIO(csv)
+    df = pl.read_csv(f, columns=["c", "b", "d"], dtypes=[pl.Int32, pl.Utf8])
+    assert df.dtypes == [pl.Utf8, pl.Int32, pl.Int64]
+
+
+def test_dtype_overwrite_with_column_idx_selection() -> None:
+    csv = """
+a,b,c,d
+1,2,3,4
+1,2,3,4
+"""
+    f = io.StringIO(csv)
+    df = pl.read_csv(f, columns=[2, 1, 3], dtypes=[pl.Int32, pl.Utf8])
+    # Columns without an explicit dtype set will get pl.Utf8 if dtypes is a list
+    # if the column selection is done with column indices instead of column names.
+    assert df.dtypes == [pl.Utf8, pl.Int32, pl.Utf8]
+    # Projections are sorted.
+    assert df.columns == ["b", "c", "d"]
+
+
 def test_partial_column_rename() -> None:
     csv = """
 a,b,c


### PR DESCRIPTION
…lection is used when reading a CSV file.

Assign dtypes to expected columns when dtypes is a list and column
selection is used when reading a CSV file.

As dtypes are passed to the polars CSV reader, projection and column
selection was not applied on the dtypes in case it is a list,
so the dtypes would be applied to the first x columns, instead of
the corresponding columns selected by the projection/column selection.

A remaining issue that is not fixed:
  Projection in combination with a list of dtypes which contain a
  pl.Date type, are converted to null dates.
  In case column names were used for the selection, the pl.Date type
  will correctly convert that column to dates.

Fixes: #3891