### PR TITLE
reduce peak memory of reading parquet by row groups  `-~22%`

### DIFF
--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -136,7 +136,7 @@ fn rg_to_dfs(
             df.with_row_count_mut(&rc.name, Some(previous_row_count + rc.offset));
         }
 
-        apply_predicate(&mut df, predicate.as_deref())?;
+        apply_predicate(&mut df, predicate.as_deref(), true)?;
         apply_aggregations(&mut df, aggregate)?;
 
         previous_row_count += current_row_count;
@@ -201,7 +201,7 @@ fn rg_to_dfs_par(
                 df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
             }
 
-            apply_predicate(&mut df, predicate.as_deref())?;
+            apply_predicate(&mut df, predicate.as_deref(), false)?;
             apply_aggregations(&mut df, aggregate)?;
 
             Ok(Some(df))


### PR DESCRIPTION
work stealing is not deterministic and may lead to work stolen from various row groups, keeping them longer in memory than needed.

This make sure we don't parallelize the filter operation if we are already in a parallel row group operation. This saves work stealing overhead and memory.