### PR TITLE
fix: use use pytest.approx to compare float in rolling_skew test

### DIFF
--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -52,7 +52,7 @@ pub fn combine_validities(opt_l: Option<&Bitmap>, opt_r: Option<&Bitmap>) -> Opt
     match (opt_l, opt_r) {
         (Some(l), Some(r)) => Some(l.bitand(r)),
         (None, Some(r)) => Some(r.clone()),
-        (Some(l), None) => (Some(l.clone())),
+        (Some(l), None) => Some(l.clone()),
         (None, None) => None,
     }
 }

--- a/polars/polars-core/src/series/ops/moment.rs
+++ b/polars/polars-core/src/series/ops/moment.rs
@@ -62,7 +62,7 @@ impl Series {
 
         if !bias {
             let n = self.len() as f64;
-            Ok(Some(((n - 1.0) * n).sqrt() / (n - 2.0) * m3 / m2.powf(1.5)))
+            Ok(Some(((n - 1.0) * n).sqrt() / (n - 2.0) * out))
         } else {
             Ok(Some(out))
         }

--- a/py-polars/tests/test_rolling.py
+++ b/py-polars/tests/test_rolling.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
+
 import polars as pl
 
 
@@ -52,7 +54,7 @@ def test_rolling_kernels_and_groupby_rolling() -> None:
 
 def test_rolling_skew() -> None:
     s = pl.Series([1, 2, 3, 3, 2, 10, 8])
-    assert s.rolling_skew(window_size=4, bias=True).to_list() == [
+    assert s.rolling_skew(window_size=4, bias=True).to_list() == pytest.approx([
         None,
         None,
         None,
@@ -60,9 +62,9 @@ def test_rolling_skew() -> None:
         0.0,
         1.097025449363867,
         0.09770939201338157,
-    ]
+    ])
 
-    assert s.rolling_skew(window_size=4, bias=False).to_list() == [
+    assert s.rolling_skew(window_size=4, bias=False).to_list() == pytest.approx([
         None,
         None,
         None,
@@ -70,4 +72,4 @@ def test_rolling_skew() -> None:
         0.0,
         1.9001038154942962,
         0.16923763134384154,
-    ]
+    ])

--- a/py-polars/tests/test_rolling.py
+++ b/py-polars/tests/test_rolling.py
@@ -54,22 +54,26 @@ def test_rolling_kernels_and_groupby_rolling() -> None:
 
 def test_rolling_skew() -> None:
     s = pl.Series([1, 2, 3, 3, 2, 10, 8])
-    assert s.rolling_skew(window_size=4, bias=True).to_list() == pytest.approx([
-        None,
-        None,
-        None,
-        -0.49338220021815865,
-        0.0,
-        1.097025449363867,
-        0.09770939201338157,
-    ])
+    assert s.rolling_skew(window_size=4, bias=True).to_list() == pytest.approx(
+        [
+            None,
+            None,
+            None,
+            -0.49338220021815865,
+            0.0,
+            1.097025449363867,
+            0.09770939201338157,
+        ]
+    )
 
-    assert s.rolling_skew(window_size=4, bias=False).to_list() == pytest.approx([
-        None,
-        None,
-        None,
-        -0.8545630383279711,
-        0.0,
-        1.9001038154942962,
-        0.16923763134384154,
-    ])
+    assert s.rolling_skew(window_size=4, bias=False).to_list() == pytest.approx(
+        [
+            None,
+            None,
+            None,
+            -0.8545630383279711,
+            0.0,
+            1.9001038154942962,
+            0.16923763134384154,
+        ]
+    )


### PR DESCRIPTION
## environement

- os: win10
- rust:

```
cargo 1.64.0-nightly (4fd148c47 2022-08-03)                       
release: 1.64.0-nightly                                           
commit-hash: 4fd148c47e733770c537efac5220744945d572ef             
commit-date: 2022-08-03                                           
host: x86_64-pc-windows-gnu                                       
libgit2: 1.4.2 (sys:0.14.2 vendored)                              
libcurl: 7.83.1-DEV (sys:0.4.55+curl-7.83.1 vendored ssl:Schannel)
os: Windows 10.0.19043 (Windows 10 Home China) [64-bit] 
```

## problem

When I run test for rolling_skew , it will raise erorr for float precision problem:

```
============================= test session starts =============================
collecting ... collected 1 item

test_rolling.py::test_rolling_skew FAILED                                [100%]
test_rolling.py:54 (test_rolling_skew)
[None,
 None,
 None,
 -0.49338220021815865,
 0.0,
 1.0970254493638667,
 0.09770939201338157] != [None,
 None,
 None,
 -0.49338220021815865,
 0.0,
 1.097025449363867,
 0.09770939201338157]

<Click to see difference>

def test_rolling_skew() -> None:
        s = pl.Series([1, 2, 3, 3, 2, 10, 8])
>       assert s.rolling_skew(window_size=4, bias=True).to_list() == [
            None,
            None,
            None,
            -0.49338220021815865,
            0.0,
            1.097025449363867,
            0.09770939201338157,
        ]
E       assert [None,\n None,\n None,\n -0.49338220021815865,\n 0.0,\n 1.0970254493638667,\n 0.09770939201338157] == [None,\n None,\n None,\n -0.49338220021815865,\n 0.0,\n 1.097025449363867,\n 0.09770939201338157]
E         At index 5 diff: 1.0970254493638667 != 1.097025449363867
E         Full diff:
E           [
E            None,
E            None,
E            None,
E            -0.49338220021815865,
E            0.0,
E         -  1.097025449363867,
E         +  1.0970254493638667,
E         ?                  +
E            0.09770939201338157,
E           ]

test_rolling.py:57: AssertionError


============================== 1 failed in 0.18s ==============================
```