### PR TITLE
Expose format parameters to `DataFrame.write_csv`

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -44,7 +44,7 @@ arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", 
 csv-core = { version = "0.1.10", optional = true }
 dirs = "4.0"
 flate2 = { version = "1", optional = true, default-features = false }
-lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-floats", "parse-integers"] }
+lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-floats", "parse-integers", "write-floats"] }
 lexical-core = { version = "0.8", optional = true }
 memchr = "2.4"
 memmap = { package = "memmap2", version = "0.5.2", optional = true }

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -71,7 +71,9 @@ where
 
     /// Set the CSV file's time format
     pub fn with_time_format(mut self, format: Option<String>) -> Self {
-        self.options.time_format = format;
+        if format.is_some() {
+            self.options.time_format = format;
+        }
         self
     }
 

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -65,7 +65,9 @@ where
 
     /// Set the CSV file's date format
     pub fn with_date_format(mut self, format: Option<String>) -> Self {
-        self.options.date_format = format;
+        if format.is_some() {
+            self.options.date_format = format;
+        }
         self
     }
 

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -79,10 +79,18 @@ where
         self
     }
 
-    /// Set the CSV file's timestamp format array
+    /// Set the CSV file's datetime format
     pub fn with_datetime_format(mut self, format: Option<String>) -> Self {
         if format.is_some() {
             self.options.datetime_format = format;
+        }
+        self
+    }
+
+    /// Set the CSV file's float precision
+    pub fn with_float_precision(mut self, precision: Option<usize>) -> Self {
+        if precision.is_some() {
+            self.options.float_precision = precision;
         }
         self
     }

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -75,9 +75,11 @@ where
         self
     }
 
-    /// Set the CSV file's timestamp format array in
-    pub fn with_datetime(mut self, format: Option<String>) -> Self {
-        self.options.datetime_format = format;
+    /// Set the CSV file's timestamp format array
+    pub fn with_datetime_format(mut self, format: Option<String>) -> Self {
+        if format.is_some() {
+            self.options.datetime_format = format;
+        }
         self
     }
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1074,6 +1074,7 @@ class DataFrame:
         sep: str = ",",
         quote: str = '"',
         batch_size: int = 1024,
+        datetime_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1087,9 +1088,13 @@ class DataFrame:
         sep
             Separate CSV fields with this symbol.
         quote
-            byte to use as quoting character
+            Byte to use as quoting character
         batch_size
-            rows that will be processed per thread
+            Rows that will be processed per thread
+        datetime_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            Rust crate.
 
         Examples
         --------
@@ -1112,13 +1117,13 @@ class DataFrame:
             raise ValueError("only single byte quote char is allowed")
         if file is None:
             buffer = BytesIO()
-            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size)
+            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size, datetime_format)
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, (str, Path)):
             file = format_path(file)
 
-        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size)
+        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size, datetime_format)
         return None
 
     def write_avro(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1075,6 +1075,7 @@ class DataFrame:
         quote: str = '"',
         batch_size: int = 1024,
         datetime_format: str | None = None,
+        date_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1092,6 +1093,10 @@ class DataFrame:
         batch_size
             Rows that will be processed per thread
         datetime_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            Rust crate.
+        date_format
             A format string, with the specifiers defined by the
             `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
             Rust crate.
@@ -1117,13 +1122,29 @@ class DataFrame:
             raise ValueError("only single byte quote char is allowed")
         if file is None:
             buffer = BytesIO()
-            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size, datetime_format)
+            self._df.write_csv(
+                buffer,
+                has_header,
+                ord(sep),
+                ord(quote),
+                batch_size,
+                datetime_format,
+                date_format,
+            )
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, (str, Path)):
             file = format_path(file)
 
-        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size, datetime_format)
+        self._df.write_csv(
+            file,
+            has_header,
+            ord(sep),
+            ord(quote),
+            batch_size,
+            datetime_format,
+            date_format,
+        )
         return None
 
     def write_avro(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1076,6 +1076,7 @@ class DataFrame:
         batch_size: int = 1024,
         datetime_format: str | None = None,
         date_format: str | None = None,
+        time_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1089,16 +1090,20 @@ class DataFrame:
         sep
             Separate CSV fields with this symbol.
         quote
-            Byte to use as quoting character
+            Byte to use as quoting character.
         batch_size
-            Rows that will be processed per thread
+            Number of rows that will be processed per thread.
         datetime_format
             A format string, with the specifiers defined by the
-            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             Rust crate.
         date_format
             A format string, with the specifiers defined by the
-            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            Rust crate.
+        time_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             Rust crate.
 
         Examples
@@ -1130,6 +1135,7 @@ class DataFrame:
                 batch_size,
                 datetime_format,
                 date_format,
+                time_format,
             )
             return str(buffer.getvalue(), encoding="utf-8")
 
@@ -1144,6 +1150,7 @@ class DataFrame:
             batch_size,
             datetime_format,
             date_format,
+            time_format,
         )
         return None
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1077,6 +1077,7 @@ class DataFrame:
         datetime_format: str | None = None,
         date_format: str | None = None,
         time_format: str | None = None,
+        float_precision: int | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1105,6 +1106,9 @@ class DataFrame:
             A format string, with the specifiers defined by the
             `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             Rust crate.
+        float_precision
+            Number of decimal places to write, applied to both ``Float32`` and
+            ``Float64`` datatypes.
 
         Examples
         --------
@@ -1125,6 +1129,8 @@ class DataFrame:
             raise ValueError("only single byte separator is allowed")
         if len(quote) > 1:
             raise ValueError("only single byte quote char is allowed")
+        if float_precision is not None and float_precision < 0:
+            raise ValueError("float_precision cannot be negative")
         if file is None:
             buffer = BytesIO()
             self._df.write_csv(
@@ -1136,6 +1142,7 @@ class DataFrame:
                 datetime_format,
                 date_format,
                 time_format,
+                float_precision,
             )
             return str(buffer.getvalue(), encoding="utf-8")
 
@@ -1151,6 +1158,7 @@ class DataFrame:
             datetime_format,
             date_format,
             time_format,
+            float_precision,
         )
         return None
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -438,6 +438,7 @@ impl PyDataFrame {
         batch_size: usize,
         datetime_format: Option<String>,
         date_format: Option<String>,
+        time_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -449,6 +450,7 @@ impl PyDataFrame {
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
+                .with_time_format(time_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -460,6 +462,7 @@ impl PyDataFrame {
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
+                .with_time_format(time_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -439,6 +439,7 @@ impl PyDataFrame {
         datetime_format: Option<String>,
         date_format: Option<String>,
         time_format: Option<String>,
+        float_precision: Option<usize>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -451,6 +452,7 @@ impl PyDataFrame {
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
                 .with_time_format(time_format)
+                .with_float_precision(float_precision)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -463,6 +465,7 @@ impl PyDataFrame {
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
                 .with_time_format(time_format)
+                .with_float_precision(float_precision)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -436,6 +436,7 @@ impl PyDataFrame {
         sep: u8,
         quote: u8,
         batch_size: usize,
+        datetime_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -445,6 +446,7 @@ impl PyDataFrame {
                 .with_delimiter(sep)
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
+                .with_datetime_format(datetime_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -454,6 +456,7 @@ impl PyDataFrame {
                 .with_delimiter(sep)
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
+                .with_datetime_format(datetime_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -437,6 +437,7 @@ impl PyDataFrame {
         quote: u8,
         batch_size: usize,
         datetime_format: Option<String>,
+        date_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -447,6 +448,7 @@ impl PyDataFrame {
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
+                .with_date_format(date_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -457,6 +459,7 @@ impl PyDataFrame {
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
+                .with_date_format(date_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -5,7 +5,7 @@ import io
 import os
 import textwrap
 import zlib
-from datetime import date, datetime
+from datetime import date, datetime, time
 from pathlib import Path
 
 import pytest
@@ -646,4 +646,17 @@ def test_datetime_format(fmt: str, expected: str) -> None:
 def test_date_format(fmt: str, expected: str) -> None:
     df = pl.DataFrame({"dt": [date(2022, 1, 2)]})
     csv = df.write_csv(date_format=fmt)
+    assert csv == expected
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        (None, "dt\n16:15:30.000000000\n"),
+        ("%R", "dt\n16:15\n"),
+    ],
+)
+def test_time_format(fmt: str, expected: str) -> None:
+    df = pl.DataFrame({"dt": [time(16, 15, 30)]})
+    csv = df.write_csv(time_format=fmt)
     assert csv == expected

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -625,10 +625,25 @@ def test_csv_dtype_overwrite_bool() -> None:
         ("%Y", "dt\n2022\n"),
         ("%m", "dt\n01\n"),
         ("%m$%d", "dt\n01$02\n"),
-        ("%R", "dt\n00:00\n")
+        ("%R", "dt\n00:00\n"),
     ],
 )
 def test_datetime_format(fmt: str, expected: str) -> None:
     df = pl.DataFrame({"dt": [datetime(2022, 1, 2)]})
     csv = df.write_csv(datetime_format=fmt)
+    assert csv == expected
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        (None, "dt\n2022-01-02\n"),
+        ("%Y", "dt\n2022\n"),
+        ("%m", "dt\n01\n"),
+        ("%m$%d", "dt\n01$02\n"),
+    ],
+)
+def test_date_format(fmt: str, expected: str) -> None:
+    df = pl.DataFrame({"dt": [date(2022, 1, 2)]})
+    csv = df.write_csv(date_format=fmt)
     assert csv == expected

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -660,3 +660,14 @@ def test_time_format(fmt: str, expected: str) -> None:
     df = pl.DataFrame({"dt": [time(16, 15, 30)]})
     csv = df.write_csv(time_format=fmt)
     assert csv == expected
+
+
+@pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
+def test_float_precision(dtype: pl.Float32 | pl.Float64) -> None:
+    df = pl.Series("col", [1.0, 2.2, 3.33], dtype=dtype).to_frame()
+
+    assert df.write_csv(float_precision=None) == "col\n1.0\n2.2\n3.33\n"
+    assert df.write_csv(float_precision=0) == "col\n1\n2\n3\n"
+    assert df.write_csv(float_precision=1) == "col\n1.0\n2.2\n3.3\n"
+    assert df.write_csv(float_precision=2) == "col\n1.00\n2.20\n3.33\n"
+    assert df.write_csv(float_precision=3) == "col\n1.000\n2.200\n3.330\n"


### PR DESCRIPTION
This MR exposes three existing format parameters on the Python side:

1. `datetime_format`
2. `date_format`
3. `time_format`

It also adds a new parameter `float_precision` which allows a user to specify how many decimal places to to write for `Float32` and `Float64` datatypes.

Closes #1125, [4297](https://github.com/pola-rs/polars/issues/4279) #4362 

EDIT: Hm, there's a failing [test](https://github.com/pola-rs/polars/runs/7810970454?check_suite_focus=true#step:7:967), but test passes locally.