### PR TITLE
Remove more deprecated functionality

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from typing import Any, Mapping, Sequence, overload
 
 from polars.internals import DataFrame, Series
@@ -158,15 +157,7 @@ def from_records(
     └─────┴─────┘
 
     """
-    if _NUMPY_AVAILABLE and isinstance(data, np.ndarray):
-        warnings.warn(
-            "using `from_records` with a numpy ndarray is deprecated, "
-            "use `from_numpy` instead",
-            DeprecationWarning,
-        )
-        return DataFrame._from_numpy(data, columns=columns, orient=orient)
-    else:
-        return DataFrame._from_records(data, columns=columns, orient=orient)
+    return DataFrame._from_records(data, columns=columns, orient=orient)
 
 
 def from_numpy(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -3663,9 +3663,6 @@ class DataFrame:
         on: str | pli.Expr | list[str | pli.Expr] | None = None,
         how: str = "inner",
         suffix: str = "_right",
-        asof_by: str | list[str] | None = None,
-        asof_by_left: str | list[str] | None = None,
-        asof_by_right: str | list[str] | None = None,
     ) -> DataFrame:
         """
         Join in SQL-like fashion.
@@ -3680,27 +3677,18 @@ class DataFrame:
             Name(s) of the right join column(s).
         on
             Name(s) of the join columns in both DataFrames.
-        how
-            Join strategy
-                - "inner"
-                - "left"
-                - "outer"
-                - "asof"
-                - "cross"
-                - "semi"
-                - "anti"
+        how : {'inner', 'left', 'outer', 'semi', 'anti', 'cross'}
+            Join strategy.
         suffix
             Suffix to append to columns with a duplicate name.
-        asof_by
-            join on these columns before doing asof join
-        asof_by_left
-            join on these columns before doing asof join
-        asof_by_right
-            join on these columns before doing asof join
 
         Returns
         -------
             Joined DataFrame
+
+        See Also
+        --------
+        join_asof
 
         Examples
         --------
@@ -3745,22 +3733,10 @@ class DataFrame:
         │ 3    ┆ 8.0  ┆ c   ┆ null  │
         └──────┴──────┴─────┴───────┘
 
-        **Asof join**
-        This is similar to a left-join except that we match on near keys rather than
-        equal keys.
-        The direction is backward
-        The keys must be sorted to perform an asof join
-
         **Joining on columns with categorical data**
         See pl.StringCache().
 
         """
-        if how == "asof":  # pragma: no cover
-            warnings.warn(
-                "using asof join via DataFrame.join is deprecated, please use"
-                " DataFrame.join_asof",
-                DeprecationWarning,
-            )
         if how == "cross":
             return self._from_pydf(self._df.join(other._df, [], [], how, suffix))
 
@@ -3786,13 +3762,7 @@ class DataFrame:
         if left_on_ is None or right_on_ is None:
             raise ValueError("You should pass the column to join on as an argument.")
 
-        if (
-            isinstance(left_on_[0], pli.Expr)
-            or isinstance(right_on_[0], pli.Expr)
-            or asof_by_left is not None
-            or asof_by_right is not None
-            or asof_by is not None
-        ):
+        if isinstance(left_on_[0], pli.Expr) or isinstance(right_on_[0], pli.Expr):
             return (
                 self.lazy()
                 .join(
@@ -3802,9 +3772,6 @@ class DataFrame:
                     on=on,
                     how=how,
                     suffix=suffix,
-                    asof_by_right=asof_by_right,
-                    asof_by_left=asof_by_left,
-                    asof_by=asof_by,
                 )
                 .collect(no_optimization=True)
             )

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -54,7 +54,6 @@ from polars.utils import (
     format_path,
     handle_projection_columns,
     is_bool_sequence,
-    is_expr_sequence,
     is_int_sequence,
     is_str_sequence,
     range_to_slice,
@@ -1667,8 +1666,6 @@ class DataFrame:
         self: DF,
         item: int
         | np.ndarray[Any, Any]
-        | pli.Expr
-        | list[pli.Expr]
         | MultiColSelector
         | tuple[int, MultiColSelector]
         | tuple[MultiRowSelector, MultiColSelector],
@@ -1697,8 +1694,6 @@ class DataFrame:
             str
             | int
             | np.ndarray[Any, Any]
-            | pli.Expr
-            | list[pli.Expr]
             | MultiColSelector
             | tuple[int, MultiColSelector]
             | tuple[MultiRowSelector, MultiColSelector]
@@ -1709,12 +1704,6 @@ class DataFrame:
         ),
     ) -> DataFrame | pli.Series:
         """Get item. Does quite a lot. Read the comments."""
-        if isinstance(item, pli.Expr):  # pragma: no cover
-            warnings.warn(
-                "'using expressions in []' is deprecated. please use 'select'",
-                DeprecationWarning,
-            )
-            return self.select(item)
         # select rows and columns at once
         # every 2d selection, i.e. tuple is row column order, just like numpy
         if isinstance(item, tuple) and len(item) == 2:
@@ -1837,8 +1826,6 @@ class DataFrame:
             # select multiple columns
             # df[["foo", "bar"]]
             return self._from_pydf(self._df.select(item))
-        elif is_expr_sequence(item):
-            return self.select(item)
         elif is_bool_sequence(item) or is_int_sequence(item):
             item = pli.Series("", item)  # fall through to next if isinstance
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -344,13 +344,13 @@ def test_window_deadlock() -> None:
         }
     )
 
-    df = df[
+    df = df.select(
         [
             col("*"),  # select all
             col("random").sum().over("groups").alias("sum[random]/groups"),
             col("random").list().over("names").alias("random/name"),
         ]
-    ]
+    )
 
 
 def test_concat_str() -> None:


### PR DESCRIPTION
Relates to #4308

Changes:
* `from_records` no longer supports NumPy arrays as input (use `from_numpy` instead)
* `DataFrame.join` and `LazyFrame.join` no longer support `how="asof"` (use `join_asof` instead)
* `DataFrame.__getitem__` no longer supports Expressions or list of Expressions (use `.select` instead)

More on the way - they're getting harder 😄 