### PR TITLE
[docs] improve python polars documentation

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4961,7 +4961,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [[3, 2, 1], [9, 1, 2]],

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2612,12 +2612,13 @@ class Expr:
     ) -> Expr:
         """
         Apply a custom python function to a Series or sequence of Series.
+
         The output of this custom function must be a Series.
-        If you want to apply a custom function elementwise over single values see `apply`.
-        A use case for map is when you want to transform an expression
+        If you want to apply a custom function elementwise over single values, see :func:`apply`.
+        A use case for ``map`` is when you want to transform an expression
         with a third-party library.
 
-        Read more in `the book <https://pola-rs.github.io/polars-book/user-guide/howcani/apply/udfs.html>`_.
+        Read more in `the book <https://pola-rs.github.io/polars-book/user-guide/dsl/custom_functions.html>`_.
 
         Parameters
         ----------
@@ -2660,24 +2661,22 @@ class Expr:
         Depending on the context it has the following behavior:
 
         * Selection
-            expected type `f`: Callable[[Any], Any]
+            Expects `f` to be of type Callable[[Any], Any].
             Applies a python function over each individual value in the column.
         * GroupBy
-            expected type `f`: Callable[[Series], Series]
+            Expects `f` to be of type Callable[[Series], Series].
             Applies a python function over each group.
 
-        Implementing logic using the .apply method is generally slower and more memory intensive
+        Implementing logic using the ``.apply`` method is generally slower and more memory intensive
         than implementing the same logic using the expression API because:
 
         - with .apply the logic is implemented in Python but with an expression the logic is implemented in Rust
-
-        - with .apply the DataFrame is materialized in memory
-
+        - with ``.apply`` the DataFrame is materialized in memory
         - expressions can be parallelised
 
         - expressions can be optimised
 
-        If possible use the expression API for best performance.
+        If possible, use the expression API for best performance.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1795,7 +1795,7 @@ class Expr:
     ) -> Expr:
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation
-        with the result of the `fill_value` expression.
+        with the result of the ``fill_value`` expression.
 
         Parameters
         ----------
@@ -1981,6 +1981,9 @@ class Expr:
     def reverse(self) -> Expr:
         """
         Reverse the selection.
+
+        Examples
+        --------
 
         >>> df = pl.DataFrame(
         ...     {

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1835,18 +1835,14 @@ class Expr:
         """
         Fill null values using a filling strategy, literal, or Expr.
 
+        Parameters
+        ----------
         fill_value
-            One of:
-            - "backward"
-            - "forward"
-            - "min"
-            - "max"
-            - "mean"
-            - "one"
-            - "zero"
-            Or an expression.
+            One of {"backward", "forward", "min", "max", "mean", "one", "zero"}
+            or an expression.
         limit
-            if strategy is 'forward' or 'backward', this the number of consecutive null values to forward/backward fill.
+            The number of consecutive null values to forward/backward fill.
+            Only valid if ``fill_value`` is 'forward' or 'backward'.
 
         Examples
         --------
@@ -1925,12 +1921,12 @@ class Expr:
 
     def forward_fill(self, limit: int | None = None) -> Expr:
         """
-        Fill missing values with the latest seen values
+        Fill missing values with the latest seen values.
 
         Parameters
         ----------
         limit
-            This the number of consecutive null values to forward/backward fill.
+            The number of consecutive null values to forward fill.
 
         Examples
         --------
@@ -1955,12 +1951,12 @@ class Expr:
 
     def backward_fill(self, limit: int | None = None) -> Expr:
         """
-        Fill missing values with the next to be seen values
+        Fill missing values with the next to be seen values.
 
         Parameters
         ----------
         limit
-            This the number of consecutive null values to forward/backward fill.
+            The number of consecutive null values to backward fill.
 
         Examples
         --------

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -256,9 +256,10 @@ class Expr:
 
     def all(self) -> Expr:
         """
-        Check if all boolean values in in a Boolean column are `True`.
-        This method is an expression - not to be confused with polars.all
-        which is a function to select all columns
+        Check if all boolean values in a Boolean column are `True`.
+
+        This method is an expression - not to be confused with
+        :func:`polars.all` which is a function to select all columns.
 
         Returns
         -------

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2695,7 +2695,7 @@ class Expr:
         ...     }
         ... )
 
-        In a selection context the function is applied by row:
+        In a selection context, the function is applied by row.
 
         >>> (
         ...     df.with_column(
@@ -2767,7 +2767,7 @@ class Expr:
 
     def flatten(self) -> Expr:
         """
-        Alias for explode.
+        Alias for :func:`explode`.
 
         Explode a list or utf8 Series. This means that every item is expanded to a new row.
 
@@ -2778,10 +2778,9 @@ class Expr:
         Examples
         --------
 
+        The following example turns each character into a separate row:
+
         >>> df = pl.DataFrame({"foo": ["hello", "world"]})
-
-        Turn each character into a separate row:
-
         >>> df.select(pl.col("foo").flatten())
         shape: (10, 1)
         ┌─────┐
@@ -2808,10 +2807,9 @@ class Expr:
         │ d   │
         └─────┘
 
+        This example turns each word into a separate row:
+
         >>> df = pl.DataFrame({"foo": ["hello world"]})
-
-        Turn each word into a separate row:
-
         >>> df.select(pl.col("foo").str.split(by=" ").flatten())
         shape: (2, 1)
         ┌───────┐
@@ -2823,13 +2821,16 @@ class Expr:
         ├╌╌╌╌╌╌╌┤
         │ world │
         └───────┘
+
         """
 
         return wrap_expr(self._pyexpr.explode())
 
     def explode(self) -> Expr:
         """
-        Explode a list or utf8 Series. This means that every item is expanded to a new row.
+        Explode a list or utf8 Series.
+
+        This means that every item is expanded to a new row.
 
         Returns
         -------

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4268,22 +4268,16 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         .. seealso::
 
-            fill_nan
+            :func:`fill_nan`
 
         Parameters
         ----------
         strategy
-            One of:
-            - "backward"
-            - "forward"
-            - "mean"
-            - "min'
-            - "max"
-            - "zero"
-            - "one"
-            Or an expression.
+            One of {"backward", "forward", "min", "max", "mean", "one", "zero"}
+            or an expression.
         limit
-            if strategy is 'forward' or 'backward', this the number of consecutive null values to forward/backward fill.
+            The number of consecutive null values to forward/backward fill.
+            Only valid if ``strategy`` is 'forward' or 'backward'.
 
         Returns
         -------
@@ -4326,17 +4320,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         .. seealso::
 
-            fill_null
+            :func:`fill_null`
 
         Warnings
         --------
         NOTE that floating point NaNs (Not a Number) are not missing values!
-        to replace missing values, use `fill_null`.
+        to replace missing values, use :func:`fill_null`.
 
         Parameters
         ----------
         fill_value
-            value to fill NaN with
+            Value to fill NaN with.
 
         Returns
         -------

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1908,7 +1908,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "key": ["a", "b", "c"],
@@ -1928,6 +1927,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ├╌╌╌╌╌┼╌╌╌╌╌┤
         │ a   ┆ 1   │
         └─────┴─────┘
+
         """
         return self.select(pli.col("*").reverse())
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -979,7 +979,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> str | None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
-            Please use `write_json`
+            Use :func:`write_json` instead.
         """
         warnings.warn(
             "'to_json' is deprecated. please use 'write_json'", DeprecationWarning
@@ -1167,7 +1167,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> str | None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
-            Please use `write_csv`
+            Use :func:`write_csv` instead.
         """
         warnings.warn(
             "'to_csv' is deprecated. please use 'write_csv'", DeprecationWarning
@@ -1204,7 +1204,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
-            Please use `write_avro`
+            Use :func:`write_avro` instead.
         """
         warnings.warn(
             "'to_avro' is deprecated. please use 'write_avro'", DeprecationWarning
@@ -1243,7 +1243,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
-            Please use `write_ipc`
+            Use :func:`write_ipc` instead.
         """
         warnings.warn(
             "'to_ipc' is deprecated. please use 'write_ipc'", DeprecationWarning
@@ -1489,7 +1489,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
-            Please use `write_parquet`
+            Use :func:`write_parquet` instead.
         """
         warnings.warn(
             "'to_parquet' is deprecated. please use 'write_parquet'", DeprecationWarning
@@ -5393,7 +5393,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     ) -> DF:
         """
         .. deprecated:: 0.13.13
-            Please use `unique`
+            Use :func:`unique` instead.
         """
         return self.unique(maintain_order, subset, keep)
 
@@ -6102,7 +6102,7 @@ class GroupBy(Generic[DF]):
         Select a single group as a new DataFrame.
 
         .. deprecated:: 0.13.32
-            Please use `partition_by`
+            Use :func:`partition_by` instead.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1906,6 +1906,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         Reverse the DataFrame.
 
+        Examples
+        --------
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "key": ["a", "b", "c"],
@@ -4243,6 +4246,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def get_column(self, name: str) -> pli.Series:
         """
         Get a single column as Series by name.
+
+        Parameters
+        ----------
+        name : str
+            Name of the column to retrieve.
 
         Examples
         --------

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -2024,7 +2024,7 @@ class LazyFrame(Generic[DF]):
     ) -> LDF:
         """
         .. deprecated:: 0.13.13
-            Please use `unique`
+            Use :func:`unique` instead.
         """
         return self.unique(maintain_order, subset, keep)
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1815,16 +1815,16 @@ class LazyFrame(Generic[DF]):
         """
         Add a column at index 0 that counts the rows.
 
-        ..warning::
+        .. warning::
             This can have a negative effect on query performance.
-            This may for instance block predicate pushdown optimization.
+            This may, for instance, block predicate pushdown optimization.
 
         Parameters
         ----------
         name
             Name of the column to add.
         offset
-            Start the row count at this offset
+            Start the row count at this offset.
 
         Examples
         --------
@@ -1890,16 +1890,14 @@ class LazyFrame(Generic[DF]):
         """
         Fill floating point NaN values.
 
-        ..warning::
-
-            NOTE that floating point NaN (No a Number) are not missing values!
-            to replace missing values, use `fill_null`.
-
+        .. warning::
+            Note that floating point NaN (Not a Number) are not missing values!
+            To replace missing values, use :func:`fill_null` instead.
 
         Parameters
         ----------
         fill_value
-            Value to fill the NaN values with
+            Value to fill the NaN values with.
         """
         if not isinstance(fill_value, pli.Expr):
             fill_value = pli.lit(fill_value)

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1048,9 +1048,9 @@ def arange(
     high
         Upper bound of range.
     step
-        Step size of the range
+        Step size of the range.
     eager
-        If eager evaluation is `True`, a Series is returned instead of an Expr
+        If eager evaluation is `True`, a Series is returned instead of an Expr.
     """
     low = pli.expr_to_lit_or_expr(low, str_to_lit=False)
     high = pli.expr_to_lit_or_expr(high, str_to_lit=False)
@@ -1444,6 +1444,7 @@ def select(
     ----------
     exprs
         Expressions to run
+
     Returns
     -------
     DataFrame

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -820,9 +820,10 @@ def map_binary(
     return_dtype: type[DataType] | None = None,
 ) -> pli.Expr:
     """
-     .. deprecated:: 0.10.4
-       use `map` or `apply`
     Map a custom function over two columns and produce a single Series result.
+
+    .. deprecated:: 0.10.4
+        Use :func:`map` or :func:`apply` instead.
 
     Parameters
     ----------

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2411,6 +2411,15 @@ class Series:
         """
         Fill null values using a filling strategy, literal, or Expr.
 
+        Parameters
+        ----------
+        strategy
+            One of {"backward", "forward", "min", "max", "mean", "one", "zero"}
+            or an expression.
+        limit
+            The number of consecutive null values to forward/backward fill.
+            Only valid if ``strategy`` is 'forward' or 'backward'.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3, None])
@@ -2442,20 +2451,6 @@ class Series:
             "z"
         ]
 
-        Parameters
-        ----------
-        strategy
-            One of:
-            - "backward"
-            - "forward"
-            - "min"
-            - "max"
-            - "mean"
-            - "one"
-            - "zero"
-            Or an expression.
-        limit
-            if strategy is 'forward' or 'backward', this the number of consecutive null values to forward/backward fill.
         """
         if not isinstance(strategy, str):
             return self.to_frame().select(pli.col(self.name).fill_null(strategy))[

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -5227,7 +5227,7 @@ class DateTimeNameSpace:
         Go from Date/Datetime to python DateTime objects
 
         .. deprecated:: 0.13.23
-            Use :func:`Series.to_list`.
+            Use :func:`Series.to_list` instead.
 
         """
         return (self.timestamp("ms") / 1000).apply(

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1846,7 +1846,9 @@ class Series:
 
     def explode(self) -> Series:
         """
-        Explode a list or utf8 Series. This means that every item is expanded to a new row.
+        Explode a list or utf8 Series.
+
+        This means that every item is expanded to a new row.
 
         Examples
         --------

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -166,11 +166,12 @@ def read_csv(
         particular storage connection.
         e.g. host, port, username, password, etc.
     skip_rows_after_header
-        Skip these number of rows when the header is parsed
+        Skip this number of rows when the header is parsed.
     row_count_name
-        If not None, this will insert a row count column with give name into the DataFrame
+        If not None, this will insert a row count column with the given name into
+        the DataFrame.
     row_count_offset
-        Offset to start the row_count column (only use if the name is set)
+        Offset to start the row_count column (only used if the name is set).
     sample_size:
         Set the sample size. This is used to sample statistics to estimate the allocation needed.
 
@@ -457,11 +458,12 @@ def scan_csv(
     rechunk
         Reallocate to contiguous memory when all chunks/ files are parsed.
     skip_rows_after_header
-        Skip these number of rows when the header is parsed
+        Skip this number of rows when the header is parsed.
     row_count_name
-        If not None, this will insert a row count column with give name into the DataFrame
+        If not None, this will insert a row count column with the given name into
+        the DataFrame.
     row_count_offset
-        Offset to start the row_count column (only use if the name is set)
+        Offset to start the row_count column (only used if the name is set).
     parse_dates
         Try to automatically parse dates. If this does not succeed,
         the column remains of data type ``pl.Utf8``.
@@ -475,11 +477,11 @@ def scan_csv(
     ...     )  # select only 2 columns (other columns will not be read)
     ...     .filter(
     ...         pl.col("a") > 10
-    ...     )  # the filter is pushed down the the scan, so less data read in memory
+    ...     )  # the filter is pushed down the scan, so less data is read into memory
     ...     .fetch(100)  # pushed a limit of 100 rows to the scan level
     ... )  # doctest: +SKIP
 
-    We can use `with_column_names` to modify the header before scanning:
+    We can use ``with_column_names`` to modify the header before scanning:
 
     >>> df = pl.DataFrame(
     ...     {"BrEeZaH": [1, 2, 3, 4], "LaNgUaGe": ["is", "terrible", "to", "read"]}
@@ -502,7 +504,6 @@ def scan_csv(
     ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
     │ 4       ┆ read     │
     └─────────┴──────────┘
-
 
     """
 
@@ -903,7 +904,6 @@ def read_sql(
 
     Examples
     --------
-
     ## Single threaded
     Read a DataFrame from a SQL query using a single thread:
 
@@ -958,7 +958,7 @@ def read_excel(
     """
     Read Excel (XLSX) sheet into a DataFrame by converting an Excel
     sheet with ``xlsx2csv.Xlsx2csv().convert()`` to CSV and parsing
-    the CSV output with ``pl.read_csv()``.
+    the CSV output with :func:`read_csv`.
 
     Parameters
     ----------
@@ -975,7 +975,7 @@ def read_excel(
         Extra options passed to ``xlsx2csv.Xlsx2csv()``.
         e.g.: ``{"skip_empty_lines": True}``
     read_csv_options
-        Extra options passed to ``read_csv()`` for parsing
+        Extra options passed to :func:`read_csv` for parsing
         the CSV file returned by ``xlsx2csv.Xlsx2csv().convert()``
         e.g.: ``{"has_header": False, "new_columns": ["a", "b", "c"], infer_schema_length=None}``
 
@@ -985,7 +985,6 @@ def read_excel(
 
     Examples
     --------
-
     Read "My Datasheet" sheet from Excel sheet file to a DataFrame.
 
     >>> excel_file = "test.xlsx"
@@ -997,7 +996,7 @@ def read_excel(
 
     Read sheet 3 from Excel sheet file to a DataFrame while skipping
     empty lines in the sheet. As sheet 3 does not have header row,
-    pass the needed settings to ``read_csv()``.
+    pass the needed settings to :func:`read_csv`.
 
     >>> excel_file = "test.xlsx"
     >>> pl.read_excel(
@@ -1008,7 +1007,7 @@ def read_excel(
     ... )  # doctest: +SKIP
 
     If the correct datatypes can't be determined by polars, look
-    at ``read_csv()`` documentation to see which options you can pass
+    at :func:`read_csv` documentation to see which options you can pass
     to fix this issue. For example ``"infer_schema_length": None``
     can be used to read the whole data twice, once to infer the
     correct output types and once to actually convert the input to
@@ -1023,8 +1022,7 @@ def read_excel(
 
     Alternative
     -----------
-
-    If ``read_excel()`` does not work or you need to read other types
+    If :func:`read_excel` does not work or you need to read other types
     of spreadsheet files, you can try pandas ``pd.read_excel()``
     (supports `xls`, `xlsx`, `xlsm`, `xlsb`, `odf`, `ods` and `odt`).
 
@@ -1078,19 +1076,20 @@ def read_excel(
 
 def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
     """
+    Scan a pyarrow dataset.
+
+    This can be useful to connect to cloud or partitioned datasets.
+
     .. warning::
         This API is experimental and may change without it being considered a breaking change.
-
-    Scan a pyarrow dataset. This can be useful to connect to cloud or partitioned datasets.
 
     Parameters
     ----------
     ds
-     Pyarrow dataset to scan.
+        Pyarrow dataset to scan.
 
     Examples
     --------
-
     >>> import pyarrow.dataset as ds
     >>> dset = ds.dataset("s3://my-partitioned-folder/", format="ipc")  # doctest: +SKIP
     >>> out = (


### PR DESCRIPTION
Few generic improvements to the docs. Highlights:

* add internal cross-referencing links wherever possible using `:func:read_csv` instead of referring by text `read_csv()`.
* fixed deprecation and warning markups so they show up correctly
* standardize the first line of the function docstring so that only a concise summary shows up in the main section page such as [this](https://pola-rs.github.io/polars/py-polars/html/reference/io.html) (probably incomplete, we can fix this incrementally in subsequent sprints)