### PR TITLE
Fix invalid inputs for trigonometric functions

### DIFF
--- a/polars/polars-lazy/src/dsl/function_expr/trigonometry.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/trigonometry.rs
@@ -16,10 +16,17 @@ pub(super) fn apply_trigonometric_function(
             let ca = s.f64().unwrap();
             apply_trigonometric_function_to_float(ca, trig_function)
         }
-        _ => {
+        dt if dt.is_numeric() => {
             let s = s.cast(&DataType::Float64)?;
             apply_trigonometric_function(&s, trig_function)
         }
+        dt => Err(PolarsError::ComputeError(
+            format!(
+                "cannot use trigonometric function on Series of dtype: {:?}",
+                dt
+            )
+            .into(),
+        )),
     }
 }
 


### PR DESCRIPTION
After discussion in #4147 , determined that these functions should not work on non-numeric types.

Changes:
* Throw a ComputeError when trigonometric functions are applied to non-numeric types
* Added tests for this
* Removed some old tests that were no longer required