### PR TITLE
Don't unwrap IPC Stream, instead use ? to not panic

### DIFF
--- a/polars/polars-io/src/ipc/ipc_stream.rs
+++ b/polars/polars-io/src/ipc/ipc_stream.rs
@@ -109,7 +109,7 @@ impl<R: Read + Seek> IpcStreamReader<R> {
     fn metadata(&mut self) -> Result<StreamMetadata> {
         match &self.metadata {
             None => {
-                let metadata = read::read_stream_metadata(&mut self.reader).unwrap();
+                let metadata = read::read_stream_metadata(&mut self.reader)?;
                 self.metadata = Option::from(metadata.clone());
                 Ok(metadata)
             }

--- a/polars/tests/it/io/ipc_stream.rs
+++ b/polars/tests/it/io/ipc_stream.rs
@@ -95,6 +95,13 @@ mod test {
     }
 
     #[test]
+    fn test_read_invalid_stream() {
+        let buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        assert!(IpcStreamReader::new(buf.clone()).arrow_schema().is_err());
+        assert!(IpcStreamReader::new(buf).finish().is_err());
+    }
+
+    #[test]
     fn test_write_with_compression() {
         let mut df = create_df();
 


### PR DESCRIPTION
Rust will panic if the passed in Reader is invalid.

I've also added a test to ensure it will fail for both the metadata and the `finish()` when passing through invalid data, though the `finish()` should always fail, but it's better to be safe.