### PR TITLE
Fix pytest warning

### DIFF
--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -144,9 +144,7 @@ def test_from_pandas_datetime() -> None:
     assert s.dt.minute()[0] == 20
     assert s.dt.second()[0] == 20
 
-    date_times = pd.date_range(
-        "2021-06-24 00:00:00", "2021-06-24 10:00:00", freq="1H", closed="left"
-    )
+    date_times = pd.date_range("2021-06-24 00:00:00", "2021-06-24 09:00:00", freq="1H")
     s = pl.from_pandas(date_times)
     assert s[0] == datetime(2021, 6, 24, 0, 0)
     assert s[-1] == datetime(2021, 6, 24, 9, 0)


### PR DESCRIPTION
`pandas` threw a warning for using a deprecated argument in `pd.date_range`. We cannot use the new argument (`inclusive`) as it is not available in Python 3.7, but we can leave the argument out entirely and rely on the default (which stays the same between `pandas` versions).