### PR TITLE
Standardize handling of agg input types

### DIFF
--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -15,6 +15,8 @@ from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import Any, Callable, Generic, Sequence, TypeVar, overload
 
+from polars.internals.expr import ensure_list_of_pyexpr
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
@@ -38,6 +40,7 @@ from polars.utils import (
     _process_null_values,
     deprecated_alias,
     format_path,
+    is_expr_sequence,
 )
 
 try:
@@ -2446,14 +2449,14 @@ class LazyGroupBy(Generic[LDF]):
         self.lgb = lgb
         self._lazyframe_class = lazyframe_class
 
-    def agg(self, aggs: list[pli.Expr] | pli.Expr) -> LDF:
+    def agg(self, aggs: pli.Expr | Sequence[pli.Expr]) -> LDF:
         """
         Describe the aggregation that need to be done on a group.
 
         Parameters
         ----------
         aggs
-            Single/ Multiple aggregation expression(s).
+            Single / multiple aggregation expression(s).
 
         Examples
         --------
@@ -2469,8 +2472,12 @@ class LazyGroupBy(Generic[LDF]):
         ... )  # doctest: +SKIP
 
         """
-        aggs = pli.selection_to_pyexpr_list(aggs)
-        return self._lazyframe_class._from_pyldf(self.lgb.agg(aggs))
+        if not (isinstance(aggs, pli.Expr) or is_expr_sequence(aggs)):
+            msg = f"expected 'Expr | Sequence[Expr]', got '{type(aggs)}'"
+            raise TypeError(msg)
+
+        pyexprs = ensure_list_of_pyexpr(aggs)
+        return self._lazyframe_class._from_pyldf(self.lgb.agg(pyexprs))
 
     def head(self, n: int = 5) -> LDF:
         """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -10,9 +10,11 @@ from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
+import polars.internals as pli
 from polars.datatypes import DataType, Date, Datetime
 
 try:
+    from polars.polars import PyExpr
     from polars.polars import pool_size as _pool_size
 
     _DOCUMENTING = False
@@ -130,6 +132,22 @@ def is_bool_sequence(val: Sequence[object]) -> TypeGuard[Sequence[bool]]:
 def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
     return _is_iterable_of(val, Sequence, int)
+
+
+def is_expr_sequence(val: object) -> TypeGuard[Sequence[pli.Expr]]:
+    """Check whether the given object is a sequence of Exprs."""
+    if isinstance(val, Sequence):
+        return _is_iterable_of(val, Sequence, pli.Expr)
+    else:
+        return False
+
+
+def is_pyexpr_sequence(val: object) -> TypeGuard[Sequence[PyExpr]]:
+    """Check whether the given object is a sequence of Exprs."""
+    if isinstance(val, Sequence):
+        return _is_iterable_of(val, Sequence, PyExpr)
+    else:
+        return False
 
 
 def is_str_sequence(


### PR DESCRIPTION
Closes #4267 

All grouped `agg` functions now take a single, consistent argument `aggs: Expr | Sequence[Expr]`, and raise an error on anything else.