### PR TITLE
feat[python]: Add show_versions

### DIFF
--- a/py-polars/docs/source/reference/index.rst
+++ b/py-polars/docs/source/reference/index.rst
@@ -19,3 +19,4 @@ methods. All classes and functions exposed in ``polars.*`` namespace are public.
    config
    exceptions
    testing
+   utils

--- a/py-polars/docs/source/reference/utils.rst
+++ b/py-polars/docs/source/reference/utils.rst
@@ -1,0 +1,10 @@
+
+============
+Utils
+============
+.. currentmodule:: polars
+
+.. autosummary::
+   :toctree: api/
+
+    show_versions

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -127,6 +127,7 @@ from polars.io import (
     scan_ipc,
     scan_parquet,
 )
+from polars.show_versions import show_versions
 from polars.string_cache import StringCache, toggle_string_cache
 from polars.utils import threadpool_size
 
@@ -251,6 +252,8 @@ __all__ = [
     # testing
     "testing",
     "threadpool_size",
+    # version
+    "show_versions",
 ]
 
 __version__ = version()

--- a/py-polars/polars/show_versions.py
+++ b/py-polars/polars/show_versions.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import platform
+import sys
+
+try:
+    from polars.polars import get_idx_type as _get_idx_type
+    from polars.polars import version
+
+    _DOCUMENTING = False
+except ImportError:
+    _DOCUMENTING = True
+
+
+def show_versions() -> None:
+    """
+    Print out version of Polars and dependencies to stdout.
+
+    Examples
+    --------
+    >>> pl.show_versions()  # doctest: +SKIP
+    ---Version info---
+    Polars: 0.14.0
+    Index type: UInt32
+    Platform: Linux-5.10.16.3-microsoft-standard-WSL2-x86_64-with-glibc2.31
+    Python: 3.10.5 (main, Jul  8 2022, 14:32:56) [GCC 10.2.1 20210110]
+    ---Optional dependencies---
+    pyarrow: 8.0.0
+    pandas: 1.4.3
+    numpy: 1.23.0
+    fsspec: <not installed>
+    connectorx: <not installed>
+    xlsx2csv: <not installed>
+
+    """
+    print("---Version info---")
+    print(f"Polars: {version()}")
+    print(f"Index type: {_get_idx_type().__name__}")
+    print(f"Platform: {platform.platform()}")
+    print(f"Python: {sys.version}")
+
+    print("---Optional dependencies---")
+    deps = _get_dependency_info()
+    for name, v in deps.items():
+        print(f"{name}: {v}")
+
+
+def _get_dependency_info() -> dict[str, str]:
+    # see the list of dependencies in pyproject.toml
+    opt_deps = ["pyarrow", "pandas", "numpy", "fsspec", "connectorx", "xlsx2csv"]
+    return {name: _get_dep_version(name) for name in opt_deps}
+
+
+def _get_dep_version(dep_name: str) -> str:
+    try:
+        module = importlib.import_module(dep_name)
+    except ImportError:
+        return "<not installed>"
+
+    # all our dependencies as of 2022-08-11 implement __version__
+    return getattr(module, "__version__", "<version not detected>")

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.7"
 [project.optional-dependencies]
 # the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS
 # (which the Rust libraries use to take advantage of Rust API changes).
+# NOTE: keep this list in sync with show_versions()
 pyarrow = ["pyarrow>=4.0.*"]
 pandas = ["pyarrow>=4.0.*", "pandas"]
 numpy = ["numpy >= 1.16.0"]

--- a/py-polars/tests/test_show_versions.py
+++ b/py-polars/tests/test_show_versions.py
@@ -1,0 +1,10 @@
+import polars as pl
+
+
+def test_show_versions(capsys) -> None:  # type: ignore[no-untyped-def]
+    pl.show_versions()
+
+    out, _ = capsys.readouterr()
+    assert "Python" in out
+    assert "Polars" in out
+    assert "Optional dependencies" in out


### PR DESCRIPTION
See #4297 for background reading.

Some choices I have made:

- Naming: picked `show_versions`, an alternative would be `debuginfo`
- I print out the runtime dependencies as per `pyproject.toml`, and ignore build dependencies. I don't think the build dependencies add real value as this would only be relevant when doing dev work, and they do clutter the output (in particular all the utilities such as flake8)
- I have opted to print out all optional dependencies, even if not installed, as a common source of errors is that users do not have the dependency installed at all for the functionality they want to use (although the errors we raise in those cases should be clear, but still)
- The formatting of the output, see the doc string