### PR TITLE
Native implementation of the sign function

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -119,6 +119,7 @@ string_justify = ["polars-lazy/string_justify", "polars-ops/string_justify"]
 arg_where = ["polars-lazy/arg_where"]
 date_offset = ["polars-lazy/date_offset"]
 trigonometry = ["polars-lazy/trigonometry"]
+sign = ["polars-lazy/sign"]
 
 test = [
   "lazy",

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -34,6 +34,7 @@ dtype-struct = ["polars-core/dtype-struct"]
 object = ["polars-core/object"]
 date_offset = []
 trigonometry = []
+sign = []
 
 true_div = []
 

--- a/polars/polars-lazy/src/dsl/function_expr/sign.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/sign.rs
@@ -12,10 +12,13 @@ pub(super) fn sign(s: &Series) -> Result<Series> {
             let ca = s.f64().unwrap();
             sign_float(ca)
         }
-        _ => {
+        dt if dt.is_numeric() => {
             let s = s.cast(&Float64)?;
             sign(&s)
         }
+        dt => Err(PolarsError::ComputeError(
+            format!("cannot use 'sign' on Series of dtype: {:?}", dt).into(),
+        )),
     }
 }
 

--- a/polars/polars-lazy/src/dsl/function_expr/sign.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/sign.rs
@@ -1,0 +1,37 @@
+use super::*;
+use polars_core::export::num;
+use DataType::*;
+
+pub(super) fn sign(s: &Series) -> Result<Series> {
+    match s.dtype() {
+        Float32 => {
+            let ca = s.f32().unwrap();
+            sign_float(ca)
+        }
+        Float64 => {
+            let ca = s.f64().unwrap();
+            sign_float(ca)
+        }
+        _ => {
+            let s = s.cast(&Float64)?;
+            sign(&s)
+        }
+    }
+}
+
+fn sign_float<T>(ca: &ChunkedArray<T>) -> Result<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    ca.apply(sign_single_float).into_series().cast(&Int64)
+}
+
+fn sign_single_float<F: num::Float>(v: F) -> F {
+    if v.is_zero() {
+        v
+    } else {
+        v.signum()
+    }
+}

--- a/polars/polars-lazy/src/dsl/function_expr/sign.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/sign.rs
@@ -28,10 +28,12 @@ where
     T::Native: num::Float,
     ChunkedArray<T>: IntoSeries,
 {
-    ca.apply(sign_single_float).into_series().cast(&Int64)
+    ca.apply(signum_improved).into_series().cast(&Int64)
 }
 
-fn sign_single_float<F: num::Float>(v: F) -> F {
+// Wrapper for the signum function that handles +/-0.0 inputs differently
+// See discussion here: https://github.com/rust-lang/rust/issues/57543
+fn signum_improved<F: num::Float>(v: F) -> F {
     if v.is_zero() {
         v
     } else {

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -1381,6 +1381,21 @@ impl Expr {
         }
     }
 
+    /// Compute the sign of the given expression
+    #[cfg(feature = "sign")]
+    pub fn sign(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Sign,
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                input_wildcard_expansion: false,
+                auto_explode: false,
+                fmt_str: "sign",
+            },
+        }
+    }
+
     /// Filter a single column
     /// Should be used in aggregation context. If you want to filter on a DataFrame level, use
     /// [LazyFrame::filter](LazyFrame::filter)

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -234,6 +234,7 @@
 //!     - `argwhere` Get indices where condition holds.
 //!     - `date_offset` Add an offset to dates that take months and leap years into account.
 //!     - `trigonometry` Trigonometric functions.
+//!     - `sign` Compute the element-wise sign of a Series.
 //! * `DataFrame` pretty printing
 //!     - `fmt` - Activate DataFrame formatting
 //!

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -43,6 +43,7 @@ ipc = ["polars/ipc"]
 is_in = ["polars/is_in"]
 json = ["polars/serde", "serde_json"]
 trigonometry = ["polars/trigonometry"]
+sign = ["polars/sign"]
 asof_join = ["polars/asof_join"]
 cross_join = ["polars/cross_join"]
 pct_change = ["polars/pct_change"]
@@ -58,6 +59,7 @@ all = [
   "json",
   "repeat_by",
   "trigonometry",
+  "sign",
   "asof_join",
   "cross_join",
   "pct_change",

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4288,31 +4288,31 @@ class Expr:
 
     def sign(self) -> Expr:
         """
-        Return an element-wise indication of the sign of a number.
+        Compute the element-wise indication of the sign.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [-9, -8, 0, 4]})
-        >>> df.select(pl.col("foo").sign())
-        shape: (4, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ -1  │
-        ├╌╌╌╌╌┤
-        │ -1  │
-        ├╌╌╌╌╌┤
-        │ 0   │
-        ├╌╌╌╌╌┤
-        │ 1   │
-        └─────┘
+        >>> df = pl.DataFrame({"a": [-9.0, -0.0, 0.0, 4.0, None]})
+        >>> df.select(pl.col("a").sign())
+        shape: (5, 1)
+        ┌──────┐
+        │ a    │
+        │ ---  │
+        │ i64  │
+        ╞══════╡
+        │ -1   │
+        ├╌╌╌╌╌╌┤
+        │ 0    │
+        ├╌╌╌╌╌╌┤
+        │ 0    │
+        ├╌╌╌╌╌╌┤
+        │ 1    │
+        ├╌╌╌╌╌╌┤
+        │ null │
+        └──────┘
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.sign(self)  # type: ignore[call-overload]
+        return wrap_expr(self._pyexpr.sign())
 
     def sin(self) -> Expr:
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2723,25 +2723,24 @@ class Series:
 
     def sign(self) -> Series:
         """
-        Return an element-wise indication of the sign of a number.
+        Compute the element-wise indication of the sign.
 
         Examples
         --------
-        >>> s = pl.Series("foo", [-9, -8, 0, 4])
-        >>> s.sign()  #
-        shape: (4,)
-        Series: 'foo' [i64]
+        >>> s = pl.Series("a", [-9.0, -0.0, 0.0, 4.0, None])
+        >>> s.sign()
+        shape: (5,)
+        Series: 'a' [i64]
         [
                 -1
-                -1
+                0
                 0
                 1
+                null
         ]
 
         """
-        if not _NUMPY_AVAILABLE:
-            raise ImportError("'numpy' is required for this functionality.")
-        return np.sign(self)  # type: ignore[return-value]
+        return self.to_frame().select(pli.col(self.name).sign()).to_series()
 
     def sin(self) -> Series:
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -426,6 +426,11 @@ impl PyExpr {
         self.clone().inner.arctanh().into()
     }
 
+    #[cfg(feature = "sign")]
+    pub fn sign(&self) -> PyExpr {
+        self.clone().inner.sign().into()
+    }
+
     pub fn is_duplicated(&self) -> PyExpr {
         self.clone().inner.is_duplicated().into()
     }

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1702,8 +1702,14 @@ def test_str_split() -> None:
 
 
 def test_sign() -> None:
-    a = pl.Series("a", [10, -20, None])
-    expected = pl.Series("a", [1, -1, None])
+    # Integers
+    a = pl.Series("a", [-9, -0, 0, 4, None])
+    expected = pl.Series("a", [-1, 0, 0, 1, None])
+    verify_series_and_expr_api(a, expected, "sign")
+
+    # Floats
+    a = pl.Series("a", [-9.0, -0.0, 0.0, 4.0, None])
+    expected = pl.Series("a", [-1, 0, 0, 1, None])
     verify_series_and_expr_api(a, expected, "sign")
 
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1712,6 +1712,11 @@ def test_sign() -> None:
     expected = pl.Series("a", [-1, 0, 0, 1, None])
     verify_series_and_expr_api(a, expected, "sign")
 
+    # Dates
+    a = pl.Series("a", [date(1950, 2, 1), date(1970, 1, 1), date(2022, 12, 12), None])
+    expected = pl.Series("a", [-1, 0, 1, None])
+    verify_series_and_expr_api(a, expected, "sign")
+
 
 def test_exp() -> None:
     a = pl.Series("a", [0.1, 0.01, None])

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1712,10 +1712,10 @@ def test_sign() -> None:
     expected = pl.Series("a", [-1, 0, 0, 1, None])
     verify_series_and_expr_api(a, expected, "sign")
 
-    # Dates
+    # Invalid input
     a = pl.Series("a", [date(1950, 2, 1), date(1970, 1, 1), date(2022, 12, 12), None])
-    expected = pl.Series("a", [-1, 0, 1, None])
-    verify_series_and_expr_api(a, expected, "sign")
+    with pytest.raises(pl.ComputeError):
+        a.sign()
 
 
 def test_exp() -> None:


### PR DESCRIPTION
Relates to #3890 

Changes:
* Added the `sign` function as a feature to the Rust code base
  * Takes the [num::signum](https://docs.rs/num/0.1.41/num/fn.signum.html) function as a starting point, but I am handling the special case where the value is zero.
  * Casts to float, does the magic, then casts to Int64. This feels a bit wasteful, as the `signum` function for integers works fine according to our specs; any helpful tips?
* Added Python bindings