### PR TITLE
external context

### DIFF
--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -887,8 +887,8 @@ impl PartialEq<ArrowDataType> for DataType {
     derive(Serialize, Deserialize)
 )]
 pub struct Field {
-    name: String,
-    dtype: DataType,
+    pub name: String,
+    pub dtype: DataType,
 }
 
 impl Field {

--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -414,6 +414,11 @@ impl LogicalPlan {
                 self.write_dot(acc_str, prev_node, &current_node, id)?;
                 input.dot(acc_str, (branch, id + 1), &current_node)
             }
+            ExtContext { input, .. } => {
+                let current_node = format!("EXTERNAL CONTEXT [{:?}]", (branch, id));
+                self.write_dot(acc_str, prev_node, &current_node, id)?;
+                input.dot(acc_str, (branch, id + 1), &current_node)
+            }
             Error { err, .. } => {
                 let current_node = format!("{:?}", &**err);
                 self.write_dot(acc_str, prev_node, &current_node, id)

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -426,6 +426,22 @@ pub(crate) fn to_alp(
             let mut err = err.lock();
             return Err(err.take().unwrap());
         }
+        LogicalPlan::ExtContext {
+            input,
+            contexts,
+            schema,
+        } => {
+            let input = to_alp(*input, expr_arena, lp_arena)?;
+            let contexts = contexts
+                .into_iter()
+                .map(|lp| to_alp(lp, expr_arena, lp_arena))
+                .collect::<Result<_>>()?;
+            ALogicalPlan::ExtContext {
+                input,
+                contexts,
+                schema,
+            }
+        }
     };
     Ok(lp_arena.add(v))
 }
@@ -903,6 +919,22 @@ pub(crate) fn node_to_lp(
                 input,
                 function,
                 options,
+                schema,
+            }
+        }
+        ALogicalPlan::ExtContext {
+            input,
+            contexts,
+            schema,
+        } => {
+            let input = Box::new(node_to_lp(input, expr_arena, lp_arena));
+            let contexts = contexts
+                .into_iter()
+                .map(|node| node_to_lp(node, expr_arena, lp_arena))
+                .collect();
+            LogicalPlan::ExtContext {
+                input,
+                contexts,
                 schema,
             }
         }

--- a/polars/polars-lazy/src/logical_plan/format.rs
+++ b/polars/polars-lazy/src/logical_plan/format.rs
@@ -175,6 +175,9 @@ FROM
             }
             Udf { input, options, .. } => write!(f, "{} \n{:?}", options.fmt_str, input),
             Error { input, err } => write!(f, "{:?}\n{:?}", err, input),
+            ExtContext { input, .. } => {
+                write!(f, "{:?}\nExtContext", input)
+            }
         }
     }
 }

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -189,6 +189,12 @@ pub enum LogicalPlan {
         input: Box<LogicalPlan>,
         err: Arc<Mutex<Option<PolarsError>>>,
     },
+    /// This allows expressions to access other tables
+    ExtContext {
+        input: Box<LogicalPlan>,
+        contexts: Vec<LogicalPlan>,
+        schema: SchemaRef,
+    },
 }
 
 impl Default for LogicalPlan {
@@ -249,6 +255,7 @@ impl LogicalPlan {
                 }
             }
             Error { input, .. } => input.schema(),
+            ExtContext { schema, .. } => Ok(Cow::Borrowed(schema)),
         }
     }
     pub fn describe(&self) -> String {

--- a/polars/polars-lazy/src/logical_plan/optimizer/fast_projection.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/fast_projection.rs
@@ -66,8 +66,12 @@ impl OptimizationRule for FastProjection {
                 schema,
                 ..
             } => {
-                let schema = Some(schema.clone());
-                impl_fast_projection(*input, expr, schema, expr_arena)
+                if !matches!(lp_arena.get(*input), ALogicalPlan::ExtContext { .. }) {
+                    let schema = Some(schema.clone());
+                    impl_fast_projection(*input, expr, schema, expr_arena)
+                } else {
+                    None
+                }
             }
             ALogicalPlan::LocalProjection {
                 input,

--- a/polars/polars-lazy/src/physical_plan/executors/cache.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/cache.rs
@@ -9,6 +9,12 @@ pub struct CacheExec {
 
 impl Executor for CacheExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run Cache")
+            }
+        }
         if let Some(df) = state.cache_hit(&self.key) {
             return Ok(df);
         }

--- a/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
@@ -9,6 +9,12 @@ pub(crate) struct DropDuplicatesExec {
 
 impl Executor for DropDuplicatesExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run DropDuplicatesExec")
+            }
+        }
         let df = self.input.execute(state)?;
         let subset = self.options.subset.as_ref().map(|v| &***v);
         let keep = self.options.keep_strategy;

--- a/polars/polars-lazy/src/physical_plan/executors/explode.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/explode.rs
@@ -9,6 +9,12 @@ pub(crate) struct ExplodeExec {
 
 impl Executor for ExplodeExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run ExplodeExec")
+            }
+        }
         let df = self.input.execute(state)?;
         df.explode(&self.columns)
     }

--- a/polars/polars-lazy/src/physical_plan/executors/ext_context.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/ext_context.rs
@@ -1,0 +1,28 @@
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+use polars_core::prelude::*;
+
+pub struct ExternalContext {
+    pub input: Box<dyn Executor>,
+    pub contexts: Vec<Box<dyn Executor>>,
+}
+
+impl Executor for ExternalContext {
+    fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run ExternalContext")
+            }
+        }
+        let df = self.input.execute(state)?;
+        let contexts = self
+            .contexts
+            .iter_mut()
+            .map(|e| e.execute(state))
+            .collect::<Result<Vec<_>>>()?;
+
+        state.ext_contexts = Arc::new(contexts);
+        Ok(df)
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/executors/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/filter.rs
@@ -15,6 +15,12 @@ impl FilterExec {
 
 impl Executor for FilterExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run FilterExec")
+            }
+        }
         let df = self.input.execute(state)?;
         let s = self.predicate.evaluate(&df, state)?;
         let mask = s.bool().expect("filter predicate wasn't of type boolean");

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -92,6 +92,12 @@ pub(super) fn groupby_helper(
 
 impl Executor for GroupByExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run GroupbyExec")
+            }
+        }
         if state.verbose() {
             eprintln!("keys/aggregates are not partitionable: running default HASH AGGREGATION")
         }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -20,6 +20,12 @@ impl Executor for GroupByDynamicExec {
 
     #[cfg(feature = "dynamic_groupby")]
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run GroupbyDynamicExec")
+            }
+        }
         let mut df = self.input.execute(state)?;
         df.as_single_chunk_par();
         state.set_schema(self.input_schema.clone());

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -193,6 +193,12 @@ fn can_run_partitioned(keys: &[Series], original_df: &DataFrame, state: &Executi
 
 impl Executor for PartitionGroupByExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run PartititonGroupbyExec")
+            }
+        }
         let dfs = {
             let original_df = self.input.execute(state)?;
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -18,6 +18,12 @@ impl Executor for GroupByRollingExec {
 
     #[cfg(feature = "dynamic_groupby")]
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run GroupbyRollingExec")
+            }
+        }
         let mut df = self.input.execute(state)?;
         df.as_single_chunk_par();
         state.set_schema(self.input_schema.clone());

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -43,6 +43,12 @@ impl JoinExec {
 
 impl Executor for JoinExec {
     fn execute<'a>(&'a mut self, state: &'a mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run JoinExec")
+            }
+        }
         if state.verbose() {
             eprintln!("join parallel: {}", self.parallel);
         };

--- a/polars/polars-lazy/src/physical_plan/executors/melt.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/melt.rs
@@ -10,6 +10,12 @@ pub struct MeltExec {
 
 impl Executor for MeltExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run MeltExec")
+            }
+        }
         let df = self.input.execute(state)?;
         let args = std::mem::take(Arc::make_mut(&mut self.args));
         df.melt2(args)

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -16,6 +16,12 @@ pub struct ProjectionExec {
 
 impl Executor for ProjectionExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run ProjectionExec")
+            }
+        }
         let df = self.input.execute(state)?;
         state.set_schema(self.input_schema.clone());
 

--- a/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
@@ -9,6 +9,12 @@ pub(crate) struct PythonScanExec {
 
 impl Executor for PythonScanExec {
     fn execute(&mut self, _state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if _state.verbose() {
+                println!("run PythonScanExec")
+            }
+        }
         let with_columns = self.options.with_columns.take();
         Python::with_gil(|py| {
             let pl = PyModule::import(py, "polars").unwrap();

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -10,6 +10,12 @@ pub struct SliceExec {
 
 impl Executor for SliceExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run SciceExec")
+            }
+        }
         let df = self.input.execute(state)?;
         Ok(df.slice(self.offset, self.len as usize))
     }

--- a/polars/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/sort.rs
@@ -10,6 +10,12 @@ pub(crate) struct SortExec {
 
 impl Executor for SortExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run SortExec")
+            }
+        }
         let mut df = self.input.execute(state)?;
         df.as_single_chunk_par();
 

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -13,6 +13,12 @@ pub struct StackExec {
 
 impl Executor for StackExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run StackExec")
+            }
+        }
         let mut df = self.input.execute(state)?;
 
         state.set_schema(self.input_schema.clone());

--- a/polars/polars-lazy/src/physical_plan/executors/udf.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/udf.rs
@@ -9,6 +9,12 @@ pub(crate) struct UdfExec {
 
 impl Executor for UdfExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run UdfExec")
+            }
+        }
         let df = self.input.execute(state)?;
         self.function.call_udf(df)
     }

--- a/polars/polars-lazy/src/physical_plan/executors/union.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/union.rs
@@ -12,6 +12,12 @@ pub(crate) struct UnionExec {
 
 impl Executor for UnionExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run UnionExec")
+            }
+        }
         let mut inputs = std::mem::take(&mut self.inputs);
 
         if self.options.slice && self.options.slice_offset >= 0 {

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -515,6 +515,16 @@ impl DefaultPlanner {
                 let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
                 Ok(Box::new(executors::UdfExec { input, function }))
             }
+            ExtContext {
+                input, contexts, ..
+            } => {
+                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
+                let contexts = contexts
+                    .into_iter()
+                    .map(|node| self.create_physical_plan(node, lp_arena, expr_arena))
+                    .collect::<Result<_>>()?;
+                Ok(Box::new(executors::ExternalContext { input, contexts }))
+            }
         }
     }
 }

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -51,6 +51,7 @@ pub struct ExecutionState {
     // every join/union split gets an increment to distinguish between schema state
     pub(super) branch_idx: usize,
     pub(super) flags: StateFlags,
+    pub(super) ext_contexts: Arc<Vec<DataFrame>>,
 }
 
 impl ExecutionState {
@@ -65,6 +66,7 @@ impl ExecutionState {
             join_tuples: Default::default(),
             branch_idx: self.branch_idx,
             flags: self.flags,
+            ext_contexts: self.ext_contexts.clone(),
         }
     }
 
@@ -83,6 +85,7 @@ impl ExecutionState {
             join_tuples: Arc::new(Mutex::new(PlHashMap::default())),
             branch_idx: 0,
             flags: StateFlags::init(),
+            ext_contexts: Default::default(),
         }
     }
 
@@ -101,6 +104,7 @@ impl ExecutionState {
             join_tuples: Arc::new(Mutex::new(PlHashMap::default())),
             branch_idx: 0,
             flags: StateFlags::init(),
+            ext_contexts: Default::default(),
         }
     }
     pub(crate) fn set_schema(&mut self, schema: SchemaRef) {

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -80,6 +80,7 @@ Manipulation/ selection
     LazyFrame.unnest
     LazyFrame.with_column
     LazyFrame.with_columns
+    LazyFrame.with_context
     LazyFrame.with_row_count
 
 Conversion

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import typing
 import warnings
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
@@ -1629,6 +1630,25 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
                 raise ValueError(f"Expected an expression, got {e}")
 
         return self._from_pyldf(self._ldf.with_columns(pyexprs))
+
+    @typing.no_type_check
+    def with_context(self, other: LDF | list[LDF]) -> LDF:
+        """
+        Add an external context to the computation graph.
+
+        This allows expressions to also access columns from DataFrames
+        that are not part of this one.
+
+        Parameters
+        ----------
+        other
+            One or multiple LazyFrames as external context
+
+        """
+        if not isinstance(other, list):
+            other = [other]
+
+        return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
     def with_column(self: LDF, expr: pli.Expr) -> LDF:
         """

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -452,6 +452,11 @@ impl PyLazyFrame {
         PyLazyGroupBy { lgb: Some(lazy_gb) }
     }
 
+    pub fn with_context(&self, contexts: Vec<PyLazyFrame>) -> PyLazyFrame {
+        let contexts = contexts.into_iter().map(|ldf| ldf.ldf).collect::<Vec<_>>();
+        self.ldf.clone().with_context(contexts).into()
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "asof_join")]
     pub fn join_asof(

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -96,7 +96,7 @@ def test_join_lazy_on_df() -> None:
 
 def test_projection_update_schema_missing_column() -> None:
     with pytest.raises(
-        pl.ComputeError, match="column colC not available in schema Schema:*"
+        pl.ComputeError, match="column 'colC' not available in schema Schema:*"
     ):
         (
             pl.DataFrame({"colA": ["a", "b", "c"], "colB": [1, 2, 3]})


### PR DESCRIPTION
This allows use to use expressions that refer to external `DataFrame`s. This is only available in lazy as we need to store the context in the computation graph.

```python
df_a = pl.DataFrame({
    "a": [1, 2, 3],
    "b": ["a", "c", None]
}).lazy()

df_b = pl.DataFrame({
    "c": ["foo", "ham"]
})

(df_a
 .with_context(df_b.lazy())
 .select([
    pl.col("b") + pl.col("c").first()
    ])
).collect()
```
```
shape: (3, 1)
┌──────┐
│ b    │
│ ---  │
│ str  │
╞══════╡
│ afoo │
├╌╌╌╌╌╌┤
│ cfoo │
├╌╌╌╌╌╌┤
│ null │
└──────┘

```

If the caller tries to select columns of different lengths an Error is raised.