### PR TITLE
Improve __getitem__ for Dataframe/Series.

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -117,6 +117,21 @@ def _date_to_pl_date(d: date) -> int:
     return int(dt.timestamp()) // (3600 * 24)
 
 
+def _is_iterable_of(val: Iterable, itertype: type, eltype: type) -> bool:
+    """Check whether the given iterable is of a certain type."""
+    return isinstance(val, itertype) and all(isinstance(x, eltype) for x in val)
+
+
+def is_bool_sequence(val: Sequence[object]) -> TypeGuard[Sequence[bool]]:
+    """Check whether the given sequence is a sequence of booleans."""
+    return _is_iterable_of(val, Sequence, bool)
+
+
+def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
+    """Check whether the given sequence is a sequence of integers."""
+    return _is_iterable_of(val, Sequence, int)
+
+
 def is_str_sequence(
     val: Sequence[object], allow_str: bool = False
 ) -> TypeGuard[Sequence[str]]:
@@ -129,16 +144,6 @@ def is_str_sequence(
     if (not allow_str) and isinstance(val, str):
         return False
     return _is_iterable_of(val, Sequence, str)
-
-
-def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
-    """Check whether the given sequence is a sequence of integers."""
-    return _is_iterable_of(val, Sequence, int)
-
-
-def _is_iterable_of(val: Iterable, itertype: type, eltype: type) -> bool:
-    """Check whether the given iterable is of a certain type."""
-    return isinstance(val, itertype) and all(isinstance(x, eltype) for x in val)
 
 
 def range_to_slice(rng: range) -> slice:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -454,10 +454,28 @@ def test_ufunc() -> None:
 
 def test_get() -> None:
     a = pl.Series("a", [1, 2, 3])
+    pos_idxs = pl.Series("idxs", [2, 0, 1, 0], dtype=pl.Int8)
+    neg_and_pos_idxs = pl.Series(
+        "neg_and_pos_idxs", [-2, 1, 0, -1, 2, -3], dtype=pl.Int8
+    )
     assert a[0] == 1
     assert a[:2] == [1, 2]
     assert a[range(1)] == [1, 2]
     assert a[range(0, 2, 2)] == [1, 3]
+    for dtype in (
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+    ):
+        assert a[pos_idxs.cast(dtype)] == [3, 1, 2, 1]
+        assert a[pos_idxs.cast(dtype).to_numpy()] == [3, 1, 2, 1]
+    for dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
+        assert a[neg_and_pos_idxs.cast(dtype).to_numpy()] == [2, 2, 1, 3, 3, 1]
 
 
 def test_set() -> None:


### PR DESCRIPTION
Improve __getitem__ for Dataframe/Series:
  - Allow fast path for retrieving multiple rows when using a
    sequence, numpy array or Series of row indexes.
    (speedup of x6).
  - Support all unsigned and signed integer types for multiple
    row indexing.
  - Allow negative indexes for multiple row indexing.
  - Add more getitem tests and fix old getitem tests that were
    wrong (didn't use assert, so didn't fail before).
  - Support getting columns from dataframe with pl.Utf8 series.