### PR TITLE
Upgrade maturin to 0.13.0

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -32,7 +32,7 @@ jobs:
           source venv/bin/activate
           pip install -r py-polars/build.requirements.txt
           cd py-polars
-          rustup override set nightly-2022-06-22 && RUSTFLAGS="-C embed-bitcode" maturin develop --rustc-extra-args="-C codegen-units=8 -C lto=thin -C target-cpu=native" --release
+          rustup override set nightly-2022-06-22 && RUSTFLAGS="-C embed-bitcode" maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
           cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
-          maturin-version: 0.12.1
+          maturin-version: '0.13.0'
           command: publish
           args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46
            # uncomment to build a universal2 wheel

--- a/.github/workflows/create-py-release-manylinux.yaml
+++ b/.github/workflows/create-py-release-manylinux.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: publish x86_64
-        uses: docker://konstin2/maturin:latest
+        uses: docker://ghcr.io/pyo3/maturin:latest
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
@@ -28,6 +28,6 @@ jobs:
           # don't use `2_17` it does not work: https://github.com/pola-rs/polars/runs/6107328960
           manylinux: '2_24'
           target: aarch64-unknown-linux-gnu
-          maturin-version: 0.12.1
+          maturin-version: '0.13.0'
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist -o wheels -i python -u ritchie46

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -28,7 +28,7 @@ jobs:
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install maturin==0.12.1
+            pip install maturin==0.13.0
         - name: Publish wheel
           shell: bash
           env:

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ This can be done by going through the following steps in sequence:
   3. Choose any of:
       * Fastest binary, very long compile times:
         ```bash
-        $ cd py-polars && maturin develop --rustc-extra-args="-C target-cpu=native" --release
+        $ cd py-polars && maturin develop --release -- -C target-cpu=native
         ```
       * Fast binary, Shorter compile times:
         ```bash
-        $ cd py-polars && maturin develop --rustc-extra-args="-C codegen-units=16 -C lto=thin -C target-cpu=native" --release
+        $ cd py-polars && maturin develop --release -- -C codegen-units=16 -C lto=thin -C target-cpu=native
         ```
 
 Note that the Rust crate implementing the Python bindings is called `py-polars` to distinguish from the wrapped

--- a/examples/python_rust_compiled_function/pyproject.toml
+++ b/examples/python_rust_compiled_function/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"
 
 [project]

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -10,7 +10,7 @@ pytz
 types-pytz
 
 # Tooling
-maturin==0.12.19
+maturin==0.13.0
 pytest==7.1.2
 pytest-cov[toml]==3.0.0
 hypothesis==6.49.1

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Changelog: https://github.com/PyO3/maturin/releases/tag/v0.13.0
Migration guide: https://maturin.rs/migration.html