### PR TITLE
feat[python]: Expose format parameters to `DataFrame.write_csv`

### DIFF
--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -71,7 +71,9 @@ where
 
     /// Set the CSV file's time format
     pub fn with_time_format(mut self, format: Option<String>) -> Self {
-        self.options.time_format = format;
+        if format.is_some() {
+            self.options.time_format = format;
+        }
         self
     }
 

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -65,7 +65,9 @@ where
 
     /// Set the CSV file's date format
     pub fn with_date_format(mut self, format: Option<String>) -> Self {
-        self.options.date_format = format;
+        if format.is_some() {
+            self.options.date_format = format;
+        }
         self
     }
 

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -75,9 +75,11 @@ where
         self
     }
 
-    /// Set the CSV file's timestamp format array in
-    pub fn with_datetime(mut self, format: Option<String>) -> Self {
-        self.options.datetime_format = format;
+    /// Set the CSV file's timestamp format array
+    pub fn with_datetime_format(mut self, format: Option<String>) -> Self {
+        if format.is_some() {
+            self.options.datetime_format = format;
+        }
         self
     }
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1077,6 +1077,7 @@ class DataFrame:
         quote: str = '"',
         batch_size: int = 1024,
         datetime_format: str | None = None,
+        date_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1094,6 +1095,10 @@ class DataFrame:
         batch_size
             Rows that will be processed per thread
         datetime_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            Rust crate.
+        date_format
             A format string, with the specifiers defined by the
             `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
             Rust crate.
@@ -1119,13 +1124,29 @@ class DataFrame:
             raise ValueError("only single byte quote char is allowed")
         if file is None:
             buffer = BytesIO()
-            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size, datetime_format)
+            self._df.write_csv(
+                buffer,
+                has_header,
+                ord(sep),
+                ord(quote),
+                batch_size,
+                datetime_format,
+                date_format,
+            )
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, (str, Path)):
             file = format_path(file)
 
-        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size, datetime_format)
+        self._df.write_csv(
+            file,
+            has_header,
+            ord(sep),
+            ord(quote),
+            batch_size,
+            datetime_format,
+            date_format,
+        )
         return None
 
     def write_avro(

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1078,6 +1078,7 @@ class DataFrame:
         batch_size: int = 1024,
         datetime_format: str | None = None,
         date_format: str | None = None,
+        time_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1091,16 +1092,20 @@ class DataFrame:
         sep
             Separate CSV fields with this symbol.
         quote
-            Byte to use as quoting character
+            Byte to use as quoting character.
         batch_size
-            Rows that will be processed per thread
+            Number of rows that will be processed per thread.
         datetime_format
             A format string, with the specifiers defined by the
-            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             Rust crate.
         date_format
             A format string, with the specifiers defined by the
-            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            Rust crate.
+        time_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             Rust crate.
 
         Examples
@@ -1132,6 +1137,7 @@ class DataFrame:
                 batch_size,
                 datetime_format,
                 date_format,
+                time_format,
             )
             return str(buffer.getvalue(), encoding="utf-8")
 
@@ -1146,6 +1152,7 @@ class DataFrame:
             batch_size,
             datetime_format,
             date_format,
+            time_format,
         )
         return None
 

--- a/py-polars/polars/internals/frame.py
+++ b/py-polars/polars/internals/frame.py
@@ -1076,6 +1076,7 @@ class DataFrame:
         sep: str = ",",
         quote: str = '"',
         batch_size: int = 1024,
+        datetime_format: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1089,9 +1090,13 @@ class DataFrame:
         sep
             Separate CSV fields with this symbol.
         quote
-            byte to use as quoting character
+            Byte to use as quoting character
         batch_size
-            rows that will be processed per thread
+            Rows that will be processed per thread
+        datetime_format
+            A format string, with the specifiers defined by the
+            `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>_
+            Rust crate.
 
         Examples
         --------
@@ -1114,13 +1119,13 @@ class DataFrame:
             raise ValueError("only single byte quote char is allowed")
         if file is None:
             buffer = BytesIO()
-            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size)
+            self._df.write_csv(buffer, has_header, ord(sep), ord(quote), batch_size, datetime_format)
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, (str, Path)):
             file = format_path(file)
 
-        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size)
+        self._df.write_csv(file, has_header, ord(sep), ord(quote), batch_size, datetime_format)
         return None
 
     def write_avro(

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -426,6 +426,7 @@ impl PyDataFrame {
         sep: u8,
         quote: u8,
         batch_size: usize,
+        datetime_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -435,6 +436,7 @@ impl PyDataFrame {
                 .with_delimiter(sep)
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
+                .with_datetime_format(datetime_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -444,6 +446,7 @@ impl PyDataFrame {
                 .with_delimiter(sep)
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
+                .with_datetime_format(datetime_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -428,6 +428,7 @@ impl PyDataFrame {
         batch_size: usize,
         datetime_format: Option<String>,
         date_format: Option<String>,
+        time_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -439,6 +440,7 @@ impl PyDataFrame {
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
+                .with_time_format(time_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -450,6 +452,7 @@ impl PyDataFrame {
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
                 .with_date_format(date_format)
+                .with_time_format(time_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -427,6 +427,7 @@ impl PyDataFrame {
         quote: u8,
         batch_size: usize,
         datetime_format: Option<String>,
+        date_format: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -437,6 +438,7 @@ impl PyDataFrame {
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
+                .with_date_format(date_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -447,6 +449,7 @@ impl PyDataFrame {
                 .with_quoting_char(quote)
                 .with_batch_size(batch_size)
                 .with_datetime_format(datetime_format)
+                .with_date_format(date_format)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -5,7 +5,7 @@ import io
 import os
 import textwrap
 import zlib
-from datetime import date, datetime
+from datetime import date, datetime, time
 from pathlib import Path
 
 import pytest
@@ -646,4 +646,17 @@ def test_datetime_format(fmt: str, expected: str) -> None:
 def test_date_format(fmt: str, expected: str) -> None:
     df = pl.DataFrame({"dt": [date(2022, 1, 2)]})
     csv = df.write_csv(date_format=fmt)
+    assert csv == expected
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        (None, "dt\n16:15:30.000000000\n"),
+        ("%R", "dt\n16:15\n"),
+    ],
+)
+def test_time_format(fmt: str, expected: str) -> None:
+    df = pl.DataFrame({"dt": [time(16, 15, 30)]})
+    csv = df.write_csv(time_format=fmt)
     assert csv == expected

--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -625,10 +625,25 @@ def test_csv_dtype_overwrite_bool() -> None:
         ("%Y", "dt\n2022\n"),
         ("%m", "dt\n01\n"),
         ("%m$%d", "dt\n01$02\n"),
-        ("%R", "dt\n00:00\n")
+        ("%R", "dt\n00:00\n"),
     ],
 )
 def test_datetime_format(fmt: str, expected: str) -> None:
     df = pl.DataFrame({"dt": [datetime(2022, 1, 2)]})
     csv = df.write_csv(datetime_format=fmt)
+    assert csv == expected
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        (None, "dt\n2022-01-02\n"),
+        ("%Y", "dt\n2022\n"),
+        ("%m", "dt\n01\n"),
+        ("%m$%d", "dt\n01$02\n"),
+    ],
+)
+def test_date_format(fmt: str, expected: str) -> None:
+    df = pl.DataFrame({"dt": [date(2022, 1, 2)]})
+    csv = df.write_csv(date_format=fmt)
     assert csv == expected


### PR DESCRIPTION
@ritchie46 

Since writing floats is a very optimized operation, I'd like to run some benchmarking before adding the `float_precision` parameter. That way we can be sure we do not accidentally introduce any regressions. But in the meantime, we can merge these changes. 

Closes #4362 