### PR TITLE
Improve handling of literal arguments: `compression`

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1177,7 +1177,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         batch_size: int = 1024,
     ) -> str | None:
         """
-        Write Dataframe to comma-separated values file (csv).
+        Write to comma-separated values (CSV) file.
 
         Parameters
         ----------
@@ -1249,13 +1249,12 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ----------
         file
             File path to which the file should be written.
-        compression
-            Compression method. Choose one of:
-                - "uncompressed"
-                - "snappy"
-                - "deflate"
+        compression : {'uncompressed', 'snappy', 'deflate'}
+            Compression method. Defaults to "uncompressed".
 
         """
+        if compression is None:
+            compression = "uncompressed"
         if isinstance(file, (str, Path)):
             file = format_path(file)
 
@@ -1278,20 +1277,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def write_ipc(
         self,
         file: BinaryIO | BytesIO | str | Path,
-        compression: Literal["uncompressed", "lz4", "zstd"] | None = "uncompressed",
+        compression: Literal["uncompressed", "lz4", "zstd"] = "uncompressed",
     ) -> None:
         """
-        Write to Arrow IPC binary stream, or a feather file.
+        Write to Arrow IPC binary stream or Feather file.
 
         Parameters
         ----------
         file
             File path to which the file should be written.
-        compression
-            Compression method. Choose one of:
-                - "uncompressed"
-                - "lz4"
-                - "zstd"
+        compression : {'uncompressed', 'lz4', 'zstd'}
+            Compression method. Defaults to "uncompressed".
 
         """
         if compression is None:
@@ -1304,7 +1300,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
     def to_ipc(
         self,
         file: BinaryIO | BytesIO | str | Path,
-        compression: Literal["uncompressed", "lz4", "zstd"] | None = "uncompressed",
+        compression: Literal["uncompressed", "lz4", "zstd"] = "uncompressed",
     ) -> None:  # pragma: no cover
         """
         .. deprecated:: 0.13.12
@@ -1449,11 +1445,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self,
         file: str | Path | BytesIO,
         *,
-        compression: (
-            Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
-            | str
-            | None
-        ) = "lz4",
+        compression: Literal[
+            "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
+        ] = "lz4",
         compression_level: int | None = None,
         statistics: bool = False,
         row_group_size: int | None = None,
@@ -1461,26 +1455,17 @@ class DataFrame(metaclass=DataFrameMetaClass):
         **kwargs: Any,
     ) -> None:
         """
-        Write the DataFrame to disk in parquet format.
+        Write to Apache Parquet file.
 
         Parameters
         ----------
         file
             File path to which the file should be written.
-        compression
-            Compression method. Choose one of:
-
-            - "uncompressed" (not supported by pyarrow)
-            - "snappy"
-            - "gzip"
-            - "lzo"
-            - "brotli"
-            - "lz4"
-            - "zstd"
-
-            The default compression "lz4" (actually lz4raw) has very good performance,
-            but may not yet been supported by older readers. If you want more
-            compatability guarantees, consider using "snappy".
+        compression : {'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}
+            Compression method. The default compression "lz4" (actually lz4raw) has very
+            good performance, but may not yet been supported by older readers. If you
+            want more compatability guarantees, consider using "snappy".
+            Method "uncompressed" is not supported by pyarrow.
         compression_level
             The level of compression to use. Higher compression means smaller files on
             disk.
@@ -1544,8 +1529,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
         file: str | Path | BytesIO,
         compression: (
             Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
-            | str
-            | None
         ) = "snappy",
         statistics: bool = False,
         use_pyarrow: bool = False,

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1446,7 +1446,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         file: str | Path | BytesIO,
         *,
         compression: Literal[
-            "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
+            "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
         ] = "lz4",
         compression_level: int | None = None,
         statistics: bool = False,
@@ -1461,7 +1461,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         ----------
         file
             File path to which the file should be written.
-        compression : {'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}
+        compression : {'lz4', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'zstd'}
             Compression method. The default compression "lz4" (actually lz4raw) has very
             good performance, but may not yet been supported by older readers. If you
             want more compatability guarantees, consider using "snappy".
@@ -1528,7 +1528,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         self,
         file: str | Path | BytesIO,
         compression: (
-            Literal["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
+            Literal["lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"]
         ) = "snappy",
         statistics: bool = False,
         use_pyarrow: bool = False,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -293,7 +293,12 @@ impl PyDataFrame {
             "uncompressed" => None,
             "snappy" => Some(AvroCompression::Snappy),
             "deflate" => Some(AvroCompression::Deflate),
-            s => return Err(PyPolarsErr::Other(format!("compression {} not supported", s)).into()),
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "compression must be one of {{'uncompressed', 'snappy', 'deflate'}}, got {}",
+                    e
+                )))
+            }
         };
 
         if let Ok(s) = py_f.extract::<&str>(py) {
@@ -462,7 +467,12 @@ impl PyDataFrame {
             "uncompressed" => None,
             "lz4" => Some(IpcCompression::LZ4),
             "zstd" => Some(IpcCompression::ZSTD),
-            s => return Err(PyPolarsErr::Other(format!("compression {} not supported", s)).into()),
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "compression must be one of {{'uncompressed', 'lz4', 'zstd'}}, got {}",
+                    e
+                )))
+            }
         };
 
         if let Ok(s) = py_f.extract::<&str>(py) {
@@ -613,7 +623,12 @@ impl PyDataFrame {
                     })
                     .transpose()?,
             ),
-            s => return Err(PyPolarsErr::Other(format!("compression {} not supported", s)).into()),
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "compression must be one of {{'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'lz4', 'zstd'}}, got {}",
+                    e
+                )))
+            }
         };
 
         if let Ok(s) = py_f.extract::<&str>(py) {

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import os
+import sys
 
 import numpy as np
 import pandas as pd
@@ -10,13 +11,25 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal_local_categoricals
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+CompressionMethod = Literal[
+    "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
+]
+
 
 @pytest.fixture
-def compressions() -> list[str]:
+def compressions() -> list[CompressionMethod]:
     return ["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
 
 
-def test_to_from_buffer(df: pl.DataFrame, compressions: list[str]) -> None:
+def test_to_from_buffer(
+    df: pl.DataFrame, compressions: list[CompressionMethod]
+) -> None:
     for compression in compressions:
         if compression == "lzo":
             # lzo compression is not supported now
@@ -47,7 +60,7 @@ def test_to_from_buffer(df: pl.DataFrame, compressions: list[str]) -> None:
 
 
 def test_to_from_file(
-    io_test_dir: str, df: pl.DataFrame, compressions: list[str]
+    io_test_dir: str, df: pl.DataFrame, compressions: list[CompressionMethod]
 ) -> None:
     f = os.path.join(io_test_dir, "small.parquet")
     for compression in compressions:

--- a/py-polars/tests/io/test_parquet.py
+++ b/py-polars/tests/io/test_parquet.py
@@ -18,13 +18,13 @@ else:
 
 
 CompressionMethod = Literal[
-    "uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"
+    "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
 ]
 
 
 @pytest.fixture
 def compressions() -> list[CompressionMethod]:
-    return ["uncompressed", "snappy", "gzip", "lzo", "brotli", "lz4", "zstd"]
+    return ["lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"]
 
 
 def test_to_from_buffer(


### PR DESCRIPTION
Relates to #4288

Changes:
* Updated type hints, error messages, and docstrings for the `compression` argument of the following functions:
  * `DataFrame.write_avro`
  * `DataFrame.write_ipc`
  * `DataFrame.write_parquet`
* Specifying `compression=None` is currently supported as an alias for `compression="uncompressed"`. I added this support for `write_avro`, but I removed `None` from the accepted types everywhere. That way, we nudge people towards one idiomatic way of specifying compression methods (string literal), but people can still use this alias outside of a type checking context.