### PR TITLE
Remove deprecated `DataFrame.__setitem__`

### DIFF
--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1861,65 +1861,6 @@ class DataFrame:
             f" of type: '{type(item)}'."
         )
 
-    def __setitem__(
-        self, key: str | list[Any] | tuple[Any, str | int], value: Any
-    ) -> None:  # pragma: no cover
-        warnings.warn(
-            "setting a DataFrame by indexing is deprecated; Consider using"
-            " DataFrame.with_column",
-            DeprecationWarning,
-        )
-        # df["foo"] = series
-        if isinstance(key, str):
-            try:
-                self.replace(key, pli.Series(key, value))
-            except Exception:
-                self.hstack([pli.Series(key, value)], in_place=True)
-        # df[["C", "D"]]
-        elif isinstance(key, list):
-            # TODO: Use python sequence constructors
-            if not _NUMPY_AVAILABLE:
-                raise ImportError("'numpy' is required for this functionality.")
-            value = np.array(value)
-            if value.ndim != 2:
-                raise ValueError("can only set multiple columns with 2D matrix")
-            if value.shape[1] != len(key):
-                raise ValueError(
-                    "matrix columns should be equal to list use to determine column"
-                    " names"
-                )
-            for (i, name) in enumerate(key):
-                self[name] = value[:, i]
-
-        # df[a, b]
-        elif isinstance(key, tuple):
-            row_selection, col_selection = key
-
-            # get series column selection
-            if isinstance(col_selection, str):
-                s = self.__getitem__(col_selection)
-            elif isinstance(col_selection, int):
-                s = self[:, col_selection]
-            else:
-                raise ValueError(f"column selection not understood: {col_selection}")
-
-            # dispatch to __setitem__ of Series to do modification
-            s[row_selection] = value
-
-            # now find the location to place series
-            # df[idx]
-            if isinstance(col_selection, int):
-                self.replace_at_idx(col_selection, s)
-            # df["foo"]
-            elif isinstance(col_selection, str):
-                self.replace(col_selection, s)
-        else:
-            raise ValueError(
-                f"Cannot __setitem__ on DataFrame with key: '{key}' "
-                f"of type: '{type(key)}' and value: '{value}' "
-                f"of type: '{type(value)}'."
-            )
-
     def __len__(self) -> int:
         return self.height
 

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -1238,7 +1238,6 @@ def test_sum_duration() -> None:
     }
 
 
-@pytest.mark.filterwarnings("ignore:setting a DataFrame by indexing:DeprecationWarning")
 def test_supertype_timezones_4174() -> None:
     df = pl.DataFrame(
         {
@@ -1252,7 +1251,7 @@ def test_supertype_timezones_4174() -> None:
 
     # test if this runs without error
     date_to_fill = df["dt_London"][0]
-    df["dt_London"] = df["dt_London"].shift_and_fill(1, date_to_fill)
+    df.with_column(df["dt_London"].shift_and_fill(1, date_to_fill))
 
 
 def test_weekday() -> None:

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -237,26 +237,6 @@ def test_replace_at_idx() -> None:
     assert_frame_equal(expected_df, df)
 
 
-def test_indexing_set() -> None:
-    # This is deprecated behaviour
-    df = pl.DataFrame({"bool": [True, True], "str": ["N/A", "N/A"], "nr": [1, 2]})
-
-    with pytest.deprecated_call():
-        df[0, "bool"] = False
-
-    with pytest.deprecated_call():
-        df[0, "nr"] = 100
-
-    with pytest.deprecated_call():
-        df[0, "str"] = "foo"
-
-    assert df.to_dict(False) == {
-        "bool": [False, True],
-        "str": ["foo", "N/A"],
-        "nr": [100, 2],
-    }
-
-
 def test_to_series() -> None:
     df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
 
@@ -640,55 +620,6 @@ def test_read_missing_file() -> None:
     with pytest.raises(FileNotFoundError, match="fake_csv_file"):
         with open("fake_csv_file", "r") as f:
             pl.read_csv(f)
-
-
-def test_set() -> None:
-    """
-    Setting a dataframe using indices is deprecated. We keep these tests because we
-    only generate a warning
-    """
-    with pytest.deprecated_call():
-        np.random.seed(1)
-        df = pl.DataFrame(
-            {"foo": np.random.rand(10), "bar": np.arange(10), "ham": ["h"] * 10}
-        )
-        df["new"] = np.random.rand(10)
-        df[df["new"] > 0.5, "new"] = 1
-
-        # set 2D
-        df = pl.DataFrame({"b": [0, 0]})
-        df[["A", "B"]] = [[1, 2], [1, 2]]
-        assert df["A"] == [1, 1]
-        assert df["B"] == [2, 2]
-
-        with pytest.raises(ValueError):
-            df[["C", "D"]] = 1
-        with pytest.raises(ValueError):
-            df[["C", "D"]] = [1, 1]
-        with pytest.raises(ValueError):
-            df[["C", "D"]] = [[1, 2, 3], [1, 2, 3]]
-
-        # set tuple
-        df = pl.DataFrame({"b": [0, 0]})
-        df[0, "b"] = 1
-        assert df[0, "b"] == 1
-
-        df[0, 0] = 2
-        assert df[0, "b"] == 2
-
-        # row and col selection have to be int or str
-        with pytest.raises(ValueError):
-            df[:, [1]] = 1  # type: ignore[index]
-        with pytest.raises(ValueError):
-            df[True, :] = 1  # type: ignore[index]
-
-        # needs to be a 2 element tuple
-        with pytest.raises(ValueError):
-            df[(1, 2, 3)] = 1  # type: ignore[index]
-
-        # we cannot index with any type, such as bool
-        with pytest.raises(ValueError):
-            df[True] = 1  # type: ignore[index]
 
 
 def test_melt() -> None:

--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -139,5 +139,7 @@ def test_getitem_errs() -> None:
     ):
         df["a"][{"strange"}]
 
-    with pytest.raises(ValueError, match="Cannot __setitem__ on DataFrame with key:.*"):
+    with pytest.raises(
+        TypeError, match="'DataFrame' object does not support item assignment"
+    ):
         df[{"some"}] = "foo"


### PR DESCRIPTION
Relates to #4308

Changes:
* Remove `DataFrame.__setitem__` (use `with_column` instead)