### PR TITLE
Refactor ewm_std and ewm_var to support adjust and bias parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.iml
+*.ipynb
 *.so
 .DS_Store
 .ENV

--- a/polars/polars-arrow/src/kernels/ewm/mod.rs
+++ b/polars/polars-arrow/src/kernels/ewm/mod.rs
@@ -9,6 +9,7 @@ pub use variance::*;
 pub struct EWMOptions {
     pub alpha: f64,
     pub adjust: bool,
+    pub bias: bool,
     pub min_periods: usize,
 }
 
@@ -17,6 +18,7 @@ impl Default for EWMOptions {
         Self {
             alpha: 0.5,
             adjust: true,
+            bias: false,
             min_periods: 1,
         }
     }

--- a/polars/polars-arrow/src/kernels/ewm/variance.rs
+++ b/polars/polars-arrow/src/kernels/ewm/variance.rs
@@ -1,47 +1,103 @@
 use num::Float;
 
-// See: https://stats.stackexchange.com/a/111912/147321
 
-pub fn ewm_std<T: Float>(x_vals: &[T], ewma_vals: &mut [T], alpha: T) {
-    if !ewma_vals.is_empty() {
-        let mut emwa_prev = ewma_vals[0];
-        let mut emvar_prev = T::zero();
-        ewma_vals[0] = T::zero();
-
-        let one_sub_alpha = T::one() - alpha;
-        let two = T::one() + T::one();
-
-        let mut x_iter = x_vals.iter();
-        x_iter.next();
-
-        for (xi, ewma_i) in x_iter.zip(ewma_vals[1..].iter_mut()) {
-            let delta_i = *xi - emwa_prev;
-            emwa_prev = *ewma_i;
-
-            emvar_prev = one_sub_alpha * (emvar_prev + alpha * delta_i.powf(two));
-            *ewma_i = emvar_prev.sqrt();
-        }
+pub fn ewm_std<T: Float>(xs: &[T], result: &mut [T], alpha: T, adjust: bool, bias: bool) {
+    if adjust {
+        ewm_var_adjusted(xs, result, alpha, bias, true)
+    } else {
+        ewm_var_unadjusted(xs, result, alpha, bias, true)
     }
 }
 
-pub fn ewm_var<T: Float>(x_vals: &[T], ewma_vals: &mut [T], alpha: T) {
-    if !ewma_vals.is_empty() {
-        let mut emwa_prev = ewma_vals[0];
-        let mut emvar_prev = T::zero();
-        ewma_vals[0] = T::zero();
+pub fn ewm_var<T: Float>(xs: &[T], result: &mut [T], alpha: T, adjust: bool, bias: bool) {
+    if adjust {
+        ewm_var_adjusted(xs, result, alpha, bias, false)
+    } else {
+        ewm_var_unadjusted(xs, result, alpha, bias, false)
+    }
+}
+
+/// Compute an adjusted, exponentially-weighted moving variance or standard deviation.
+///
+/// Sources:
+///  - https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Weighted_incremental_algorithm
+///  - https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+fn ewm_var_adjusted<T: Float>(xs: &[T], result: &mut [T], alpha: T, bias: bool, take_sqrt: bool) {
+    let mut wgt_sum = T::zero();
+    let mut wgt_sum_sqr = T::zero();
+    let mut var = T::zero();
+    let mut mean = T::zero();
+
+    let one_sub_alpha = T::one() - alpha;
+
+    let n = T::from(xs.len()).unwrap() - T::one();
+    let mut i = T::zero();
+
+    for &x in xs.iter() {
+        let wgt = alpha * one_sub_alpha.powf(n - i);
+        wgt_sum = wgt_sum + wgt;
+        wgt_sum_sqr = wgt_sum_sqr + wgt * wgt;
+        let mean_old = mean;
+        mean = mean_old + (wgt / wgt_sum) * (x - mean_old);
+        var = var + wgt * (x - mean_old) * (x - mean);
+
+        let bias_correction = if bias {
+            wgt_sum
+        } else if i == T::zero() {
+            // Prevent a NaN from cropping up in the first entry
+            T::one()
+        } else {
+            wgt_sum - wgt_sum_sqr / wgt_sum
+        };
+
+        result[i.to_usize().unwrap()] = if take_sqrt {
+            (var / bias_correction).sqrt()
+        } else {
+            var / bias_correction
+        };
+
+        i = i + T::one();
+    }
+}
+
+
+/// Compute an unadjusted, exponentially-weighted moving variance or standard deviation
+///
+/// Sources:
+///  - https://web.archive.org/web/20181222175223/http://people.ds.cam.ac.uk/fanf2/hermes/doc/antiforgery/stats.pdf
+///  - https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Weighted_sample_variance
+fn ewm_var_unadjusted<T: Float>(xs: &[T], result: &mut [T], alpha: T, bias: bool, take_sqrt: bool) {
+    if !xs.is_empty() {
+        let mut mean_prev = xs[0];
+        let mut var_prev = T::zero();
+        result[0] = T::zero();
+
+        let mut wgt = T::one();
+        let mut wgt_sum_sqr = T::one();
 
         let one_sub_alpha = T::one() - alpha;
         let two = T::one() + T::one();
 
-        let mut x_iter = x_vals.iter();
-        x_iter.next();
+        for (i, &x_i) in xs.iter().skip(1).enumerate() {
+            let delta = x_i - mean_prev;
+            let var_i = one_sub_alpha * (var_prev + alpha * delta.powf(two));
 
-        for (xi, ewma_i) in x_iter.zip(ewma_vals[1..].iter_mut()) {
-            let delta_i = *xi - emwa_prev;
-            emwa_prev = *ewma_i;
+            let bias_correction = if bias {
+                T::one()
+            } else {
+                wgt = wgt * one_sub_alpha;
+                let correction = T::one() - (alpha * alpha * wgt_sum_sqr + wgt * wgt);
+                wgt_sum_sqr = wgt_sum_sqr + wgt * wgt;
+                correction
+            };
 
-            emvar_prev = one_sub_alpha * (emvar_prev + alpha * delta_i.powf(two));
-            *ewma_i = emvar_prev;
+            result[i + 1] = if take_sqrt {
+                (var_i / bias_correction).sqrt()
+            } else {
+                var_i / bias_correction
+            };
+            var_prev = var_i;
+            mean_prev = one_sub_alpha * mean_prev + alpha * x_i;
         }
     }
 }
@@ -50,29 +106,70 @@ pub fn ewm_var<T: Float>(x_vals: &[T], ewma_vals: &mut [T], alpha: T) {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_emw_var() {
-        let x = [1.0, 5.0, 7.0, 1.0, 2.0, 1.0, 4.0];
-        let mut ewma = [
-            1.0,
-            3.6666666666666665,
-            5.571428571428571,
-            3.1333333333333333,
-            2.5483870967741935,
-            1.7619047619047619,
-            2.8897637795275593,
-        ];
+    static XS: [f64; 7] = [1.0, 5.0, 7.0, 1.0, 2.0, 1.0, 4.0];
+    static ALPHA: f64 = 0.5;
 
-        ewm_var(&x, &mut ewma, 0.5);
-        let expected = [
+    #[test]
+    fn test_emw_var_adjusted_unbiased() {
+        let mut polars_result: [f64; 7] = Default::default();
+        ewm_var(&XS, &mut polars_result, ALPHA, true, false);
+        let pandas_result = [
+            0.0,
+            8.0,
+            7.428571428571429,
+            11.542857142857143,
+            5.8838709677419345,
+            3.7603686635944706,
+            3.7435320584926886,
+        ];
+        assert_eq!(polars_result, pandas_result);
+    }
+
+    #[test]
+    fn test_emw_var_adjusted_biased() {
+        let mut polars_result: [f64; 7] = Default::default();
+        ewm_var(&XS, &mut polars_result, ALPHA, true, true);
+        let pandas_result = [
+            0.0,
+            3.555555555555556,
+            4.244897959183674,
+            7.182222222222221,
+            3.796045785639958,
+            2.467120181405896,
+            2.4760369520739043,
+        ];
+        assert_eq!(polars_result, pandas_result);
+    }
+
+    #[test]
+    fn test_ewm_var_unadjusted_unbiased() {
+        let mut polars_result: [f64; 7] = Default::default();
+        ewm_var(&XS, &mut polars_result, ALPHA, false, false);
+        let pandas_result = [
+            0.0,
+            8.0,
+            9.600000000000001,
+            10.666666666666666,
+            5.647058823529411,
+            3.659824046920821,
+            3.7274725274725276,
+        ];
+        assert_eq!(polars_result, pandas_result);
+    }
+
+    #[test]
+    fn test_ewm_var_unadjusted_biased() {
+        let mut polars_result: [f64; 7] = Default::default();
+        ewm_var(&XS, &mut polars_result, ALPHA, false, true);
+        let pandas_result = [
             0.0,
             4.0,
-            4.777777777777779,
-            7.613378684807256,
-            4.127800453514739,
-            2.6632758771215737,
-            2.583905512256932,
+            6.0,
+            7.0,
+            3.75,
+            2.4375,
+            2.484375,
         ];
-        assert_eq!(ewma, expected);
+        assert_eq!(polars_result, pandas_result);
     }
 }

--- a/polars/polars-core/src/series/ops/ewm.rs
+++ b/polars/polars-core/src/series/ops/ewm.rs
@@ -110,82 +110,65 @@ impl Series {
     }
 
     pub fn ewm_std(&self, options: EWMOptions) -> Result<Self> {
+        if self.null_count() > 0 {
+            unimplemented!("ewm_std does not yet handle missing data")
+        }
+
         let ca = self.rechunk();
         match ca.dtype() {
             DataType::Float32 | DataType::Float64 => {}
             _ => return self.cast(&DataType::Float64)?.ewm_std(options),
         }
-        let ewma = ca.ewm_mean(options)?;
 
         match ewma.dtype() {
             DataType::Float64 => {
-                let ewma_arr = ewma.f64().unwrap().downcast_iter().next().unwrap();
-                // Safety:
-                // we are the only owners for arr;
-                let ewma_slice = unsafe { to_mutable_slice(ewma_arr.values().as_slice()) };
                 let arr = ca.f64().unwrap().downcast_iter().next().unwrap();
-                let x_slice = arr.values().as_slice();
+                let xs = arr.values().as_slice();
 
-                ewm_std(x_slice, ewma_slice, options.alpha);
-                // we mask the original null values until we know better how to deal with them.
-                let out =
-                    Box::new(ewma_arr.clone().with_validity(arr.validity().cloned())) as ArrayRef;
-                Series::try_from((self.name(), out))
+                let result = ;
+                ewm_std(xs, result, options.alpha, options.adjust, options.bias);
             }
             DataType::Float32 => {
-                let ewma_arr = ewma.f32().unwrap().downcast_iter().next().unwrap();
-                // Safety:
-                // we are the only owners for arr;
-                let ewma_slice = unsafe { to_mutable_slice(ewma_arr.values().as_slice()) };
                 let arr = ca.f32().unwrap().downcast_iter().next().unwrap();
-                let x_slice = arr.values().as_slice();
+                let xs = arr.values().as_slice();
 
-                ewm_std(x_slice, ewma_slice, options.alpha as f32);
-                // we mask the original null values until we know better how to deal with them.
-                let out =
-                    Box::new(ewma_arr.clone().with_validity(arr.validity().cloned())) as ArrayRef;
-                Series::try_from((self.name(), out))
+                let result = ???;
+                ewm_std(xs, result, options.alpha, options.adjust, options.bias);
+
             }
             _ => unimplemented!(),
         }
     }
 
     pub fn ewm_var(&self, options: EWMOptions) -> Result<Self> {
+        if self.null_count() > 0 {
+            unimplemented!("ewm_var does not yet handle missing data")
+        }
+
         let ca = self.rechunk();
         match ca.dtype() {
             DataType::Float32 | DataType::Float64 => {}
             _ => return self.cast(&DataType::Float64)?.ewm_var(options),
         }
-        let ewma = ca.ewm_mean(options)?;
 
         match ewma.dtype() {
             DataType::Float64 => {
-                let ewma_arr = ewma.f64().unwrap().downcast_iter().next().unwrap();
-                // Safety:
-                // we are the only owners for arr;
-                let ewma_slice = unsafe { to_mutable_slice(ewma_arr.values().as_slice()) };
                 let arr = ca.f64().unwrap().downcast_iter().next().unwrap();
-                let x_slice = arr.values().as_slice();
+                let xs = arr.values().as_slice();
 
-                ewm_var(x_slice, ewma_slice, options.alpha);
+                let result = ???;
+                ewm_var(xs, result, options.alpha, options.adjust, options.bias);
                 // we mask the original null values until we know better how to deal with them.
                 let out =
                     Box::new(ewma_arr.clone().with_validity(arr.validity().cloned())) as ArrayRef;
                 Series::try_from((self.name(), out))
             }
             DataType::Float32 => {
-                let ewma_arr = ewma.f32().unwrap().downcast_iter().next().unwrap();
-                // Safety:
-                // we are the only owners for arr;
-                let ewma_slice = unsafe { to_mutable_slice(ewma_arr.values().as_slice()) };
                 let arr = ca.f32().unwrap().downcast_iter().next().unwrap();
-                let x_slice = arr.values().as_slice();
+                let xs = arr.values().as_slice();
 
-                ewm_var(x_slice, ewma_slice, options.alpha as f32);
-                // we mask the original null values until we know better how to deal with them.
-                let out =
-                    Box::new(ewma_arr.clone().with_validity(arr.validity().cloned())) as ArrayRef;
-                Series::try_from((self.name(), out))
+                let result = ???;
+                ewm_var(x_slice, result, options.alpha as f32, options.adjust, options.bias);
             }
             _ => unimplemented!(),
         }

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5387,6 +5387,7 @@ class Expr:
         half_life: float | None = None,
         alpha: float | None = None,
         adjust: bool = True,
+        bias: bool = False,
         min_periods: int = 1,
     ) -> Expr:
         r"""
@@ -5424,6 +5425,12 @@ class Expr:
                   .. math::
                     y_0 &= x_0 \\
                     y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t
+        bias
+            Optionally provide a correction to make the variance estimate
+            statistically unbiased. That is, if ``bias=False`` then
+
+                .. math::
+                    \mathbf{E} \left[ \hat{y} \right] = y
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
@@ -5447,7 +5454,7 @@ class Expr:
 
         """
         alpha = _prepare_alpha(com, span, half_life, alpha)
-        return wrap_expr(self._pyexpr.ewm_std(alpha, adjust, min_periods))
+        return wrap_expr(self._pyexpr.ewm_std(alpha, adjust, bias, min_periods))
 
     def ewm_var(
         self,
@@ -5456,6 +5463,7 @@ class Expr:
         half_life: float | None = None,
         alpha: float | None = None,
         adjust: bool = True,
+        bias: bool = False,
         min_periods: int = 1,
     ) -> Expr:
         r"""
@@ -5493,6 +5501,12 @@ class Expr:
                   .. math::
                     y_0 &= x_0 \\
                     y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t
+        bias
+            Optionally provide a correction to make the variance estimate
+            statistically unbiased. That is, if ``bias=False`` then
+
+                .. math::
+                    \mathbf{E} \left[ \hat{y} \right] = y
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
@@ -5516,7 +5530,7 @@ class Expr:
 
         """
         alpha = _prepare_alpha(com, span, half_life, alpha)
-        return wrap_expr(self._pyexpr.ewm_var(alpha, adjust, min_periods))
+        return wrap_expr(self._pyexpr.ewm_var(alpha, adjust, bias, min_periods))
 
     def extend_constant(self, value: int | float | str | bool | None, n: int) -> Expr:
         """
@@ -5930,6 +5944,8 @@ def _prepare_alpha(
         alpha = 1.0 - math.exp(-math.log(2.0) / half_life)
     if alpha is None:
         raise ValueError("at least one of {com, span, half_life, alpha} should be set")
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError("alpha must be between zero and one, exclusive")
     return alpha
 
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4124,6 +4124,7 @@ class Series:
         half_life: float | None = None,
         alpha: float | None = None,
         adjust: bool = True,
+        bias: bool = False,
         min_periods: int = 1,
     ) -> Series:
         r"""
@@ -4161,6 +4162,12 @@ class Series:
                   .. math::
                     y_0 &= x_0 \\
                     y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t
+        bias
+            Optionally provide a correction to make the variance estimate
+            statistically unbiased. That is, if ``bias=False`` then
+
+                .. math::
+                    \mathbf{E} \left[ \hat{y} \right] = y
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
@@ -4170,7 +4177,7 @@ class Series:
             self.to_frame()
             .select(
                 pli.col(self.name).ewm_std(
-                    com, span, half_life, alpha, adjust, min_periods
+                    com, span, half_life, alpha, adjust, bias, min_periods
                 )
             )
             .to_series()
@@ -4183,6 +4190,7 @@ class Series:
         half_life: float | None = None,
         alpha: float | None = None,
         adjust: bool = True,
+        bias: bool = False,
         min_periods: int = 1,
     ) -> Series:
         r"""
@@ -4220,6 +4228,12 @@ class Series:
                   .. math::
                     y_0 &= x_0 \\
                     y_t &= (1 - \alpha)y_{t - 1} + \alpha x_t
+        bias
+            Optionally provide a correction to make the variance estimate
+            statistically unbiased. That is, if ``bias=False`` then
+
+                .. math::
+                    \mathbf{E} \left[ \hat{y} \right] = y
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
@@ -4229,7 +4243,7 @@ class Series:
             self.to_frame()
             .select(
                 pli.col(self.name).ewm_var(
-                    com, span, half_life, alpha, adjust, min_periods
+                    com, span, half_life, alpha, adjust, bias, min_periods
                 )
             )
             .to_series()

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1460,22 +1460,25 @@ impl PyExpr {
         let options = EWMOptions {
             alpha,
             adjust,
+            bias: false, // bias=true and bias=false give same result
             min_periods,
         };
         self.inner.clone().ewm_mean(options).into()
     }
-    pub fn ewm_std(&self, alpha: f64, adjust: bool, min_periods: usize) -> Self {
+    pub fn ewm_std(&self, alpha: f64, adjust: bool, bias: bool, min_periods: usize) -> Self {
         let options = EWMOptions {
             alpha,
             adjust,
+            bias,
             min_periods,
         };
         self.inner.clone().ewm_std(options).into()
     }
-    pub fn ewm_var(&self, alpha: f64, adjust: bool, min_periods: usize) -> Self {
+    pub fn ewm_var(&self, alpha: f64, adjust: bool, bias: bool, min_periods: usize) -> Self {
         let options = EWMOptions {
             alpha,
             adjust,
+            bias,
             min_periods,
         };
         self.inner.clone().ewm_var(options).into()

--- a/py-polars/tests_parametric/test_series.py
+++ b/py-polars/tests_parametric/test_series.py
@@ -3,11 +3,17 @@
 # -------------------------------------------------
 from __future__ import annotations
 
+
+import pandas as pd
+import pytest
 from hypothesis import given, settings
-from hypothesis.strategies import sampled_from
+from hypothesis.strategies import booleans, floats, lists, sampled_from, SearchStrategy
+from numpy.testing import assert_allclose
+from pandas.core.window.ewm import ExponentialMovingWindow
 
 import polars as pl
-from polars.testing import assert_series_equal, series  # , verify_series_and_expr_api
+from polars import PolarsDataType
+from polars.testing import assert_series_equal, series
 
 # # TODO: exclude obvious/known overflow inside the strategy before commenting back in
 # @given(s=series(allowed_dtypes=_NUMERIC_COL_TYPES, name="a"))
@@ -39,3 +45,62 @@ def test_series_slice(
 
     assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
     assert_series_equal(srs, srs, check_exact=True)
+
+
+EWM_VAR_PARAMS = [
+    (
+        pl.Float32,
+        "float32",
+        floats(width=16, allow_infinity=False, allow_nan=False),
+    ),
+    (
+        pl.Float64,
+        "float64",
+        floats(width=32, allow_infinity=False, allow_nan=False),
+    ),
+]
+
+
+@pytest.mark.parametrize("polars_dtype,pandas_dtype,strategy", EWM_VAR_PARAMS)
+def test_ewm_var_no_nans_no_infs(
+    polars_dtype: PolarsDataType,
+    pandas_dtype: str,
+    strategy: SearchStrategy[float],
+) -> None:
+    """Test pl.Series.ewm_var against the pandas output."""
+
+    @given(
+        data=lists(strategy, max_size=10),
+        alpha=floats(
+            min_value=0,
+            max_value=1,
+            exclude_min=True,
+            exclude_max=True,
+            allow_nan=False,
+            allow_infinity=False,
+            width=16,
+        ),
+        adjust=booleans(),
+        bias=booleans(),
+    )
+    def run_hypothesis_tests(
+        data: list[float | None], alpha: float, adjust: bool, bias: bool
+    ) -> None:
+        pl_series = pl.Series(data, dtype=polars_dtype)
+        pd_series = pd.Series(data, dtype=pandas_dtype)
+
+        pl_ewm_var = pl_series.ewm_var(alpha=alpha, adjust=adjust, bias=bias)
+        pd_ewm_var = ExponentialMovingWindow(
+            obj=pd_series, alpha=alpha, adjust=adjust
+        ).var(bias=bias)
+
+        # There's an inconsistency in the pandas function.
+        #   bias is False -> first variance value is always NaN
+        #   bias is True -> first variance value is always 0.0
+        # We've chosen to show zero variance in both cases.
+        if data and not bias:
+            pd_ewm_var[0] = 0.0
+
+        assert_allclose(pl_ewm_var, pd_ewm_var, rtol=1e-4)
+
+    run_hypothesis_tests()


### PR DESCRIPTION
This is a WIP.

I'm still fairly green in Rust, so comments and critiques are welcome!

TODO:
- [x] Complete the implementation of `Series::ewm_var` and `Series::ewm_std`
- [x] Handle `min_periods` parameter
- [x] Expose the `bias` parameter in `py-polars`
- [ ] Write test cases on the Python side.
- [ ] Better handling of NaNs?