### PR TITLE
python: remove deprecated to_python_datetime

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -288,7 +288,6 @@ The following methods are available under the `expr.dt` attribute.
     ExprDateTimeNameSpace.seconds
     ExprDateTimeNameSpace.strftime
     ExprDateTimeNameSpace.timestamp
-    ExprDateTimeNameSpace.to_python_datetime
     ExprDateTimeNameSpace.truncate
     ExprDateTimeNameSpace.week
     ExprDateTimeNameSpace.weekday

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -241,7 +241,6 @@ The following methods are available under the `Series.dt` attribute.
     DateTimeNameSpace.seconds
     DateTimeNameSpace.strftime
     DateTimeNameSpace.timestamp
-    DateTimeNameSpace.to_python_datetime
     DateTimeNameSpace.truncate
     DateTimeNameSpace.week
     DateTimeNameSpace.weekday

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -15,7 +15,6 @@ from polars.datatypes import (
     Datetime,
     Float64,
     Int32,
-    Object,
     Time,
     UInt32,
     py_type_to_dtype,
@@ -6865,12 +6864,6 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.nanosecond())
-
-    def to_python_datetime(self) -> Expr:
-        """Go from Date/Datetime to python DateTime objects."""
-        return wrap_expr(self._pyexpr).map(
-            lambda s: s.dt.to_python_datetime(), return_dtype=Object
-        )
 
     def epoch(self, tu: str = "us") -> Expr:
         """

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -5660,18 +5660,6 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s.timestamp(tu))
 
-    def to_python_datetime(self) -> Series:
-        """
-        Go from Date/Datetime to python DateTime objects
-
-        .. deprecated:: 0.13.23
-            Use :func:`Series.to_list` instead.
-
-        """
-        return (self.timestamp("ms") / 1000).apply(
-            lambda ts: datetime.utcfromtimestamp(ts), Object
-        )
-
     def min(self) -> date | datetime | timedelta:
         """Return minimum as python DateTime."""
         # we can ignore types because we are certain we get a logical type

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -90,19 +90,6 @@ def test_diff_datetime() -> None:
     assert out[0] == out[1]
 
 
-def test_timestamp() -> None:
-    a = pl.Series("a", [a * 1000_000 for a in [10000, 20000, 30000]], dtype=pl.Datetime)
-    assert a.dt.timestamp("ms") == [10000, 20000, 30000]
-    out = a.dt.to_python_datetime()
-    assert isinstance(out[0], datetime)
-    assert a.dt.min() == out[0]
-    assert a.dt.max() == out[2]
-
-    df = pl.DataFrame([out])
-    # test if rows returns objects
-    assert isinstance(df.row(0)[0], datetime)
-
-
 def test_from_pydatetime() -> None:
     datetimes = [
         datetime(2021, 1, 1),
@@ -127,10 +114,6 @@ def test_from_pydatetime() -> None:
 
 def test_to_python_datetime() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
-    assert (
-        df.select(pl.col("a").cast(pl.Datetime).dt.to_python_datetime())["a"].dtype
-        == pl.Object
-    )
     assert (
         df.select(pl.col("a").cast(pl.Datetime).dt.timestamp())["a"].dtype == pl.Int64
     )


### PR DESCRIPTION
#4308