### PR TITLE
Implement pow/rpow for Series

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -141,7 +141,9 @@ class Expr:
     def __rmod__(self, other: Any) -> Expr:
         return wrap_expr(self.__to_pyexpr(other) % self._pyexpr)
 
-    def __pow__(self, power: int | float | Expr, modulo: None = None) -> Expr:
+    def __pow__(
+        self, power: int | float | pli.Series | Expr, modulo: None = None
+    ) -> Expr:
         return self.pow(power)
 
     def __rpow__(self, base: int | float | Expr) -> Expr:
@@ -2063,7 +2065,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.tail(n))
 
-    def pow(self, exponent: int | float | Expr) -> Expr:
+    def pow(self, exponent: int | float | pli.Series | Expr) -> Expr:
         """
         Raise expression to the power of exponent.
         Examples

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -141,10 +141,10 @@ class Expr:
     def __rmod__(self, other: Any) -> Expr:
         return wrap_expr(self.__to_pyexpr(other) % self._pyexpr)
 
-    def __pow__(self, power: float | Expr | int, modulo: None = None) -> Expr:
+    def __pow__(self, power: int | float | Expr, modulo: None = None) -> Expr:
         return self.pow(power)
 
-    def __rpow__(self, base: float | Expr | int) -> Expr:
+    def __rpow__(self, base: int | float | Expr) -> Expr:
         return pli.expr_to_lit_or_expr(base) ** self
 
     def __ge__(self, other: Any) -> Expr:
@@ -2063,7 +2063,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.tail(n))
 
-    def pow(self, exponent: float | Expr) -> Expr:
+    def pow(self, exponent: int | float | Expr) -> Expr:
         """
         Raise expression to the power of exponent.
         Examples

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -141,9 +141,7 @@ class Expr:
     def __rmod__(self, other: Any) -> Expr:
         return wrap_expr(self.__to_pyexpr(other) % self._pyexpr)
 
-    def __pow__(
-        self, power: int | float | pli.Series | Expr, modulo: None = None
-    ) -> Expr:
+    def __pow__(self, power: int | float | pli.Series | Expr) -> Expr:
         return self.pow(power)
 
     def __rpow__(self, base: int | float | Expr) -> Expr:

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -434,23 +434,19 @@ class Series:
             raise ValueError("first cast to integer before multiplying datelike dtypes")
         return self._arithmetic(other, "mul", "mul_<>")
 
-    def __pow__(self, power: float, modulo: None = None) -> Series:
+    def __pow__(self, power: int | float, modulo: None = None) -> Series:
         if self.is_datelike():
             raise ValueError(
                 "first cast to integer before raising datelike dtypes to a power"
             )
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.power(self, power)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).pow(power)).to_series()
 
     def __rpow__(self, other: Any) -> Series:
         if self.is_datelike():
             raise ValueError(
                 "first cast to integer before raising datelike dtypes to a power"
             )
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.power(other, self)  # type: ignore
+        return self.to_frame().select(other ** pli.col(self.name)).to_series()
 
     def __neg__(self) -> Series:
         return 0 - self

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -434,7 +434,7 @@ class Series:
             raise ValueError("first cast to integer before multiplying datelike dtypes")
         return self._arithmetic(other, "mul", "mul_<>")
 
-    def __pow__(self, power: int | float, modulo: None = None) -> Series:
+    def __pow__(self, power: int | float | Series, modulo: None = None) -> Series:
         if self.is_datelike():
             raise ValueError(
                 "first cast to integer before raising datelike dtypes to a power"

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -434,7 +434,7 @@ class Series:
             raise ValueError("first cast to integer before multiplying datelike dtypes")
         return self._arithmetic(other, "mul", "mul_<>")
 
-    def __pow__(self, power: int | float | Series, modulo: None = None) -> Series:
+    def __pow__(self, power: int | float | Series) -> Series:
         if self.is_datelike():
             raise ValueError(
                 "first cast to integer before raising datelike dtypes to a power"

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -201,9 +201,9 @@ def test_power() -> None:
     # pow
     assert_series_equal(a**2, pl.Series([1.0, 4.0], dtype=Float64))
     assert_series_equal(b**3, pl.Series([None, 8.0], dtype=Float64))
-    assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))  # type: ignore[operator]
-    assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))  # type: ignore[operator]
-    assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))  # type: ignore[operator]
+    assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))
+    assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))
+    assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))
     with pytest.raises(ValueError):
         c**2
     with pytest.raises(pl.ComputeError):

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import Float64, Int32, Int64, UInt32, UInt64
+from polars.datatypes import Date, Float64, Int32, Int64, UInt32, UInt64
 from polars.testing import assert_series_equal, verify_series_and_expr_api
 
 
@@ -191,6 +191,31 @@ def test_arithmetic(s: pl.Series) -> None:
         2 % a
     with pytest.raises(ValueError):
         2**a
+
+
+def test_power() -> None:
+    a = pl.Series([1, 2], dtype=Int64)
+    b = pl.Series([None, 2.0], dtype=Float64)
+    c = pl.Series([date(2020, 2, 28), date(2020, 3, 1)], dtype=Date)
+
+    # pow
+    assert_series_equal(a**2, pl.Series([1.0, 4.0], dtype=Float64))
+    assert_series_equal(b**3, pl.Series([None, 8.0], dtype=Float64))
+    assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))  # type: ignore[operator]
+    assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))  # type: ignore[operator]
+    assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))  # type: ignore[operator]
+    with pytest.raises(ValueError):
+        c**2
+    with pytest.raises(pl.ComputeError):
+        a ** "hi"  # type: ignore[operator]
+
+    # rpow
+    assert_series_equal(2.0**a, pl.Series("literal", [2.0, 4.0], dtype=Float64))
+    assert_series_equal(2**b, pl.Series("literal", [None, 4.0], dtype=Float64))
+    with pytest.raises(ValueError):
+        2**c
+    with pytest.raises(pl.ComputeError):
+        "hi" ** a
 
 
 def test_add_string() -> None:


### PR DESCRIPTION
Relates to #3890

Changes:
* Implemented `__pow__`/`__rpow__` for the `Series` class without relying on numpy.
* Added `int` as a possible type for the exponent
* Added tests

Questions:
* Turns out you can do `Series ** Series` just fine - should we add this as a possible type?
* Why is the `modulo` argument there? Can we get rid of it?