### PR TITLE
Update flake8 settings

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -1,7 +1,12 @@
 [flake8]
-# just stop shouting as black decides line lengths.
-max-line-length = 180
-# E203, W503: due to black fmt
-ignore = E203,W503
-exclude = docs, venv, target
-
+# Satisfy black: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+# TODO: Handle long lines adequately
+max-line-length = 160
+extend-ignore = E203
+per-file-ignores =
+    __init__.py:F401
+    tests/*.py: E101, W191
+extend-exclude =
+    # Automatically generated test artifacts
+    venv/,
+    target/,

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -1,9 +1,8 @@
-# flake8: noqa
 import warnings
 
 try:
     from polars.polars import version
-except ImportError as e:  # pragma: no cover
+except ImportError:  # pragma: no cover
 
     def version() -> str:
         return ""
@@ -12,10 +11,7 @@ except ImportError as e:  # pragma: no cover
     warnings.warn("polars binary missing!")
 
 import polars.testing as testing
-from polars.cfg import (  # flake8: noqa. We do not export in __all__
-    Config,
-    toggle_string_cache,
-)
+from polars.cfg import Config, toggle_string_cache  # We do not export in __all__
 from polars.convert import (
     from_arrow,
     from_dict,
@@ -61,10 +57,7 @@ from polars.exceptions import (
     ShapeError,
 )
 from polars.internals.expr import Expr
-from polars.internals.frame import (  # flake8: noqa # TODO: remove need for wrap_df
-    DataFrame,
-    wrap_df,
-)
+from polars.internals.frame import DataFrame, wrap_df  # TODO: remove need for wrap_df
 from polars.internals.functions import concat, date_range, get_dummies
 from polars.internals.io import read_ipc_schema, read_parquet_schema
 from polars.internals.lazy_frame import LazyFrame
@@ -113,10 +106,7 @@ from polars.internals.lazy_functions import (
 )
 from polars.internals.lazy_functions import to_list as list
 from polars.internals.lazy_functions import var
-from polars.internals.series import (  # flake8: noqa # TODO: remove need for wrap_s
-    Series,
-    wrap_s,
-)
+from polars.internals.series import Series, wrap_s  # TODO: remove need for wrap_s
 from polars.internals.whenthen import when
 from polars.io import (
     read_avro,

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -42,7 +42,12 @@ class Tag:
 
 
 class HTMLFormatter:
-    def __init__(self, df: DataFrame, max_cols: int = 75, max_rows: int = 40):  # type: ignore  # noqa
+    def __init__(
+        self,
+        df: DataFrame,  # type: ignore[name-defined] # noqa: F821
+        max_cols: int = 75,
+        max_rows: int = 40,
+    ):
         self.df = df
         self.elements: list[str] = []
         self.max_cols = max_cols

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """
 The modules within `polars.internals` are interdependent. To prevent cyclical imports, they all import from each other
 via this __init__ file using `import polars.internals as pli`. The imports below are being shared across this module.

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1071,7 +1071,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def to_pandas(
         self, *args: Any, date_as_object: bool = False, **kwargs: Any
-    ) -> pd.DataFrame:  # noqa: F821
+    ) -> pd.DataFrame:
         """
         Cast to a pandas DataFrame.
         This requires that pandas and pyarrow are installed.

--- a/py-polars/tests/io/test_avro.py
+++ b/py-polars/tests/io/test_avro.py
@@ -1,8 +1,6 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import os
-from typing import List
 
 import pytest
 

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -1,4 +1,3 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import gzip

--- a/py-polars/tests/io/test_ipc.py
+++ b/py-polars/tests/io/test_ipc.py
@@ -1,10 +1,8 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import io
 import os
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 import pytest

--- a/py-polars/tests/io/test_json.py
+++ b/py-polars/tests/io/test_json.py
@@ -1,10 +1,7 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import io
 import os
-
-import pytest
 
 import polars as pl
 

--- a/py-polars/tests/io/test_lazy_csv.py
+++ b/py-polars/tests/io/test_lazy_csv.py
@@ -1,7 +1,5 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
-import io
 from os import path
 from pathlib import Path
 

--- a/py-polars/tests/io/test_lazy_ipc.py
+++ b/py-polars/tests/io/test_lazy_ipc.py
@@ -1,4 +1,3 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import polars as pl

--- a/py-polars/tests/io/test_lazy_parquet.py
+++ b/py-polars/tests/io/test_lazy_parquet.py
@@ -1,4 +1,3 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 from os import path

--- a/py-polars/tests/io/test_other.py
+++ b/py-polars/tests/io/test_other.py
@@ -1,4 +1,3 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import copy

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -1,9 +1,7 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import io
 import os
-from typing import List
 
 import numpy as np
 import pandas as pd

--- a/py-polars/tests/io/test_sql.py
+++ b/py-polars/tests/io/test_sql.py
@@ -11,7 +11,7 @@ def test_read_sql() -> None:
     import tempfile
 
     try:
-        import connectorx  # noqa
+        import connectorx  # noqa: F401
 
         with tempfile.TemporaryDirectory() as tmpdir_name:
             test_db = os.path.join(tmpdir_name, "test.db")

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,4 +1,3 @@
-# flake8: noqa: W191,E101
 from __future__ import annotations
 
 import sys
@@ -6,7 +5,7 @@ import typing
 from builtins import range
 from datetime import date, datetime, timedelta
 from io import BytesIO
-from typing import Any, Iterator, Type
+from typing import Any, Iterator
 from unittest.mock import patch
 
 import numpy as np
@@ -24,7 +23,7 @@ else:
 
 
 def test_version() -> None:
-    _version = pl.__version__
+    pl.__version__
 
 
 def test_null_count() -> None:
@@ -2152,9 +2151,9 @@ def test_join_suffixes() -> None:
 
     for how in ["left", "inner", "outer", "cross"]:
         # no need for an assert, we error if wrong
-        _df = df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
+        df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
 
-    _df = df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
+    df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
 
 
 def test_preservation_of_subclasses() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1621,7 +1621,7 @@ def test_apply_dataframe_return() -> None:
     assert out.frame_equal(expected, null_equal=True)
 
 
-def test_groupby_cat_list() -> None:  # noqa: W191,E101
+def test_groupby_cat_list() -> None:
     grouped = (
         pl.DataFrame(
             [


### PR DESCRIPTION
Changes:
* Use `extend-ignore` instead of `ignore` to keep the [default ignores](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore) intact. W503 is already ignored by default.
* Use `extend-exclude` instead of `exlude` to keep the [default excludes](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-exclude) intact. Removed the `docs` here folder as it does not contain Python files and is thus excluded by default.
* Use `per-file-ignores` to address some existing blanket ignores in various files:
  * Ignore `F401` (unused import) for all `__init__.py` files. Removed the `# flake: noqa` at the top of the files and fixed any non-F401 errors.
   * Ignore `E101, W191` (indentation with tabs/spaces) for all `tests/*.py` files. Removed the `# flake: noqa` at the top of the files and fixed any non-indentation errors.
     * Note that specifying specific errors here does NOT work, e.g. `# flake8: noqa: W191,E101` just ignores all flake8 errors in the file
     * We should probably ignore these in a per-case basis instead of for all tests - I'll consider that a TODO.
* Removed some unused `# noqa` statements.