### PR TITLE
Fix Pandas date_range warnings in tests

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2,7 +2,7 @@
 import sys
 import typing
 from builtins import range
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from io import BytesIO
 from typing import Any, Iterator, Type
 from unittest.mock import patch
@@ -1431,12 +1431,14 @@ def test_repeat_by() -> None:
 
 
 def test_join_dates() -> None:
-    date_times = pd.date_range(
-        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", closed="left"
+    dts_in = pl.date_range(
+        datetime(2021, 6, 24),
+        datetime(2021, 6, 24, 10, 0, 0),
+        interval=timedelta(hours=1),
+        closed="left",
     )
     dts = (
-        pl.from_pandas(date_times)
-        .cast(int)
+        dts_in.cast(int)
         .apply(lambda x: x + np.random.randint(1_000 * 60, 60_000 * 60))
         .cast(pl.Datetime)
     )
@@ -1449,7 +1451,8 @@ def test_join_dates() -> None:
             "value": [2, 3, 4, 1, 2, 3, 5, 1, 2, 3],
         }
     )
-    df.join(df, on="datetime")
+    out = df.join(df, on="datetime")
+    assert len(out) == len(df)
 
 
 def test_asof_cross_join() -> None:

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -142,7 +142,7 @@ def test_from_pandas_datetime() -> None:
     assert s.dt.second()[0] == 20
 
     date_times = pd.date_range(
-        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", inclusive="left"
+        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", closed="left"
     )
     s = pl.from_pandas(date_times)
     assert s[0] == datetime(2021, 6, 24, 0, 0)

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -142,7 +142,7 @@ def test_from_pandas_datetime() -> None:
     assert s.dt.second()[0] == 20
 
     date_times = pd.date_range(
-        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", closed="left"
+        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", inclusive="left"
     )
     s = pl.from_pandas(date_times)
     assert s[0] == datetime(2021, 6, 24, 0, 0)


### PR DESCRIPTION
Since Pandas 1.4 (released Jan 2022), the input arg `closed` for `pd.date_range` has been deprecated in favor of `inclusive` (https://pandas.pydata.org/docs/reference/api/pandas.date_range.html). This generated two warnings in our Python test suite. In one of the two cases, we just needed a range of dates, so switched that to `polars.date_range`, for the other use case updated the keyword. This does mean one needs Pandas >= 1.4 for running the test suite.