### PR TITLE
Complete pythonic slice support (inc. negative indexing/stride) for DataFrame and Series

### DIFF
--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -13,7 +13,7 @@ types-pytz
 maturin==0.12.19
 pytest==7.1.2
 pytest-cov[toml]==3.0.0
-hypothesis==6.48
+hypothesis==6.49.1
 black==22.3.0
 blackdoc==0.3.4
 isort~=5.10.1

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -41,6 +41,7 @@ from polars.internals.construction import (
     sequence_to_pyseries,
     series_to_pyseries,
 )
+from polars.internals.functions import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
     _datetime_to_pl_timestamp,
@@ -479,12 +480,7 @@ class Series:
 
         # slice
         if isinstance(item, slice):
-            start, stop, stride = item.indices(self.len())
-            out = self.slice(start, stop - start)
-            if stride != 1:
-                return out.take_every(stride)
-            else:
-                return out
+            return PolarsSlice(self).apply(item)
 
         raise NotImplementedError
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -606,7 +606,6 @@ def test_slice() -> None:
     ):
         # confirm frame slice matches python slice
         assert df[py_slice].rows() == df.rows()[py_slice]
-        print(df.rows()[py_slice])
 
 
 def test_head_tail_limit() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -587,14 +587,26 @@ def test_take_every() -> None:
 
 
 def test_slice() -> None:
-    df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"]})
-    expected = pl.DataFrame({"a": [1, 3], "b": ["b", "c"]})
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+    expected = pl.DataFrame({"a": [2, 3], "b": ["b", "c"]})
     for slice_params in (
         [1, 10],  # slice > len(df)
         [1, 2],  # slice == len(df)
         [1],  # optional len
     ):
         assert df.slice(*slice_params).frame_equal(expected)
+
+    for py_slice in (
+        slice(1, 2),
+        slice(0, 2, 2),
+        slice(3, -3, -1),
+        slice(1, None, -2),
+        slice(-1, -3, -1),
+        slice(-3, None, -3),
+    ):
+        # confirm frame slice matches python slice
+        assert df[py_slice].rows() == df.rows()[py_slice]
+        print(df.rows()[py_slice])
 
 
 def test_head_tail_limit() -> None:

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -86,4 +86,3 @@ def test_frame_slice(df: pl.DataFrame) -> None:
         assert (
             sliced_py_data == sliced_df_data
         ), f"slice [{start}:{stop}:{step}] failed on df w/len={len(df)}"
-        print(f"[{start}:{stop}:{step}]")

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -1,10 +1,11 @@
 # -------------------------------------------------
 # Validate Series behaviour with parameteric tests
 # -------------------------------------------------
-from hypothesis import given
+from hypothesis import example, given, settings
+from hypothesis.strategies import integers
 
 import polars as pl
-from polars.testing import dataframes
+from polars.testing import column, dataframes
 
 
 @given(df=dataframes())
@@ -13,8 +14,11 @@ def test_repr(df: pl.DataFrame) -> None:
     # print(df)
 
 
-@given(df=dataframes(allowed_dtypes=[pl.Boolean, pl.UInt64, pl.Utf8, pl.Time]))
+@given(df=dataframes(min_size=1, min_cols=1, null_probability=0.25))
+@example(df=pl.DataFrame(columns=["x", "y", "z"]))
+@example(df=pl.DataFrame())
 def test_null_count(df: pl.DataFrame) -> None:
+    # note: the zero-row and zero-col cases are always passed as explicit examples
     null_count, ncols = df.null_count(), len(df.columns)
     if ncols == 0:
         assert null_count.shape == (0, 0)
@@ -22,3 +26,64 @@ def test_null_count(df: pl.DataFrame) -> None:
         assert null_count.shape == (1, ncols)
         for idx, count in enumerate(null_count.rows()[0]):
             assert count == sum(v is None for v in df.select_at_idx(idx).to_list())
+    print(null_count.rows())
+
+
+@given(
+    df=dataframes(
+        max_size=20,
+        cols=[
+            column(
+                "start",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-12, max_value=12),
+            ),
+            column(
+                "stop",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-10, max_value=10),
+            ),
+            column(
+                "step",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-8, max_value=8).filter(lambda x: x != 0),
+            ),
+            column("misc", dtype=pl.Int32),
+        ],
+    )
+    # generated dataframe example -
+    # ┌───────┬──────┬──────┬───────┐
+    # │ start ┆ stop ┆ step ┆ misc  │
+    # │ ---   ┆ ---  ┆ ---  ┆ ---   │
+    # │ i8    ┆ i8   ┆ i8   ┆ i32   │
+    # ╞═══════╪══════╪══════╪═══════╡
+    # │ 2     ┆ -1   ┆ null ┆ -55   │
+    # ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+    # │ -3    ┆ 0    ┆ -2   ┆ 61582 │
+    # ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+    # │ null  ┆ 1    ┆ 2    ┆ 5865  │
+    # └───────┴──────┴──────┴───────┘
+)
+@settings(max_examples=500)
+def test_frame_slice(df: pl.DataFrame) -> None:
+    # take strategy-generated integer values from the frame as slice bounds.
+    # use these bounds to slice the same frame, and then validate the result
+    # against a py-native slice of the same data using the same bounds.
+    #
+    # given the average number of rows in the frames, and the value of
+    # max_examples, this will result in close to 5000 test permutations,
+    # running in around ~3 secs (depending on hardware/etc).
+    py_data = df.rows()
+
+    for start, stop, step, _ in py_data:
+        s = slice(start, stop, step)
+        sliced_py_data = py_data[s]
+        sliced_df_data = df[s].rows()
+
+        assert (
+            sliced_py_data == sliced_df_data
+        ), f"slice [{start}:{stop}:{step}] failed on df w/len={len(df)}"
+        print(f"[{start}:{stop}:{step}]")

--- a/py-polars/tests_parametric/test_series.py
+++ b/py-polars/tests_parametric/test_series.py
@@ -1,11 +1,10 @@
 # -------------------------------------------------
 # Validate Series behaviour with parameteric tests
 # -------------------------------------------------
-import random
 from typing import Optional
 
 from hypothesis import given, settings
-from hypothesis.strategies import integers, sampled_from
+from hypothesis.strategies import sampled_from
 
 import polars as pl
 from polars.testing import series  # , verify_series_and_expr_api

--- a/py-polars/tests_parametric/test_series.py
+++ b/py-polars/tests_parametric/test_series.py
@@ -1,16 +1,15 @@
 # -------------------------------------------------
 # Validate Series behaviour with parameteric tests
 # -------------------------------------------------
+import random
+from typing import Optional
 
-# from hypothesis import given
-#
-# import polars as pl
-# from polars.testing import (
-#     series,
-#     verify_series_and_expr_api,
-# )
-#
-#
+from hypothesis import given, settings
+from hypothesis.strategies import integers, sampled_from
+
+import polars as pl
+from polars.testing import series  # , verify_series_and_expr_api
+
 # # TODO: exclude obvious/known overflow inside the strategy before commenting back in
 # @given(s=series(allowed_dtypes=_NUMERIC_COL_TYPES, name="a"))
 # def test_cum_agg_extra(s: pl.Series) -> None:
@@ -18,3 +17,26 @@
 #     # note: testing codepath-equivalence, not correctness.
 #     for op in ("cumsum", "cummin", "cummax", "cumprod"):
 #          verify_series_and_expr_api(s, None, op)
+
+
+@given(
+    srs=series(max_size=10, dtype=pl.Int64),
+    start=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
+    stop=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
+    step=sampled_from([-5, -4, -3, -2, -1, None, 1, 2, 3, 4, 5]),
+)
+@settings(max_examples=500)
+def test_series_slice(
+    srs: pl.Series,
+    start: Optional[int],
+    stop: Optional[int],
+    step: Optional[int],
+) -> None:
+    py_data = srs.to_list()
+
+    s = slice(start, stop, step)
+    sliced_py_data = py_data[s]
+    sliced_pl_data = srs[s].to_list()
+
+    assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
+    print((s, len(srs)))

--- a/py-polars/tests_parametric/test_series.py
+++ b/py-polars/tests_parametric/test_series.py
@@ -39,4 +39,3 @@ def test_series_slice(
     sliced_pl_data = srs[s].to_list()
 
     assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
-    print((s, len(srs)))


### PR DESCRIPTION
Closes #3759.

**Testing notes**

Much happier releasing this now that the parametric tests have probed at it (I ran ~500,000 permutations locally, though the included tests will run no more than ~5000, in 2-3 secs). Additional quick tests are also included to cover a (much smaller ;) selection of examples with negative start/stop/stride.

**Features**

Supports _all_ python slice syntax for `DataFrame` and `Series`, without limitation (positive/negative stride of arbitrary size, positive/negative indexing, mixed args, optional args, etc - all fine), eg:

```python
df[-3:1:3]
df[10:-20]
df[2:None:6]
df[7:1:-2]
df[10:4:3]
df[-7:0:-2]
df[None:3:-3]
```

Will take fast-paths where available (eg: on identification of zero-length slice, unbounded slice with negative unit stride, and so on). Is optimal for negative stride in the general case as it identifies the slice window before reversing and operates as a LazyFrame when more than one op is required (eg: `obj.slice(i,j).reverse().take_every(n)`).

**TODO**

A lot of this (though probably not all?) can be added for `LazyFrame` later, but as it doesn't know its own length some slightly different logic is required, and I'll tackle that another day ;)

-----

**Fun related reading...** ;p

* ["Where did we go wrong with negative stride?"](https://groups.google.com/g/python-ideas/c/VKlPrkQWk50) - Guido van Rossum.
* The underlying [C source](https://github.com/python/cpython/blob/main/Objects/sliceobject.c) for PySliceObject and related methods, which includes the encouraging comment (twice!) 
  _"/* this is harder to get right than you might think */"_.