### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ venv/
 coverage.lcov
 coverage.xml
 .DS_Store
+.python-version

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1164,6 +1164,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
 
         Examples
         --------
+        >>> import pathlib
+        >>>
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3, 4, 5],
@@ -1171,7 +1173,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ...         "ham": ["a", "b", "c", "d", "e"],
         ...     }
         ... )
-        >>> df.write_csv("new_file.csv", sep=",")
+        >>> path: pathlib.Path = dirpath / "new_file.csv"
+        >>> df.write_csv(path, sep=",")
 
         """
         if len(sep) > 1:

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -505,6 +505,8 @@ def scan_csv(
 
     Examples
     --------
+    >>> import pathlib
+    >>>
     >>> (
     ...     pl.scan_csv("my_long_file.csv")  # lazy, doesn't do a thing
     ...     .select(
@@ -521,9 +523,10 @@ def scan_csv(
     >>> df = pl.DataFrame(
     ...     {"BrEeZaH": [1, 2, 3, 4], "LaNgUaGe": ["is", "terrible", "to", "read"]}
     ... )
-    >>> df.to_csv("mydf.csv")
+    >>> path: pathlib.Path = dirpath / "mydf.csv"
+    >>> df.to_csv(path)
     >>> pl.scan_csv(
-    ...     "mydf.csv", with_column_names=lambda cols: [col.lower() for col in cols]
+    ...     path, with_column_names=lambda cols: [col.lower() for col in cols]
     ... ).fetch()
     shape: (4, 2)
     ┌─────────┬──────────┐

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -337,11 +337,11 @@ if HYPOTHESIS_INSTALLED:
         UInt32: integers(min_value=0, max_value=(2**32) - 1),
         UInt64: integers(min_value=0, max_value=(2**64) - 1),
         # TODO: when generating text for categorical, ensure there are repeats -
-        # don't want all to be unique.
+        #  don't want all to be unique.
         Categorical: text(),
         Utf8: text(),
         # TODO: generate arrow temporal types with different resolution (32/64) to
-        # validate compatibility.
+        #  validate compatibility.
         Time: times(),
         Date: dates(),
         Duration: timedeltas(),
@@ -592,7 +592,6 @@ if HYPOTHESIS_INSTALLED:
         >>> @given(df=series())
         ... def test_repr(s: pl.Series) -> None:
         ...     assert isinstance(repr(s), str)
-        ...     # print(s)
         >>>
         >>> s = series(dtype=pl.Int32, max_size=5)
         >>> s.example()  # doctest: +SKIP
@@ -748,7 +747,6 @@ if HYPOTHESIS_INSTALLED:
         >>> @given(df=dataframes())
         ... def test_repr(df: pl.DataFrame) -> None:
         ...     assert isinstance(repr(df), str)
-        ...     # print(df)
         >>>
         >>> # generate LazyFrames with at least 1 column, random dtypes, and specific size:
         >>> df = dataframes(min_cols=1, lazy=True, max_size=5)

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------
-# Validate DataFrame behaviour with parameteric tests
+# Validate DataFrame behaviour with parametric tests
 # ----------------------------------------------------
 from __future__ import annotations
 
@@ -14,7 +14,6 @@ from polars.testing import assert_frame_equal, column, dataframes
 def test_repr(df: pl.DataFrame) -> None:
     assert isinstance(repr(df), str)
     assert_frame_equal(df, df, check_exact=True)
-    # print(df)
 
 
 @given(df=dataframes(min_size=1, min_cols=1, max_size=10, null_probability=0.25))
@@ -29,7 +28,6 @@ def test_null_count(df: pl.DataFrame) -> None:
         assert null_count.shape == (1, ncols)
         for idx, count in enumerate(null_count.rows()[0]):
             assert count == sum(v is None for v in df.select_at_idx(idx).to_list())
-    print(null_count.rows())
 
 
 @given(

--- a/py-polars/tests_parametric/test_series.py
+++ b/py-polars/tests_parametric/test_series.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------
-# Validate Series behaviour with parameteric tests
+# Validate Series behaviour with parametric tests
 # -------------------------------------------------
 from __future__ import annotations
 


### PR DESCRIPTION
This MR addresses a few relatively minor issues

1. Adds `.python-version` to the `.gitignore`. This file is generated by users who employ `pyenv` for environment management. 
2. It makes several cosmetic changes, including fixing typos, removing various `print` statments, and adding white space to a few comments (this helps PyCharm  with comment highlighting).
3. Previously, `python tests/run_doc_examples.py ` generated two artifacts: `mydf.csv` and `new_file.csv`. This MR saves those files to a temporary directory, so there are no leftover artifacts.