### PR TITLE
Fixed most `See Also` docstring formatting, quietened the last warnings coming from `doctests`

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -31,6 +31,7 @@ test-all: venv
 	$(PYTHON_BIN)/maturin develop
 	$(PYTHON) -m pytest tests
 	$(PYTHON) -m pytest tests_parametric
+	$(PYTHON) tests/run_doc_examples.py
 
 test-with-cov: venv
 	$(PYTHON) -m pytest \

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -41,7 +41,6 @@ def from_dict(
 
     Examples
     --------
-
     >>> data = {"a": [1, 2], "b": [3, 4]}
     >>> df = pl.from_dict(data)
     >>> df
@@ -92,7 +91,7 @@ def from_records(
     >>> data = [[1, 2, 3], [4, 5, 6]]
     >>> df = pl.from_records(data, columns=["a", "b"])
     >>> df
-        shape: (3, 2)
+    shape: (3, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
     │ --- ┆ --- │

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5680,7 +5680,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": ["Crab", "cat and dog", "rab$bit", None]})
         >>> df.select(
         ...     [
@@ -5704,6 +5703,10 @@ class ExprStringNameSpace:
         │ null        ┆ null  ┆ null    │
         └─────────────┴───────┴─────────┘
 
+        See Also
+        --------
+        starts_with : Check if string values start with a substring.
+        ends_with : Check if string values end with a substring.
         """
         return wrap_expr(self._pyexpr.str_contains(pattern, literal))
 
@@ -5714,11 +5717,10 @@ class ExprStringNameSpace:
         Parameters
         ----------
         sub
-            Suffix
+            Suffix substring.
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"fruits": ["apple", "mango", None]})
         >>> df.with_column(
         ...     pl.col("fruits").str.ends_with("go").alias("has_suffix"),
@@ -5751,7 +5753,7 @@ class ExprStringNameSpace:
         See Also
         --------
         contains : Check if string contains a substring that matches a regex.
-
+        starts_with : Check if string values start with a substring.
         """
         return wrap_expr(self._pyexpr.str_ends_with(sub))
 
@@ -5762,11 +5764,10 @@ class ExprStringNameSpace:
         Parameters
         ----------
         sub
-            Prefix
+            Prefix substring.
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"fruits": ["apple", "mango", None]})
         >>> df.with_column(
         ...     pl.col("fruits").str.starts_with("app").alias("has_prefix"),
@@ -5799,7 +5800,7 @@ class ExprStringNameSpace:
         See Also
         --------
         contains : Check if string contains a substring that matches a regex.
-
+        ends_with : Check if string values end with a substring.
         """
         return wrap_expr(self._pyexpr.str_starts_with(sub))
 
@@ -5823,7 +5824,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"json_val": ['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}']}
         ... )
@@ -6174,7 +6174,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"id": [1, 2], "text": ["123abc", "abc456"]})
         >>> df.with_column(
         ...     pl.col("text").str.replace(r"abc\b", "ABC")

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -776,7 +776,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         json_lines: bool = False,
     ) -> DF:
         """
-        See Also pl.read_json
+        See Also
+        --------
+        read_json
         """
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
@@ -2178,7 +2180,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         See Also
         --------
-        schema : Return a dict of [column name, dtype]
+        schema : Returns a {colname:dtype} mapping.
         """
         return self._df.dtypes()
 
@@ -2507,7 +2509,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -2536,7 +2537,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         Get first N rows as DataFrame.
 
-        See Also `DataFrame.head`
+        See Also
+        --------
+        head, tail, slice
 
         Parameters
         ----------
@@ -6486,7 +6489,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": ["one", "one", "one", "two", "two", "two"],
@@ -6494,7 +6496,7 @@ class GroupBy(Generic[DF]):
         ...         "baz": [1, 2, 3, 4, 5, 6],
         ...     }
         ... )
-        >>> df.groupby("foo", maintain_order=True).pivot(
+        >>> df.groupby("foo", maintain_order=True).pivot(  # doctest: +SKIP
         ...     pivot_column="bar", values_column="baz"
         ... ).first()
         shape: (2, 4)
@@ -6527,7 +6529,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6559,7 +6560,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6591,7 +6591,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6623,7 +6622,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6655,7 +6653,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6687,7 +6684,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6719,7 +6715,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6752,7 +6747,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 1, 3, 4, 5],
@@ -6790,7 +6784,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6821,7 +6814,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 2, 3, 4, 5],
@@ -6850,7 +6842,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": ["one", "two", "one", "two"], "b": [1, 2, 3, 4]})
         >>> df.groupby("a", maintain_order=True).agg_list()
         shape: (2, 2)

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -5968,7 +5968,6 @@ class GroupBy(Generic[DF]):
 
     Examples
     --------
-
     >>> df = pl.DataFrame({"foo": ["a", "a", "b"], "bar": [1, 2, 3]})
     >>> for group in df.groupby("foo"):
     ...     print(group)

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -132,7 +132,9 @@ class LazyFrame(Generic[DF]):
         parse_dates: bool = False,
     ) -> LDF:
         """
-        See Also: `pl.scan_csv`
+        See Also
+        --------
+        scan_csv
         """
         dtype_list: list[tuple[str, type[DataType]]] | None = None
         if dtypes is not None:
@@ -178,7 +180,9 @@ class LazyFrame(Generic[DF]):
         storage_options: dict | None = None,
     ) -> LDF:
         """
-        See Also: `pl.scan_parquet`
+        See Also
+        --------
+        scan_ipc, scan_csv
         """
 
         # try fsspec scanner
@@ -213,7 +217,9 @@ class LazyFrame(Generic[DF]):
         storage_options: dict | None = None,
     ) -> LDF:
         """
-        See Also: `pl.scan_ipc`
+        See Also
+        --------
+        scan_parquet, scan_csv
         """
         if isinstance(file, (str, Path)):
             file = format_path(file)
@@ -240,7 +246,9 @@ class LazyFrame(Generic[DF]):
     @classmethod
     def from_json(cls, json: str) -> LazyFrame:
         """
-        See Also pl.read_json
+        See Also
+        --------
+        read_json
         """
         f = StringIO(json)
         return cls.read_json(f)
@@ -251,7 +259,11 @@ class LazyFrame(Generic[DF]):
         file: str | Path | IOBase,
     ) -> LazyFrame:
         """
-        See Also pl.read_json
+        Read into a DataFrame from JSON format.
+
+        See Also
+        --------
+        write_json
         """
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
@@ -302,6 +314,10 @@ class LazyFrame(Generic[DF]):
             Write to this file instead of returning a string.
         to_string
             Ignore file argument and return a string.
+
+        See Also
+        --------
+        read_json
         """
         if isinstance(file, (str, Path)):
             file = format_path(file)
@@ -355,7 +371,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> def cast_str_to_int(data, col_name):
         ...     return data.with_column(pl.col(col_name).cast(pl.Int64))
         ...
@@ -716,7 +731,7 @@ class LazyFrame(Generic[DF]):
 
         See Also
         --------
-        schema : Return a dict of [column name, dtype]
+        schema : Returns a {colname:dtype} mapping.
         """
         return self._ldf.dtypes()
 

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -82,7 +82,6 @@ def col(
 
     Examples
     --------
-
     >>> df = pl.DataFrame(
     ...     {
     ...         "ham": [1, 2, 3],
@@ -895,10 +894,8 @@ def exclude(columns: str | list[str]) -> pli.Expr:
     columns
         Column(s) to exclude from selection
 
-
     Examples
     --------
-
     >>> df = pl.DataFrame(
     ...     {
     ...         "a": [1, 2, 3],
@@ -1271,7 +1268,6 @@ def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
 
     Examples
     --------
-
     >>> df = pl.DataFrame(
     ...     {
     ...         "a": ["a", "b", "c"],
@@ -1450,7 +1446,6 @@ def select(
 
     Examples
     --------
-
     >>> foo = pl.Series("foo", [1, 2, 3])
     >>> bar = pl.Series("bar", [3, 2, 1])
     >>> pl.select(
@@ -1515,7 +1510,6 @@ def struct(
 
     Examples
     --------
-
     >>> pl.DataFrame(
     ...     {
     ...         "int": [1, 2],
@@ -1661,7 +1655,6 @@ def arg_where(
 
     Examples
     --------
-
     >>> df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
     >>> df.select(
     ...     [

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -4035,7 +4035,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series(["Crab", "cat and dog", "rab$bit", None])
         >>> s.str.contains("cat|bit")
         shape: (4,)
@@ -4066,7 +4065,7 @@ class StringNameSpace:
         Parameters
         ----------
         sub
-            Suffix
+            Suffix substring.
 
         Examples
         --------
@@ -4084,7 +4083,7 @@ class StringNameSpace:
         See Also
         --------
         contains : Check if string contains a substring that matches a regex.
-
+        starts_with : Check if string values start with a substring.
         """
         s = wrap_s(self._s)
         return s.to_frame().select(pli.col(s.name).str.ends_with(sub)).to_series()
@@ -4096,11 +4095,10 @@ class StringNameSpace:
         Parameters
         ----------
         sub
-            Prefix
+            Prefix substring.
 
         Examples
         --------
-
         >>> s = pl.Series("fruits", ["apple", "mango", None])
         >>> s.str.starts_with("app")
         shape: (3,)
@@ -4114,7 +4112,7 @@ class StringNameSpace:
         See Also
         --------
         contains : Check if string contains a substring that matches a regex.
-
+        ends_with : Check if string values end with a substring.
         """
         s = wrap_s(self._s)
         return s.to_frame().select(pli.col(s.name).str.starts_with(sub)).to_series()
@@ -4203,7 +4201,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"json_val": ['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}']}
         ... )
@@ -4240,7 +4237,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [
@@ -4360,7 +4356,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"x": ["a_1", None, "c", "d_4"]})
         >>> df.select(
         ...     [
@@ -4436,7 +4431,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series(["123abc", "abc456"])
         >>> s.str.replace(r"abc\b", "ABC")  # doctest: +IGNORE_RESULT
         shape: (2,)
@@ -4594,7 +4588,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series([[1, 2, 3], [5]])
         >>> s.arr.lengths()
         shape: (2,)
@@ -4691,7 +4684,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series([["foo", "bar"], ["hello", "world"]])
         >>> s.arr.join(separator="-")
         shape: (2,)
@@ -4767,7 +4759,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.diff()
         shape: (2,)
@@ -4793,7 +4784,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.shift()
         shape: (2,)
@@ -4819,7 +4809,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.slice(1, 2)
         shape: (2,)
@@ -4845,7 +4834,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.head(2)
         shape: (2,)
@@ -4869,7 +4857,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.tail(2)
         shape: (2,)
@@ -4898,7 +4885,6 @@ class ListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
         >>> df.with_column(
         ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
@@ -4969,7 +4955,6 @@ class DateTimeNameSpace:
 
         Examples
         --------
-
         >>> from datetime import timedelta, datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 2)
@@ -5491,7 +5476,6 @@ class CatNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"cats": ["z", "z", "k", "a", "b"], "vals": [3, 1, 2, 2, 3]}
         ... ).with_columns(

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -22,7 +22,7 @@ class WhenThenThen:
 
     def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
         """
-        Start another when, then, otherwise layer.
+        Start another "when, then, otherwise" layer.
         """
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
@@ -42,7 +42,10 @@ class WhenThenThen:
         """
         Values to return in case of the predicate being `True`.
 
-        See Also: the `when` function.
+        See Also
+        --------
+        when : Start another when, then, otherwise layer.
+        otherwise : Values to return in case of the predicate being `False`.
         """
         expr_ = pli.expr_to_lit_or_expr(expr)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
@@ -56,7 +59,10 @@ class WhenThenThen:
         """
         Values to return in case of the predicate being `False`.
 
-        See Also: the `when` function.
+        See Also
+        --------
+        when : Start another when, then, otherwise layer.
+        then : Values to return in case of the predicate being `True`.
         """
         expr = pli.expr_to_lit_or_expr(expr)
         return pli.wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
@@ -72,7 +78,7 @@ class WhenThen:
 
     def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
         """
-        Start another when, then, otherwise layer.
+        Start another "when, then, otherwise" layer.
         """
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
@@ -81,7 +87,10 @@ class WhenThen:
         """
         Values to return in case of the predicate being `False`.
 
-        See Also: the `when` function.
+        See Also
+        --------
+        when : Start another when, then, otherwise layer.
+        then : Values to return in case of the predicate being `True`.
         """
         expr = pli.expr_to_lit_or_expr(expr)
         return pli.wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
@@ -110,7 +119,10 @@ class When:
         """
         Values to return in case of the predicate being `True`.
 
-        See Also: the `when` function.
+        See Also
+        --------
+        when : Start another when, then, otherwise layer.
+        otherwise : Values to return in case of the predicate being `False`.
         """
         expr = pli.expr_to_lit_or_expr(expr)
         pywhenthen = self._pywhen.then(expr._pyexpr)
@@ -119,11 +131,10 @@ class When:
 
 def when(expr: pli.Expr | bool) -> When:
     """
-    Start a when, then, otherwise expression.
+    Start a "when, then, otherwise" expression.
 
     Examples
     --------
-
     Below we add a column with the value 1, where column "foo" > 2 and the value -1 where it isn't.
 
     >>> df = pl.DataFrame({"foo": [1, 3, 4], "bar": [3, 4, 0]})
@@ -163,6 +174,10 @@ def when(expr: pli.Expr | bool) -> When:
     │ 4   ┆ 0   ┆ 1       │
     └─────┴─────┴─────────┘
 
+    See Also
+    --------
+    then : Values to return in case of the predicate being `True`.
+    otherwise : Values to return in case of the predicate being `False`.
     """
     expr = pli.expr_to_lit_or_expr(expr)
     pw = pywhen(expr._pyexpr)

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1090,7 +1090,6 @@ def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
 
     Examples
     --------
-
     >>> import pyarrow.dataset as ds
     >>> dset = ds.dataset("s3://my-partitioned-folder/", format="ipc")  # doctest: +SKIP
     >>> out = (

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -68,7 +68,7 @@ if HYPOTHESIS_INSTALLED:
     # else:
     settings.load_profile("polars.default")
 
-MAX_DATA_SIZE = 50
+MAX_DATA_SIZE = 20
 MAX_COLS = 8
 
 
@@ -553,7 +553,7 @@ if HYPOTHESIS_INSTALLED:
         ...     # print(s)
         >>>
         >>> s = series(dtype=pl.Int32, max_size=5)
-        >>> s.example()  # doctest: +IGNORE_RESULT
+        >>> s.example()  # doctest: +SKIP
         shape: (4,)
         Series: '' [i64]
         [
@@ -715,7 +715,7 @@ if HYPOTHESIS_INSTALLED:
         ...     ],
         ...     size=2,
         ... )
-        >>> df_strategy.example()  # doctest: +IGNORE_RESULT
+        >>> df_strategy.example()  # doctest: +SKIP
         shape: (2, 2)
         ┌───────────┬────────────┐
         │ x         ┆ y          │

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -14,7 +14,7 @@ def test_repr(df: pl.DataFrame) -> None:
     # print(df)
 
 
-@given(df=dataframes(min_size=1, min_cols=1, null_probability=0.25))
+@given(df=dataframes(min_size=1, min_cols=1, max_size=10, null_probability=0.25))
 @example(df=pl.DataFrame(columns=["x", "y", "z"]))
 @example(df=pl.DataFrame())
 def test_null_count(df: pl.DataFrame) -> None:
@@ -31,25 +31,25 @@ def test_null_count(df: pl.DataFrame) -> None:
 
 @given(
     df=dataframes(
-        max_size=20,
+        max_size=10,
         cols=[
             column(
                 "start",
                 dtype=pl.Int8,
                 null_probability=0.15,
-                strategy=integers(min_value=-12, max_value=12),
+                strategy=integers(min_value=-8, max_value=8),
             ),
             column(
                 "stop",
                 dtype=pl.Int8,
                 null_probability=0.15,
-                strategy=integers(min_value=-10, max_value=10),
+                strategy=integers(min_value=-6, max_value=6),
             ),
             column(
                 "step",
                 dtype=pl.Int8,
                 null_probability=0.15,
-                strategy=integers(min_value=-8, max_value=8).filter(lambda x: x != 0),
+                strategy=integers(min_value=-4, max_value=4).filter(lambda x: x != 0),
             ),
             column("misc", dtype=pl.Int32),
         ],

--- a/py-polars/tests_parametric/test_testing.py
+++ b/py-polars/tests_parametric/test_testing.py
@@ -116,6 +116,7 @@ def test_strategy_dtypes(
         include_cols=[column(name="colx", null_probability=0.20)],
     ),
 )
+@settings(max_examples=50)
 def test_strategy_null_probability(
     s: pl.Series,
     df1: pl.DataFrame,


### PR DESCRIPTION
* The formatting for most of the `See Also` subsections in docstrings was a bit off, so they weren't being rendered properly on the Sphinx Polars API [website](https://pola-rs.github.io/polars/py-polars/html/reference/). This should fix them. Will be worth adding some more of these links/refs later.

* Also, found the last two or three `doctests` warnings and took care of them - everything there passes cleanly.

* As they now run clean, I added `doctests` to the recently introduced `make test-all` option in the py-polars Makefile; this is not currently run automatically anywhere, it's manual/opt-in (as it runs both `tests` _and_ `parametric_tests`), but as I have been bitten a couple of times by doctests not passing on commit, it will help prevent a few of those before they hit GitHub... ;)

* Reduced the default scale of parametric tests to speed them up a touch. 