### PR TITLE
fix issue4258

### DIFF
--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -906,8 +906,8 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.min()
-        1
+        >>> s.max()
+        3
 
         """
         return self._s.max()

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -258,6 +258,7 @@ def _to_python_datetime(
             raise ValueError(f"time unit: {tu} not expected")
         if tz is not None and len(tz) > 0:
             import pytz
+
             return pytz.timezone(tz).localize(dt)
         return dt
     else:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -242,7 +242,9 @@ def _to_python_datetime(
         # days to seconds
         # important to create from utc. Not doing this leads
         # to inconsistencies dependent on the timezone you are in.
-        return datetime.utcfromtimestamp(value * 3600 * 24).date()
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        dt += timedelta(seconds=value * 3600 * 24)
+        return dt.date()
     elif dtype == Datetime:
         if tu == "ns":
             # nanoseconds to seconds
@@ -251,16 +253,13 @@ def _to_python_datetime(
             dt = EPOCH + timedelta(microseconds=value)
         elif tu == "ms":
             # milliseconds to seconds
-            dt = datetime.utcfromtimestamp(value / 1_000)
+            dt = datetime.utcfromtimestamp(value / 1000)
         else:
             raise ValueError(f"time unit: {tu} not expected")
         if tz is not None and len(tz) > 0:
             import pytz
-
-            timezone = pytz.timezone(tz)
-            return timezone.localize(dt)
+            return pytz.timezone(tz).localize(dt)
         return dt
-
     else:
         raise NotImplementedError  # pragma: no cover
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -141,6 +141,16 @@ def test_agg() -> None:
     assert series.max() == 2
 
 
+def test_date_agg() -> None:
+    series = pl.Series([
+        date(2022, 8, 2),
+        date(2096, 8, 1),
+        date(9009, 9, 9),
+    ], dtype=pl.Date)
+    assert series.min() == date(2022, 8, 2)
+    assert series.max() == date(9009, 9, 9)
+
+
 @pytest.mark.parametrize(
     "s", [pl.Series([1, 2], dtype=Int64), pl.Series([1, 2], dtype=Float64)]
 )

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -142,11 +142,14 @@ def test_agg() -> None:
 
 
 def test_date_agg() -> None:
-    series = pl.Series([
-        date(2022, 8, 2),
-        date(2096, 8, 1),
-        date(9009, 9, 9),
-    ], dtype=pl.Date)
+    series = pl.Series(
+        [
+            date(2022, 8, 2),
+            date(2096, 8, 1),
+            date(9009, 9, 9),
+        ],
+        dtype=pl.Date,
+    )
     assert series.min() == date(2022, 8, 2)
     assert series.max() == date(9009, 9, 9)
 


### PR DESCRIPTION
The max function will raise error, when date type series has too larger year from https://github.com/pola-rs/polars/issues/4258. This is because that function `utcfromtimestamp(timestamp)` has an os dependent year limit. One can fix this by using `datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=timestamp)`.

Reference:

- [utcfromtimestamp python doc](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp)