### PR TITLE
Remove deprecated `DataFrame.select_at_idx`

### DIFF
--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -112,7 +112,6 @@ Manipulation/ selection
     DataFrame.rows
     DataFrame.sample
     DataFrame.select
-    DataFrame.select_at_idx
     DataFrame.shift
     DataFrame.shift_and_fill
     DataFrame.shrink_to_fit

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -258,7 +258,7 @@ class DataFrame:
 
     >>> class MyDataFrame(pl.DataFrame):
     ...     pass
-    >>>
+    ...
     >>> isinstance(MyDataFrame().lazy().collect(), MyDataFrame)
     False
 
@@ -4026,40 +4026,6 @@ class DataFrame:
 
         """
         return pli.wrap_s(self._df.drop_in_place(name))
-
-    def select_at_idx(self, idx: int) -> pli.Series:
-        """
-        Select column at index location.
-
-        Parameters
-        ----------
-        idx
-            Location of selection.
-
-        .. deprecated:: 0.10.20
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "foo": [1, 2, 3],
-        ...         "bar": [6, 7, 8],
-        ...         "ham": ["a", "b", "c"],
-        ...     }
-        ... )
-        >>> df.select_at_idx(1)
-        shape: (3,)
-        Series: 'bar' [i64]
-        [
-                6
-                7
-                8
-        ]
-
-        """
-        if idx < 0:
-            idx = len(self.columns) + idx
-        return pli.wrap_s(self._df.select_at_idx(idx))
 
     def cleared(self: DF) -> DF:
         """

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -127,7 +127,7 @@ def test_selection() -> None:
 
     assert df[[0, 1], "b"].shape == (2, 1)
     assert df[[2], ["a", "b"]].shape == (1, 2)
-    assert df.select_at_idx(0).name == "a"
+    assert df.to_series(0).name == "a"
     assert (df["a"] == df["a"]).sum() == 3
     assert (df["c"] == df["a"].cast(str)).sum() == 0
     assert df[:, "a":"b"].shape == (3, 2)  # type: ignore[misc]
@@ -202,15 +202,6 @@ def test_assignment() -> None:
         pl.when(pl.col("foo") > 1).then(9).otherwise(pl.col("foo")).alias("foo")
     )
     assert df["foo"].to_list() == [1, 9, 9]
-
-
-def test_select_at_idx() -> None:
-    df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
-    for idx in range(len(df.columns)):
-        assert_series_equal(
-            df.select_at_idx(idx),  # regular positive indexing
-            df.select_at_idx(idx - len(df.columns)),  # equivalent negative index
-        )
 
 
 def test_insert_at_idx() -> None:
@@ -821,34 +812,34 @@ def test_lazy_functions() -> None:
         ]
     )
     expected = 1.0
-    assert np.isclose(out.select_at_idx(0), expected)
+    assert np.isclose(out.to_series(0), expected)
     assert np.isclose(pl.var(df["b"]), expected)  # type: ignore[arg-type]
     expected = 1.0
-    assert np.isclose(out.select_at_idx(1), expected)
+    assert np.isclose(out.to_series(1), expected)
     assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
     expected = 3
-    assert np.isclose(out.select_at_idx(2), expected)
+    assert np.isclose(out.to_series(2), expected)
     assert np.isclose(pl.max(df["b"]), expected)
     expected = 1
-    assert np.isclose(out.select_at_idx(3), expected)
+    assert np.isclose(out.to_series(3), expected)
     assert np.isclose(pl.min(df["b"]), expected)
     expected = 6
-    assert np.isclose(out.select_at_idx(4), expected)
+    assert np.isclose(out.to_series(4), expected)
     assert np.isclose(pl.sum(df["b"]), expected)
     expected = 2
-    assert np.isclose(out.select_at_idx(5), expected)
+    assert np.isclose(out.to_series(5), expected)
     assert np.isclose(pl.mean(df["b"]), expected)
     expected = 2
-    assert np.isclose(out.select_at_idx(6), expected)
+    assert np.isclose(out.to_series(6), expected)
     assert np.isclose(pl.median(df["b"]), expected)
     expected = 3
-    assert np.isclose(out.select_at_idx(7), expected)
+    assert np.isclose(out.to_series(7), expected)
     assert np.isclose(pl.n_unique(df["b"]), expected)
     expected = 1
-    assert np.isclose(out.select_at_idx(8), expected)
+    assert np.isclose(out.to_series(8), expected)
     assert np.isclose(pl.first(df["b"]), expected)
     expected = 3
-    assert np.isclose(out.select_at_idx(9), expected)
+    assert np.isclose(out.to_series(9), expected)
     assert np.isclose(pl.last(df["b"]), expected)
 
 
@@ -883,7 +874,7 @@ def test_describe() -> None:
         }
     )
     assert df.describe().shape != df.shape
-    assert set(df.describe().select_at_idx(2)) == {1.0, 4.0, 5.0, 6.0}
+    assert set(df.describe().to_series(2)) == {1.0, 4.0, 5.0, 6.0}
 
 
 def test_string_cache_eager_lazy() -> None:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -809,7 +809,7 @@ def test_arange_expr() -> None:
     df = pl.DataFrame({"a": ["foobar", "barfoo"]})
     out = df.select([pl.arange(0, pl.col("a").count() * 10)])
     assert out.shape == (20, 1)
-    assert out.select_at_idx(0)[-1] == 19
+    assert out.to_series(0)[-1] == 19
 
     # eager arange
     out2 = pl.arange(0, 10, 2, eager=True)

--- a/py-polars/tests_parametric/test_dataframe.py
+++ b/py-polars/tests_parametric/test_dataframe.py
@@ -27,7 +27,7 @@ def test_null_count(df: pl.DataFrame) -> None:
     else:
         assert null_count.shape == (1, ncols)
         for idx, count in enumerate(null_count.rows()[0]):
-            assert count == sum(v is None for v in df.select_at_idx(idx).to_list())
+            assert count == sum(v is None for v in df.to_series(idx).to_list())
 
 
 @given(


### PR DESCRIPTION
Relates to #4308

Changes:
* Remove `DataFrame.set_at_idx` (use `DataFrame.to_series()` instead)

This one actually had a one-to-one replica in to_series, so an easy removal!