### PR TITLE
feat(python): Display struct field's name and dtype

### DIFF
--- a/polars/polars-core/src/config.rs
+++ b/polars/polars-core/src/config.rs
@@ -2,6 +2,7 @@
 pub(crate) const FMT_MAX_COLS: &str = "POLARS_FMT_MAX_COLS";
 pub(crate) const FMT_MAX_ROWS: &str = "POLARS_FMT_MAX_ROWS";
 pub(crate) const FMT_STR_LEN: &str = "POLARS_FMT_STR_LEN";
+pub(crate) const FMT_STRUCT_DATA_TYPE: &str = "POLARS_FMT_STRUCT_DATA_TYPE";
 pub(crate) const FMT_TABLE_CELL_ALIGNMENT: &str = "POLARS_FMT_TABLE_CELL_ALIGNMENT";
 pub(crate) const FMT_TABLE_DATAFRAME_SHAPE_BELOW: &str = "POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW";
 pub(crate) const FMT_TABLE_FORMATTING: &str = "POLARS_FMT_TABLE_FORMATTING";

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::*;
+use crate::config::FMT_STRUCT_DATA_TYPE;
 
 pub type TimeZone = String;
 

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::config::FMT_STRUCT_DATA_TYPE;
+use crate::fmt::env_is_true;
 
 pub type TimeZone = String;
 
@@ -250,10 +251,6 @@ impl PartialEq<ArrowDataType> for DataType {
         let dt: DataType = other.into();
         self == &dt
     }
-}
-
-fn env_is_true(varname: &str) -> bool {
-    std::env::var(varname).as_deref().unwrap_or("0") == "1"
 }
 
 impl Display for DataType {

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -285,7 +285,13 @@ impl Display for DataType {
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => "cat",
             #[cfg(feature = "dtype-struct")]
-            DataType::Struct(fields) => return write!(f, "struct[{}]", fields.len()),
+            DataType::Struct(fields) => {
+                writeln!(f, "Struct:",);
+                for field in fields {
+                    writeln!(f, "|-- {}: {} ", field.name, field.dtype);
+                }
+                return Ok(());
+            }
             DataType::Unknown => unreachable!(),
         };
         f.write_str(s)

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -331,7 +331,7 @@ fn prepare_row(
     row_str
 }
 
-fn env_is_true(varname: &str) -> bool {
+pub fn env_is_true(varname: &str) -> bool {
     std::env::var(varname).as_deref().unwrap_or("0") == "1"
 }
 

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -280,6 +280,38 @@ class Config:
         return cls
 
     @classmethod
+    def set_fmt_struct_data_type(cls, active: bool = True) -> type[Config]:
+        """
+        Displays all fields (name, dtype) of struct dtype.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({
+            "a": ["A", "AA"],
+            "b": ["B", "BB"],
+            "c": ["C", "CC"],
+            "d": [{"D1": "D2", "DD1": None}, {"D1": None, "DD1": "DD2"}],
+            })
+        >>> pl.Config.set_fmt_struct_data_type(True)  # doctest: +SKIP
+        # ...
+        # shape: (2, 4)                         shape: (2, 4)
+        # ┌─────┬─────┬─────┬──────────────┐    ┌─────┬─────┬─────┬───────────────┐
+        # │ a   ┆ b   ┆ c   ┆ d            │    │ a   ┆ b   ┆ c   ┆ d             │
+        # │ --- ┆ --- ┆ --- ┆ ---          │    │ --- ┆ --- ┆ --- ┆ ---           │
+        # │ str ┆ str ┆ str ┆ struct[2]    │    │ str ┆ str ┆ str ┆ struct[2]:    │
+        # │     ┆     ┆     ┆              │    │     ┆     ┆     ┆  |-- D1: str  │
+        # │     ┆     ┆     ┆              │    │     ┆     ┆     ┆  |-- DD1: str │
+        # ╞═════╪═════╪═════╪══════════════╡ >> ╞═════╪═════╪═════╪═══════════════╡
+        # │ A   ┆ B   ┆ C   ┆ {"D2",null}  │    │ A   ┆ B   ┆ C   ┆ {"D2",null}   │
+        # ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤    ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        # │ AA  ┆ BB  ┆ CC  ┆ {null,"DD2"} │    │ AA  ┆ BB  ┆ CC  ┆ {null,"DD2"}  │
+        # └─────┴─────┴─────┴──────────────┘    └─────┴─────┴─────┴───────────────┘
+
+        """
+        os.environ["POLARS_FMT_STRUCT_DATA_TYPE"] = str(int(active))
+        return cls
+
+    @classmethod
     def set_tbl_column_data_type_inline(cls, active: bool = True) -> type[Config]:
         """
         Moves the data type inline with the column name (to the right, in parentheses).


### PR DESCRIPTION
Related #3925
I know there is a lot missing here, but I wanted to start with the rust side first. As there is already a good idea how modify the schema method in python: #3953

This displays the structs field's name and dtype in a simple way, but formatting will fail for structs with further structs as fields. Display follows pyspark style from example in #3925 

Not sure if this is the best way going forward, as the result in python would look as follows (also check python test checks):
![image](https://user-images.githubusercontent.com/57916112/182215902-350be103-5286-4217-843a-58225a51cc34.png)

Instead of:
![image](https://user-images.githubusercontent.com/57916112/182215781-c28c62cf-f753-4eec-ae83-48a4c643567d.png)

Hence all doctest examples would have to be adjusted. I can do that, but wanted to make sure this approach goes into the right direction.