### PR TITLE
make clippy a bit happier

### DIFF
--- a/examples/python_rust_compiled_function/src/ffi.rs
+++ b/examples/python_rust_compiled_function/src/ffi.rs
@@ -25,7 +25,7 @@ fn array_to_rust(arrow_array: &PyAny) -> PyResult<ArrayRef> {
     unsafe {
         let field = ffi::import_field_from_c(schema.as_ref()).unwrap();
         let array = ffi::import_array_from_c(*array, field.data_type).unwrap();
-        Ok(array.into())
+        Ok(array)
     }
 }
 

--- a/examples/python_rust_compiled_function/src/lib.rs
+++ b/examples/python_rust_compiled_function/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::borrow_deref_ref)]
 mod ffi;
 
 use polars::prelude::*;

--- a/polars-sql/src/context.rs
+++ b/polars-sql/src/context.rs
@@ -165,7 +165,7 @@ impl SQLContext {
             Ok(match ast {
                 Statement::Query(query) => {
                     let rs = match &query.body {
-                        SetExpr::Select(select_stmt) => self.execute_select(&*select_stmt)?,
+                        SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
                         _ => {
                             return Err(PolarsError::ComputeError(
                                 "INSERT, UPDATE is not supported for polars".into(),

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_borrow)]
 pub mod array;
 pub mod bit_util;
 mod bitmap;

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -160,7 +160,7 @@ impl ChunkCast for ListChunked {
                 let mut ca = if child_type.to_physical() != self.inner_dtype() {
                     let chunks = self
                         .downcast_iter()
-                        .map(|list| cast_inner_list_type(list, &**child_type))
+                        .map(|list| cast_inner_list_type(list, child_type))
                         .collect::<Result<_>>()?;
                     ListChunked::from_chunks(self.name(), chunks)
                 } else {

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_borrow)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate core;
 #[macro_use]

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -907,6 +907,7 @@ impl Series {
     }
 }
 
+#[allow(clippy::explicit_auto_deref)]
 impl Deref for Series {
     type Target = dyn SeriesTrait;
 
@@ -915,6 +916,7 @@ impl Deref for Series {
     }
 }
 
+#[allow(clippy::explicit_auto_deref)]
 impl<'a> AsRef<(dyn SeriesTrait + 'a)> for Series {
     fn as_ref(&self) -> &(dyn SeriesTrait + 'a) {
         &*self.0

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -609,7 +609,7 @@ where
                 }
                 _ => Cow::Owned(Schema::default()),
             };
-            df = parse_dates(df, &*fixed_schema)
+            df = parse_dates(df, &fixed_schema)
         }
 
         cast_columns(&mut df, &to_cast_local, true)?;

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -1,4 +1,6 @@
+#![allow(clippy::needless_borrow)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
 
 #[cfg(feature = "private")]
 pub mod aggregations;

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::physical_plan::state::ExecutionState;
 use rayon::prelude::*;
 
+#[cfg(feature = "list_eval")]
 pub(super) fn prepare_eval_expr(mut expr: Expr) -> Expr {
     expr.mutate().apply(|e| match e {
         Expr::Column(name) => {

--- a/polars/polars-lazy/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/mod.rs
@@ -57,8 +57,6 @@ impl FunctionExpr {
             })
         };
 
-        let same_type = || map_dtype(&|dtype| dtype.clone());
-
         use FunctionExpr::*;
         match self {
             NullCount => with_dtype(IDX_DTYPE),
@@ -74,17 +72,19 @@ impl FunctionExpr {
                 with_dtype(DataType::Boolean)
             }
             #[cfg(feature = "date_offset")]
-            DateOffset(_) => same_type(),
+            DateOffset(_) => map_dtype(&|dtype| dtype.clone()),
         }
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! wrap {
     ($e:expr) => {
         SpecialEq::new(Arc::new($e))
     };
 }
 
+#[allow(unused_macros)]
 macro_rules! map_with_args {
     ($func:path, $($args:expr),*) => {{
         let f = move |s: &mut [Series]| {
@@ -96,6 +96,7 @@ macro_rules! map_with_args {
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! map_owned_with_args {
     ($func:path, $($args:expr),*) => {{
         let f = move |s: &mut [Series]| {

--- a/polars/polars-lazy/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/temporal.rs
@@ -1,4 +1,7 @@
+#![cfg(feature = "date_offset")]
+
 use super::*;
+
 
 pub(super) fn date_offset(s: Series, offset: Duration) -> Result<Series> {
     match s.dtype().clone() {

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -1,11 +1,16 @@
+#[cfg(feature = "list_eval")]
 use crate::dsl::eval::prepare_eval_expr;
+#[allow(unused_imports)]
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
+#[allow(unused_imports)]
 use parking_lot::Mutex;
+#[allow(unused_imports)]
 use polars_arrow::utils::CustomIterTools;
 use polars_core::prelude::*;
 use polars_core::series::ops::NullBehavior;
 use polars_ops::prelude::*;
+#[allow(unused_imports)]
 use rayon::prelude::*;
 
 /// Specialized expressions for [`Series`] of [`DataType::List`].

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -18,7 +18,6 @@ mod options;
 pub mod string;
 #[cfg(feature = "dtype-struct")]
 mod struct_;
-use polars_time::series::SeriesOpsTime;
 
 use crate::prelude::*;
 use crate::utils::has_expr;
@@ -617,6 +616,7 @@ impl Expr {
         }
     }
 
+    #[cfg(feature = "row_hash")]
     fn map_private(self, function_expr: FunctionExpr, fmt_str: &'static str) -> Self {
         Expr::Function {
             input: vec![self],
@@ -1400,6 +1400,7 @@ impl Expr {
     }
 
     #[allow(clippy::type_complexity)]
+    #[cfg(feature = "rolling_window")]
     fn finish_rolling(
         self,
         options: RollingOptions,

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_borrow)]
 //! Lazy variant of a [DataFrame](polars_core::frame::DataFrame).
 #[cfg(feature = "csv-file")]
 mod csv;
@@ -715,12 +716,12 @@ impl LazyFrame {
             planner.create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
 
         let state = ExecutionState::with_finger_prints(finger_prints);
-        let out = physical_plan.execute(&state);
+        
         #[cfg(feature = "dtype-categorical")]
         if use_string_cache {
             toggle_string_cache(!use_string_cache);
         }
-        out
+        physical_plan.execute(&state)
     }
 
     /// Filter by some predicate expression.

--- a/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "is_in")]
 use crate::dsl::function_expr::FunctionExpr;
 use polars_core::prelude::*;
 use polars_core::utils::get_supertype;

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -19,6 +19,7 @@ pub struct CsvParserOptions {
     pub(crate) with_columns: Option<Arc<Vec<String>>>,
     pub(crate) low_memory: bool,
     pub(crate) ignore_errors: bool,
+    #[allow(dead_code)] //only read in features
     pub(crate) cache: bool,
     pub(crate) null_values: Option<NullValues>,
     pub(crate) rechunk: bool,
@@ -33,6 +34,7 @@ pub struct CsvParserOptions {
 pub struct ParquetOptions {
     pub(crate) n_rows: Option<usize>,
     pub(crate) with_columns: Option<Arc<Vec<String>>>,
+    #[allow(dead_code)]
     pub(crate) cache: bool,
     pub(crate) parallel: polars_io::parquet::ParallelStrategy,
     pub(crate) rechunk: bool,
@@ -55,6 +57,7 @@ pub struct IpcScanOptions {
 pub struct IpcScanOptionsInner {
     pub(crate) n_rows: Option<usize>,
     pub(crate) with_columns: Option<Arc<Vec<String>>>,
+    #[allow(dead_code)]
     pub(crate) cache: bool,
     pub(crate) row_count: Option<RowCount>,
     pub(crate) rechunk: bool,

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -6,7 +6,9 @@ use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::{GroupByMethod, GroupsProxy};
 use polars_core::utils::NoNull;
-use polars_core::{prelude::*, POOL};
+use polars_core::prelude::*;
+#[cfg(feature = "dtype-struct")]
+use polars_core::POOL;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -1,6 +1,7 @@
 use crate::logical_plan::Context;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
+#[cfg(feature = "chunked_ids")]
 use polars_arrow::export::arrow::Either;
 use polars_core::frame::groupby::{GroupBy, GroupsProxy};
 use polars_core::frame::hash_join::{

--- a/polars/polars-ops/src/series/implementations/time.rs
+++ b/polars/polars-ops/src/series/implementations/time.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[allow(unused_imports)]
 use std::ops::Deref;
 
 impl SeriesOps for Wrap<TimeChunked> {

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -16,12 +16,7 @@ fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    for fmt in ["%T", "%T%.3f", "%T%.6f", "%T%.9f"] {
-        if convert(val, fmt).is_ok() {
-            return Some(fmt);
-        }
-    }
-    None
+    ["%T", "%T%.3f", "%T%.6f", "%T%.9f"].into_iter().find(|&fmt| convert(val, fmt).is_ok())
 }
 
 fn datetime_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
@@ -29,7 +24,7 @@ fn datetime_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    for fmt in [
+    [
         // 21/12/31 12:54:98
         "%y/%m/%d %H:%M:%S",
         // 2021-12-31 24:58:01
@@ -55,12 +50,8 @@ where
         "%Y-%m-%dT%H:%M:%S.%6f",
         // nanoseconds
         "%Y-%m-%dT%H:%M:%S.%9f",
-    ] {
-        if convert(val, fmt).is_ok() {
-            return Some(fmt);
-        }
-    }
-    None
+        ].into_iter().find(|&fmt| convert(val, fmt).is_ok())
+
 }
 
 fn date_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
@@ -68,17 +59,12 @@ fn date_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    for fmt in [
-        // 2021-12-31
-        "%Y-%m-%d", // 31-12-2021
-        "%d-%m-%Y", // 2021319 (2021-03-19)
-        "%Y%m%d",
-    ] {
-        if convert(val, fmt).is_ok() {
-            return Some(fmt);
-        }
-    }
-    None
+        [
+         // 2021-12-31
+         "%Y-%m-%d", // 31-12-2021
+         "%d-%m-%Y", // 2021319 (2021-03-19)
+         "%Y%m%d",
+     ].into_iter().find(|&fmt| convert(val, fmt).is_ok())
 }
 
 struct ParseErrorByteCopy(ParseErrorKind);

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -1564,7 +1564,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
             let iter = self
                 .into_no_null_iter()
                 .skip(init_null_count + 1)
-                .map(|val| call_with_value(val));
+                .map(call_with_value);
             avs.extend(iter);
         }
         Ok(Series::new(self.name(), &avs))

--- a/py-polars/src/arrow_interop/to_rust.rs
+++ b/py-polars/src/arrow_interop/to_rust.rs
@@ -20,7 +20,7 @@ pub fn field_to_rust(obj: &PyAny) -> PyResult<Field> {
 
 // PyList<Field> which you get by calling `list(schema)`
 pub fn pyarrow_schema_to_rust(obj: &PyList) -> PyResult<Schema> {
-    obj.into_iter().map(|fld| field_to_rust(fld)).collect()
+    obj.into_iter().map(field_to_rust).collect()
 }
 
 pub fn array_to_rust(obj: &PyAny) -> PyResult<ArrayRef> {
@@ -41,7 +41,7 @@ pub fn array_to_rust(obj: &PyAny) -> PyResult<ArrayRef> {
     unsafe {
         let field = ffi::import_field_from_c(schema.as_ref()).map_err(PyPolarsErr::from)?;
         let array = ffi::import_array_from_c(*array, field.data_type).map_err(PyPolarsErr::from)?;
-        Ok(array.into())
+        Ok(array)
     }
 }
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -995,7 +995,7 @@ impl PyDataFrame {
     pub fn slice(&self, offset: usize, length: Option<usize>) -> Self {
         let df = self
             .df
-            .slice(offset as i64, length.unwrap_or(self.df.height()));
+            .slice(offset as i64, length.unwrap_or_else(|| self.df.height()));
         df.into()
     }
 

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -64,10 +64,10 @@ impl From<DataType> for PyDataType {
     }
 }
 
-impl Into<DataType> for PyDataType {
-    fn into(self) -> DataType {
+impl From<PyDataType> for DataType {
+    fn from(dt: PyDataType) -> DataType {
         use DataType::*;
-        match self {
+        match dt {
             PyDataType::Int8 => Int8,
             PyDataType::Int16 => Int16,
             PyDataType::Int32 => Int32,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1137,7 +1137,7 @@ impl PyExpr {
         };
         self.inner.clone().rolling_median(options).into()
     }
-
+    #[allow(clippy::too_many_arguments)]
     pub fn rolling_quantile(
         &self,
         quantile: f64,

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(vec_into_raw_parts)]
 #![allow(clippy::nonstandard_macro_braces)] // needed because clippy does not understand proc macro of pyo3
 #![allow(clippy::transmute_undefined_repr)]
+#![allow(clippy::borrow_deref_ref)] // generates a lot of false positives
+#![allow(clippy::needless_borrow)] // generates a lot of false positives
 #[macro_use]
 extern crate polars;
 extern crate core;

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -282,7 +282,7 @@ impl PySeries {
                 if fast_explode {
                     out.set_fast_explode()
                 }
-                return Ok(out.into_series().into());
+                Ok(out.into_series().into())
             }
             _ => {
                 let series: Series =
@@ -484,7 +484,7 @@ impl PySeries {
     pub fn slice(&self, offset: i64, length: Option<usize>) -> Self {
         let series = self
             .series
-            .slice(offset, length.unwrap_or(self.series.len()));
+            .slice(offset, length.unwrap_or_else(|| self.series.len()));
         series.into()
     }
 


### PR DESCRIPTION
Fixes a bunch of compiler and clippy warnings, most notably when building thought features. `clippy::needless_borrow` seemed to generate A LOT of false positives so in a lot of cases I just added an exception for that one. Otherwise this PR introduces no changes