### PR TITLE
Unify type annotations for `DataFrame.select` and `LazyFrame.select`

### DIFF
--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -889,7 +889,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def select(
         self: LDF,
-        exprs: str | pli.Expr | Sequence[str | pli.Expr] | pli.Series,
+        exprs: str | pli.Expr | pli.Series | Sequence[str | pli.Expr | pli.Series],
     ) -> LDF:
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -572,9 +572,8 @@ class Series:
             if item.dtype == bool:
                 return wrap_s(self._s.filter(pli.Series("", item).inner()))
 
-        if isinstance(item, Sequence):
-            if is_bool_sequence(item) or is_int_sequence(item):
-                item = Series("", item)  # fall through to next if isinstance
+        if is_bool_sequence(item) or is_int_sequence(item):
+            item = Series("", item)  # fall through to next if isinstance
 
         if isinstance(item, Series):
             if item.dtype == Boolean:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -119,39 +119,45 @@ def _date_to_pl_date(d: date) -> int:
     return int(dt.timestamp()) // (3600 * 24)
 
 
-def _is_iterable_of(val: Iterable[object], itertype: type, eltype: type) -> bool:
+def _is_iterable_of(val: Iterable[object], eltype: type) -> bool:
     """Check whether the given iterable is of a certain type."""
-    return isinstance(val, itertype) and all(isinstance(x, eltype) for x in val)
+    return all(isinstance(x, eltype) for x in val)
 
 
-def is_bool_sequence(val: Sequence[object]) -> TypeGuard[Sequence[bool]]:
+def is_bool_sequence(val: object) -> TypeGuard[Sequence[bool]]:
     """Check whether the given sequence is a sequence of booleans."""
-    return _is_iterable_of(val, Sequence, bool)
+    if isinstance(val, Sequence):
+        return _is_iterable_of(val, bool)
+    else:
+        return False
 
 
-def is_int_sequence(val: Sequence[object]) -> TypeGuard[Sequence[int]]:
+def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
-    return _is_iterable_of(val, Sequence, int)
+    if isinstance(val, Sequence):
+        return _is_iterable_of(val, int)
+    else:
+        return False
 
 
 def is_expr_sequence(val: object) -> TypeGuard[Sequence[pli.Expr]]:
     """Check whether the given object is a sequence of Exprs."""
     if isinstance(val, Sequence):
-        return _is_iterable_of(val, Sequence, pli.Expr)
+        return _is_iterable_of(val, pli.Expr)
     else:
         return False
 
 
 def is_pyexpr_sequence(val: object) -> TypeGuard[Sequence[PyExpr]]:
-    """Check whether the given object is a sequence of Exprs."""
+    """Check whether the given object is a sequence of PyExprs."""
     if isinstance(val, Sequence):
-        return _is_iterable_of(val, Sequence, PyExpr)
+        return _is_iterable_of(val, PyExpr)
     else:
         return False
 
 
 def is_str_sequence(
-    val: Sequence[object], allow_str: bool = False
+    val: object, *, allow_str: bool = False
 ) -> TypeGuard[Sequence[str]]:
     """
     Check that `val` is a sequence of strings.
@@ -159,9 +165,12 @@ def is_str_sequence(
     Note that a single string is a sequence of strings by definition, use
     `allow_str=False` to return False on a single string.
     """
-    if (not allow_str) and isinstance(val, str):
+    if allow_str is False and isinstance(val, str):
         return False
-    return _is_iterable_of(val, Sequence, str)
+    if isinstance(val, Sequence):
+        return _is_iterable_of(val, str)
+    else:
+        return False
 
 
 def range_to_slice(rng: range) -> slice:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -151,6 +151,13 @@ def test_selection() -> None:
     assert df[::2].frame_equal(expect)
 
 
+def test_mixed_sequence_selection() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    result = df.select(["a", pl.col("b"), pl.lit("c")])
+    expected = pl.DataFrame({"a": [1, 2], "b": [3, 4], "literal": ["c", "c"]})
+    assert_frame_equal(result, expected)
+
+
 def test_from_arrow() -> None:
     tbl = pa.table(
         {

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -594,13 +594,6 @@ def test_col_series_selection() -> None:
     assert df.select(pl.col(srs)).columns == ["b", "c"]
 
 
-def test_literal_projection() -> None:
-    df = pl.DataFrame({"a": [1, 2]})
-    assert df.select([True]).dtypes == [pl.Boolean]
-    assert df.select([1]).dtypes == [pl.Int32]
-    assert df.select([2.0]).dtypes == [pl.Float64]
-
-
 def test_interpolate() -> None:
     df = pl.DataFrame({"a": [1, None, 3]})
     assert df.select(col("a").interpolate())["a"] == [1, 2, 3]


### PR DESCRIPTION
Closes #4291 

This MR does three things

1. **(primary goal)** It simplifies and unifies the type annotations for `DataFrame.select` and `LazyFrame.select`. To this end, I've removed a test that checks `assert df.select([True]).dtypes == [pl.Boolean]` as passing a literal `bool` is no longer officially supported behavior. I've instead introduced a test that confirms `Sequence[str | pli.Expr | pli.Series]` is a valid input parameter.
2. It makes the `allow_str` kwarg of `is_str_sequence` a required **named** parameter. IMO this greatly improves readability -- it was not clear at first glance what `is_str_sequence(val, False)` meant.
3. I've moved the `isinstance(val, Sequence)` check into the various `is_X_sequence` functions. This small changes eliminates some duplicated code and saves us a level of indentation. Previously we had to write

```python
if isinstance(val, Sequence):
    if is_bool_sequence(val):
       fn()
```