### PR TITLE
Native trigonometry functions

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -118,6 +118,7 @@ timezones = ["polars-core/timezones"]
 string_justify = ["polars-lazy/string_justify", "polars-ops/string_justify"]
 arg_where = ["polars-lazy/arg_where"]
 date_offset = ["polars-lazy/date_offset"]
+trigo = ["polars-lazy/trigo"]
 
 test = [
   "lazy",

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -33,6 +33,7 @@ dtype-categorical = ["polars-core/dtype-categorical"]
 dtype-struct = ["polars-core/dtype-struct"]
 object = ["polars-core/object"]
 date_offset = []
+trigo = []
 
 true_div = []
 

--- a/polars/polars-lazy/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/mod.rs
@@ -7,6 +7,8 @@ mod pow;
 mod strings;
 #[cfg(any(feature = "temporal", feature = "date_offset"))]
 mod temporal;
+#[cfg(feature = "trigo")]
+mod trigo;
 
 use super::*;
 use polars_core::prelude::*;
@@ -35,6 +37,23 @@ pub enum FunctionExpr {
     StringEndsWith(String),
     #[cfg(feature = "date_offset")]
     DateOffset(Duration),
+    #[cfg(feature = "trigo")]
+    Trigo(TrigoType),
+}
+
+#[cfg(feature = "trigo")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
+pub enum TrigoType {
+    Sin,
+    Cos,
+    Tan,
+    ArcSin,
+    ArcCos,
+    ArcTan,
+    Sinh,
+    Cosh,
+    Tanh,
 }
 
 impl FunctionExpr {
@@ -75,6 +94,8 @@ impl FunctionExpr {
             }
             #[cfg(feature = "date_offset")]
             DateOffset(_) => same_type(),
+            #[cfg(feature = "trigo")]
+            Trigo(_) => float_dtype(),
         }
     }
 }
@@ -152,6 +173,10 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "date_offset")]
             DateOffset(offset) => {
                 map_owned_with_args!(temporal::date_offset, offset)
+            }
+            #[cfg(feature = "trigo")]
+            Trigo(trigotype) => {
+                map_with_args!(trigo::trigo, trigotype)
             }
         }
     }

--- a/polars/polars-lazy/src/dsl/function_expr/trigo.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/trigo.rs
@@ -1,0 +1,121 @@
+use super::*;
+use num::Float;
+use polars_core::export::num;
+
+pub(super) fn trigo(s: &Series, trigotype: TrigoType) -> Result<Series> {
+    use DataType::*;
+    match s.dtype() {
+        Float32 => {
+            let ca = s.f32().unwrap();
+            trigo_float(ca, trigotype)
+        }
+        Float64 => {
+            let ca = s.f64().unwrap();
+            trigo_float(ca, trigotype)
+        }
+        _ => {
+            let s = s.cast(&DataType::Float64)?;
+            trigo(&s, trigotype)
+        }
+    }
+}
+
+fn trigo_float<T>(ca: &ChunkedArray<T>, trigotype: TrigoType) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    match trigotype {
+        TrigoType::Sin => sin(ca),
+        TrigoType::Cos => cos(ca),
+        TrigoType::Tan => tan(ca),
+        TrigoType::ArcSin => arcsin(ca),
+        TrigoType::ArcCos => arccos(ca),
+        TrigoType::ArcTan => arctan(ca),
+        TrigoType::Sinh => sinh(ca),
+        TrigoType::Cosh => cosh(ca),
+        TrigoType::Tanh => tanh(ca),
+    }
+}
+
+fn sin<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.sin()).into_series())
+}
+
+fn cos<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.cos()).into_series())
+}
+
+fn tan<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.tan()).into_series())
+}
+
+fn arcsin<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.asin()).into_series())
+}
+
+fn arccos<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.acos()).into_series())
+}
+
+fn arctan<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.atan()).into_series())
+}
+
+fn sinh<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.sinh()).into_series())
+}
+
+fn cosh<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.cosh()).into_series())
+}
+
+fn tanh<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.tanh()).into_series())
+}

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -42,6 +42,10 @@ pub use functions::*;
 pub use options::*;
 
 use crate::dsl::function_expr::FunctionExpr;
+
+#[cfg(feature = "trigo")]
+use crate::dsl::function_expr::TrigoType;
+
 use polars_arrow::array::default_arrays::FromData;
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
@@ -1194,6 +1198,141 @@ impl Expr {
                 input_wildcard_expansion: false,
                 auto_explode: false,
                 fmt_str: "pow",
+            },
+        }
+    }
+
+    /// Compute the sine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn sin(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Sin),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "sin",
+            },
+        }
+    }
+
+    /// Compute the cosine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn cos(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Cos),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "cos",
+            },
+        }
+    }
+
+    /// Compute the tangent of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn tan(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Tan),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "tan",
+            },
+        }
+    }
+
+    /// Compute the arcsine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn arcsin(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::ArcSin),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "arcsin",
+            },
+        }
+    }
+
+    /// Compute the arccosine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn arccos(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::ArcCos),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "arccos",
+            },
+        }
+    }
+
+    /// Compute the arctangent of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn arctan(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::ArcTan),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "arctan",
+            },
+        }
+    }
+
+    /// Compute the hyperbolic sine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn sinh(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Sinh),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "sinh",
+            },
+        }
+    }
+
+    /// Compute the hyperbolic cosine of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn cosh(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Cosh),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "cosh",
+            },
+        }
+    }
+
+    /// Compute the hyperbolic tangent of the given expression
+    #[cfg(feature = "trigo")]
+    pub fn tanh(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Trigo(TrigoType::Tanh),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "tanh",
             },
         }
     }

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -233,6 +233,7 @@
 //!     - `cumulative_eval` - Apply expressions over cumulatively increasing windows.
 //!     - `argwhere` Get indices where condition holds.
 //!     - `date_offset` Add an offset to dates that take months and leap years into account.
+//!     - `trigo` Add trigonometry functionality.
 //! * `DataFrame` pretty printing
 //!     - `fmt` - Activate DataFrame formatting
 //!

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -109,6 +109,7 @@ features = [
   "arg_where",
   "timezones",
   "date_offset",
+  "trigo",
 ]
 
 # [patch.crates-io]

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -127,6 +127,7 @@ Computations
     Expr.arctan
     Expr.arg_unique
     Expr.cos
+    Expr.cosh
     Expr.cumcount
     Expr.cummax
     Expr.cummin
@@ -162,9 +163,11 @@ Computations
     Expr.rolling_var
     Expr.sign
     Expr.sin
+    Expr.sinh
     Expr.skew
     Expr.sqrt
     Expr.tan
+    Expr.tanh
     Expr.unique
     Expr.unique_counts
     Expr.value_counts

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -108,6 +108,7 @@ Computations
     Series.arg_true
     Series.arg_unique
     Series.cos
+    Series.cosh
     Series.cummax
     Series.cummin
     Series.cumprod
@@ -140,9 +141,11 @@ Computations
     Series.rolling_var
     Series.sign
     Series.sin
+    Series.sinh
     Series.skew
     Series.sqrt
     Series.tan
+    Series.tanh
     Series.unique
 
 Manipulation/ selection

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4210,7 +4210,7 @@ class Expr:
 
     def sin(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric sine on an array.
+        Compute the element-wise value for the sine.
 
         Returns
         -------
@@ -4234,7 +4234,7 @@ class Expr:
 
     def cos(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric cosine on an array.
+        Compute the element-wise value for the cosine.
 
         Returns
         -------
@@ -4258,7 +4258,7 @@ class Expr:
 
     def tan(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric tangent on an array.
+        Compute the element-wise value for the tangent.
 
         Returns
         -------
@@ -4282,7 +4282,7 @@ class Expr:
 
     def arcsin(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric arcsine on an array.
+        Compute the element-wise value for the inverse sine.
 
         Returns
         -------
@@ -4306,7 +4306,7 @@ class Expr:
 
     def arccos(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric arccosine on an array.
+        Compute the element-wise value for the inverse cosine.
 
         Returns
         -------
@@ -4330,7 +4330,7 @@ class Expr:
 
     def arctan(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric arctangent on an array.
+        Compute the element-wise value for the inverse tangent.
 
         Returns
         -------
@@ -4354,7 +4354,7 @@ class Expr:
 
     def sinh(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric hyperbolic sine on an array.
+        Compute the element-wise value for the hyperbolic sine.
 
         Returns
         -------
@@ -4363,14 +4363,14 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1.0]})
-        >>> df.select(pl.col("a").arctan())
+        >>> df.select(pl.col("a").sinh())
         shape: (1, 1)
         ┌──────────┐
         │ a        │
         │ ---      │
         │ f64      │
         ╞══════════╡
-        │ 0.785398 │
+        │ 1.175201 │
         └──────────┘
 
         """
@@ -4378,7 +4378,7 @@ class Expr:
 
     def cosh(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric hyperbolic cosine on an array.
+        Compute the element-wise value for the hyperbolic cosine.
 
         Returns
         -------
@@ -4387,14 +4387,14 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1.0]})
-        >>> df.select(pl.col("a").arctan())
+        >>> df.select(pl.col("a").cosh())
         shape: (1, 1)
         ┌──────────┐
         │ a        │
         │ ---      │
         │ f64      │
         ╞══════════╡
-        │ 0.785398 │
+        │ 1.543081 │
         └──────────┘
 
         """
@@ -4402,7 +4402,7 @@ class Expr:
 
     def tanh(self) -> Expr:
         """
-        Compute the element-wise value for trigonometric hyperbolic tangent on an array.
+        Compute the element-wise value for the hyperbolic tangent.
 
         Returns
         -------
@@ -4411,14 +4411,14 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1.0]})
-        >>> df.select(pl.col("a").arctan())
+        >>> df.select(pl.col("a").tanh())
         shape: (1, 1)
         ┌──────────┐
         │ a        │
         │ ---      │
         │ f64      │
         ╞══════════╡
-        │ 0.785398 │
+        │ 0.761594 │
         └──────────┘
 
         """

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4210,7 +4210,7 @@ class Expr:
 
     def sin(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric sine on an array
+        Compute the element-wise value for trigonometric sine on an array.
 
         Returns
         -------
@@ -4230,13 +4230,11 @@ class Expr:
         └─────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.sin(self)  # type: ignore
+        return wrap_expr(self._pyexpr.sin())
 
     def cos(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric cosine on an array
+        Compute the element-wise value for trigonometric cosine on an array.
 
         Returns
         -------
@@ -4256,13 +4254,11 @@ class Expr:
         └─────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.cos(self)  # type: ignore
+        return wrap_expr(self._pyexpr.cos())
 
     def tan(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric tangent on an array
+        Compute the element-wise value for trigonometric tangent on an array.
 
         Returns
         -------
@@ -4282,13 +4278,11 @@ class Expr:
         └──────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.tan(self)  # type: ignore
+        return wrap_expr(self._pyexpr.tan())
 
     def arcsin(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric sine on an array
+        Compute the element-wise value for trigonometric arcsine on an array.
 
         Returns
         -------
@@ -4308,13 +4302,11 @@ class Expr:
         └──────────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arcsin(self)  # type: ignore
+        return wrap_expr(self._pyexpr.arcsin())
 
     def arccos(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric cosine on an array
+        Compute the element-wise value for trigonometric arccosine on an array.
 
         Returns
         -------
@@ -4334,13 +4326,11 @@ class Expr:
         └──────────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arccos(self)  # type: ignore
+        return wrap_expr(self._pyexpr.arccos())
 
     def arctan(self) -> Expr:
         """
-        Compute the element-wise value for Trigonometric tangent on an array
+        Compute the element-wise value for trigonometric arctangent on an array.
 
         Returns
         -------
@@ -4360,9 +4350,79 @@ class Expr:
         └──────────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arctan(self)  # type: ignore
+        return wrap_expr(self._pyexpr.arctan())
+
+    def sinh(self) -> Expr:
+        """
+        Compute the element-wise value for trigonometric hyperbolic sine on an array.
+
+        Returns
+        -------
+        Series of dtype Float64
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1.0]})
+        >>> df.select(pl.col("a").arctan())
+        shape: (1, 1)
+        ┌──────────┐
+        │ a        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 0.785398 │
+        └──────────┘
+
+        """
+        return wrap_expr(self._pyexpr.sinh())
+
+    def cosh(self) -> Expr:
+        """
+        Compute the element-wise value for trigonometric hyperbolic cosine on an array.
+
+        Returns
+        -------
+        Series of dtype Float64
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1.0]})
+        >>> df.select(pl.col("a").arctan())
+        shape: (1, 1)
+        ┌──────────┐
+        │ a        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 0.785398 │
+        └──────────┘
+
+        """
+        return wrap_expr(self._pyexpr.cosh())
+
+    def tanh(self) -> Expr:
+        """
+        Compute the element-wise value for trigonometric hyperbolic tangent on an array.
+
+        Returns
+        -------
+        Series of dtype Float64
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1.0]})
+        >>> df.select(pl.col("a").arctan())
+        shape: (1, 1)
+        ┌──────────┐
+        │ a        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 0.785398 │
+        └──────────┘
+
+        """
+        return wrap_expr(self._pyexpr.tanh())
 
     def reshape(self, dims: tuple[int, ...]) -> Expr:
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2594,12 +2594,12 @@ class Series:
 
     def sin(self) -> Series:
         """
-        Compute the element-wise value for trigonometric sine.
+        Compute the element-wise value for the sine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((0.0, np.pi / 2.0, np.pi)))
+        >>> import math
+        >>> s = pl.Series("a", [0.0, math.pi / 2.0, math.pi])
         >>> s.sin()
         shape: (3,)
         Series: 'a' [f64]
@@ -2614,12 +2614,12 @@ class Series:
 
     def cos(self) -> Series:
         """
-        Compute the element-wise value for trigonometric cosine.
+        Compute the element-wise value for the cosine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((0.0, np.pi / 2.0, np.pi)))
+        >>> import math
+        >>> s = pl.Series("a", [0.0, math.pi / 2.0, math.pi])
         >>> s.cos()
         shape: (3,)
         Series: 'a' [f64]
@@ -2634,12 +2634,12 @@ class Series:
 
     def tan(self) -> Series:
         """
-        Compute the element-wise value for trigonometric tangent.
+        Compute the element-wise value for the tangent.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((0.0, np.pi / 2.0, np.pi)))
+        >>> import math
+        >>> s = pl.Series("a", [0.0, math.pi / 2.0, math.pi])
         >>> s.tan()
         shape: (3,)
         Series: 'a' [f64]
@@ -2654,12 +2654,11 @@ class Series:
 
     def arcsin(self) -> Series:
         """
-        Compute the element-wise value for trigonometric arcsine.
+        Compute the element-wise value for the inverse sine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
         >>> s.arcsin()
         shape: (3,)
         Series: 'a' [f64]
@@ -2674,12 +2673,11 @@ class Series:
 
     def arccos(self) -> Series:
         """
-        Compute the element-wise value for trigonometric arccosine.
+        Compute the element-wise value for the inverse cosine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
         >>> s.arccos()
         shape: (3,)
         Series: 'a' [f64]
@@ -2694,12 +2692,11 @@ class Series:
 
     def arctan(self) -> Series:
         """
-        Compute the element-wise value for trigonometric arctangent.
+        Compute the element-wise value for the inverse tangent.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
         >>> s.arctan()
         shape: (3,)
         Series: 'a' [f64]
@@ -2714,19 +2711,18 @@ class Series:
 
     def sinh(self) -> Series:
         """
-        Compute the element-wise value for trigonometric hyperbolic sine.
+        Compute the element-wise value for the hyperbolic sine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
-        >>> s.arctan()
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
+        >>> s.sinh()
         shape: (3,)
         Series: 'a' [f64]
         [
-            0.785398
+            1.175201
             0.0
-            -0.785398
+            -1.175201
         ]
 
         """
@@ -2734,19 +2730,18 @@ class Series:
 
     def cosh(self) -> Series:
         """
-        Compute the element-wise value for trigonometric hyperbolic cosine.
+        Compute the element-wise value for the hyperbolic cosine.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
-        >>> s.arctan()
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
+        >>> s.cosh()
         shape: (3,)
         Series: 'a' [f64]
         [
-            0.785398
-            0.0
-            -0.785398
+            1.543081
+            1.0
+            1.543081
         ]
 
         """
@@ -2754,19 +2749,18 @@ class Series:
 
     def tanh(self) -> Series:
         """
-        Compute the element-wise value for trigonometric hyperbolic tangent.
+        Compute the element-wise value for the hyperbolic tangent.
 
         Examples
         --------
-        >>> import numpy as np
-        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
-        >>> s.arctan()
+        >>> s = pl.Series("a", [1.0, 0.0, -1.0])
+        >>> s.tanh()
         shape: (3,)
         Series: 'a' [f64]
         [
-            0.785398
+            0.761594
             0.0
-            -0.785398
+            -0.761594
         ]
 
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2594,7 +2594,7 @@ class Series:
 
     def sin(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric sine.
+        Compute the element-wise value for trigonometric sine.
 
         Examples
         --------
@@ -2610,13 +2610,11 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.sin(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).sin()).to_series()
 
     def cos(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric cosine.
+        Compute the element-wise value for trigonometric cosine.
 
         Examples
         --------
@@ -2632,13 +2630,11 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.cos(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).cos()).to_series()
 
     def tan(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric tangent.
+        Compute the element-wise value for trigonometric tangent.
 
         Examples
         --------
@@ -2654,13 +2650,11 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.tan(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).tan()).to_series()
 
     def arcsin(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric Inverse sine.
+        Compute the element-wise value for trigonometric arcsine.
 
         Examples
         --------
@@ -2676,13 +2670,11 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arcsin(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).arcsin()).to_series()
 
     def arccos(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric Inverse cosine.
+        Compute the element-wise value for trigonometric arccosine.
 
         Examples
         --------
@@ -2698,13 +2690,11 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arccos(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).arccos()).to_series()
 
     def arctan(self) -> Series:
         """
-        Compute the element-wise value for Trigonometric Inverse tangent.
+        Compute the element-wise value for trigonometric arctangent.
 
         Examples
         --------
@@ -2720,9 +2710,67 @@ class Series:
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.arctan(self)  # type: ignore
+        return self.to_frame().select(pli.col(self.name).arctan()).to_series()
+
+    def sinh(self) -> Series:
+        """
+        Compute the element-wise value for trigonometric hyperbolic sine.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s.arctan()
+        shape: (3,)
+        Series: 'a' [f64]
+        [
+            0.785398
+            0.0
+            -0.785398
+        ]
+
+        """
+        return self.to_frame().select(pli.col(self.name).sinh()).to_series()
+
+    def cosh(self) -> Series:
+        """
+        Compute the element-wise value for trigonometric hyperbolic cosine.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s.arctan()
+        shape: (3,)
+        Series: 'a' [f64]
+        [
+            0.785398
+            0.0
+            -0.785398
+        ]
+
+        """
+        return self.to_frame().select(pli.col(self.name).cosh()).to_series()
+
+    def tanh(self) -> Series:
+        """
+        Compute the element-wise value for trigonometric hyperbolic tangent.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> s = pl.Series("a", np.array((1.0, 0.0, -1)))
+        >>> s.arctan()
+        shape: (3,)
+        Series: 'a' [f64]
+        [
+            0.785398
+            0.0
+            -0.785398
+        ]
+
+        """
+        return self.to_frame().select(pli.col(self.name).tanh()).to_series()
 
     def apply(
         self,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -363,6 +363,42 @@ impl PyExpr {
         self.clone().inner.abs().into()
     }
 
+    pub fn sin(&self) -> PyExpr {
+        self.clone().inner.sin().into()
+    }
+
+    pub fn cos(&self) -> PyExpr {
+        self.clone().inner.cos().into()
+    }
+
+    pub fn tan(&self) -> PyExpr {
+        self.clone().inner.tan().into()
+    }
+
+    pub fn arcsin(&self) -> PyExpr {
+        self.clone().inner.arcsin().into()
+    }
+
+    pub fn arccos(&self) -> PyExpr {
+        self.clone().inner.arccos().into()
+    }
+
+    pub fn arctan(&self) -> PyExpr {
+        self.clone().inner.arctan().into()
+    }
+
+    pub fn sinh(&self) -> PyExpr {
+        self.clone().inner.sinh().into()
+    }
+
+    pub fn cosh(&self) -> PyExpr {
+        self.clone().inner.cosh().into()
+    }
+
+    pub fn tanh(&self) -> PyExpr {
+        self.clone().inner.tanh().into()
+    }
+
     pub fn is_duplicated(&self) -> PyExpr {
         self.clone().inner.is_duplicated().into()
     }

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1441,7 +1441,9 @@ def test_is_between_datetime() -> None:
     assert_series_equal(result.rename("a"), expected)
 
 
-@pytest.mark.parametrize("f", ["sin", "cos", "tan", "arcsin", "arccos", "arctan"])
+@pytest.mark.parametrize(
+    "f", ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "sinh", "cosh", "tanh"]
+)
 def test_trigonometric(f: str) -> None:
     s = pl.Series("a", [0.0])
     expected = pl.Series("a", getattr(np, f)(s.to_numpy()))


### PR DESCRIPTION
Relates to #3890

Changes:
* Implemented the following trigonometry functions natively in Rust under the `trigo` feature flag:
  * sin, cos, tan
  * arcsin, arccos, arctan
  * sinh, cosh, tanh
* Updated the Python bindings in `Series` and `Expr` to dispatch to these Rust functions.
* Added `sinh`, `cosh`, and `arctan` functions for Python `Series` and `Expr` and added these to the test and documentation stubs.
* Updated the docstrings.

Notes:
* Should I also add `arcsinh`, `arccosh`, `arctanh`? Would be a small effort.
* Are you happy with the naming on the Rust side? Maybe it would be more clear to name the feature flag `trigonometry`; or do you prefer the compact version? Same for the related function names, types, etc.