### PR TITLE
Fix constructor `orient` type hint

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import warnings
 from typing import Any, Mapping, Sequence, overload
 
@@ -25,6 +26,11 @@ try:
     _PANDAS_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PANDAS_AVAILABLE = False
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
 
 
 def from_dict(
@@ -111,7 +117,7 @@ def from_dicts(
 def from_records(
     data: Sequence[Sequence[Any]],
     columns: Sequence[str] | None = None,
-    orient: str | None = None,
+    orient: Literal["col", "row"] | None = None,
 ) -> DataFrame:
     """
     Construct a DataFrame from a numpy ndarray or sequence of sequences.
@@ -168,7 +174,7 @@ def from_records(
 def from_numpy(
     data: np.ndarray,
     columns: Sequence[str] | None = None,
-    orient: str | None = None,
+    orient: Literal["col", "row"] | None = None,
 ) -> DataFrame:
     """
     Construct a DataFrame from a numpy ndarray.

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import warnings
 from datetime import date, datetime, time, timedelta
 from itertools import zip_longest
@@ -52,6 +53,11 @@ try:
     _PYARROW_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PYARROW_AVAILABLE = False
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
 
 
 ################################
@@ -449,7 +455,7 @@ def dict_to_pydf(
 def sequence_to_pydf(
     data: Sequence[Any],
     columns: ColumnsType | None = None,
-    orient: str | None = None,
+    orient: Literal["col", "row"] | None = None,
 ) -> PyDataFrame:
     """
     Construct a PyDataFrame from a sequence.
@@ -507,7 +513,7 @@ def sequence_to_pydf(
 def numpy_to_pydf(
     data: np.ndarray,
     columns: ColumnsType | None = None,
-    orient: str | None = None,
+    orient: Literal["col", "row"] | None = None,
 ) -> PyDataFrame:
     """
     Construct a PyDataFrame from a numpy ndarray.

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -297,7 +297,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             | pli.Series
         ) = None,
         columns: ColumnsType | None = None,
-        orient: str | None = None,
+        orient: Literal["col", "row"] | None = None,
     ):
         if data is None:
             self._df = dict_to_pydf({}, columns=columns)
@@ -390,7 +390,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         cls: type[DF],
         data: Sequence[Sequence[Any]],
         columns: Sequence[str] | None = None,
-        orient: str | None = None,
+        orient: Literal["col", "row"] | None = None,
     ) -> DF:
         """
         Construct a DataFrame from a sequence of sequences.
@@ -418,7 +418,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         cls: type[DF],
         data: np.ndarray,
         columns: Sequence[str] | None = None,
-        orient: str | None = None,
+        orient: Literal["col", "row"] | None = None,
     ) -> DF:
         """
         Construct a DataFrame from a numpy ndarray.

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -182,7 +182,7 @@ def test_init_ndarray() -> None:
     assert df.frame_equal(truth)
 
     # 2D array - default to column orientation
-    df = pl.DataFrame(np.array([[1, 2], [3, 4]]), orient="column")
+    df = pl.DataFrame(np.array([[1, 2], [3, 4]]), orient="col")
     truth = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
     assert df.frame_equal(truth)
 


### PR DESCRIPTION
The orientation argument `orient` for the `from_records` / `from_numpy` functions must be either `col` or `row`. Updated the type hint to a Literal to reflect this.