### PR TITLE
Update mypy settings

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -23,10 +23,24 @@ xlsx2csv = ["xlsx2csv"]
 profile = "black"
 
 [tool.mypy]
-disallow_untyped_defs = true
-warn_unused_ignores = true
-show_error_codes = true
 files = ["polars", "tests"]
+namespace_packages = true
+show_error_codes = true
+
+warn_unused_configs = true
+disallow_subclassing_any = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_unused_ignores = true
+strict_concatenate = true
+# TODO: Uncomment flags below and fix mypy errors
+# disallow_any_generics = true
+# disallow_untyped_calls = true
+# warn_redundant_casts = true
+# warn_return_any = true
+# no_implicit_reexport = true
+# strict_equality = true
+# TODO: When all flags are enabled, replace by strict = true
 
 [[tool.mypy.overrides]]
 module = ["pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx", "IPython.*"]


### PR DESCRIPTION
Relates to #4044

This update prepares more strict type checking by `mypy`.

Changes:
* Enabled some strictness flags that we already comply to.
* Added commented-out strictness flags that we want to comply to in the future, and added TODO comments.
* Enabled `namespace_packages`, which makes sure files will get checked even if they do not fall below an `__init__.py` file. See [here](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages) for more information on this. This does not directly impact polars at this moment, but avoids nasty surprises in the future.