### PR TITLE
python polars 0.14.0

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.13.62"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.13.62"
+version = "0.14.0"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"


### PR DESCRIPTION
Thanks a lot for making this ready in the last couple of days @stinodego, @zundertj  and @matteosantama. 

This release cleans up all deprecated code in python polars and ensure that there is one clear method for certain operations. E.g. predicates should be applied to `filter` and not `__getitem__`, expressions should be applied to `select` and not `__getitem__` etc.