### PR TITLE
Mypy warn redundant casts

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -36,7 +36,7 @@ strict_concatenate = true
 # TODO: Uncomment flags below and fix mypy errors
 # disallow_any_generics = true
 # disallow_untyped_calls = true
-# warn_redundant_casts = true
+warn_redundant_casts = true
 # warn_return_any = true
 # no_implicit_reexport = true
 # strict_equality = true

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -16,11 +16,6 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal, columns
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
 
 def test_version() -> None:
     pl.__version__
@@ -1920,9 +1915,9 @@ def test_shrink_to_fit(in_place: bool) -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]})
 
     if in_place:
-        assert df.shrink_to_fit(typing.cast(Literal[True], in_place)) is None
+        assert df.shrink_to_fit(in_place) is None
     else:
-        assert df.shrink_to_fit(typing.cast(Literal[False], in_place)).frame_equal(df)
+        assert df.shrink_to_fit(in_place).frame_equal(df)
 
 
 def test_arithmetic() -> None:


### PR DESCRIPTION
Lets get this in, otherwise we may be having too many different mypy changes.

Fixes mypy "warn_redundant_casts" in #4044.
