### PR TITLE
Remove accessing GroupBy by index

### DIFF
--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -160,7 +160,6 @@ This namespace comes available by calling `DataFrame.groupby(..)`.
     GroupBy.apply
     GroupBy.count
     GroupBy.first
-    GroupBy.groups
     GroupBy.head
     GroupBy.last
     GroupBy.max

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -344,10 +344,6 @@ def test_groupby() -> None:
     assert df.groupby("a").apply(lambda df: df[["c"]].sum()).sort("c")["c"][0] == 1
 
     with pytest.deprecated_call():
-        df_groups = df.groupby("a").groups().sort("a")
-        assert df_groups["a"].series_equal(pl.Series("a", ["a", "b", "c"]))
-
-    with pytest.deprecated_call():
         # TODO: find a way to avoid indexing into GroupBy
         for subdf in df.groupby("a"):  # type: ignore[attr-defined]
             # TODO: add __next__() to GroupBy


### PR DESCRIPTION
Relates to #4308

Changes (updated):
* Removed `GroupBy.__getitem__`. The same functionality is still available through the private method `_select`.
* Made `GroupBy.groups` private.

I think we can improve a lot here. I'll make a separate issue and we'll come back to this later.