### PR TITLE
Remove deprecated sort in-place

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -2394,47 +2394,12 @@ class DataFrame:
             index = len(self.columns) + index
         self._df.replace_at_idx(index, series._s)
 
-    @overload
-    def sort(
-        self,
-        by: str | pli.Expr | list[str] | list[pli.Expr],
-        reverse: bool | list[bool] = ...,
-        nulls_last: bool = ...,
-        *,
-        in_place: Literal[False] = ...,
-    ) -> DataFrame:
-        ...
-
-    @overload
-    def sort(
-        self,
-        by: str | pli.Expr | list[str] | list[pli.Expr],
-        reverse: bool | list[bool] = ...,
-        nulls_last: bool = ...,
-        *,
-        in_place: Literal[True],
-    ) -> None:
-        ...
-
-    @overload
-    def sort(
-        self,
-        by: str | pli.Expr | list[str] | list[pli.Expr],
-        reverse: bool | list[bool] = ...,
-        nulls_last: bool = ...,
-        *,
-        in_place: bool,
-    ) -> DataFrame | None:
-        ...
-
     def sort(
         self,
         by: str | pli.Expr | list[str] | list[pli.Expr],
         reverse: bool | list[bool] = False,
         nulls_last: bool = False,
-        *,
-        in_place: bool = False,
-    ) -> DataFrame | None:
+    ) -> DataFrame:
         """
         Sort the DataFrame by column.
 
@@ -2444,8 +2409,6 @@ class DataFrame:
             By which column to sort. Only accepts string.
         reverse
             Reverse/descending sort.
-        in_place
-            Perform operation in-place.
         nulls_last
             Place null values last. Can only be used if sorted by a single column.
 
@@ -2499,23 +2462,8 @@ class DataFrame:
                 .sort(by, reverse, nulls_last)
                 .collect(no_optimization=True, string_cache=False)
             )
-            if in_place:  # pragma: no cover
-                warnings.warn(
-                    "in-place sorting is deprecated; please use default sorting",
-                    DeprecationWarning,
-                )
-                self._df = df._df
-                return self
             return df
-        if in_place:  # pragma: no cover
-            warnings.warn(
-                "in-place sorting is deprecated; please use default sorting",
-                DeprecationWarning,
-            )
-            self._df.sort_in_place(by, reverse)
-            return None
-        else:
-            return self._from_pydf(self._df.sort(by, reverse, nulls_last))
+        return self._from_pydf(self._df.sort(by, reverse, nulls_last))
 
     def frame_equal(self, other: DataFrame, null_equal: bool = True) -> bool:
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -984,13 +984,6 @@ impl PyDataFrame {
         Ok(PyDataFrame::new(df))
     }
 
-    pub fn sort_in_place(&mut self, by_column: &str, reverse: bool) -> PyResult<()> {
-        self.df
-            .sort_in_place([by_column], reverse)
-            .map_err(PyPolarsErr::from)?;
-        Ok(())
-    }
-
     pub fn replace(&mut self, column: &str, new_col: PySeries) -> PyResult<()> {
         self.df
             .replace(column, new_col.series)

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -180,15 +180,10 @@ def test_dataframe_membership_operator() -> None:
 
 def test_sort() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
-    with pytest.deprecated_call():
-        df.sort("a", in_place=True)
-    assert df.frame_equal(pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
-
-    # test in-place + passing a list
-    df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
-    with pytest.deprecated_call():
-        df.sort(["a", "b"], in_place=True)
-    assert df.frame_equal(pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
+    assert df.sort("a").frame_equal(pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
+    assert df.sort(["a", "b"]).frame_equal(
+        pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
+    )
 
 
 def test_replace() -> None:

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 import polars as pl
 
 
@@ -55,16 +53,6 @@ def test_sort_by() -> None:
     # by can also be a single column
     out = df.select([pl.col("a").sort_by("b", reverse=[False])])
     assert out["a"].to_list() == [1, 2, 3, 4, 5]
-
-
-def test_sort_in_place() -> None:
-    df = pl.DataFrame({"a": [1, 3, 2, 4, 5]})
-    with pytest.deprecated_call():
-        ret = df.sort("a", in_place=True)
-    result = df["a"].to_list()
-    expected = [1, 2, 3, 4, 5]
-    assert result == expected
-    assert ret is None
 
 
 def test_sort_by_exprs() -> None:


### PR DESCRIPTION
Relates to #4308

Changes:
* `DataFrame.sort` no longer supports in-place sorting.