### PR TITLE
Improve coverage report settings

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -2,7 +2,7 @@ import warnings
 
 try:
     from polars.polars import version
-except ImportError:  # pragma: no cover
+except ImportError:
 
     def version() -> str:
         return ""

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -9,21 +9,21 @@ try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 try:
     import pandas as pd
 
     _PANDAS_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PANDAS_AVAILABLE = False
 
 

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -9,7 +9,7 @@ try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 from _ctypes import _SimpleCData  # type: ignore
@@ -18,7 +18,7 @@ try:
     from polars.polars import dtype_str_repr
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -29,14 +29,14 @@ try:
     from polars.polars import PySeries
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 if not _DOCUMENTING:
@@ -101,10 +101,8 @@ def numpy_type_to_constructor(dtype: type[np.dtype]) -> Callable[..., PySeries]:
         return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:
         return PySeries.new_object
-    except NameError:
-        raise ImportError(
-            "'numpy' is required for this functionality."
-        )  # pragma: no cover
+    except NameError:  # pragma: no cover
+        raise ImportError("'numpy' is required for this functionality.")
 
 
 if not _DOCUMENTING:

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -9,7 +9,7 @@ try:
         SchemaError,
         ShapeError,
     )
-except ImportError:  # pragma: no cover
+except ImportError:
     # They are only redefined for documentation purposes
     # when there is no binary yet
 

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -10,7 +10,7 @@ try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -45,10 +45,8 @@ def _scan_ds_impl(
     -------
 
     """
-    if not _PYARROW_AVAILABLE:
-        raise ImportError(  # pragma: no cover
-            "'pyarrow' is required for scanning from pyarrow datasets."
-        )
+    if not _PYARROW_AVAILABLE:  # pragma: no cover
+        raise ImportError("'pyarrow' is required for scanning from pyarrow datasets.")
     return pl.from_arrow(ds.to_table(columns=with_columns))  # type: ignore
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -36,21 +36,21 @@ try:
     from polars.polars import PyDataFrame, PySeries
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -29,7 +29,7 @@ from polars.datatypes_constructor import (
 )
 from polars.utils import threadpool_size
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import pandas as pd
 
 try:

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -203,8 +203,8 @@ class Expr:
 
         args = [inp for inp in inputs if not isinstance(inp, Expr)]
 
-        def function(s: pli.Series) -> pli.Series:
-            return ufunc(s, *args, **kwargs)  # pragma: no cover
+        def function(s: pli.Series) -> pli.Series:  # pragma: no cover
+            return ufunc(s, *args, **kwargs)
 
         if "dtype" in kwargs:
             dtype = kwargs["dtype"]
@@ -5604,20 +5604,16 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
-        if not issubclass(datatype, DataType):
-            raise ValueError(
-                f"expected: {DataType} got: {datatype}"
-            )  # pragma: no cover
+        if not issubclass(datatype, DataType):  # pragma: no cover
+            raise ValueError(f"expected: {DataType} got: {datatype}")
         if datatype == Date:
             return wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact))
         elif datatype == Datetime:
             return wrap_expr(self._pyexpr.str_parse_datetime(fmt, strict, exact))
         elif datatype == Time:
             return wrap_expr(self._pyexpr.str_parse_time(fmt, strict, exact))
-        else:
-            raise ValueError(
-                "dtype should be of type {Date, Datetime, Time}"
-            )  # pragma: no cover
+        else:  # pragma: no cover
+            raise ValueError("dtype should be of type {Date, Datetime, Time}")
 
     def lengths(self) -> Expr:
         """

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -26,14 +26,14 @@ try:
     from polars.polars import PyExpr
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -83,7 +83,7 @@ except ImportError:
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal  # pragma: no cover
+    from typing_extensions import Literal
 
 # A type variable used to refer to a polars.DataFrame or any subclass of it.
 # Used to annotate DataFrame methods which returns the same type as self.

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -320,8 +320,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             self._df = series_to_pydf(data, columns=columns)
 
         elif _PANDAS_AVAILABLE and isinstance(data, pd.DataFrame):
-            if not _PYARROW_AVAILABLE:
-                raise ImportError(  # pragma: no cover
+            if not _PYARROW_AVAILABLE:  # pragma: no cover
+                raise ImportError(
                     "'pyarrow' is required for converting a pandas DataFrame to a polars DataFrame."
                 )
             self._df = pandas_to_pydf(data, columns=columns)
@@ -819,8 +819,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Data types that do copy:
             - CategoricalType
         """
-        if not _PYARROW_AVAILABLE:
-            raise ImportError(  # pragma: no cover
+        if not _PYARROW_AVAILABLE:  # pragma: no cover
+            raise ImportError(
                 "'pyarrow' is required for converting a polars DataFrame to an Arrow Table."
             )
         record_batches = self._df.to_arrow()
@@ -1101,10 +1101,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         <class 'pandas.core.frame.DataFrame'>
 
         """
-        if not _PYARROW_AVAILABLE:
-            raise ImportError(  # pragma: no cover
-                "'pyarrow' is required when using to_pandas()."
-            )
+        if not _PYARROW_AVAILABLE:  # pragma: no cover
+            raise ImportError("'pyarrow' is required when using to_pandas().")
         record_batches = self._df.to_pandas()
         tbl = pa.Table.from_batches(record_batches)
         return tbl.to_pandas(*args, date_as_object=date_as_object, **kwargs)
@@ -1443,8 +1441,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             file = format_path(file)
 
         if use_pyarrow:
-            if not _PYARROW_AVAILABLE:
-                raise ImportError(  # pragma: no cover
+            if not _PYARROW_AVAILABLE:  # pragma: no cover
+                raise ImportError(
                     "'pyarrow' is required when using 'write_parquet(..., use_pyarrow=True)'."
                 )
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -52,14 +52,14 @@ try:
     from polars.polars import PyDataFrame, PySeries
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 try:
@@ -70,14 +70,14 @@ try:
     import pyarrow.parquet
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 try:
     import pandas as pd
 
     _PANDAS_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PANDAS_AVAILABLE = False
 
 if sys.version_info >= (3, 8):

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -20,7 +20,7 @@ try:
     from polars.polars import py_hor_concat_df as _hor_concat_df
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -21,7 +21,7 @@ except ImportError:
 try:
     from polars.polars import ipc_schema as _ipc_schema
     from polars.polars import parquet_schema as _parquet_schema
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Generic, Sequence, TypeVar, overload
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal  # pragma: no cover
+    from typing_extensions import Literal
 
 try:
     from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -22,7 +22,7 @@ try:
     from polars.polars import PyExpr, PyLazyFrame, PyLazyGroupBy
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 
@@ -42,7 +42,7 @@ try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 # Used to type any type or subclass of LazyFrame.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -61,7 +61,7 @@ except ImportError:
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal  # pragma: no cover
+    from typing_extensions import Literal
 
 
 def col(

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -48,14 +48,14 @@ try:
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 if sys.version_info >= (3, 8):

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2331,8 +2331,8 @@ class Series:
         """
         Convert this Series to a pandas Series
         """
-        if not _PYARROW_AVAILABLE:
-            raise ImportError(  # pragma: no cover
+        if not _PYARROW_AVAILABLE:  # pragma: no cover
+            raise ImportError(
                 "'pyarrow' is required for converting a 'polars' Series to a 'pandas' Series."
             )
         return self.to_arrow().to_pandas()

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -54,28 +54,28 @@ try:
     from polars.polars import PyDataFrame, PySeries
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 try:
     import pyarrow as pa
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 try:
     import pandas as pd
 
     _PANDAS_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PANDAS_AVAILABLE = False
 
 if sys.version_info >= (3, 8):

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -81,7 +81,7 @@ except ImportError:
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal  # pragma: no cover
+    from typing_extensions import Literal
 
 
 def get_ffi_func(

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -6,7 +6,7 @@ try:
     from polars.polars import when as pywhen
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 from polars import internals as pli

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -15,7 +15,7 @@ try:
     import pyarrow.parquet
 
     _PYARROW_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _PYARROW_AVAILABLE = False
 
 from polars.convert import from_arrow

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -6,7 +6,7 @@ try:
     from polars.polars import toggle_string_cache as pytoggle_string_cache
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -28,7 +28,7 @@ except ImportError:
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
 else:
-    from typing_extensions import TypeGuard  # pragma: no cover
+    from typing_extensions import TypeGuard
 
 
 def _process_null_values(

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -15,14 +15,14 @@ try:
     from polars.polars import pool_size as _pool_size
 
     _DOCUMENTING = False
-except ImportError:  # pragma: no cover
+except ImportError:
     _DOCUMENTING = True
 
 try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError:
     _NUMPY_AVAILABLE = False
 
 if sys.version_info >= (3, 10):

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -33,4 +33,8 @@ module = ["pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx"
 ignore_missing_imports = true
 
 [tool.coverage.report]
-exclude_lines = ["pragma: no cover", "@overload"]
+exclude_lines = [
+  "pragma: no cover",
+  "@overload",
+  "except ImportError",
+]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -38,4 +38,5 @@ exclude_lines = [
   "@overload",
   "except ImportError",
   "if TYPE_CHECKING:",
+  "from typing_extensions import ",
 ]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -37,4 +37,5 @@ exclude_lines = [
   "pragma: no cover",
   "@overload",
   "except ImportError",
+  "if TYPE_CHECKING:",
 ]

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -19,7 +19,7 @@ from polars.testing import assert_frame_equal, assert_series_equal, columns
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal  # pragma: no cover
+    from typing_extensions import Literal
 
 
 def test_version() -> None:


### PR DESCRIPTION
There are some patterns that can never be covered by our tests. I added these patterns to be excluded by default, so we don't have to add `# pragma: no cover` every single time.

Changes:
* Excluded the following patterns from coverage:
  * `except ImportError`: Our test suite needs all optional dependencies available, so we cannot check for this.
  * `if TYPE_CHECKING:`: By definition, if we're running tests, we're not type checking
  * `from typing_extensions import `: This extension is not available in our test suite, as it is only installed on older Python versions.
* Removed the `# pragma: no cover` line for all the individual cases of patterns mentioned above.
* Improved consistency of placement for some other `# pragma: no cover` comments.