### PR TITLE
add from_numpy to docs

### DIFF
--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -19,6 +19,7 @@ Conversion
     from_arrow
     from_dict
     from_dicts
+    from_numpy
     from_pandas
     from_records
 


### PR DESCRIPTION
This is just a small PR to add `from_numpy` to the docs (functionality was added in #3944).

Currently, it's missing from the online documentation:

![image](https://user-images.githubusercontent.com/30731072/178211542-4af024c3-d52b-4c90-85d4-065f692c0f4a.png)
