### PR TITLE
docs: rework some MWE and minor formatting fixes

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3143,14 +3143,14 @@ class Expr:
     def reinterpret(self, signed: bool) -> Expr:
         """
         Reinterpret the underlying bits as a signed/unsigned integer.
+
         This operation is only allowed for 64bit integers. For lower bits integers,
         you can safely use that cast operation.
 
         Parameters
         ----------
         signed
-            True -> pl.Int64
-            False -> pl.UInt64
+            If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
         """
         return wrap_expr(self._pyexpr.reinterpret(signed))
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3966,30 +3966,32 @@ class Expr:
 
         Parameters
         ----------
-        method
-            {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
+        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
             The method used to assign ranks to tied elements.
             The following methods are available (default is 'average'):
-            - 'average': The average of the ranks that would have been assigned to
-            all the tied values is assigned to each value.
-            - 'min': The minimum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.  (This is also
-            referred to as "competition" ranking.)
-            - 'max': The maximum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.
-            - 'dense': Like 'min', but the rank of the next highest element is
-            assigned the rank immediately after those assigned to the tied
-            elements.
-            - 'ordinal': All values are given a distinct rank, corresponding to
-            the order that the values occur in `a`.
-            - 'random': Like 'ordinal', but the rank for ties is not dependent
-            on the order that the values occur in `a`.
+
+            - 'average' : The average of the ranks that would have been assigned to
+              all the tied values is assigned to each value.
+            - 'min' : The minimum of the ranks that would have been assigned to all
+              the tied values is assigned to each value. (This is also referred to
+              as "competition" ranking.)
+            - 'max' : The maximum of the ranks that would have been assigned to all
+              the tied values is assigned to each value.
+            - 'dense' : Like 'min', but the rank of the next highest element is
+              assigned the rank immediately after those assigned to the tied
+              elements.
+            - 'ordinal' : All values are given a distinct rank, corresponding to
+              the order that the values occur in the Series.
+            - 'random' : Like 'ordinal', but the rank for ties is not dependent
+              on the order that the values occur in the Series.
         reverse
             Reverse the operation.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"a": [0, 1, 2, 2, 4]})
+        The 'average' method:
+
+        >>> df = pl.DataFrame({"a": [3, 6, 1, 1, 6]})
         >>> df.select(pl.col("a").rank())
         shape: (5, 1)
         ┌─────┐
@@ -3997,15 +3999,36 @@ class Expr:
         │ --- │
         │ f32 │
         ╞═════╡
-        │ 1.0 │
+        │ 3.0 │
         ├╌╌╌╌╌┤
-        │ 2.0 │
+        │ 4.5 │
         ├╌╌╌╌╌┤
-        │ 3.5 │
+        │ 1.5 │
         ├╌╌╌╌╌┤
-        │ 3.5 │
+        │ 1.5 │
         ├╌╌╌╌╌┤
-        │ 5.0 │
+        │ 4.5 │
+        └─────┘
+
+        The 'ordinal' method:
+
+        >>> df = pl.DataFrame({"a": [3, 6, 1, 1, 6]})
+        >>> df.select(pl.col("a").rank("ordinal"))
+        shape: (5, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ u32 │
+        ╞═════╡
+        │ 3   │
+        ├╌╌╌╌╌┤
+        │ 4   │
+        ├╌╌╌╌╌┤
+        │ 1   │
+        ├╌╌╌╌╌┤
+        │ 2   │
+        ├╌╌╌╌╌┤
+        │ 5   │
         └─────┘
 
         """

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -6400,11 +6400,54 @@ class ExprStringNameSpace:
             Starting index of the slice (zero-indexed). Negative indexing
             may be used.
         length
-            Optional length of the slice.
+            Optional length of the slice. If None (default), the slice is taken to the end
+            of the string.
 
         Returns
         -------
         Series of Utf8 type
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"s": ["pear", None, "papaya", "dragonfruit"]})
+        >>> df.with_column(
+        ...     pl.col("s").str.slice(-3).alias("s_sliced"),
+        ... )
+        shape: (4, 2)
+        ┌─────────────┬──────────┐
+        │ s           ┆ s_sliced │
+        │ ---         ┆ ---      │
+        │ str         ┆ str      │
+        ╞═════════════╪══════════╡
+        │ pear        ┆ ear      │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ null        ┆ null     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ papaya      ┆ aya      │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ dragonfruit ┆ uit      │
+        └─────────────┴──────────┘
+
+        Using the optional `length` parameter
+
+        >>> df.with_column(
+        ...     pl.col("s").str.slice(4, length=3).alias("s_sliced"),
+        ... )
+        shape: (4, 2)
+        ┌─────────────┬──────────┐
+        │ s           ┆ s_sliced │
+        │ ---         ┆ ---      │
+        │ str         ┆ str      │
+        ╞═════════════╪══════════╡
+        │ pear        ┆          │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ null        ┆ null     │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ papaya      ┆ ya       │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
+        │ dragonfruit ┆ onf      │
+        └─────────────┴──────────┘
+
         """
         return wrap_expr(self._pyexpr.str_slice(start, length))
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -2650,6 +2650,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         Return a new DataFrame where the null values are dropped.
 
+        Parameters
+        ----------
+        subset
+            Subset of column(s) on which ``drop_nulls`` will be applied.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -5874,8 +5874,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
     def unnest(self: DF, names: str | list[str]) -> DF:
         """
-        Decompose a struct into its fields. The fields will be inserted in to the `DataFrame` on the
-        location of the `struct` type.
+        Decompose a struct into its fields.
+
+        The fields will be inserted into the `DataFrame` on the location of the
+        `struct` type.
 
         Parameters
         ----------
@@ -5884,40 +5886,38 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
-        >>> df = (
-        ...     pl.DataFrame(
-        ...         {
-        ...             "int": [1, 2],
-        ...             "str": ["a", "b"],
-        ...             "bool": [True, None],
-        ...             "list": [[1, 2], [3]],
-        ...         }
-        ...     )
-        ...     .to_struct("my_struct")
-        ...     .to_frame()
-        ... )
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "before": ["foo", "bar"],
+        ...         "t_a": [1, 2],
+        ...         "t_b": ["a", "b"],
+        ...         "t_c": [True, None],
+        ...         "t_d": [[1, 2], [3]],
+        ...         "after": ["baz", "womp"],
+        ...     }
+        ... ).select(["before", pl.struct(pl.col("^t_.$")).alias("t_struct"), "after"])
         >>> df
-        shape: (2, 1)
-        ┌─────────────────────┐
-        │ my_struct           │
-        │ ---                 │
-        │ struct[4]           │
-        ╞═════════════════════╡
-        │ {1,"a",true,[1, 2]} │
-        ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ {2,"b",null,[3]}    │
-        └─────────────────────┘
-        >>> df.unnest("my_struct")
-        shape: (2, 4)
-        ┌─────┬─────┬──────┬───────────┐
-        │ int ┆ str ┆ bool ┆ list      │
-        │ --- ┆ --- ┆ ---  ┆ ---       │
-        │ i64 ┆ str ┆ bool ┆ list[i64] │
-        ╞═════╪═════╪══════╪═══════════╡
-        │ 1   ┆ a   ┆ true ┆ [1, 2]    │
-        ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 2   ┆ b   ┆ null ┆ [3]       │
-        └─────┴─────┴──────┴───────────┘
+        shape: (2, 3)
+        ┌────────┬─────────────────────┬───────┐
+        │ before ┆ t_struct            ┆ after │
+        │ ---    ┆ ---                 ┆ ---   │
+        │ str    ┆ struct[4]           ┆ str   │
+        ╞════════╪═════════════════════╪═══════╡
+        │ foo    ┆ {1,"a",true,[1, 2]} ┆ baz   │
+        ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ bar    ┆ {2,"b",null,[3]}    ┆ womp  │
+        └────────┴─────────────────────┴───────┘
+        >>> df.unnest("t_struct")
+        shape: (2, 6)
+        ┌────────┬─────┬─────┬──────┬───────────┬───────┐
+        │ before ┆ t_a ┆ t_b ┆ t_c  ┆ t_d       ┆ after │
+        │ ---    ┆ --- ┆ --- ┆ ---  ┆ ---       ┆ ---   │
+        │ str    ┆ i64 ┆ str ┆ bool ┆ list[i64] ┆ str   │
+        ╞════════╪═════╪═════╪══════╪═══════════╪═══════╡
+        │ foo    ┆ 1   ┆ a   ┆ true ┆ [1, 2]    ┆ baz   │
+        ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ bar    ┆ 2   ┆ b   ┆ null ┆ [3]       ┆ womp  │
+        └────────┴─────┴─────┴──────┴───────────┴───────┘
 
         """
         if isinstance(names, str):

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -4856,13 +4856,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Operations on a `LazyFrame` are not executed until this is requested by either calling:
 
-        * `.fetch()` (run on a small number of rows)
-        * `.collect()` (run on all data)
-        * `.describe_plan()` (print unoptimized query plan)
-        * `.describe_optimized_plan()` (print optimized query plan)
-        * `.show_graph()` (show (un)optimized query plan) as graphviz graph)
+        * :meth:`.fetch() <polars.LazyFrame.fetch>` (run on a small number of rows)
+        * :meth:`.collect() <polars.LazyFrame.collect>` (run on all data)
+        * :meth:`.describe_plan() <polars.LazyFrame.describe_plan>` (print unoptimized query plan)
+        * :meth:`.describe_optimized_plan() <polars.LazyFrame.describe_optimized_plan>` (print optimized query plan)
+        * :meth:`.show_graph() <polars.LazyFrame.show_graph>` (show (un)optimized query plan as graphviz graph)
 
         Lazy operations are advised because they allow for query optimization and more parallelization.
+
+        Returns
+        -------
+        LazyFrame
         """
         return self._lazyframe_class._from_pyldf(self._df.lazy())
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -651,8 +651,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
         row_count_offset: int = 0,
         low_memory: bool = False,
     ) -> DF:
-        """
-        See Also: `pl.read_csv`
+        """Read into a DataFrame from a parquet file.
+
+        See Also
+        --------
+        read_parquet
+
         """
         if isinstance(file, (str, Path)):
             file = format_path(file)
@@ -1273,11 +1277,11 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Parameters
         ----------
-        include_header:
+        include_header
             If set, the column names will be added as first column.
-        header_name:
-            If `include_header` is set, this determines the name of the column that will be inserted
-        column_names:
+        header_name
+            If `include_header` is set, this determines the name of the column that will be inserted.
+        column_names
             Optional generator/iterator that yields column names. Will be used to replace the columns in the DataFrame.
 
         Notes
@@ -1303,7 +1307,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         │ b      ┆ 1        ┆ 2        ┆ 3        │
         └────────┴──────────┴──────────┴──────────┘
 
-        # replace the auto generated column names with a list
+        Replace the auto-generated column names with a list
 
         >>> df.transpose(include_header=False, column_names=["a", "b", "c"])
         shape: (2, 3)
@@ -1333,7 +1337,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         │ b   ┆ 1   ┆ 2   ┆ 3   │
         └─────┴─────┴─────┴─────┘
 
-        Replace the auto generated column with column names from a generator function
+        Replace the auto-generated column with column names from a generator function
 
         >>> def name_generator():
         ...     base_name = "my_column_"
@@ -1385,7 +1389,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         **kwargs: Any,
     ) -> None:
         """
-        Write the DataFrame disk in parquet format.
+        Write the DataFrame to disk in parquet format.
 
         Parameters
         ----------
@@ -1393,38 +1397,34 @@ class DataFrame(metaclass=DataFrameMetaClass):
             File path to which the file should be written.
         compression
             Compression method. Choose one of:
-                - "uncompressed" (not supported by pyarrow)
-                - "snappy"
-                - "gzip"
-                - "lzo"
-                - "brotli"
-                - "lz4"
-                - "zstd"
+
+            - "uncompressed" (not supported by pyarrow)
+            - "snappy"
+            - "gzip"
+            - "lzo"
+            - "brotli"
+            - "lz4"
+            - "zstd"
 
             The default compression "lz4" (actually lz4raw) has very good performance, but may not yet been supported
             by older readers. If you want more compatability guarantees, consider using "snappy".
         compression_level
-            Supported by {'gzip', 'brotli', 'zstd'}
-                - "gzip"
-                    * min-level: 0
-                    * max-level: 10
-                - "brotli"
-                    * min-level: 0
-                    * max-level: 11
-                - "zstd"
-                    * min-level: 1
-                    * max-level: 22
+            The level of compression to use. Higher compression means smaller files on disk.
+
+            - "gzip" : min-level: 0, max-level: 10.
+            - "brotli" : min-level: 0, max-level: 11.
+            - "zstd" : min-level: 1, max-level: 22.
         statistics
             Write statistics to the parquet headers. This requires extra compute.
         row_group_size
-            Size of the row groups. If none the chunks of the `DataFrame` are used.
+            Size of the row groups. If None (default), the chunks of the `DataFrame` are used.
             Writing in smaller chunks may reduce memory pressure and improve writing speeds.
             This argument has no effect if 'pyarrow' is used.
         use_pyarrow
             Use C++ parquet implementation vs rust parquet implementation.
             At the moment C++ supports more features.
         kwargs
-            Arguments are passed to pyarrow.parquet.write_table.
+            Arguments are passed to ``pyarrow.parquet.write_table``.
         """
         if compression is None:
             compression = "uncompressed"

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -2104,7 +2104,12 @@ class LazyFrame(Generic[DF]):
 
     def drop_nulls(self: LDF, subset: list[str] | str | None = None) -> LDF:
         """
-        Drop rows with null values from this DataFrame.
+        Drop rows with null values from this LazyFrame.
+
+        Parameters
+        ----------
+        subset
+            Subset of column(s) on which ``drop_nulls`` will be applied.
 
         Examples
         --------

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -2317,13 +2317,56 @@ class LazyFrame(Generic[DF]):
 
     def unnest(self: LDF, names: str | list[str]) -> LDF:
         """
-        Decompose a struct into its fields. The fields will be inserted in to the `DataFrame` on the
-        location of the `struct` type.
+        Decompose a struct into its fields.
+
+        The fields will be inserted into the `DataFrame` on the location of the
+        `struct` type.
 
         Parameters
         ----------
         names
            Names of the struct columns that will be decomposed by its fields
+
+        Examples
+        --------
+        >>> df = (
+        ...     pl.DataFrame(
+        ...         {
+        ...             "before": ["foo", "bar"],
+        ...             "t_a": [1, 2],
+        ...             "t_b": ["a", "b"],
+        ...             "t_c": [True, None],
+        ...             "t_d": [[1, 2], [3]],
+        ...             "after": ["baz", "womp"],
+        ...         }
+        ...     )
+        ...     .lazy()
+        ...     .select(
+        ...         ["before", pl.struct(pl.col("^t_.$")).alias("t_struct"), "after"]
+        ...     )
+        ... )
+        >>> df.fetch()
+        shape: (2, 3)
+        ┌────────┬─────────────────────┬───────┐
+        │ before ┆ t_struct            ┆ after │
+        │ ---    ┆ ---                 ┆ ---   │
+        │ str    ┆ struct[4]           ┆ str   │
+        ╞════════╪═════════════════════╪═══════╡
+        │ foo    ┆ {1,"a",true,[1, 2]} ┆ baz   │
+        ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ bar    ┆ {2,"b",null,[3]}    ┆ womp  │
+        └────────┴─────────────────────┴───────┘
+        >>> df.unnest("t_struct").fetch()
+        shape: (2, 6)
+        ┌────────┬─────┬─────┬──────┬───────────┬───────┐
+        │ before ┆ t_a ┆ t_b ┆ t_c  ┆ t_d       ┆ after │
+        │ ---    ┆ --- ┆ --- ┆ ---  ┆ ---       ┆ ---   │
+        │ str    ┆ i64 ┆ str ┆ bool ┆ list[i64] ┆ str   │
+        ╞════════╪═════╪═════╪══════╪═══════════╪═══════╡
+        │ foo    ┆ 1   ┆ a   ┆ true ┆ [1, 2]    ┆ baz   │
+        ├╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+        │ bar    ┆ 2   ┆ b   ┆ null ┆ [3]       ┆ womp  │
+        └────────┴─────┴─────┴──────┴───────────┴───────┘
 
         """
         if isinstance(names, str):

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -254,9 +254,10 @@ def count(column: str | pli.Series | None = None) -> pli.Expr | int:
     ----------
     column
         If dtype is:
-            pl.Series -> count the values in the series
-            str -> count the values in this column
-            None -> count the number of values in this context
+
+        * ``pl.Series`` : count the values in the series.
+        * ``str`` : count the values in this column.
+        * ``None`` : count the number of values in this context.
     """
     if column is None:
         return pli.wrap_expr(_count())

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3607,26 +3607,57 @@ class Series:
 
         Parameters
         ----------
-        method
-            {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
+        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
             The method used to assign ranks to tied elements.
             The following methods are available (default is 'average'):
-            - 'average': The average of the ranks that would have been assigned to
-            all the tied values is assigned to each value.
-            - 'min': The minimum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.  (This is also
-            referred to as "competition" ranking.)
-            - 'max': The maximum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.
-            - 'dense': Like 'min', but the rank of the next highest element is
-            assigned the rank immediately after those assigned to the tied
-            elements.
-            - 'ordinal': All values are given a distinct rank, corresponding to
-            the order that the values occur in `a`.
-            - 'random': Like 'ordinal', but the rank for ties is not dependent
-            on the order that the values occur in `a`.
+
+            - 'average' : The average of the ranks that would have been assigned to
+              all the tied values is assigned to each value.
+            - 'min' : The minimum of the ranks that would have been assigned to all
+              the tied values is assigned to each value. (This is also referred to
+              as "competition" ranking.)
+            - 'max' : The maximum of the ranks that would have been assigned to all
+              the tied values is assigned to each value.
+            - 'dense' : Like 'min', but the rank of the next highest element is
+              assigned the rank immediately after those assigned to the tied
+              elements.
+            - 'ordinal' : All values are given a distinct rank, corresponding to
+              the order that the values occur in the Series.
+            - 'random' : Like 'ordinal', but the rank for ties is not dependent
+              on the order that the values occur in the Series.
         reverse
-            reverse the operation
+            Reverse the operation.
+
+        Examples
+        --------
+        The 'average' method:
+
+        >>> s = pl.Series("a", [3, 6, 1, 1, 6])
+        >>> s.rank()
+        shape: (5,)
+        Series: 'a' [f32]
+        [
+            3.0
+            4.5
+            1.5
+            1.5
+            4.5
+        ]
+
+        The 'ordinal' method:
+
+        >>> s = pl.Series("a", [3, 6, 1, 1, 6])
+        >>> s.rank("ordinal")
+        shape: (5,)
+        Series: 'a' [u32]
+        [
+            3
+            4
+            1
+            2
+            5
+        ]
+
         """
         return wrap_s(self._s.rank(method, reverse))
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3563,14 +3563,14 @@ class Series:
     def reinterpret(self, signed: bool = True) -> Series:
         """
         Reinterpret the underlying bits as a signed/unsigned integer.
+
         This operation is only allowed for 64bit integers. For lower bits integers,
         you can safely use that cast operation.
 
         Parameters
         ----------
         signed
-            True -> pl.Int64
-            False -> pl.UInt64
+            If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
         """
         return wrap_s(self._s.reinterpret(signed))
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -4773,11 +4773,38 @@ class StringNameSpace:
             Starting index of the slice (zero-indexed). Negative indexing
             may be used.
         length
-            Optional length of the slice.
+            Optional length of the slice. If None (default), the slice is taken to the end
+            of the string.
 
         Returns
         -------
         Series of Utf8 type
+
+        Examples
+        --------
+        >>> s = pl.Series("s", ["pear", None, "papaya", "dragonfruit"])
+        >>> s.str.slice(-3)
+        shape: (4,)
+        Series: 's' [str]
+        [
+            "ear"
+            null
+            "aya"
+            "uit"
+        ]
+
+        Using the optional `length` parameter
+
+        >>> s.str.slice(4, length=3)
+        shape: (4,)
+        Series: 's' [str]
+        [
+            ""
+            null
+            "ya"
+            "onf"
+        ]
+
         """
         return wrap_s(self._s.str_slice(start, length))
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -149,10 +149,9 @@ def read_csv(
         Stop reading from CSV file after reading ``n_rows``.
         During multi-threaded parsing, an upper bound of ``n_rows``
         rows cannot be guaranteed.
-    encoding
-        Allowed encodings: ``utf8`` or ``utf8-lossy``.
+    encoding : {'utf8', 'utf8-lossy'}
         Lossy means that invalid utf8 values are replaced with ``�``
-        characters.
+        characters. Defaults to "utf8".
     low_memory
         Reduce memory usage at expense of performance.
     rechunk
@@ -458,10 +457,9 @@ def scan_csv(
         If set to ``None``, a full table scan will be done (slow).
     n_rows
         Stop reading from CSV file after reading ``n_rows``.
-    encoding
-        Allowed encodings: ``utf8`` or ``utf8-lossy``.
+    encoding : {'utf8', 'utf8-lossy'}
         Lossy means that invalid utf8 values are replaced with ``�``
-        characters.
+        characters. Defaults to "utf8".
     low_memory
         Reduce memory usage in expense of performance.
     rechunk
@@ -636,8 +634,7 @@ def scan_parquet(
         Stop reading from parquet file after reading ``n_rows``.
     cache
         Cache the result after reading.
-    parallel
-        Any of { 'auto', 'columns', 'row_groups', 'none' }
+    parallel : {'auto', 'columns', 'row_groups', 'none'}
         This determines the direction of parallelism. 'auto' will try to determine the optimal direction.
     rechunk
         In case of reading multiple files via a glob pattern rechunk the final DataFrame into contiguous memory chunks.
@@ -815,8 +812,7 @@ def read_parquet(
         Only used when ``use_pyarrow=True``.
     storage_options
         Extra options that make sense for ``fsspec.open()`` or a particular storage connection, e.g. host, port, username, password, etc.
-    parallel
-        Any of { 'auto', 'columns', 'row_groups', 'none' }
+    parallel : {'auto', 'columns', 'row_groups', 'none'}
         This determines the direction of parallelism. 'auto' will try to determine the optimal direction.
     row_count_name
         If not None, this will insert a row count column with give name into the DataFrame.


### PR DESCRIPTION
**MWE**  
Added some examples, but also reworked some examples to better illustrate the use of the functions/methods.

One example is `unnest`, the original example only created a bunch of columns, aggregated all of them into a struct column, then unnested them again. And I found the original column names a little confusing/distracting.

I added a `before` and `after` column around the struct to (hopefully) better demonstrate how un-nesting actually affects the datafame.

**Others**
- Fixed some formatting, especially for lists embedded within the descriptions of parameters (a blank line is needed). I'm not positive I've gotten them all yet, will slowly go through and fix those I come across.
- Also, for docstrings, I'm trying to keep to the standard of 1 summary line ; and extended summary should go into the next paragraph, cf. the change for `unnest` or `reinterpret`.
