### PR TITLE
allow joining on expressions

### DIFF
--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -70,8 +70,8 @@ impl Executor for JoinExec {
             (input_left.execute(state), input_right.execute(state))
         };
 
-        let df_left = df_left?;
-        let df_right = df_right?;
+        let mut df_left = df_left?;
+        let mut df_right = df_right?;
 
         let left_on_series = self
             .left_on
@@ -84,6 +84,14 @@ impl Executor for JoinExec {
             .iter()
             .map(|e| e.evaluate(&df_right, state))
             .collect::<Result<Vec<_>>>()?;
+
+        // make sure that we can join on evaluated expressions
+        for s in &left_on_series {
+            df_left.with_column(s.clone())?;
+        }
+        for s in &right_on_series {
+            df_right.with_column(s.clone())?;
+        }
 
         // prepare the tolerance
         // we must ensure that we use the right units

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -200,3 +200,13 @@ def test_deprecated() -> None:
         df.lazy().join(other=other.lazy(), on="a").collect().to_numpy(),
         result.to_numpy(),
     )
+
+
+def test_join_on_expressions() -> None:
+    df_a = pl.DataFrame({"a": [1, 2, 3]})
+
+    df_b = pl.DataFrame({"b": [1, 4, 9, 9, 0]})
+
+    assert df_a.join(df_b, left_on=(pl.col("a") ** 2).cast(int), right_on=pl.col("b"))[
+        "a"
+    ].to_list() == [1, 4, 9, 9]


### PR DESCRIPTION
Allows joining on expressions. 

```python
    df_a = pl.DataFrame({"a": [1, 2, 3]})

    df_b = pl.DataFrame({"b": [1, 4, 9, 9, 0]})

    assert df_a.join(df_b, left_on=(pl.col("a") ** 2).cast(int), right_on=pl.col("b"))[
        "a"
    ].to_list() == [1, 4, 9, 9]
```