### PR TITLE
parquet: parallelize over row groups `~3x`

### DIFF
--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -1,14 +1,14 @@
 use crate::aggregations::{apply_aggregations, ScanAggregation};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
-use crate::parquet::mmap;
 use crate::parquet::mmap::mmap_columns;
-use crate::parquet::predicates::collect_statistics;
+use crate::parquet::predicates::read_this_row_group;
+use crate::parquet::{mmap, ParallelStrategy};
 use crate::predicates::{apply_predicate, arrow_schema_to_empty_df, PhysicalIoExpr};
 use crate::utils::apply_projection;
 use crate::RowCount;
 use arrow::array::new_empty_array;
 use arrow::io::parquet::read;
-use arrow::io::parquet::read::{ArrayIter, FileMetaData};
+use arrow::io::parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
 use polars_core::prelude::*;
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_core::POOL;
@@ -17,6 +17,25 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::sync::Arc;
+
+fn column_idx_to_series(
+    column_i: usize,
+    md: &RowGroupMetaData,
+    remaining_rows: usize,
+    schema: &ArrowSchema,
+    bytes: &[u8],
+    chunk_size: usize,
+) -> Result<Series> {
+    let field = &schema.fields[column_i];
+    let columns = mmap_columns(bytes, md.columns(), &field.name);
+    let iter = mmap::to_deserializer(columns, field.clone(), remaining_rows, Some(chunk_size))?;
+
+    if remaining_rows < md.num_rows() {
+        array_iter_to_series(iter, field, Some(remaining_rows))
+    } else {
+        array_iter_to_series(iter, field, None)
+    }
+}
 
 fn array_iter_to_series(
     iter: ArrayIter,
@@ -51,56 +70,32 @@ fn array_iter_to_series(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn read_parquet<R: MmapBytesReader>(
-    mut reader: R,
+// might parallelize over columns
+fn rg_to_dfs(
+    bytes: &[u8],
+    n_row_groups: usize,
     limit: usize,
-    projection: Option<&[usize]>,
+    file_metadata: &FileMetaData,
     schema: &ArrowSchema,
-    metadata: Option<FileMetaData>,
     predicate: Option<Arc<dyn PhysicalIoExpr>>,
     aggregate: Option<&[ScanAggregation]>,
-    mut parallel: bool,
     row_count: Option<RowCount>,
-) -> Result<DataFrame> {
-    let file_metadata = metadata
-        .map(Ok)
-        .unwrap_or_else(|| read::read_metadata(&mut reader))?;
-    let row_group_len = file_metadata.row_groups.len();
-
-    let projection = projection
-        .map(Cow::Borrowed)
-        .unwrap_or_else(|| Cow::Owned((0usize..schema.fields.len()).collect::<Vec<_>>()));
-
-    if projection.len() == 1 {
-        parallel = false;
-    }
-
-    let mut dfs = Vec::with_capacity(row_group_len);
+    parallel: ParallelStrategy,
+    projection: &[usize],
+) -> Result<Vec<DataFrame>> {
+    let mut dfs = Vec::with_capacity(n_row_groups);
 
     let mut remaining_rows = limit;
 
-    let reader = ReaderBytes::from(&reader);
-    let bytes = reader.deref();
-
     let mut previous_row_count = 0;
-    for rg in 0..row_group_len {
+    for rg in 0..n_row_groups {
         let md = &file_metadata.row_groups[rg];
         let current_row_count = md.num_rows() as IdxSize;
-        if let Some(pred) = &predicate {
-            if let Some(pred) = pred.as_stats_evaluator() {
-                if let Some(stats) = collect_statistics(&file_metadata.row_groups, schema)? {
-                    let should_read = pred.should_read(&stats);
-                    // a parquet file may not have statistics of all columns
-                    if matches!(should_read, Ok(false)) {
-                        previous_row_count += current_row_count;
-                        continue;
-                    } else if !matches!(should_read, Err(PolarsError::NotFound(_))) {
-                        let _ = should_read?;
-                    }
-                }
-            }
-        }
 
+        if !read_this_row_group(predicate.as_ref(), file_metadata, schema)? {
+            previous_row_count += current_row_count;
+            continue;
+        }
         // test we don't read the parquet file if this env var is set
         #[cfg(debug_assertions)]
         {
@@ -108,25 +103,19 @@ pub fn read_parquet<R: MmapBytesReader>(
         }
 
         let chunk_size = md.num_rows() as usize;
-        let columns = if parallel {
+        let columns = if let ParallelStrategy::Columns = parallel {
             POOL.install(|| {
                 projection
                     .par_iter()
                     .map(|column_i| {
-                        let field = &schema.fields[*column_i];
-                        let columns = mmap_columns(bytes, md.columns(), &field.name);
-                        let iter = mmap::to_deserializer(
-                            columns,
-                            field.clone(),
+                        column_idx_to_series(
+                            *column_i,
+                            md,
                             remaining_rows,
-                            Some(chunk_size),
-                        )?;
-
-                        if remaining_rows < md.num_rows() {
-                            array_iter_to_series(iter, field, Some(remaining_rows))
-                        } else {
-                            array_iter_to_series(iter, field, None)
-                        }
+                            schema,
+                            bytes,
+                            chunk_size,
+                        )
                     })
                     .collect::<Result<Vec<_>>>()
             })?
@@ -134,20 +123,7 @@ pub fn read_parquet<R: MmapBytesReader>(
             projection
                 .iter()
                 .map(|column_i| {
-                    let field = &schema.fields[*column_i];
-                    let columns = mmap_columns(bytes, md.columns(), &field.name);
-                    let iter = mmap::to_deserializer(
-                        columns,
-                        field.clone(),
-                        remaining_rows,
-                        Some(chunk_size),
-                    )?;
-
-                    if remaining_rows < md.num_rows() {
-                        array_iter_to_series(iter, field, Some(remaining_rows))
-                    } else {
-                        array_iter_to_series(iter, field, None)
-                    }
+                    column_idx_to_series(*column_i, md, remaining_rows, schema, bytes, chunk_size)
                 })
                 .collect::<Result<Vec<_>>>()?
         };
@@ -166,6 +142,135 @@ pub fn read_parquet<R: MmapBytesReader>(
         previous_row_count += current_row_count;
         dfs.push(df)
     }
+    Ok(dfs)
+}
+
+#[allow(clippy::too_many_arguments)]
+// parallelizes over row groups
+fn rg_to_dfs_par(
+    bytes: &[u8],
+    limit: usize,
+    file_metadata: &FileMetaData,
+    schema: &ArrowSchema,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    aggregate: Option<&[ScanAggregation]>,
+    row_count: Option<RowCount>,
+    projection: &[usize],
+) -> Result<Vec<DataFrame>> {
+    let mut remaining_rows = limit;
+    let mut previous_row_count = 0;
+
+    // compute the limits per row group and the row count offsets
+    let row_groups = file_metadata
+        .row_groups
+        .iter()
+        .map(|rg_md| {
+            let row_count_start = previous_row_count;
+            let num_rows = rg_md.num_rows();
+            previous_row_count += num_rows;
+            let local_limit = remaining_rows;
+            remaining_rows = remaining_rows.saturating_sub(num_rows);
+
+            (rg_md, local_limit, row_count_start)
+        })
+        .collect::<Vec<_>>();
+
+    let dfs = row_groups
+        .into_par_iter()
+        .map(|(md, local_limit, row_count_start)| {
+            if !read_this_row_group(predicate.as_ref(), file_metadata, schema)? {
+                return Ok(None);
+            }
+            // test we don't read the parquet file if this env var is set
+            #[cfg(debug_assertions)]
+            {
+                assert!(std::env::var("POLARS_PANIC_IF_PARQUET_PARSED").is_err())
+            }
+
+            let chunk_size = md.num_rows() as usize;
+            let columns = projection
+                .iter()
+                .map(|column_i| {
+                    column_idx_to_series(*column_i, md, local_limit, schema, bytes, chunk_size)
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let mut df = DataFrame::new_no_checks(columns);
+
+            if let Some(rc) = &row_count {
+                df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
+            }
+
+            apply_predicate(&mut df, predicate.as_deref())?;
+            apply_aggregations(&mut df, aggregate)?;
+
+            Ok(Some(df))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(dfs.into_iter().flatten().collect())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn read_parquet<R: MmapBytesReader>(
+    mut reader: R,
+    limit: usize,
+    projection: Option<&[usize]>,
+    schema: &ArrowSchema,
+    metadata: Option<FileMetaData>,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    aggregate: Option<&[ScanAggregation]>,
+    mut parallel: ParallelStrategy,
+    row_count: Option<RowCount>,
+) -> Result<DataFrame> {
+    let file_metadata = metadata
+        .map(Ok)
+        .unwrap_or_else(|| read::read_metadata(&mut reader))?;
+    let row_group_len = file_metadata.row_groups.len();
+
+    let projection = projection
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned((0usize..schema.fields.len()).collect::<Vec<_>>()));
+
+    if let ParallelStrategy::Auto = parallel {
+        if row_group_len > projection.len() || row_group_len > POOL.current_num_threads() {
+            parallel = ParallelStrategy::RowGroups;
+        } else {
+            parallel = ParallelStrategy::Columns;
+        }
+    }
+
+    if let (ParallelStrategy::Columns, true) = (parallel, projection.len() == 1) {
+        parallel = ParallelStrategy::None;
+    }
+
+    let reader = ReaderBytes::from(&reader);
+    let bytes = reader.deref();
+    let dfs = match parallel {
+        ParallelStrategy::Columns | ParallelStrategy::None => rg_to_dfs(
+            bytes,
+            row_group_len,
+            limit,
+            &file_metadata,
+            schema,
+            predicate,
+            aggregate,
+            row_count,
+            parallel,
+            &projection,
+        )?,
+        ParallelStrategy::RowGroups => rg_to_dfs_par(
+            bytes,
+            limit,
+            &file_metadata,
+            schema,
+            predicate,
+            aggregate,
+            row_count,
+            &projection,
+        )?,
+        // auto should already be replaced by Columns or RowGroups
+        ParallelStrategy::Auto => unimplemented!(),
+    };
 
     if dfs.is_empty() {
         let schema = if let Cow::Borrowed(_) = projection {

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -1,12 +1,13 @@
 use crate::prelude::*;
 use polars_core::prelude::*;
+use polars_io::parquet::ParallelStrategy;
 use polars_io::RowCount;
 
 #[derive(Clone)]
 pub struct ScanArgsParquet {
     pub n_rows: Option<usize>,
     pub cache: bool,
-    pub parallel: bool,
+    pub parallel: ParallelStrategy,
     pub rechunk: bool,
     pub row_count: Option<RowCount>,
 }
@@ -16,7 +17,7 @@ impl Default for ScanArgsParquet {
         Self {
             n_rows: None,
             cache: true,
-            parallel: true,
+            parallel: Default::default(),
             rechunk: true,
             row_count: None,
         }
@@ -28,7 +29,7 @@ impl LazyFrame {
         path: String,
         n_rows: Option<usize>,
         cache: bool,
-        parallel: bool,
+        parallel: ParallelStrategy,
         row_count: Option<RowCount>,
         rechunk: bool,
     ) -> Result<Self> {
@@ -54,7 +55,7 @@ impl LazyFrame {
                         path_string,
                         args.n_rows,
                         args.cache,
-                        false,
+                        ParallelStrategy::None,
                         None,
                         args.rechunk,
                     )

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -88,7 +88,7 @@ impl LogicalPlanBuilder {
         path: P,
         n_rows: Option<usize>,
         cache: bool,
-        parallel: bool,
+        parallel: polars_io::parquet::ParallelStrategy,
         row_count: Option<RowCount>,
         rechunk: bool,
     ) -> Result<Self> {

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -34,7 +34,7 @@ pub struct ParquetOptions {
     pub(crate) n_rows: Option<usize>,
     pub(crate) with_columns: Option<Arc<Vec<String>>>,
     pub(crate) cache: bool,
-    pub(crate) parallel: bool,
+    pub(crate) parallel: polars_io::parquet::ParallelStrategy,
     pub(crate) rechunk: bool,
     pub(crate) row_count: Option<RowCount>,
     pub(crate) file_counter: FileCount,

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -153,7 +153,7 @@ fn test_parquet_globbing() -> Result<()> {
         ScanArgsParquet {
             n_rows: None,
             cache: true,
-            parallel: true,
+            parallel: Default::default(),
             rechunk: false,
             row_count: None,
         },

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -90,6 +90,11 @@ fn init_files() {
 fn scan_foods_parquet(parallel: bool) -> LazyFrame {
     init_files();
     let out_path = FOODS_PARQUET.to_string();
+    let parallel = if parallel {
+        ParallelStrategy::Auto
+    } else {
+        ParallelStrategy::None
+    };
 
     let args = ScanArgsParquet {
         n_rows: None,

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -624,7 +624,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         file: str | Path | BinaryIO,
         columns: list[int] | list[str] | None = None,
         n_rows: int | None = None,
-        parallel: bool = True,
+        parallel: str = "auto",
         row_count_name: str | None = None,
         row_count_offset: int = 0,
     ) -> DF:
@@ -640,7 +640,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         n_rows
             Stop reading from parquet file after reading ``n_rows``.
         parallel
-            Read the parquet file in parallel. The single threaded reader consumes less memory.
+            Any of { 'auto', 'columns', 'row_groups', 'none' }
+            This determines the direction of parallelism. 'auto' will try to determine the optimal direction.
         """
         if isinstance(file, (str, Path)):
             file = format_path(file)

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -171,7 +171,7 @@ class LazyFrame(Generic[DF]):
         file: str,
         n_rows: int | None = None,
         cache: bool = True,
-        parallel: bool = True,
+        parallel: str = "auto",
         rechunk: bool = True,
         row_count_name: str | None = None,
         row_count_offset: int = 0,

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -596,7 +596,7 @@ def scan_parquet(
     file: str | Path,
     n_rows: int | None = None,
     cache: bool = True,
-    parallel: bool = True,
+    parallel: str = "auto",
     rechunk: bool = True,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
@@ -618,7 +618,8 @@ def scan_parquet(
     cache
         Cache the result after reading.
     parallel
-        Read the parquet file in parallel. The single threaded reader consumes less memory.
+        Any of { 'auto', 'columns', 'row_groups', 'none' }
+        This determines the direction of parallelism. 'auto' will try to determine the optimal direction.
     rechunk
         In case of reading multiple files via a glob pattern rechunk the final DataFrame into contiguous memory chunks.
     row_count_name
@@ -765,7 +766,7 @@ def read_parquet(
     use_pyarrow: bool = False,
     memory_map: bool = True,
     storage_options: dict | None = None,
-    parallel: bool = True,
+    parallel: str = "auto",
     row_count_name: str | None = None,
     row_count_offset: int = 0,
     **kwargs: Any,
@@ -792,7 +793,8 @@ def read_parquet(
     storage_options
         Extra options that make sense for ``fsspec.open()`` or a particular storage connection, e.g. host, port, username, password, etc.
     parallel
-        Read the parquet file in parallel. The single threaded reader consumes less memory.
+        Any of { 'auto', 'columns', 'row_groups', 'none' }
+        This determines the direction of parallelism. 'auto' will try to determine the optimal direction.
     row_count_name
         If not None, this will insert a row count column with give name into the DataFrame.
     row_count_offset

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -853,3 +853,19 @@ pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<Fill
         Ok(strat)
     }
 }
+impl FromPyObject<'_> for Wrap<ParallelStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let unit = match ob.str()?.to_str()? {
+            "auto" => ParallelStrategy::Auto,
+            "columns" => ParallelStrategy::Columns,
+            "row_groups" => ParallelStrategy::RowGroups,
+            "none" => ParallelStrategy::None,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "expected one of {'auto', 'columns', 'row_groups', 'none'}",
+                ))
+            }
+        };
+        Ok(Wrap(unit))
+    }
+}

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -208,7 +208,7 @@ impl PyDataFrame {
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
         n_rows: Option<usize>,
-        parallel: bool,
+        parallel: Wrap<ParallelStrategy>,
         row_count: Option<(String, IdxSize)>,
     ) -> PyResult<Self> {
         use EitherRustPythonFile::*;
@@ -220,15 +220,15 @@ impl PyDataFrame {
                 ParquetReader::new(buf)
                     .with_projection(projection)
                     .with_columns(columns)
-                    .read_parallel(parallel)
+                    .read_parallel(parallel.0)
                     .with_n_rows(n_rows)
                     .with_row_count(row_count)
                     .finish()
             }
-            Rust(f) => ParquetReader::new(f)
+            Rust(f) => ParquetReader::new(f.into_inner())
                 .with_projection(projection)
                 .with_columns(columns)
-                .read_parallel(parallel)
+                .read_parallel(parallel.0)
                 .with_n_rows(n_rows)
                 .with_row_count(row_count)
                 .finish(),

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -4,7 +4,9 @@ use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::file::get_file_like;
 use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
-use crate::prelude::{IdxSize, LogicalPlan, NullValues, ScanArgsIpc, ScanArgsParquet};
+use crate::prelude::{
+    IdxSize, LogicalPlan, NullValues, ParallelStrategy, ScanArgsIpc, ScanArgsParquet,
+};
 use polars::io::RowCount;
 use polars::lazy::frame::{AllowedOptimizations, LazyCsvReader, LazyFrame, LazyGroupBy};
 use polars::lazy::prelude::col;
@@ -222,7 +224,7 @@ impl PyLazyFrame {
         path: String,
         n_rows: Option<usize>,
         cache: bool,
-        parallel: bool,
+        parallel: Wrap<ParallelStrategy>,
         rechunk: bool,
         row_count: Option<(String, IdxSize)>,
     ) -> PyResult<Self> {
@@ -230,7 +232,7 @@ impl PyLazyFrame {
         let args = ScanArgsParquet {
             n_rows,
             cache,
-            parallel,
+            parallel: parallel.0,
             rechunk,
             row_count,
         };

--- a/py-polars/tests/io/test_lazy_parquet.py
+++ b/py-polars/tests/io/test_lazy_parquet.py
@@ -57,7 +57,7 @@ def test_categorical_parquet_statistics(io_test_dir: str) -> None:
         .write_parquet(file, statistics=True)
     )
 
-    for par in [True, False]:
+    for par in ["auto", "columns", "row_groups", "none"]:
         df = (
             pl.scan_parquet(file, parallel=par)
             .filter(pl.col("book") == "bookA")


### PR DESCRIPTION
Can be ~3x faster if a parquet file contains many row groups.

Some timings:

![image](https://user-images.githubusercontent.com/3023000/177730048-eba3025d-2fc1-45df-9129-99896edf1537.png)
