### PR TITLE
Align the exclude docstrings and annotation

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -405,7 +405,8 @@ class Expr:
         columns
             Column(s) to exclude from selection.
             This can be:
-            - a column name, or multiple names
+
+            - a column name, or multiple column names
             - a regular expression starting with `^` and ending with `$`
             - a dtype or multiple dtypes
 
@@ -413,39 +414,72 @@ class Expr:
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [1, 2, 3],
-        ...         "b": ["a", "b", None],
-        ...         "c": [None, 2, 1],
+        ...         "aa": [1, 2, 3],
+        ...         "ba": ["a", "b", None],
+        ...         "cc": [None, 2.5, 1.5],
         ...     }
         ... )
         >>> df
         shape: (3, 3)
         ┌─────┬──────┬──────┐
-        │ a   ┆ b    ┆ c    │
+        │ aa  ┆ ba   ┆ cc   │
         │ --- ┆ ---  ┆ ---  │
-        │ i64 ┆ str  ┆ i64  │
+        │ i64 ┆ str  ┆ f64  │
         ╞═════╪══════╪══════╡
         │ 1   ┆ a    ┆ null │
         ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
-        │ 2   ┆ b    ┆ 2    │
+        │ 2   ┆ b    ┆ 2.5  │
         ├╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
-        │ 3   ┆ null ┆ 1    │
+        │ 3   ┆ null ┆ 1.5  │
         └─────┴──────┴──────┘
-        >>> df.select(
-        ...     pl.all().exclude("b"),
-        ... )
+
+        Exclude by column name(s):
+
+        >>> df.select(pl.all().exclude("ba"))
         shape: (3, 2)
         ┌─────┬──────┐
-        │ a   ┆ c    │
+        │ aa  ┆ cc   │
         │ --- ┆ ---  │
-        │ i64 ┆ i64  │
+        │ i64 ┆ f64  │
         ╞═════╪══════╡
         │ 1   ┆ null │
         ├╌╌╌╌╌┼╌╌╌╌╌╌┤
-        │ 2   ┆ 2    │
+        │ 2   ┆ 2.5  │
         ├╌╌╌╌╌┼╌╌╌╌╌╌┤
-        │ 3   ┆ 1    │
+        │ 3   ┆ 1.5  │
         └─────┴──────┘
+
+        Exclude by regex, e.g. removing all columns whose names end with the letter "a":
+
+        >>> df.select(pl.all().exclude("^.*a$"))
+        shape: (3, 1)
+        ┌──────┐
+        │ cc   │
+        │ ---  │
+        │ f64  │
+        ╞══════╡
+        │ null │
+        ├╌╌╌╌╌╌┤
+        │ 2.5  │
+        ├╌╌╌╌╌╌┤
+        │ 1.5  │
+        └──────┘
+
+        Exclude by dtype(s), e.g. removing all columns of type Int64 or Float64:
+
+        >>> df.select(pl.all().exclude([pl.Int64, pl.Float64]))
+        shape: (3, 1)
+        ┌──────┐
+        │ ba   │
+        │ ---  │
+        │ str  │
+        ╞══════╡
+        │ a    │
+        ├╌╌╌╌╌╌┤
+        │ b    │
+        ├╌╌╌╌╌╌┤
+        │ null │
+        └──────┘
 
         """
         if isinstance(columns, str):


### PR DESCRIPTION
* Improve the MWE used in `exclude` slightly (show the 3 possible combinations that the `columns` parameter can take), instead of just the straightforward example of excluding a single column.
* The `pl.exclude` type annotation in the function signature was out-of-date; I've aligned it with that of `pl.Expr.exclude` (including data types)