### PR TITLE
Remove deprecated `DataFrame.__getattr__`

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -61,7 +61,7 @@ from polars.utils import (
 )
 
 try:
-    from polars.polars import PyDataFrame, PySeries
+    from polars.polars import PyDataFrame
 
     _DOCUMENTING = False
 except ImportError:
@@ -1532,25 +1532,6 @@ class DataFrame:
 
     def __repr__(self) -> str:
         return self.__str__()
-
-    def __getattr__(self, item: Any) -> PySeries:
-        """Access columns as attribute."""
-        # it is important that we return an AttributeError here
-        # this is used by ipython to check some private
-        # `_ipython_canary_method_should_not_exist_`
-        # if we return any other error than AttributeError pretty printing
-        # will not work in notebooks.
-        # See: https://github.com/jupyter/notebook/issues/2014
-        if item.startswith("_"):
-            raise AttributeError(item)
-        try:  # pragma: no cover
-            warnings.warn(
-                "accessing series as Attribute of a DataFrame is deprecated",
-                DeprecationWarning,
-            )
-            return pli.wrap_s(self._df.column(item))
-        except Exception as exc:
-            raise AttributeError(item) from exc
 
     def __contains__(self, key: str) -> bool:
         return key in self.columns

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1681,15 +1681,6 @@ def test_add_string() -> None:
     assert result.frame_equal(expected)
 
 
-def test_getattr() -> None:
-    with pytest.deprecated_call():
-        df = pl.DataFrame({"a": [1.0, 2.0]})
-        assert_series_equal(df.a, pl.Series("a", [1.0, 2.0]))
-
-        with pytest.raises(AttributeError):
-            _ = df.b
-
-
 def test_get_item() -> None:
     """Test all the methods to use [] on a dataframe."""
     df = pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0], "b": [3, 4, 5, 6]})

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -433,14 +433,14 @@ def test_groupby_agg_input_types(lazy: bool) -> None:
         with pytest.raises(TypeError):
             result = df_or_lazy.groupby("a").agg(bad_param)  # type: ignore[arg-type]
             if lazy:
-                result.collect()
+                result.collect()  # type: ignore[union-attr]
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 7]})
 
     for good_param in GOOD_AGG_PARAMETERS:
         result = df_or_lazy.groupby("a", maintain_order=True).agg(good_param)
         if lazy:
-            result = result.collect()
+            result = result.collect()  # type: ignore[union-attr]
         assert_frame_equal(result, expected)
 
 
@@ -457,7 +457,7 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
                 bad_param  # type: ignore[arg-type]
             )
             if lazy:
-                result.collect()
+                result.collect()  # type: ignore[union-attr]
 
     expected = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 4, 4, 3]})
 
@@ -466,7 +466,7 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
             index_column="index_column", period="2i"
         ).agg(good_param)
         if lazy:
-            result = result.collect()
+            result = result.collect()  # type: ignore[union-attr]
         assert_frame_equal(result, expected)
 
 
@@ -483,7 +483,7 @@ def test_groupby_dynamic_agg_input_types(lazy: bool) -> None:
                 bad_param  # type: ignore[arg-type]
             )
             if lazy:
-                result.collect()
+                result.collect()  # type: ignore[union-attr]
 
     expected = pl.DataFrame({"index_column": [0, 0, 2], "b": [1, 4, 2]})
 
@@ -492,7 +492,7 @@ def test_groupby_dynamic_agg_input_types(lazy: bool) -> None:
             index_column="index_column", every="2i"
         ).agg(good_param)
         if lazy:
-            result = result.collect()
+            result = result.collect()  # type: ignore[union-attr]
         assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/test_interop.py
+++ b/py-polars/tests/test_interop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, no_type_check
+from typing import Any, cast, no_type_check
 from unittest.mock import patch
 
 import numpy as np
@@ -176,7 +176,7 @@ def test_arrow_dict_to_polars() -> None:
 def test_arrow_list_chunked_array() -> None:
     a = pa.array([[1, 2], [3, 4]])
     ca = pa.chunked_array([a, a, a])
-    s = pl.from_arrow(ca)
+    s = cast(pl.Series, pl.from_arrow(ca))
     assert s.dtype == pl.List
 
 
@@ -404,8 +404,8 @@ def test_cat_int_types_3500() -> None:
     with pl.StringCache():
         # Create an enum / categorical / dictionary typed pyarrow array
         # Most simply done by creating a pandas categorical series first
-        categorical_df = pd.Series(["a", "a", "b"], dtype="category")
-        pyarrow_array = pa.Array.from_pandas(categorical_df)
+        categorical_s = pd.Series(["a", "a", "b"], dtype="category")
+        pyarrow_array = pa.Array.from_pandas(categorical_s)
 
         # The in-memory representation of each category can either be a signed or
         # unsigned 8-bit integer. Pandas uses Int8...
@@ -414,7 +414,7 @@ def test_cat_int_types_3500() -> None:
         uint_dict_type = pa.dictionary(index_type=pa.uint8(), value_type=pa.utf8())
 
         for t in [int_dict_type, uint_dict_type]:
-            s = pl.from_arrow(pyarrow_array.cast(t))
+            s = cast(pl.Series, pl.from_arrow(pyarrow_array.cast(t)))
             assert s.series_equal(pl.Series(["a", "a", "b"]).cast(pl.Categorical))
 
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -349,10 +349,12 @@ def test_arrow() -> None:
     a = pa.array(["foo", "bar"], pa.dictionary(pa.int32(), pa.utf8()))
     s = pl.Series("a", a)
     assert s.dtype == pl.Categorical
-    assert (
-        pl.from_arrow(pa.array([["foo"], ["foo", "bar"]], pa.list_(pa.utf8()))).dtype
-        == pl.List
+
+    s = cast(
+        pl.Series,
+        pl.from_arrow(pa.array([["foo"], ["foo", "bar"]], pa.list_(pa.utf8()))),
     )
+    assert s.dtype == pl.List
 
 
 def test_view() -> None:


### PR DESCRIPTION
Relates to https://github.com/pola-rs/polars/issues/4308

Changes:

* `DataFrame` no longer supports using `getattr` to get its columns by name. (use indexing instead, i.e. `df["col"]`)
* Reverted to default `__getattr__` implementation. This woke up `mypy` somehow, so I had to fix some typing errors.