### PR TITLE
Improve handling of literal arguments: `strategy`

### DIFF
--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -5567,17 +5567,16 @@ class ExprListNameSpace:
 
     def to_struct(
         self,
-        n_field_strategy: str = "first_non_null",
+        n_field_strategy: Literal["first_non_null", "max_width"] = "first_non_null",
         name_generator: Callable[[int], str] | None = None,
     ) -> Expr:
         """
-        Convert the series of type `List` to a series of type `Struct`.
+        Convert the series of type ``List`` to a series of type ``Struct``.
 
         Parameters
         ----------
-        n_field_strategy
+        n_field_strategy : {'first_non_null', 'max_width'}
             Strategy to determine the number of fields of the struct.
-            Any of {'first_non_null', 'max_width'}
         name_generator
             A custom function that can be used to generate the field names.
             Default field names are `field_0, field_1 .. field_n`

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3713,7 +3713,7 @@ class DataFrame(metaclass=DataFrameMetaClass):
         by_left: str | list[str] | None = None,
         by_right: str | list[str] | None = None,
         by: str | list[str] | None = None,
-        strategy: str = "backward",
+        strategy: Literal["backward", "forward"] = "backward",
         suffix: str = "_right",
         tolerance: str | int | float | None = None,
         allow_parallel: bool = True,
@@ -3752,8 +3752,8 @@ class DataFrame(metaclass=DataFrameMetaClass):
             join on these columns before doing asof join
         by_right
             join on these columns before doing asof join
-        strategy
-            One of {'forward', 'backward'}
+        strategy : {'backward', 'forward'}
+            Join strategy.
         suffix
             Suffix to append to columns with a duplicate name.
         tolerance
@@ -4583,19 +4583,21 @@ class DataFrame(metaclass=DataFrameMetaClass):
         return self[name]
 
     def fill_null(
-        self: DF, strategy: str | pli.Expr | Any, limit: int | None = None
+        self: DF,
+        strategy: (
+            Literal["backward", "forward", "min", "max", "mean", "zero", "one"]
+            | pli.Expr
+            | Any
+        ),
+        limit: int | None = None,
     ) -> DF:
         """
         Fill null values using a filling strategy, literal, or Expr.
 
-        .. seealso::
-
-            :func:`fill_nan`
-
         Parameters
         ----------
         strategy
-            One of {"backward", "forward", "min", "max", "mean", "one", "zero"}
+            One of {'backward', 'forward', 'min', 'max', 'mean', 'zero', 'one'}
             or an expression.
         limit
             The number of consecutive null values to forward/backward fill.
@@ -4604,6 +4606,10 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Returns
         -------
             DataFrame with None values replaced by the filling strategy.
+
+        See Also
+        --------
+        fill_nan
 
         Examples
         --------
@@ -4640,15 +4646,6 @@ class DataFrame(metaclass=DataFrameMetaClass):
         """
         Fill floating point NaN values by an Expression evaluation.
 
-        .. seealso::
-
-            :func:`fill_null`
-
-        Warnings
-        --------
-        NOTE that floating point NaNs (Not a Number) are not missing values!
-        to replace missing values, use :func:`fill_null`.
-
         Parameters
         ----------
         fill_value
@@ -4657,6 +4654,15 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Returns
         -------
             DataFrame with NaN replaced with fill_value
+
+        Warnings
+        --------
+        Note that floating point NaNs (Not a Number) are not missing values!
+        To replace missing values, use :func:`fill_null`.
+
+        See Also
+        --------
+        fill_null
 
         Examples
         --------
@@ -5414,21 +5420,37 @@ class DataFrame(metaclass=DataFrameMetaClass):
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
     @overload
-    def sum(self: DF, *, axis: Literal[0] = ..., null_strategy: str = "ignore") -> DF:
-        ...
-
-    @overload
-    def sum(self, *, axis: Literal[1], null_strategy: str = "ignore") -> pli.Series:
+    def sum(
+        self: DF,
+        *,
+        axis: Literal[0] = ...,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
+    ) -> DF:
         ...
 
     @overload
     def sum(
-        self: DF, *, axis: int = 0, null_strategy: str = "ignore"
+        self,
+        *,
+        axis: Literal[1],
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
+    ) -> pli.Series:
+        ...
+
+    @overload
+    def sum(
+        self: DF,
+        *,
+        axis: int = 0,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
     ) -> DF | pli.Series:
         ...
 
     def sum(
-        self: DF, *, axis: int = 0, null_strategy: str = "ignore"
+        self: DF,
+        *,
+        axis: int = 0,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
     ) -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their sum value.
@@ -5436,10 +5458,9 @@ class DataFrame(metaclass=DataFrameMetaClass):
         Parameters
         ----------
         axis
-            either 0 or 1
-        null_strategy
-            {'ignore', 'propagate'}
-            this argument is only used if axis == 1
+            Either 0 or 1.
+        null_strategy : {'ignore', 'propagate'}
+            This argument is only used if axis == 1.
 
         Examples
         --------
@@ -5468,30 +5489,46 @@ class DataFrame(metaclass=DataFrameMetaClass):
         raise ValueError("Axis should be 0 or 1.")  # pragma: no cover
 
     @overload
-    def mean(self: DF, *, axis: Literal[0] = ..., null_strategy: str = "ignore") -> DF:
-        ...
-
-    @overload
-    def mean(self, *, axis: Literal[1], null_strategy: str = "ignore") -> pli.Series:
+    def mean(
+        self: DF,
+        *,
+        axis: Literal[0] = ...,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
+    ) -> DF:
         ...
 
     @overload
     def mean(
-        self: DF, *, axis: int = 0, null_strategy: str = "ignore"
+        self,
+        *,
+        axis: Literal[1],
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
+    ) -> pli.Series:
+        ...
+
+    @overload
+    def mean(
+        self: DF,
+        *,
+        axis: int = 0,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
     ) -> DF | pli.Series:
         ...
 
-    def mean(self: DF, axis: int = 0, null_strategy: str = "ignore") -> DF | pli.Series:
+    def mean(
+        self: DF,
+        axis: int = 0,
+        null_strategy: Literal["ignore", "propagate"] = "ignore",
+    ) -> DF | pli.Series:
         """
         Aggregate the columns of this DataFrame to their mean value.
 
         Parameters
         ----------
         axis
-            either 0 or 1
-        null_strategy
-            {'ignore', 'propagate'}
-            this argument is only used if axis == 1
+            Either 0 or 1.
+        null_strategy : {'ignore', 'propagate'}
+            This argument is only used if axis == 1.
 
         Examples
         --------

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -1216,7 +1216,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by_left: str | list[str] | None = None,
         by_right: str | list[str] | None = None,
         by: str | list[str] | None = None,
-        strategy: str = "backward",
+        strategy: Literal["backward", "forward"] = "backward",
         suffix: str = "_right",
         tolerance: str | int | float | None = None,
         allow_parallel: bool = True,
@@ -1250,13 +1250,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Join column of both DataFrames. If set, `left_on` and `right_on` should be
             None.
         by
-            join on these columns before doing asof join
+            Join on these columns before doing asof join.
         by_left
-            join on these columns before doing asof join
+            Join on these columns before doing asof join.
         by_right
-            join on these columns before doing asof join
-        strategy
-            One of {'forward', 'backward'}
+            Join on these columns before doing asof join.
+        strategy : {'backward', 'forward'}
+            Join strategy.
         suffix
             Suffix to append to columns with a duplicate name.
         tolerance

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2588,7 +2588,13 @@ class Series:
         )
 
     def fill_null(
-        self, strategy: str | int | pli.Expr, limit: int | None = None
+        self,
+        strategy: (
+            Literal["backward", "forward", "min", "max", "mean", "zero", "one"]
+            | pli.Expr
+            | Any
+        ),
+        limit: int | None = None,
     ) -> Series:
         """
         Fill null values using a filling strategy, literal, or Expr.
@@ -2596,7 +2602,7 @@ class Series:
         Parameters
         ----------
         strategy
-            One of {"backward", "forward", "min", "max", "mean", "one", "zero"}
+            One of {'backward', 'forward', 'min', 'max', 'mean', 'zero', 'one'}
             or an expression.
         limit
             The number of consecutive null values to forward/backward fill.

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -792,10 +792,11 @@ pub(crate) fn str_to_null_strategy(strategy: &str) -> PyResult<NullStrategy> {
     let strategy = match strategy {
         "ignore" => NullStrategy::Ignore,
         "propagate" => NullStrategy::Propagate,
-        _ => {
-            return Err(PyValueError::new_err(
-                "use one of 'ignore', 'propagate'".to_string(),
-            ))
+        e => {
+            return Err(PyValueError::new_err(format!(
+                "null_strategy must be one of {{'ignore', 'propagate'}}, got {}",
+                e,
+            )))
         }
     };
     Ok(strategy)
@@ -846,10 +847,10 @@ pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<Fill
             "mean" => FillNullStrategy::Mean,
             "zero" => FillNullStrategy::Zero,
             "one" => FillNullStrategy::One,
-            s => {
+            e => {
                 return Err(PyValueError::new_err(format!(
-                    "Strategy {} not supported",
-                    s
+                    "strategy must be one of {{'backward', 'forward', 'min', 'max', 'mean', 'zero', 'one'}}, got {}",
+                    e,
                 )))
             }
         };

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -473,18 +473,24 @@ impl PyLazyFrame {
         strategy: &str,
         tolerance: Option<Wrap<AnyValue<'_>>>,
         tolerance_str: Option<String>,
-    ) -> PyLazyFrame {
+    ) -> PyResult<Self> {
         let strategy = match strategy {
-            "forward" => AsofStrategy::Forward,
             "backward" => AsofStrategy::Backward,
-            _ => panic!("expected one of {{'forward', 'backward'}}"),
+            "forward" => AsofStrategy::Forward,
+            e => {
+                return Err(PyValueError::new_err(format!(
+                    "strategy must be one of {{'backward', 'forward'}}, got {}",
+                    e,
+                )))
+            }
         };
 
         let ldf = self.ldf.clone();
         let other = other.ldf;
         let left_on = left_on.inner;
         let right_on = right_on.inner;
-        ldf.join_builder()
+        Ok(ldf
+            .join_builder()
             .with(other)
             .left_on([left_on])
             .right_on([right_on])
@@ -499,7 +505,7 @@ impl PyLazyFrame {
             }))
             .suffix(suffix)
             .finish()
-            .into()
+            .into())
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1359,10 +1359,11 @@ impl PyExpr {
         let n_fields = match width_strat {
             "first_non_null" => ListToStructWidthStrategy::FirstNonNull,
             "max_width" => ListToStructWidthStrategy::MaxWidth,
-            strat => {
+            e => {
                 return Err(PyValueError::new_err(format!(
-                "strategy: {strat} not allowed, choose any of {{ 'first_non_null', 'max_width' }}"
-            )))
+                    "n_field_strategy must be one of {{'first_non_null', 'max_width'}}, got {}",
+                    e,
+                )))
             }
         };
 

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -20,7 +20,7 @@ def test_fill_null() -> None:
     s = pl.Series("A", [dt, None])
 
     for fill_val in (dt, pl.lit(dt)):
-        out = s.fill_null(fill_val)  # type: ignore[arg-type]
+        out = s.fill_null(fill_val)
 
         assert out.null_count() == 0
         assert out.dt[0] == dt
@@ -32,7 +32,7 @@ def test_fill_null() -> None:
     s = pl.Series("a", [dt1, dt2, dt3, None])
     dt_2 = date(2001, 1, 4)
     for fill_val in (dt_2, pl.lit(dt_2)):
-        out = s.fill_null(fill_val)  # type: ignore[arg-type]
+        out = s.fill_null(fill_val)
 
         assert out.null_count() == 0
         assert out.dt[0] == dt1


### PR DESCRIPTION
Relates to #4288

Changes:
* Define literal types for `strategy` (asof joins), `strategy` (fill_null), `null_strategy` (sum, mean) and `n_field_strategy` (to_struct)
* Update type hints, error messages, and docstrings for these arguments in all relevant functions