### PR TITLE
Add recursive Struct parsing to df.schema

### DIFF
--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -186,8 +186,12 @@ def test_struct_cols() -> None:
     # struct column
     df = build_struct_df([{"struct_col": {"inner": 1}}])
     assert df.columns == ["struct_col"]
-    assert df.schema == {"struct_col": pl.Struct}
+    assert df.schema == {"struct_col": {"inner": pl.Int64}}
     assert df["struct_col"].struct.field("inner").to_list() == [1]
+
+    # double nested struct
+    df = build_struct_df([{"struct_col": {"inner1": {"inner2": 1}}}])
+    assert df.schema == {"struct_col": {"inner1": {"inner2": pl.Int64}}}
 
     # struct in struct
     df = build_struct_df([{"nested_struct_col": {"struct_col": {"inner": 1}}}])


### PR DESCRIPTION
related #3925

TODO:
- [ ] `Struct`
- [ ] ...

I'd assume we can close the issue once all nested types are covered. This covers `Struct` but I'm happy to throw in the rest if needed.

Edit: Need to implement this in Rust.