### PR TITLE
Improve typing for `__getitem__`

### DIFF
--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -534,7 +534,9 @@ class Series:
 
         raise NotImplementedError("Unsupported idxs datatype.")
 
-    def __getitem__(self, item: int | Series | range | slice | np.ndarray) -> Any:
+    def __getitem__(
+        self, item: int | Series | range | slice | np.ndarray | list[int] | list[bool]
+    ) -> Any:
         if isinstance(item, int):
             if item < 0:
                 item = self.len() + item

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -298,9 +298,7 @@ def verify_series_and_expr_api(
 
     """
     expr = _getattr_multi(pli.col("*"), op)(*args, **kwargs)
-    result_expr: pli.Series = input.to_frame().select(expr)[  # type: ignore[assignment]
-        :, 0
-    ]
+    result_expr = input.to_frame().select(expr)[:, 0]
     result_series = _getattr_multi(input, op)(*args, **kwargs)
     if expected is None:
         assert_series_equal(result_series, result_expr)

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -53,14 +53,10 @@ def test_flatten_explode() -> None:
     df = pl.Series("a", ["Hello", "World"])
     expected = pl.Series("a", ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"])
 
-    result: pl.Series = df.to_frame().select(  # type: ignore[assignment]
-        pl.col("a").flatten()
-    )[:, 0]
+    result = df.to_frame().select(pl.col("a").flatten())[:, 0]
     assert_series_equal(result, expected)
 
-    result: pl.Series = df.to_frame().select(  # type: ignore[no-redef]
-        pl.col("a").explode()
-    )[:, 0]
+    result = df.to_frame().select(pl.col("a").explode())[:, 0]
     assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
Previously, calling `DataFrame.__getitem__` with any tuple was typed to return another `DataFrame`. Of course, this is not really the case. For example consider `df[0, 0]` (returns a scalar), `df[0, "a"]` (returns a scalar), `df[:, "a"]` (returns a `pli.Series`). This MR enumerates more of the `DataFrame` indexing combinations. 

By improving the typing, I found we support

- `Series.__getitem__(list[int])`
- `Series.__getitem__(list[bool])`
- `DataFrame.__getitem__(list[pli.Expr])`

none of which were previously annotated.