### PR TITLE
Validation for groupby arguments

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3104,6 +3104,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         └─────┴─────┴─────┘
 
         """
+        if not isinstance(maintain_order, bool):
+            raise TypeError(
+                f"invalid input for groupby arg `maintain_order`: {maintain_order}."
+            )
         if isinstance(by, str):
             by = [by]
         return GroupBy(

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -419,6 +419,10 @@ def test_groupby() -> None:
     # assert df.groupby("b").quantile(0.5).shape == (2, 3)
     assert df.groupby("b").agg_list().shape == (2, 3)
 
+    # Invalid input: `by` not specified as a sequence
+    with pytest.raises(TypeError):
+        df.groupby("a", "b")  # type: ignore[arg-type]
+
 
 @pytest.mark.parametrize(
     "stack,exp_shape,exp_columns",


### PR DESCRIPTION
I tried grouping by multiple columns using the following (wrong) syntax:

```
>>>pl.DataFrame({'a': [1, 1, 2], 'b': [4, 5, 6]}).groupby('a', 'b').groups()
shape: (2, 2)
┌─────┬───────────┐
│ a   ┆ groups    │
│ --- ┆ ---       │
│ i64 ┆ list[u32] │
╞═════╪═══════════╡
│ 1   ┆ [0, 1]    │
├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
│ 2   ┆ [2]       │
└─────┴───────────┘
```

It did not give me the expected output, but it turns out the `'b'` is passed as the `maintain_order` argument and it doesn't fail. In `LazyFrame`, this fails as expected:

```
>>>pl.DataFrame({'a': [1, 1, 2], 'b': [4, 5, 6]}).lazy().groupby('a', 'b').groups()
TypeError: argument 'maintain_order': 'str' object cannot be converted to 'PyBool'
```

So I added validation to the `maintain_order` argument, to make sure it is a boolean. Now it will do this:

```
>>>pl.DataFrame({'a': [1, 1, 2], 'b': [4, 5, 6]}).groupby('a', 'b').groups()
TypeError: invalid input for groupby arg `maintain_order`: b.
```

Should be useful for people like myself that come from a Spark background where such syntax is allowed.