### PR TITLE
Update build versions

### DIFF
--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -10,36 +10,29 @@ pytz
 types-pytz
 
 # Tooling
-maturin==0.13.0
+maturin==0.13.1
 pytest==7.1.2
 pytest-cov[toml]==3.0.0
-hypothesis==6.49.1
-black==22.3.0
-blackdoc==0.3.4
-isort~=5.10.1
+hypothesis==6.53.0
+black==22.6.0
+blackdoc==0.3.5
+isort==5.10.1
 mypy==0.961
-ghp-import==2.1.0
-flake8==4.0.1
+flake8==5.0.0
 flake8-bugbear==22.7.1
 flake8-docstrings==1.6.0
-sphinx==4.2.0
-pydata-sphinx-theme==0.6.3
-sphinx-panels==0.6.0
+ghp-import==2.1.0
+Sphinx==5.1.1
+pydata-sphinx-theme==0.9.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-sphinxcontrib-napoleon
+sphinxcontrib-napoleon==0.7
 commonmark==0.9.1
-numpydoc==1.3.1
+numpydoc==1.4.0
 
 # Stub files
-pandas-stubs==1.2.0.61
-
-
-# pinned third rate deps
-# to be removed later
-click==8.0.4
-
+pandas-stubs==1.4.3.220724

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -39,7 +39,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
-    "sphinx_panels",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
There are new black, mypy, and flake8 versions. I thought it was worth doing a version upgrade across the board.

Changes:
* Removed the `sphinx-panels` dependency, as it requires Sphinx<5 so it was not compatible. I checked, and it seems like we aren't using the panels functionality anywhere.
* Not sure why `click` was pinned - I removed it