### PR TITLE
[mypy] Add error codes

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -70,7 +70,7 @@ def from_dict(
     └─────┴─────┘
 
     """
-    return DataFrame._from_dict(data=data, columns=columns)  # type: ignore
+    return DataFrame._from_dict(data=data, columns=columns)  # type: ignore[arg-type]
 
 
 def from_dicts(

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     _PYARROW_AVAILABLE = False
 
-from _ctypes import _SimpleCData  # type: ignore
+from _ctypes import _SimpleCData  # type: ignore[import]
 
 try:
     from polars.polars import dtype_str_repr

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -27,7 +27,7 @@ class DataType:
     Base class for all Polars data types.
     """
 
-    def __new__(cls, *args, **kwargs) -> PolarsDataType:  # type: ignore
+    def __new__(cls, *args: Any, **kwargs: Any) -> PolarsDataType:  # type: ignore[misc]
         # this formulation allows for equivalent use of "pl.Type" and "pl.Type()", while
         # still respecting types that take initialisation params (eg: Duration/Datetime)
         if args or kwargs:
@@ -115,7 +115,7 @@ class List(DataType):
         """
         self.inner = py_type_to_dtype(inner)
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
         # The comparison allows comparing objects to classes
         # and specific inner types to none specific.
         # if one of the arguments is not specific about its inner type
@@ -161,7 +161,7 @@ class Datetime(DataType):
         self.tu = time_unit
         self.tz = time_zone
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Datetime):
             return True
@@ -188,7 +188,7 @@ class Duration(DataType):
         """
         self.tu = time_unit
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Duration):
             return True
@@ -228,7 +228,7 @@ class Field:
         self.name = name
         self.dtype = py_type_to_dtype(dtype)
 
-    def __eq__(self, other: Field) -> bool:  # type: ignore
+    def __eq__(self, other: Field) -> bool:  # type: ignore[override]
         return (self.name == other.name) & (self.dtype == other.dtype)
 
     def __repr__(self) -> str:
@@ -251,7 +251,7 @@ class Struct(DataType):
         """
         self.fields = fields
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore
+    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
         # The comparison allows comparing objects to classes
         # and specific inner types to none specific.
         # if one of the arguments is not specific about its inner type

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -47,7 +47,7 @@ def _scan_ds_impl(
     """
     if not _PYARROW_AVAILABLE:  # pragma: no cover
         raise ImportError("'pyarrow' is required for scanning from pyarrow datasets.")
-    return pl.from_arrow(ds.to_table(columns=with_columns))  # type: ignore
+    return pl.from_arrow(ds.to_table(columns=with_columns))  # type: ignore[return-value]
 
 
 def _scan_ds(ds: pa.dataset.dataset) -> pli.LazyFrame:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -299,7 +299,7 @@ def _pandas_series_to_arrow(
     """
     dtype = values.dtype
     if dtype == "object" and len(values) > 0:
-        first_non_none = _get_first_non_none(values.values)  # type: ignore
+        first_non_none = _get_first_non_none(values.values)  # type: ignore[arg-type]
 
         if isinstance(first_non_none, str):
             return pa.array(values, pa.large_utf8(), from_pandas=nan_to_none)

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4220,7 +4220,7 @@ class Expr:
         """
         if not _NUMPY_AVAILABLE:
             raise ImportError("'numpy' is required for this functionality.")
-        return np.sign(self)  # type: ignore
+        return np.sign(self)  # type: ignore[call-overload]
 
     def sin(self) -> Expr:
         """
@@ -5173,7 +5173,7 @@ class ExprListNameSpace:
         if not isinstance(other, list):
             other_list = [other]
         else:
-            other_list = copy.copy(other)  # type: ignore
+            other_list = copy.copy(other)  # type: ignore[arg-type]
 
         other_list.insert(0, wrap_expr(self._pyexpr))
         return pli.concat_list(other_list)

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -166,7 +166,7 @@ class DataFrameMetaClass(type):
             # LazyFrame subclass by setting `cls._lazyframe_class`. We must therefore
             # dynamically create a subclass of LazyFrame with `_dataframe_class` set
             # to `cls` in order to preserve types after `.lazy().collect()` roundtrips.
-            cls._lazyframe_class = type(  # type: ignore
+            cls._lazyframe_class = type(  # type: ignore[assignment]
                 f"Lazy{name}",
                 (LazyFrame,),
                 {"_dataframe_class": cls},
@@ -289,14 +289,14 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def __init__(
         self,
-        data: None
-        | (
+        data: (
             dict[str, Sequence[Any]]
             | Sequence[Any]
             | np.ndarray
             | pa.Table
             | pd.DataFrame
             | pli.Series
+            | None
         ) = None,
         columns: ColumnsType | None = None,
         orient: Literal["col", "row"] | None = None,
@@ -1519,10 +1519,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         else:
             return out
 
-    def __getstate__(self):  # type: ignore
+    def __getstate__(self) -> list[pli.Series]:
         return self.get_columns()
 
-    def __setstate__(self, state):  # type: ignore
+    def __setstate__(self, state) -> None:  # type: ignore[no-untyped-def]
         self._df = DataFrame(state)._df
 
     def __mul__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
@@ -1750,7 +1750,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         # df[:]
         if isinstance(item, slice):
-            return PolarsSlice(self).apply(item)  # type: ignore
+            return PolarsSlice(self).apply(item)  # type: ignore[return-value]
 
         # select rows by numpy mask or index
         # df[[1, 2, 3]]
@@ -1827,7 +1827,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             if isinstance(col_selection, str):
                 s = self.__getitem__(col_selection)
             elif isinstance(col_selection, int):
-                s = self[:, col_selection]  # type: ignore
+                s = self[:, col_selection]  # type: ignore[assignment]
             else:
                 raise ValueError(f"column selection not understood: {col_selection}")
 
@@ -2890,7 +2890,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
             by = [by]
         return GroupBy(
             self._df,
-            by,  # type: ignore
+            by,  # type: ignore[arg-type]
             dataframe_class=self.__class__,
             maintain_order=maintain_order,
         )
@@ -4192,7 +4192,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def __copy__(self: DF) -> DF:
         return self.clone()
 
-    def __deepcopy__(self: DF, memodict={}) -> DF:  # type: ignore
+    def __deepcopy__(self: DF, memodict: dict = {}) -> DF:
         return self.clone()
 
     def get_columns(self) -> list[pli.Series]:
@@ -4904,7 +4904,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return (
             self.lazy()
-            .select(exprs)  # type: ignore
+            .select(exprs)  # type: ignore[arg-type]
             .collect(no_optimization=True, string_cache=False)
         )
 
@@ -6165,7 +6165,7 @@ class GroupBy(Generic[DF]):
 
         # should be only one match
         try:
-            groups_idx = groups[mask][0]  # type: ignore
+            groups_idx = groups[mask][0]  # type: ignore[index]
         except IndexError:
             raise ValueError(f"no group: {group_value} found")
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -140,7 +140,7 @@ def concat(
     elif isinstance(first, pli.Expr):
         out = first
         for e in items[1:]:
-            out = out.append(e)  # type: ignore
+            out = out.append(e)  # type: ignore[arg-type]
     else:
         raise ValueError(f"did not expect type: {type(first)} in 'pl.concat'.")
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -107,7 +107,7 @@ class LazyFrame(Generic[DF]):
         This property is dynamically overwritten when DataFrame is sub-classed. See
         `polars.internals.frame.DataFrameMetaClass.__init__` for implementation details.
         """
-        return pli.DataFrame  # type: ignore
+        return pli.DataFrame  # type: ignore[return-value]
 
     @classmethod
     def scan_csv(
@@ -195,7 +195,7 @@ class LazyFrame(Generic[DF]):
                 scan = scan.head(n_rows)
             if row_count_name is not None:
                 scan = scan.with_row_count(row_count_name, row_count_offset)
-            return scan  # type: ignore
+            return scan  # type: ignore[return-value]
 
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_parquet(
@@ -235,7 +235,7 @@ class LazyFrame(Generic[DF]):
                 scan = scan.head(n_rows)
             if row_count_name is not None:
                 scan = scan.with_row_count(row_count_name, row_count_offset)
-            return scan  # type: ignore
+            return scan  # type: ignore[return-value]
 
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ipc(
@@ -809,7 +809,7 @@ class LazyFrame(Generic[DF]):
     def __copy__(self: LDF) -> LDF:
         return self.clone()
 
-    def __deepcopy__(self: LDF, memodict={}) -> LDF:  # type: ignore
+    def __deepcopy__(self: LDF, memodict: dict = {}) -> LDF:
         return self.clone()
 
     def filter(self: LDF, predicate: pli.Expr | str) -> LDF:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -157,7 +157,7 @@ def col(
 
     """
     if isinstance(name, pli.Series):
-        name = name.to_list()  # type: ignore
+        name = name.to_list()  # type: ignore[assignment]
 
     # note: we need the typing.cast call here twice to make mypy happy under Python 3.7
     # On Python 3.10, it is not needed. We use cast as it works across versions, ignoring
@@ -685,7 +685,7 @@ def lit(
     # numpy literals like np.float32(0)
     # have an item
     if hasattr(value, "item"):
-        value = value.item()  # type: ignore
+        value = value.item()  # type: ignore[union-attr]
     return pli.wrap_expr(pylit(value))
 
 
@@ -1697,7 +1697,7 @@ def repeat(
         if name is None:
             name = ""
         dtype = py_type_to_dtype(type(value))
-        s = pli.Series._repeat(name, value, n, dtype)  # type: ignore
+        s = pli.Series._repeat(name, value, n, dtype)  # type: ignore[arg-type]
         return s
     else:
         if isinstance(n, int):

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2286,7 +2286,7 @@ class Series:
             kwargs will be sent to pyarrow.Array.to_numpy
         """
 
-        def convert_to_date(arr):  # type: ignore
+        def convert_to_date(arr):  # type: ignore[no-untyped-def]
             if self.dtype == Date:
                 tp = "datetime64[D]"
             elif self.dtype == Duration:
@@ -2591,7 +2591,7 @@ class Series:
         """
         if not _NUMPY_AVAILABLE:
             raise ImportError("'numpy' is required for this functionality.")
-        return np.sign(self)  # type: ignore
+        return np.sign(self)  # type: ignore[return-value]
 
     def sin(self) -> Series:
         """
@@ -5423,13 +5423,13 @@ class DateTimeNameSpace:
         Return minimum as python DateTime
         """
         # we can ignore types because we are certain we get a logical type
-        return wrap_s(self._s).min()  # type: ignore
+        return wrap_s(self._s).min()  # type: ignore[return-value]
 
     def max(self) -> date | datetime | timedelta:
         """
         Return maximum as python DateTime
         """
-        return wrap_s(self._s).max()  # type: ignore
+        return wrap_s(self._s).max()  # type: ignore[return-value]
 
     def median(self) -> date | datetime | timedelta:
         """

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1056,7 +1056,7 @@ def read_excel(
     """
 
     try:
-        import xlsx2csv  # type: ignore
+        import xlsx2csv  # type: ignore[import]
     except ImportError:
         raise ImportError(
             "xlsx2csv is not installed. Please run `pip install xlsx2csv`."

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -137,8 +137,8 @@ def assert_frame_equal(
     # this does not assume a particular order
     for c in left.columns:
         _assert_series_inner(
-            left[c],  # type: ignore
-            right[c],  # type: ignore
+            left[c],  # type: ignore[arg-type, index]
+            right[c],  # type: ignore[arg-type, index]
             check_dtype,
             check_exact,
             nans_compare_equal,

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -148,13 +148,13 @@ def handle_projection_columns(
     projection: list[int] | None = None
     if columns:
         if is_int_sequence(columns):
-            projection = columns  # type: ignore
+            projection = columns  # type: ignore[assignment]
             columns = None
         elif not is_str_sequence(columns):
             raise ValueError(
                 "columns arg should contain a list of all integers or all strings values."
             )
-    return projection, columns  # type: ignore
+    return projection, columns  # type: ignore[return-value]
 
 
 def _to_python_time(value: int) -> time:

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -44,7 +44,6 @@ warn_redundant_casts = true
 enable_error_code = [
   "redundant-expr",
   "truthy-bool",
-  # TODO: Uncomment error below and fix mypy errors
   # "ignore-without-code",
 ]
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -44,7 +44,7 @@ warn_redundant_casts = true
 enable_error_code = [
   "redundant-expr",
   "truthy-bool",
-  # "ignore-without-code",
+  "ignore-without-code",
 ]
 
 [[tool.mypy.overrides]]

--- a/py-polars/tests/io/test_avro.py
+++ b/py-polars/tests/io/test_avro.py
@@ -21,7 +21,7 @@ def compressions() -> list[str]:
 def test_from_to_buffer(example_df: pl.DataFrame, compressions: list[str]) -> None:
     for compression in compressions:
         buf = io.BytesIO()
-        example_df.write_avro(buf, compression=compression)  # type: ignore
+        example_df.write_avro(buf, compression=compression)  # type: ignore[arg-type]
         buf.seek(0)
         read_df = pl.read_avro(buf)
         assert example_df.frame_equal(read_df)
@@ -33,7 +33,7 @@ def test_from_to_file(
     f = os.path.join(io_test_dir, "small.avro")
 
     for compression in compressions:
-        example_df.write_avro(f, compression=compression)  # type: ignore
+        example_df.write_avro(f, compression=compression)  # type: ignore[arg-type]
         df_read = pl.read_avro(str(f))
         assert example_df.frame_equal(df_read)
 

--- a/py-polars/tests/io/test_ipc.py
+++ b/py-polars/tests/io/test_ipc.py
@@ -18,7 +18,7 @@ def compressions() -> list[str]:
 def test_from_to_buffer(df: pl.DataFrame, compressions: list[str]) -> None:
     for compression in compressions:
         buf = io.BytesIO()
-        df.write_ipc(buf, compression=compression)  # type: ignore
+        df.write_ipc(buf, compression=compression)  # type: ignore[arg-type]
         buf.seek(0)
         read_df = pl.read_ipc(buf)
         assert df.frame_equal(read_df)
@@ -33,8 +33,8 @@ def test_from_to_file(
     if os.name != "nt":
         for compression in compressions:
             for f in (str(f_ipc), Path(f_ipc)):
-                df.write_ipc(f, compression=compression)  # type: ignore
-                df_read = pl.read_ipc(f)  # type: ignore
+                df.write_ipc(f, compression=compression)  # type: ignore[arg-type]
+                df_read = pl.read_ipc(f)  # type: ignore[arg-type]
                 assert df.frame_equal(df_read)
 
 
@@ -67,7 +67,7 @@ def test_compressed_simple() -> None:
 
     for compression in compressions:
         f = io.BytesIO()
-        df.write_ipc(f, compression)  # type: ignore
+        df.write_ipc(f, compression)  # type: ignore[arg-type]
         f.seek(0)
 
         df_read = pl.read_ipc(f, use_pyarrow=False)
@@ -79,7 +79,7 @@ def test_ipc_schema(compressions: list[str]) -> None:
 
     for compression in compressions:
         f = io.BytesIO()
-        df.write_ipc(f, compression=compression)  # type: ignore
+        df.write_ipc(f, compression=compression)  # type: ignore[arg-type]
         f.seek(0)
 
         assert pl.read_ipc_schema(f) == {"a": pl.Int64, "b": pl.Utf8, "c": pl.Boolean}
@@ -95,8 +95,8 @@ def test_ipc_schema_from_file(
     if os.name != "nt":
         for compression in compressions:
             for f in (str(f_ipc), Path(f_ipc)):
-                df.write_ipc(f, compression=compression)  # type: ignore
-                assert pl.read_ipc_schema(f) == {  # type: ignore
+                df.write_ipc(f, compression=compression)  # type: ignore[arg-type]
+                assert pl.read_ipc_schema(f) == {  # type: ignore[arg-type]
                     "bools": pl.Boolean,
                     "bools_nulls": pl.Boolean,
                     "int": pl.Int64,

--- a/py-polars/tests/io/test_json.py
+++ b/py-polars/tests/io/test_json.py
@@ -44,7 +44,7 @@ def test_write_json() -> None:
     assert out == r"""[{"a":1,"b":"a"},{"a":2,"b":"b"},{"a":3,"b":null}]"""
     # test round trip
     f = io.BytesIO()
-    f.write(out.encode())  # type: ignore
+    f.write(out.encode())  # type: ignore[attr-defined]
     f.seek(0)
     df = pl.read_json(f, json_lines=False)
     assert df.frame_equal(expected)
@@ -59,7 +59,7 @@ def test_write_json() -> None:
     )
     # test round trip
     f = io.BytesIO()
-    f.write(out.encode())  # type: ignore
+    f.write(out.encode())  # type: ignore[attr-defined]
     f.seek(0)
     df = pl.read_json(f, json_lines=True)
     expected = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", None]})

--- a/py-polars/tests/io/test_other.py
+++ b/py-polars/tests/io/test_other.py
@@ -22,7 +22,7 @@ def test_categorical_round_trip() -> None:
     tbl = df.to_arrow()
     assert "dictionary" in str(tbl["cat"].type)
 
-    df2: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore
+    df2: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore[assignment]
     assert df2.dtypes == [pl.Int64, pl.Categorical]
 
 

--- a/py-polars/tests/run_doc_examples.py
+++ b/py-polars/tests/run_doc_examples.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
             else:
                 return OutputChecker.check_output(self, want, got, optionflags)
 
-    doctest.OutputChecker = CustomOutputChecker  # type: ignore
+    doctest.OutputChecker = CustomOutputChecker  # type: ignore[misc]
 
     # We want to be relaxed about whitespace, but strict on True vs 1
     doctest.NORMALIZE_WHITESPACE = True

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -20,7 +20,7 @@ def test_fill_null() -> None:
     s = pl.Series("A", [dt, None])
 
     for fill_val in (dt, pl.lit(dt)):
-        out = s.fill_null(fill_val)  # type: ignore
+        out = s.fill_null(fill_val)  # type: ignore[arg-type]
 
         assert out.null_count() == 0
         assert out.dt[0] == dt
@@ -32,7 +32,7 @@ def test_fill_null() -> None:
     s = pl.Series("a", [dt1, dt2, dt3, None])
     dt_2 = date(2001, 1, 4)
     for fill_val in (dt_2, pl.lit(dt_2)):
-        out = s.fill_null(fill_val)  # type: ignore
+        out = s.fill_null(fill_val)  # type: ignore[arg-type]
 
         assert out.null_count() == 0
         assert out.dt[0] == dt1
@@ -104,20 +104,20 @@ def test_timestamp() -> None:
 
 
 def test_from_pydatetime() -> None:
-    dates = [
+    datetimes = [
         datetime(2021, 1, 1),
         datetime(2021, 1, 2),
         datetime(2021, 1, 3),
         datetime(2021, 1, 4, 12, 12),
         None,
     ]
-    s = pl.Series("name", dates)
+    s = pl.Series("name", datetimes)
     assert s.dtype == pl.Datetime
     assert s.name == "name"
     assert s.null_count() == 1
-    assert s.dt[0] == dates[0]
+    assert s.dt[0] == datetimes[0]
 
-    dates = [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3), None]  # type: ignore
+    dates = [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3), None]
     s = pl.Series("name", dates)
     assert s.dtype == pl.Date
     assert s.name == "name"
@@ -155,13 +155,13 @@ def test_datetime_consistency() -> None:
 def test_timezone() -> None:
     ts = pa.timestamp("s")
     data = pa.array([1000, 2000], type=ts)
-    s: pl.Series = pl.from_arrow(data)  # type: ignore
+    s: pl.Series = pl.from_arrow(data)  # type: ignore[assignment]
 
     # with timezone; we do expect a warning here
     tz_ts = pa.timestamp("s", tz="America/New_York")
     tz_data = pa.array([1000, 2000], type=tz_ts)
     # with pytest.warns(Warning):
-    tz_s: pl.Series = pl.from_arrow(tz_data)  # type: ignore
+    tz_s: pl.Series = pl.from_arrow(tz_data)  # type: ignore[assignment]
 
     # timezones have no effect, i.e. `s` equals `tz_s`
     assert not s.series_equal(tz_s)
@@ -291,8 +291,8 @@ def test_date_comp() -> None:
     assert (a < one).to_list() == [False, False]
     assert (a <= one).to_list() == [True, False]
 
-    one = date(2001, 1, 1)  # type: ignore
-    two = date(2001, 1, 2)  # type: ignore
+    one = date(2001, 1, 1)  # type: ignore[assignment]
+    two = date(2001, 1, 2)  # type: ignore[assignment]
     a = pl.Series("a", [one, two])
     assert (a == one).to_list() == [True, False]
     assert (a != one).to_list() == [False, True]
@@ -302,14 +302,14 @@ def test_date_comp() -> None:
     assert (a <= one).to_list() == [True, False]
 
     # also test if the conversion stays correct with wide date ranges
-    one = date(201, 1, 1)  # type: ignore
-    two = date(201, 1, 2)  # type: ignore
+    one = date(201, 1, 1)  # type: ignore[assignment]
+    two = date(201, 1, 2)  # type: ignore[assignment]
     a = pl.Series("a", [one, two])
     assert (a == one).to_list() == [True, False]
     assert (a == two).to_list() == [False, True]
 
-    one = date(5001, 1, 1)  # type: ignore
-    two = date(5001, 1, 2)  # type: ignore
+    one = date(5001, 1, 1)  # type: ignore[assignment]
+    two = date(5001, 1, 2)  # type: ignore[assignment]
     a = pl.Series("a", [one, two])
     assert (a == one).to_list() == [True, False]
     assert (a == two).to_list() == [False, True]
@@ -531,7 +531,7 @@ def test_microseconds_accuracy() -> None:
         ),
     )
 
-    assert pl.from_arrow(a)["timestamp"].to_list() == timestamps  # type: ignore
+    assert pl.from_arrow(a)["timestamp"].to_list() == timestamps  # type: ignore[index]
 
 
 def test_cast_time_units() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -45,7 +45,7 @@ def test_init_only_columns() -> None:
     for no_data in (None, {}, []):
         df = pl.DataFrame(
             data=no_data,
-            columns=[  # type: ignore
+            columns=[  # type: ignore[arg-type]
                 ("a", pl.Date),
                 ("b", pl.UInt64),
                 ("c", pl.datatypes.Int8),
@@ -480,8 +480,8 @@ def test_selection() -> None:
     assert df.select_at_idx(0).name == "a"
     assert (df["a"] == df["a"]).sum() == 3
     assert (df["c"] == df["a"].cast(str)).sum() == 0
-    assert df[:, "a":"b"].shape == (3, 2)  # type: ignore
-    assert df[:, "a":"c"].columns == ["a", "b", "c"]  # type: ignore
+    assert df[:, "a":"b"].shape == (3, 2)  # type: ignore[misc]
+    assert df[:, "a":"c"].columns == ["a", "b", "c"]  # type: ignore[misc]
     expect = pl.DataFrame({"c": ["b"]})
     assert df[1, [2]].frame_equal(expect)
     expect = pl.DataFrame({"b": [1.0, 3.0]})
@@ -706,7 +706,7 @@ def test_groupby() -> None:
 
     with pytest.deprecated_call():
         # TODO: find a way to avoid indexing into GroupBy
-        for subdf in df.groupby("a"):  # type: ignore
+        for subdf in df.groupby("a"):  # type: ignore[attr-defined]
             # TODO: add __next__() to GroupBy
             if subdf["a"][0] == "b":
                 assert subdf.shape == (3, 3)
@@ -879,7 +879,7 @@ def test_vstack(in_place: bool) -> None:
     if in_place:
         assert df1.frame_equal(expected)
     else:
-        assert out.frame_equal(expected)  # type: ignore
+        assert out.frame_equal(expected)  # type: ignore[union-attr]
 
 
 def test_extend() -> None:
@@ -1001,17 +1001,17 @@ def test_set() -> None:
 
         # row and col selection have to be int or str
         with pytest.raises(ValueError):
-            df[:, [1]] = 1  # type: ignore
+            df[:, [1]] = 1  # type: ignore[index]
         with pytest.raises(ValueError):
-            df[True, :] = 1  # type: ignore
+            df[True, :] = 1  # type: ignore[index]
 
         # needs to be a 2 element tuple
         with pytest.raises(ValueError):
-            df[(1, 2, 3)] = 1  # type: ignore
+            df[(1, 2, 3)] = 1  # type: ignore[index]
 
         # we cannot index with any type, such as bool
         with pytest.raises(NotImplementedError):
-            df[True] = 1  # type: ignore
+            df[True] = 1  # type: ignore[index]
 
 
 def test_melt() -> None:
@@ -1140,7 +1140,7 @@ def test_from_arrow_table() -> None:
     data = {"a": [1, 2], "b": [1, 2]}
     tbl = pa.table(data)
 
-    df: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore
+    df: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore[assignment]
     df.frame_equal(pl.DataFrame(data))
 
 
@@ -1198,7 +1198,7 @@ def test_column_names() -> None:
             "b": pa.array([1, 2, 3, 4, 5], pa.int64()),
         }
     )
-    df: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore
+    df: pl.DataFrame = pl.from_arrow(tbl)  # type: ignore[assignment]
     assert df.columns == ["a", "b"]
 
 
@@ -1223,10 +1223,10 @@ def test_lazy_functions() -> None:
     )
     expected = 1.0
     assert np.isclose(out.select_at_idx(0), expected)
-    assert np.isclose(pl.var(df["b"]), expected)  # type: ignore
+    assert np.isclose(pl.var(df["b"]), expected)  # type: ignore[arg-type]
     expected = 1.0
     assert np.isclose(out.select_at_idx(1), expected)
-    assert np.isclose(pl.std(df["b"]), expected)  # type: ignore
+    assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
     expected = 3
     assert np.isclose(out.select_at_idx(2), expected)
     assert np.isclose(pl.max(df["b"]), expected)
@@ -1341,7 +1341,7 @@ def test_literal_series() -> None:
     )
     out = (
         df.lazy()
-        .with_column(pl.Series("e", [2, 1, 3]))  # type: ignore
+        .with_column(pl.Series("e", [2, 1, 3]))  # type: ignore[arg-type]
         .with_column(pl.col("e").cast(pl.Float32))
         .collect()
     )
@@ -1539,13 +1539,13 @@ def test_hashing_on_python_objects() -> None:
     df = pl.DataFrame({"a": [1, 1, 3, 4], "b": [1, 1, 2, 2]})
 
     class Foo:
-        def __init__(self):  # type: ignore
+        def __init__(self):  # type: ignore[no-untyped-def]
             pass
 
-        def __hash__(self):  # type: ignore
+        def __hash__(self):  # type: ignore[no-untyped-def]
             return 0
 
-        def __eq__(self, other):  # type: ignore
+        def __eq__(self, other):  # type: ignore[no-untyped-def]
             return True
 
     df = df.with_column(pl.col("a").apply(lambda x: Foo()).alias("foo"))
@@ -1747,10 +1747,10 @@ def test_transpose() -> None:
 
 def test_extension() -> None:
     class Foo:
-        def __init__(self, value):  # type: ignore
+        def __init__(self, value):  # type: ignore[no-untyped-def]
             self.value = value
 
-        def __repr__(self):  # type: ignore
+        def __repr__(self):  # type: ignore[no-untyped-def]
             return f"foo({self.value})"
 
     foos = [Foo(1), Foo(2), Foo(3)]
@@ -1988,7 +1988,7 @@ def test_arithmetic() -> None:
 
     # cannot do arithmetic with a sequence
     with pytest.raises(ValueError, match="Operation not supported"):
-        _ = df + [1]  # type: ignore
+        _ = df + [1]  # type: ignore[operator]
 
 
 def test_add_string() -> None:

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -53,10 +53,10 @@ def test_flatten_explode() -> None:
     df = pl.Series("a", ["Hello", "World"])
     expected = pl.Series("a", ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"])
 
-    result: pl.Series = df.to_frame().select(pl.col("a").flatten())[:, 0]  # type: ignore
+    result: pl.Series = df.to_frame().select(pl.col("a").flatten())[:, 0]  # type: ignore[assignment]
     assert_series_equal(result, expected)
 
-    result: pl.Series = df.to_frame().select(pl.col("a").explode())[:, 0]  # type: ignore
+    result: pl.Series = df.to_frame().select(pl.col("a").explode())[:, 0]  # type: ignore[no-redef]
     assert_series_equal(result, expected)
 
 

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -125,7 +125,7 @@ def test_from_pandas_nan_to_none() -> None:
     with pytest.raises(ArrowInvalid, match="Could not convert"):
         pl.from_pandas(df, nan_to_none=False)
 
-    df = pd.Series([2, np.nan, None], name="pd")  # type: ignore
+    df = pd.Series([2, np.nan, None], name="pd")  # type: ignore[assignment]
     out_true = pl.from_pandas(df)
     out_false = pl.from_pandas(df, nan_to_none=False)
     df.loc[2] = pd.NA
@@ -270,7 +270,7 @@ def test_from_pandas_dataframe() -> None:
 
     # if not a pandas dataframe, raise a ValueError
     with pytest.raises(ValueError):
-        _ = pl.from_pandas([1, 2])  # type: ignore
+        _ = pl.from_pandas([1, 2])  # type: ignore[call-overload]
 
 
 def test_from_pandas_series() -> None:
@@ -357,19 +357,19 @@ def test_from_empty_pandas_strings() -> None:
 
 def test_from_empty_arrow() -> None:
     df = pl.from_arrow(pa.table(pd.DataFrame({"a": [], "b": []})))
-    assert df.columns == ["a", "b"]  # type: ignore
-    assert df.dtypes == [pl.Float64, pl.Float64]  # type: ignore
+    assert df.columns == ["a", "b"]  # type: ignore[union-attr]
+    assert df.dtypes == [pl.Float64, pl.Float64]  # type: ignore[union-attr]
 
     # 2705
     df1 = pd.DataFrame(columns=["b"], dtype=float)
     tbl = pa.Table.from_pandas(df1)
     out = pl.from_arrow(tbl)
-    assert out.columns == ["b", "__index_level_0__"]  # type: ignore
-    assert out.dtypes == [pl.Float64, pl.Utf8]  # type: ignore
+    assert out.columns == ["b", "__index_level_0__"]  # type: ignore[union-attr]
+    assert out.dtypes == [pl.Float64, pl.Utf8]  # type: ignore[union-attr]
     tbl = pa.Table.from_pandas(df1, preserve_index=False)
     out = pl.from_arrow(tbl)
-    assert out.columns == ["b"]  # type: ignore
-    assert out.dtypes == [pl.Float64]  # type: ignore
+    assert out.columns == ["b"]  # type: ignore[union-attr]
+    assert out.dtypes == [pl.Float64]  # type: ignore[union-attr]
 
 
 def test_from_null_column() -> None:

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -643,7 +643,7 @@ def test_take(fruits_cars: pl.DataFrame) -> None:
 
     for index in [[0, 1], pl.Series([0, 1]), np.array([0, 1])]:
         out = df.sort("fruits").select(
-            [col("B").reverse().take(index).list().over("fruits"), "fruits"]  # type: ignore
+            [col("B").reverse().take(index).list().over("fruits"), "fruits"]  # type: ignore[arg-type]
         )
 
         assert out[0, "B"] == [2, 3]
@@ -872,7 +872,7 @@ def test_arithmetic() -> None:
 
 def test_ufunc() -> None:
     df = pl.DataFrame({"a": [1, 2]})
-    out = df.select(np.log(col("a")))  # type: ignore
+    out = df.select(np.log(col("a")))  # type: ignore[call-overload]
     assert out["a"][1] == 0.6931471805599453
 
 
@@ -1108,25 +1108,25 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_is_between(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, False, True, False, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, False))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, False))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, False, True, False, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, [False, False]))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, [False, False]))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, False, True, False, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, True))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, True))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, True, True, True, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, [True, True]))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, [True, True]))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, True, True, True, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, [False, True]))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, [False, True]))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, False, True, True, False])
     )
-    assert fruits_cars.select(pl.col("A").is_between(2, 4, [True, False]))["is_between"].series_equal(  # type: ignore
+    assert fruits_cars.select(pl.col("A").is_between(2, 4, [True, False]))["is_between"].series_equal(  # type: ignore[arg-type]
         pl.Series("is_between", [False, True, True, False, False])
     )
 

--- a/py-polars/tests/test_lists.py
+++ b/py-polars/tests/test_lists.py
@@ -71,11 +71,11 @@ def test_dtype() -> None:
             "dt": [[date(2022, 12, 31)]],
             "dtm": [[datetime(2022, 12, 31, 1, 2, 3)]],
         },
-        columns=[  # type: ignore
-            ["i", pl.List(pl.Int8)],
-            ["tm", pl.List(pl.Time)],
-            ["dt", pl.List(pl.Date)],
-            ["dtm", pl.List(pl.Datetime)],
+        columns=[
+            ("i", pl.List(pl.Int8)),
+            ("tm", pl.List(pl.Time)),
+            ("dt", pl.List(pl.Date)),
+            ("dtm", pl.List(pl.Datetime)),
         ],
     )
     assert df.schema == {
@@ -233,7 +233,7 @@ def test_cast_inner() -> None:
 
     # this creates an inner null type
     df = pl.from_pandas(pd.DataFrame(data=[[[]], [[]]], columns=["A"]))
-    assert df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore
+    assert df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore[arg-type, attr-defined]
 
 
 def test_list_eval_dtype_inference() -> None:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -98,9 +98,9 @@ def test_bitwise_ops() -> None:
     # rand/rxor/ror we trigger by casting the left hand to a list here in the test
     # Note that the type annotations only allow Series to be passed in, but there is
     # specific code to deal with non-Series inputs.
-    assert (True & a).series_equal(pl.Series([True, False, True]))  # type: ignore
-    assert (True | a).series_equal(pl.Series([True, True, True]))  # type: ignore
-    assert (True ^ a).series_equal(pl.Series([False, True, False]))  # type: ignore
+    assert (True & a).series_equal(pl.Series([True, False, True]))  # type: ignore[operator]
+    assert (True | a).series_equal(pl.Series([True, True, True]))  # type: ignore[operator]
+    assert (True ^ a).series_equal(pl.Series([False, True, False]))  # type: ignore[operator]
 
 
 def test_bitwise_floats_invert() -> None:

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -39,7 +39,7 @@ def test_sort_by() -> None:
     )
 
     by: list[pl.Expr | str]
-    for by in [["b", "c"], [pl.col("b"), "c"]]:  # type: ignore
+    for by in [["b", "c"], [pl.col("b"), "c"]]:  # type: ignore[assignment]
         out = df.select([pl.col("a").sort_by(by)])
         assert out["a"].to_list() == [3, 1, 2, 5, 4]
 

--- a/py-polars/tests/test_testing.py
+++ b/py-polars/tests/test_testing.py
@@ -52,7 +52,7 @@ def test_compare_series_type_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.DataFrame({"col1": [2, 3, 4]})
     with pytest.raises(AssertionError, match="Series are different\n\nType mismatch"):
-        assert_series_equal(srs1, srs2)  # type: ignore
+        assert_series_equal(srs1, srs2)  # type: ignore[arg-type]
 
     srs3 = pl.Series([1.0, 2.0, 3.0])
     with pytest.raises(AssertionError, match="Series are different\n\nDtype mismatch"):
@@ -110,7 +110,7 @@ def test_assert_frame_equal_types() -> None:
     df1 = pl.DataFrame({"a": [1, 2]})
     srs1 = pl.Series(values=[1, 2], name="a")
     with pytest.raises(AssertionError):
-        assert_frame_equal(df1, srs1)  # type: ignore
+        assert_frame_equal(df1, srs1)  # type: ignore[arg-type]
 
 
 def test_assert_frame_equal_length_mismatch() -> None:

--- a/py-polars/tests/test_window.py
+++ b/py-polars/tests/test_window.py
@@ -98,13 +98,13 @@ def test_window_function_cache() -> None:
 
 def test_arange_no_rows() -> None:
     df = pl.DataFrame(dict(x=[5, 5, 4, 4, 2, 2]))
-    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore
+    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore[union-attr]
     assert out.frame_equal(
         pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "literal": [0, 1, 0, 1, 0, 1]})
     )
 
     df = pl.DataFrame(dict(x=[]))
-    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore
+    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore[union-attr]
     assert out.frame_equal(pl.DataFrame({"x": [], "literal": []}))
 
 


### PR DESCRIPTION
Specifying a specific error code when adding a `# type: ignore` is good practice:
* It makes sure only the specified error is ignored, preventing unintended errors from passing silently.
* It is more clear from reading the code what is going on

Changes:
* Enabled setting to enforce adding error codes when adding a `# type: ignore` comment
* Added error codes to all `# type: ignore` comments
* Fixed typing in a few cases where the solution was immediately obvious