### PR TITLE
docs: conventions, mwe and docstring fixes

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -219,7 +219,7 @@ Column names
 ------------
    Expressions that help renaming/ selecting columns by name.
 
-   A wildcard `col("*")`/`pl.all()` selects all columns in a DataFrame.
+   A wildcard ``col("*")``/:func:`polars.all()` selects all columns in a DataFrame.
 
    >>> df.select(pl.all())
 

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -176,7 +176,6 @@ Manipulation/ selection
 
     Expr.append
     Expr.arg_sort
-    Expr.arg_sort
     Expr.argsort
     Expr.backward_fill
     Expr.cast

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -71,7 +71,6 @@ class Config:
 
         Examples
         --------
-
         >>> pl.cfg.Config.set_tbl_cols(5)
         >>> df = pl.DataFrame({str(i): [i] for i in range(100)})
         >>> df

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -87,7 +87,6 @@ def from_dicts(
 
     Examples
     --------
-
     >>> data = [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
     >>> df = pl.from_dicts(data)
     >>> df
@@ -136,7 +135,6 @@ def from_records(
 
     Examples
     --------
-
     >>> data = [[1, 2, 3], [4, 5, 6]]
     >>> df = pl.from_records(data, columns=["a", "b"])
     >>> df
@@ -193,7 +191,6 @@ def from_numpy(
 
     Examples
     --------
-
     >>> import numpy as np
     >>> data = np.array([[1, 2, 3], [4, 5, 6]])
     >>> df = pl.from_numpy(data, columns=["a", "b"], orient="col")

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -241,7 +241,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"TF": [True, False], "FF": [False, False]})
-        >>> df.select(pl.col("*").any())
+        >>> df.select(pl.all().any())
         shape: (1, 2)
         ┌──────┬───────┐
         │ TF   ┆ FF    │
@@ -399,7 +399,7 @@ class Expr:
         │ 3   ┆ null ┆ 1    │
         └─────┴──────┴──────┘
         >>> df.select(
-        ...     pl.col("*").exclude("b"),
+        ...     pl.all().exclude("b"),
         ... )
         shape: (3, 2)
         ┌─────┬──────┐
@@ -616,7 +616,7 @@ class Expr:
         ...     }
         ... )
         >>> df.select(
-        ...     pl.col("*").reverse().map_alias(lambda colName: colName + "_reverse")
+        ...     pl.all().reverse().map_alias(lambda colName: colName + "_reverse")
         ... )
         shape: (2, 2)
         ┌───────────┬───────────┐
@@ -757,7 +757,7 @@ class Expr:
         ...         "B": [3.0, np.inf],
         ...     }
         ... )
-        >>> df.select(pl.col("*").is_finite())
+        >>> df.select(pl.all().is_finite())
         shape: (2, 2)
         ┌──────┬───────┐
         │ A    ┆ B     │
@@ -788,7 +788,7 @@ class Expr:
         ...         "B": [3.0, np.inf],
         ...     }
         ... )
-        >>> df.select(pl.col("*").is_infinite())
+        >>> df.select(pl.all().is_infinite())
         shape: (2, 2)
         ┌───────┬───────┐
         │ A     ┆ B     │
@@ -910,7 +910,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
-        >>> df.select(pl.col("*").count())  # counts nulls
+        >>> df.select(pl.all().count())  # counts nulls
         shape: (1, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -963,7 +963,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
-        >>> df.select(pl.col("*").slice(1, 2))
+        >>> df.select(pl.all().slice(1, 2))
         shape: (2, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -996,7 +996,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
-        >>> df.select(pl.col("*").head(1).append(pl.col("*").tail(1)))
+        >>> df.select(pl.all().head(1).append(pl.all().tail(1)))
         shape: (2, 2)
         ┌─────┬──────┐
         │ a   ┆ b    │
@@ -1893,7 +1893,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 2, None], "b": [4, None, 6]})
-        >>> df.select(pl.col("*").forward_fill())
+        >>> df.select(pl.all().forward_fill())
         shape: (3, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -1922,7 +1922,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 2, None], "b": [4, None, 6]})
-        >>> df.select(pl.col("*").backward_fill())
+        >>> df.select(pl.all().backward_fill())
         shape: (3, 2)
         ┌──────┬─────┐
         │ a    ┆ b   │
@@ -2166,7 +2166,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [None, 1, None], "b": [1, 2, 3]})
-        >>> df.select(pl.col("*").null_count())
+        >>> df.select(pl.all().null_count())
         shape: (1, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -925,7 +925,7 @@ class Expr:
 
     def len(self) -> Expr:
         """
-        Alias for count
+        Alias for :func:`count`.
         Count the number of values in this expression
 
         Examples
@@ -1022,10 +1022,9 @@ class Expr:
         """
         Drop null values.
 
-        Warnings
-        --------
-        NOTE that null values are not floating point NaN values!
-        To drop NaN values, use `drop_nans()`.
+        .. warning::
+            Note that null values are not floating point NaN values!
+            To drop NaN values, use :func:`drop_nans`.
 
         Examples
         --------
@@ -1052,10 +1051,10 @@ class Expr:
     def drop_nans(self) -> Expr:
         """
         Drop floating point NaN values
-        Warnings
-        --------
-        NOTE that NaN values are not null values!
-        To drop null values, use `drop_nulls()`.
+
+        .. warning::
+            Note that NaN values are not null values!
+            To drop null values, use :func:`drop_nulls`.
 
         Examples
         --------
@@ -3077,6 +3076,8 @@ class Expr:
         """
         Prints the value that this expression evaluates to and passes on the value.
 
+        Examples
+        --------
         >>> df = pl.DataFrame({"foo": [1, 1, 2]})
         >>> df.select(pl.col("foo").cumsum().inspect("value is: {}").alias("bar"))
         value is: shape: (3,)

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4101,7 +4101,8 @@ class Expr:
 
         Only works for the following dtypes: {Int32, Int64, Float32, Float64, UInt32}.
 
-        If you want to clip other dtypes, consider writing a when -> then -> otherwise expression
+        If you want to clip other dtypes, consider writing a "when, then, otherwise" expression.
+        See :func:`when` for more information.
 
         Parameters
         ----------
@@ -4109,6 +4110,26 @@ class Expr:
             Minimum value.
         max_val
             Maximum value.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": [-50, 5, None, 50]})
+        >>> df.with_column(pl.col("foo").clip(1, 10).alias("foo_clipped"))
+        shape: (4, 2)
+        ┌──────┬─────────────┐
+        │ foo  ┆ foo_clipped │
+        │ ---  ┆ ---         │
+        │ i64  ┆ i64         │
+        ╞══════╪═════════════╡
+        │ -50  ┆ 1           │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 5    ┆ 5           │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ null ┆ null        │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 50   ┆ 10          │
+        └──────┴─────────────┘
+
         """
         return wrap_expr(self._pyexpr.clip(min_val, max_val))
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -223,10 +223,43 @@ class Expr:
         """
         Cast to physical representation of the logical dtype.
 
-        Date -> Int32
-        Datetime -> Int64
-        Time -> Int64
-        other -> other
+        - :func:`polars.datatypes.Date` -> :func:`polars.datatypes.Int32`
+        - :func:`polars.datatypes.Datetime` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Time` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Duration` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Categorical` -> :func:`polars.datatypes.UInt32`
+        - Other data types will be left unchanged.
+
+        Examples
+        --------
+        Replicating the pandas
+        `pd.factorize <https://pandas.pydata.org/docs/reference/api/pandas.factorize.html>`_
+        function.
+
+        >>> pl.DataFrame({"vals": ["a", "x", None, "a"]}).with_columns(
+        ...     [
+        ...         pl.col("vals").cast(pl.Categorical),
+        ...         pl.col("vals")
+        ...         .cast(pl.Categorical)
+        ...         .to_physical()
+        ...         .alias("vals_physical"),
+        ...     ]
+        ... )
+        shape: (4, 2)
+        ┌──────┬───────────────┐
+        │ vals ┆ vals_physical │
+        │ ---  ┆ ---           │
+        │ cat  ┆ u32           │
+        ╞══════╪═══════════════╡
+        │ a    ┆ 0             │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ x    ┆ 1             │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ null ┆ null          │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ a    ┆ 0             │
+        └──────┴───────────────┘
+
         """
         return wrap_expr(self._pyexpr.to_physical())
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -240,7 +240,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"TF": [True, False], "FF": [False, False]})
         >>> df.select(pl.col("*").any())
         shape: (1, 2)
@@ -267,7 +266,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"TT": [True, True], "TF": [True, False], "FF": [False, False]}
         ... )
@@ -312,7 +310,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3],
@@ -381,7 +378,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3],
@@ -445,7 +441,6 @@ class Expr:
 
         Examples
         --------
-
         A groupby aggregation often changes the name of a column.
         With `keep_name` we can keep the original name of the column
 
@@ -491,11 +486,10 @@ class Expr:
 
     def prefix(self, prefix: str) -> Expr:
         """
-        Add a prefix the to root column name of the expression.
+        Add a prefix to the root column name of the expression.
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1, 2, 3, 4, 5],
@@ -549,11 +543,10 @@ class Expr:
 
     def suffix(self, suffix: str) -> Expr:
         """
-        Add a suffix the to root column name of the expression.
+        Add a suffix to the root column name of the expression.
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1, 2, 3, 4, 5],
@@ -612,10 +605,10 @@ class Expr:
         Parameters
         ----------
         f
-            function that maps root name to new name
+            Function that maps root name to new name.
+
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1, 2],
@@ -635,6 +628,7 @@ class Expr:
         ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
         │ 1         ┆ 3         │
         └───────────┴───────────┘
+
         """
         return wrap_expr(self._pyexpr.map_alias(f))
 
@@ -644,7 +638,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [True, False, False],
@@ -687,7 +680,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, None, 1, 5],
@@ -721,7 +713,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, None, 1, 5],
@@ -760,7 +751,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1.0, 2],
@@ -792,7 +782,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1.0, 2],
@@ -819,7 +808,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, None, 1, 5],
@@ -853,7 +841,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, None, 1, 5],
@@ -877,6 +864,7 @@ class Expr:
         ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
         │ 5    ┆ 5.0 ┆ true         ┆ true         │
         └──────┴─────┴──────────────┴──────────────┘
+
         """
         return wrap_expr(self._pyexpr.is_not_nan())
 
@@ -887,7 +875,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "group": [
@@ -922,7 +909,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
         >>> df.select(pl.col("*").count())  # counts nulls
         shape: (1, 2)
@@ -944,7 +930,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [8, 9, 10],
@@ -977,7 +962,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
         >>> df.select(pl.col("*").slice(1, 2))
         shape: (2, 2)
@@ -1005,13 +989,12 @@ class Expr:
         Parameters
         ----------
         other
-            Expression to append
+            Expression to append.
         upcast
-            Cast both `Series` to the same supertype
+            Cast both `Series` to the same supertype.
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
         >>> df.select(pl.col("*").head(1).append(pl.col("*").tail(1)))
         shape: (2, 2)
@@ -1046,7 +1029,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"a": [8, 9, 10, 11], "b": [None, 4.0, 4.0, float("nan")]}
         ... )
@@ -1077,7 +1059,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"a": [8, 9, 10, 11], "b": [None, 4.0, 4.0, float("nan")]}
         ... )
@@ -1113,7 +1094,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
         >>> df.select(
         ...     [
@@ -1154,7 +1134,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
         >>> df.select(
         ...     [
@@ -1190,7 +1169,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
         >>> df.select(
         ...     [
@@ -1226,7 +1204,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
         >>> df.select(
         ...     [
@@ -1264,7 +1241,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
         >>> df.select(
         ...     [
@@ -1297,7 +1273,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0.3, 0.5, 1.0, 1.1]})
         >>> df.select(pl.col("a").floor())
         shape: (4, 1)
@@ -1325,7 +1300,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0.3, 0.5, 1.0, 1.1]})
         >>> df.select(pl.col("a").ceil())
         shape: (4, 1)
@@ -1356,7 +1330,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0.33, 0.52, 1.02, 1.17]})
         >>> df.select(pl.col("a").round(1))
         shape: (4, 1)
@@ -1383,11 +1356,10 @@ class Expr:
         Parameters
         ----------
         other
-            Expression to compute dot product with
+            Expression to compute dot product with.
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -1415,7 +1387,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 1, 2, 3],
@@ -1443,13 +1414,13 @@ class Expr:
         Parameters
         ----------
         dtype
-            DataType to cast to
+            DataType to cast to.
         strict
-            Throw an error if a cast could not be done for instance due to an overflow
+            Throw an error if a cast could not be done.
+            For instance, due to an overflow.
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3], "b": ["4", "5", "6"]})
         >>> df.with_columns(
         ...     [
@@ -1489,7 +1460,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "group": [
@@ -1572,7 +1542,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [20, 10, 30],
@@ -1600,7 +1569,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [20, 10, 30],
@@ -1624,7 +1592,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [20, 10, 30],
@@ -1663,7 +1630,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "group": [
@@ -1720,7 +1686,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "group": [
@@ -1770,7 +1735,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4]})
         >>> df.select(pl.col("foo").shift(1))
         shape: (4, 1)
@@ -1807,7 +1771,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4]})
         >>> df.select(pl.col("foo").shift_and_fill(1, "a"))
         shape: (4, 1)
@@ -1847,7 +1810,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, None], "b": [4, None, 6]})
         >>> df.fill_null("zero")
         shape: (3, 2)
@@ -1899,7 +1861,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"a": [1.0, None, float("nan")], "b": [4.0, float("nan"), 6]}
         ... )
@@ -1931,7 +1892,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, None], "b": [4, None, 6]})
         >>> df.select(pl.col("*").forward_fill())
         shape: (3, 2)
@@ -1961,7 +1921,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, None], "b": [4, None, 6]})
         >>> df.select(pl.col("*").backward_fill())
         shape: (3, 2)
@@ -1985,7 +1944,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1, 2, 3, 4, 5],
@@ -2026,7 +1984,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").std())
         shape: (1, 1)
@@ -2046,7 +2003,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").var())
         shape: (1, 1)
@@ -2067,7 +2023,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").max())
         shape: (1, 1)
@@ -2087,7 +2042,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").min())
         shape: (1, 1)
@@ -2113,7 +2067,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").sum())
         shape: (1, 1)
@@ -2134,7 +2087,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").mean())
         shape: (1, 1)
@@ -2155,7 +2107,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
         >>> df.select(pl.col("a").median())
         shape: (1, 1)
@@ -2175,7 +2126,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3]})
         >>> df.select(pl.col("a").product())
         shape: (1, 1)
@@ -2195,7 +2145,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").n_unique())
         shape: (1, 1)
@@ -2216,7 +2165,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [None, 1, None], "b": [1, 2, 3]})
         >>> df.select(pl.col("*").null_count())
         shape: (1, 2)
@@ -2236,7 +2184,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
         >>> df.select(pl.col("a").arg_unique())
         shape: (3, 1)
@@ -2277,7 +2224,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").unique())
         shape: (2, 1)
@@ -2313,7 +2259,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").first())
         shape: (1, 1)
@@ -2333,7 +2278,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").last())
         shape: (1, 1)
@@ -2354,7 +2298,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3],
@@ -2387,7 +2330,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "groups": [1, 1, 2, 2, 1, 2, 3, 3, 1],
@@ -2440,7 +2382,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").is_unique())
         shape: (3, 1)
@@ -2468,7 +2409,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "num": [1, 2, 3, 1, 5],
@@ -2501,7 +2441,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
         >>> df.select(pl.col("a").is_duplicated())
         shape: (3, 1)
@@ -2534,7 +2473,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0, 1, 2, 3, 4, 5]})
         >>> df.select(pl.col("a").quantile(0.3))
         shape: (1, 1)
@@ -2633,7 +2571,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "sine": [0.0, 1.0, 0.0, -1.0],
@@ -2691,7 +2628,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3, 1],
@@ -2781,7 +2717,6 @@ class Expr:
 
         Examples
         --------
-
         The following example turns each character into a separate row:
 
         >>> df = pl.DataFrame({"foo": ["hello", "world"]})
@@ -2842,7 +2777,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"b": [[1, 2, 3], [4, 5, 6]]})
         >>> df.select(pl.col("b").explode())
         shape: (6, 1)
@@ -2873,7 +2807,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
         >>> df.select(pl.col("foo").take_every(3))
         shape: (3, 1)
@@ -2912,7 +2845,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4]})
         >>> df.select(pl.col("foo").pow(3))
         shape: (4, 1)
@@ -2989,7 +2921,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": ["x", "y", "z"],
@@ -3043,7 +2974,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "num": [1, 2, 3, 4, 5],
@@ -3105,7 +3035,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3],
@@ -3245,7 +3174,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
         >>> (
         ...     df.select(
@@ -3342,7 +3270,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
         >>> (
         ...     df.select(
@@ -3440,7 +3367,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"A": [1.0, 8.0, 6.0, 2.0, 16.0, 10.0]})
         >>> df.select(
         ...     [
@@ -3536,7 +3462,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
         >>> (
         ...     df.select(
@@ -3891,7 +3816,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1.0, 2.0, 9.0, 2.0, 13.0],
@@ -3978,11 +3902,10 @@ class Expr:
             - 'random': Like 'ordinal', but the rank for ties is not dependent
             on the order that the values occur in `a`.
         reverse
-            reverse the operation
+            Reverse the operation.
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0, 1, 2, 2, 4]})
         >>> df.select(pl.col("a").rank())
         shape: (5, 1)
@@ -4018,7 +3941,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [20, 10, 30],
@@ -4055,7 +3977,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [10, 11, 12, None, 12],
@@ -4175,7 +4096,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [-9, -8, 0, 4]})
         >>> df.select(pl.col("foo").sign())
         shape: (4, 1)
@@ -4208,7 +4128,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0.0]})
         >>> df.select(pl.col("a").sin())
         shape: (1, 1)
@@ -4235,7 +4154,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [0.0]})
         >>> df.select(pl.col("a").cos())
         shape: (1, 1)
@@ -4262,7 +4180,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1.0]})
         >>> df.select(pl.col("a").tan().round(2))
         shape: (1, 1)
@@ -4375,7 +4292,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
         >>> df.select(pl.col("foo").reshape((3, 3)))
         shape: (3, 1)
@@ -4548,7 +4464,6 @@ class Expr:
 
         Examples
         --------
-
         >>> s = pl.Series([1, 2, 3])
         >>> s.extend_constant(99, n=2)
         shape: (5,)
@@ -4579,7 +4494,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "id": ["a", "b", "b", "c", "c", "c"],
@@ -4615,7 +4529,6 @@ class Expr:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "id": ["a", "b", "b", "c", "c", "c"],
@@ -4797,7 +4710,6 @@ class ExprStructNameSpace:
 
         Examples
         --------
-
         >>> df = (
         ...     pl.DataFrame(
         ...         {
@@ -4836,7 +4748,6 @@ class ExprStructNameSpace:
 
         Examples
         --------
-
         >>> df = (
         ...     pl.DataFrame(
         ...         {
@@ -4887,7 +4798,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2], "bar": [["a", "b"], ["c"]]})
         >>> df.select(pl.col("bar").arr.lengths())
         shape: (2, 1)
@@ -4934,7 +4844,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [[3, 2, 1], [9, 1, 2]],
@@ -5000,7 +4909,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [["a"], ["x"]],
@@ -5048,7 +4956,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
         >>> df.select(pl.col("foo").arr.get(0))
         shape: (3, 1)
@@ -5073,7 +4980,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
         >>> df.select(pl.col("foo").arr.first())
         shape: (3, 1)
@@ -5098,7 +5004,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
         >>> df.select(pl.col("foo").arr.last())
         shape: (3, 1)
@@ -5132,7 +5037,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
         >>> df.select(pl.col("foo").arr.contains(1))
         shape: (3, 1)
@@ -5167,7 +5071,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"s": [["a", "b", "c"], ["x", "y"]]})
         >>> df.select(pl.col("s").arr.join(" "))
         shape: (2, 1)
@@ -5218,7 +5121,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.diff()
         shape: (2,)
@@ -5243,7 +5145,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.shift()
         shape: (2,)
@@ -5263,13 +5164,12 @@ class ExprListNameSpace:
         Parameters
         ----------
         offset
-            Take the values from this index offset
+            Take the values from this index offset.
         length
-            The length of the slice to take
+            The length of the slice to take.
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.slice(1, 2)
         shape: (2,)
@@ -5293,7 +5193,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.head(2)
         shape: (2,)
@@ -5317,7 +5216,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
         >>> s.arr.tail(2)
         shape: (2,)
@@ -5349,7 +5247,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [[1, 2, 3], [1, 2]]})
         >>> df.select([pl.col("a").arr.to_struct()])
         shape: (2, 1)
@@ -5392,7 +5289,6 @@ class ExprListNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
         >>> df.with_column(
         ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
@@ -5448,7 +5344,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         Dealing with different formats.
 
         >>> s = pl.Series(
@@ -5508,7 +5403,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"s": [None, "bears", "110"]})
         >>> df.select(["s", pl.col("s").str.lengths().alias("len")])
         shape: (3, 2)
@@ -5542,7 +5436,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, None, 2]})
         >>> df.select(pl.col("foo").str.concat("-"))
         shape: (1, 1)
@@ -5601,7 +5494,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "num": [-10, -1, 0, 1, 10, 100, 1000, 10000, 100000, 1000000, None],
@@ -5941,7 +5833,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [
@@ -6055,7 +5946,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"s": ["foo bar", "foo-bar", "foo bar baz"]})
         >>> df.select(pl.col("s").str.split(by=" "))
         shape: (3, 1)
@@ -6097,7 +5987,6 @@ class ExprStringNameSpace:
 
         Examples
         --------
-
         >>> (
         ...     pl.DataFrame({"x": ["a_1", None, "c", "d_4"]}).select(
         ...         [
@@ -6287,7 +6176,6 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
-
         >>> from datetime import timedelta, datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 2)
@@ -6827,7 +6715,6 @@ class ExprCatNameSpace:
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"cats": ["z", "z", "k", "a", "b"], "vals": [3, 1, 2, 2, 3]}
         ... ).with_columns(

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3056,35 +3056,36 @@ class Expr:
 
     def hash(self, seed: int = 0, **kwargs: Any) -> Expr:
         """
-        Hash the Series.
+        Hash the elements in the selection.
 
-        The hash value is of type `UInt64`
+        The hash value is of type `UInt64`.
 
         Parameters
         ----------
         seed
-            seed parameter
+            The random seed to set.
 
         Examples
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [1, 2, 3],
+        ...         "a": [1, 2, None],
+        ...         "b": ["x", None, "z"],
         ...     }
         ... )
-        >>> df.with_column(pl.col("a").hash(0))  # doctest: +IGNORE_RESULT
-        shape: (3, 1)
-        ┌─────────────────────┐
-        │ a                   │
-        │ ---                 │
-        │ u64                 │
-        ╞═════════════════════╡
-        │ 2818902862237899908 │
-        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 1584708464793912000 │
-        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 8337078092773689561 │
-        └─────────────────────┘
+        >>> df.with_column(pl.all().hash(0))  # doctest: +IGNORE_RESULT
+        shape: (3, 2)
+        ┌──────────────────────┬──────────────────────┐
+        │ a                    ┆ b                    │
+        │ ---                  ┆ ---                  │
+        │ u64                  ┆ u64                  │
+        ╞══════════════════════╪══════════════════════╡
+        │ 1156793252771347292  ┆ 16009526192193213963 │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 5223293301138196316  ┆ 12128596533331663936 │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 12128596533331663936 ┆ 97974125653717906    │
+        └──────────────────────┴──────────────────────┘
 
         """
         # kwargs is for backward compatibility

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -852,7 +852,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "A": [1, 2, 3, 4, 5],
@@ -1087,7 +1086,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> import pandas
         >>> df = pl.DataFrame(
         ...     {
@@ -1135,7 +1133,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3, 4, 5],
@@ -1260,7 +1257,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df.to_dicts()
         [{'foo': 1, 'bar': 4}, {'foo': 2, 'bar': 5}, {'foo': 3, 'bar': 6}]
@@ -1303,7 +1299,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
         >>> df.transpose(include_header=True)
         shape: (2, 4)
@@ -1515,7 +1510,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
         ... )
@@ -1944,7 +1938,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
         ... )
@@ -1978,7 +1971,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> s = pl.Series("baz", [97, 98, 99])
         >>> df.insert_at_idx(1, s)  # returns None
@@ -2037,7 +2029,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -2100,7 +2091,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4, 5]})
         >>> df.height
         5
@@ -2115,7 +2105,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4, 5]})
         >>> df.width
         1
@@ -2130,7 +2119,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -2386,7 +2374,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -2501,7 +2488,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> s = pl.Series([10, 20, 30])
         >>> df.replace("foo", s)  # works in-place!
@@ -2779,7 +2765,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> def cast_str_to_int(data, col_name):
         ...     return data.with_column(pl.col(col_name).cast(pl.Int64))
         ...
@@ -2816,7 +2801,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -2980,7 +2964,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> dates = [
         ...     "2020-01-01 13:45:48",
         ...     "2020-01-01 16:42:13",
@@ -3099,7 +3082,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> from datetime import datetime
         >>> # create an example dataframe
         >>> df = pl.DataFrame(
@@ -3373,7 +3355,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         Upsample a DataFrame by a certain interval.
 
         >>> from datetime import datetime
@@ -3506,7 +3487,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> from datetime import datetime
         >>> gdp = pl.DataFrame(
         ...     {
@@ -3754,7 +3734,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [-1, 5, 8]})
 
         Return a DataFrame by mapping each row to a tuple:
@@ -3816,7 +3795,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -3949,7 +3927,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df1 = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2],
@@ -4011,7 +3988,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df1 = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df2 = pl.DataFrame({"foo": [10, 20, 30], "bar": [40, 50, 60]})
         >>> df1.extend(df2)  # returns None
@@ -4049,7 +4025,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -4195,7 +4170,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df.get_columns()
         [shape: (3,)
@@ -4257,7 +4231,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df.get_column("foo")
         shape: (3,)
@@ -4349,7 +4322,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1.5, 2, float("NaN"), 4],
@@ -4489,7 +4461,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": ["one", "one", "one", "two", "two", "two"],
@@ -4550,7 +4521,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": ["x", "y", "z"],
@@ -4643,7 +4613,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": ["A", "A", "B", "B", "C"],
@@ -4801,7 +4770,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3, 1],
@@ -4827,7 +4795,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3, 1],
@@ -5310,7 +5277,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3],
@@ -5436,7 +5402,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 1, 2, 3, 4, 5],
@@ -5683,7 +5648,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -5785,7 +5749,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, None, 9, 10],
@@ -5818,7 +5781,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df.is_empty()
         False
@@ -5839,7 +5801,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 2, 3, 4, 5],
@@ -5872,7 +5833,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-
         >>> df = (
         ...     pl.DataFrame(
         ...         {
@@ -6121,7 +6081,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": ["one", "one", "one", "two", "two", "two"],
@@ -6214,7 +6173,7 @@ class GroupBy(Generic[DF]):
 
     def apply(self, f: Callable[[DataFrame], DataFrame]) -> DF:
         """
-         Apply a function over the groups as a sub-DataFrame.
+        Apply a function over the groups as a sub-DataFrame.
 
         Implementing logic using this .apply method is generally slower and more memory intensive
         than implementing the same logic using the expression API because:
@@ -6225,18 +6184,17 @@ class GroupBy(Generic[DF]):
 
         If possible use the expression API for best performance.
 
-         Parameters
-         ----------
-         f
-             Custom function.
+        Parameters
+        ----------
+        f
+            Custom function.
 
-         Returns
-         -------
-         DataFrame
+        Returns
+        -------
+        DataFrame
 
-         Examples
-         --------
-
+        Examples
+        --------
         >>> df = pl.DataFrame(
         ...     {
         ...         "id": [0, 1, 2, 3, 4],
@@ -6315,7 +6273,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {"foo": ["one", "two", "two", "one", "two"], "bar": [5, 3, 2, 4, 1]}
         ... )
@@ -6390,7 +6347,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "letters": ["c", "c", "a", "c", "a", "b"],
@@ -6454,7 +6410,6 @@ class GroupBy(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "letters": ["c", "c", "a", "c", "a", "b"],
@@ -7054,7 +7009,6 @@ class GBSelection(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, None, 3, 4],

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -694,7 +694,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = (
         ...     pl.DataFrame(
         ...         {
@@ -791,7 +790,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> lf = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -845,7 +843,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -888,7 +885,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": ["a", "b", "a", "b", "b", "c"],
@@ -983,7 +979,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> dates = [
         ...     "2020-01-01 13:45:48",
         ...     "2020-01-01 16:42:13",
@@ -1316,7 +1311,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -1561,7 +1555,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -1644,7 +1637,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -1699,7 +1691,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -1751,7 +1742,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": ["x", "y", "z"],
@@ -1843,7 +1833,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, 3, 5],
@@ -1975,7 +1964,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "letters": ["c", "c", "a", "c", "a", "b"],
@@ -2178,7 +2166,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": ["x", "y", "z"],
@@ -2253,7 +2240,6 @@ class LazyFrame(Generic[DF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, None, 9, 10],
@@ -2316,7 +2302,6 @@ class LazyGroupBy(Generic[LDF]):
 
         Examples
         --------
-
         >>> (
         ...     pl.scan_csv("data.csv")
         ...     .groupby("groups")
@@ -2343,7 +2328,6 @@ class LazyGroupBy(Generic[LDF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "letters": ["c", "c", "a", "c", "a", "b"],
@@ -2401,7 +2385,6 @@ class LazyGroupBy(Generic[LDF]):
 
         Examples
         --------
-
         >>> df = pl.DataFrame(
         ...     {
         ...         "letters": ["c", "c", "a", "c", "a", "b"],
@@ -2467,7 +2450,6 @@ class LazyGroupBy(Generic[LDF]):
 
         Examples
         --------
-
         The function is applied by group.
 
         >>> df = pl.DataFrame(

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1239,14 +1239,49 @@ def _date(
 
 def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli.Expr:
     """
-    Horizontally Concat Utf8 Series in linear time. Non utf8 columns are cast to utf8.
+    Horizontally concat Utf8 Series in linear time. Non-Utf8 columns are cast to Utf8.
 
     Parameters
     ----------
     exprs
-        Columns to concat into a Utf8 Series
+        Columns to concat into a Utf8 Series.
     sep
         String value that will be used to separate the values.
+
+    Examples
+    --------
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 2, 3],
+    ...         "b": ["dogs", "cats", None],
+    ...         "c": ["play", "swim", "walk"],
+    ...     }
+    ... )
+    >>> df.with_columns(
+    ...     [
+    ...         pl.concat_str(
+    ...             [
+    ...                 pl.col("a") * 2,
+    ...                 pl.col("b"),
+    ...                 pl.col("c"),
+    ...             ],
+    ...             sep=" ",
+    ...         ).alias("full_sentence"),
+    ...     ]
+    ... )
+    shape: (3, 4)
+    ┌─────┬──────┬──────┬───────────────┐
+    │ a   ┆ b    ┆ c    ┆ full_sentence │
+    │ --- ┆ ---  ┆ ---  ┆ ---           │
+    │ i64 ┆ str  ┆ str  ┆ str           │
+    ╞═════╪══════╪══════╪═══════════════╡
+    │ 1   ┆ dogs ┆ play ┆ 2 dogs play   │
+    ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    │ 2   ┆ cats ┆ swim ┆ 4 cats swim   │
+    ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+    │ 3   ┆ null ┆ walk ┆ null          │
+    └─────┴──────┴──────┴───────────────┘
+
     """
     exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(_concat_str(exprs, sep))

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -886,7 +886,7 @@ def exclude(columns: str | list[str]) -> pli.Expr:
 
     Syntactic sugar for:
 
-    >>> pl.col("*").exclude(columns)  # doctest: +SKIP
+    >>> pl.all().exclude(columns)  # doctest: +SKIP
 
     Parameters
     ----------

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -188,7 +188,6 @@ def element() -> pli.Expr:
 
     Examples
     --------
-
     A horizontal rank computation by taking the elements of a list
 
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
@@ -624,7 +623,6 @@ def lit(
 
     Examples
     --------
-
     Literal integer:
 
     >>> pl.lit(1)  # doctest: +IGNORE_RESULT
@@ -951,7 +949,6 @@ def all(name: str | list[pli.Expr] | None = None) -> pli.Expr:
 
     Examples
     --------
-
     Sum all columns
 
     >>> df = pl.DataFrame(
@@ -1322,7 +1319,6 @@ def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.
 
     Examples
     --------
-
     Create lagged columns and collect them into a list. This mimics a rolling window.
 
     >>> df = pl.DataFrame(

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -1964,10 +1964,30 @@ class Series:
         """
         Cast to physical representation of the logical dtype.
 
-        Date -> Int32
-        Datetime -> Int64
-        Time -> Int64
-        other -> other
+        - :func:`polars.datatypes.Date` -> :func:`polars.datatypes.Int32`
+        - :func:`polars.datatypes.Datetime` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Time` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Duration` -> :func:`polars.datatypes.Int64`
+        - :func:`polars.datatypes.Categorical` -> :func:`polars.datatypes.UInt32`
+        - Other data types will be left unchanged.
+
+        Examples
+        --------
+        Replicating the pandas
+        `pd.Series.factorize <https://pandas.pydata.org/docs/reference/api/pandas.Series.factorize.html>`_
+        method.
+
+        >>> s = pl.Series("values", ["a", None, "x", "a"])
+        >>> s.cast(pl.Categorical).to_physical()
+        shape: (4,)
+        Series: 'values' [u32]
+        [
+            0
+            null
+            1
+            0
+        ]
+
         """
         return wrap_s(self._s.to_physical())
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3617,12 +3617,29 @@ class Series:
 
         Only works for the following dtypes: {Int32, Int64, Float32, Float64, UInt32}.
 
-        If you want to clip other dtypes, consider writing a when -> then -> otherwise expression
+        If you want to clip other dtypes, consider writing a "when, then, otherwise" expression.
+        See :func:`when` for more information.
 
         Parameters
         ----------
-        min_val, max_val
-            Minimum and maximum value.
+        min_val
+            Minimum value.
+        max_val
+            Maximum value.
+
+        Examples
+        --------
+        >>> s = pl.Series("foo", [-50, 5, None, 50])
+        >>> s.clip(1, 10)
+        shape: (4,)
+        Series: 'foo' [i64]
+        [
+            1
+            5
+            null
+            10
+        ]
+
         """
         return self.to_frame().select(pli.col(self.name).clip(min_val, max_val))[
             self.name

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -939,7 +939,6 @@ class Series:
 
         Examples
         --------
-
         >>> s = pl.Series("id", ["a", "b", "b", "c", "c", "c"])
         >>> s.unique_counts()
         shape: (3,)
@@ -968,7 +967,6 @@ class Series:
 
         Examples
         --------
-
         >>> a = pl.Series([0.99, 0.005, 0.005])
         >>> a.entropy(normalize=True)
         0.06293300616044681
@@ -1004,7 +1002,6 @@ class Series:
 
         Examples
         --------
-
         >>> s = pl.Series("values", [1, 2, 3, 4, 5])
         >>> s.cumulative_eval(pl.element().first() - pl.element().last() ** 2)
         shape: (5,)
@@ -2540,7 +2537,6 @@ class Series:
 
         Examples
         --------
-
         >>> s = pl.Series("foo", [-9, -8, 0, 4])
         >>> s.sign()  #
         shape: (4,)
@@ -2793,7 +2789,6 @@ class Series:
 
         Examples
         --------
-
         >>> s1 = pl.Series([1, 2, 3, 4, 5])
         >>> s2 = pl.Series([5, 4, 3, 2, 1])
         >>> s1.zip_with(s1 < s2, s2)
@@ -3778,7 +3773,6 @@ class Series:
 
         Examples
         --------
-
         >>> s = pl.Series([1, 2, 3])
         >>> s.extend_constant(99, n=2)
         shape: (5,)
@@ -3934,7 +3928,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         Dealing with different formats.
 
         >>> s = pl.Series(
@@ -3991,7 +3984,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series(["foo", None, "hello", "world"])
         >>> s.str.lengths()
         shape: (4,)
@@ -4079,7 +4071,6 @@ class StringNameSpace:
 
         Examples
         --------
-
         >>> s = pl.Series("fruits", ["apple", "mango", None])
         >>> s.str.ends_with("go")
         shape: (3,)

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -869,19 +869,21 @@ def read_sql(
 ) -> DataFrame:
     """
     Read a SQL query into a DataFrame.
-    Make sure to install connectorx>=0.2
 
-    # Sources
-    Supports reading a sql query from the following data sources:
+    .. note::
+        Make sure to install connectorx>=0.2.2. Read the documentation
+        `here <https://sfu-db.github.io/connector-x/intro.html>`_.
 
-    * Postgres
-    * Mysql
-    * Sqlite
-    * Redshift (through postgres protocol)
-    * Clickhouse (through mysql protocol)
+    Reading a SQL query from the following data sources are supported:
 
-    ## Source not supported?
-    If a database source is not supported, pandas can be used to load the query:
+        * Postgres
+        * Mysql
+        * Sqlite
+        * Redshift (through postgres protocol)
+        * Clickhouse (through mysql protocol)
+
+    If a database source is not supported, an alternative solution is to first use pandas
+    to load the SQL query, then converting the result into a polars DataFrame:
 
     >>> import pandas as pd
     >>> df = pl.from_pandas(pd.read_sql(sql, engine))  # doctest: +SKIP
@@ -889,29 +891,28 @@ def read_sql(
     Parameters
     ----------
     sql
-        raw sql query.
+        Raw SQL query / queries.
     connection_uri
-        connectorx connection uri:
-            - "postgresql://username:password@server:port/database"
+        Connectorx connection uri, for example
+
+        * "postgresql://username:password@server:port/database"
     partition_on
-      the column on which to partition the result.
+        The column on which to partition the result.
     partition_range
-      the value range of the partition column.
+        The value range of the partition column.
     partition_num
-      how many partitions to generate.
+        How many partitions to generate.
     protocol
-      backend-specific transfer protocol directive; see connectorx documentation for details.
+        Backend-specific transfer protocol directive; see connectorx documentation for details.
 
     Examples
     --------
-    ## Single threaded
     Read a DataFrame from a SQL query using a single thread:
 
     >>> uri = "postgresql://username:password@server:port/database"
     >>> query = "SELECT * FROM lineitem"
     >>> pl.read_sql(query, uri)  # doctest: +SKIP
 
-    ## Using 10 threads
     Read a DataFrame in parallel using 10 threads by automatically partitioning the provided SQL on the partition column:
 
     >>> uri = "postgresql://username:password@server:port/database"
@@ -920,7 +921,6 @@ def read_sql(
     ...     query, uri, partition_on="partition_col", partition_num=10
     ... )  # doctest: +SKIP
 
-    ## Using
     Read a DataFrame in parallel using 2 threads by explicitly providing two SQL queries:
 
     >>> uri = "postgresql://username:password@server:port/database"
@@ -928,7 +928,7 @@ def read_sql(
     ...     "SELECT * FROM lineitem WHERE partition_col <= 10",
     ...     "SELECT * FROM lineitem WHERE partition_col > 10",
     ... ]
-    >>> pl.read_sql(uri, queries)  # doctest: +SKIP
+    >>> pl.read_sql(queries, uri)  # doctest: +SKIP
 
     """
     if _WITH_CX:


### PR DESCRIPTION
**Conventions**
* As mentioned in #3932 , we'll go with no newline after the Examples section like so
  ```python
      Examples
      ----------
      >>> pl.col("....")
  ```
  instead of
  ```python
      Examples
      ----------

      >>> pl.col("....")
  ```
  I've gone ahead and wrote a script to fix (all?) of the remaining such patterns in the `py-polars` package. I might finish up the standardization of the remaining section types in the next PR if no one else does that.
* I also saw somewhere that `pl.all()` is recommended over `pl.col('*')`, so I've also gone ahead and changed this throughout.

**MWE**
* `to_physical` added an example inspired from #3922 
* `clip`, `concat_str`, `hash` (refer to the individual commits for more info)

**Generic Fixes**
* Duplicate `arg_sort` entry in the doc sources
* Added back in some missing sections in docstring