### PR TITLE
CSV starting point offset meaningless when no data

### DIFF
--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -337,10 +337,10 @@ impl<'a> CoreReader<'a> {
             }
         }
 
-        let starting_point_offset = if bytes.len() > 0 {
-            Some(bytes.as_ptr() as usize - starting_point_offset)
-        } else {
+        let starting_point_offset = if bytes.is_empty() {
             None
+        } else {
+            Some(bytes.as_ptr() as usize - starting_point_offset)
         };
 
         Ok((bytes, starting_point_offset))

--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -342,7 +342,7 @@ impl<'a> CoreReader<'a> {
         } else {
             None
         };
-        
+
         Ok((bytes, starting_point_offset))
     }
 

--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -338,7 +338,7 @@ impl<'a> CoreReader<'a> {
         }
 
         let starting_point_offset = if bytes.len() > 0 {
-            Some(starting_point_offset)
+            Some(bytes.as_ptr() as usize - starting_point_offset)
         } else {
             None
         };

--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -293,7 +293,7 @@ impl<'a> CoreReader<'a> {
         &self,
         mut bytes: &'b [u8],
         eol_char: u8,
-    ) -> Result<(&'b [u8], usize)> {
+    ) -> Result<(&'b [u8], Option<usize>)> {
         let starting_point_offset = bytes.as_ptr() as usize;
 
         // Skip all leading white space and the occasional utf8-bom
@@ -337,8 +337,12 @@ impl<'a> CoreReader<'a> {
             }
         }
 
-        let starting_point_offset = bytes.as_ptr() as usize - starting_point_offset;
-
+        let starting_point_offset = if bytes.len() > 0 {
+            Some(starting_point_offset)
+        } else {
+            None
+        };
+        
         Ok((bytes, starting_point_offset))
     }
 
@@ -523,7 +527,7 @@ impl<'a> CoreReader<'a> {
                             let local_bytes = &bytes[read..stop_at_nbytes];
 
                             last_read = read;
-                            let offset = read + starting_point_offset;
+                            let offset = read + starting_point_offset.unwrap();
                             read += parse_lines(
                                 local_bytes,
                                 offset,
@@ -642,7 +646,7 @@ impl<'a> CoreReader<'a> {
                             let local_bytes = &bytes[read..stop_at_nbytes];
 
                             last_read = read;
-                            let offset = read + starting_point_offset;
+                            let offset = read + starting_point_offset.unwrap();
                             read += parse_lines(
                                 local_bytes,
                                 offset,


### PR DESCRIPTION
resolves #4260 

When a CSV contains no row, the `starting_point_offset` value that represents the position of the data may be anything and will not be used. But it can overflow in some situation and panic in debug mode.

The safer solution in my opinion is to return `starting_point_offset` as an `Option` which will be `None` when no data. And use it by calling `unwrap()` ; this should never panic because this part of the code is never reached when no data.

All tests pass in `io::csv`