### PR TITLE
Corrected .select type hint to Sequence[str, Expr]

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -2813,7 +2813,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def groupby(
         self: DF,
-        by: str | pli.Expr | Sequence[str] | Sequence[pli.Expr],
+        by: str | pli.Expr | Sequence[str | pli.Expr],
         maintain_order: bool = False,
     ) -> GroupBy[DF]:
         """

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -817,7 +817,7 @@ class LazyFrame(Generic[DF]):
 
     def select(
         self: LDF,
-        exprs: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | pli.Series,
+        exprs: str | pli.Expr | Sequence[str | pli.Expr] | pli.Series,
     ) -> LDF:
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1433,7 +1433,7 @@ def collect_all(
 
 
 def select(
-    exprs: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | pli.Series,
+    exprs: str | pli.Expr | Sequence[str | pli.Expr] | pli.Series,
 ) -> pli.DataFrame:
     """
     Run polars expressions without a context.


### PR DESCRIPTION
We can do this:

```python
df = pl.DataFrame(
    {
        "foo": [1, 2, 3],
        "bar": [6, 7, 8],
        "ham": ["a", "b", "c"],
    }
)
df.select(["ham", pl.all().exclude("ham")]) # <- Mixing str and pli.Expr works fine

shape: (3, 3)
┌─────┬─────┬─────┐
│ ham ┆ foo ┆ bar │
│ --- ┆ --- ┆ --- │
│ str ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ a   ┆ 1   ┆ 6   │
├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
│ b   ┆ 2   ┆ 7   │
├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
│ c   ┆ 3   ┆ 8   │
└─────┴─────┴─────┘
```

But that raised a typing warning since we specified _either_ `Sequence[int]` or `Sequence[pli.Expr]`