### PR TITLE
Pythonic slice support for `LazyFrame` (efficient computation paths only)

### DIFF
--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -59,6 +59,31 @@ def test_take_every() -> None:
     assert_frame_equal(expected_df, df.take_every(2).collect())
 
 
+def test_slice() -> None:
+    ldf = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]}).lazy()
+    expected = pl.DataFrame({"a": [3, 4], "b": ["c", "d"]}).lazy()
+    for slice_params in (
+        [2, 10],  # slice > len(df)
+        [2, 4],  # slice == len(df)
+        [2],  # optional len
+    ):
+        assert_frame_equal(ldf.slice(*slice_params), expected)
+
+    for py_slice in (
+        slice(1, 2),
+        slice(0, 3, 2),
+        slice(-3, None),
+        slice(None, 2, 2),
+        slice(3, None, -1),
+        slice(1, None, -2),
+    ):
+        # confirm frame slice matches python slice
+        assert ldf[py_slice].collect().rows() == ldf.collect().rows()[py_slice]
+
+    assert_frame_equal(ldf[::-1], ldf.reverse())
+    assert_frame_equal(ldf[::-2], ldf.reverse().take_every(2))
+
+
 def test_agg() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     ldf = df.lazy().min()

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -78,7 +78,7 @@ def test_frame_slice(df: pl.DataFrame) -> None:
     #
     # given the average number of rows in the frames, and the value of
     # max_examples, this will result in close to 5000 test permutations,
-    # running in around ~3 secs (depending on hardware/etc).
+    # running in around ~1.5 secs (depending on hardware/etc).
     py_data = df.rows()
 
     for start, stop, step, _ in py_data:

--- a/py-polars/tests_parametric/test_lazyframe.py
+++ b/py-polars/tests_parametric/test_lazyframe.py
@@ -1,1 +1,52 @@
-# TODO:
+from hypothesis import given, settings
+from hypothesis.strategies import integers
+
+import polars as pl
+from polars.testing import column, dataframes
+
+
+@given(
+    ldf=dataframes(
+        max_size=10,
+        lazy=True,
+        cols=[
+            column(
+                "start",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-4, max_value=6),
+            ),
+            column(
+                "stop",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-2, max_value=8),
+            ),
+            column(
+                "step",
+                dtype=pl.Int8,
+                null_probability=0.15,
+                strategy=integers(min_value=-3, max_value=3).filter(lambda x: x != 0),
+            ),
+            column("misc", dtype=pl.Int32),
+        ],
+    )
+)
+@settings(max_examples=500)
+def test_lazyframe_slice(ldf: pl.LazyFrame) -> None:
+    py_data = ldf.collect().rows()
+
+    for start, stop, step, _ in py_data:
+        s = slice(start, stop, step)
+        sliced_py_data = py_data[s]
+        try:
+            sliced_df_data = ldf[s].collect().rows()
+            assert (
+                sliced_py_data == sliced_df_data
+            ), f"slice [{start}:{stop}:{step}] failed on lazy df w/len={len(py_data)}"
+
+        except ValueError as err:
+            # test params will trigger some known
+            # unsupported cases; filter them here.
+            if "not supported" not in str(err):
+                raise


### PR DESCRIPTION
As remarked upon in the previous slice-related patch (#3904), `LazyFrame` is a different beast. While it is technically _possible_ to support all slices in lazy-context, it is not necessarily _desirable_ - as `LazyFrame` lacks length information, not all slices map efficiently onto existing lazy methods (most slices with negative `stop`, for example). Given that the purpose of LazyFrame is efficient computation, that is not a property you want to bake-in by default.

So, this patch _only_ adds support for pythonic-style slicing where there is an efficient/direct straight-through mapping  to an existing `LazyFrame` method. The code is very explicit about what is supported, and documented in-line (take a look at `LazyPolarsSlice` for the details).

Examples of what _is_ supported:

```python
[2:5]   =>  slice
[:10]   =>  head
[-5:]   =>  tail
[::-1]  =>  reverse
[::2]   =>  take_every
```

Examples of what is _not_ supported:

```python
[0:-8]    # negative stop
[5:1:-4]  # negative stride + start & stop
```

Attempts to call one of the unsupported slice patterns results in a clear/explanatory exception, suggesting a rethink might be in order. Observationally the supported syntax does actually cover the _vast_ majority of common cases.

**Also**

* Parametric (and quick) testing coverage for lazy slices.
* Extended `assert_frame_equal` to work with both DataFrame and LazyFrame (left/right not being of the same type is an error, so won't accidentally allow matches if one frame is lazy and the other isn't).
* Was able to slightly streamline the non-lazy `PolarsSlice`.
