### PR TITLE
Revert "Upgrade Windows 10 tests, benchmark and doc jobs to Python3.10"

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: 3.9
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
@zundertj I had to revert because python 3.10 was not yet available in the github action.

Reverts pola-rs/polars#4059