### PR TITLE
Standardize conversion of Python string literals to Rust enums

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -743,34 +743,16 @@ pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<Fill
     Ok(strat)
 }
 
-impl FromPyObject<'_> for Wrap<NullStrategy> {
+impl FromPyObject<'_> for Wrap<ClosedWindow> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {
-            "ignore" => NullStrategy::Ignore,
-            "propagate" => NullStrategy::Propagate,
+            "left" => ClosedWindow::Left,
+            "right" => ClosedWindow::Right,
+            "both" => ClosedWindow::Both,
+            "none" => ClosedWindow::None,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "null strategy must be one of {{'ignore', 'propagate'}}, got {}",
-                    v
-                )))
-            }
-        };
-        Ok(Wrap(parsed))
-    }
-}
-
-impl FromPyObject<'_> for Wrap<RankMethod> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
-        let parsed = match ob.extract::<&str>()? {
-            "min" => RankMethod::Min,
-            "max" => RankMethod::Max,
-            "average" => RankMethod::Average,
-            "dense" => RankMethod::Dense,
-            "ordinal" => RankMethod::Ordinal,
-            "random" => RankMethod::Random,
-            v => {
-                return Err(PyValueError::new_err(format!(
-                    "method must be one of {{'min', 'max', 'average', 'dense', 'ordinal', 'random'}}, got {}",
+                    "closed must be one of {{'left', 'right', 'both', 'none'}}, got {}",
                     v
                 )))
             }
@@ -795,16 +777,14 @@ impl FromPyObject<'_> for Wrap<NullBehavior> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<ClosedWindow> {
+impl FromPyObject<'_> for Wrap<NullStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {
-            "left" => ClosedWindow::Left,
-            "right" => ClosedWindow::Right,
-            "both" => ClosedWindow::Both,
-            "none" => ClosedWindow::None,
+            "ignore" => NullStrategy::Ignore,
+            "propagate" => NullStrategy::Propagate,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "closed must be one of {{'left', 'right', 'both', 'none'}}, got {}",
+                    "null strategy must be one of {{'ignore', 'propagate'}}, got {}",
                     v
                 )))
             }
@@ -813,15 +793,17 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<TimeUnit> {
+#[cfg(feature = "parquet")]
+impl FromPyObject<'_> for Wrap<ParallelStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {
-            "ns" => TimeUnit::Nanoseconds,
-            "us" => TimeUnit::Microseconds,
-            "ms" => TimeUnit::Milliseconds,
+            "auto" => ParallelStrategy::Auto,
+            "columns" => ParallelStrategy::Columns,
+            "row_groups" => ParallelStrategy::RowGroups,
+            "none" => ParallelStrategy::None,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "time unit must be one of {{'ns', 'us', 'ms'}}, got {}",
+                    "parallel must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {}",
                     v
                 )))
             }
@@ -871,14 +853,18 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
+impl FromPyObject<'_> for Wrap<RankMethod> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {
-            "first" => UniqueKeepStrategy::First,
-            "last" => UniqueKeepStrategy::Last,
+            "min" => RankMethod::Min,
+            "max" => RankMethod::Max,
+            "average" => RankMethod::Average,
+            "dense" => RankMethod::Dense,
+            "ordinal" => RankMethod::Ordinal,
+            "random" => RankMethod::Random,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "keep must be one of {{'first', 'last'}}, got {}",
+                    "method must be one of {{'min', 'max', 'average', 'dense', 'ordinal', 'random'}}, got {}",
                     v
                 )))
             }
@@ -887,17 +873,31 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
     }
 }
 
-#[cfg(feature = "parquet")]
-impl FromPyObject<'_> for Wrap<ParallelStrategy> {
+impl FromPyObject<'_> for Wrap<TimeUnit> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {
-            "auto" => ParallelStrategy::Auto,
-            "columns" => ParallelStrategy::Columns,
-            "row_groups" => ParallelStrategy::RowGroups,
-            "none" => ParallelStrategy::None,
+            "ns" => TimeUnit::Nanoseconds,
+            "us" => TimeUnit::Microseconds,
+            "ms" => TimeUnit::Milliseconds,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "parallel must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {}",
+                    "time unit must be one of {{'ns', 'us', 'ms'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
+impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "first" => UniqueKeepStrategy::First,
+            "last" => UniqueKeepStrategy::Last,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "keep must be one of {{'first', 'last'}}, got {}",
                     v
                 )))
             }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -794,10 +794,10 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
             "right" => ClosedWindow::Right,
             "both" => ClosedWindow::Both,
             "none" => ClosedWindow::None,
-            e => {
+            v => {
                 return Err(PyValueError::new_err(format!(
                     "closed must be one of {{'left', 'right', 'both', 'none'}}, got {}",
-                    e,
+                    v
                 )))
             }
         };
@@ -811,7 +811,12 @@ impl FromPyObject<'_> for Wrap<TimeUnit> {
             "ns" => TimeUnit::Nanoseconds,
             "us" => TimeUnit::Microseconds,
             "ms" => TimeUnit::Milliseconds,
-            _ => return Err(PyValueError::new_err("expected one of {'ns', 'us', 'ms'}")),
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "time unit must be one of {{'ns', 'us', 'ms'}}, got {}",
+                    v
+                )))
+            }
         };
         Ok(Wrap(parsed))
     }
@@ -828,7 +833,12 @@ impl FromPyObject<'_> for Wrap<PivotAgg> {
             "median" => PivotAgg::Median,
             "count" => PivotAgg::Count,
             "last" => PivotAgg::Last,
-            s => panic!("aggregation {} is not supported", s),
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "aggregate_fn must be one of {{'sum', 'min', 'max', 'first', 'mean', 'median', 'count', 'last'}}, got {}",
+                    v
+                )))
+            }
         };
         Ok(Wrap(parsed))
     }
@@ -842,10 +852,10 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
             "nearest" => QuantileInterpolOptions::Nearest,
             "linear" => QuantileInterpolOptions::Linear,
             "midpoint" => QuantileInterpolOptions::Midpoint,
-            e => {
+            v => {
                 return Err(PyValueError::new_err(format!(
                     "interpolation must be one of {{'lower', 'higher', 'nearest', 'linear', 'midpoint'}}, got {}",
-                    e,
+                    v
                 )))
             }
         };
@@ -858,7 +868,12 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
         let parsed = match ob.extract::<&str>()? {
             "first" => UniqueKeepStrategy::First,
             "last" => UniqueKeepStrategy::Last,
-            s => panic!("keep strategy {} is not supported", s),
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "keep must be one of {{'first', 'last'}}, got {}",
+                    v
+                )))
+            }
         };
         Ok(Wrap(parsed))
     }
@@ -872,10 +887,10 @@ impl FromPyObject<'_> for Wrap<ParallelStrategy> {
             "columns" => ParallelStrategy::Columns,
             "row_groups" => ParallelStrategy::RowGroups,
             "none" => ParallelStrategy::None,
-            e => {
+            v => {
                 return Err(PyValueError::new_err(format!(
                     "parallel must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {}",
-                    e,
+                    v
                 )))
             }
         };

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -774,17 +774,20 @@ pub(crate) fn str_to_rankmethod(method: &str) -> PyResult<RankMethod> {
     Ok(method)
 }
 
-pub(crate) fn str_to_null_behavior(null_behavior: &str) -> PyResult<NullBehavior> {
-    let null_behavior = match null_behavior {
-        "drop" => NullBehavior::Drop,
-        "ignore" => NullBehavior::Ignore,
-        _ => {
-            return Err(PyValueError::new_err(
-                "use one of 'drop', 'ignore'".to_string(),
-            ))
-        }
-    };
-    Ok(null_behavior)
+impl FromPyObject<'_> for Wrap<NullBehavior> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "drop" => NullBehavior::Drop,
+            "ignore" => NullBehavior::Ignore,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "null behavior must be one of {{'drop', 'ignore'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
 }
 
 impl FromPyObject<'_> for Wrap<ClosedWindow> {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -788,7 +788,7 @@ pub(crate) fn str_to_null_behavior(null_behavior: &str) -> PyResult<NullBehavior
 }
 
 impl FromPyObject<'_> for Wrap<ClosedWindow> {
-    fn extract(ob: &'_ PyAny) -> PyResult<Self> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
         let s = ob.extract::<&str>()?;
         Ok(Wrap(match s {
             "left" => ClosedWindow::Left,
@@ -817,8 +817,8 @@ impl FromPyObject<'_> for Wrap<TimeUnit> {
     }
 }
 
-impl<'a> FromPyObject<'a> for Wrap<PivotAgg> {
-    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+impl FromPyObject<'_> for Wrap<PivotAgg> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
         match ob.extract::<&str>()? {
             "sum" => Ok(Wrap(PivotAgg::Sum)),
             "min" => Ok(Wrap(PivotAgg::Min)),
@@ -834,7 +834,7 @@ impl<'a> FromPyObject<'a> for Wrap<PivotAgg> {
 }
 
 impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
-    fn extract(ob: &'_ PyAny) -> PyResult<Self> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
         let s = ob.extract::<&str>()?;
         Ok(Wrap(match s {
             "lower" => QuantileInterpolOptions::Lower,
@@ -852,8 +852,8 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
     }
 }
 
-impl<'a> FromPyObject<'a> for Wrap<UniqueKeepStrategy> {
-    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
         match ob.extract::<&str>()? {
             "first" => Ok(Wrap(UniqueKeepStrategy::First)),
             "last" => Ok(Wrap(UniqueKeepStrategy::Last)),

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -743,18 +743,20 @@ pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<Fill
     Ok(strat)
 }
 
-pub(crate) fn str_to_null_strategy(strategy: &str) -> PyResult<NullStrategy> {
-    let strategy = match strategy {
-        "ignore" => NullStrategy::Ignore,
-        "propagate" => NullStrategy::Propagate,
-        e => {
-            return Err(PyValueError::new_err(format!(
-                "null_strategy must be one of {{'ignore', 'propagate'}}, got {}",
-                e,
-            )))
-        }
-    };
-    Ok(strategy)
+impl FromPyObject<'_> for Wrap<NullStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "ignore" => NullStrategy::Ignore,
+            "propagate" => NullStrategy::Propagate,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "null strategy must be one of {{'ignore', 'propagate'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
 }
 
 impl FromPyObject<'_> for Wrap<RankMethod> {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -789,8 +789,7 @@ pub(crate) fn str_to_null_behavior(null_behavior: &str) -> PyResult<NullBehavior
 
 impl FromPyObject<'_> for Wrap<ClosedWindow> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let s = ob.extract::<&str>()?;
-        Ok(Wrap(match s {
+        let parsed = match ob.extract::<&str>()? {
             "left" => ClosedWindow::Left,
             "right" => ClosedWindow::Right,
             "both" => ClosedWindow::Both,
@@ -801,42 +800,43 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
                     e,
                 )))
             }
-        }))
+        };
+        Ok(Wrap(parsed))
     }
 }
 
 impl FromPyObject<'_> for Wrap<TimeUnit> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let unit = match ob.extract::<&str>()? {
+        let parsed = match ob.extract::<&str>()? {
             "ns" => TimeUnit::Nanoseconds,
             "us" => TimeUnit::Microseconds,
             "ms" => TimeUnit::Milliseconds,
             _ => return Err(PyValueError::new_err("expected one of {'ns', 'us', 'ms'}")),
         };
-        Ok(Wrap(unit))
+        Ok(Wrap(parsed))
     }
 }
 
 impl FromPyObject<'_> for Wrap<PivotAgg> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        match ob.extract::<&str>()? {
-            "sum" => Ok(Wrap(PivotAgg::Sum)),
-            "min" => Ok(Wrap(PivotAgg::Min)),
-            "max" => Ok(Wrap(PivotAgg::Max)),
-            "first" => Ok(Wrap(PivotAgg::First)),
-            "mean" => Ok(Wrap(PivotAgg::Mean)),
-            "median" => Ok(Wrap(PivotAgg::Median)),
-            "count" => Ok(Wrap(PivotAgg::Count)),
-            "last" => Ok(Wrap(PivotAgg::Last)),
+        let parsed = match ob.extract::<&str>()? {
+            "sum" => PivotAgg::Sum,
+            "min" => PivotAgg::Min,
+            "max" => PivotAgg::Max,
+            "first" => PivotAgg::First,
+            "mean" => PivotAgg::Mean,
+            "median" => PivotAgg::Median,
+            "count" => PivotAgg::Count,
+            "last" => PivotAgg::Last,
             s => panic!("aggregation {} is not supported", s),
-        }
+        };
+        Ok(Wrap(parsed))
     }
 }
 
 impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let s = ob.extract::<&str>()?;
-        Ok(Wrap(match s {
+        let parsed = match ob.extract::<&str>()? {
             "lower" => QuantileInterpolOptions::Lower,
             "higher" => QuantileInterpolOptions::Higher,
             "nearest" => QuantileInterpolOptions::Nearest,
@@ -848,24 +848,26 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
                     e,
                 )))
             }
-        }))
+        };
+        Ok(Wrap(parsed))
     }
 }
 
 impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        match ob.extract::<&str>()? {
-            "first" => Ok(Wrap(UniqueKeepStrategy::First)),
-            "last" => Ok(Wrap(UniqueKeepStrategy::Last)),
+        let parsed = match ob.extract::<&str>()? {
+            "first" => UniqueKeepStrategy::First,
+            "last" => UniqueKeepStrategy::Last,
             s => panic!("keep strategy {} is not supported", s),
-        }
+        };
+        Ok(Wrap(parsed))
     }
 }
 
 #[cfg(feature = "parquet")]
 impl FromPyObject<'_> for Wrap<ParallelStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let unit = match ob.extract::<&str>()? {
+        let parsed = match ob.extract::<&str>()? {
             "auto" => ParallelStrategy::Auto,
             "columns" => ParallelStrategy::Columns,
             "row_groups" => ParallelStrategy::RowGroups,
@@ -877,6 +879,6 @@ impl FromPyObject<'_> for Wrap<ParallelStrategy> {
                 )))
             }
         };
-        Ok(Wrap(unit))
+        Ok(Wrap(parsed))
     }
 }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -807,7 +807,7 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
 
 impl FromPyObject<'_> for Wrap<TimeUnit> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let unit = match ob.str()?.to_str()? {
+        let unit = match ob.extract::<&str>()? {
             "ns" => TimeUnit::Nanoseconds,
             "us" => TimeUnit::Microseconds,
             "ms" => TimeUnit::Milliseconds,
@@ -865,7 +865,7 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
 #[cfg(feature = "parquet")]
 impl FromPyObject<'_> for Wrap<ParallelStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let unit = match ob.str()?.to_str()? {
+        let unit = match ob.extract::<&str>()? {
             "auto" => ParallelStrategy::Auto,
             "columns" => ParallelStrategy::Columns,
             "row_groups" => ParallelStrategy::RowGroups,

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -757,21 +757,24 @@ pub(crate) fn str_to_null_strategy(strategy: &str) -> PyResult<NullStrategy> {
     Ok(strategy)
 }
 
-pub(crate) fn str_to_rankmethod(method: &str) -> PyResult<RankMethod> {
-    let method = match method {
-        "min" => RankMethod::Min,
-        "max" => RankMethod::Max,
-        "average" => RankMethod::Average,
-        "dense" => RankMethod::Dense,
-        "ordinal" => RankMethod::Ordinal,
-        "random" => RankMethod::Random,
-        _ => {
-            return Err(PyValueError::new_err(
-                "use one of 'avg, min, max, dense, ordinal'".to_string(),
-            ))
-        }
-    };
-    Ok(method)
+impl FromPyObject<'_> for Wrap<RankMethod> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "min" => RankMethod::Min,
+            "max" => RankMethod::Max,
+            "average" => RankMethod::Average,
+            "dense" => RankMethod::Dense,
+            "ordinal" => RankMethod::Ordinal,
+            "random" => RankMethod::Random,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "method must be one of {{'min', 'max', 'average', 'dense', 'ordinal', 'random'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
 }
 
 impl FromPyObject<'_> for Wrap<NullBehavior> {

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -15,7 +15,7 @@ use crate::apply::dataframe::{
 use crate::conversion::{ObjectValue, Wrap};
 use crate::file::get_mmap_bytes_reader;
 use crate::lazy::dataframe::PyLazyFrame;
-use crate::prelude::{dicts_to_rows, str_to_null_strategy};
+use crate::prelude::dicts_to_rows;
 use crate::{
     arrow_interop,
     error::PyPolarsErr,
@@ -1261,9 +1261,8 @@ impl PyDataFrame {
         self.df.median().into()
     }
 
-    pub fn hmean(&self, null_strategy: &str) -> PyResult<Option<PySeries>> {
-        let strategy = str_to_null_strategy(null_strategy)?;
-        let s = self.df.hmean(strategy).map_err(PyPolarsErr::from)?;
+    pub fn hmean(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
+        let s = self.df.hmean(null_strategy.0).map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 
@@ -1277,9 +1276,8 @@ impl PyDataFrame {
         Ok(s.map(|s| s.into()))
     }
 
-    pub fn hsum(&self, null_strategy: &str) -> PyResult<Option<PySeries>> {
-        let strategy = str_to_null_strategy(null_strategy)?;
-        let s = self.df.hsum(strategy).map_err(PyPolarsErr::from)?;
+    pub fn hsum(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
+        let s = self.df.hsum(null_strategy.0).map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1105,19 +1105,11 @@ impl PyDataFrame {
         by: Vec<&str>,
         select: Vec<String>,
         quantile: f64,
-        interpolation: &str,
+        interpolation: Wrap<QuantileInterpolOptions>,
     ) -> PyResult<Self> {
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
         let gb = self.df.groupby(&by).map_err(PyPolarsErr::from)?;
         let selection = gb.select(&select);
-        let df = selection.quantile(quantile, interpol);
+        let df = selection.quantile(quantile, interpolation.0);
         let df = df.map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }
@@ -1281,18 +1273,14 @@ impl PyDataFrame {
         Ok(s.map(|s| s.into()))
     }
 
-    pub fn quantile(&self, quantile: f64, interpolation: &str) -> PyResult<Self> {
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
+    pub fn quantile(
+        &self,
+        quantile: f64,
+        interpolation: Wrap<QuantileInterpolOptions>,
+    ) -> PyResult<Self> {
         let df = self
             .df
-            .quantile(quantile, interpol)
+            .quantile(quantile, interpolation.0)
             .map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -628,18 +628,9 @@ impl PyLazyFrame {
         ldf.median().into()
     }
 
-    pub fn quantile(&self, quantile: f64, interpolation: &str) -> Self {
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
-
+    pub fn quantile(&self, quantile: f64, interpolation: Wrap<QuantileInterpolOptions>) -> Self {
         let ldf = self.ldf.clone();
-        ldf.quantile(quantile, interpol).into()
+        ldf.quantile(quantile, interpolation.0).into()
     }
 
     pub fn explode(&self, column: Vec<PyExpr>) -> Self {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -2,7 +2,7 @@ use super::apply::*;
 use crate::conversion::Wrap;
 use crate::lazy::map_single;
 use crate::lazy::utils::py_exprs_to_exprs;
-use crate::prelude::{parse_strategy, str_to_rankmethod};
+use crate::prelude::parse_strategy;
 use crate::series::PySeries;
 use crate::utils::reinterpret;
 use polars::lazy::dsl;
@@ -1384,10 +1384,9 @@ impl PyExpr {
             .into())
     }
 
-    fn rank(&self, method: &str, reverse: bool) -> Self {
-        let method = str_to_rankmethod(method).unwrap();
+    fn rank(&self, method: Wrap<RankMethod>, reverse: bool) -> Self {
         let options = RankOptions {
-            method,
+            method: method.0,
             descending: reverse,
         };
         self.inner.clone().rank(options).into()

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1,5 +1,5 @@
 use super::apply::*;
-use crate::conversion::{str_to_null_behavior, Wrap};
+use crate::conversion::Wrap;
 use crate::lazy::map_single;
 use crate::lazy::utils::py_exprs_to_exprs;
 use crate::prelude::{parse_strategy, str_to_rankmethod};
@@ -8,6 +8,7 @@ use crate::utils::reinterpret;
 use polars::lazy::dsl;
 use polars::lazy::dsl::Operator;
 use polars::prelude::*;
+use polars::series::ops::NullBehavior;
 use polars_core::prelude::QuantileInterpolOptions;
 use pyo3::class::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
@@ -1331,9 +1332,8 @@ impl PyExpr {
         self.inner.clone().arr().arg_max().into()
     }
 
-    fn lst_diff(&self, n: usize, null_behavior: &str) -> PyResult<Self> {
-        let null_behavior = str_to_null_behavior(null_behavior)?;
-        Ok(self.inner.clone().arr().diff(n, null_behavior).into())
+    fn lst_diff(&self, n: usize, null_behavior: Wrap<NullBehavior>) -> PyResult<Self> {
+        Ok(self.inner.clone().arr().diff(n, null_behavior.0).into())
     }
 
     fn lst_shift(&self, periods: i64) -> Self {
@@ -1393,9 +1393,8 @@ impl PyExpr {
         self.inner.clone().rank(options).into()
     }
 
-    fn diff(&self, n: usize, null_behavior: &str) -> Self {
-        let null_behavior = str_to_null_behavior(null_behavior).unwrap();
-        self.inner.clone().diff(n, null_behavior).into()
+    fn diff(&self, n: usize, null_behavior: Wrap<NullBehavior>) -> Self {
+        self.inner.clone().diff(n, null_behavior.0).into()
     }
 
     #[cfg(feature = "pct_change")]

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -179,16 +179,11 @@ impl PyExpr {
     pub fn list(&self) -> PyExpr {
         self.clone().inner.list().into()
     }
-    pub fn quantile(&self, quantile: f64, interpolation: &str) -> PyExpr {
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
-        self.clone().inner.quantile(quantile, interpol).into()
+    pub fn quantile(&self, quantile: f64, interpolation: Wrap<QuantileInterpolOptions>) -> PyExpr {
+        self.clone()
+            .inner
+            .quantile(quantile, interpolation.0)
+            .into()
     }
     pub fn agg_groups(&self) -> PyExpr {
         self.clone().inner.agg_groups().into()
@@ -1224,7 +1219,7 @@ impl PyExpr {
     pub fn rolling_quantile(
         &self,
         quantile: f64,
-        interpolation: &str,
+        interpolation: Wrap<QuantileInterpolOptions>,
         window_size: &str,
         weights: Option<Vec<f64>>,
         min_periods: usize,
@@ -1232,15 +1227,6 @@ impl PyExpr {
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
     ) -> Self {
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
-
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
             weights,
@@ -1252,7 +1238,7 @@ impl PyExpr {
 
         self.inner
             .clone()
-            .rolling_quantile(quantile, interpol, options)
+            .rolling_quantile(quantile, interpolation.0, options)
             .into()
     }
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -11,12 +11,12 @@ use crate::{
     prelude::*,
 };
 use numpy::PyArray1;
+use polars::series::ops::NullBehavior;
 use polars_core::prelude::QuantileInterpolOptions;
 use polars_core::series::IsSorted;
 use polars_core::utils::CustomIterTools;
 use pyo3::types::{PyBytes, PyList, PyTuple};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, Python};
-
 #[pyclass]
 #[repr(transparent)]
 #[derive(Clone)]
@@ -1387,9 +1387,8 @@ impl PySeries {
         Ok(self.series.rank(options).into())
     }
 
-    pub fn diff(&self, n: usize, null_behavior: &str) -> PyResult<Self> {
-        let null_behavior = str_to_null_behavior(null_behavior)?;
-        Ok(self.series.diff(n, null_behavior).into())
+    pub fn diff(&self, n: usize, null_behavior: Wrap<NullBehavior>) -> PyResult<Self> {
+        Ok(self.series.diff(n, null_behavior.0).into())
     }
 
     pub fn skew(&self, bias: bool) -> PyResult<Option<f64>> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1378,10 +1378,9 @@ impl PySeries {
         }
     }
 
-    pub fn rank(&self, method: &str, reverse: bool) -> PyResult<Self> {
-        let method = str_to_rankmethod(method).unwrap();
+    pub fn rank(&self, method: Wrap<RankMethod>, reverse: bool) -> PyResult<Self> {
         let options = RankOptions {
-            method,
+            method: method.0,
             descending: reverse,
         };
         Ok(self.series.rank(options).into())

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -830,22 +830,17 @@ impl PySeries {
         }
     }
 
-    pub fn quantile(&self, quantile: f64, interpolation: &str) -> PyObject {
+    pub fn quantile(
+        &self,
+        quantile: f64,
+        interpolation: Wrap<QuantileInterpolOptions>,
+    ) -> PyObject {
         let gil = Python::acquire_gil();
         let py = gil.python();
 
-        let interpol = match interpolation {
-            "nearest" => QuantileInterpolOptions::Nearest,
-            "lower" => QuantileInterpolOptions::Lower,
-            "higher" => QuantileInterpolOptions::Higher,
-            "midpoint" => QuantileInterpolOptions::Midpoint,
-            "linear" => QuantileInterpolOptions::Linear,
-            _ => panic!("not supported"),
-        };
-
         Wrap(
             self.series
-                .quantile_as_series(quantile, interpol)
+                .quantile_as_series(quantile, interpolation.0)
                 .expect("invalid quantile")
                 .get(0),
         )


### PR DESCRIPTION
Relates to #4288 

Changes:
* Grouped all string-to-enum conversion functionality together on the bottom of `conversion.rs` in alphabetized order.
* Made sure all conversions were uniform regarding:
  * Lifetime specifiers
  * Parsing object to a string (favor `ob.extract::<&str>()?` as it will result in a `TypeError` when a wrong type is supplied)
  * Match flow
  * Error message
* Provide Wrap extract implementations for:
  * NullBehavior
  * NullStrategy
  * RankMethod
* Made sure the conversions were used properly throughout the rest of the code.

Still on the TO DO for future PRs:
* Provide a wrap implementation for some string literals that are currently being parsed outside of the `conversion.rs` module.
* Create a function or macro for easier specification of this conversion logic