### PR TITLE
python: prefer pyarrow when we can memory map the file

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -618,6 +618,14 @@ def scan_ipc(
     # Map legacy arguments to current ones and remove them from kwargs.
     n_rows = kwargs.pop("stop_after_n_rows", n_rows)
 
+    if (
+        _PYARROW_AVAILABLE
+        and row_count_name is None
+        and row_count_offset is None
+        and "*" not in file
+    ):
+        read_ipc(file=file, n_rows=n_rows, use_pyarrow=True, cache=False, rechunk=False)
+
     return LazyFrame.scan_ipc(
         file=file,
         n_rows=n_rows,
@@ -729,7 +737,7 @@ def read_ipc(
     file: str | BinaryIO | BytesIO | Path | bytes,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
-    use_pyarrow: bool = False,
+    use_pyarrow: bool = _PYARROW_AVAILABLE,
     memory_map: bool = True,
     storage_options: dict | None = None,
     row_count_name: str | None = None,

--- a/py-polars/tests/io/test_ipc.py
+++ b/py-polars/tests/io/test_ipc.py
@@ -21,7 +21,7 @@ def test_from_to_buffer(df: pl.DataFrame, compressions: list[str]) -> None:
         buf = io.BytesIO()
         df.write_ipc(buf, compression=compression)  # type: ignore[arg-type]
         buf.seek(0)
-        read_df = pl.read_ipc(buf)
+        read_df = pl.read_ipc(buf, use_pyarrow=False)
         assert_frame_equal_local_categoricals(df, read_df)
 
 
@@ -35,7 +35,7 @@ def test_from_to_file(
         for compression in compressions:
             for f in (str(f_ipc), Path(f_ipc)):
                 df.write_ipc(f, compression=compression)  # type: ignore[arg-type]
-                df_read = pl.read_ipc(f)  # type: ignore[arg-type]
+                df_read = pl.read_ipc(f, use_pyarrow=False)  # type: ignore[arg-type]
                 assert_frame_equal_local_categoricals(df, df_read)
 
 
@@ -134,7 +134,7 @@ def test_glob_ipc(io_test_dir: str) -> None:
     if os.name != "nt":
         path = os.path.join(io_test_dir, "small*.ipc")
         assert pl.scan_ipc(path).collect().shape == (3, 12)
-        assert pl.read_ipc(path).shape == (3, 12)
+        assert pl.read_ipc(path, use_pyarrow=False).shape == (3, 12)
 
 
 def test_from_float16() -> None:
@@ -143,4 +143,4 @@ def test_from_float16() -> None:
     f = io.BytesIO()
     pandas_df.to_feather(f)
     f.seek(0)
-    assert pl.read_ipc(f).dtypes == [pl.Float32]
+    assert pl.read_ipc(f, use_pyarrow=False).dtypes == [pl.Float32]


### PR DESCRIPTION
This change prefers the pyarrow reader because we can memory map the file. This will only trigger an IO read syscall when we actually read the colums, and only the parts that we read.

In lazy we can do projection/predicate pushdown on the memory mapped columns. The columns that will be filtered out never trigger a read call.

Another advantage is that we might be able to work on larger than memory data as the OS will purge pages back that are not used when it needs more RAM.

If the files do easily fit in RAM, we can query from the file system. Subsequent queries on a file may be much faster as the file/or large parts of it can still be in RAM.

I have some ideas for being able to do this natively as well. Might follow up on that.