### PR TITLE
Re-order Python API reference menu by importance

### DIFF
--- a/py-polars/docs/source/reference/index.rst
+++ b/py-polars/docs/source/reference/index.rst
@@ -9,13 +9,13 @@ methods. All classes and functions exposed in ``polars.*`` namespace are public.
 .. toctree::
    :maxdepth: 2
 
-   config
-   dataframe
-   datatypes
-   exceptions
-   expression
-   functions
    io
-   lazyframe
+   functions
    series
+   dataframe
+   lazyframe
+   expression
+   datatypes
+   config
+   exceptions
    testing


### PR DESCRIPTION
Relates to #4156

Proposal for a new ordering of the API reference menu. Open to suggestions!