### PR TITLE
Disallow generics in mypy typing check

### DIFF
--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     _NUMPY_AVAILABLE = False
 
 if not _DOCUMENTING:
-    _POLARS_TYPE_TO_CONSTRUCTOR: dict[PolarsDataType, Callable] = {
+    _POLARS_TYPE_TO_CONSTRUCTOR: dict[PolarsDataType, Callable[[str, Sequence[Any], bool], PySeries]] = {
         Float32: PySeries.new_opt_f32,
         Float64: PySeries.new_opt_f64,
         Int8: PySeries.new_opt_i8,
@@ -93,7 +93,7 @@ if _NUMPY_AVAILABLE and not _DOCUMENTING:
     }
 
 
-def numpy_type_to_constructor(dtype: type[np.dtype]) -> Callable[..., PySeries]:
+def numpy_type_to_constructor(dtype: type[np.dtype]) -> Callable[[str, Any, bool], PySeries]:
     """
     Get the right PySeries constructor for the given Polars dtype.
     """

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 from functools import partial
+from typing import Any
 
 import polars as pl
 from polars import internals as pli
@@ -52,7 +53,7 @@ def _scan_ds_impl(
     return pl.from_arrow(ds.to_table(columns=with_columns))  # type: ignore
 
 
-def _scan_ds(ds: pa.dataset.dataset) -> pli.LazyFrame:
+def _scan_ds(ds: pa.dataset.dataset) -> pli.LazyFrame[Any]:
     """
     This pickles the partially applied function `_scan_ds_impl`. That bytes are then send to in the polars
     logical plan. It can be deserialized once executed and ran.
@@ -83,8 +84,8 @@ def _scan_ipc_impl(uri: str, with_columns: list[str] | None) -> pli.DataFrame:
 
 def _scan_ipc_fsspec(
     file: str,
-    storage_options: dict | None = None,
-) -> pli.LazyFrame:
+    storage_options: dict[str, Any] | None = None,
+) -> pli.LazyFrame[Any]:
     func = partial(_scan_ipc_impl, file)
     func_serialized = pickle.dumps(func)
 
@@ -111,8 +112,8 @@ def _scan_parquet_impl(uri: str, with_columns: list[str] | None) -> pli.DataFram
 
 def _scan_parquet_fsspec(
     file: str,
-    storage_options: dict | None = None,
-) -> pli.LazyFrame:
+    storage_options: dict[str, Any] | None = None,
+) -> pli.LazyFrame[Any]:
     func = partial(_scan_parquet_impl, file)
     func_serialized = pickle.dumps(func)
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -89,7 +89,7 @@ def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySe
 
 
 def numpy_to_pyseries(
-    name: str, values: np.ndarray, strict: bool = True, nan_to_null: bool = False
+    name: str, values: np.ndarray, strict: bool = True, nan_to_null: bool = False  # type: ignore[type-arg]
 ) -> PySeries:
     """
     Construct a PySeries from a numpy array.

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -1737,7 +1737,7 @@ class Expr:
 
         return wrap_expr(self._pyexpr.sort_by(by, reverse))
 
-    def take(self, index: List[int] | Expr | pli.Series | np.ndarray) -> Expr:
+    def take(self, index: List[int] | Expr | pli.Series | np.ndarray) -> Expr:  # type: ignore[type-arg]
         """
         Take values by index.
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import Sequence, Union, overload
+from typing import Any, Sequence, Union, overload
 
 from polars import internals as pli
 from polars.datatypes import Date
@@ -56,7 +56,7 @@ def concat(
 
 @overload
 def concat(
-    items: Sequence[pli.LazyFrame],
+    items: Sequence[pli.LazyFrame[Any]],
     rechunk: bool = True,
     how: str = "vertical",
 ) -> pli.LazyFrame:
@@ -71,12 +71,11 @@ def concat(
 ) -> pli.Expr:
     ...
 
-
 def concat(
     items: (
         Sequence[pli.DataFrame]
         | Sequence[pli.Series]
-        | Sequence[pli.LazyFrame]
+        | Sequence[pli.LazyFrame[Any]]
         | Sequence[pli.Expr]
     ),
     rechunk: bool = True,
@@ -102,6 +101,8 @@ def concat(
 
     Examples
     --------
+
+
     >>> df1 = pl.DataFrame({"a": [1], "b": [3]})
     >>> df2 = pl.DataFrame({"a": [2], "b": [4]})
     >>> pl.concat([df1, df2])
@@ -120,7 +121,7 @@ def concat(
     if not len(items) > 0:
         raise ValueError("cannot concat empty list")
 
-    out: pli.Series | pli.DataFrame | pli.LazyFrame | pli.Expr
+    out: pli.Series | pli.DataFrame[Any] | pli.LazyFrame | pli.Expr
     first = items[0]
     if isinstance(first, pli.DataFrame):
         if how == "vertical":

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -608,7 +608,7 @@ def tail(column: str | pli.Series, n: int | None = None) -> pli.Expr | pli.Serie
 
 
 def lit(
-    value: None | (float | int | str | date | datetime | pli.Series | np.ndarray | Any),
+    value: None | (float | int | str | date | datetime | pli.Series | np.ndarray | Any),  # type: ignore [type-arg]
     dtype: type[DataType] | None = None,
 ) -> pli.Expr:
     """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -41,7 +41,7 @@ def _process_null_values(
 
 
 # https://stackoverflow.com/questions/4355524/getting-data-from-ctypes-array-into-numpy
-def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:
+def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray:  # type: ignore[type-arg]
     """
 
     Parameters
@@ -131,7 +131,7 @@ def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
     return _is_iterable_of(val, Sequence, int)
 
 
-def _is_iterable_of(val: Iterable, itertype: type, eltype: type) -> bool:
+def _is_iterable_of(val: Iterable[Any], itertype: type, eltype: type) -> bool:
     return isinstance(val, itertype) and all(isinstance(x, eltype) for x in val)
 
 
@@ -255,7 +255,7 @@ def threadpool_size() -> int:
     return _pool_size()
 
 
-def deprecated_alias(**aliases: str) -> Callable:
+def deprecated_alias(**aliases: str) -> Callable[[Any], Any]:
     """Decorator for deprecated function and method arguments.
 
     Use as follows:
@@ -265,9 +265,9 @@ def deprecated_alias(**aliases: str) -> Callable:
         ...
     """
 
-    def deco(f: Callable) -> Callable:
+    def deco(f: Callable[[Any], Any]) -> Callable[[Any], Any]:
         @functools.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Callable:
+        def wrapper(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
             rename_kwargs(f.__name__, kwargs, aliases)
             return f(*args, **kwargs)
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -34,7 +34,7 @@ no_implicit_optional = true
 warn_unused_ignores = true
 strict_concatenate = true
 # TODO: Uncomment flags below and fix mypy errors
-# disallow_any_generics = true
+disallow_any_generics = true
 # disallow_untyped_calls = true
 # warn_redundant_casts = true
 # warn_return_any = true


### PR DESCRIPTION
Aim: fulfill task `disallow_any_generics` in #4044.

This PR is far from complete. There are over 100 warnings, and I ran into several issues. We should decide on those first before going through all issues.

1. `LazyFrame` has due to #2862 and related PR's become a GenericType, to allow for nice typing synergy where one can subclass `DataFrame` and get the `LazyFrame` typed version as well. This is implemented (sorry for non-precise language here) by carrying around the type of `DataFrame` that `LazyFrame` refers to, or in other words, `LazyFrame` wraps around the `DataFrame`. This does mean that the specific DataFrame is a type input into LazyFrame, and mypy does not accept the default value: https://github.com/python/mypy/issues/3737 So the solution for now is for each type annotation in the polars code base that involves `LazyFrame` to write `LazyFrame[Any]` I would think that we could also use `LazyFrame[DF]` instead, but ran into issues with that. Open to suggestions

2. numpy has been strongly improving their typing, and where we currently use `np.ndarray` as the type annotation, it seems we should move towards `numpy.typing.NDArray` (https://numpy.org/doc/stable/reference/typing.html#numpy.typing.NDArray) However, this was only introduced in numpy 1.21, released in June 2021. We have always been very reluctant to impose version constraints on dependencies (as our usage of numpy is mostly high level). If we go down this path, we will have to. Otherwise, what I have done so far in some of the PR, is to simply add ignores.

Most of the other issues are us not typing built-in generics such as `list`, `tuple`, `dict`, `Callable`, `Sequence` etc, those should be easy to fix.
