### PR TITLE
reduce supertype match by calling twice/ allow Some(tz)/None supertype

### DIFF
--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -417,369 +417,243 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Result<DataType> {
 
 /// Given two datatypes, determine the supertype that both types can safely be cast to
 fn _get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
-    use DataType::*;
-    if l == r {
-        return Some(l.clone());
+    fn inner(l: &DataType, r: &DataType) -> Option<DataType> {
+        use DataType::*;
+        if l == r {
+            return Some(l.clone());
+        }
+
+        match (l, r) {
+            #[cfg(feature = "dtype-i8")]
+            (Int8, Boolean) => Some(Int8),
+            //(Int8, Int8) => Some(Int8),
+            #[cfg(all(feature = "dtype-i8", feature = "dtype-i16"))]
+            (Int8, Int16) => Some(Int16),
+            #[cfg(feature = "dtype-i8")]
+            (Int8, Int32) => Some(Int32),
+            #[cfg(feature = "dtype-i8")]
+            (Int8, Int64) => Some(Int64),
+            #[cfg(all(feature = "dtype-i8", feature = "dtype-i16"))]
+            (Int8, UInt8) => Some(Int16),
+            #[cfg(all(feature = "dtype-i8", feature = "dtype-u16"))]
+            (Int8, UInt16) => Some(Int32),
+            #[cfg(feature = "dtype-i8")]
+            (Int8, UInt32) => Some(Int64),
+            #[cfg(feature = "dtype-i8")]
+            (Int8, UInt64) => Some(Float64), // Follow numpy
+            #[cfg(feature = "dtype-i8")]
+            (Int8, Float32) => Some(Float32),
+            #[cfg(feature = "dtype-i8")]
+            (Int8, Float64) => Some(Float64),
+
+            #[cfg(feature = "dtype-i16")]
+            (Int16, Boolean) => Some(Int16),
+            #[cfg(all(feature = "dtype-i16", feature = "dtype-i8"))]
+            (Int16, Int8) => Some(Int16),
+            //(Int16, Int16) => Some(Int16),
+            #[cfg(feature = "dtype-i16")]
+            (Int16, Int32) => Some(Int32),
+            #[cfg(feature = "dtype-i16")]
+            (Int16, Int64) => Some(Int64),
+            #[cfg(all(feature = "dtype-i16", feature = "dtype-u8"))]
+            (Int16, UInt8) => Some(Int16),
+            #[cfg(all(feature = "dtype-i16", feature = "dtype-u16"))]
+            (Int16, UInt16) => Some(Int32),
+            #[cfg(feature = "dtype-i16")]
+            (Int16, UInt32) => Some(Int64),
+            #[cfg(feature = "dtype-i16")]
+            (Int16, UInt64) => Some(Float64), // Follow numpy
+            #[cfg(feature = "dtype-i16")]
+            (Int16, Float32) => Some(Float32),
+            #[cfg(feature = "dtype-i16")]
+            (Int16, Float64) => Some(Float64),
+
+            (Int32, Boolean) => Some(Int32),
+            #[cfg(feature = "dtype-i8")]
+            (Int32, Int8) => Some(Int32),
+            #[cfg(feature = "dtype-i16")]
+            (Int32, Int16) => Some(Int32),
+            //(Int32, Int32) => Some(Int32),
+            (Int32, Int64) => Some(Int64),
+            #[cfg(feature = "dtype-u8")]
+            (Int32, UInt8) => Some(Int32),
+            #[cfg(feature = "dtype-u16")]
+            (Int32, UInt16) => Some(Int32),
+            (Int32, UInt32) => Some(Int64),
+            #[cfg(not(feature = "bigidx"))]
+            (Int32, UInt64) => Some(Float64), // Follow numpy
+            #[cfg(feature = "bigidx")]
+            (Int32, UInt64) => Some(Int64), // Needed for bigidx
+            (Int32, Float32) => Some(Float64), // Follow numpy
+            (Int32, Float64) => Some(Float64),
+
+            (Int64, Boolean) => Some(Int64),
+            #[cfg(feature = "dtype-i8")]
+            (Int64, Int8) => Some(Int64),
+            #[cfg(feature = "dtype-i16")]
+            (Int64, Int16) => Some(Int64),
+            (Int64, Int32) => Some(Int64),
+            //(Int64, Int64) => Some(Int64),
+            #[cfg(feature = "dtype-u8")]
+            (Int64, UInt8) => Some(Int64),
+            #[cfg(feature = "dtype-u16")]
+            (Int64, UInt16) => Some(Int64),
+            (Int64, UInt32) => Some(Int64),
+            #[cfg(not(feature = "bigidx"))]
+            (Int64, UInt64) => Some(Float64), // Follow numpy
+            #[cfg(feature = "bigidx")]
+            (Int64, UInt64) => Some(Int64), // Needed for bigidx
+            (Int64, Float32) => Some(Float64), // Follow numpy
+            (Int64, Float64) => Some(Float64),
+
+            #[cfg(all(feature = "dtype-u16", feature = "dtype-u8"))]
+            (UInt16, UInt8) => Some(UInt16),
+            #[cfg(feature = "dtype-u16")]
+            (UInt16, UInt32) => Some(UInt32),
+            #[cfg(feature = "dtype-u16")]
+            (UInt16, UInt64) => Some(UInt64),
+
+            #[cfg(feature = "dtype-u8")]
+            (UInt8, UInt32) => Some(UInt32),
+            #[cfg(feature = "dtype-u8")]
+            (UInt8, UInt64) => Some(UInt64),
+
+            (UInt32, UInt64) => Some(UInt64),
+
+            #[cfg(feature = "dtype-u8")]
+            (Float32, UInt8) => Some(Float32),
+            #[cfg(feature = "dtype-u16")]
+            (Float32, UInt16) => Some(Float32),
+            (Float32, UInt32) => Some(Float64),
+            (Float32, UInt64) => Some(Float64),
+
+            #[cfg(feature = "dtype-u8")]
+            (Float64, UInt8) => Some(Float64),
+            #[cfg(feature = "dtype-u16")]
+            (Float64, UInt16) => Some(Float64),
+            (Float64, UInt32) => Some(Float64),
+            (Float64, UInt64) => Some(Float64),
+
+            (Float64, Float32) => Some(Float64),
+
+            // Time related dtypes
+            #[cfg(feature = "dtype-date")]
+            (Date, UInt32) => Some(Int64),
+            #[cfg(feature = "dtype-date")]
+            (Date, UInt64) => Some(Int64),
+            #[cfg(feature = "dtype-date")]
+            (Date, Int32) => Some(Int32),
+            #[cfg(feature = "dtype-date")]
+            (Date, Int64) => Some(Int64),
+            #[cfg(feature = "dtype-date")]
+            (Date, Float32) => Some(Float32),
+            #[cfg(feature = "dtype-date")]
+            (Date, Float64) => Some(Float64),
+            #[cfg(all(feature = "dtype-date", feature = "dtype-datetime"))]
+            (Date, Datetime(tu, tz)) => Some(Datetime(*tu, tz.clone())),
+
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), UInt32) => Some(Int64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), UInt64) => Some(Int64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), Int32) => Some(Int64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), Int64) => Some(Int64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), Float32) => Some(Float64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(_, _), Float64) => Some(Float64),
+            #[cfg(all(feature = "dtype-datetime", feature = "dtype=date"))]
+            (Datetime(tu, tz), Date) => Some(Datetime(*tu, tz.clone())),
+
+            (Boolean, Float32) => Some(Float32),
+            (Boolean, Float64) => Some(Float64),
+
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), UInt32) => Some(Int64),
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), UInt64) => Some(Int64),
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), Int32) => Some(Int64),
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), Int64) => Some(Int64),
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), Float32) => Some(Float64),
+            #[cfg(feature = "dtype-duration")]
+            (Duration(_), Float64) => Some(Float64),
+
+            #[cfg(feature = "dtype-time")]
+            (Time, Int32) => Some(Int64),
+            #[cfg(feature = "dtype-time")]
+            (Time, Int64) => Some(Int64),
+            #[cfg(feature = "dtype-time")]
+            (Time, Float32) => Some(Float64),
+            #[cfg(feature = "dtype-time")]
+            (Time, Float64) => Some(Float64),
+
+            #[cfg(all(feature = "dtype-time", feature = "dtype-datetime"))]
+            (Time, Datetime(_, _)) => Some(Int64),
+            #[cfg(all(feature = "dtype-datetime", feature = "dtype-time"))]
+            (Datetime(_, _), Time) => Some(Int64),
+            #[cfg(all(feature = "dtype-time", feature = "dtype-date"))]
+            (Time, Date) => Some(Int64),
+            #[cfg(all(feature = "dtype-date", feature = "dtype-time"))]
+            (Date, Time) => Some(Int64),
+
+            // everything can be cast to a string
+            (_, Utf8) => Some(Utf8),
+
+            (dt, Null) => Some(dt.clone()),
+            (Null, dt) => Some(dt.clone()),
+
+            #[cfg(all(feature = "dtype-duration", feature = "dtype-datetime"))]
+            (Duration(lu), Datetime(ru, Some(tz))) | (Datetime(lu, Some(tz)), Duration(ru)) => {
+                if tz.is_empty() {
+                    Some(Datetime(get_time_units(lu, ru), None))
+                } else {
+                    Some(Datetime(get_time_units(lu, ru), Some(tz.clone())))
+                }
+            }
+            #[cfg(all(feature = "dtype-duration", feature = "dtype-datetime"))]
+            (Duration(lu), Datetime(ru, None)) | (Datetime(lu, None), Duration(ru)) => {
+                Some(Datetime(get_time_units(lu, ru), None))
+            }
+            #[cfg(all(feature = "dtype-duration", feature = "dtype-date"))]
+            (Duration(_), Date) | (Date, Duration(_)) => {
+                Some(Datetime(TimeUnit::Milliseconds, None))
+            }
+            #[cfg(feature = "dtype-duration")]
+            (Duration(lu), Duration(ru)) => Some(Duration(get_time_units(lu, ru))),
+
+            // None and Some("") timezones
+            // we cast from more precision to higher precision as that always fits with occasional loss of precision
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r))
+                if (tz_l.is_none() || tz_l.as_deref() == Some(""))
+                    && (tz_r.is_none() || tz_r.as_deref() == Some("")) =>
+            {
+                let tu = get_time_units(tu_l, tu_r);
+                Some(Datetime(tu, None))
+            }
+            // None and Some("<tz>") timezones
+            // we cast from more precision to higher precision as that always fits with occasional loss of precision
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r)) if tz_l.is_none() && tz_r.is_some() => {
+                let tu = get_time_units(tu_l, tu_r);
+                Some(Datetime(tu, tz_r.clone()))
+            }
+            (List(inner), other) | (other, List(inner)) => {
+                let st = _get_supertype(inner, other)?;
+                Some(DataType::List(Box::new(st)))
+            }
+            _ => None,
+        }
     }
 
-    match (l, r) {
-        #[cfg(feature = "dtype-i8")]
-        (Int8, Boolean) => Some(Int8),
-        //(Int8, Int8) => Some(Int8),
-        #[cfg(all(feature = "dtype-i8", feature = "dtype-i16"))]
-        (Int8, Int16) => Some(Int16),
-        #[cfg(feature = "dtype-i8")]
-        (Int8, Int32) => Some(Int32),
-        #[cfg(feature = "dtype-i8")]
-        (Int8, Int64) => Some(Int64),
-        #[cfg(all(feature = "dtype-i8", feature = "dtype-i16"))]
-        (Int8, UInt8) => Some(Int16),
-        #[cfg(all(feature = "dtype-i8", feature = "dtype-u16"))]
-        (Int8, UInt16) => Some(Int32),
-        #[cfg(feature = "dtype-i8")]
-        (Int8, UInt32) => Some(Int64),
-        #[cfg(feature = "dtype-i8")]
-        (Int8, UInt64) => Some(Float64), // Follow numpy
-        #[cfg(feature = "dtype-i8")]
-        (Int8, Float32) => Some(Float32),
-        #[cfg(feature = "dtype-i8")]
-        (Int8, Float64) => Some(Float64),
-
-        #[cfg(feature = "dtype-i16")]
-        (Int16, Boolean) => Some(Int16),
-        #[cfg(all(feature = "dtype-i16", feature = "dtype-i8"))]
-        (Int16, Int8) => Some(Int16),
-        //(Int16, Int16) => Some(Int16),
-        #[cfg(feature = "dtype-i16")]
-        (Int16, Int32) => Some(Int32),
-        #[cfg(feature = "dtype-i16")]
-        (Int16, Int64) => Some(Int64),
-        #[cfg(all(feature = "dtype-i16", feature = "dtype-u8"))]
-        (Int16, UInt8) => Some(Int16),
-        #[cfg(all(feature = "dtype-i16", feature = "dtype-u16"))]
-        (Int16, UInt16) => Some(Int32),
-        #[cfg(feature = "dtype-i16")]
-        (Int16, UInt32) => Some(Int64),
-        #[cfg(feature = "dtype-i16")]
-        (Int16, UInt64) => Some(Float64), // Follow numpy
-        #[cfg(feature = "dtype-i16")]
-        (Int16, Float32) => Some(Float32),
-        #[cfg(feature = "dtype-i16")]
-        (Int16, Float64) => Some(Float64),
-
-        (Int32, Boolean) => Some(Int32),
-        #[cfg(feature = "dtype-i8")]
-        (Int32, Int8) => Some(Int32),
-        #[cfg(feature = "dtype-i16")]
-        (Int32, Int16) => Some(Int32),
-        //(Int32, Int32) => Some(Int32),
-        (Int32, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-u8")]
-        (Int32, UInt8) => Some(Int32),
-        #[cfg(feature = "dtype-u16")]
-        (Int32, UInt16) => Some(Int32),
-        (Int32, UInt32) => Some(Int64),
-        #[cfg(not(feature = "bigidx"))]
-        (Int32, UInt64) => Some(Float64), // Follow numpy
-        #[cfg(feature = "bigidx")]
-        (Int32, UInt64) => Some(Int64), // Needed for bigidx
-        (Int32, Float32) => Some(Float64), // Follow numpy
-        (Int32, Float64) => Some(Float64),
-
-        (Int64, Boolean) => Some(Int64),
-        #[cfg(feature = "dtype-i8")]
-        (Int64, Int8) => Some(Int64),
-        #[cfg(feature = "dtype-i16")]
-        (Int64, Int16) => Some(Int64),
-        (Int64, Int32) => Some(Int64),
-        //(Int64, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-u8")]
-        (Int64, UInt8) => Some(Int64),
-        #[cfg(feature = "dtype-u16")]
-        (Int64, UInt16) => Some(Int64),
-        (Int64, UInt32) => Some(Int64),
-        #[cfg(not(feature = "bigidx"))]
-        (Int64, UInt64) => Some(Float64), // Follow numpy
-        #[cfg(feature = "bigidx")]
-        (Int64, UInt64) => Some(Int64), // Needed for bigidx
-        (Int64, Float32) => Some(Float64), // Follow numpy
-        (Int64, Float64) => Some(Float64),
-
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, Boolean) => Some(UInt8),
-        #[cfg(all(feature = "dtype-u8", feature = "dtype-i8"))]
-        (UInt8, Int8) => Some(Int16),
-        #[cfg(all(feature = "dtype-u8", feature = "dtype-i16"))]
-        (UInt8, Int16) => Some(Int16),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, Int32) => Some(Int32),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, Int64) => Some(Int64),
-        //(UInt8, UInt8) => Some(UInt8),
-        #[cfg(all(feature = "dtype-u8", feature = "dtype-u16"))]
-        (UInt8, UInt16) => Some(UInt16),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, UInt32) => Some(UInt32),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, UInt64) => Some(UInt64),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, Float32) => Some(Float32),
-        #[cfg(feature = "dtype-u8")]
-        (UInt8, Float64) => Some(Float64),
-
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Boolean) => Some(UInt16),
-        #[cfg(all(feature = "dtype-u16", feature = "dtype-i8"))]
-        (UInt16, Int8) => Some(Int32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Int16) => Some(Int32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Int32) => Some(Int32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Int64) => Some(Int64),
-        #[cfg(all(feature = "dtype-u16", feature = "dtype-u8"))]
-        (UInt16, UInt8) => Some(UInt16),
-        //(UInt16, UInt16) => Some(UInt16),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, UInt32) => Some(UInt32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, UInt64) => Some(UInt64),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Float32) => Some(Float32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt16, Float64) => Some(Float64),
-
-        (UInt32, Boolean) => Some(UInt32),
-        #[cfg(feature = "dtype-i8")]
-        (UInt32, Int8) => Some(Int64),
-        #[cfg(feature = "dtype-i16")]
-        (UInt32, Int16) => Some(Int64),
-        (UInt32, Int32) => Some(Int64),
-        (UInt32, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-u8")]
-        (UInt32, UInt8) => Some(UInt32),
-        #[cfg(feature = "dtype-u16")]
-        (UInt32, UInt16) => Some(UInt32),
-        //(UInt32, UInt32) => Some(UInt32),
-        (UInt32, UInt64) => Some(UInt64),
-        (UInt32, Float32) => Some(Float64), // Follow numpy
-        (UInt32, Float64) => Some(Float64),
-
-        (UInt64, Boolean) => Some(UInt64),
-        #[cfg(feature = "dtype-i8")]
-        (UInt64, Int8) => Some(Float64), // Follow numpy
-        #[cfg(feature = "dtype-i16")]
-        (UInt64, Int16) => Some(Float64), // Follow numpy
-        #[cfg(not(feature = "bigidx"))]
-        (UInt64, Int32) => Some(Float64), // Follow numpy
-        #[cfg(feature = "bigidx")]
-        (UInt64, Int32) => Some(Int64), // Needed for bigidx
-        #[cfg(not(feature = "bigidx"))]
-        (UInt64, Int64) => Some(Float64), // Follow numpy
-        #[cfg(feature = "bigidx")]
-        (UInt64, Int64) => Some(Int64), // Needed for bigidx
-        #[cfg(feature = "dtype-u8")]
-        (UInt64, UInt8) => Some(UInt64),
-        #[cfg(feature = "dtype-u16")]
-        (UInt64, UInt16) => Some(UInt64),
-        (UInt64, UInt32) => Some(UInt64),
-        //(UInt64, UInt64) => Some(UInt64),
-        (UInt64, Float32) => Some(Float64), // Follow numpy
-        (UInt64, Float64) => Some(Float64),
-
-        (Float32, Boolean) => Some(Float32),
-        #[cfg(feature = "dtype-i8")]
-        (Float32, Int8) => Some(Float32),
-        #[cfg(feature = "dtype-i16")]
-        (Float32, Int16) => Some(Float32),
-        (Float32, Int32) => Some(Float64),
-        (Float32, Int64) => Some(Float64),
-        #[cfg(feature = "dtype-u8")]
-        (Float32, UInt8) => Some(Float32),
-        #[cfg(feature = "dtype-u16")]
-        (Float32, UInt16) => Some(Float32),
-        (Float32, UInt32) => Some(Float64),
-        (Float32, UInt64) => Some(Float64),
-        //(Float32, Float32) => Some(Float32),
-        (Float32, Float64) => Some(Float64),
-
-        (Float64, Boolean) => Some(Float64),
-        #[cfg(feature = "dtype-i8")]
-        (Float64, Int8) => Some(Float64),
-        #[cfg(feature = "dtype-i16")]
-        (Float64, Int16) => Some(Float64),
-        (Float64, Int32) => Some(Float64),
-        (Float64, Int64) => Some(Float64),
-        #[cfg(feature = "dtype-u8")]
-        (Float64, UInt8) => Some(Float64),
-        #[cfg(feature = "dtype-u16")]
-        (Float64, UInt16) => Some(Float64),
-        (Float64, UInt32) => Some(Float64),
-        (Float64, UInt64) => Some(Float64),
-        (Float64, Float32) => Some(Float64),
-        //(Float64, Float64) => Some(Float64),
-
-        // Time related dtypes
-        #[cfg(feature = "dtype-date")]
-        (UInt32, Date) => Some(Int64),
-        #[cfg(feature = "dtype-datetime")]
-        (UInt32, Datetime(_, _)) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (UInt32, Duration(_)) => Some(Int64),
-        #[cfg(feature = "dtype-time")]
-        (UInt32, Time) => Some(Int64),
-
-        #[cfg(feature = "dtype-date")]
-        (Int32, Date) => Some(Int32),
-        #[cfg(feature = "dtype-datetime")]
-        (Int32, Datetime(_, _)) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Int32, Duration(_)) => Some(Int64),
-        #[cfg(feature = "dtype-time")]
-        (Int32, Time) => Some(Int64),
-
-        #[cfg(feature = "dtype-datetime")]
-        (Int64, Datetime(_, _)) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Int64, Duration(_)) => Some(Int64),
-        #[cfg(feature = "dtype-date")]
-        (Int64, Date) => Some(Int64),
-        #[cfg(feature = "dtype-time")]
-        (Int64, Time) => Some(Int64),
-
-        #[cfg(feature = "dtype-date")]
-        (Float32, Date) => Some(Float32),
-        #[cfg(feature = "dtype-datetime")]
-        (Float32, Datetime(_, _)) => Some(Float64),
-        #[cfg(feature = "dtype-duration")]
-        (Float32, Duration(_)) => Some(Float64),
-        #[cfg(feature = "dtype-time")]
-        (Float32, Time) => Some(Float64),
-
-        #[cfg(feature = "dtype-date")]
-        (Float64, Date) => Some(Float64),
-        #[cfg(feature = "dtype-datetime")]
-        (Float64, Datetime(_, _)) => Some(Float64),
-        #[cfg(feature = "dtype-duration")]
-        (Float64, Duration(_)) => Some(Float64),
-        #[cfg(feature = "dtype-time")]
-        (Float64, Time) => Some(Float64),
-
-        #[cfg(feature = "dtype-date")]
-        (Date, UInt32) => Some(Int64),
-        #[cfg(feature = "dtype-date")]
-        (Date, UInt64) => Some(Int64),
-        #[cfg(feature = "dtype-date")]
-        (Date, Int32) => Some(Int32),
-        #[cfg(feature = "dtype-date")]
-        (Date, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-date")]
-        (Date, Float32) => Some(Float32),
-        #[cfg(feature = "dtype-date")]
-        (Date, Float64) => Some(Float64),
-        #[cfg(all(feature = "dtype-date", feature = "dtype-datetime"))]
-        (Date, Datetime(tu, tz)) => Some(Datetime(*tu, tz.clone())),
-
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), UInt32) => Some(Int64),
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), UInt64) => Some(Int64),
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), Int32) => Some(Int64),
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), Int64) => Some(Int64),
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), Float32) => Some(Float64),
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), Float64) => Some(Float64),
-        #[cfg(all(feature = "dtype-datetime", feature = "dtype=date"))]
-        (Datetime(tu, tz), Date) => Some(Datetime(*tu, tz.clone())),
-
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), UInt32) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), UInt64) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), Int32) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), Int64) => Some(Int64),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), Float32) => Some(Float64),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(_), Float64) => Some(Float64),
-
-        #[cfg(feature = "dtype-time")]
-        (Time, Int32) => Some(Int64),
-        #[cfg(feature = "dtype-time")]
-        (Time, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-time")]
-        (Time, Float32) => Some(Float64),
-        #[cfg(feature = "dtype-time")]
-        (Time, Float64) => Some(Float64),
-
-        #[cfg(all(feature = "dtype-time", feature = "dtype-datetime"))]
-        (Time, Datetime(_, _)) => Some(Int64),
-        #[cfg(all(feature = "dtype-datetime", feature = "dtype-time"))]
-        (Datetime(_, _), Time) => Some(Int64),
-        #[cfg(all(feature = "dtype-time", feature = "dtype-date"))]
-        (Time, Date) => Some(Int64),
-        #[cfg(all(feature = "dtype-date", feature = "dtype-time"))]
-        (Date, Time) => Some(Int64),
-
-        (Utf8, _) => Some(Utf8),
-        (_, Utf8) => Some(Utf8),
-
-        (Boolean, Boolean) => Some(Boolean),
-        #[cfg(feature = "dtype-i8")]
-        (Boolean, Int8) => Some(Int8),
-        #[cfg(feature = "dtype-i16")]
-        (Boolean, Int16) => Some(Int16),
-        (Boolean, Int32) => Some(Int32),
-        (Boolean, Int64) => Some(Int64),
-        #[cfg(feature = "dtype-u8")]
-        (Boolean, UInt8) => Some(UInt8),
-        #[cfg(feature = "dtype-u16")]
-        (Boolean, UInt16) => Some(UInt16),
-        (Boolean, UInt32) => Some(UInt32),
-        (Boolean, UInt64) => Some(UInt64),
-        (Boolean, Float32) => Some(Float32),
-        (Boolean, Float64) => Some(Float64),
-
-        (dt, Null) => Some(dt.clone()),
-        (Null, dt) => Some(dt.clone()),
-
-        #[cfg(all(feature = "dtype-duration", feature = "dtype-datetime"))]
-        (Duration(lu), Datetime(ru, Some(tz))) | (Datetime(lu, Some(tz)), Duration(ru)) => {
-            if tz.is_empty() {
-                Some(Datetime(get_time_units(lu, ru), None))
-            } else {
-                Some(Datetime(get_time_units(lu, ru), Some(tz.clone())))
-            }
-        }
-        #[cfg(all(feature = "dtype-duration", feature = "dtype-datetime"))]
-        (Duration(lu), Datetime(ru, None)) | (Datetime(lu, None), Duration(ru)) => {
-            Some(Datetime(get_time_units(lu, ru), None))
-        }
-        #[cfg(all(feature = "dtype-duration", feature = "dtype-date"))]
-        (Duration(_), Date) | (Date, Duration(_)) => Some(Datetime(TimeUnit::Milliseconds, None)),
-        #[cfg(feature = "dtype-duration")]
-        (Duration(lu), Duration(ru)) => Some(Duration(get_time_units(lu, ru))),
-
-        // None and Some("") timezones
-        // we cast from more precision to higher precision as that always fits with occasional loss of precision
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r))
-            if (tz_l.is_none() || tz_l.as_deref() == Some(""))
-                && (tz_r.is_none() || tz_r.as_deref() == Some("")) =>
-        {
-            let tu = get_time_units(tu_l, tu_r);
-            Some(Datetime(tu, None))
-        }
-        (List(inner), other) | (other, List(inner)) => {
-            let st = _get_supertype(inner, other)?;
-            Some(DataType::List(Box::new(st)))
-        }
-        _ => None,
+    match inner(l, r) {
+        Some(dt) => Some(dt),
+        None => inner(r, l),
     }
 }
 

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -1240,3 +1240,19 @@ def test_sum_duration() -> None:
         "duration": [timedelta(seconds=150)],
         "sec": [150],
     }
+
+
+def test_supertype_timezones_4174() -> None:
+    df = pl.DataFrame(
+        {
+            "dt": pl.date_range(datetime(2020, 3, 1), datetime(2020, 5, 1), "1mo"),
+        }
+    ).with_columns(
+        [
+            pl.col("dt").dt.with_time_zone("Europe/London").suffix("_London"),
+        ]
+    )
+
+    # test if this runs without error
+    date_to_fill = df["dt_London"][0]
+    df["dt_London"] = df["dt_London"].shift_and_fill(1, date_to_fill)


### PR DESCRIPTION
Fixes #4174

This still imports datetimes as naive datetime because it is very expensive to clone all the timezone information. However, we now do allow for naive datetimes as arguments to arrays with timezones. Which prevents the issue occurring in #4174