### PR TITLE
Added `literal` param to string-replace functions, optimized `replace` performance in small-string regime (30-80% faster)

### DIFF
--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -4,7 +4,7 @@ use polars_arrow::{
     export::arrow::{self, compute::substring::substring},
     kernels::string::*,
 };
-use polars_core::export::regex::Regex;
+use polars_core::export::regex::{escape, Regex};
 use std::borrow::Cow;
 
 fn f_regex_extract<'a>(reg: &Regex, input: &'a str, group_index: usize) -> Option<Cow<'a, str>> {
@@ -100,28 +100,19 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         ca.apply(f)
     }
 
-    /// Check if strings contain a regex pattern; select literal fast-path if no special chars
+    /// Check if strings contain a regex pattern; take literal fast-path if
+    /// no special chars and strlen <= 96 chars (otherwise regex faster).
     fn contains(&self, pat: &str) -> Result<BooleanChunked> {
-        if pat.chars().all(|c| !c.is_ascii_punctuation()) {
-            self.contains_literal(pat)
-        } else {
-            let ca = self.as_utf8();
-            let reg = Regex::new(pat)?;
-            let f = |s| reg.is_match(s);
-            let mut out: BooleanChunked = if !ca.has_validity() {
-                ca.into_no_null_iter().map(f).collect()
-            } else {
-                ca.into_iter().map(|opt_s| opt_s.map(f)).collect()
-            };
-            out.rename(ca.name());
-            Ok(out)
-        }
-    }
-
-    /// Check if strings contain a given literal
-    fn contains_literal(&self, lit: &str) -> Result<BooleanChunked> {
+        let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
         let ca = self.as_utf8();
-        let f = |s: &str| s.contains(lit);
+        let reg = Regex::new(pat)?;
+        let f = |s: &str| {
+            if lit && (s.len() <= 96) {
+                s.contains(pat)
+            } else {
+                reg.is_match(s)
+            }
+        };
         let mut out: BooleanChunked = if !ca.has_validity() {
             ca.into_no_null_iter().map(f).collect()
         } else {
@@ -129,6 +120,11 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         };
         out.rename(ca.name());
         Ok(out)
+    }
+
+    /// Check if strings contain a given literal
+    fn contains_literal(&self, lit: &str) -> Result<BooleanChunked> {
+        self.contains(escape(lit).as_str())
     }
 
     /// Check if strings ends with a substring
@@ -149,20 +145,38 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         out
     }
 
-    /// Replace the leftmost (sub)string by a regex pattern
-    fn replace(&self, pat: &str, val: &str) -> Result<Utf8Chunked> {
+    /// Replace the leftmost regex-matched (sub)string with another string; take
+    /// fast-path for small (<= 32 chars) strings (otherwise regex faster).
+    fn replace<'a>(&'a self, pat: &str, val: &str) -> Result<Utf8Chunked> {
+        let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
         let ca = self.as_utf8();
         let reg = Regex::new(pat)?;
-        let f = |s| reg.replace(s, val);
+        let f = |s: &'a str| {
+            if lit && (s.len() <= 32) {
+                Cow::Owned(s.replacen(pat, val, 1))
+            } else {
+                reg.replace(s, val)
+            }
+        };
         Ok(ca.apply(f))
     }
 
-    /// Replace all (sub)strings by a regex pattern
+    /// Replace the leftmost literal (sub)string with another string
+    fn replace_literal(&self, pat: &str, val: &str) -> Result<Utf8Chunked> {
+        self.replace(escape(pat).as_str(), val)
+    }
+
+    /// Replace all regex-matched (sub)strings with another string
     fn replace_all(&self, pat: &str, val: &str) -> Result<Utf8Chunked> {
         let ca = self.as_utf8();
         let reg = Regex::new(pat)?;
         let f = |s| reg.replace_all(s, val);
         Ok(ca.apply(f))
+    }
+
+    /// Replace all matching literal (sub)strings with another string
+    fn replace_literal_all(&self, pat: &str, val: &str) -> Result<Utf8Chunked> {
+        self.replace_all(escape(pat).as_str(), val)
     }
 
     /// Extract the nth capture group from pattern

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -6323,9 +6323,9 @@ class ExprStringNameSpace:
             return wrap_expr(self._pyexpr.str_split_exact_inclusive(by, n))
         return wrap_expr(self._pyexpr.str_split_exact(by, n))
 
-    def replace(self, pattern: str, value: str) -> Expr:
+    def replace(self, pattern: str, value: str, literal: bool = False) -> Expr:
         """
-        Replace first regex match with a string value.
+        Replace first matching regex/literal substring with a new string value.
 
         Parameters
         ----------
@@ -6333,10 +6333,12 @@ class ExprStringNameSpace:
             Regex pattern.
         value
             Replacement string.
+        literal
+             Treat pattern as a literal string.
 
         See Also
         --------
-        replace_all : Replace substring on all regex pattern matches.
+        replace_all : Replace all matching regex/literal substrings.
 
         Examples
         --------
@@ -6356,11 +6358,11 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        return wrap_expr(self._pyexpr.str_replace(pattern, value))
+        return wrap_expr(self._pyexpr.str_replace(pattern, value, literal))
 
-    def replace_all(self, pattern: str, value: str) -> Expr:
+    def replace_all(self, pattern: str, value: str, literal: bool = False) -> Expr:
         """
-        Replace substring on all regex pattern matches.
+        Replace all matching regex/literal substrings with a new string value.
 
         Parameters
         ----------
@@ -6368,10 +6370,12 @@ class ExprStringNameSpace:
             Regex pattern.
         value
             Replacement string.
+        literal
+             Treat pattern as a literal string.
 
         See Also
         --------
-        replace : Replace first regex match with a string value.
+        replace : Replace first matching regex/literal substring.
 
         Examples
         --------
@@ -6388,7 +6392,7 @@ class ExprStringNameSpace:
         │ 2   ┆ 123-123 │
         └─────┴─────────┘
         """
-        return wrap_expr(self._pyexpr.str_replace_all(pattern, value))
+        return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal))
 
     def slice(self, start: int, length: int | None = None) -> Expr:
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -4588,9 +4588,9 @@ class StringNameSpace:
             .to_series()
         )
 
-    def replace(self, pattern: str, value: str) -> Series:
+    def replace(self, pattern: str, value: str, literal: bool = False) -> Series:
         """
-        Replace first regex match with a string value.
+        Replace first matching regex/literal substring with a new string value.
 
         Parameters
         ----------
@@ -4598,10 +4598,12 @@ class StringNameSpace:
             A valid regex pattern.
         value
             Substring to replace.
+        literal
+             Treat pattern as a literal string.
 
         See Also
         --------
-        replace_all : Replace all regex matches with a string value.
+        replace_all : Replace all matching regex/literal substrings.
 
         Examples
         --------
@@ -4615,11 +4617,11 @@ class StringNameSpace:
         ]
 
         """
-        return wrap_s(self._s.str_replace(pattern, value))
+        return wrap_s(self._s.str_replace(pattern, value, literal))
 
-    def replace_all(self, pattern: str, value: str) -> Series:
+    def replace_all(self, pattern: str, value: str, literal: bool = False) -> Series:
         """
-        Replace all regex matches with a string value.
+        Replace all matching regex/literal substrings with a new string value.
 
         Parameters
         ----------
@@ -4627,10 +4629,12 @@ class StringNameSpace:
             A valid regex pattern.
         value
             Substring to replace.
+        literal
+             Treat pattern as a literal string.
 
         See Also
         --------
-        replace : Replace first regex match with a string value.
+        replace : Replace first matching regex/literal substring.
 
         Examples
         --------
@@ -4643,7 +4647,7 @@ class StringNameSpace:
             "123-123"
         ]
         """
-        return wrap_s(self._s.str_replace_all(pattern, value))
+        return wrap_s(self._s.str_replace_all(pattern, value, literal))
 
     def strip(self) -> Series:
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -591,10 +591,14 @@ impl PyExpr {
             .into()
     }
 
-    pub fn str_replace(&self, pat: String, val: String) -> PyExpr {
+    pub fn str_replace(&self, pat: String, val: String, literal: Option<bool>) -> PyExpr {
         let function = move |s: Series| {
             let ca = s.utf8()?;
-            match ca.replace(&pat, &val) {
+            let replaced = match literal {
+                Some(true) => ca.replace_literal(&pat, &val),
+                _ => ca.replace(&pat, &val),
+            };
+            match replaced {
                 Ok(ca) => Ok(ca.into_series()),
                 Err(e) => Err(PolarsError::ComputeError(format!("{:?}", e).into())),
             }
@@ -606,10 +610,14 @@ impl PyExpr {
             .into()
     }
 
-    pub fn str_replace_all(&self, pat: String, val: String) -> PyExpr {
+    pub fn str_replace_all(&self, pat: String, val: String, literal: Option<bool>) -> PyExpr {
         let function = move |s: Series| {
             let ca = s.utf8()?;
-            match ca.replace_all(&pat, &val) {
+            let replaced = match literal {
+                Some(true) => ca.replace_literal_all(&pat, &val),
+                _ => ca.replace_all(&pat, &val),
+            };
+            match replaced {
                 Ok(ca) => Ok(ca.into_series()),
                 Err(e) => Err(PolarsError::ComputeError(format!("{:?}", e).into())),
             }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1117,10 +1117,9 @@ impl PySeries {
 
     pub fn str_contains(&self, pat: &str, literal: Option<bool>) -> PyResult<Self> {
         let ca = self.series.utf8().map_err(PyPolarsErr::from)?;
-        let s = if literal.unwrap_or(false) {
-            ca.contains_literal(pat)
-        } else {
-            ca.contains(pat)
+        let s = match literal {
+            Some(true) => ca.contains_literal(pat),
+            _ => ca.contains(pat),
         }
         .map_err(PyPolarsErr::from)?
         .into_series();
@@ -1145,21 +1144,25 @@ impl PySeries {
         Ok(s.into())
     }
 
-    pub fn str_replace(&self, pat: &str, val: &str) -> PyResult<Self> {
+    pub fn str_replace(&self, pat: &str, val: &str, literal: Option<bool>) -> PyResult<Self> {
         let ca = self.series.utf8().map_err(PyPolarsErr::from)?;
-        let s = ca
-            .replace(pat, val)
-            .map_err(PyPolarsErr::from)?
-            .into_series();
+        let s = match literal {
+            Some(true) => ca.replace_literal(pat, val),
+            _ => ca.replace(pat, val),
+        }
+        .map_err(PyPolarsErr::from)?
+        .into_series();
         Ok(s.into())
     }
 
-    pub fn str_replace_all(&self, pat: &str, val: &str) -> PyResult<Self> {
+    pub fn str_replace_all(&self, pat: &str, val: &str, literal: Option<bool>) -> PyResult<Self> {
         let ca = self.series.utf8().map_err(PyPolarsErr::from)?;
-        let s = ca
-            .replace_all(pat, val)
-            .map_err(PyPolarsErr::from)?
-            .into_series();
+        let s = match literal {
+            Some(true) => ca.replace_literal_all(pat, val),
+            _ => ca.replace_all(pat, val),
+        }
+        .map_err(PyPolarsErr::from)?
+        .into_series();
         Ok(s.into())
     }
 

--- a/py-polars/tests/test_strings.py
+++ b/py-polars/tests/test_strings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import polars as pl
 import pytest
+
+import polars as pl
 
 
 def test_extract_binary() -> None:


### PR DESCRIPTION
This is a comprehensive revisit of a previously proposed patch; buckle-up for the fun details - "there will be graphs"  ;)

TLDR
-----
* Python: string `replace` and `replace_all` methods have a new `literal` param.
* Rust: added `replace_literal` and `replace_literal_all` methods.
* String `replace` ops for strings <= 32 chars are 30-80% faster for literal values.
* String `contains` op speed restored for larger strings (> 96 chars) when searching for literals (regex not impacted).
* Nothing (in any string-size regime) got slower.

Deeper-dive
-----
Originally it was thought that the regex engine would display overhead resulting in slower string find/replace for literals vs a simple `str.replace` op, and early testing appeared to confirm this. However... I had a few reservations, so I put together some benchmarking functionality to investigate performance across multiple dimensions, specifically:

* Varied underlying string length from small (8) to large (65,536).
* Position within the string of the target literal (front, back, random).
* Percentage of strings in the dataframe/series that would match & get replaced.


Test DataFrame was composed of 5 cols, each containing 100,000 strings.
This analysis showed some very interesting results...
```
x-axis: % of strings replaced in the frame (from 5% to 100%).
y-axis: time taken to complete replace op (in secs).
```
* The `str.replace` op _is_ faster than regex across the entire replace % domain... but _only_ for <= 32 chars.
* There is an immediate fall-off from 32-33 chars; str.replace is faster only when replacing > 35% of the strings.
  
  <img width="649" alt="image" src="https://user-images.githubusercontent.com/2613171/179400205-654d59a3-e6e7-4af7-9c63-28b4b3ab277f.png">

* The str.replace gradient across different string-size regimes varies; regex gradient is relatively stable:

  <img width="649" alt="image" src="https://user-images.githubusercontent.com/2613171/179400171-e165a88b-f3e8-4de2-9639-1d42aea21c2f.png">

  * Inference - regex is much faster at identifying literal null-matches over larger strings.
    Corroboration: aho-corasick / memchr usage within regex lib source for literal matches -
    https://github.com/rust-lang/regex/blob/master/src/literal/imp.rs
  *  Inference - str.replace is faster to replace once a match is found.
     Corroboration - the narrowing gap between regex/str.replace as a higher percentage of matches are found.

What this PR does
-----
Based on the amassed data, `str.replace` is used for literal replace only in the region where it is guaranteed to be faster in all cases (<= 32 chars target string). In this region it is, however, _much_ faster - between 30-80%, depending on how many strings will be replaced (the more, the better).

In all other cases the existing regex replace is used. So, the patch will _never_ be slower than the current code, but in the common short-string regime it can be a lot faster.

The previous `contains` patch for literals contains a similar, but not identical, fall-off; I have modified that function similarly so that `str.contains` is invoked for literal search when the target string is <= 96 chars - otherwise the regex lib is used.

Future work
-----
* Potential hybrid strategy, using regex find_iter in conjunction with str.replace to get "best of both worlds" performance.
* I experimented with `cow_utils.cow_replacen` instead of `str.replacen`, but saw no gains in the small-string regime. Will return to this sometime, as it seems gains _should_ be possible.
* Modifying existing str buffer for literal replaces of the same size (buffer re-use).

Additional note
-----
* regex lib is faster across all regimes for `replace_all` functionality, so only added literal param option.
* Updating string functionality requires testing across multiple regimes to validate performance characteristics!
