### PR TITLE
Extended `with_columns` to allow **kwargs style named expressions

### DIFF
--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, Union
 
 from polars.string_cache import toggle_string_cache
 
@@ -10,6 +9,7 @@ class Config:
     """
     Configure polars
     """
+
     # class-local boolean flags can be used for options that don't have
     # a Rust component (so no need to register environment variables).
     with_columns_kwargs: bool = False

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import Optional, Union
 
 from polars.string_cache import toggle_string_cache
 
@@ -104,6 +105,19 @@ class Config:
         """
         toggle_string_cache(True)
         return cls
+
+    @classmethod
+    def set_with_columns_kwargs(
+        cls, enable: Optional[bool] = None
+    ) -> Union[type[Config], bool]:
+        """
+        Enable experimental support for kwargs in `with_columns` method.
+        """
+        if enable is None:
+            return bool(int(os.environ.get("POLARS_WITH_COLUMNS_KWARGS", 0)))
+        else:
+            os.environ["POLARS_WITH_COLUMNS_KWARGS"] = "1" if enable else "0"
+            return cls
 
     @classmethod
     def unset_global_string_cache(cls) -> type[Config]:

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -10,6 +10,9 @@ class Config:
     """
     Configure polars
     """
+    # class-local boolean flags can be used for options that don't have
+    # a Rust component (so no need to register environment variables).
+    with_columns_kwargs: bool = False
 
     @classmethod
     def set_utf8_tables(cls) -> type[Config]:
@@ -53,7 +56,6 @@ class Config:
         n
             number of rows to print
         """
-
         os.environ["POLARS_FMT_MAX_ROWS"] = str(n)
         return cls
 
@@ -94,7 +96,6 @@ class Config:
         └─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
 
         """
-
         os.environ["POLARS_FMT_MAX_COLS"] = str(n)
         return cls
 
@@ -105,19 +106,6 @@ class Config:
         """
         toggle_string_cache(True)
         return cls
-
-    @classmethod
-    def set_with_columns_kwargs(
-        cls, enable: Optional[bool] = None
-    ) -> Union[type[Config], bool]:
-        """
-        Enable experimental support for kwargs in `with_columns` method.
-        """
-        if enable is None:
-            return bool(int(os.environ.get("POLARS_WITH_COLUMNS_KWARGS", 0)))
-        else:
-            os.environ["POLARS_WITH_COLUMNS_KWARGS"] = "1" if enable else "0"
-            return cls
 
     @classmethod
     def unset_global_string_cache(cls) -> type[Config]:

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4928,8 +4928,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
         >>> # Support for kwarg expressions is considered EXPERIMENTAL.
-        >>> # Currently requires opt-in via `pl.Config`, eg:
-        >>> pl.Config.set_with_columns_kwargs(True)
+        >>> # Currently requires opt-in via `pl.Config` boolean flag:
+        >>>
+        >>> pl.Config.with_columns_kwargs = True
         >>> df.with_columns(
         ...     d=pl.col("a") * pl.col("b"),
         ...     e=pl.col("c").is_not(),

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4883,7 +4883,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def with_columns(
         self: DF,
-        exprs: pli.Expr | pli.Series | list[pli.Expr | pli.Series],
+        exprs: pli.Expr | pli.Series | Sequence[pli.Expr | pli.Series] | None = None,
+        **named_exprs: pli.Expr | pli.Series,
     ) -> DF:
         """
         Add or overwrite multiple columns in a DataFrame.
@@ -4893,9 +4894,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
         exprs
             List of Expressions that evaluate to columns.
 
+        **named_exprs
+            Named column Expressions, provided as kwargs.
+
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3, 4],
@@ -4924,13 +4927,31 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
-
+        ...
+        >>> df.with_columns(
+        ...     d=pl.col("a") * pl.col("b"),
+        ...     e=~pl.col("c"),
+        ... )
+        shape: (4, 5)
+        ┌─────┬──────┬───────┬──────┬───────┐
+        │ a   ┆ b    ┆ c     ┆ d    ┆ e     │
+        │ --- ┆ ---  ┆ ---   ┆ ---  ┆ ---   │
+        │ i64 ┆ f64  ┆ bool  ┆ f64  ┆ bool  │
+        ╞═════╪══════╪═══════╪══════╪═══════╡
+        │ 1   ┆ 0.5  ┆ true  ┆ 0.5  ┆ false │
+        ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 2   ┆ 4.0  ┆ true  ┆ 8.0  ┆ false │
+        ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 3   ┆ 10.0 ┆ false ┆ 30.0 ┆ true  │
+        ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
+        └─────┴──────┴───────┴──────┴───────┘
         """
-        if not isinstance(exprs, list):
+        if exprs is not None and not isinstance(exprs, Sequence):
             exprs = [exprs]
         return (
             self.lazy()
-            .with_columns(exprs)
+            .with_columns(exprs, **named_exprs)
             .collect(no_optimization=True, string_cache=False)
         )
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4927,8 +4927,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
-        >>> # Support for kwarg expressions is currently EXPERIMENTAL:
-        >>> # requires opt-in via `pl.Config.set_with_columns_kwargs(True)`
+        >>> # Support for kwarg expressions is considered EXPERIMENTAL.
+        >>> # Currently requires opt-in via `pl.Config`, eg:
+        >>> pl.Config.set_with_columns_kwargs(True)
         >>> df.with_columns(
         ...     d=pl.col("a") * pl.col("b"),
         ...     e=pl.col("c").is_not(),

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4893,7 +4893,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ----------
         exprs
             List of Expressions that evaluate to columns.
-
         **named_exprs
             Named column Expressions, provided as kwargs.
 
@@ -4928,9 +4927,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
+        >>> # Support for kwarg expressions is currently EXPERIMENTAL:
+        >>> # requires opt-in via `pl.Config.set_with_columns_kwargs(True)`
         >>> df.with_columns(
         ...     d=pl.col("a") * pl.col("b"),
-        ...     e=~pl.col("c"),
+        ...     e=pl.col("c").is_not(),
         ... )
         shape: (4, 5)
         ┌─────┬──────┬───────┬──────┬───────┐

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1486,7 +1486,7 @@ class LazyFrame(Generic[DF]):
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
         >>> # Support for kwarg expressions is considered EXPERIMENTAL.
-        >>> # requires opt-in via `pl.Config`, eg:
+        >>> # Currently requires opt-in via `pl.Config`, eg:
         >>> pl.Config.set_with_columns_kwargs(True)
         >>> ldf.with_columns(
         ...     d=pl.col("a") * pl.col("b"),

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1451,7 +1451,6 @@ class LazyFrame(Generic[DF]):
         ----------
         exprs
             List of Expressions that evaluate to columns.
-
         **named_exprs
             Named column Expressions, provided as kwargs.
 
@@ -1486,8 +1485,9 @@ class LazyFrame(Generic[DF]):
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
-        >>> # Support for kwarg expressions is currently EXPERIMENTAL:
-        >>> # requires opt-in via `pl.Config.set_with_columns_kwargs(True)`
+        >>> # Support for kwarg expressions is considered EXPERIMENTAL.
+        >>> # requires opt-in via `pl.Config`, eg:
+        >>> pl.Config.set_with_columns_kwargs(True)
         >>> ldf.with_columns(
         ...     d=pl.col("a") * pl.col("b"),
         ...     e=pl.col("c").is_not(),

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1486,8 +1486,9 @@ class LazyFrame(Generic[DF]):
         └─────┴──────┴───────┴──────┴──────┴───────┘
         ...
         >>> # Support for kwarg expressions is considered EXPERIMENTAL.
-        >>> # Currently requires opt-in via `pl.Config`, eg:
-        >>> pl.Config.set_with_columns_kwargs(True)
+        >>> # Currently requires opt-in via `pl.Config` boolean flag:
+        >>>
+        >>> pl.Config.with_columns_kwargs = True
         >>> ldf.with_columns(
         ...     d=pl.col("a") * pl.col("b"),
         ...     e=pl.col("c").is_not(),
@@ -1507,7 +1508,7 @@ class LazyFrame(Generic[DF]):
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
         """
-        if named_exprs and not Config.set_with_columns_kwargs():
+        if named_exprs and not Config.with_columns_kwargs:
             raise RuntimeError(
                 "**kwargs support is experimental; requires opt-in via `pl.Config.set_with_columns_kwargs(True)`"
             )

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1031,16 +1031,17 @@ class Series:
 
     def alias(self, name: str) -> Series:
         """
-        Rename the Series
+        Returns a copy of the Series with a new alias/name.
 
         Parameters
         ----------
         name
-            New name
+            New name.
 
-        Returns
-        -------
-
+        Examples
+        --------
+        >>> srs = pl.Series("x", [1, 2, 3])
+        >>> new_aliased_srs = srs.alias("y")
         """
         s = self.clone()
         s._s.rename(name)

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -381,7 +381,7 @@ if HYPOTHESIS_INSTALLED:
                 self.null_probability < 0 or self.null_probability > 1
             ):
                 raise InvalidArgument(
-                    f"null_probability should be between 0.0 and 1.0; found {self.null_probability}"
+                    f"null_probability should be between 0.0 and 1.0, or None; found {self.null_probability}"
                 )
             if self.dtype is None and not self.strategy:
                 self.dtype = random.choice(strategy_dtypes)
@@ -660,7 +660,7 @@ if HYPOTHESIS_INSTALLED:
         max_cols : int, optional
             if not passing an exact size, can set a maximum value here (defaults to MAX_COLS).
         size : int, optional
-            if set, will create a Series of exactly this size (and ignore min/max len params).
+            if set, will create a DataFrame of exactly this size (and ignore min/max len params).
         min_size : int, optional
             if not passing an exact size, set the minimum number of rows in the DataFrame.
         max_size : int, optional

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2406,7 +2406,7 @@ def test_with_columns() -> None:
     assert_frame_equal(dx, expected)
 
     # as **kwargs (experimental feature: requires opt-in)
-    pl.Config.set_with_columns_kwargs(True)
+    pl.Config.with_columns_kwargs = True
 
     dx = df.with_columns(
         d=pl.col("a") * pl.col("b"),

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2375,3 +2375,52 @@ def test_selection_regex_and_multicol() -> None:
         "b": [25, 36, 49, 64],
         "c": [81, 100, 121, 144],
     }
+
+
+def test_with_columns() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, 3, 4],
+            "b": [0.5, 4, 10, 13],
+            "c": [True, True, False, True],
+        }
+    )
+    srs_named = pl.Series("f", [3, 2, 1, 0])
+    srs_unnamed = pl.Series(values=[3, 2, 1, 0])
+
+    expected = pl.DataFrame(
+        {
+            "a": [1, 2, 3, 4],
+            "b": [0.5, 4, 10, 13],
+            "c": [True, True, False, True],
+            "d": [0.5, 8.0, 30.0, 52.0],
+            "e": [False, False, True, False],
+            "f": [3, 2, 1, 0],
+        }
+    )
+
+    # as exprs list
+    dx = df.with_columns(
+        [(pl.col("a") * pl.col("b")).alias("d"), ~pl.col("c").alias("e"), srs_named]
+    )
+    assert_frame_equal(dx, expected)
+
+    # as **kwargs
+    dx = df.with_columns(
+        d=pl.col("a") * pl.col("b"),
+        e=~pl.col("c"),
+        f=srs_unnamed,
+    )
+    assert_frame_equal(dx, expected)
+
+    # mixed
+    dx = df.with_columns(
+        [(pl.col("a") * pl.col("b")).alias("d")],
+        e=~pl.col("c"),
+        f=srs_unnamed,
+    )
+    assert_frame_equal(dx, expected)
+
+    # at least one of exprs/**named_exprs required
+    with pytest.raises(ValueError):
+        _ = df.with_columns()

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2405,7 +2405,9 @@ def test_with_columns() -> None:
     )
     assert_frame_equal(dx, expected)
 
-    # as **kwargs
+    # as **kwargs (experimental feature: requires opt-in)
+    pl.Config.set_with_columns_kwargs(True)
+
     dx = df.with_columns(
         d=pl.col("a") * pl.col("b"),
         e=~pl.col("c"),


### PR DESCRIPTION
_Suggested by @kdcd in #3866, but implemented via simple extension of `with_columns`, not as a new function._

-----

Default behavior completely unchanged, but now _also_ allows for the following clean/readable calling convention:

```python
import polars as pl

df = pl.DataFrame({
    "a": [1, 2, 3, 4],
    "b": [0.5, 4, 10, 13],
    "c": [True, True, False, True],
})

# can opt to provide expressions as **kwargs, for 
# additional readability in some common cases.
df.with_columns(
    d = pl.col("a") * pl.col("b"),
    e = pl.col("c").is_not(),
)
# ┌─────┬──────┬───────┬──────┬───────┐
# │ a   ┆ b    ┆ c     ┆ d    ┆ e     │
# │ --- ┆ ---  ┆ ---   ┆ ---  ┆ ---   │
# │ i64 ┆ f64  ┆ bool  ┆ f64  ┆ bool  │
# ╞═════╪══════╪═══════╪══════╪═══════╡
# │ 1   ┆ 0.5  ┆ true  ┆ 0.5  ┆ false │
# ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
# │ 2   ┆ 4.0  ┆ true  ┆ 8.0  ┆ false │
# ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
# │ 3   ┆ 10.0 ┆ false ┆ 30.0 ┆ true  │
# ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
# │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
# └─────┴──────┴───────┴──────┴───────┘
```
Can freely mix & match with an existing expressions list, or just use one or the other.
All unit tests pass as-is, and some new test coverage was added.

(I think the other idea in that feature request involving `col` also has merit, with a few minor tweaks; however, this PR doesn't touch on that as it is a more fundamental change and likely needs some thought/care ;)

**Update:**

For consistency, the same optional calling pattern is now also allowed with `select` and `agg`.

**Additional update:**

Following discussion, reverted `select` and `agg` updates - they don't read as cleanly as `with_columns`.

**Final update:**

This syntax is considered experimental for now, and requires explicit opt-in via 
```python
pl.Config.set_with_columns_kwargs(True)
```