### PR TITLE
Add pyupgrade

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -31,7 +31,13 @@ jobs:
           pip install -r py-polars/build.requirements.txt
       - name: Run formatting checks
         run: |
-          cd py-polars && black --check . && blackdoc --check . && isort --check . && rustup override set nightly-2022-07-24 && cargo fmt --all -- --check && cd ..
+          cd py-polars
+          black --check .
+          blackdoc --check .
+          isort --check .
+          pyupgrade --py37-plus `find . -name "*.py" -type f`
+          rustup override set nightly-2022-07-24 && cargo fmt --all -- --check
+          cd ..
       - name: Run linting
         run: |
           cd py-polars && flake8 && cd ..
@@ -76,7 +82,13 @@ jobs:
           pip install -r py-polars/build.requirements.txt
       - name: Run formatting checks
         run: |
-          cd py-polars && black --check . && blackdoc --check . && isort --check . && rustup override set nightly-2022-07-24 && cargo fmt --all -- --check && cd ..
+          cd py-polars
+          black --check .
+          blackdoc --check .
+          isort --check .
+          pyupgrade --py37-plus `find . -name "*.py" -type f`
+          rustup override set nightly-2022-07-24 && cargo fmt --all -- --check
+          cd ..
       - name: Run linting
         run: |
           cd py-polars && flake8 && cd ..

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -18,6 +18,7 @@ pre-commit: venv
 	$(PYTHON_BIN)/isort .
 	$(PYTHON_BIN)/black .
 	$(PYTHON_BIN)/blackdoc .
+	$(PYTHON_BIN)/pyupgrade --py37-plus `find polars/ tests/ -name "*.py" -type f`
 	$(PYTHON_BIN)/mypy
 	$(PYTHON_BIN)/flake8
 	make -C .. fmt_toml

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -16,7 +16,7 @@ pytest-cov==3.0.0
 hypothesis==6.49.1
 black==22.6.0
 blackdoc==0.3.5
-isort~=5.10.1
+isort==5.10.1
 mypy==0.971
 flake8==5.0.2
 flake8-bugbear==22.7.1
@@ -24,6 +24,7 @@ flake8-comprehensions==3.10.0
 flake8-docstrings==1.6.0
 flake8-simplify==0.19.3
 flake8-tidy-imports==4.8.0
+pyupgrade==2.37.3
 ghp-import==2.1.0
 sphinx==4.3.2
 pydata-sphinx-theme==0.9.0

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -23,7 +23,7 @@ except ImportError:
     _DOCUMENTING = True
 
 
-def get_idx_type() -> Type[DataType]:
+def get_idx_type() -> type[DataType]:
     """
     Get the datatype used for polars Indexing
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -2398,31 +2398,6 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.last())
 
-    def list(self) -> Expr:
-        """
-        Aggregate to list.
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [1, 2, 3],
-        ...         "b": [4, 5, 6],
-        ...     }
-        ... )
-        >>> df.select(pl.all().list())
-        shape: (1, 2)
-        ┌───────────┬───────────┐
-        │ a         ┆ b         │
-        │ ---       ┆ ---       │
-        │ list[i64] ┆ list[i64] │
-        ╞═══════════╪═══════════╡
-        │ [1, 2, 3] ┆ [4, 5, 6] │
-        └───────────┴───────────┘
-
-        """
-        return wrap_expr(self._pyexpr.list())
-
     def over(self, expr: str | Expr | List[Expr | str]) -> Expr:
         """
         Apply window function over a subgroup.
@@ -5052,18 +5027,43 @@ class Expr:
         """
         return self.map(lambda s: s.set_sorted(reverse))
 
-    # Below are the namespaces defined. Keep these at the end of the definition of Expr,
-    # as to not confuse mypy with the type annotation `str` with the namespace "str"
+    # Keep the `list` and `str` methods below at the end of the definition of Expr,
+    # as to not confuse mypy with the type annotation `str` and `list`
 
-    @property
-    def dt(self) -> ExprDateTimeNameSpace:
-        """Create an object namespace of all datetime related methods."""
-        return ExprDateTimeNameSpace(self)
+    def list(self) -> Expr:
+        """
+        Aggregate to list.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, 2, 3],
+        ...         "b": [4, 5, 6],
+        ...     }
+        ... )
+        >>> df.select(pl.all().list())
+        shape: (1, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ b         │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [1, 2, 3] ┆ [4, 5, 6] │
+        └───────────┴───────────┘
+
+        """
+        return wrap_expr(self._pyexpr.list())
 
     @property
     def str(self) -> ExprStringNameSpace:
         """Create an object namespace of all string related methods."""
         return ExprStringNameSpace(self)
+
+    @property
+    def dt(self) -> ExprDateTimeNameSpace:
+        """Create an object namespace of all datetime related methods."""
+        return ExprDateTimeNameSpace(self)
 
     @property
     def arr(self) -> ExprListNameSpace:

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -4,7 +4,7 @@ import copy
 import math
 import random
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Callable, List, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -385,7 +385,7 @@ class Expr:
         self,
         columns: (
             str
-            | List[str]
+            | list[str]
             | DataType
             | type[DataType]
             | DataType
@@ -1696,8 +1696,8 @@ class Expr:
 
     def sort_by(
         self,
-        by: Expr | str | List[Expr | str],
-        reverse: bool | List[bool] = False,
+        by: Expr | str | list[Expr | str],
+        reverse: bool | list[bool] = False,
     ) -> Expr:
         """
         Sort this column by the ordering of another column, or multiple other columns.
@@ -1756,7 +1756,7 @@ class Expr:
 
         return wrap_expr(self._pyexpr.sort_by(by, reverse))
 
-    def take(self, index: List[int] | Expr | pli.Series | np.ndarray[Any, Any]) -> Expr:
+    def take(self, index: list[int] | Expr | pli.Series | np.ndarray[Any, Any]) -> Expr:
         """
         Take values by index.
 
@@ -2243,7 +2243,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.product())
 
-    def n_unique(self) -> "Expr":
+    def n_unique(self) -> Expr:
         """
         Count unique values.
 
@@ -2263,7 +2263,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.n_unique())
 
-    def null_count(self) -> "Expr":
+    def null_count(self) -> Expr:
         """
         Count null values.
 
@@ -2398,7 +2398,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.last())
 
-    def over(self, expr: str | Expr | List[Expr | str]) -> Expr:
+    def over(self, expr: str | Expr | list[Expr | str]) -> Expr:
         """
         Apply window function over a subgroup.
 
@@ -3225,7 +3225,7 @@ class Expr:
     def rolling_min(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3325,7 +3325,7 @@ class Expr:
     def rolling_max(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3424,7 +3424,7 @@ class Expr:
     def rolling_mean(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3521,7 +3521,7 @@ class Expr:
     def rolling_sum(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3620,7 +3620,7 @@ class Expr:
     def rolling_std(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3690,7 +3690,7 @@ class Expr:
     def rolling_var(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3760,7 +3760,7 @@ class Expr:
     def rolling_median(
         self,
         window_size: int | str,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3828,7 +3828,7 @@ class Expr:
         quantile: float,
         interpolation: InterpolationMethod = "nearest",
         window_size: int | str = 2,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
@@ -3906,7 +3906,7 @@ class Expr:
         self,
         function: Callable[[pli.Series], Any],
         window_size: int,
-        weights: List[float] | None = None,
+        weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
     ) -> Expr:
@@ -5125,7 +5125,7 @@ class ExprStructNameSpace:
         """
         return wrap_expr(self._pyexpr.struct_field_by_name(name))
 
-    def rename_fields(self, names: List[str]) -> Expr:
+    def rename_fields(self, names: list[str]) -> Expr:
         """
         Rename the fields of the struct
 
@@ -5273,7 +5273,7 @@ class ExprListNameSpace:
         return wrap_expr(self._pyexpr.lst_unique())
 
     def concat(
-        self, other: List[Expr | str] | Expr | str | pli.Series | List[Any]
+        self, other: list[Expr | str] | Expr | str | pli.Series | list[Any]
     ) -> Expr:
         """
         Concat the arrays in a Series dtype List in linear time.
@@ -5309,7 +5309,7 @@ class ExprListNameSpace:
         ):
             return self.concat(pli.Series([other]))
 
-        other_list: List[Expr | str | pli.Series]
+        other_list: list[Expr | str | pli.Series]
         if not isinstance(other, list):
             other_list = [other]
         else:

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Optional, Sequence, overload
+from typing import TYPE_CHECKING, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Categorical, Date, Float64
@@ -273,7 +273,7 @@ def date_range(
 def cut(
     s: pli.Series,
     bins: list[float],
-    labels: Optional[list[str]] = None,
+    labels: list[str] | None = None,
     break_point_label: str = "break_point",
     category_label: str = "category",
 ) -> pli.DataFrame:

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -2557,7 +2557,7 @@ class Series:
         self._s = f(idx_array, value)
         return self
 
-    def cleared(self) -> "Series":
+    def cleared(self) -> Series:
         """
         Create an empty copy of the current Series, with identical name/dtype but no
         data.
@@ -2578,7 +2578,7 @@ class Series:
         """
         return self.limit(0) if len(self) > 0 else self.clone()
 
-    def clone(self) -> "Series":
+    def clone(self) -> Series:
         """
         Very cheap deepcopy/clone.
 

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import typing
-from builtins import range
 from datetime import datetime, timedelta
 from io import BytesIO
 from typing import Any, Iterator
@@ -594,7 +593,7 @@ def test_read_missing_file() -> None:
         pl.read_csv("fake_csv_file")
 
     with pytest.raises(FileNotFoundError, match="fake_csv_file"):
-        with open("fake_csv_file", "r") as f:
+        with open("fake_csv_file") as f:
             pl.read_csv(f)
 
 


### PR DESCRIPTION
Relates to #4044 

I made a PR recently where I used `pyupgrade` to upgrade the type hints and some other small things. Now I am adding it to the CI to make sure we stay compliant (a few 'old' language features already snuck in in the meantime...).

Changes:
* Added [pyupgrade](https://github.com/asottile/pyupgrade) - Makes sure to use that we're using the latest language features.
  * Added to CI
  * Added to `make pre-commit` command
* Ran pyupgrade
* Moved `Expr.list` to the bottom of the class definition, in order not to confuse mypy