### PR TITLE
Wrap long strings

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -188,7 +188,8 @@ def sequence_to_pyseries(
         if dtype_ in py_temporal_types:
             if not _PYARROW_AVAILABLE:  # pragma: no cover
                 raise ImportError(
-                    "'pyarrow' is required for converting a Sequence of date or datetime values to a PySeries."
+                    "'pyarrow' is required for converting a Sequence of date or"
+                    " datetime values to a PySeries."
                 )
             # let arrow infer dtype if not timedelta
             # arrow uses microsecond durations by default, not supported yet.
@@ -670,7 +671,8 @@ def pandas_to_pydf(
     """
     if not _PYARROW_AVAILABLE:  # pragma: no cover
         raise ImportError(
-            "'pyarrow' is required when constructing a PyDataFrame from a pandas DataFrame."
+            "'pyarrow' is required when constructing a PyDataFrame from a pandas"
+            " DataFrame."
         )
     length = data.shape[0]
     arrow_dict = {

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -7036,7 +7036,8 @@ def expr_to_lit_or_expr(
         return pli.lit(pli.Series("", [expr]))
     else:
         raise ValueError(
-            f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with pl.lit or pl.col"
+            f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with"
+            " pl.lit or pl.col"
         )
 
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -322,7 +322,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         elif _PANDAS_AVAILABLE and isinstance(data, pd.DataFrame):
             if not _PYARROW_AVAILABLE:  # pragma: no cover
                 raise ImportError(
-                    "'pyarrow' is required for converting a pandas DataFrame to a polars DataFrame."
+                    "'pyarrow' is required for converting a pandas DataFrame to a"
+                    " polars DataFrame."
                 )
             self._df = pandas_to_pydf(data, columns=columns)
 
@@ -580,7 +581,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 dtypes_dict = {name: dt for (name, dt) in dtype_list}
             if dtype_slice is not None:
                 raise ValueError(
-                    "cannot use glob patterns and unnamed dtypes as `dtypes` argument; Use dtypes: Mapping[str, Type[DataType]"
+                    "cannot use glob patterns and unnamed dtypes as `dtypes` argument;"
+                    " Use dtypes: Mapping[str, Type[DataType]"
                 )
             from polars import scan_csv
 
@@ -609,7 +611,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 return self._from_pydf(scan.select(columns).collect()._df)
             else:
                 raise ValueError(
-                    "cannot use glob patterns and integer based projection as `columns` argument; Use columns: List[str]"
+                    "cannot use glob patterns and integer based projection as `columns`"
+                    " argument; Use columns: List[str]"
                 )
 
         projection, columns = handle_projection_columns(columns)
@@ -683,7 +686,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 return cls._from_pydf(scan.select(columns).collect()._df)
             else:
                 raise ValueError(
-                    "cannot use glob patterns and integer based projection as `columns` argument; Use columns: List[str]"
+                    "cannot use glob patterns and integer based projection as `columns`"
+                    " argument; Use columns: List[str]"
                 )
 
         projection, columns = handle_projection_columns(columns)
@@ -775,7 +779,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 return scan.select(columns).collect()
             else:
                 raise ValueError(
-                    "cannot use glob patterns and integer based projection as `columns` argument; Use columns: List[str]"
+                    "cannot use glob patterns and integer based projection as `columns`"
+                    " argument; Use columns: List[str]"
                 )
 
         projection, columns = handle_projection_columns(columns)
@@ -819,7 +824,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         if not _PYARROW_AVAILABLE:  # pragma: no cover
             raise ImportError(
-                "'pyarrow' is required for converting a polars DataFrame to an Arrow Table."
+                "'pyarrow' is required for converting a polars DataFrame to an Arrow"
+                " Table."
             )
         record_batches = self._df.to_arrow()
         return pa.Table.from_batches(record_batches)
@@ -1437,7 +1443,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:  # pragma: no cover
                 raise ImportError(
-                    "'pyarrow' is required when using 'write_parquet(..., use_pyarrow=True)'."
+                    "'pyarrow' is required when using 'write_parquet(...,"
+                    " use_pyarrow=True)'."
                 )
 
             tbl = self.to_arrow()
@@ -1765,7 +1772,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 return self._from_pydf(self._df.select(item))
             if item.dtype == bool:
                 warnings.warn(
-                    "index notation '[]' is deprecated for boolean masks. Consider using 'filter'.",
+                    "index notation '[]' is deprecated for boolean masks. Consider"
+                    " using 'filter'.",
                     DeprecationWarning,
                 )
                 return self._from_pydf(self._df.filter(pli.Series("", item).inner()))
@@ -1798,7 +1806,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self, key: str | list | tuple[Any, str | int], value: Any
     ) -> None:  # pragma: no cover
         warnings.warn(
-            "setting a DataFrame by indexing is deprecated; Consider using DataFrame.with_column",
+            "setting a DataFrame by indexing is deprecated; Consider using"
+            " DataFrame.with_column",
             DeprecationWarning,
         )
         # df["foo"] = series
@@ -1817,7 +1826,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
                 raise ValueError("can only set multiple columns with 2D matrix")
             if value.shape[1] != len(key):
                 raise ValueError(
-                    "matrix columns should be equal to list use to determine column names"
+                    "matrix columns should be equal to list use to determine column"
+                    " names"
                 )
             for (i, name) in enumerate(key):
                 self[name] = value[:, i]
@@ -3660,7 +3670,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         if how == "asof":  # pragma: no cover
             warnings.warn(
-                "using asof join via DataFrame.join is deprecated, please use DataFrame.join_asof",
+                "using asof join via DataFrame.join is deprecated, please use"
+                " DataFrame.join_asof",
                 DeprecationWarning,
             )
         if how == "cross":
@@ -3842,7 +3853,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         if isinstance(column, list):
             raise ValueError(
-                "`with_column` expects a single expression, not a list. Consider using `with_columns`"
+                "`with_column` expects a single expression, not a list. Consider using"
+                " `with_columns`"
             )
         if isinstance(column, pli.Expr):
             return self.with_columns([column])
@@ -6102,7 +6114,8 @@ class GroupBy(Generic[DF]):
             One or multiple columns.
         """
         warnings.warn(
-            "accessing GroupBy by index is deprecated, consider using the `.agg` method",
+            "accessing GroupBy by index is deprecated, consider using the `.agg`"
+            " method",
             DeprecationWarning,
         )
         if isinstance(columns, str):
@@ -6218,7 +6231,8 @@ class GroupBy(Generic[DF]):
 
         """
         warnings.warn(
-            "accessing GroupBy by index is deprecated, consider using the `.agg` method",
+            "accessing GroupBy by index is deprecated, consider using the `.agg`"
+            " method",
             DeprecationWarning,
         )
         return self._dataframe_class._from_pydf(
@@ -6377,11 +6391,13 @@ class GroupBy(Generic[DF]):
                 )
             else:
                 raise ValueError(
-                    f"argument: {column_to_agg} not understood, have you passed a list of expressions?"
+                    f"argument: {column_to_agg} not understood, have you passed a list"
+                    " of expressions?"
                 )
         else:
             raise ValueError(
-                f"argument: {column_to_agg} not understood, have you passed a list of expressions?"
+                f"argument: {column_to_agg} not understood, have you passed a list of"
+                " expressions?"
             )
 
         return self._dataframe_class._from_pydf(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1443,8 +1443,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:  # pragma: no cover
                 raise ImportError(
-                    "'pyarrow' is required when using 'write_parquet(...,"
-                    " use_pyarrow=True)'."
+                    "'pyarrow' is required when using"
+                    " 'write_parquet(..., use_pyarrow=True)'."
                 )
 
             tbl = self.to_arrow()

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -360,7 +360,8 @@ class LazyFrame(Generic[DF]):
     def __getitem__(self: LDF, item: int | range | slice) -> LazyFrame:
         if not isinstance(item, slice):
             raise TypeError(
-                "'LazyFrame' object is not subscriptable (aside from slicing). Use 'select()' or 'filter()' instead."
+                "'LazyFrame' object is not subscriptable (aside from slicing). Use"
+                " 'select()' or 'filter()' instead."
             )
         return LazyPolarsSlice(self).apply(item)
 
@@ -411,7 +412,10 @@ class LazyFrame(Generic[DF]):
             svg = subprocess.check_output(
                 ["dot", "-Nshape=box", "-Tsvg"], input=f"{dot}".encode()
             )
-            return f"<h4>NAIVE QUERY PLAN</h4><p>run <b>LazyFrame.show_graph()</b> to see the optimized version</p>{svg.decode()}"
+            return (
+                "<h4>NAIVE QUERY PLAN</h4><p>run <b>LazyFrame.show_graph()</b> to see"
+                f" the optimized version</p>{svg.decode()}"
+            )
         except Exception:
             insert = self.describe_plan().replace("\n", "<p></p>")
 
@@ -491,14 +495,16 @@ class LazyFrame(Generic[DF]):
                 return display(SVG(svg))
             except Exception as exc:
                 raise ImportError(
-                    "Graphviz dot binary should be on your PATH and matplotlib should be installed to show graph."
+                    "Graphviz dot binary should be on your PATH and matplotlib should"
+                    " be installed to show graph."
                 ) from exc
         try:
             import matplotlib.image as mpimg
             import matplotlib.pyplot as plt
         except ImportError:
             raise ImportError(
-                "Graphviz dot binary should be on your PATH and matplotlib should be installed to show graph."
+                "Graphviz dot binary should be on your PATH and matplotlib should be"
+                " installed to show graph."
             ) from None
         dot = self._ldf.to_dot(optimized)
         if raw_output:
@@ -1404,7 +1410,8 @@ class LazyFrame(Generic[DF]):
 
         if how == "asof":
             warnings.warn(
-                "using asof join via LazyFrame.join is deprecated, please use LazyFrame.join_asof",
+                "using asof join via LazyFrame.join is deprecated, please use"
+                " LazyFrame.join_asof",
                 DeprecationWarning,
             )
         if how == "cross":
@@ -1567,7 +1574,8 @@ class LazyFrame(Generic[DF]):
         """
         if named_exprs and not Config.with_columns_kwargs:
             raise RuntimeError(
-                "**kwargs support is experimental; requires opt-in via `pl.Config.set_with_columns_kwargs(True)`"
+                "**kwargs support is experimental; requires opt-in via"
+                " `pl.Config.set_with_columns_kwargs(True)`"
             )
         elif exprs is None and not named_exprs:
             raise ValueError("Expected at least one of 'exprs' or **named_exprs")

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1753,7 +1753,8 @@ def arg_where(
     if eager:
         if not isinstance(condition, pli.Series):
             raise ValueError(
-                f"expected 'Series' in 'arg_where' if 'eager=True', got {type(condition)}"
+                "expected 'Series' in 'arg_where' if 'eager=True', got"
+                f" {type(condition)}"
             )
         return (
             condition.to_frame().select(arg_where(pli.col(condition.name))).to_series()

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -359,7 +359,8 @@ class Series:
             f = get_ffi_func(op_ffi, self.dtype, self._s)
         if f is None:
             raise ValueError(
-                f"cannot do arithmetic with series of dtype: {self.dtype} and argument of type: {type(other)}"
+                f"cannot do arithmetic with series of dtype: {self.dtype} and argument"
+                f" of type: {type(other)}"
             )
         return wrap_s(f(other))
 
@@ -495,7 +496,8 @@ class Series:
                 self.set_at_idx(key, value)  # type: ignore[arg-type]
                 return None
             raise ValueError(
-                f"cannot set Series of dtype: {self.dtype} with list/tuple as value; use a scalar value"
+                f"cannot set Series of dtype: {self.dtype} with list/tuple as value;"
+                " use a scalar value"
             )
         if isinstance(key, Series):
             if key.dtype == Boolean:
@@ -2260,7 +2262,8 @@ class Series:
             return wrap_s(series)
         else:
             raise NotImplementedError(
-                f"Only `__call__` is implemented for numpy ufuncs on a Series, got `{method}`."
+                "Only `__call__` is implemented for numpy ufuncs on a Series, got"
+                f" `{method}`."
             )
 
     def to_numpy(
@@ -2344,7 +2347,8 @@ class Series:
         """
         if not _PYARROW_AVAILABLE:  # pragma: no cover
             raise ImportError(
-                "'pyarrow' is required for converting a 'polars' Series to a 'pandas' Series."
+                "'pyarrow' is required for converting a 'polars' Series to a 'pandas'"
+                " Series."
             )
         return self.to_arrow().to_pandas()
 
@@ -2419,7 +2423,8 @@ class Series:
         f = get_ffi_func("set_at_idx_<>", self.dtype, self._s)
         if f is None:
             raise ValueError(
-                f"could not find the FFI function needed to set at idx for series {self._s}"
+                "could not find the FFI function needed to set at idx for series"
+                f" {self._s}"
             )
         if isinstance(idx, Series):
             # make sure the dtype matches

--- a/py-polars/polars/internals/slice.py
+++ b/py-polars/polars/internals/slice.py
@@ -205,5 +205,5 @@ class LazyPolarsSlice:
 
         raise ValueError(
             f"The given slice {s} is not supported by lazy computation; consider a "
-            f"more efficient approach, or construct explicitly with other methods"
+            "more efficient approach, or construct explicitly with other methods"
         )

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -774,8 +774,8 @@ def read_ipc(
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_ipc(...,"
-                    " use_pyarrow=True)'."
+                    "'pyarrow' is required when using"
+                    " 'read_ipc(..., use_pyarrow=True)'."
                 )
 
             tbl = pa.feather.read_table(data, memory_map=memory_map, columns=columns)
@@ -856,8 +856,8 @@ def read_parquet(
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_parquet(...,"
-                    " use_pyarrow=True)'."
+                    "'pyarrow' is required when using"
+                    " 'read_parquet(..., use_pyarrow=True)'."
                 )
 
             return from_arrow(  # type: ignore[return-value]

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -39,11 +39,13 @@ def _check_arg_is_1byte(
         if can_be_empty:
             if arg_byte_length > 1:
                 raise ValueError(
-                    f'{arg_name}="{arg}" should be a single byte character or empty, but is {arg_byte_length} bytes long.'
+                    f'{arg_name}="{arg}" should be a single byte character or empty,'
+                    f" but is {arg_byte_length} bytes long."
                 )
         elif arg_byte_length != 1:
             raise ValueError(
-                f'{arg_name}="{arg}" should be a single byte character, but is {arg_byte_length} bytes long.'
+                f'{arg_name}="{arg}" should be a single byte character, but is'
+                f" {arg_byte_length} bytes long."
             )
 
 
@@ -305,7 +307,8 @@ def read_csv(
         if columns:
             if len(columns) < len(new_columns):
                 raise ValueError(
-                    "More new column names are specified than there are selected columns."
+                    "More new column names are specified than there are selected"
+                    " columns."
                 )
 
             # Get column names of requested columns.
@@ -316,7 +319,8 @@ def read_csv(
             if projection:
                 if columns and len(columns) < len(new_columns):
                     raise ValueError(
-                        "More new column names are specified than there are selected columns."
+                        "More new column names are specified than there are selected"
+                        " columns."
                     )
                 # Convert column indices from projection to 'column_1', 'column_2', ... column names.
                 current_columns = [
@@ -770,7 +774,8 @@ def read_ipc(
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_ipc(..., use_pyarrow=True)'."
+                    "'pyarrow' is required when using 'read_ipc(...,"
+                    " use_pyarrow=True)'."
                 )
 
             tbl = pa.feather.read_table(data, memory_map=memory_map, columns=columns)
@@ -851,7 +856,8 @@ def read_parquet(
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:
                 raise ImportError(
-                    "'pyarrow' is required when using 'read_parquet(..., use_pyarrow=True)'."
+                    "'pyarrow' is required when using 'read_parquet(...,"
+                    " use_pyarrow=True)'."
                 )
 
             return from_arrow(  # type: ignore[return-value]

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -402,7 +402,8 @@ if HYPOTHESIS_INSTALLED:
                 self.null_probability < 0 or self.null_probability > 1
             ):
                 raise InvalidArgument(
-                    f"null_probability should be between 0.0 and 1.0, or None; found {self.null_probability}"
+                    "null_probability should be between 0.0 and 1.0, or None; found"
+                    f" {self.null_probability}"
                 )
             if self.dtype is None and not self.strategy:
                 self.dtype = random.choice(strategy_dtypes)
@@ -590,7 +591,8 @@ if HYPOTHESIS_INSTALLED:
         ]
         if null_probability and (null_probability < 0 or null_probability > 1):
             raise InvalidArgument(
-                f"null_probability should be between 0.0 and 1.0; found {null_probability}"
+                "null_probability should be between 0.0 and 1.0; found"
+                f" {null_probability}"
             )
         null_probability = float(null_probability or 0.0)
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -152,7 +152,8 @@ def handle_projection_columns(
             columns = None
         elif not is_str_sequence(columns):
             raise ValueError(
-                "columns arg should contain a list of all integers or all strings values."
+                "columns arg should contain a list of all integers or all strings"
+                " values."
             )
     return projection, columns  # type: ignore[return-value]
 

--- a/py-polars/tests/test_categorical.py
+++ b/py-polars/tests/test_categorical.py
@@ -188,6 +188,9 @@ def test_categorical_error_on_local_cmp() -> None:
     )
     with pytest.raises(
         pl.ComputeError,
-        match="Cannot compare categoricals originating from different sources. Consider setting a global string cache.",
+        match=(
+            "Cannot compare categoricals originating from different sources. Consider"
+            " setting a global string cache."
+        ),
     ):
         df_cat.filter(pl.col("a_cat") == pl.col("b_cat"))

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -23,7 +23,8 @@ def test_tables(environ: None) -> None:
     pl.Config.set_ascii_tables()
     df_asci = str(df)
     assert (
-        df_asci == "shape: (3, 3)\n"
+        df_asci
+        == "shape: (3, 3)\n"
         "+-----+-----+-----+\n"
         "| a   | b   | c   |\n"
         "| --- | --- | --- |\n"
@@ -40,7 +41,8 @@ def test_tables(environ: None) -> None:
     pl.Config.set_utf8_tables()
     df_utf8 = str(df)
     assert (
-        df_utf8 == "shape: (3, 3)\n"
+        df_utf8
+        == "shape: (3, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -101,7 +103,8 @@ def test_set_tbl_rows(environ: None) -> None:
 
     pl.Config.set_tbl_rows(1)
     assert (
-        str(df) == "shape: (4, 3)\n"
+        str(df)
+        == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -116,7 +119,8 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(2)
     assert (
-        str(df) == "shape: (4, 3)\n"
+        str(df)
+        == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -131,7 +135,8 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(3)
     assert (
-        str(df) == "shape: (4, 3)\n"
+        str(df)
+        == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -148,7 +153,8 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(4)
     assert (
-        str(df) == "shape: (4, 3)\n"
+        str(df)
+        == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -174,7 +180,8 @@ def test_set_tbl_rows(environ: None) -> None:
 
     pl.Config.set_tbl_rows(3)
     assert (
-        str(df) == "shape: (5, 3)\n"
+        str(df)
+        == "shape: (5, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"

--- a/py-polars/tests/test_cfg.py
+++ b/py-polars/tests/test_cfg.py
@@ -23,8 +23,7 @@ def test_tables(environ: None) -> None:
     pl.Config.set_ascii_tables()
     df_asci = str(df)
     assert (
-        df_asci
-        == "shape: (3, 3)\n"
+        df_asci == "shape: (3, 3)\n"
         "+-----+-----+-----+\n"
         "| a   | b   | c   |\n"
         "| --- | --- | --- |\n"
@@ -41,8 +40,7 @@ def test_tables(environ: None) -> None:
     pl.Config.set_utf8_tables()
     df_utf8 = str(df)
     assert (
-        df_utf8
-        == "shape: (3, 3)\n"
+        df_utf8 == "shape: (3, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -103,8 +101,7 @@ def test_set_tbl_rows(environ: None) -> None:
 
     pl.Config.set_tbl_rows(1)
     assert (
-        str(df)
-        == "shape: (4, 3)\n"
+        str(df) == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -119,8 +116,7 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(2)
     assert (
-        str(df)
-        == "shape: (4, 3)\n"
+        str(df) == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -135,8 +131,7 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(3)
     assert (
-        str(df)
-        == "shape: (4, 3)\n"
+        str(df) == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -153,8 +148,7 @@ def test_set_tbl_rows(environ: None) -> None:
     )
     pl.Config.set_tbl_rows(4)
     assert (
-        str(df)
-        == "shape: (4, 3)\n"
+        str(df) == "shape: (4, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"
@@ -180,8 +174,7 @@ def test_set_tbl_rows(environ: None) -> None:
 
     pl.Config.set_tbl_rows(3)
     assert (
-        str(df)
-        == "shape: (5, 3)\n"
+        str(df) == "shape: (5, 3)\n"
         "┌─────┬─────┬─────┐\n"
         "│ a   ┆ b   ┆ c   │\n"
         "│ --- ┆ --- ┆ --- │\n"

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -23,7 +23,10 @@ def test_error_on_reducing_map() -> None:
 
     with pytest.raises(
         pl.ComputeError,
-        match="A 'map' functions output length must be equal to that of the input length. Consider using 'apply' in favor of 'map'.",
+        match=(
+            "A 'map' functions output length must be equal to that of the input length."
+            " Consider using 'apply' in favor of 'map'."
+        ),
     ):
         df.groupby("id").agg(pl.map(["t", "y"], np.trapz))
 
@@ -74,13 +77,19 @@ def test_join_lazy_on_df() -> None:
 
     with pytest.raises(
         ValueError,
-        match="Expected a `LazyFrame` as join table, got <class 'polars.internals.frame.DataFrame'>",
+        match=(
+            "Expected a `LazyFrame` as join table, got <class"
+            " 'polars.internals.frame.DataFrame'>"
+        ),
     ):
         df_left.lazy().join(df_right, on="Id")
 
     with pytest.raises(
         ValueError,
-        match="Expected a `LazyFrame` as join table, got <class 'polars.internals.frame.DataFrame'>",
+        match=(
+            "Expected a `LazyFrame` as join table, got <class"
+            " 'polars.internals.frame.DataFrame'>"
+        ),
     ):
         df_left.lazy().join_asof(df_right, on="Id")
 

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -78,8 +78,8 @@ def test_join_lazy_on_df() -> None:
     with pytest.raises(
         ValueError,
         match=(
-            "Expected a `LazyFrame` as join table, got <class"
-            " 'polars.internals.frame.DataFrame'>"
+            "Expected a `LazyFrame` as join table, got"
+            " <class 'polars.internals.frame.DataFrame'>"
         ),
     ):
         df_left.lazy().join(df_right, on="Id")
@@ -87,8 +87,8 @@ def test_join_lazy_on_df() -> None:
     with pytest.raises(
         ValueError,
         match=(
-            "Expected a `LazyFrame` as join table, got <class"
-            " 'polars.internals.frame.DataFrame'>"
+            "Expected a `LazyFrame` as join table, got"
+            " <class 'polars.internals.frame.DataFrame'>"
         ),
     ):
         df_left.lazy().join_asof(df_right, on="Id")

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1050,12 +1050,18 @@ def test_comparisons_bool_series_to_int() -> None:
     srs_bool = pl.Series([True, False])
     # todo: do we want this to work?
     assert_series_equal(srs_bool / 1, pl.Series([True, False], dtype=Float64))
-    match = r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'> and argument of type: <class 'bool'>"
+    match = (
+        r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'>"
+        r" and argument of type: <class 'bool'>"
+    )
     with pytest.raises(ValueError, match=match):
         srs_bool - 1
     with pytest.raises(ValueError, match=match):
         srs_bool + 1
-    match = r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'> and argument of type: <class 'bool'>"
+    match = (
+        r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'>"
+        r" and argument of type: <class 'bool'>"
+    )
     with pytest.raises(ValueError, match=match):
         srs_bool % 2
     with pytest.raises(ValueError, match=match):

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -479,12 +479,18 @@ def test_struct_schema_on_append_extend_3452() -> None:
     housing1, housing2 = pl.Series(housing1_data), pl.Series(housing2_data)
     with pytest.raises(
         pl.SchemaError,
-        match="cannot append field with name: address to struct with field name: city, please check your schema",
+        match=(
+            "cannot append field with name: address to struct with field name: city,"
+            " please check your schema"
+        ),
     ):
         housing1.append(housing2, append_chunks=True)
     with pytest.raises(
         pl.SchemaError,
-        match="cannot extend field with name: address to struct with field name: city, please check your schema",
+        match=(
+            "cannot extend field with name: address to struct with field name: city,"
+            " please check your schema"
+        ),
     ):
         housing1.append(housing2, append_chunks=False)
 


### PR DESCRIPTION
Relates to #4044

I want to improve consistency for line lengths. Because there is a lot to go through, I'm chopping it up in pieces:
* Long strings in the code (this PR)
* Long comments
* Long docstrings

Changes:
* Use black to automatically wrap long strings (this will ensure compliance with black in the future).
* Improve clarity for some of the string wrapping.
