### PR TITLE
Fix connector-x integration for PostgreSQL

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -952,7 +952,7 @@ def read_sql(
         tbl = cx.read_sql(
             conn=connection_uri,
             query=sql,
-            return_type="arrow",
+            return_type="arrow2",
             partition_on=partition_on,
             partition_range=partition_range,
             partition_num=partition_num,


### PR DESCRIPTION
Fix #4009, connector-x integration with PostgreSQL.
Tested on local PostgreSQL instance.
