### PR TITLE
Update build dependencies

### DIFF
--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -26,7 +26,6 @@ flake8-docstrings==1.6.0
 flake8-simplify==0.19.3
 sphinx==4.2.0
 pydata-sphinx-theme==0.6.3
-sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -18,23 +18,23 @@ black==22.6.0
 blackdoc==0.3.5
 isort~=5.10.1
 mypy==0.971
-ghp-import==2.1.0
 flake8==5.0.2
 flake8-bugbear==22.7.1
 flake8-comprehensions==3.10.0
 flake8-docstrings==1.6.0
 flake8-simplify==0.19.3
-sphinx==4.2.0
-pydata-sphinx-theme==0.6.3
+ghp-import==2.1.0
+sphinx==4.3.2
+pydata-sphinx-theme==0.9.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-sphinxcontrib-napoleon
+sphinxcontrib-napoleon==0.7
 commonmark==0.9.1
-numpydoc==1.3.1
+numpydoc==1.4.0
 
 # Stub files
 pandas-stubs==1.2.0.61

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -39,9 +39,3 @@ numpydoc==1.3.1
 
 # Stub files
 pandas-stubs==1.2.0.61
-
-
-# pinned third rate deps
-# to be removed later
-click==8.0.4
-

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -39,7 +39,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
-    "sphinx_panels",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Changes:
* Unpinned `click`. This was pinned in #3001 but I don't see why.
* Removed `sphinx-panels` dependency. We don't seem to be using the `.. panels::` functionality anywhere, and this package is [not being maintained](https://sphinx-panels.readthedocs.io/en/latest/).
* Updated `sphinx` and other docs dependencies. Cannot update `sphinx` to 4.4.0 or higher due to clash with `flake8` in Python 3.7.