### PR TITLE
fix[rust]: fix flawed simplify expression rule

### DIFF
--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -206,7 +206,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 AExpr::Literal(LiteralValue::Boolean(true))
             ) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(false)))
+                Some(AExpr::Literal(LiteralValue::Boolean(true)))
             }
 
             // x OR true => true
@@ -219,7 +219,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 AExpr::Literal(LiteralValue::Boolean(true))
             ) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(false)))
+                Some(AExpr::Literal(LiteralValue::Boolean(true)))
             }
             AExpr::Ternary {
                 truthy, predicate, ..

--- a/py-polars/tests/test_filter.py
+++ b/py-polars/tests/test_filter.py
@@ -1,0 +1,11 @@
+import polars as pl
+
+
+def test_simplify_expression_lit_true_4376() -> None:
+    df = pl.DataFrame([[1, 4, 7], [2, 5, 8], [3, 6, 9]])
+    assert df.lazy().filter(pl.lit(True) | (pl.col("column_0") == 1)).collect(
+        simplify_expression=True
+    ).shape == (3, 3)
+    assert df.lazy().filter((pl.col("column_0") == 1) | pl.lit(True)).collect(
+        simplify_expression=True
+    ).shape == (3, 3)


### PR DESCRIPTION
'lit(true) | expr' was replaced with 'lit(false)',
where it should produce 'lit(true)'

fixes #4376