### PR TITLE
Improve pytz integration

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -256,7 +256,7 @@ def _to_python_datetime(
             raise ValueError(f"time unit: {tu} not expected")
         if tz is not None and len(tz) > 0:
             try:
-                import pytz  # type: ignore[import]
+                import pytz
             except ImportError:
                 raise ImportError(
                     "pytz is not installed. Please run `pip install pytz`."

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -255,7 +255,12 @@ def _to_python_datetime(
         else:
             raise ValueError(f"time unit: {tu} not expected")
         if tz is not None and len(tz) > 0:
-            import pytz
+            try:
+                import pytz  # type: ignore[import]
+            except ImportError:
+                raise ImportError(
+                    "pytz is not installed. Please run `pip install pytz`."
+                ) from None
 
             return pytz.timezone(tz).localize(dt)
         return dt

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -18,6 +18,7 @@ numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
+pytz = ["pytz"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Following up on #3357
- list pytz as an optional dependency. No version bound, I dont think the api has changed in a long time as far as I can see
- provide user with more clear error message if pytz import fails in case not installed