### PR TITLE
improve error on missing column access

### DIFF
--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -573,18 +573,14 @@ impl LazyFrame {
         if projection_pushdown {
             let projection_pushdown_opt = ProjectionPushDown {};
             let alp = lp_arena.take(lp_top);
-            let alp = projection_pushdown_opt
-                .optimize(alp, lp_arena, expr_arena)
-                .expect("projection pushdown failed");
+            let alp = projection_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
             lp_arena.replace(lp_top, alp);
         }
 
         if predicate_pushdown {
             let predicate_pushdown_opt = PredicatePushDown::default();
             let alp = lp_arena.take(lp_top);
-            let alp = predicate_pushdown_opt
-                .optimize(alp, lp_arena, expr_arena)
-                .expect("predicate pushdown failed");
+            let alp = predicate_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
             lp_arena.replace(lp_top, alp);
         }
 
@@ -625,9 +621,7 @@ impl LazyFrame {
         if slice_pushdown {
             let slice_pushdown_opt = SlicePushDown {};
             let alp = lp_arena.take(lp_top);
-            let alp = slice_pushdown_opt
-                .optimize(alp, lp_arena, expr_arena)
-                .expect("slice pushdown failed");
+            let alp = slice_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
 
             lp_arena.replace(lp_top, alp);
 

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -83,3 +83,17 @@ def test_join_lazy_on_df() -> None:
         match="Expected a `LazyFrame` as join table, got <class 'polars.internals.frame.DataFrame'>",
     ):
         df_left.lazy().join_asof(df_right, on="Id")
+
+
+def test_projection_update_schema_missing_column() -> None:
+    with pytest.raises(
+        pl.ComputeError, match="column colC not available in schema Schema:*"
+    ):
+        (
+            pl.DataFrame({"colA": ["a", "b", "c"], "colB": [1, 2, 3]})
+            .lazy()
+            .filter(~pl.col("colC").is_null())
+            .groupby(["colA"])
+            .agg([pl.col("colB").sum().alias("result")])
+            .collect()
+        )


### PR DESCRIPTION
```python
  (
      pl.DataFrame({"colA": ["a", "b", "c"], "colB": [1, 2, 3]})
      .lazy()
      .filter(~pl.col("colC").is_null())
      .groupby(["colA"])
      .agg([pl.col("colB").sum().alias("result")])
      .collect()
  )
```
```
---------------------------------------------------------------------------
ComputeError                              Traceback (most recent call last)
Input In [4], in <cell line: 2>()
      1 (
----> 2     pl.DataFrame(
      3         {
      4             "colA" : ["a","b","c"],
      5             "colB" : [1,2,3]
      6         }
      7     ).lazy()
      8     .filter(~pl.col("colC").is_null())
      9     .groupby(["colA"])
     10     .agg([
     11         pl.col("colB").sum().alias("result")
     12     ])
     13     .collect()
     14 )

File ~/code/polars/py-polars/polars/internals/lazy_frame.py:634, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, string_cache, no_optimization, slice_pushdown)
    624     projection_pushdown = False
    626 ldf = self._ldf.optimization_toggle(
    627     type_coercion,
    628     predicate_pushdown,
   (...)
    632     slice_pushdown,
    633 )
--> 634 return self._dataframe_class._from_pydf(ldf.collect())

ComputeError: column colC not available in schema Schema:
name: colA, data type: Utf8
name: colB, data type: Int64



```