### PR TITLE
Small fixes in type formatting

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1416,10 +1416,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self,
         file: str | Path | BytesIO,
         *,
-        compression: None
-        | (
+        compression: (
             Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
             | str
+            | None
         ) = "lz4",
         compression_level: int | None = None,
         statistics: bool = False,
@@ -1509,10 +1509,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def to_parquet(
         self,
         file: str | Path | BytesIO,
-        compression: None
-        | (
+        compression: (
             Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
             | str
+            | None
         ) = "snappy",
         statistics: bool = False,
         use_pyarrow: bool = False,

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -65,7 +65,7 @@ else:
 
 
 def col(
-    name: (str | list[str] | Sequence[PolarsDataType] | pli.Series | PolarsDataType),
+    name: str | list[str] | Sequence[PolarsDataType] | pli.Series | PolarsDataType,
 ) -> pli.Expr:
     """
     Return an expression representing a column in a DataFrame.
@@ -603,7 +603,7 @@ def tail(column: str | pli.Series, n: int | None = None) -> pli.Expr | pli.Serie
 
 
 def lit(
-    value: None | (float | int | str | date | datetime | pli.Series | np.ndarray | Any),
+    value: float | int | str | date | datetime | pli.Series | np.ndarray | Any | None,
     dtype: type[DataType] | None = None,
 ) -> pli.Expr:
     """


### PR DESCRIPTION
Having upgraded the type hints using `pyupgrade`, some of the types ended up having weird formatting.

This PR fixes the formatting of a few type hints. No changes to the type hints themselves.