### PR TITLE
Run PR workflows on definition changes

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'polars/**'
+      - '.github/workflows/benchmark.yaml'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'polars/**'
+      - '.github/workflows/build-test.yaml'
 jobs:
 
   examples:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'polars/**'
       - 'py-polars/**'
+      - '.github/workflows/coverage.yaml'
 
 jobs:
   coverage:

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'py-polars/**'
+    - '.github/workflows/docs_check.yaml'
 jobs:
   test:
     name: Docs check

--- a/.github/workflows/test-js.yaml
+++ b/.github/workflows/test-js.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'nodejs-polars/**'
+      - '.github/workflows/test-js.yaml'
 jobs: 
   test-js: 
     runs-on: ubuntu-latest

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'py-polars/**'
       - 'polars/**'
+      - '.github/workflows/test-python.yaml'
 jobs:
   test-python:
     name: Build and test Python

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'py-polars/**'
+      - '.github/workflows/test-windows-python.yaml'
 jobs:
   test-python:
     name: Build and test Python


### PR DESCRIPTION
As discussed in #4099, but then rolled out for all workflows that are triggered on particular files being changed.  All workflows that are triggered on a PR (`pull_request`) have this now, with the exception of `fmt_all`, because that does not define a `paths`, and is thus always triggered.