### PR TITLE
Upgrade black, blackdoc, mypy, flake8

### DIFF
--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -12,14 +12,14 @@ types-pytz
 # Tooling
 maturin==0.13.0
 pytest==7.1.2
-pytest-cov[toml]==3.0.0
+pytest-cov==3.0.0
 hypothesis==6.49.1
-black==22.3.0
-blackdoc==0.3.4
+black==22.6.0
+blackdoc==0.3.5
 isort~=5.10.1
-mypy==0.961
+mypy==0.971
 ghp-import==2.1.0
-flake8==4.0.1
+flake8==5.0.2
 flake8-bugbear==22.7.1
 flake8-comprehensions==3.10.0
 flake8-docstrings==1.6.0


### PR DESCRIPTION
This MR upgrades several toolchain dependencies
- `black`
- `blackdoc`
- `mypy`
- `flake8`

It also removes the `[toml]` option from `pytest-cov`, which no longer exists.

```
WARNING: pytest-cov 3.0.0 does not provide the extra 'toml'
```

EDIT: If this gets merged, we may want to send out a message on Discord so people can pull the new requirements file and upgrade their development environment.