### PR TITLE
chore[python]: Standardize conversion of Python string literals to Rust enums [Part 2]

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -760,6 +760,22 @@ impl FromPyObject<'_> for Wrap<AsofStrategy> {
     }
 }
 
+impl FromPyObject<'_> for Wrap<CategoricalOrdering> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "physical" => CategoricalOrdering::Physical,
+            "lexical" => CategoricalOrdering::Lexical,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "ordering must be one of {{'physical', 'lexical'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 impl FromPyObject<'_> for Wrap<ClosedWindow> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -724,25 +724,6 @@ pub(crate) fn dicts_to_rows(records: &PyAny) -> PyResult<(Vec<Row>, Vec<String>)
     Ok((rows, keys_first))
 }
 
-pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<FillNullStrategy> {
-    let strat = match strat {
-        "forward" => FillNullStrategy::Forward(limit),
-        "backward" => FillNullStrategy::Backward(limit),
-        "min" => FillNullStrategy::Min,
-        "max" => FillNullStrategy::Max,
-        "mean" => FillNullStrategy::Mean,
-        "zero" => FillNullStrategy::Zero,
-        "one" => FillNullStrategy::One,
-        e => {
-            return Err(PyValueError::new_err(format!(
-                "strategy must be one of {{'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}}, got {}",
-                e,
-            )))
-        }
-    };
-    Ok(strat)
-}
-
 #[cfg(feature = "asof_join")]
 impl FromPyObject<'_> for Wrap<AsofStrategy> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
@@ -990,4 +971,26 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
         };
         Ok(Wrap(parsed))
     }
+}
+
+pub(crate) fn parse_fill_null_strategy(
+    strategy: &str,
+    limit: FillNullLimit,
+) -> PyResult<FillNullStrategy> {
+    let parsed = match strategy {
+        "forward" => FillNullStrategy::Forward(limit),
+        "backward" => FillNullStrategy::Backward(limit),
+        "min" => FillNullStrategy::Min,
+        "max" => FillNullStrategy::Max,
+        "mean" => FillNullStrategy::Mean,
+        "zero" => FillNullStrategy::Zero,
+        "one" => FillNullStrategy::One,
+        e => {
+            return Err(PyValueError::new_err(format!(
+                "strategy must be one of {{'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}}, got {}",
+                e,
+            )))
+        }
+    };
+    Ok(parsed)
 }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -743,6 +743,23 @@ pub(crate) fn parse_strategy(strat: &str, limit: FillNullLimit) -> PyResult<Fill
     Ok(strat)
 }
 
+#[cfg(feature = "asof_join")]
+impl FromPyObject<'_> for Wrap<AsofStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "backward" => AsofStrategy::Backward,
+            "forward" => AsofStrategy::Forward,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "strategy must be one of {{'backward', 'forward'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 impl FromPyObject<'_> for Wrap<ClosedWindow> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -761,6 +761,22 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
     }
 }
 
+impl FromPyObject<'_> for Wrap<CsvEncoding> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "utf8" => CsvEncoding::Utf8,
+            "utf8-lossy" => CsvEncoding::LossyUtf8,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "encoding must be one of {{'utf8', 'utf8-lossy'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 impl FromPyObject<'_> for Wrap<NullBehavior> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -777,6 +777,27 @@ impl FromPyObject<'_> for Wrap<CsvEncoding> {
     }
 }
 
+impl FromPyObject<'_> for Wrap<JoinType> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "inner" => JoinType::Inner,
+            "left" => JoinType::Left,
+            "outer" => JoinType::Outer,
+            "semi" => JoinType::Semi,
+            "anti" => JoinType::Anti,
+            #[cfg(feature = "cross_join")]
+            "cross" => JoinType::Cross,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                "how must be one of {{'inner', 'left', 'outer', 'semi', 'anti', 'cross'}}, got {}",
+                v
+            )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 impl FromPyObject<'_> for Wrap<NullBehavior> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -815,6 +815,22 @@ impl FromPyObject<'_> for Wrap<JoinType> {
     }
 }
 
+impl FromPyObject<'_> for Wrap<ListToStructWidthStrategy> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "first_non_null" => ListToStructWidthStrategy::FirstNonNull,
+            "max_width" => ListToStructWidthStrategy::MaxWidth,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "n_field_strategy must be one of {{'first_non_null', 'max_width'}}, got {}",
+                    v
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 impl FromPyObject<'_> for Wrap<NullBehavior> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let parsed = match ob.extract::<&str>()? {

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1048,22 +1048,19 @@ impl PyDataFrame {
         by: Vec<String>,
         pivot_column: Vec<String>,
         values_column: Vec<String>,
-        agg: &str,
+        agg: Wrap<PivotAgg>,
     ) -> PyResult<Self> {
         let mut gb = self.df.groupby(&by).map_err(PyPolarsErr::from)?;
         let pivot = gb.pivot(pivot_column, values_column);
-        let df = match agg {
-            "first" => pivot.first(),
-            "min" => pivot.min(),
-            "max" => pivot.max(),
-            "mean" => pivot.mean(),
-            "median" => pivot.median(),
-            "sum" => pivot.sum(),
-            "count" => pivot.count(),
-            "last" => pivot.last(),
-            a => Err(PolarsError::ComputeError(
-                format!("agg fn {} does not exists", a).into(),
-            )),
+        let df = match agg.0 {
+            PivotAgg::First => pivot.first(),
+            PivotAgg::Min => pivot.min(),
+            PivotAgg::Max => pivot.max(),
+            PivotAgg::Mean => pivot.mean(),
+            PivotAgg::Median => pivot.median(),
+            PivotAgg::Sum => pivot.sum(),
+            PivotAgg::Count => pivot.count(),
+            PivotAgg::Last => pivot.last(),
         };
         let df = df.map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -791,31 +791,12 @@ impl PyDataFrame {
         other: &PyDataFrame,
         left_on: Vec<&str>,
         right_on: Vec<&str>,
-        how: &str,
+        how: Wrap<JoinType>,
         suffix: String,
     ) -> PyResult<Self> {
-        let how = match how {
-            "left" => JoinType::Left,
-            "inner" => JoinType::Inner,
-            "outer" => JoinType::Outer,
-            "semi" => JoinType::Semi,
-            "anti" => JoinType::Anti,
-            #[cfg(feature = "asof_join")]
-            "asof" => JoinType::AsOf(AsOfOptions {
-                strategy: AsofStrategy::Backward,
-                left_by: None,
-                right_by: None,
-                tolerance: None,
-                tolerance_str: None,
-            }),
-            #[cfg(feature = "cross_join")]
-            "cross" => JoinType::Cross,
-            _ => panic!("not supported"),
-        };
-
         let df = self
             .df
-            .join(&other.df, left_on, right_on, how, Some(suffix))
+            .join(&other.df, left_on, right_on, how.0, Some(suffix))
             .map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -118,7 +118,7 @@ impl PyDataFrame {
         sep: &str,
         rechunk: bool,
         columns: Option<Vec<String>>,
-        encoding: &str,
+        encoding: Wrap<CsvEncoding>,
         n_threads: Option<usize>,
         path: Option<String>,
         overwrite_dtype: Option<Vec<(&str, Wrap<DataType>)>>,
@@ -148,16 +148,6 @@ impl PyDataFrame {
         } else {
             None
         };
-        let encoding = match encoding {
-            "utf8" => CsvEncoding::Utf8,
-            "utf8-lossy" => CsvEncoding::LossyUtf8,
-            e => {
-                return Err(PyValueError::new_err(format!(
-                    "encoding must be one of {{'utf8', 'utf8-lossy'}}, got {}",
-                    e
-                )))
-            }
-        };
 
         let overwrite_dtype = overwrite_dtype.map(|overwrite_dtype| {
             let fields = overwrite_dtype.iter().map(|(name, dtype)| {
@@ -185,7 +175,7 @@ impl PyDataFrame {
             .with_projection(projection)
             .with_rechunk(rechunk)
             .with_chunk_size(chunk_size)
-            .with_encoding(encoding)
+            .with_encoding(encoding.0)
             .with_columns(columns)
             .with_n_threads(n_threads)
             .with_path(path)

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -150,7 +150,7 @@ impl PyLazyFrame {
         with_schema_modify: Option<PyObject>,
         rechunk: bool,
         skip_rows_after_header: usize,
-        encoding: &str,
+        encoding: Wrap<CsvEncoding>,
         row_count: Option<(String, IdxSize)>,
         parse_dates: bool,
         eol_char: &str,
@@ -162,17 +162,6 @@ impl PyLazyFrame {
         let eol_char = eol_char.as_bytes()[0];
 
         let row_count = row_count.map(|(name, offset)| RowCount { name, offset });
-
-        let encoding = match encoding {
-            "utf8" => CsvEncoding::Utf8,
-            "utf8-lossy" => CsvEncoding::LossyUtf8,
-            e => {
-                return Err(PyValueError::new_err(format!(
-                    "encoding must be one of {{'utf8', 'utf8-lossy'}}, got {}",
-                    e
-                )))
-            }
-        };
 
         let overwrite_dtype = overwrite_dtype.map(|overwrite_dtype| {
             let fields = overwrite_dtype
@@ -195,7 +184,7 @@ impl PyLazyFrame {
             .with_end_of_line_char(eol_char)
             .with_rechunk(rechunk)
             .with_skip_rows_after_header(skip_rows_after_header)
-            .with_encoding(encoding)
+            .with_encoding(encoding.0)
             .with_row_count(row_count)
             .with_parse_dates(parse_dates)
             .with_null_values(null_values);

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -505,24 +505,9 @@ impl PyLazyFrame {
         right_on: Vec<PyExpr>,
         allow_parallel: bool,
         force_parallel: bool,
-        how: &str,
+        how: Wrap<JoinType>,
         suffix: String,
     ) -> PyResult<Self> {
-        let how = match how {
-            "left" => JoinType::Left,
-            "inner" => JoinType::Inner,
-            "outer" => JoinType::Outer,
-            "semi" => JoinType::Semi,
-            "anti" => JoinType::Anti,
-            "cross" => JoinType::Cross,
-            e => {
-                return Err(PyValueError::new_err(format!(
-                "how must be one of {{'left', 'inner', 'outer', 'semi', 'anti', 'cross'}}, got {}",
-                e,
-            )))
-            }
-        };
-
         let ldf = self.ldf.clone();
         let other = other.ldf;
         let left_on = left_on
@@ -541,7 +526,7 @@ impl PyLazyFrame {
             .right_on(right_on)
             .allow_parallel(allow_parallel)
             .force_parallel(force_parallel)
-            .how(how)
+            .how(how.0)
             .suffix(suffix)
             .finish()
             .into())

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -459,21 +459,10 @@ impl PyLazyFrame {
         allow_parallel: bool,
         force_parallel: bool,
         suffix: String,
-        strategy: &str,
+        strategy: Wrap<AsofStrategy>,
         tolerance: Option<Wrap<AnyValue<'_>>>,
         tolerance_str: Option<String>,
     ) -> PyResult<Self> {
-        let strategy = match strategy {
-            "backward" => AsofStrategy::Backward,
-            "forward" => AsofStrategy::Forward,
-            e => {
-                return Err(PyValueError::new_err(format!(
-                    "strategy must be one of {{'backward', 'forward'}}, got {}",
-                    e,
-                )))
-            }
-        };
-
         let ldf = self.ldf.clone();
         let other = other.ldf;
         let left_on = left_on.inner;
@@ -486,7 +475,7 @@ impl PyLazyFrame {
             .allow_parallel(allow_parallel)
             .force_parallel(force_parallel)
             .how(JoinType::AsOf(AsOfOptions {
-                strategy,
+                strategy: strategy.0,
                 left_by,
                 right_by,
                 tolerance: tolerance.map(|t| t.0.into_static().unwrap()),

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1,8 +1,8 @@
 use super::apply::*;
+use crate::conversion::parse_fill_null_strategy;
 use crate::conversion::Wrap;
 use crate::lazy::map_single;
 use crate::lazy::utils::py_exprs_to_exprs;
-use crate::prelude::parse_strategy;
 use crate::series::PySeries;
 use crate::utils::reinterpret;
 use polars::lazy::dsl;
@@ -266,7 +266,7 @@ impl PyExpr {
         strategy: &str,
         limit: FillNullLimit,
     ) -> PyResult<PyExpr> {
-        let strat = parse_strategy(strategy, limit)?;
+        let strat = parse_fill_null_strategy(strategy, limit)?;
         Ok(self
             .inner
             .clone()

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1389,14 +1389,8 @@ impl PyExpr {
         self.inner.clone().str().concat(delimiter).into()
     }
 
-    fn cat_set_ordering(&self, ordering: &str) -> Self {
-        let ordering = match ordering {
-            "physical" => CategoricalOrdering::Physical,
-            "lexical" => CategoricalOrdering::Lexical,
-            _ => panic!("expected one of {{'physical', 'lexical'}}"),
-        };
-
-        self.inner.clone().cat().set_ordering(ordering).into()
+    fn cat_set_ordering(&self, ordering: Wrap<CategoricalOrdering>) -> Self {
+        self.inner.clone().cat().set_ordering(ordering.0).into()
     }
 
     fn date_truncate(&self, every: &str, offset: &str) -> Self {


### PR DESCRIPTION
Relates to #4288 

Changes:
* Moved all string-to-enum conversions to the `conversions.rs` module, following the existing standards. Affected enums:
  * CsvEncoding
  * JoinType
  * AsofStrategy
  * ListToStructWidthStrategy
  * CategoricalOrdering
  * ParquetCompression
  * AvroCompression
  * IpcCompression

Now handling all user string input consistently on the Rust side 🥳 