### PR TITLE
Add flake8-tidy-imports extension

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 88
+ban-relative-imports = true
 docstring-convention=all
 extend-ignore =
     # Satisfy black: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -23,6 +23,7 @@ flake8-bugbear==22.7.1
 flake8-comprehensions==3.10.0
 flake8-docstrings==1.6.0
 flake8-simplify==0.19.3
+flake8-tidy-imports==4.8.0
 ghp-import==2.1.0
 sphinx==4.3.2
 pydata-sphinx-theme==0.9.0

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -10,7 +10,7 @@ except ImportError:
     # this is only useful for documentation
     warnings.warn("polars binary missing!")
 
-import polars.testing as testing
+from polars import testing
 from polars.cfg import Config
 from polars.convert import (
     from_arrow,

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -3,19 +3,29 @@ The modules within `polars.internals` are interdependent. To prevent cyclical im
 they all import from each other via this __init__ file using
 `import polars.internals as pli`. The imports below are being shared across this module.
 """
-from .anonymous_scan import (
+from polars.internals.anonymous_scan import (
     _deser_and_exec,
     _scan_ds,
     _scan_ipc_fsspec,
     _scan_parquet_fsspec,
 )
-from .datatypes import IntoExpr
-from .expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
-from .frame import DataFrame, wrap_df
-from .functions import concat, date_range
-from .io import _is_local_file, _prepare_file_arg, read_ipc_schema, read_parquet_schema
-from .lazy_frame import LazyFrame, wrap_ldf
-from .lazy_functions import (
+from polars.internals.datatypes import IntoExpr
+from polars.internals.expr import (
+    Expr,
+    expr_to_lit_or_expr,
+    selection_to_pyexpr_list,
+    wrap_expr,
+)
+from polars.internals.frame import DataFrame, wrap_df
+from polars.internals.functions import concat, date_range
+from polars.internals.io import (
+    _is_local_file,
+    _prepare_file_arg,
+    read_ipc_schema,
+    read_parquet_schema,
+)
+from polars.internals.lazy_frame import LazyFrame, wrap_ldf
+from polars.internals.lazy_functions import (
     all,
     arg_where,
     argsort_by,
@@ -26,8 +36,8 @@ from .lazy_functions import (
     lit,
     select,
 )
-from .series import Series, wrap_s
-from .whenthen import when  # used in expr.clip()
+from polars.internals.series import Series, wrap_s
+from polars.internals.whenthen import when  # used in expr.clip()
 
 __all__ = [
     "DataFrame",

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -47,6 +47,7 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
+from polars.internals.lazy_frame import LazyFrame
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
@@ -59,8 +60,6 @@ from polars.utils import (
     is_str_sequence,
     range_to_slice,
 )
-
-from .lazy_frame import LazyFrame  # noqa: F401
 
 try:
     from polars.polars import PyDataFrame, PySeries

--- a/py-polars/tests/test_datatypes.py
+++ b/py-polars/tests/test_datatypes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 
 import polars as pl
-import polars.datatypes as datatypes
+from polars import datatypes
 
 
 def test_dtype_init_equivalence() -> None:


### PR DESCRIPTION
Relates to #4044

Changes:
* Add the [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) extension
* Add setting to ban relative imports
* Fix linting errors