### PR TITLE
Improve handling of literal arguments: `closed` and `interpolation`

### DIFF
--- a/py-polars/polars/internals/datatypes.py
+++ b/py-polars/polars/internals/datatypes.py
@@ -13,3 +13,4 @@ else:
 IntoExpr = Union[int, float, str, "pli.Expr", "pli.Series"]
 
 ClosedWindow = Literal["left", "right", "both", "none"]
+InterpolationMethod = Literal["nearest", "higher", "lower", "midpoint", "linear"]

--- a/py-polars/polars/internals/datatypes.py
+++ b/py-polars/polars/internals/datatypes.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import sys
 from typing import Union
 
 from polars import internals as pli
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 IntoExpr = Union[int, float, str, "pli.Expr", "pli.Series"]
+
+ClosedWindow = Literal["left", "right", "both", "none"]

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5,7 +5,7 @@ import math
 import random
 import sys
 from datetime import date, datetime, timedelta
-from typing import Any, Callable, List, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Sequence
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -20,7 +20,6 @@ from polars.datatypes import (
     UInt32,
     py_type_to_dtype,
 )
-from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 from polars.utils import _timedelta_to_pl_duration
 
 try:
@@ -41,6 +40,9 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 
 
 def selection_to_pyexpr_list(

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -20,6 +20,7 @@ from polars.datatypes import (
     UInt32,
     py_type_to_dtype,
 )
+from polars.internals.datatypes import ClosedWindow
 from polars.utils import _timedelta_to_pl_duration
 
 try:
@@ -3241,7 +3242,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Apply a rolling min (moving min) over the values in this array.
@@ -3342,7 +3343,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Apply a rolling max (moving max) over the values in this array.
@@ -3442,7 +3443,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Apply a rolling mean (moving mean) over the values in this array.
@@ -3540,7 +3541,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Apply a rolling sum (moving sum) over the values in this array.
@@ -3640,7 +3641,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Compute a rolling standard deviation.
@@ -3711,7 +3712,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Compute a rolling variance.
@@ -3782,7 +3783,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Compute a rolling median.
@@ -3845,13 +3846,15 @@ class Expr:
     def rolling_quantile(
         self,
         quantile: float,
-        interpolation: str = "nearest",
+        interpolation: Literal[
+            "nearest", "higher", "lower", "midpoint", "linear"
+        ] = "nearest",
         window_size: int | str = 2,
         weights: List[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: str = "left",
+        closed: ClosedWindow = "left",
     ) -> Expr:
         """
         Compute a rolling quantile.

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -20,7 +20,7 @@ from polars.datatypes import (
     UInt32,
     py_type_to_dtype,
 )
-from polars.internals.datatypes import ClosedWindow
+from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 from polars.utils import _timedelta_to_pl_duration
 
 try:
@@ -2556,7 +2556,11 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.is_duplicated())
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> Expr:
+    def quantile(
+        self,
+        quantile: float,
+        interpolation: InterpolationMethod = "nearest",
+    ) -> Expr:
         """
         Get quantile value.
 
@@ -2564,11 +2568,9 @@ class Expr:
         Parameters
         ----------
         quantile
-            quantile between 0.0 and 1.0
-
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
 
         Examples
         --------
@@ -3839,9 +3841,7 @@ class Expr:
     def rolling_quantile(
         self,
         quantile: float,
-        interpolation: Literal[
-            "nearest", "higher", "lower", "midpoint", "linear"
-        ] = "nearest",
+        interpolation: InterpolationMethod = "nearest",
         window_size: int | str = 2,
         weights: List[float] | None = None,
         min_periods: int | None = None,
@@ -3855,10 +3855,9 @@ class Expr:
         Parameters
         ----------
         quantile
-            quantile to compute
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
             size indicated by the following string language:

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -3283,9 +3283,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
 
         .. warning::
@@ -3384,9 +3383,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3484,9 +3482,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3582,9 +3579,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3682,9 +3678,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3753,9 +3748,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3820,9 +3814,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change
@@ -3896,9 +3889,8 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
-        closed
-            Defines if the temporal window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'left', 'right', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
 
         .. warning::
             The dynamic windows functionality is still experimental and may change

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -47,6 +47,7 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
+from polars.internals.datatypes import ClosedWindow
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
@@ -3182,7 +3183,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         index_column: str,
         period: str,
         offset: str | None = None,
-        closed: str = "right",
+        closed: ClosedWindow = "right",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ) -> RollingGroupBy[DF]:
         """
@@ -3236,9 +3237,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             length of the window
         offset
             offset of the window. Default is -period
-        closed
+        closed : {'left', 'right', 'both', 'none'}
             Defines if the window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
         by
             Also group by this column/these columns
 
@@ -3296,7 +3296,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         offset: str | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
-        closed: str = "right",
+        closed: ClosedWindow = "right",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ) -> DynamicGroupBy:
         """
@@ -6260,7 +6260,7 @@ class RollingGroupBy(Generic[DF]):
         index_column: str,
         period: str,
         offset: str | None,
-        closed: str = "none",
+        closed: ClosedWindow = "none",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ):
         self.df = df
@@ -6304,7 +6304,7 @@ class DynamicGroupBy(Generic[DF]):
         offset: str | None,
         truncate: bool = True,
         include_boundaries: bool = True,
-        closed: str = "none",
+        closed: ClosedWindow = "none",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ):
         self.df = df

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3237,8 +3237,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             length of the window
         offset
             offset of the window. Default is -period
-        closed : {'left', 'right', 'both', 'none'}
-            Defines if the window interval is closed or not.
+        closed : {'right', 'left', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
 
@@ -3360,9 +3360,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             Add the lower and upper bound of the window to the "_lower_bound" and
             "_upper_bound" columns. This will impact performance because it's harder to
             parallelize
-        closed
-            Defines if the window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'right', 'left', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -47,7 +47,7 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-from polars.internals.datatypes import ClosedWindow
+from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
@@ -5653,18 +5653,18 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         return self.select(pli.all().product())
 
-    def quantile(self: DF, quantile: float, interpolation: str = "nearest") -> DF:
+    def quantile(
+        self: DF, quantile: float, interpolation: InterpolationMethod = "nearest"
+    ) -> DF:
         """
         Aggregate the columns of this DataFrame to their quantile value.
 
         Parameters
         ----------
         quantile
-            quantile between 0.0 and 1.0
-
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
 
         Examples
         --------
@@ -7150,18 +7150,18 @@ class GroupBy(Generic[DF]):
         """
         return self.agg(pli.all().n_unique())
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> DF:
+    def quantile(
+        self, quantile: float, interpolation: InterpolationMethod = "nearest"
+    ) -> DF:
         """
         Compute the quantile per group.
 
         Parameters
         ----------
         quantile
-            quantile between 0.0 and 1.0
-
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
 
         Examples
         --------
@@ -7394,18 +7394,18 @@ class GBSelection(Generic[DF]):
             self._df.groupby(self.by, self.selection, "n_unique")
         )
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> DF:
+    def quantile(
+        self, quantile: float, interpolation: InterpolationMethod = "nearest"
+    ) -> DF:
         """
         Compute the quantile per group.
 
         Parameters
         ----------
         quantile
-            quantile between 0.0 and 1.0
-
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
 
         """
         return self._dataframe_class._from_pydf(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -47,7 +47,6 @@ from polars.internals.construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
@@ -105,11 +104,14 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
+
 # A type variable used to refer to a polars.DataFrame or any subclass of it.
 # Used to annotate DataFrame methods which returns the same type as self.
 DF = TypeVar("DF", bound="DataFrame")
 
 if TYPE_CHECKING:
+    from polars.internals.datatypes import ClosedWindow, InterpolationMethod
+
     # these aliases are used to annotate DataFrame.__getitem__()
     # MultiRowSelector indexes into the vertical axis and
     # MultiColSelector indexes into the horizontal axis

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -5,6 +5,7 @@ from typing import Optional, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Categorical, Date, Float64
+from polars.internals.datatypes import ClosedWindow
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
@@ -168,7 +169,7 @@ def date_range(
     low: date | datetime,
     high: date | datetime,
     interval: str | timedelta,
-    closed: str | None = "both",
+    closed: ClosedWindow = "both",
     name: str | None = None,
     time_unit: str | None = None,
 ) -> pli.Series:

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import Optional, Sequence, overload
+from typing import TYPE_CHECKING, Optional, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Categorical, Date, Float64
-from polars.internals.datatypes import ClosedWindow
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
@@ -23,6 +22,9 @@ try:
     _DOCUMENTING = False
 except ImportError:
     _DOCUMENTING = True
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import ClosedWindow
 
 
 def get_dummies(df: pli.DataFrame) -> pli.DataFrame:

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -186,8 +186,8 @@ def date_range(
         Interval periods. It can be a python timedelta object, like
         ``timedelta(days=10)``, or a polars duration string, such as ``3d12h4m25s``
         representing 3 days, 12 hours, 4 minutes, and 25 seconds.
-    closed : {None, 'left', 'right', 'both', 'none'}
-        Make the interval closed to the 'left', 'right', 'none' or 'both' sides.
+    closed : {'both', 'left', 'right', 'none'}
+        Define whether the temporal window interval is closed or not.
     name
         Name of the output Series.
     time_unit : {'ns', 'us', 'ms'}

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1048,9 +1048,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             length of the window
         offset
             offset of the window. Default is -period
-        closed
-            Defines if the window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'right', 'left', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
 
@@ -1181,9 +1180,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Add the lower and upper bound of the window to the "_lower_bound" and
             "_upper_bound" columns. This will impact performance because it's harder to
             parallelize
-        closed
-            Defines if the window interval is closed or not.
-            Any of {"left", "right", "both" "none"}
+        closed : {'right', 'left', 'both', 'none'}
+            Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
 

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -15,7 +15,7 @@ from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import Any, Callable, Generic, Sequence, TypeVar, overload
 
-from polars.internals.datatypes import ClosedWindow
+from polars.internals.datatypes import ClosedWindow, InterpolationMethod
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -2058,8 +2058,20 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """Aggregate the columns in the DataFrame to their median value."""
         return self._from_pyldf(self._ldf.median())
 
-    def quantile(self: LDF, quantile: float, interpolation: str = "nearest") -> LDF:
-        """Aggregate the columns in the DataFrame to their quantile value."""
+    def quantile(
+        self: LDF, quantile: float, interpolation: InterpolationMethod = "nearest"
+    ) -> LDF:
+        """
+        Aggregate the columns in the DataFrame to their quantile value.
+
+        Parameters
+        ----------
+        quantile
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
+
+        """
         return self._from_pyldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -15,6 +15,8 @@ from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import Any, Callable, Generic, Sequence, TypeVar, overload
 
+from polars.internals.datatypes import ClosedWindow
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
@@ -992,7 +994,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         index_column: str,
         period: str,
         offset: str | None = None,
-        closed: str = "right",
+        closed: ClosedWindow = "right",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """
@@ -1111,7 +1113,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         offset: str | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
-        closed: str = "right",
+        closed: ClosedWindow = "right",
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -13,9 +13,7 @@ import typing
 import warnings
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
-from typing import Any, Callable, Generic, Sequence, TypeVar, overload
-
-from polars.internals.datatypes import ClosedWindow, InterpolationMethod
+from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, TypeVar, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -48,6 +46,10 @@ try:
     _PYARROW_AVAILABLE = True
 except ImportError:
     _PYARROW_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import ClosedWindow, InterpolationMethod
+
 
 # Used to type any type or subclass of LazyFrame.
 # Used to indicate when LazyFrame methods return the same type as self,

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from datetime import date, datetime, timedelta
 from inspect import isclass
-from typing import Any, Callable, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Sequence, cast, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -14,7 +14,6 @@ from polars.datatypes import (
     PolarsDataType,
     py_type_to_dtype,
 )
-from polars.internals.datatypes import InterpolationMethod
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_timedelta,
@@ -63,6 +62,9 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import InterpolationMethod
 
 
 def col(
@@ -1037,6 +1039,8 @@ def quantile(
 
     Parameters
     ----------
+    column
+        Column name.
     quantile
         Quantile between 0.0 and 1.0.
     interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -14,6 +14,7 @@ from polars.datatypes import (
     PolarsDataType,
     py_type_to_dtype,
 )
+from polars.internals.datatypes import InterpolationMethod
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_timedelta,
@@ -1028,8 +1029,20 @@ def groups(column: str) -> pli.Expr:
     return col(column).agg_groups()
 
 
-def quantile(column: str, quantile: float, interpolation: str = "nearest") -> pli.Expr:
-    """Syntactic sugar for `pl.col("foo").quantile(..)`."""
+def quantile(
+    column: str, quantile: float, interpolation: InterpolationMethod = "nearest"
+) -> pli.Expr:
+    """
+    Syntactic sugar for `pl.col("foo").quantile(..)`.
+
+    Parameters
+    ----------
+    quantile
+        Quantile between 0.0 and 1.0.
+    interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+        Interpolation method.
+
+    """
     return col(column).quantile(quantile, interpolation)
 
 

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import sys
 from datetime import date, datetime, timedelta
-from typing import Any, Callable, Sequence, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Sequence, Union, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -42,7 +42,6 @@ from polars.internals.construction import (
     sequence_to_pyseries,
     series_to_pyseries,
 )
-from polars.internals.datatypes import InterpolationMethod
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
@@ -87,6 +86,9 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import InterpolationMethod
 
 
 def get_ffi_func(

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -42,6 +42,7 @@ from polars.internals.construction import (
     sequence_to_pyseries,
     series_to_pyseries,
 )
+from polars.internals.datatypes import InterpolationMethod
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
@@ -967,18 +968,18 @@ class Series:
         """
         return self._s.median()
 
-    def quantile(self, quantile: float, interpolation: str = "nearest") -> float:
+    def quantile(
+        self, quantile: float, interpolation: InterpolationMethod = "nearest"
+    ) -> float:
         """
         Get the quantile value of this Series.
 
         Parameters
         ----------
         quantile
-            quantile between 0.0 and 1.0
-
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
 
         Examples
         --------
@@ -3492,7 +3493,7 @@ class Series:
     def rolling_quantile(
         self,
         quantile: float,
-        interpolation: str = "nearest",
+        interpolation: InterpolationMethod = "nearest",
         window_size: int = 2,
         weights: list[float] | None = None,
         min_periods: int | None = None,
@@ -3504,10 +3505,9 @@ class Series:
         Parameters
         ----------
         quantile
-            quantile to compute
-        interpolation
-            interpolation type, options:
-            ['nearest', 'higher', 'lower', 'midpoint', 'linear']
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
         window_size
             The length of the window.
         weights

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -327,7 +327,12 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
             "nearest" => QuantileInterpolOptions::Nearest,
             "linear" => QuantileInterpolOptions::Linear,
             "midpoint" => QuantileInterpolOptions::Midpoint,
-            _ => panic!("{}", "interpolation should be any of {'lower', 'higher', 'nearest', 'linear', 'midpoint'}"),
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "interpolation must be one of {{'lower', 'higher', 'nearest', 'linear', 'midpoint'}}, got {}",
+                    e,
+                )))
+            }
         }))
     }
 }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -304,11 +304,16 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
     fn extract(ob: &'_ PyAny) -> PyResult<Self> {
         let s = ob.extract::<&str>()?;
         Ok(Wrap(match s {
-            "none" => ClosedWindow::None,
-            "both" => ClosedWindow::Both,
             "left" => ClosedWindow::Left,
             "right" => ClosedWindow::Right,
-            _ => panic!("{}", "closed should be any of {'none', 'left', 'right'}"),
+            "both" => ClosedWindow::Both,
+            "none" => ClosedWindow::None,
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "closed must be one of {{'left', 'right', 'both', 'none'}}, got {}",
+                    e,
+                )))
+            }
         }))
     }
 }

--- a/py-polars/tests/test_rolling.py
+++ b/py-polars/tests/test_rolling.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from polars.internals.datatypes import ClosedWindow
 
 
 def test_rolling_kernels_and_groupby_rolling() -> None:
@@ -19,7 +23,8 @@ def test_rolling_kernels_and_groupby_rolling() -> None:
         }
     )
     for period in ["1d", "2d", "3d"]:
-        for closed in ["left", "right", "none", "both"]:
+        closed_windows: list[ClosedWindow] = ["left", "right", "none", "both"]
+        for closed in closed_windows:
 
             out1 = df.select(
                 [


### PR DESCRIPTION
Relates to #4288

Changes:
* Define type aliases for `closed` and `interpolation` arguments. _(I like this approach, feels closer to how you would do things in Rust.)_
* Update type hints, error messages, and docstrings for these arguments in all relevant functions