### PR TITLE
Fix test warnings

### DIFF
--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -1238,6 +1238,7 @@ def test_sum_duration() -> None:
     }
 
 
+@pytest.mark.filterwarnings("ignore:setting a DataFrame by indexing:DeprecationWarning")
 def test_supertype_timezones_4174() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -120,6 +120,7 @@ def test_not_found_on_rename() -> None:
 
 
 @typing.no_type_check
+@pytest.mark.filterwarnings("ignore:setting a DataFrame by indexing:DeprecationWarning")
 def test_getitem_errs() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 


### PR DESCRIPTION
Two tests were throwing DeprecationWarnings. I silenced these.

Maybe we should set the CI to fail on pytest warnings?