### PR TITLE
Minor docs updates

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -86,7 +86,6 @@ Aggregation
     Expr.list
     Expr.max
     Expr.mean
-    Expr.mean
     Expr.median
     Expr.min
     Expr.product

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -119,14 +119,14 @@ def from_records(
     orient: Literal["col", "row"] | None = None,
 ) -> DataFrame:
     """
-    Construct a DataFrame from a numpy ndarray or sequence of sequences.
+    Construct a DataFrame from a sequence of sequences.
 
     Note that this is slower than creating from columnar memory.
 
     Parameters
     ----------
-    data : numpy ndarray or Sequence of sequences
-        Two-dimensional data represented as numpy ndarray or sequence of sequences.
+    data : Sequence of sequences
+        Two-dimensional data represented as a sequence of sequences.
     columns : Sequence of str, default None
         Column labels to use for resulting DataFrame. Must match data dimensions.
         If not specified, columns will be named `column_0`, `column_1`, etc.


### PR DESCRIPTION
I came across a few things while going through our API docs.

Changes:
* Removed duplicate Expr.mean entry
* Removed deprecated functionality from the `from_records` docstring description.

(planned some other things for this PR but now it's just a very skinny PR 😄)