### PR TITLE
chore[python]: added more string literal types

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import ctypes
 import sys
 from datetime import date, datetime, time, timedelta
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 try:
     import pyarrow as pa
@@ -21,6 +31,9 @@ try:
     _DOCUMENTING = False
 except ImportError:
     _DOCUMENTING = True
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import TimeUnit
 
 
 def get_idx_type() -> type[DataType]:
@@ -157,16 +170,16 @@ class Date(DataType):
 class Datetime(DataType):
     """Calendar date and time type."""
 
-    def __init__(self, time_unit: str = "us", time_zone: str | None = None):
+    def __init__(self, time_unit: TimeUnit = "us", time_zone: str | None = None):
         """
         Calendar date and time type.
 
         Parameters
         ----------
-        time_unit
-            Any of {'ns', 'us', 'ms'}
+        time_unit : {'us', 'ns', 'ms'}
+            Time unit.
         time_zone
-            Timezone string as defined in pytz
+            Timezone string as defined in pytz.
 
         """
         self.tu = time_unit
@@ -188,14 +201,14 @@ class Datetime(DataType):
 class Duration(DataType):
     """Time duration/delta type."""
 
-    def __init__(self, time_unit: str = "us"):
+    def __init__(self, time_unit: TimeUnit = "us"):
         """
         Time duration/delta type.
 
         Parameters
         ----------
-        time_unit
-            Any of {'ns', 'us', 'ms'}
+        time_unit : {'us', 'ns', 'ms'}
+            Time unit.
 
         """
         self.tu = time_unit
@@ -285,7 +298,7 @@ class Struct(DataType):
         return hash(Struct)
 
 
-DTYPE_TEMPORAL_UNITS = frozenset(["ms", "us", "ns"])
+DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
 
 
 _DTYPE_TO_FFINAME: dict[PolarsDataType, str] = {
@@ -513,7 +526,7 @@ def numpy_char_code_to_dtype(dtype: str) -> type[DataType]:
 
 
 def maybe_cast(
-    el: type[DataType], dtype: type, time_unit: str | None = None
+    el: type[DataType], dtype: type, time_unit: TimeUnit | None = None
 ) -> type[DataType]:
     # cast el if it doesn't match
     from polars.utils import _datetime_to_pl_timestamp, _timedelta_to_pl_timedelta

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -37,10 +37,12 @@ except ImportError:
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
         ClosedWindow,
+        EpochTimeUnit,
         FillNullStrategy,
         InterpolationMethod,
         NullBehavior,
         RankMethod,
+        TimeUnit,
         ToStructStrategy,
         TransferEncoding,
     )
@@ -6898,60 +6900,62 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.nanosecond())
 
-    def epoch(self, tu: str = "us") -> Expr:
+    def epoch(self, tu: EpochTimeUnit = "us") -> Expr:
         """
         Get the time passed since the Unix EPOCH in the give time unit
 
         Parameters
         ----------
-        tu
-            One of {'ns', 'us', 'ms', 's', 'd'}
+        tu : {'us', 'ns', 'ms', 's', 'd'}
+            Time unit.
 
         """
         if tu in DTYPE_TEMPORAL_UNITS:
-            return self.timestamp(tu)
-        if tu == "s":
+            return self.timestamp(tu)  # type: ignore[arg-type]
+        elif tu == "s":
             return wrap_expr(self._pyexpr.dt_epoch_seconds())
-        if tu == "d":
+        elif tu == "d":
             return wrap_expr(self._pyexpr).cast(Date).cast(Int32)
         else:
-            raise ValueError(f"time unit {tu} not understood")
+            raise ValueError(
+                f"tu must be one of {{'ns', 'us', 'ms', 's', 'd'}}, got {tu}"
+            )
 
-    def timestamp(self, tu: str = "us") -> Expr:
+    def timestamp(self, tu: TimeUnit = "us") -> Expr:
         """
         Return a timestamp in the given time unit.
 
         Parameters
         ----------
-        tu
-            One of {'ns', 'us', 'ms'}
+        tu : {'us', 'ns', 'ms'}
+            Time unit.
 
         """
         return wrap_expr(self._pyexpr.timestamp(tu))
 
-    def with_time_unit(self, tu: str) -> Expr:
+    def with_time_unit(self, tu: TimeUnit) -> Expr:
         """
-        Set time unit a Series of dtype Datetime or Duration.
+        Set time unit of a Series of dtype Datetime or Duration.
 
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
 
         Parameters
         ----------
-        tu
-            Time unit for the `Datetime` Series: one of {"ns", "us", "ms"}
+        tu : {'ns', 'us', 'ms'}
+            Time unit for the ``Datetime`` Series.
 
         """
         return wrap_expr(self._pyexpr.dt_with_time_unit(tu))
 
-    def cast_time_unit(self, tu: str) -> Expr:
+    def cast_time_unit(self, tu: TimeUnit) -> Expr:
         """
         Cast the underlying data to another time unit. This may lose precision.
 
         Parameters
         ----------
-        tu
-            Time unit for the `Datetime` Series: any of {"ns", "us", "ms"}
+        tu : {'ns', 'us', 'ms'}
+            Time unit for the ``Datetime`` Series.
 
         """
         return wrap_expr(self._pyexpr.dt_cast_time_unit(tu))

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         FillNullStrategy,
         InterpolationMethod,
         NullBehavior,
+        RankMethod,
         ToStructStrategy,
         TransferEncoding,
     )
@@ -3998,13 +3999,13 @@ class Expr:
         """Alias for `arg_sort`."""
         return self.arg_sort(reverse)
 
-    def rank(self, method: str = "average", reverse: bool = False) -> Expr:
+    def rank(self, method: RankMethod = "average", reverse: bool = False) -> Expr:
         """
         Assign ranks to data, dealing with ties appropriately.
 
         Parameters
         ----------
-        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
+        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}
             The method used to assign ranks to tied elements.
             The following methods are available (default is 'average'):
 

--- a/py-polars/polars/internals/expr.py
+++ b/py-polars/polars/internals/expr.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         ClosedWindow,
         FillNullStrategy,
         InterpolationMethod,
+        NullBehavior,
         ToStructStrategy,
         TransferEncoding,
     )
@@ -4071,7 +4072,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.rank(method, reverse))
 
-    def diff(self, n: int = 1, null_behavior: str = "ignore") -> Expr:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Expr:
         """
         Calculate the n-th discrete difference.
 
@@ -4079,8 +4080,8 @@ class Expr:
         ----------
         n
             number of slots to shift
-        null_behavior
-            {'ignore', 'drop'}
+        null_behavior : {'ignore', 'drop'}
+            How to handle null values.
 
         Examples
         --------
@@ -5485,16 +5486,16 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.lst_arg_max())
 
-    def diff(self, n: int = 1, null_behavior: str = "ignore") -> Expr:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Expr:
         """
         Calculate the n-th discrete difference of every sublist.
 
         Parameters
         ----------
         n
-            number of slots to shift
-        null_behavior
-            {'ignore', 'drop'}
+            Number of slots to shift.
+        null_behavior : {'ignore', 'drop'}
+            How to handle null values.
 
         Examples
         --------

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
         Orientation,
         ParallelStrategy,
         ParquetCompression,
+        PivotAgg,
     )
 
     # these aliases are used to annotate DataFrame.__getitem__()
@@ -4343,7 +4344,7 @@ class DataFrame:
         values: list[str] | str,
         index: list[str] | str,
         columns: list[str] | str,
-        aggregate_fn: str = "first",
+        aggregate_fn: PivotAgg = "first",
         maintain_order: bool = True,
         sort_columns: bool = False,
     ) -> DF:
@@ -4359,18 +4360,8 @@ class DataFrame:
             One or multiple keys to group by
         columns
             Columns whose values will be used as the header of the output DataFrame
-        aggregate_fn
-            Any of:
-
-            - "sum"
-            - "max"
-            - "min"
-            - "mean"
-            - "median"
-            - "first"
-            - "last"
-            - "count"
-
+        aggregate_fn : {'first', 'sum', 'max', 'min', 'mean', 'median', 'last', 'count'}
+            Aggregate function.
         maintain_order
             Sort the grouped keys so that the output order is predictable.
         sort_columns

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -119,6 +119,7 @@ if TYPE_CHECKING:
         ParallelStrategy,
         ParquetCompression,
         PivotAgg,
+        UniqueKeepStrategy,
     )
 
     # these aliases are used to annotate DataFrame.__getitem__()
@@ -5329,7 +5330,7 @@ class DataFrame:
         self: DF,
         maintain_order: bool = True,
         subset: str | list[str] | None = None,
-        keep: str = "first",
+        keep: UniqueKeepStrategy = "first",
     ) -> DF:
         """
         Drop duplicate rows from this DataFrame.
@@ -5345,9 +5346,9 @@ class DataFrame:
             Keep the same order as the original DataFrame. This requires more work to
             compute.
         subset
-            Subset to use to compare rows
-        keep
-            any of {"first", "last"}
+            Subset to use to compare rows.
+        keep : {'first', 'last'}
+            Which of the duplicate rows to keep.
 
         Returns
         -------

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -24,7 +24,7 @@ except ImportError:
     _DOCUMENTING = True
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import ClosedWindow
+    from polars.internals.type_aliases import ClosedWindow, TimeUnit
 
 
 def get_dummies(df: pli.DataFrame) -> pli.DataFrame:
@@ -173,7 +173,7 @@ def date_range(
     interval: str | timedelta,
     closed: ClosedWindow = "both",
     name: str | None = None,
-    time_unit: str | None = None,
+    time_unit: TimeUnit | None = None,
 ) -> pli.Series:
     """
     Create a range of type `Datetime` (or `Date`).
@@ -192,7 +192,7 @@ def date_range(
         Define whether the temporal window interval is closed or not.
     name
         Name of the output Series.
-    time_unit : {'ns', 'us', 'ms'}
+    time_unit : {None, 'ns', 'us', 'ms'}
         Set the time unit.
 
     Notes
@@ -247,6 +247,7 @@ def date_range(
     low, low_is_date = _ensure_datetime(low)
     high, high_is_date = _ensure_datetime(high)
 
+    tu: TimeUnit
     if in_nanoseconds_window(low) and in_nanoseconds_window(high) and time_unit is None:
         tu = "ns"
     elif time_unit is not None:

--- a/py-polars/polars/internals/lazy_frame.py
+++ b/py-polars/polars/internals/lazy_frame.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         FillNullStrategy,
         InterpolationMethod,
         ParallelStrategy,
+        UniqueKeepStrategy,
     )
 
 
@@ -2086,7 +2087,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         self: LDF,
         maintain_order: bool = True,
         subset: str | list[str] | None = None,
-        keep: str = "first",
+        keep: UniqueKeepStrategy = "first",
     ) -> LDF:
         """
         Drop duplicate rows from this DataFrame.
@@ -2099,9 +2100,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Keep the same order as the original DataFrame. This requires more work to
             compute.
         subset
-            Subset to use to compare rows
-        keep
-            any of {"first", "last"}
+            Subset to use to compare rows.
+        keep : {'first', 'last'}
+            Which of the duplicate rows to keep.
 
         Returns
         -------

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -62,7 +62,7 @@ else:
     from typing_extensions import Literal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import InterpolationMethod, IntoExpr
+    from polars.internals.type_aliases import InterpolationMethod, IntoExpr, TimeUnit
 
 
 def col(
@@ -640,6 +640,7 @@ def lit(value: Any, dtype: type[DataType] | None = None) -> pli.Expr:
     >>> pl.lit(pl.Series("a", [1, 2, 3]))  # doctest: +IGNORE_RESULT
 
     """
+    tu: TimeUnit
     if isinstance(value, datetime):
         tu = "us"
         return lit(_datetime_to_pl_timestamp(value, tu)).cast(Datetime(tu))

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
         ComparisonOperator,
         FillNullStrategy,
         InterpolationMethod,
+        NullBehavior,
         TransferEncoding,
     )
 
@@ -3834,16 +3835,16 @@ class Series:
         """
         return wrap_s(self._s.rank(method, reverse))
 
-    def diff(self, n: int = 1, null_behavior: str = "ignore") -> Series:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
         Calculate the n-th discrete difference.
 
         Parameters
         ----------
         n
-            number of slots to shift
-        null_behavior
-            {'ignore', 'drop'}
+            Number of slots to shift.
+        null_behavior : {'ignore', 'drop'}
+            How to handle null values.
 
         """
         return wrap_s(self._s.diff(n, null_behavior))
@@ -5227,16 +5228,16 @@ class ListNameSpace:
         """
         return pli.select(pli.lit(wrap_s(self._s)).arr.arg_max()).to_series()
 
-    def diff(self, n: int = 1, null_behavior: str = "ignore") -> Series:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
         Calculate the n-th discrete difference of every sublist.
 
         Parameters
         ----------
         n
-            number of slots to shift
-        null_behavior
-            {'ignore', 'drop'}
+            Number of slots to shift.
+        null_behavior : {'ignore', 'drop'}
+            How to handle null values.
 
         Examples
         --------

--- a/py-polars/polars/internals/series.py
+++ b/py-polars/polars/internals/series.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
         FillNullStrategy,
         InterpolationMethod,
         NullBehavior,
+        RankMethod,
         TransferEncoding,
     )
 
@@ -3775,13 +3776,13 @@ class Series:
         """Compute absolute values."""
         return wrap_s(self._s.abs())
 
-    def rank(self, method: str = "average", reverse: bool = False) -> Series:
+    def rank(self, method: RankMethod = "average", reverse: bool = False) -> Series:
         """
         Assign ranks to data, dealing with ties appropriately.
 
         Parameters
         ----------
-        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}, optional
+        method : {'average', 'min', 'max', 'dense', 'ordinal', 'random'}
             The method used to assign ranks to tied elements.
             The following methods are available (default is 'average'):
 

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -32,6 +32,7 @@ IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
 ParquetCompression: TypeAlias = Literal[
     "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
 ]
+RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
 
 # The following have a Rust enum equivalent with a different name
 ToStructStrategy: TypeAlias = Literal[

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -37,6 +37,7 @@ PivotAgg: TypeAlias = Literal[
     "first", "sum", "max", "min", "mean", "median", "last", "count"
 ]
 UniqueKeepStrategy: TypeAlias = Literal["first", "last"]
+TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
 
 # The following have a Rust enum equivalent with a different name
 ToStructStrategy: TypeAlias = Literal[
@@ -48,5 +49,7 @@ InterpolationMethod: TypeAlias = Literal[
 ]  # QuantileInterpolOptions
 
 # The following have no equivalent on the Rust side
+EpochTimeUnit = Literal["ns", "us", "ms", "s", "d"]
 Orientation: TypeAlias = Literal["col", "row"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
+EpochTimeUnit = TimeUnit | Literal["s", "d"]

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -19,37 +19,36 @@ ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq
 
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name
+AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
 ClosedWindow: TypeAlias = Literal["left", "right", "both", "none"]
+CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 FillNullStrategy: TypeAlias = Literal[
     "forward", "backward", "min", "max", "mean", "zero", "one"
 ]
-NullStrategy: TypeAlias = Literal["ignore", "propagate"]
-NullBehavior: TypeAlias = Literal["ignore", "drop"]
-ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]
-CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
-AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
 IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
+NullBehavior: TypeAlias = Literal["ignore", "drop"]
+NullStrategy: TypeAlias = Literal["ignore", "propagate"]
+ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]
 ParquetCompression: TypeAlias = Literal[
     "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
 ]
-RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
 PivotAgg: TypeAlias = Literal[
     "first", "sum", "max", "min", "mean", "median", "last", "count"
 ]
-UniqueKeepStrategy: TypeAlias = Literal["first", "last"]
+RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
 TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
+UniqueKeepStrategy: TypeAlias = Literal["first", "last"]
 
 # The following have a Rust enum equivalent with a different name
-ToStructStrategy: TypeAlias = Literal[
-    "first_non_null", "max_width"
-]  # ListToStructWidthStrategy
 AsofJoinStrategy: TypeAlias = Literal["backward", "forward"]  # AsofStrategy
 InterpolationMethod: TypeAlias = Literal[
     "nearest", "higher", "lower", "midpoint", "linear"
 ]  # QuantileInterpolOptions
+ToStructStrategy: TypeAlias = Literal[
+    "first_non_null", "max_width"
+]  # ListToStructWidthStrategy
 
 # The following have no equivalent on the Rust side
 EpochTimeUnit = Literal["ns", "us", "ms", "s", "d"]
 Orientation: TypeAlias = Literal["col", "row"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
-EpochTimeUnit = TimeUnit | Literal["s", "d"]

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -36,6 +36,7 @@ RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "ra
 PivotAgg: TypeAlias = Literal[
     "first", "sum", "max", "min", "mean", "median", "last", "count"
 ]
+UniqueKeepStrategy: TypeAlias = Literal["first", "last"]
 
 # The following have a Rust enum equivalent with a different name
 ToStructStrategy: TypeAlias = Literal[

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -33,6 +33,9 @@ ParquetCompression: TypeAlias = Literal[
     "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
+PivotAgg: TypeAlias = Literal[
+    "first", "sum", "max", "min", "mean", "median", "last", "count"
+]
 
 # The following have a Rust enum equivalent with a different name
 ToStructStrategy: TypeAlias = Literal[

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -24,6 +24,7 @@ FillNullStrategy: TypeAlias = Literal[
     "forward", "backward", "min", "max", "mean", "zero", "one"
 ]
 NullStrategy: TypeAlias = Literal["ignore", "propagate"]
+NullBehavior: TypeAlias = Literal["ignore", "drop"]
 ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]
 CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar
 
 import polars.internals as pli
 from polars.datatypes import DataType, Date, Datetime
@@ -32,6 +32,9 @@ if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeGuard
 else:
     from typing_extensions import ParamSpec, TypeGuard
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import TimeUnit
 
 
 def _process_null_values(
@@ -83,7 +86,7 @@ def timedelta_in_nanoseconds_window(td: timedelta) -> bool:
     return in_nanoseconds_window(datetime(1970, 1, 1) + td)
 
 
-def _datetime_to_pl_timestamp(dt: datetime, tu: str | None) -> int:
+def _datetime_to_pl_timestamp(dt: datetime, tu: TimeUnit | None) -> int:
     """Convert a python datetime to a timestamp in nanoseconds."""
     if tu == "ns":
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1e9)
@@ -91,25 +94,25 @@ def _datetime_to_pl_timestamp(dt: datetime, tu: str | None) -> int:
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1e6)
     elif tu == "ms":
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1e3)
-    if tu is None:
+    elif tu is None:
         # python has us precision
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1e6)
     else:
-        raise ValueError("expected one of {'ns', 'us', 'ms'}")
+        raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
 
 
-def _timedelta_to_pl_timedelta(td: timedelta, tu: str | None = None) -> int:
+def _timedelta_to_pl_timedelta(td: timedelta, tu: TimeUnit | None = None) -> int:
     if tu == "ns":
         return int(td.total_seconds() * 1e9)
     elif tu == "us":
         return int(td.total_seconds() * 1e6)
     elif tu == "ms":
         return int(td.total_seconds() * 1e3)
-    if tu is None:
+    elif tu is None:
         # python has us precision
         return int(td.total_seconds() * 1e6)
     else:
-        raise ValueError("expected one of {'ns', 'us, 'ms'}")
+        raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
 
 
 def _date_to_pl_date(d: date) -> int:
@@ -206,7 +209,7 @@ def _to_python_time(value: int) -> time:
     return time(hour=hours, minute=minutes, second=seconds, microsecond=microsecond)
 
 
-def _to_python_timedelta(value: int | float, tu: str | None = "ns") -> timedelta:
+def _to_python_timedelta(value: int | float, tu: TimeUnit = "ns") -> timedelta:
     if tu == "ns":
         return timedelta(microseconds=value // 1e3)
     elif tu == "us":
@@ -214,7 +217,7 @@ def _to_python_timedelta(value: int | float, tu: str | None = "ns") -> timedelta
     elif tu == "ms":
         return timedelta(milliseconds=value)
     else:
-        raise ValueError(f"time unit: {tu} not expected")
+        raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
 
 
 def _prepare_row_count_args(
@@ -233,7 +236,7 @@ EPOCH = datetime(1970, 1, 1).replace(tzinfo=None)
 def _to_python_datetime(
     value: int | float,
     dtype: type[DataType],
-    tu: str | None = "ns",
+    tu: TimeUnit | None = "ns",
     tz: str | None = None,
 ) -> date | datetime:
     if dtype == Date:
@@ -253,7 +256,7 @@ def _to_python_datetime(
             # milliseconds to seconds
             dt = datetime.utcfromtimestamp(value / 1000)
         else:
-            raise ValueError(f"time unit: {tu} not expected")
+            raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
         if tz is not None and len(tz) > 0:
             try:
                 import pytz

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import typing
 from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -13,6 +14,9 @@ import pytz
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.testing import verify_series_and_expr_api
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import TimeUnit
 
 
 def test_fill_null() -> None:
@@ -1275,7 +1279,8 @@ def test_weekday() -> None:
     # monday
     s = pl.Series([datetime(2020, 1, 6)])
 
-    for tu in ["ns", "us", "ms"]:
+    time_units: list[TimeUnit] = ["ns", "us", "ms"]
+    for tu in time_units:
         assert s.dt.cast_time_unit(tu).dt.weekday()[0] == 0
 
     assert s.cast(pl.Date).dt.weekday()[0] == 0

--- a/py-polars/tests/test_pivot.py
+++ b/py-polars/tests/test_pivot.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import polars as pl
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import PivotAgg
 
 
 def test_pivot_list() -> None:
@@ -33,7 +40,8 @@ def test_pivot() -> None:
     assert gb.count().shape == (2, 6)
     assert gb.median().shape == (2, 6)
 
-    for agg_fn in ["sum", "min", "max", "mean", "count", "median", "mean"]:
+    agg_fns: list[PivotAgg] = ["sum", "min", "max", "mean", "count", "median", "mean"]
+    for agg_fn in agg_fns:
         out = df.pivot(
             values="c", index="b", columns="a", aggregate_fn=agg_fn, sort_columns=True
         )

--- a/py-polars/tests/test_utils.py
+++ b/py-polars/tests/test_utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
 
 import polars as pl
 from polars.utils import (
@@ -10,20 +13,26 @@ from polars.utils import (
     in_nanoseconds_window,
 )
 
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import TimeUnit
+
 
 def test_in_ns_window() -> None:
     assert not in_nanoseconds_window(datetime(year=2600, month=1, day=1))
     assert in_nanoseconds_window(datetime(year=2000, month=1, day=1))
 
 
-def test_datetime_to_pl_timestamp() -> None:
-    for dt, tu, expected in (
+@pytest.mark.parametrize(
+    "dt, tu, expected",
+    [
         (datetime(2121, 1, 1), "ns", 4765132800000000000),
         (datetime(2121, 1, 1), "us", 4765132800000000),
         (datetime(2121, 1, 1), "ms", 4765132800000),
-    ):
-        out = _datetime_to_pl_timestamp(dt, tu)
-        assert out == expected
+    ],
+)
+def test_datetime_to_pl_timestamp(dt: datetime, tu: TimeUnit, expected: int) -> None:
+    out = _datetime_to_pl_timestamp(dt, tu)
+    assert out == expected
 
 
 def test_date_to_pl_date() -> None:


### PR DESCRIPTION
Relates to #4288 

This PR became bigger than I expected 😅 the commits are nicely separated so you could go through these one-by-one if you like.

Changes:
* Added string literals for:
  * NullBehavior
  * RankMethod
  * PivotAgg
  * UniqueKeepStrategy
  * TimeUnit
* Alphabetized the type aliases