### PR TITLE
Use new maturin api for compiling pypolars

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ This can be done by going through the following steps in sequence:
   3. Choose any of:
       * Fastest binary, very long compile times:
         ```bash
-        $ cd py-polars && maturin develop --rustc-extra-args="-C target-cpu=native" --release
+        $ cd py-polars && maturin develop target-cpu=native --release
         ```
       * Fast binary, Shorter compile times:
         ```bash
-        $ cd py-polars && maturin develop --rustc-extra-args="-C codegen-units=16 -C lto=thin -C target-cpu=native" --release
+        $ cd py-polars && maturin develop codegen-units=16 lto=thin target-cpu=native --release
         ```
 
 Note that the Rust crate implementing the Python bindings is called `py-polars` to distinguish from the wrapped


### PR DESCRIPTION
The old calls give an error on maturin 0.13. 

The github actions may need to be updated if we bump the pinned version of maturin from 0.12.1 to 0.13.