### PR TITLE
python 0.13.58

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.13.57"
+version = "0.13.58"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.13.57"
+version = "0.13.58"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"


### PR DESCRIPTION
An early patch because of a regression introduced by #4105. Lengths of list arrays were not updated after a filter operation.