### PR TITLE
refactor[rust]: Enable grouped imports for `rustfmt`

### DIFF
--- a/polars/benches/bench.rs
+++ b/polars/benches/bench.rs
@@ -1,7 +1,8 @@
 #![feature(test)]
 extern crate test;
-use polars::prelude::*;
 use std::iter;
+
+use polars::prelude::*;
 use test::Bencher;
 
 #[bench]

--- a/polars/benches/csv.rs
+++ b/polars/benches/csv.rs
@@ -1,6 +1,7 @@
+use std::fs::File;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use polars::prelude::*;
-use std::fs::File;
 
 fn prepare_reader() -> Result<CsvReader<'static, File>> {
     let path =

--- a/polars/benches/sort.rs
+++ b/polars/benches/sort.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate criterion;
 use criterion::Criterion;
-
 use polars::prelude::*;
 
 fn bench_sort(s: &Int32Chunked) {

--- a/polars/polars-arrow/src/array/get.rs
+++ b/polars/polars-arrow/src/array/get.rs
@@ -1,8 +1,9 @@
-use crate::is_valid::IsValid;
 use arrow::{
     array::{Array, BooleanArray, ListArray, PrimitiveArray, Utf8Array},
     types::NativeType,
 };
+
+use crate::is_valid::IsValid;
 
 pub trait ArrowGetItem {
     type Item;

--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
 use arrow::array::{Array, ListArray};
 use arrow::bitmap::MutableBitmap;
 use arrow::compute::concatenate;
 use arrow::datatypes::DataType;
 use arrow::error::Result;
+
+use crate::prelude::*;
 
 pub struct AnonymousBuilder<'a> {
     arrays: Vec<&'a dyn Array>,

--- a/polars/polars-arrow/src/array/mod.rs
+++ b/polars/polars-arrow/src/array/mod.rs
@@ -1,9 +1,9 @@
-use crate::prelude::*;
 use arrow::array::{Array, BooleanArray, ListArray, PrimitiveArray, Utf8Array};
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::DataType;
 use arrow::types::NativeType;
 
+use crate::prelude::*;
 use crate::utils::CustomIterTools;
 
 pub mod default_arrays;

--- a/polars/polars-arrow/src/compute/take/boolean.rs
+++ b/polars/polars-arrow/src/compute/take/boolean.rs
@@ -1,8 +1,9 @@
-use crate::index::IdxSize;
 use arrow::{
     array::{Array, BooleanArray, PrimitiveArray},
     bitmap::{Bitmap, MutableBitmap},
 };
+
+use crate::index::IdxSize;
 
 unsafe fn take_values(values: &Bitmap, indices: &[IdxSize]) -> Bitmap {
     let values = indices.iter().map(|&index| {

--- a/polars/polars-arrow/src/compute/take/mod.rs
+++ b/polars/polars-arrow/src/compute/take/mod.rs
@@ -1,13 +1,14 @@
 mod boolean;
 
-use crate::trusted_len::{PushUnchecked, TrustedLen};
-use crate::utils::with_match_primitive_type;
-use crate::{bit_util::unset_bit_raw, prelude::*, utils::CustomIterTools};
 use arrow::array::*;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, PhysicalType};
 use arrow::types::NativeType;
+
+use crate::trusted_len::{PushUnchecked, TrustedLen};
+use crate::utils::with_match_primitive_type;
+use crate::{bit_util::unset_bit_raw, prelude::*, utils::CustomIterTools};
 
 /// # Safety
 /// Does not do bounds checks

--- a/polars/polars-arrow/src/conversion.rs
+++ b/polars/polars-arrow/src/conversion.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use arrow::array::StructArray;
 use arrow::chunk::Chunk;
 use arrow::datatypes::{DataType, Field};
+
+use crate::prelude::*;
 
 pub fn chunk_to_struct(chunk: Chunk<ArrayRef>, fields: Vec<Field>) -> StructArray {
     let dtype = DataType::Struct(fields);

--- a/polars/polars-arrow/src/error.rs
+++ b/polars/polars-arrow/src/error.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+
 use thiserror::Error as ThisError;
 
 type ErrString = Cow<'static, str>;

--- a/polars/polars-arrow/src/kernels/concatenate.rs
+++ b/polars/polars-arrow/src/kernels/concatenate.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use arrow::array::growable::make_growable;
 use arrow::error::{Error as ArrowError, Result};
+
+use crate::prelude::*;
 
 /// Concatenate multiple [Array] of the same type into a single [`Array`].
 /// This does not check the arrays types.

--- a/polars/polars-arrow/src/kernels/ewm/average.rs
+++ b/polars/polars-arrow/src/kernels/ewm/average.rs
@@ -1,7 +1,9 @@
-use crate::trusted_len::{PushUnchecked, TrustedLen};
-use num::Float;
 use std::fmt::Debug;
 use std::ops::AddAssign;
+
+use num::Float;
+
+use crate::trusted_len::{PushUnchecked, TrustedLen};
 // See:
 // https://github.com/pola-rs/polars/issues/2148
 // https://stackoverflow.com/a/51392341/6717054

--- a/polars/polars-arrow/src/kernels/float.rs
+++ b/polars/polars-arrow/src/kernels/float.rs
@@ -1,9 +1,10 @@
-use crate::array::default_arrays::FromData;
-use crate::prelude::*;
 use arrow::array::{BooleanArray, PrimitiveArray};
 use arrow::bitmap::Bitmap;
 use arrow::types::NativeType;
 use num::Float;
+
+use crate::array::default_arrays::FromData;
+use crate::prelude::*;
 
 pub fn is_nan<T>(arr: &PrimitiveArray<T>) -> ArrayRef
 where

--- a/polars/polars-arrow/src/kernels/list.rs
+++ b/polars/polars-arrow/src/kernels/list.rs
@@ -1,9 +1,10 @@
+use arrow::array::ListArray;
+use arrow::buffer::Buffer;
+
 use crate::compute::take::take_unchecked;
 use crate::prelude::*;
 use crate::trusted_len::PushUnchecked;
 use crate::utils::CustomIterTools;
-use arrow::array::ListArray;
-use arrow::buffer::Buffer;
 
 /// Get the indices that would result in a get operation on the lists values.
 /// for example, consider this list:
@@ -93,10 +94,11 @@ pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use arrow::array::{Array, Int32Array, PrimitiveArray};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
+
+    use super::*;
 
     fn get_array() -> ListArray<i64> {
         let values = Int32Array::from_slice(&[1, 2, 3, 4, 5, 6]);

--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -1,6 +1,7 @@
+use std::iter::Enumerate;
+
 use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitChunks;
-use std::iter::Enumerate;
 pub mod concatenate;
 pub mod ewm;
 pub mod float;

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -2,17 +2,19 @@ pub mod no_nulls;
 pub mod nulls;
 mod window;
 
-use crate::data_types::IsFloat;
-use crate::prelude::*;
-use crate::utils::CustomIterTools;
+use std::cmp::Ordering;
+use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
+
 use arrow::array::PrimitiveArray;
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::NativeType;
 use num::ToPrimitive;
 use num::{Bounded, Float, NumCast, One, Zero};
-use std::cmp::Ordering;
-use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use window::*;
+
+use crate::data_types::IsFloat;
+use crate::prelude::*;
+use crate::utils::CustomIterTools;
 
 type Start = usize;
 type End = usize;

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
@@ -1,6 +1,7 @@
+use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
+
 use super::sum::SumWindow;
 use super::*;
-use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
 
 pub struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -1,6 +1,7 @@
-use super::*;
 use no_nulls;
 use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
+
+use super::*;
 
 pub struct SortedMinMax<'a, T: NativeType> {
     slice: &'a [T],

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -4,21 +4,22 @@ mod quantile;
 mod sum;
 mod variance;
 
-use super::*;
-use crate::utils::CustomIterTools;
+use std::fmt::Debug;
+
 use arrow::array::PrimitiveArray;
 use arrow::datatypes::DataType;
 use arrow::types::NativeType;
-use num::{Float, NumCast};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-
 pub use mean::*;
 pub use min_max::*;
+use num::{Float, NumCast};
 pub use quantile::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 pub use sum::*;
 pub use variance::*;
+
+use super::*;
+use crate::utils::CustomIterTools;
 
 pub trait RollingAggWindowNoNulls<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize) -> Self;

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
@@ -1,7 +1,8 @@
+use std::fmt::Debug;
+
 use super::*;
 use crate::index::IdxSize;
 use crate::trusted_len::TrustedLen;
-use std::fmt::Debug;
 
 // used by agg_quantile
 pub fn rolling_quantile_by_iter<T, O>(

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/sum.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/sum.rs
@@ -1,6 +1,7 @@
-use super::*;
 use no_nulls;
 use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
+
+use super::*;
 
 pub struct SumWindow<'a, T> {
     slice: &'a [T],

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -1,7 +1,8 @@
-use super::mean::MeanWindow;
-use super::*;
 use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
 use num::pow::Pow;
+
+use super::mean::MeanWindow;
+use super::*;
 
 pub(super) struct SumSquaredWindow<'a, T> {
     slice: &'a [T],

--- a/polars/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -1,7 +1,8 @@
-use super::*;
 use arrow::bitmap::utils::{count_zeros, zip_validity};
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
+
+use super::*;
 
 pub fn is_reverse_sorted_max_nulls<T: NativeType + PartialOrd + IsFloat>(
     values: &[T],

--- a/polars/polars-arrow/src/kernels/rolling/nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/mod.rs
@@ -4,12 +4,13 @@ mod quantile;
 mod sum;
 mod variance;
 
-use super::*;
 pub use mean::*;
 pub use min_max::*;
 pub use quantile::*;
 pub use sum::*;
 pub use variance::*;
+
+use super::*;
 
 pub trait RollingAggWindowNulls<'a, T: NativeType> {
     /// # Safety
@@ -85,10 +86,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::kernels::rolling::nulls::mean::rolling_mean;
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
+
+    use super::*;
+    use crate::kernels::rolling::nulls::mean::rolling_mean;
 
     fn get_null_arr() -> PrimitiveArray<f64> {
         // 1, None, -1, 4

--- a/polars/polars-arrow/src/kernels/rolling/nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/quantile.rs
@@ -294,10 +294,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::kernels::rolling::nulls::{rolling_max, rolling_min};
     use arrow::buffer::Buffer;
     use arrow::datatypes::DataType;
+
+    use super::*;
+    use crate::kernels::rolling::nulls::{rolling_max, rolling_min};
 
     #[test]
     fn test_rolling_median_nulls() {

--- a/polars/polars-arrow/src/kernels/rolling/nulls/sum.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/sum.rs
@@ -1,6 +1,7 @@
-use super::*;
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
+
+use super::*;
 
 pub struct SumWindow<'a, T> {
     slice: &'a [T],

--- a/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
@@ -1,8 +1,9 @@
-use super::*;
 use mean::MeanWindow;
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
 use num::pow::Pow;
+
+use super::*;
 
 pub(super) struct SumSquaredWindow<'a, T> {
     slice: &'a [T],

--- a/polars/polars-arrow/src/kernels/set.rs
+++ b/polars/polars-arrow/src/kernels/set.rs
@@ -1,10 +1,12 @@
+use std::ops::BitOr;
+
+use arrow::array::*;
+use arrow::{datatypes::DataType, types::NativeType};
+
 use crate::array::default_arrays::FromData;
 use crate::error::{PolarsError, Result};
 use crate::kernels::BinaryMaskedSliceIterator;
 use crate::trusted_len::PushUnchecked;
-use arrow::array::*;
-use arrow::{datatypes::DataType, types::NativeType};
-use std::ops::BitOr;
 
 /// Set values in a primitive array where the primitive array has null values.
 /// this is faster because we don't have to invert and combine bitmaps
@@ -96,9 +98,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use arrow::array::UInt32Array;
     use std::iter::FromIterator;
+
+    use arrow::array::UInt32Array;
+
+    use super::*;
 
     #[test]
     fn test_set_mask() {

--- a/polars/polars-arrow/src/kernels/sort_partition.rs
+++ b/polars/polars-arrow/src/kernels/sort_partition.rs
@@ -1,6 +1,8 @@
-use crate::index::IdxSize;
-use arrow::types::NativeType;
 use std::fmt::Debug;
+
+use arrow::types::NativeType;
+
+use crate::index::IdxSize;
 
 /// Find partition indexes such that every partition contains unique groups.
 fn find_partition_points<T>(values: &[T], n: usize, reverse: bool) -> Vec<usize>

--- a/polars/polars-arrow/src/kernels/sorted_join/mod.rs
+++ b/polars/polars-arrow/src/kernels/sorted_join/mod.rs
@@ -1,8 +1,9 @@
 pub mod inner;
 pub mod left;
 
-use crate::index::IdxSize;
 use std::fmt::Debug;
+
+use crate::index::IdxSize;
 
 type JoinOptIds = Vec<Option<IdxSize>>;
 type JoinIds = Vec<IdxSize>;

--- a/polars/polars-arrow/src/kernels/string.rs
+++ b/polars/polars-arrow/src/kernels/string.rs
@@ -1,8 +1,9 @@
-use crate::prelude::*;
-use crate::trusted_len::PushUnchecked;
 use arrow::array::{UInt32Array, Utf8Array};
 use arrow::buffer::Buffer;
 use arrow::datatypes::DataType;
+
+use crate::prelude::*;
+use crate::trusted_len::PushUnchecked;
 
 pub fn string_lengths(array: &Utf8Array<i64>) -> ArrayRef {
     let values = array.offsets().windows(2).map(|x| (x[1] - x[0]) as u32);

--- a/polars/polars-arrow/src/kernels/take_agg.rs
+++ b/polars/polars-arrow/src/kernels/take_agg.rs
@@ -1,9 +1,10 @@
 //! kernels that combine take and aggregations.
-use crate::array::PolarsArray;
-use crate::index::IdxSize;
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
 use num::{NumCast, ToPrimitive};
+
+use crate::array::PolarsArray;
+use crate::index::IdxSize;
 
 /// Take kernel for single chunk without nulls and an iterator as index.
 /// # Safety

--- a/polars/polars-arrow/src/prelude.rs
+++ b/polars/polars-arrow/src/prelude.rs
@@ -1,8 +1,9 @@
+use arrow::array::{ListArray, Utf8Array};
+
 pub use crate::array::default_arrays::*;
 pub use crate::bitmap::mutable::MutableBitmapExtension;
 pub use crate::kernels::rolling::no_nulls::QuantileInterpolOptions;
 pub use crate::{array::*, data_types::*, index::*};
-use arrow::array::{ListArray, Utf8Array};
 
 pub type LargeStringArray = Utf8Array<i64>;
 pub type LargeListArray = ListArray<i64>;

--- a/polars/polars-arrow/src/trusted_len/boolean.rs
+++ b/polars/polars-arrow/src/trusted_len/boolean.rs
@@ -1,8 +1,9 @@
+use arrow::array::BooleanArray;
+use arrow::bitmap::MutableBitmap;
+
 use crate::array::default_arrays::FromData;
 use crate::trusted_len::TrustedLen;
 use crate::utils::FromTrustedLenIterator;
-use arrow::array::BooleanArray;
-use arrow::bitmap::MutableBitmap;
 
 impl FromTrustedLenIterator<Option<bool>> for BooleanArray {
     fn from_iter_trusted_length<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self

--- a/polars/polars-arrow/src/trusted_len/mod.rs
+++ b/polars/polars-arrow/src/trusted_len/mod.rs
@@ -2,12 +2,14 @@ mod boolean;
 mod push_unchecked;
 mod rev;
 
-use crate::utils::TrustMyLength;
+use std::iter::Scan;
+use std::slice::Iter;
+
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
 pub use push_unchecked::*;
 pub use rev::FromIteratorReversed;
-use std::iter::Scan;
-use std::slice::Iter;
+
+use crate::utils::TrustMyLength;
 
 /// An iterator of known, fixed size.
 /// A trait denoting Rusts' unstable [TrustedLen](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -1,8 +1,10 @@
-use crate::trusted_len::{FromIteratorReversed, PushUnchecked, TrustedLen};
+use std::ops::BitAnd;
+
 use arrow::array::PrimitiveArray;
 use arrow::bitmap::Bitmap;
 use arrow::types::NativeType;
-use std::ops::BitAnd;
+
+use crate::trusted_len::{FromIteratorReversed, PushUnchecked, TrustedLen};
 
 #[derive(Clone)]
 pub struct TrustMyLength<I: Iterator<Item = J>, J> {

--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -1,11 +1,13 @@
 //! Implementations of arithmetic operations on ChunkedArray's.
-use crate::prelude::*;
-use crate::utils::{align_chunks_binary, align_chunks_binary_owned};
+use std::borrow::Cow;
+use std::ops::{Add, Div, Mul, Rem, Sub};
+
 use arrow::array::PrimitiveArray;
 use arrow::compute::{arithmetics::basic, arity_assign};
 use num::{Num, NumCast, ToPrimitive};
-use std::borrow::Cow;
-use std::ops::{Add, Div, Mul, Rem, Sub};
+
+use crate::prelude::*;
+use crate::utils::{align_chunks_binary, align_chunks_binary_owned};
 
 macro_rules! apply_operand_on_chunkedarray_by_iter {
 

--- a/polars/polars-core/src/chunked_array/bitwise.rs
+++ b/polars/polars-core/src/chunked_array/bitwise.rs
@@ -1,7 +1,9 @@
+use std::ops::{BitAnd, BitOr, BitXor, Not};
+
+use arrow::compute;
+
 use super::*;
 use crate::utils::{align_chunks_binary, combine_validities, CustomIterTools};
-use arrow::compute;
-use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 impl<T> BitAnd for &ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/builder/from.rs
+++ b/polars/polars-core/src/chunked_array/builder/from.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
+
+use crate::prelude::*;
 
 impl<T: PolarsNumericType> From<(&str, PrimitiveArray<T::Native>)> for ChunkedArray<T> {
     fn from(tpl: (&str, PrimitiveArray<T::Native>)) -> Self {

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_arrow::{array::list::AnonymousBuilder, prelude::*};
+
+use super::*;
 
 pub trait ListBuilderTrait {
     fn append_opt_series(&mut self, opt_s: Option<&Series>) {

--- a/polars/polars-core/src/chunked_array/builder/mod.rs
+++ b/polars/polars-core/src/chunked_array/builder/mod.rs
@@ -4,16 +4,18 @@ pub mod list;
 mod primitive;
 mod utf8;
 
-use crate::{
-    prelude::*,
-    utils::{get_iter_capacity, NoNull},
-};
-use arrow::{array::*, bitmap::Bitmap};
 use std::borrow::Cow;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::sync::Arc;
+
+use arrow::{array::*, bitmap::Bitmap};
 pub use {boolean::*, list::*, primitive::*, utf8::*};
+
+use crate::{
+    prelude::*,
+    utils::{get_iter_capacity, NoNull},
+};
 
 // N: the value type; T: the sentinel type
 pub trait ChunkedBuilder<N, T: PolarsDataType> {

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -1,10 +1,12 @@
 //! Implementations of the ChunkCast Trait.
+use std::convert::TryFrom;
+
+use arrow::compute::cast::CastOptions;
+use polars_arrow::compute::cast;
+
 #[cfg(feature = "dtype-categorical")]
 use crate::chunked_array::categorical::CategoricalChunkedBuilder;
 use crate::prelude::*;
-use arrow::compute::cast::CastOptions;
-use polars_arrow::compute::cast;
-use std::convert::TryFrom;
 
 pub(crate) fn cast_chunks(
     chunks: &[ArrayRef],

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -1,5 +1,5 @@
-use crate::utils::align_chunks_binary;
-use crate::{prelude::*, utils::NoNull};
+use std::ops::Not;
+
 use arrow::scalar::{PrimitiveScalar, Scalar, Utf8Scalar};
 use arrow::{
     array::{BooleanArray, PrimitiveArray, Utf8Array},
@@ -8,7 +8,9 @@ use arrow::{
 };
 use num::{NumCast, ToPrimitive};
 use polars_arrow::prelude::FromData;
-use std::ops::Not;
+
+use crate::utils::align_chunks_binary;
+use crate::{prelude::*, utils::NoNull};
 
 impl<T> ChunkedArray<T>
 where
@@ -954,9 +956,10 @@ impl ChunkCompare<&StructChunked> for StructChunked {
 
 #[cfg(test)]
 mod test {
+    use std::iter::repeat;
+
     use super::super::{arithmetic::test::create_two_chunked, test::get_chunked_array};
     use crate::prelude::*;
-    use std::iter::repeat;
 
     #[test]
     fn test_bitwise_ops() {

--- a/polars/polars-core/src/chunked_array/float.rs
+++ b/polars/polars-core/src/chunked_array/float.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use num::Float;
 use polars_arrow::kernels::float::*;
 use polars_arrow::kernels::set::set_at_nulls;
+
+use crate::prelude::*;
 
 impl<T> ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -1,9 +1,11 @@
+use std::convert::TryFrom;
+
+use arrow::array::*;
+
 use crate::prelude::*;
 #[cfg(feature = "dtype-struct")]
 use crate::series::iterator::SeriesIter;
 use crate::utils::CustomIterTools;
-use arrow::array::*;
-use std::convert::TryFrom;
 
 type LargeStringArray = Utf8Array<i64>;
 type LargeListArray = ListArray<i64>;

--- a/polars/polars-core/src/chunked_array/iterator/par/list.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/list.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use rayon::prelude::*;
+
+use crate::prelude::*;
 
 unsafe fn idx_to_array(idx: usize, arr: &ListArray<i64>, dtype: &DataType) -> Option<Series> {
     if arr.is_valid(idx) {

--- a/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use rayon::prelude::*;
+
+use crate::prelude::*;
 
 unsafe fn idx_to_str(idx: usize, arr: &Utf8Array<i64>) -> Option<&str> {
     if arr.is_valid(idx) {

--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -1,9 +1,11 @@
-use crate::prelude::*;
+use std::convert::TryFrom;
+
 use arrow::bitmap::MutableBitmap;
 use polars_arrow::array::PolarsArray;
 use polars_arrow::bit_util::unset_bit_raw;
 use polars_arrow::compute::take::take_value_indices_from_list;
-use std::convert::TryFrom;
+
+use crate::prelude::*;
 
 /// Take kernel for multiple chunks. We directly return a ChunkedArray because that path chooses the fastest collection path.
 pub(crate) fn take_primitive_iter_n_chunks<T: PolarsNumericType, I: IntoIterator<Item = usize>>(

--- a/polars/polars-core/src/chunked_array/list/iterator.rs
+++ b/polars/polars-core/src/chunked_array/list/iterator.rs
@@ -1,8 +1,9 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
 use crate::prelude::*;
 use crate::series::unstable::{ArrayBox, UnstableSeries};
 use crate::utils::CustomIterTools;
-use std::marker::PhantomData;
-use std::ptr::NonNull;
 
 #[cfg(feature = "private")]
 pub struct AmortizedListIter<'a, I: Iterator<Item = Option<ArrayBox>>> {

--- a/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -1,11 +1,13 @@
-use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
-use crate::prelude::*;
-use crate::{datatypes::PlHashMap, use_string_cache, StrHashGlobal, StringCache, POOL};
+use std::hash::{Hash, Hasher};
+
 use ahash::CallHasher;
 use arrow::array::*;
 use hashbrown::hash_map::RawEntryMut;
 use polars_arrow::trusted_len::PushUnchecked;
-use std::hash::{Hash, Hasher};
+
+use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
+use crate::prelude::*;
+use crate::{datatypes::PlHashMap, use_string_cache, StrHashGlobal, StringCache, POOL};
 
 pub enum RevMappingBuilder {
     /// Hashmap: maps the indexes from the global cache/categorical array to indexes in the local Utf8Array

--- a/polars/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -1,8 +1,9 @@
-use super::*;
-use crate::use_string_cache;
 use arrow::array::DictionaryArray;
 use arrow::datatypes::IntegerType;
 use polars_arrow::compute::cast::cast;
+
+use super::*;
+use crate::use_string_cache;
 
 impl From<&CategoricalChunked> for DictionaryArray<u32> {
     fn from(ca: &CategoricalChunked) -> Self {

--- a/polars/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -1,6 +1,8 @@
-use super::*;
-use arrow::bitmap::MutableBitmap;
 use std::sync::Arc;
+
+use arrow::bitmap::MutableBitmap;
+
+use super::*;
 
 impl CategoricalChunked {
     pub(crate) fn merge_categorical_map(&self, other: &Self) -> Result<Arc<RevMapping>> {

--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -4,10 +4,11 @@ mod merge;
 mod ops;
 pub mod stringcache;
 
-use super::*;
-use crate::prelude::*;
 pub use builder::*;
 pub(crate) use ops::{CategoricalTakeRandomGlobal, CategoricalTakeRandomLocal};
+
+use super::*;
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct CategoricalChunked {
@@ -206,9 +207,10 @@ impl<'a> ExactSizeIterator for CatIter<'a> {}
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryFrom;
+
     use super::*;
     use crate::{reset_string_cache, toggle_string_cache, SINGLE_LOCK};
-    use std::convert::TryFrom;
 
     #[test]
     fn test_categorical_round_trip() -> Result<()> {

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/mod.rs
@@ -5,5 +5,6 @@ mod unique;
 #[cfg(feature = "zip_with")]
 mod zip;
 
-use super::*;
 pub(crate) use take_random::{CategoricalTakeRandomGlobal, CategoricalTakeRandomLocal};
+
+use super::*;

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/take_random.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/take_random.rs
@@ -1,10 +1,12 @@
+use std::cmp::Ordering;
+
+use arrow::array::Utf8Array;
+
 use crate::prelude::compare_inner::PartialOrdInner;
 use crate::prelude::{
     CategoricalChunked, IntoTakeRandom, NumTakeRandomChunked, NumTakeRandomCont,
     NumTakeRandomSingleChunk, PlHashMap, RevMapping, TakeRandBranch3, TakeRandom,
 };
-use arrow::array::Utf8Array;
-use std::cmp::Ordering;
 
 type TakeCats<'a> = TakeRandBranch3<
     NumTakeRandomCont<'a, u32>,

--- a/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -1,13 +1,15 @@
-use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
-use crate::prelude::PlHashMap;
-use ahash::RandomState;
-use once_cell::sync::Lazy;
-use smartstring::{LazyCompact, SmartString};
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use ahash::RandomState;
+use once_cell::sync::Lazy;
+use smartstring::{LazyCompact, SmartString};
+
+use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
+use crate::prelude::PlHashMap;
 
 pub(crate) static USE_STRING_CACHE: AtomicBool = AtomicBool::new(false);
 

--- a/polars/polars-core/src/chunked_array/logical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/mod.rs
@@ -17,18 +17,17 @@ mod struct_;
 #[cfg(feature = "dtype-time")]
 mod time;
 
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
 #[cfg(feature = "dtype-categorical")]
 pub use categorical::*;
-
+#[cfg(feature = "dtype-struct")]
+pub use struct_::*;
 #[cfg(feature = "dtype-time")]
 pub use time::*;
 
-#[cfg(feature = "dtype-struct")]
-pub use struct_::*;
-
 use crate::prelude::*;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
 
 /// Maps a logical type to a a chunked array implementation of the physical type.
 /// This saves a lot of compiler bloat and allows us to reuse functionality.

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -1,10 +1,12 @@
 //! The typed heart of every Series column.
-use crate::prelude::*;
-use arrow::{array::*, bitmap::Bitmap};
-use polars_arrow::prelude::ValueSize;
 use std::iter::Map;
 use std::marker::PhantomData;
 use std::sync::Arc;
+
+use arrow::{array::*, bitmap::Bitmap};
+use polars_arrow::prelude::ValueSize;
+
+use crate::prelude::*;
 
 pub mod ops;
 #[macro_use]
@@ -41,15 +43,16 @@ pub mod temporal;
 mod trusted_len;
 pub mod upstream_traits;
 
+use std::mem;
+use std::slice::Iter;
+
+use bitflags::bitflags;
 use polars_arrow::prelude::*;
 
 #[cfg(feature = "dtype-categorical")]
 use crate::chunked_array::categorical::RevMapping;
 use crate::series::IsSorted;
 use crate::utils::{first_non_null, last_non_null, CustomIterTools};
-use bitflags::bitflags;
-use std::mem;
-use std::slice::Iter;
 
 #[cfg(not(feature = "dtype-categorical"))]
 pub struct RevMapping {}

--- a/polars/polars-core/src/chunked_array/ndarray.rs
+++ b/polars/polars-core/src/chunked_array/ndarray.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use ndarray::prelude::*;
 use rayon::prelude::*;
+
+use crate::prelude::*;
 
 impl<T> ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/object/builder.rs
+++ b/polars/polars-core/src/chunked_array/object/builder.rs
@@ -1,8 +1,10 @@
-use super::*;
-use crate::utils::get_iter_capacity;
-use arrow::bitmap::MutableBitmap;
 use std::marker::PhantomData;
 use std::sync::Arc;
+
+use arrow::bitmap::MutableBitmap;
+
+use super::*;
+use crate::utils::get_iter_capacity;
 
 pub struct ObjectChunkedBuilder<T> {
     field: Field,

--- a/polars/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/mod.rs
@@ -2,12 +2,14 @@ pub(crate) mod drop;
 mod list;
 pub(crate) mod polars_extension;
 
-use crate::{prelude::*, PROCESS_ID};
+use std::mem;
+
 use arrow::array::{Array, FixedSizeBinaryArray};
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
 use polars_extension::PolarsExtension;
-use std::mem;
+
+use crate::{prelude::*, PROCESS_ID};
 
 /// Invariants
 /// `ptr` must point to start a `T` allocation
@@ -136,8 +138,9 @@ pub(crate) fn create_extension<
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::fmt::{Display, Formatter};
+
+    use super::*;
 
     #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
     struct Foo {

--- a/polars/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/polars/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -1,7 +1,9 @@
+use std::mem::ManuallyDrop;
+
+use arrow::array::FixedSizeBinaryArray;
+
 use super::*;
 use crate::prelude::*;
-use arrow::array::FixedSizeBinaryArray;
-use std::mem::ManuallyDrop;
 
 pub struct PolarsExtension {
     array: Option<FixedSizeBinaryArray>,

--- a/polars/polars-core/src/chunked_array/object/is_valid.rs
+++ b/polars/polars-core/src/chunked_array/object/is_valid.rs
@@ -1,4 +1,5 @@
-use super::{ObjectArray, PolarsObject};
 use polars_arrow::is_valid::ArrowArray;
+
+use super::{ObjectArray, PolarsObject};
 
 impl<T: PolarsObject> ArrowArray for ObjectArray<T> {}

--- a/polars/polars-core/src/chunked_array/object/iterator.rs
+++ b/polars/polars-core/src/chunked_array/object/iterator.rs
@@ -1,6 +1,7 @@
-use crate::chunked_array::object::{ObjectArray, PolarsObject};
 use arrow::array::Array;
 use polars_arrow::trusted_len::TrustedLen;
+
+use crate::chunked_array::object::{ObjectArray, PolarsObject};
 
 /// An iterator that returns Some(T) or None, that can be used on any ObjectArray
 // Note: This implementation is based on std's [Vec]s' [IntoIter].

--- a/polars/polars-core/src/chunked_array/ops/abs.rs
+++ b/polars/polars-core/src/chunked_array/ops/abs.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use num::Signed;
+
+use crate::prelude::*;
 
 impl<T: PolarsNumericType> ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -1,15 +1,17 @@
 //! Implementations of the ChunkAgg trait.
-use crate::chunked_array::builder::get_list_builder;
-use crate::chunked_array::ChunkedArray;
-use crate::datatypes::BooleanChunked;
-use crate::series::IsSorted;
-use crate::{datatypes::PolarsNumericType, prelude::*, utils::CustomIterTools};
+use std::ops::Add;
+
 use arrow::compute;
 use arrow::types::simd::Simd;
 use num::Float;
 use num::ToPrimitive;
 use polars_arrow::prelude::QuantileInterpolOptions;
-use std::ops::Add;
+
+use crate::chunked_array::builder::get_list_builder;
+use crate::chunked_array::ChunkedArray;
+use crate::datatypes::BooleanChunked;
+use crate::series::IsSorted;
+use crate::{datatypes::PolarsNumericType, prelude::*, utils::CustomIterTools};
 
 /// Aggregations that return Series of unit length. Those can be used in broadcasting operations.
 pub trait ChunkAggSeries {
@@ -881,8 +883,9 @@ impl<T: PolarsObject> ArgAgg for ObjectChunked<T> {}
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
     use polars_arrow::prelude::QuantileInterpolOptions;
+
+    use crate::prelude::*;
 
     #[test]
     fn test_var() {

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use std::convert::TryFrom;
+
+use crate::prelude::*;
 
 #[inline]
 #[allow(unused_variables)]

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -1,11 +1,13 @@
 //! Implementations of the ChunkApply Trait.
-use crate::prelude::*;
-use crate::utils::{CustomIterTools, NoNull};
+use std::borrow::Cow;
+use std::convert::TryFrom;
+
 use arrow::array::{BooleanArray, PrimitiveArray};
 use polars_arrow::array::PolarsArray;
 use polars_arrow::trusted_len::PushUnchecked;
-use std::borrow::Cow;
-use std::convert::TryFrom;
+
+use crate::prelude::*;
+use crate::utils::{CustomIterTools, NoNull};
 
 macro_rules! try_apply {
     ($self:expr, $f:expr) => {{

--- a/polars/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/polars/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use arrow::buffer::Buffer;
+
+use crate::prelude::*;
 
 #[cfg(feature = "performant")]
 impl Int16Chunked {

--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "object")]
+use arrow::array::Array;
+use arrow::compute::concatenate;
+
 use super::*;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::utils::slice_offsets;
-#[cfg(feature = "object")]
-use arrow::array::Array;
-use arrow::compute::concatenate;
 
 #[inline]
 fn slice(

--- a/polars/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/polars/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -2,6 +2,8 @@
 //! Used to speed up PartialEq and PartialOrd of elements within an array
 //!
 
+use std::cmp::{Ordering, PartialEq};
+
 use crate::chunked_array::ops::take::take_random::{
     BoolTakeRandom, BoolTakeRandomSingleChunk, NumTakeRandomChunked, NumTakeRandomCont,
     NumTakeRandomSingleChunk, Utf8TakeRandom, Utf8TakeRandomSingleChunk,
@@ -9,7 +11,6 @@ use crate::chunked_array::ops::take::take_random::{
 #[cfg(feature = "object")]
 use crate::chunked_array::ops::take::take_random::{ObjectTakeRandom, ObjectTakeRandomSingleChunk};
 use crate::prelude::*;
-use std::cmp::{Ordering, PartialEq};
 
 pub trait PartialEqInner: Send + Sync {
     /// Safety:

--- a/polars/polars-core/src/chunked_array/ops/concat_str.rs
+++ b/polars/polars-core/src/chunked_array/ops/concat_str.rs
@@ -1,7 +1,9 @@
+use std::fmt::{Display, Write};
+
+use polars_arrow::array::default_arrays::FromDataUtf8;
+
 use super::StrConcat;
 use crate::prelude::*;
-use polars_arrow::array::default_arrays::FromDataUtf8;
-use std::fmt::{Display, Write};
 
 fn fmt_and_write<T: Display>(value: Option<T>, buf: &mut String) {
     match value {

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -1,8 +1,10 @@
-use crate::prelude::*;
-use crate::utils::CustomIterTools;
-use num::Bounded;
 use std::iter::FromIterator;
 use std::ops::{Add, AddAssign, Mul};
+
+use num::Bounded;
+
+use crate::prelude::*;
+use crate::utils::CustomIterTools;
 
 fn det_max<T>(state: &mut T, v: Option<T>) -> Option<Option<T>>
 where

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -1,9 +1,11 @@
+use std::marker::PhantomData;
+
+use arrow::array::*;
+
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
 use crate::utils::index_to_chunked_index;
-use arrow::array::*;
-use std::marker::PhantomData;
 
 pub struct Chunks<'a, T> {
     chunks: &'a [ArrayRef],

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -1,11 +1,13 @@
-use crate::chunked_array::builder::AnonymousOwnedListBuilder;
-use crate::prelude::*;
+use std::convert::TryFrom;
+
 use arrow::bitmap::Bitmap;
 use arrow::{array::*, bitmap::MutableBitmap, buffer::Buffer};
 use polars_arrow::array::PolarsArray;
 use polars_arrow::bit_util::unset_bit_raw;
 use polars_arrow::prelude::{FromDataUtf8, ValueSize};
-use std::convert::TryFrom;
+
+use crate::chunked_array::builder::AnonymousOwnedListBuilder;
+use crate::prelude::*;
 
 pub(crate) trait ExplodeByOffsets {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series;

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use arrow::{compute::concatenate::concatenate, Either};
+
+use crate::prelude::*;
 
 fn extend_immutable(immutable: &dyn Array, chunks: &mut Vec<ArrayRef>, other_chunks: &[ArrayRef]) {
     let out = if chunks.len() == 1 {

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -1,10 +1,12 @@
-use crate::prelude::*;
+use std::ops::Add;
+
 use arrow::compute;
 use arrow::types::simd::Simd;
 use num::{Bounded, NumCast, One, Zero};
 use polars_arrow::kernels::set::set_at_nulls;
 use polars_arrow::utils::CustomIterTools;
-use std::ops::Add;
+
+use crate::prelude::*;
 
 fn fill_forward_limit<T>(ca: &ChunkedArray<T>, limit: IdxSize) -> ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -1,10 +1,11 @@
 #[cfg(feature = "object")]
+use arrow::array::Array;
+use arrow::compute::filter::filter as filter_fn;
+
+#[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::prelude::*;
 use crate::utils::align_chunks_binary;
-#[cfg(feature = "object")]
-use arrow::array::Array;
-use arrow::compute::filter::filter as filter_fn;
 
 macro_rules! check_filter_len {
     ($self:expr, $filter:expr) => {{

--- a/polars/polars-core/src/chunked_array/ops/full.rs
+++ b/polars/polars-core/src/chunked_array/ops/full.rs
@@ -1,8 +1,9 @@
+use arrow::bitmap::MutableBitmap;
+use polars_arrow::array::default_arrays::FromData;
+
 use crate::chunked_array::builder::get_list_builder;
 use crate::prelude::*;
 use crate::utils::NoNull;
-use arrow::bitmap::MutableBitmap;
-use polars_arrow::array::default_arrays::FromData;
 
 impl<T> ChunkFull<T::Native> for ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/ops/interpolate.rs
+++ b/polars/polars-core/src/chunked_array/ops/interpolate.rs
@@ -1,7 +1,9 @@
-use crate::prelude::*;
+use std::ops::{Add, Div, Mul, Sub};
+
 use arrow::bitmap::MutableBitmap;
 use num::{FromPrimitive, Zero};
-use std::ops::{Add, Div, Mul, Sub};
+
+use crate::prelude::*;
 
 fn linear_itp<T>(low: T, step: T, diff: T, steps_n: T) -> T
 where

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -1,7 +1,9 @@
+use std::hash::Hash;
+
+use hashbrown::hash_set::HashSet;
+
 use crate::prelude::*;
 use crate::utils::{get_supertype, CustomIterTools};
-use hashbrown::hash_set::HashSet;
-use std::hash::Hash;
 
 unsafe fn is_in_helper<T, P>(ca: &ChunkedArray<T>, other: &Series) -> Result<BooleanChunked>
 where

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -1,12 +1,13 @@
 //! Traits for miscellaneous operations on ChunkedArray
 use std::marker::Sized;
 
+use arrow::buffer::Buffer;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 pub use self::take::*;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectType;
 use crate::prelude::*;
-use arrow::buffer::Buffer;
-use polars_arrow::prelude::QuantileInterpolOptions;
 
 #[cfg(feature = "abs")]
 mod abs;

--- a/polars/polars-core/src/chunked_array/ops/peaks.rs
+++ b/polars/polars-core/src/chunked_array/ops/peaks.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use num::Zero;
+
+use crate::prelude::*;
 
 impl<T> ChunkPeaks for ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/ops/repeat_by.rs
+++ b/polars/polars-core/src/chunked_array/ops/repeat_by.rs
@@ -1,7 +1,8 @@
-use super::RepeatBy;
-use crate::prelude::*;
 use arrow::array::ListArray;
 use polars_arrow::array::ListFromIter;
+
+use super::RepeatBy;
+use crate::prelude::*;
 
 type LargeListArray = ListArray<i64>;
 

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -24,14 +24,16 @@ impl Default for RollingOptionsFixedWindow {
 
 #[cfg(feature = "rolling_window")]
 mod inner_mod {
-    use crate::prelude::*;
+    use std::ops::SubAssign;
+
     use arrow::array::{Array, PrimitiveArray};
     use arrow::bitmap::MutableBitmap;
     use num::{Float, Zero};
     use polars_arrow::bit_util::unset_bit_raw;
     use polars_arrow::data_types::IsFloat;
     use polars_arrow::trusted_len::PushUnchecked;
-    use std::ops::SubAssign;
+
+    use crate::prelude::*;
 
     /// utility
     fn check_input(window_size: usize, min_periods: usize) -> Result<()> {

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
-use crate::utils::{align_chunks_binary, CustomIterTools};
 use arrow::bitmap::MutableBitmap;
 use polars_arrow::array::ValueSize;
 use polars_arrow::kernels::set::{set_at_idx_no_null, set_with_mask};
 use polars_arrow::prelude::FromData;
+
+use crate::prelude::*;
+use crate::utils::{align_chunks_binary, CustomIterTools};
 
 macro_rules! impl_set_at_idx_with {
     ($self:ident, $builder:ident, $idx:ident, $f:ident) => {{

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use num::{abs, clamp};
+
+use crate::prelude::*;
 
 macro_rules! impl_shift_fill {
     ($self:ident, $periods:expr, $fill_value:expr) => {{

--- a/polars/polars-core/src/chunked_array/ops/sort/argsort_multiple.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/argsort_multiple.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_arrow::data_types::IsFloat;
+
+use super::*;
 
 pub(crate) fn args_validate<T: PolarsDataType>(
     ca: &ChunkedArray<T>,

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -4,20 +4,22 @@ mod argsort_multiple;
 #[cfg(feature = "dtype-categorical")]
 mod categorical;
 
-use crate::prelude::compare_inner::PartialOrdInner;
-#[cfg(feature = "sort_multiple")]
-use crate::prelude::sort::argsort_multiple::{args_validate, argsort_multiple_impl};
-use crate::prelude::*;
-use crate::utils::{CustomIterTools, NoNull};
+use std::cmp::Ordering;
+use std::hint::unreachable_unchecked;
+use std::iter::FromIterator;
+
 use arrow::{bitmap::MutableBitmap, buffer::Buffer};
 use num::Float;
 use polars_arrow::array::default_arrays::FromDataUtf8;
 use polars_arrow::prelude::{FromData, ValueSize};
 use polars_arrow::trusted_len::PushUnchecked;
 use rayon::prelude::*;
-use std::cmp::Ordering;
-use std::hint::unreachable_unchecked;
-use std::iter::FromIterator;
+
+use crate::prelude::compare_inner::PartialOrdInner;
+#[cfg(feature = "sort_multiple")]
+use crate::prelude::sort::argsort_multiple::{args_validate, argsort_multiple_impl};
+use crate::prelude::*;
+use crate::utils::{CustomIterTools, NoNull};
 
 #[inline]
 fn sort_cmp<T: PartialOrd + IsFloat>(a: &T, b: &T) -> Ordering {

--- a/polars/polars-core/src/chunked_array/ops/take/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/mod.rs
@@ -3,17 +3,16 @@
 //! IntoTakeRandom provides structs that implement the TakeRandom trait.
 //! There are several structs that implement the fastest path for random access.
 //!
-use polars_arrow::compute::take::*;
-
-use crate::chunked_array::kernels::take::*;
-
-use crate::prelude::*;
-use crate::utils::NoNull;
+use std::borrow::Cow;
 
 use polars_arrow::array::PolarsArray;
-use std::borrow::Cow;
+use polars_arrow::compute::take::*;
 pub use take_random::*;
 pub use traits::*;
+
+use crate::chunked_array::kernels::take::*;
+use crate::prelude::*;
+use crate::utils::NoNull;
 
 mod take_chunked;
 mod take_every;

--- a/polars/polars-core/src/chunked_array/ops/take/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_random.rs
@@ -1,12 +1,14 @@
-#[cfg(feature = "object")]
-use crate::chunked_array::object::ObjectArray;
-use crate::prelude::downcast::Chunks;
-use crate::prelude::*;
+use std::convert::TryFrom;
+
 use arrow::array::{Array, BooleanArray, ListArray, PrimitiveArray, Utf8Array};
 use arrow::bitmap::utils::get_bit_unchecked;
 use arrow::bitmap::Bitmap;
 use polars_arrow::is_valid::*;
-use std::convert::TryFrom;
+
+#[cfg(feature = "object")]
+use crate::chunked_array::object::ObjectArray;
+use crate::prelude::downcast::Chunks;
+use crate::prelude::*;
 
 macro_rules! take_random_get {
     ($self:ident, $index:ident) => {{

--- a/polars/polars-core/src/chunked_array/ops/take/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_single.rs
@@ -1,9 +1,11 @@
+use std::convert::TryFrom;
+
+use arrow::array::*;
+use polars_arrow::is_valid::IsValid;
+
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
-use arrow::array::*;
-use polars_arrow::is_valid::IsValid;
-use std::convert::TryFrom;
 
 macro_rules! impl_take_random_get {
     ($self:ident, $index:ident, $array_type:ty) => {{

--- a/polars/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/traits.rs
@@ -1,7 +1,8 @@
 //! Traits that indicate the allowed arguments in a ChunkedArray::take operation.
+use polars_arrow::array::PolarsArray;
+
 use crate::frame::groupby::GroupsProxyIter;
 use crate::prelude::*;
-use polars_arrow::array::PolarsArray;
 
 // Utility traits
 pub trait TakeIterator: Iterator<Item = usize> + TrustedLen {

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "rank")]
 pub(crate) mod rank;
 
+use std::hash::Hash;
+
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectType;
 use crate::datatypes::PlHashSet;
@@ -10,7 +12,6 @@ use crate::frame::groupby::GroupsProxy;
 use crate::frame::groupby::IntoGroupsProxy;
 use crate::prelude::*;
 use crate::series::IsSorted;
-use std::hash::Hash;
 
 fn finish_is_unique_helper(
     mut unique_idx: Vec<IdxSize>,
@@ -339,9 +340,10 @@ impl ChunkUnique<Float64Type> for Float64Chunked {
 
 #[cfg(feature = "is_first")]
 mod is_first {
+    use arrow::array::BooleanArray;
+
     use super::*;
     use crate::utils::CustomIterTools;
-    use arrow::array::BooleanArray;
 
     fn is_first<T>(ca: &ChunkedArray<T>) -> BooleanChunked
     where

--- a/polars/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -1,10 +1,10 @@
-use crate::prelude::*;
-
 use polars_arrow::prelude::FromData;
 #[cfg(feature = "random")]
 use rand::prelude::SliceRandom;
 #[cfg(feature = "random")]
 use rand::{rngs::SmallRng, thread_rng, SeedableRng};
+
+use crate::prelude::*;
 
 #[derive(Copy, Clone)]
 pub enum RankMethod {

--- a/polars/polars-core/src/chunked_array/ops/zip.rs
+++ b/polars/polars-core/src/chunked_array/ops/zip.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
-use crate::utils::{align_chunks_ternary, CustomIterTools};
 use arrow::compute::if_then_else::if_then_else;
 use polars_arrow::array::default_arrays::FromData;
+
+use crate::prelude::*;
+use crate::utils::{align_chunks_ternary, CustomIterTools};
 
 fn ternary_apply<T>(predicate: bool, truthy: T, falsy: T) -> T {
     if predicate {

--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
-use crate::utils::{CustomIterTools, NoNull};
 use num::{Float, NumCast};
 use rand::distributions::Bernoulli;
 use rand::prelude::*;
 use rand_distr::{Distribution, Normal, Standard, StandardNormal, Uniform};
+
+use crate::prelude::*;
+use crate::utils::{CustomIterTools, NoNull};
 
 fn get_random_seed() -> u64 {
     let mut rng = SmallRng::from_entropy();

--- a/polars/polars-core/src/chunked_array/strings/encoding.rs
+++ b/polars/polars-core/src/chunked_array/strings/encoding.rs
@@ -1,7 +1,7 @@
-use crate::prelude::*;
-
 use base64;
 use hex;
+
+use crate::prelude::*;
 
 impl Utf8Chunked {
     #[cfg(feature = "string_encoding")]

--- a/polars/polars-core/src/chunked_array/strings/json_path.rs
+++ b/polars/polars-core/src/chunked_array/strings/json_path.rs
@@ -1,7 +1,9 @@
-use crate::prelude::*;
+use std::borrow::Cow;
+
 use jsonpath_lib::PathCompiled;
 use serde_json::Value;
-use std::borrow::Cow;
+
+use crate::prelude::*;
 
 #[cfg(feature = "extract_jsonpath")]
 fn extract_json<'a>(expr: &PathCompiled, json_str: &'a str) -> Option<Cow<'a, str>> {

--- a/polars/polars-core/src/chunked_array/temporal/conversion.rs
+++ b/polars/polars-core/src/chunked_array/temporal/conversion.rs
@@ -1,8 +1,7 @@
-use crate::prelude::*;
-
 use arrow::temporal_conversions::*;
-
 use chrono::*;
+
+use crate::prelude::*;
 
 /// Number of seconds in a day
 pub(crate) const SECONDS_IN_DAY: i64 = 86_400;

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -1,7 +1,9 @@
+use std::fmt::Write;
+
+use arrow::temporal_conversions::date32_to_date;
+
 use super::*;
 use crate::prelude::*;
-use arrow::temporal_conversions::date32_to_date;
-use std::fmt::Write;
 
 pub(crate) fn naive_date_to_date(nd: NaiveDate) -> i32 {
     let nt = NaiveTime::from_hms(0, 0, 0);

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -1,11 +1,13 @@
+use std::fmt::Write;
+
+use arrow::temporal_conversions::{
+    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
+};
+
 use super::conversion::{datetime_to_timestamp_ms, datetime_to_timestamp_ns};
 use super::*;
 use crate::prelude::DataType::Datetime;
 use crate::prelude::*;
-use arrow::temporal_conversions::{
-    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
-};
-use std::fmt::Write;
 
 impl DatetimeChunked {
     pub fn as_datetime_iter(
@@ -164,8 +166,9 @@ impl DatetimeChunked {
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
     use chrono::NaiveDateTime;
+
+    use crate::prelude::*;
 
     #[test]
     fn from_datetime() {

--- a/polars/polars-core/src/chunked_array/temporal/mod.rs
+++ b/polars/polars-core/src/chunked_array/temporal/mod.rs
@@ -9,14 +9,13 @@ mod duration;
 #[cfg(feature = "dtype-time")]
 mod time;
 
-pub use self::conversion::*;
-
+#[cfg(feature = "dtype-date")]
+use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 #[cfg(any(feature = "dtype-time", feature = "dtype-date"))]
 use chrono::NaiveTime;
 
-#[cfg(feature = "dtype-date")]
-use chrono::NaiveDate;
+pub use self::conversion::*;
 
 pub fn unix_time() -> NaiveDateTime {
     NaiveDateTime::from_timestamp(0, 0)

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -1,7 +1,8 @@
-use super::*;
-use crate::prelude::*;
 use arrow::temporal_conversions::{time64ns_to_time, NANOSECONDS};
 use chrono::Timelike;
+
+use super::*;
+use crate::prelude::*;
 
 const SECONDS_IN_MINUTE: i64 = 60;
 const SECONDS_IN_HOUR: i64 = 3_600;

--- a/polars/polars-core/src/chunked_array/trusted_len.rs
+++ b/polars/polars-core/src/chunked_array/trusted_len.rs
@@ -1,10 +1,12 @@
-use crate::chunked_array::upstream_traits::PolarsAsRef;
-use crate::prelude::*;
-use crate::utils::{CustomIterTools, FromTrustedLenIterator, NoNull};
+use std::borrow::Borrow;
+
 use arrow::bitmap::MutableBitmap;
 use polars_arrow::bit_util::{set_bit_raw, unset_bit_raw};
 use polars_arrow::trusted_len::{FromIteratorReversed, PushUnchecked};
-use std::borrow::Borrow;
+
+use crate::chunked_array::upstream_traits::PolarsAsRef;
+use crate::prelude::*;
+use crate::utils::{CustomIterTools, FromTrustedLenIterator, NoNull};
 
 impl<T> FromTrustedLenIterator<Option<T::Native>> for ChunkedArray<T>
 where

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -1,4 +1,15 @@
 //! Implementations of upstream traits for ChunkedArray<T>
+use std::borrow::{Borrow, Cow};
+use std::collections::LinkedList;
+use std::iter::FromIterator;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
+use polars_arrow::utils::TrustMyLength;
+use rayon::iter::{FromParallelIterator, IntoParallelIterator};
+use rayon::prelude::*;
+
 use crate::chunked_array::builder::{
     get_list_builder, AnonymousListBuilder, AnonymousOwnedListBuilder,
 };
@@ -7,15 +18,6 @@ use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
 use crate::utils::NoNull;
 use crate::utils::{get_iter_capacity, CustomIterTools};
-use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
-use polars_arrow::utils::TrustMyLength;
-use rayon::iter::{FromParallelIterator, IntoParallelIterator};
-use rayon::prelude::*;
-use std::borrow::{Borrow, Cow};
-use std::collections::LinkedList;
-use std::iter::FromIterator;
-use std::marker::PhantomData;
-use std::sync::Arc;
 
 impl<T: PolarsDataType> Default for ChunkedArray<T> {
     fn default() -> Self {

--- a/polars/polars-core/src/datatypes/_serde.rs
+++ b/polars/polars-core/src/datatypes/_serde.rs
@@ -3,9 +3,10 @@
 //!
 //! We could use https://github.com/serde-rs/serde/issues/1712, but that gave problems caused by
 //! https://github.com/rust-lang/rust/issues/96956, so we make a dummy type without static
-use super::*;
 pub use arrow::datatypes::DataType as ArrowDataType;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::*;
 
 impl<'a> Deserialize<'a> for DataType {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -9,11 +9,11 @@
 #[cfg(feature = "serde")]
 mod _serde;
 
-pub use crate::chunked_array::logical::*;
-#[cfg(feature = "object")]
-use crate::chunked_array::object::PolarsObjectSafe;
-use crate::prelude::*;
-use crate::utils::Wrap;
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, AddAssign, Div, Mul, Rem, Sub, SubAssign};
+
 use ahash::RandomState;
 use arrow::compute::arithmetics::basic::NativeArithmetics;
 use arrow::compute::comparison::Simd8;
@@ -26,10 +26,12 @@ use num::{Bounded, FromPrimitive, Num, NumCast, Zero};
 use polars_arrow::data_types::IsFloat;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::ops::{Add, AddAssign, Div, Mul, Rem, Sub, SubAssign};
+
+pub use crate::chunked_array::logical::*;
+#[cfg(feature = "object")]
+use crate::chunked_array::object::PolarsObjectSafe;
+use crate::prelude::*;
+use crate::utils::Wrap;
 
 pub struct Utf8Type {}
 

--- a/polars/polars-core/src/error.rs
+++ b/polars/polars-core/src/error.rs
@@ -1,5 +1,6 @@
-use anyhow::Error;
 use std::borrow::Cow;
+
+use anyhow::Error;
 use thiserror::Error as ThisError;
 
 type ErrString = Cow<'static, str>;

--- a/polars/polars-core/src/export.rs
+++ b/polars/polars-core/src/export.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "private")]
+pub use ahash;
 pub use arrow;
 #[cfg(feature = "temporal")]
 pub use chrono;
-
-#[cfg(feature = "private")]
-pub use ahash;
 #[cfg(feature = "private")]
 pub use num;
 #[cfg(feature = "private")]

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -1,15 +1,19 @@
-use crate::config::{FMT_MAX_COLS, FMT_MAX_ROWS, FMT_STR_LEN};
-use crate::prelude::*;
-
-#[cfg(feature = "timezones")]
-use chrono::TimeZone;
-use num::{Num, NumCast};
 use std::{
     fmt,
     fmt::{Debug, Display, Formatter},
 };
 
+#[cfg(feature = "timezones")]
+use chrono::TimeZone;
+use num::{Num, NumCast};
+
+use crate::config::{FMT_MAX_COLS, FMT_MAX_ROWS, FMT_STR_LEN};
+use crate::prelude::*;
+
 const LIMIT: usize = 25;
+
+#[cfg(feature = "fmt")]
+use std::borrow::Cow;
 
 #[cfg(any(
     feature = "dtype-date",
@@ -21,8 +25,6 @@ use arrow::temporal_conversions::*;
 use comfy_table::presets::{ASCII_FULL, UTF8_FULL};
 #[cfg(feature = "fmt")]
 use comfy_table::*;
-#[cfg(feature = "fmt")]
-use std::borrow::Cow;
 
 macro_rules! format_array {
     ($f:ident, $a:expr, $dtype:expr, $name:expr, $array_type:expr) => {{

--- a/polars/polars-core/src/frame/arithmetic.rs
+++ b/polars/polars-core/src/frame/arithmetic.rs
@@ -1,7 +1,9 @@
+use std::ops::{Add, Div, Mul, Rem, Sub};
+
+use rayon::prelude::*;
+
 use crate::prelude::*;
 use crate::utils::get_supertype;
-use rayon::prelude::*;
-use std::ops::{Add, Div, Mul, Rem, Sub};
 
 /// Get the supertype that is valid for all columns in the DataFrame.
 /// This reduces casting of the rhs in arithmetic.

--- a/polars/polars-core/src/frame/asof_join/asof.rs
+++ b/polars/polars-core/src/frame/asof_join/asof.rs
@@ -1,6 +1,7 @@
-use polars_arrow::index::IdxSize;
 use std::fmt::Debug;
 use std::ops::Sub;
+
+use polars_arrow::index::IdxSize;
 
 pub(super) fn join_asof_forward_with_tolerance<T: PartialOrd + Copy + Debug + Sub<Output = T>>(
     left: &[T],

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -1,21 +1,22 @@
-use super::*;
-use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
-use crate::utils::{split_ca, split_df};
-use crate::vector_hasher::{df_rows_to_hashes_threaded, AsU64};
-use crate::POOL;
-use ahash::RandomState;
-use arrow::types::NativeType;
-use num::Zero;
-use rayon::prelude::*;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Sub;
 
+use ahash::RandomState;
+use arrow::types::NativeType;
+use num::Zero;
+use rayon::prelude::*;
+
+use super::*;
+use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
 #[cfg(feature = "dtype-categorical")]
 use crate::frame::hash_join::check_categorical_src;
 use crate::frame::hash_join::{
     create_probe_table, get_hash_tbl_threaded_join_partitioned, multiple_keys as mk, prepare_strs,
 };
+use crate::utils::{split_ca, split_df};
+use crate::vector_hasher::{df_rows_to_hashes_threaded, AsU64};
+use crate::POOL;
 
 pub(super) unsafe fn join_asof_backward_with_indirection_and_tolerance<
     T: PartialOrd + Copy + Sub<Output = T> + Debug,

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -1,15 +1,17 @@
 mod asof;
 mod groups;
 
-use crate::prelude::*;
-use crate::utils::slice_slice;
+use std::borrow::Cow;
+
 use asof::*;
 use num::Bounded;
 #[cfg(feature = "serde")]
 use serde::Deserializer;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
+
+use crate::prelude::*;
+use crate::utils::slice_slice;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]

--- a/polars/polars-core/src/frame/chunks.rs
+++ b/polars/polars-core/src/frame/chunks.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use arrow::chunk::Chunk;
+
+use crate::prelude::*;
 
 pub type ArrowChunk = Chunk<ArrayRef>;
 

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -1,10 +1,11 @@
-use crate::chunked_array::ops::explode::offsets_to_indexes;
-use crate::prelude::*;
-use crate::utils::get_supertype;
 use arrow::buffer::Buffer;
 use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::chunked_array::ops::explode::offsets_to_indexes;
+use crate::prelude::*;
+use crate::utils::get_supertype;
 
 fn get_exploded(series: &Series) -> Result<(Series, Buffer<i64>)> {
     match series.dtype() {

--- a/polars/polars-core/src/frame/from.rs
+++ b/polars/polars-core/src/frame/from.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use arrow::array::StructArray;
+
+use crate::prelude::*;
 
 impl TryFrom<StructArray> for DataFrame {
     type Error = PolarsError;

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -1,3 +1,11 @@
+use std::hash::{BuildHasher, Hash};
+
+use ahash::CallHasher;
+use hashbrown::hash_map::Entry;
+use hashbrown::{hash_map::RawEntryMut, HashMap};
+use polars_utils::flatten;
+use rayon::prelude::*;
+
 use super::GroupsProxy;
 use crate::frame::groupby::{GroupsIdx, IdxItem};
 use crate::prelude::compare_inner::PartialEqInner;
@@ -7,12 +15,6 @@ use crate::vector_hasher::{df_rows_to_hashes_threaded, IdBuildHasher, IdxHash};
 use crate::vector_hasher::{this_partition, AsU64};
 use crate::POOL;
 use crate::{datatypes::PlHashMap, utils::split_df};
-use ahash::CallHasher;
-use hashbrown::hash_map::Entry;
-use hashbrown::{hash_map::RawEntryMut, HashMap};
-use polars_utils::flatten;
-use rayon::prelude::*;
-use std::hash::{BuildHasher, Hash};
 
 fn finish_group_order(mut out: Vec<Vec<IdxItem>>, sorted: bool) -> GroupsProxy {
     if sorted {

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -1,8 +1,9 @@
-use super::*;
-use crate::utils::{copy_from_slice_unchecked, split_offsets};
 use polars_arrow::kernels::sort_partition::{create_clean_partitions, partition_to_groups};
 use polars_arrow::prelude::*;
 use polars_utils::flatten;
+
+use super::*;
+use crate::utils::{copy_from_slice_unchecked, split_offsets};
 
 /// Used to create the tuples for a groupby operation.
 pub trait IntoGroupsProxy {

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1,3 +1,11 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use ahash::{CallHasher, RandomState};
+use num::NumCast;
+use polars_arrow::prelude::QuantileInterpolOptions;
+use rayon::prelude::*;
+
 use self::hashing::*;
 use crate::prelude::*;
 #[cfg(feature = "groupby_list")]
@@ -5,12 +13,6 @@ use crate::utils::Wrap;
 use crate::utils::{accumulate_dataframes_vertical, set_partition_size, split_offsets};
 use crate::vector_hasher::{get_null_hash_value, AsU64, StrHash};
 use crate::POOL;
-use ahash::{CallHasher, RandomState};
-use num::NumCast;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use rayon::prelude::*;
-use std::fmt::Debug;
-use std::hash::Hash;
 
 pub mod aggregations;
 pub(crate) mod hashing;
@@ -19,10 +21,9 @@ mod into_groups;
 pub(crate) mod pivot;
 mod proxy;
 
+pub use into_groups::*;
 #[cfg(feature = "rows")]
 pub use pivot::PivotAgg;
-
-pub use into_groups::*;
 use polars_arrow::array::ValueSize;
 pub use proxy::*;
 
@@ -936,10 +937,11 @@ pub fn fmt_groupby_column(name: &str, method: GroupByMethod) -> String {
 
 #[cfg(test)]
 mod test {
+    use num::traits::FloatConst;
+
     use crate::frame::groupby::{groupby, groupby_threaded_num};
     use crate::prelude::*;
     use crate::utils::split_ca;
-    use num::traits::FloatConst;
 
     #[test]
     #[cfg(feature = "dtype-date")]

--- a/polars/polars-core/src/frame/groupby/pivot.rs
+++ b/polars/polars-core/src/frame/groupby/pivot.rs
@@ -1,8 +1,8 @@
-use super::GroupBy;
-use crate::prelude::*;
 use rayon::prelude::*;
 
+use super::GroupBy;
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
+use crate::prelude::*;
 use crate::POOL;
 
 #[derive(Copy, Clone)]

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -1,11 +1,13 @@
-use crate::prelude::*;
-use crate::utils::{slice_slice, NoNull};
-use crate::POOL;
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+
 use polars_arrow::utils::CustomIterTools;
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::prelude::*;
-use std::mem::ManuallyDrop;
-use std::ops::Deref;
+
+use crate::prelude::*;
+use crate::utils::{slice_slice, NoNull};
+use crate::POOL;
 
 /// Indexes of the groups, the first index is stored separately.
 /// this make sorting fast.

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -1,3 +1,7 @@
+use hashbrown::hash_map::RawEntryMut;
+use hashbrown::HashMap;
+use rayon::prelude::*;
+
 use super::*;
 use crate::frame::groupby::hashing::{populate_multiple_key_hashmap, HASHMAP_INIT_SIZE};
 use crate::frame::hash_join::{
@@ -8,9 +12,6 @@ use crate::utils::series::to_physical_and_bit_repr;
 use crate::utils::{set_partition_size, split_df};
 use crate::vector_hasher::{df_rows_to_hashes_threaded, this_partition, IdBuildHasher, IdxHash};
 use crate::POOL;
-use hashbrown::hash_map::RawEntryMut;
-use hashbrown::HashMap;
-use rayon::prelude::*;
 
 /// Compare the rows of two DataFrames
 pub(crate) unsafe fn compare_df_rows2(

--- a/polars/polars-core/src/frame/hash_join/single_keys_left.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_left.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_utils::flatten;
+
+use super::*;
 
 #[cfg(feature = "chunked_ids")]
 unsafe fn apply_mapping(idx: Vec<IdxSize>, chunk_mapping: &[ChunkId]) -> Vec<ChunkId> {

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -1,10 +1,11 @@
-use super::*;
-#[cfg(feature = "performant")]
-use crate::utils::split_offsets;
 #[cfg(feature = "performant")]
 use polars_arrow::kernels::sorted_join;
 #[cfg(feature = "performant")]
 use polars_utils::flatten;
+
+use super::*;
+#[cfg(feature = "performant")]
+use crate::utils::split_offsets;
 
 pub(super) fn use_sort_merge(s_left: &Series, s_right: &Series) -> bool {
     // only use for numeric data for now

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -10,10 +10,9 @@ use rayon::prelude::*;
 
 use crate::chunked_array::ops::unique::is_unique_helper;
 use crate::prelude::*;
-use crate::utils::{get_supertype, split_ca, split_df, NoNull};
-
 #[cfg(feature = "describe")]
 use crate::utils::concat_df_unchecked;
+use crate::utils::{get_supertype, split_ca, split_df, NoNull};
 
 #[cfg(feature = "dataframe_arithmetic")]
 mod arithmetic;
@@ -30,19 +29,20 @@ pub mod hash_join;
 pub mod row;
 mod upstream_traits;
 
+use std::hash::{BuildHasher, Hash, Hasher};
+
+pub use chunks::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::frame::groupby::GroupsIndicator;
 #[cfg(feature = "sort_multiple")]
 use crate::prelude::sort::prepare_argsort;
+use crate::series::IsSorted;
 use crate::vector_hasher::_boost_hash_combine;
 #[cfg(feature = "row_hash")]
 use crate::vector_hasher::df_rows_to_hashes_threaded;
 use crate::POOL;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::hash::{BuildHasher, Hash, Hasher};
-
-use crate::frame::groupby::GroupsIndicator;
-use crate::series::IsSorted;
-pub use chunks::*;
 
 #[derive(Copy, Clone, Debug)]
 pub enum NullStrategy {

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -1,11 +1,12 @@
-use crate::prelude::*;
-use crate::utils::get_supertype;
-use crate::POOL;
+use std::borrow::Borrow;
+use std::fmt::Debug;
 
 use arrow::bitmap::Bitmap;
 use rayon::prelude::*;
-use std::borrow::Borrow;
-use std::fmt::Debug;
+
+use crate::prelude::*;
+use crate::utils::get_supertype;
+use crate::POOL;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Row<'a>(pub Vec<AnyValue<'a>>);
 

--- a/polars/polars-core/src/frame/upstream_traits.rs
+++ b/polars/polars-core/src/frame/upstream_traits.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use std::iter::FromIterator;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+use crate::prelude::*;
 
 impl FromIterator<Series> for DataFrame {
     /// # Panics

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -2,12 +2,8 @@
 //!
 //! Functions that might be useful.
 //!
-#[cfg(feature = "sort_multiple")]
-use crate::chunked_array::ops::sort::prepare_argsort;
-use crate::prelude::*;
-use crate::utils::coalesce_nulls;
-#[cfg(feature = "diagonal_concat")]
-use crate::utils::concat_df;
+use std::ops::Add;
+
 #[cfg(feature = "diagonal_concat")]
 use ahash::AHashSet;
 use arrow::compute;
@@ -15,7 +11,13 @@ use arrow::types::simd::Simd;
 use num::{Float, NumCast, ToPrimitive};
 #[cfg(feature = "concat_str")]
 use polars_arrow::prelude::ValueSize;
-use std::ops::Add;
+
+#[cfg(feature = "sort_multiple")]
+use crate::chunked_array::ops::sort::prepare_argsort;
+use crate::prelude::*;
+use crate::utils::coalesce_nulls;
+#[cfg(feature = "diagonal_concat")]
+use crate::utils::concat_df;
 
 /// Compute the covariance between two columns.
 pub fn cov_f<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) -> Option<T::Native>

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -24,13 +24,12 @@ pub mod testing;
 mod tests;
 pub(crate) mod vector_hasher;
 
-use once_cell::sync::Lazy;
-
+use std::sync::Mutex;
 #[cfg(feature = "object")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use once_cell::sync::Lazy;
 use rayon::{ThreadPool, ThreadPoolBuilder};
-use std::sync::Mutex;
 
 #[cfg(feature = "dtype-categorical")]
 pub use crate::chunked_array::logical::categorical::stringcache::*;

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -1,5 +1,5 @@
-use crate::chunked_array::builder::{get_list_builder, AnonymousListBuilder};
-use crate::prelude::*;
+use std::borrow::Cow;
+
 #[cfg(feature = "dtype-duration")]
 use chrono::Duration as ChronoDuration;
 #[cfg(feature = "dtype-date")]
@@ -8,7 +8,9 @@ use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 #[cfg(feature = "dtype-time")]
 use chrono::NaiveTime;
-use std::borrow::Cow;
+
+use crate::chunked_array::builder::{get_list_builder, AnonymousListBuilder};
+use crate::prelude::*;
 
 pub trait NamedFrom<T, Phantom: ?Sized> {
     /// Initialize by name and values.

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -1,6 +1,30 @@
 //! Everything you need to get started with Polars.
+pub use std::sync::Arc;
+
+pub(crate) use arrow::array::*;
+pub use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
+pub(crate) use polars_arrow::export::*;
+#[cfg(feature = "ewma")]
+pub use polars_arrow::kernels::ewm::EWMOptions;
+pub use polars_arrow::prelude::*;
+pub(crate) use polars_arrow::trusted_len::TrustedLen;
+
+#[cfg(feature = "dtype-categorical")]
+pub use crate::chunked_array::logical::categorical::*;
+#[cfg(feature = "object")]
+pub use crate::chunked_array::object::PolarsObject;
+#[cfg(feature = "rolling_window")]
+pub use crate::chunked_array::ops::rolling_window::RollingOptionsFixedWindow;
+#[cfg(feature = "rank")]
+pub use crate::chunked_array::ops::unique::rank::{RankMethod, RankOptions};
+#[cfg(feature = "temporal")]
+pub use crate::chunked_array::temporal::conversion::*;
 pub(crate) use crate::chunked_array::{to_array, ChunkIdIter};
+#[cfg(feature = "asof_join")]
+pub use crate::frame::asof_join::*;
 pub(crate) use crate::frame::{groupby::aggregations::*, hash_join::*};
+#[cfg(feature = "checked_arithmetic")]
+pub use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 pub(crate) use crate::utils::CustomIterTools;
 pub use crate::{
     chunked_array::{
@@ -33,32 +57,3 @@ pub use crate::{
     utils::IntoVec,
     vector_hasher::VecHash,
 };
-pub(crate) use arrow::array::*;
-pub use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
-pub(crate) use polars_arrow::trusted_len::TrustedLen;
-pub use std::sync::Arc;
-
-#[cfg(feature = "object")]
-pub use crate::chunked_array::object::PolarsObject;
-#[cfg(feature = "temporal")]
-pub use crate::chunked_array::temporal::conversion::*;
-#[cfg(feature = "checked_arithmetic")]
-pub use crate::series::arithmetic::checked::NumOpsDispatchChecked;
-
-#[cfg(feature = "rank")]
-pub use crate::chunked_array::ops::unique::rank::{RankMethod, RankOptions};
-
-#[cfg(feature = "rolling_window")]
-pub use crate::chunked_array::ops::rolling_window::RollingOptionsFixedWindow;
-
-#[cfg(feature = "ewma")]
-pub use polars_arrow::kernels::ewm::EWMOptions;
-
-pub(crate) use polars_arrow::export::*;
-pub use polars_arrow::prelude::*;
-
-#[cfg(feature = "dtype-categorical")]
-pub use crate::chunked_array::logical::categorical::*;
-
-#[cfg(feature = "asof_join")]
-pub use crate::frame::asof_join::*;

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
-use indexmap::IndexMap;
 use std::fmt::{Debug, Formatter};
 
+use indexmap::IndexMap;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 
 #[derive(PartialEq, Eq, Clone, Default)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]

--- a/polars/polars-core/src/serde/chunked_array.rs
+++ b/polars/polars-core/src/serde/chunked_array.rs
@@ -1,8 +1,10 @@
-use super::DeDataType;
-use crate::prelude::*;
+use std::cell::RefCell;
+
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
-use std::cell::RefCell;
+
+use super::DeDataType;
+use crate::prelude::*;
 
 pub struct IterSer<I>
 where

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -1,9 +1,11 @@
-use crate::prelude::*;
-use crate::serde::DeDataType;
-use serde::de::{MapAccess, Visitor};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::fmt::Formatter;
+
+use serde::de::{MapAccess, Visitor};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::prelude::*;
+use crate::serde::DeDataType;
 
 impl Serialize for Series {
     fn serialize<S>(

--- a/polars/polars-core/src/series/arithmetic/borrowed.rs
+++ b/polars/polars-core/src/series/arithmetic/borrowed.rs
@@ -103,9 +103,10 @@ impl NumOpsDispatch for Utf8Chunked {
 
 #[cfg(feature = "checked_arithmetic")]
 pub mod checked {
+    use num::{CheckedDiv, ToPrimitive, Zero};
+
     use super::*;
     use crate::utils::align_chunks_binary;
-    use num::{CheckedDiv, ToPrimitive, Zero};
 
     pub trait NumOpsDispatchChecked: Debug {
         /// Checked integer division. Computes self / rhs, returning None if rhs == 0 or the division results in overflow.

--- a/polars/polars-core/src/series/arithmetic/mod.rs
+++ b/polars/polars-core/src/series/arithmetic/mod.rs
@@ -1,11 +1,12 @@
 mod borrowed;
 mod owned;
 
-use crate::prelude::*;
-use crate::utils::{get_supertype, get_time_units};
-use num::{Num, NumCast};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::{self, Add, Div, Mul, Sub};
 
 pub use borrowed::*;
+use num::{Num, NumCast};
+
+use crate::prelude::*;
+use crate::utils::{get_supertype, get_time_units};

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -1,9 +1,5 @@
 //! Comparison operations on Series.
 
-use super::Series;
-use crate::apply_method_physical_numeric;
-use crate::prelude::*;
-use crate::series::arithmetic::coerce_lhs_rhs;
 #[cfg(any(
     feature = "dtype-duration",
     feature = "dtype-datetime",
@@ -12,6 +8,11 @@ use crate::series::arithmetic::coerce_lhs_rhs;
     feature = "dtype-struct"
 ))]
 use std::ops::Deref;
+
+use super::Series;
+use crate::apply_method_physical_numeric;
+use crate::prelude::*;
+use crate::series::arithmetic::coerce_lhs_rhs;
 
 macro_rules! impl_compare {
     ($self:expr, $rhs:expr, $method:ident) => {{

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -1,7 +1,5 @@
-use crate::chunked_array::cast::cast_chunks;
-#[cfg(feature = "object")]
-use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
-use crate::prelude::*;
+use std::convert::TryFrom;
+
 use arrow::compute::cast::utf8_to_large_utf8;
 #[cfg(any(
     feature = "dtype-date",
@@ -12,7 +10,11 @@ use arrow::temporal_conversions::*;
 use polars_arrow::compute::cast::cast;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
-use std::convert::TryFrom;
+
+use crate::chunked_array::cast::cast_chunks;
+#[cfg(feature = "object")]
+use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
+use crate::prelude::*;
 
 impl Series {
     /// Takes chunks and a polars datatype and constructs the Series

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -1,3 +1,9 @@
+use std::borrow::Cow;
+use std::ops::{BitAnd, BitOr, BitXor};
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -15,10 +21,6 @@ use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
-use std::ops::{BitAnd, BitOr, BitXor};
 
 impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn compute_len(&mut self) {

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -15,9 +20,6 @@ use crate::frame::groupby::*;
 use crate::frame::hash_join::{check_categorical_src, ZipOuterJoinColumn};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
 
 impl IntoSeries for CategoricalChunked {
     fn into_series(self) -> Series {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -7,6 +7,12 @@
 //! opting for a little more run time cost. We cast to the physical type -> apply the operation and
 //! (depending on the result) cast back to the original type
 //!
+use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -19,10 +25,6 @@ use crate::chunked_array::{
 use crate::fmt::FmtList;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
 
 macro_rules! impl_dyn_series {
     ($ca: ident, $into_logical: ident) => {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
+
+use ahash::RandomState;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -7,9 +12,6 @@ use crate::chunked_array::{ops::explode::ExplodeByOffsets, AsSinglePtr};
 use crate::fmt::FmtList;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
-use ahash::RandomState;
-use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
 
 impl IntoSeries for DatetimeChunked {
     fn into_series(self) -> Series {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
+
+use ahash::RandomState;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -7,9 +12,6 @@ use crate::chunked_array::{comparison::*, ops::explode::ExplodeByOffsets, AsSing
 use crate::fmt::FmtList;
 use crate::frame::{groupby::*, hash_join::*};
 use crate::prelude::*;
-use ahash::RandomState;
-use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
 
 impl IntoSeries for DurationChunked {
     fn into_series(self) -> Series {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -18,9 +23,6 @@ use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
 #[cfg(feature = "checked_arithmetic")]
 use crate::series::arithmetic::checked::NumOpsDispatchChecked;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
 
 macro_rules! impl_dyn_series {
     ($ca: ident) => {

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -1,3 +1,8 @@
+use std::any::Any;
+use std::borrow::Cow;
+
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -8,9 +13,6 @@ use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::IsSorted;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::any::Any;
-use std::borrow::Cow;
 
 impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn compute_len(&mut self) {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -21,6 +21,12 @@ mod utf8;
 
 #[cfg(feature = "object")]
 use std::any::Any;
+use std::borrow::Cow;
+use std::ops::Deref;
+use std::ops::{BitAnd, BitOr, BitXor};
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
 
 use super::private;
 use super::IntoSeries;
@@ -41,11 +47,6 @@ use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
 #[cfg(feature = "checked_arithmetic")]
 use crate::series::arithmetic::checked::NumOpsDispatchChecked;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
-use std::ops::Deref;
-use std::ops::{BitAnd, BitOr, BitXor};
 
 // Utility wrapper struct
 pub(crate) struct SeriesWrap<T>(pub T);

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -1,3 +1,8 @@
+use std::any::Any;
+use std::borrow::Cow;
+
+use ahash::RandomState;
+
 use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::fmt::FmtList;
@@ -6,9 +11,6 @@ use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
 use crate::series::IsSorted;
-use ahash::RandomState;
-use std::any::Any;
-use std::borrow::Cow;
 
 impl<T: PolarsObject> PrivateSeriesNumeric for SeriesWrap<ObjectChunked<T>> {}
 

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -1,7 +1,8 @@
+use std::any::Any;
+
 use super::*;
 use crate::prelude::*;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
-use std::any::Any;
 
 impl IntoSeries for StructChunked {
     fn into_series(self) -> Series {

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+
+use ahash::RandomState;
+use polars_arrow::prelude::QuantileInterpolOptions;
+
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
@@ -15,9 +20,6 @@ use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
-use ahash::RandomState;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use std::borrow::Cow;
 
 impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn compute_len(&mut self) {

--- a/polars/polars-core/src/series/into.rs
+++ b/polars/polars-core/src/series/into.rs
@@ -1,4 +1,3 @@
-use crate::prelude::*;
 #[cfg(any(
     feature = "dtype-datetime",
     feature = "dtype-date",
@@ -6,6 +5,8 @@ use crate::prelude::*;
     feature = "dtype-time"
 ))]
 use polars_arrow::compute::cast::cast;
+
+use crate::prelude::*;
 
 impl Series {
     /// Returns a reference to the Arrow ArrayRef

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -14,6 +14,20 @@ mod series_trait;
 #[cfg(feature = "private")]
 pub mod unstable;
 
+use std::borrow::Cow;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::Arc;
+
+use ahash::RandomState;
+use arrow::compute::aggregate::estimated_bytes_size;
+pub use from::*;
+pub use iterator::SeriesIter;
+use num::NumCast;
+use rayon::prelude::*;
+pub use series_trait::IsSorted;
+pub use series_trait::*;
+
 #[cfg(feature = "rank")]
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "zip_with")]
@@ -21,19 +35,6 @@ use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::utils::{split_ca, split_series};
 use crate::utils::{split_offsets, Wrap};
 use crate::POOL;
-use ahash::RandomState;
-use arrow::compute::aggregate::estimated_bytes_size;
-pub use from::*;
-use num::NumCast;
-use rayon::prelude::*;
-pub use series_trait::*;
-use std::borrow::Cow;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::sync::Arc;
-
-pub use iterator::SeriesIter;
-pub use series_trait::IsSorted;
 
 /// # Series
 /// The columnar data type for a DataFrame.
@@ -973,9 +974,10 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryFrom;
+
     use crate::prelude::*;
     use crate::series::*;
-    use std::convert::TryFrom;
 
     #[test]
     fn cast() {

--- a/polars/polars-core/src/series/ops/ewm.rs
+++ b/polars/polars-core/src/series/ops/ewm.rs
@@ -1,4 +1,5 @@
-use crate::prelude::*;
+use std::convert::TryFrom;
+
 use arrow::bitmap::MutableBitmap;
 use arrow::types::NativeType;
 pub use polars_arrow::kernels::ewm::EWMOptions;
@@ -7,7 +8,8 @@ use polars_arrow::kernels::ewm::{
 };
 use polars_arrow::prelude::FromData;
 use polars_utils::mem::to_mutable_slice;
-use std::convert::TryFrom;
+
+use crate::prelude::*;
 
 fn prepare_primitive_array<T: NativeType>(
     vals: Vec<T>,

--- a/polars/polars-core/src/series/ops/to_list.rs
+++ b/polars/polars-core/src/series/ops/to_list.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
+use polars_arrow::kernels::list::array_to_unit_list;
+
 use crate::chunked_array::builder::get_list_builder;
 use crate::prelude::*;
-use polars_arrow::kernels::list::array_to_unit_list;
-use std::borrow::Cow;
 
 fn reshape_fast_path(name: &str, s: &Series) -> Series {
     let chunks = match s.dtype() {

--- a/polars/polars-core/src/series/ops/unique.rs
+++ b/polars/polars-core/src/series/ops/unique.rs
@@ -1,10 +1,11 @@
 #[cfg(feature = "unique_counts")]
+use std::hash::Hash;
+
+#[cfg(feature = "unique_counts")]
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
 use crate::prelude::*;
 #[cfg(feature = "unique_counts")]
 use crate::utils::NoNull;
-#[cfg(feature = "unique_counts")]
-use std::hash::Hash;
 
 #[cfg(feature = "unique_counts")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unique_counts")))]

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -1,12 +1,14 @@
-#[cfg(feature = "object")]
-use crate::chunked_array::object::PolarsObjectSafe;
-pub use crate::prelude::ChunkCompare;
-use crate::prelude::*;
-use polars_arrow::prelude::QuantileInterpolOptions;
 use std::any::Any;
 use std::borrow::Cow;
 #[cfg(feature = "temporal")]
 use std::sync::Arc;
+
+use polars_arrow::prelude::QuantileInterpolOptions;
+
+#[cfg(feature = "object")]
+use crate::chunked_array::object::PolarsObjectSafe;
+pub use crate::prelude::ChunkCompare;
+use crate::prelude::*;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum IsSorted {
@@ -36,12 +38,12 @@ macro_rules! invalid_operation_panic {
 }
 
 pub(crate) mod private {
+    use ahash::RandomState;
+
     use super::*;
+    use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
     #[cfg(feature = "rows")]
     use crate::frame::groupby::GroupsProxy;
-
-    use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
-    use ahash::RandomState;
 
     pub trait PrivateSeriesNumeric {
         fn bit_repr_is_large(&self) -> bool {

--- a/polars/polars-core/src/series/unstable.rs
+++ b/polars/polars-core/src/series/unstable.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
+
+use crate::prelude::*;
 
 /// A wrapper type that should make it a bit more clear that we should not clone Series
 #[derive(Debug, Copy, Clone)]

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -1,6 +1,7 @@
 //! Testing utilities.
-use crate::prelude::*;
 use std::ops::Deref;
+
+use crate::prelude::*;
 
 impl Series {
     /// Check if series are equal. Note that `None == None` evaluates to `false`

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -1,19 +1,20 @@
 pub(crate) mod series;
 
-use crate::prelude::*;
-use crate::POOL;
+use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
+
 pub use arrow;
 use arrow::bitmap::Bitmap;
 pub use polars_arrow::utils::TrustMyLength;
 pub use polars_arrow::utils::*;
 pub use rayon;
 use rayon::prelude::*;
-use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
+pub use series::*;
 
 #[cfg(feature = "private")]
 pub use crate::chunked_array::ops::sort::argsort_no_nulls;
-pub use series::*;
+use crate::prelude::*;
+use crate::POOL;
 
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -1,14 +1,16 @@
-use crate::datatypes::UInt64Chunked;
-use crate::prelude::*;
-use crate::utils::arrow::array::Array;
-use crate::POOL;
+use std::convert::TryInto;
+use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+
 use ahash::{CallHasher, RandomState};
 use arrow::bitmap::utils::get_bit_unchecked;
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 use polars_arrow::utils::CustomIterTools;
 use rayon::prelude::*;
-use std::convert::TryInto;
-use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+
+use crate::datatypes::UInt64Chunked;
+use crate::prelude::*;
+use crate::utils::arrow::array::Array;
+use crate::POOL;
 
 // Read more:
 //  https://www.cockroachlabs.com/blog/vectorized-hash-joiner/

--- a/polars/polars-io/src/avro/mod.rs
+++ b/polars/polars-io/src/avro/mod.rs
@@ -1,10 +1,11 @@
 mod read;
 mod write;
 
-use super::*;
 use arrow::io::avro::avro_schema::error::Error as AvroError;
 pub use read::*;
 pub use write::*;
+
+use super::*;
 
 // we cannot implement the From trait because of the orphan rule
 fn convert_err(e: AvroError) -> PolarsError {
@@ -13,11 +14,13 @@ fn convert_err(e: AvroError) -> PolarsError {
 
 #[cfg(test)]
 mod test {
-    use super::{write, AvroReader, AvroWriter};
-    use crate::prelude::*;
+    use std::io::Cursor;
+
     use polars_core::df;
     use polars_core::prelude::*;
-    use std::io::Cursor;
+
+    use super::{write, AvroReader, AvroWriter};
+    use crate::prelude::*;
 
     #[test]
     fn test_write_and_read_with_compression() -> Result<()> {

--- a/polars/polars-io/src/avro/read.rs
+++ b/polars/polars-io/src/avro/read.rs
@@ -1,11 +1,11 @@
 use std::io::{Read, Seek};
 
-use super::{finish_reader, ArrowChunk, ArrowReader, ArrowResult};
-use crate::prelude::*;
+use arrow::io::avro::{self, read};
 use polars_core::prelude::*;
 
+use super::{finish_reader, ArrowChunk, ArrowReader, ArrowResult};
 use crate::avro::convert_err;
-use arrow::io::avro::{self, read};
+use crate::prelude::*;
 
 /// Read Apache Avro format into a DataFrame
 ///

--- a/polars/polars-io/src/avro/write.rs
+++ b/polars/polars-io/src/avro/write.rs
@@ -1,11 +1,11 @@
-use super::*;
+pub use arrow::io::avro::avro_schema::file::Compression;
 use arrow::io::avro::{
     avro_schema::{self},
     write,
 };
-
-pub use arrow::io::avro::avro_schema::file::Compression;
 pub use Compression as AvroCompression;
+
+use super::*;
 
 /// Write a DataFrame to Apache Avro format
 ///

--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -1,7 +1,3 @@
-use crate::csv::parser::{is_whitespace, skip_whitespace};
-use crate::csv::read_impl::RunningSize;
-use crate::csv::utils::escape_field;
-use crate::csv::CsvEncoding;
 use arrow::array::Utf8Array;
 use arrow::bitmap::MutableBitmap;
 use polars_arrow::prelude::FromDataUtf8;
@@ -10,6 +6,11 @@ use polars_core::prelude::*;
 use polars_time::chunkedarray::utf8::Pattern;
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
 use polars_time::prelude::utf8::infer::{infer_pattern_single, DatetimeInfer};
+
+use crate::csv::parser::{is_whitespace, skip_whitespace};
+use crate::csv::read_impl::RunningSize;
+use crate::csv::utils::escape_field;
+use crate::csv::CsvEncoding;
 
 pub(crate) trait PrimitiveParser: PolarsNumericType {
     fn parse(bytes: &[u8]) -> Option<Self::Native>;

--- a/polars/polars-io/src/csv/mod.rs
+++ b/polars/polars-io/src/csv/mod.rs
@@ -52,6 +52,21 @@ pub mod utils;
 mod write;
 pub(super) mod write_impl;
 
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use polars_core::prelude::*;
+#[cfg(feature = "temporal")]
+use polars_time::prelude::*;
+#[cfg(feature = "temporal")]
+use rayon::prelude::*;
+pub use read::{CsvEncoding, CsvReader, NullValues};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+pub use write::CsvWriter;
+
 use crate::aggregations::ScanAggregation;
 use crate::csv::read_impl::{cast_columns, CoreReader};
 use crate::csv::utils::get_reader_bytes;
@@ -59,18 +74,3 @@ use crate::mmap::MmapBytesReader;
 use crate::predicates::PhysicalIoExpr;
 use crate::utils::resolve_homedir;
 use crate::{RowCount, SerReader, SerWriter};
-
-use polars_core::prelude::*;
-#[cfg(feature = "temporal")]
-use polars_time::prelude::*;
-#[cfg(feature = "temporal")]
-use rayon::prelude::*;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
-pub use read::{CsvEncoding, CsvReader, NullValues};
-pub use write::CsvWriter;

--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -1,7 +1,8 @@
-use super::buffer::*;
-use crate::csv::read::NullValuesCompiled;
 use num::traits::Pow;
 use polars_core::prelude::*;
+
+use super::buffer::*;
+use crate::csv::read::NullValuesCompiled;
 
 /// Skip the utf-8 Byte Order Mark.
 /// credits to csv-core

--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -1,3 +1,17 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::sync::atomic::Ordering;
+use std::sync::{atomic::AtomicUsize, Arc};
+
+use polars_arrow::array::*;
+use polars_core::utils::accumulate_dataframes_vertical;
+use polars_core::{prelude::*, POOL};
+#[cfg(feature = "polars-time")]
+use polars_time::prelude::*;
+use polars_utils::flatten;
+use rayon::prelude::*;
+use rayon::ThreadPoolBuilder;
+
 use crate::aggregations::ScanAggregation;
 use crate::csv::read::NullValuesCompiled;
 use crate::csv::utils::*;
@@ -7,18 +21,6 @@ use crate::mmap::ReaderBytes;
 use crate::predicates::PhysicalIoExpr;
 use crate::utils::update_row_counts;
 use crate::RowCount;
-use polars_arrow::array::*;
-use polars_core::utils::accumulate_dataframes_vertical;
-use polars_core::{prelude::*, POOL};
-#[cfg(feature = "polars-time")]
-use polars_time::prelude::*;
-use polars_utils::flatten;
-use rayon::prelude::*;
-use rayon::ThreadPoolBuilder;
-use std::borrow::Cow;
-use std::fmt;
-use std::sync::atomic::Ordering;
-use std::sync::{atomic::AtomicUsize, Arc};
 
 pub(crate) fn cast_columns(df: &mut DataFrame, to_cast: &[Field], parallel: bool) -> Result<()> {
     use DataType::*;

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -1,9 +1,7 @@
-#[cfg(any(feature = "decompress", feature = "decompress-fast"))]
-use crate::csv::parser::next_line_position_naive;
-use crate::csv::parser::{next_line_position, skip_bom, skip_line_ending, SplitFields, SplitLines};
-use crate::csv::CsvEncoding;
-use crate::mmap::{MmapBytesReader, ReaderBytes};
-use crate::prelude::NullValues;
+use std::borrow::Cow;
+use std::io::Read;
+use std::mem::MaybeUninit;
+
 use once_cell::sync::Lazy;
 use polars_core::datatypes::PlHashSet;
 use polars_core::prelude::*;
@@ -12,9 +10,13 @@ use polars_time::chunkedarray::utf8::infer as date_infer;
 #[cfg(feature = "polars-time")]
 use polars_time::prelude::utf8::Pattern;
 use regex::{Regex, RegexBuilder};
-use std::borrow::Cow;
-use std::io::Read;
-use std::mem::MaybeUninit;
+
+#[cfg(any(feature = "decompress", feature = "decompress-fast"))]
+use crate::csv::parser::next_line_position_naive;
+use crate::csv::parser::{next_line_position, skip_bom, skip_line_ending, SplitFields, SplitLines};
+use crate::csv::CsvEncoding;
+use crate::mmap::{MmapBytesReader, ReaderBytes};
+use crate::prelude::NullValues;
 
 pub(crate) fn get_file_chunks(
     bytes: &[u8],

--- a/polars/polars-io/src/csv/write_impl.rs
+++ b/polars/polars-io/src/csv/write_impl.rs
@@ -1,10 +1,11 @@
+use std::io::Write;
+
 use arrow::temporal_conversions;
 use lexical_core::{FormattedSize, ToLexical};
 use memchr::{memchr, memchr2};
 use polars_core::{prelude::*, series::SeriesIter, POOL};
 use polars_utils::contention_pool::LowContentionPool;
 use rayon::prelude::*;
-use std::io::Write;
 
 fn fmt_and_escape_str(f: &mut Vec<u8>, v: &str, options: &SerializeOptions) -> std::io::Result<()> {
     if v.is_empty() {

--- a/polars/polars-io/src/ipc/ipc_file.rs
+++ b/polars/polars-io/src/ipc/ipc_file.rs
@@ -32,17 +32,17 @@
 //! let df_read = IpcReader::new(buf).finish().unwrap();
 //! assert!(df.frame_equal(&df_read));
 //! ```
-use super::{finish_reader, ArrowReader, ArrowResult};
-use crate::predicates::PhysicalIoExpr;
-use crate::{prelude::*, WriterFactory};
+use std::io::{Read, Seek, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use arrow::io::ipc::write::WriteOptions;
 use arrow::io::ipc::{read, write};
 use polars_core::prelude::*;
 
-use std::io::{Read, Seek, Write};
-
-use std::path::PathBuf;
-use std::sync::Arc;
+use super::{finish_reader, ArrowReader, ArrowResult};
+use crate::predicates::PhysicalIoExpr;
+use crate::{prelude::*, WriterFactory};
 
 /// Read Arrows IPC format into a DataFrame
 ///
@@ -264,11 +264,12 @@ pub struct IpcWriter<W> {
     compression: Option<write::Compression>,
 }
 
+use polars_core::frame::ArrowChunk;
+pub use write::Compression as IpcCompression;
+
 use crate::aggregations::ScanAggregation;
 use crate::mmap::MmapBytesReader;
 use crate::RowCount;
-use polars_core::frame::ArrowChunk;
-pub use write::Compression as IpcCompression;
 
 impl<W> IpcWriter<W> {
     /// Set the compression used. Defaults to None.
@@ -353,11 +354,13 @@ impl WriterFactory for IpcWriterOption {
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
+    use std::io::Cursor;
+
     use arrow::io::ipc::write;
     use polars_core::df;
     use polars_core::prelude::*;
-    use std::io::Cursor;
+
+    use crate::prelude::*;
 
     #[test]
     fn write_and_read_ipc() {

--- a/polars/polars-io/src/ipc/ipc_stream.rs
+++ b/polars/polars-io/src/ipc/ipc_stream.rs
@@ -33,14 +33,16 @@
 //! let df_read = IpcStreamReader::new(buf).finish().unwrap();
 //! assert!(df.frame_equal(&df_read));
 //! ```
-use crate::{finish_reader, ArrowReader, ArrowResult};
-use crate::{prelude::*, WriterFactory};
+use std::io::{Read, Seek, Write};
+use std::path::PathBuf;
+
 use arrow::io::ipc::read::{StreamMetadata, StreamState};
 use arrow::io::ipc::write::WriteOptions;
 use arrow::io::ipc::{read, write};
 use polars_core::prelude::*;
-use std::io::{Read, Seek, Write};
-use std::path::PathBuf;
+
+use crate::{finish_reader, ArrowReader, ArrowResult};
+use crate::{prelude::*, WriterFactory};
 
 /// Read Arrows Stream IPC format into a DataFrame
 ///
@@ -239,9 +241,10 @@ pub struct IpcStreamWriter<W> {
     compression: Option<write::Compression>,
 }
 
-use crate::RowCount;
 use polars_core::frame::ArrowChunk;
 pub use write::Compression as IpcCompression;
+
+use crate::RowCount;
 
 impl<W> IpcStreamWriter<W> {
     /// Set the compression used. Defaults to None.

--- a/polars/polars-io/src/ipc/mmap.rs
+++ b/polars/polars-io/src/ipc/mmap.rs
@@ -1,11 +1,12 @@
-use super::*;
-use crate::mmap::MmapBytesReader;
-use crate::utils::apply_projection;
 use arrow::chunk::Chunk;
 use arrow::io::ipc::read;
 use arrow::io::ipc::read::{Dictionaries, FileMetadata};
 use arrow::mmap::{mmap_dictionaries_unchecked, mmap_unchecked};
 use memmap::Mmap;
+
+use super::*;
+use crate::mmap::MmapBytesReader;
+use crate::utils::apply_projection;
 
 struct MMapChunkIter<'a> {
     dictionaries: Dictionaries,

--- a/polars/polars-io/src/ipc/mod.rs
+++ b/polars/polars-io/src/ipc/mod.rs
@@ -9,6 +9,5 @@ mod mmap;
 
 #[cfg(feature = "ipc")]
 pub use ipc_file::{IpcCompression, IpcReader, IpcWriter, IpcWriterOption};
-
 #[cfg(feature = "ipc_streaming")]
 pub use ipc_stream::*;

--- a/polars/polars-io/src/json.rs
+++ b/polars/polars-io/src/json.rs
@@ -61,15 +61,17 @@
 //! +-----+--------+-------+--------+
 //! ```
 //!
-use crate::mmap::{MmapBytesReader, ReaderBytes};
-use crate::prelude::*;
+use std::convert::TryFrom;
+use std::io::Write;
+use std::ops::Deref;
+
 use arrow::array::StructArray;
 pub use arrow::{error::Result as ArrowResult, io::json};
 use polars_arrow::conversion::chunk_to_struct;
 use polars_core::prelude::*;
-use std::convert::TryFrom;
-use std::io::Write;
-use std::ops::Deref;
+
+use crate::mmap::{MmapBytesReader, ReaderBytes};
+use crate::prelude::*;
 
 pub enum JsonFormat {
     Json,
@@ -240,8 +242,9 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
     use std::io::Cursor;
+
+    use crate::prelude::*;
 
     #[test]
     fn read_json() {

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -42,7 +42,15 @@ pub(crate) mod utils;
 #[cfg(feature = "partition")]
 pub mod partition;
 
+use std::io::{Read, Seek, Write};
+use std::path::PathBuf;
+
+#[allow(unused)] // remove when updating to rust nightly >= 1.61
+use arrow::array::new_empty_array;
+use arrow::error::Result as ArrowResult;
 pub use options::*;
+use polars_core::frame::ArrowChunk;
+use polars_core::prelude::*;
 
 #[cfg(any(
     feature = "ipc",
@@ -58,13 +66,6 @@ use crate::aggregations::{apply_aggregations, ScanAggregation};
     feature = "ipc_streaming"
 ))]
 use crate::predicates::PhysicalIoExpr;
-#[allow(unused)] // remove when updating to rust nightly >= 1.61
-use arrow::array::new_empty_array;
-use arrow::error::Result as ArrowResult;
-use polars_core::frame::ArrowChunk;
-use polars_core::prelude::*;
-use std::io::{Read, Seek, Write};
-use std::path::PathBuf;
 
 pub trait SerReader<R>
 where

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -1,19 +1,19 @@
-use crate::csv::parser::*;
-use crate::csv::utils::*;
-use crate::mmap::ReaderBytes;
-use crate::ndjson_core::buffer::*;
-use crate::prelude::*;
-
-pub use arrow::{array::StructArray, io::ndjson};
-
-use crate::mmap::MmapBytesReader;
-use polars_core::{prelude::*, utils::accumulate_dataframes_vertical, POOL};
-use rayon::prelude::*;
-use serde_json::{Deserializer, Value};
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Cursor;
 use std::path::PathBuf;
+
+pub use arrow::{array::StructArray, io::ndjson};
+use polars_core::{prelude::*, utils::accumulate_dataframes_vertical, POOL};
+use rayon::prelude::*;
+use serde_json::{Deserializer, Value};
+
+use crate::csv::parser::*;
+use crate::csv::utils::*;
+use crate::mmap::MmapBytesReader;
+use crate::mmap::ReaderBytes;
+use crate::ndjson_core::buffer::*;
+use crate::prelude::*;
 const QUOTE_CHAR: u8 = "\"".as_bytes()[0];
 const SEP: u8 = ",".as_bytes()[0];
 

--- a/polars/polars-io/src/parquet/mmap.rs
+++ b/polars/polars-io/src/parquet/mmap.rs
@@ -1,9 +1,10 @@
-use super::*;
 use arrow::datatypes::Field;
 use arrow::io::parquet::read::{
     column_iter_to_arrays, get_field_columns, ArrayIter, BasicDecompressor, ColumnChunkMetaData,
     PageReader,
 };
+
+use super::*;
 
 /// memory maps all columns that are part of the parquet field `field_name`
 pub(super) fn mmap_columns<'a>(

--- a/polars/polars-io/src/parquet/mod.rs
+++ b/polars/polars-io/src/parquet/mod.rs
@@ -20,16 +20,19 @@ mod read;
 mod read_impl;
 mod write;
 
-use super::*;
 pub use read::*;
 pub use write::*;
 
+use super::*;
+
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
-    use polars_core::{df, prelude::*};
     use std::fs::File;
     use std::io::Cursor;
+
+    use polars_core::{df, prelude::*};
+
+    use crate::prelude::*;
 
     #[test]
     fn test_parquet() {

--- a/polars/polars-io/src/parquet/predicates.rs
+++ b/polars/polars-io/src/parquet/predicates.rs
@@ -1,10 +1,11 @@
-use crate::predicates::PhysicalIoExpr;
-use crate::ArrowResult;
 use arrow::array::Array;
 use arrow::compute::concatenate::concatenate;
 use arrow::io::parquet::read::statistics::{self, deserialize, Statistics};
 use arrow::io::parquet::read::RowGroupMetaData;
 use polars_core::prelude::*;
+
+use crate::predicates::PhysicalIoExpr;
+use crate::ArrowResult;
 
 /// The statistics for a column in a Parquet file
 /// they typically hold

--- a/polars/polars-io/src/parquet/read.rs
+++ b/polars/polars-io/src/parquet/read.rs
@@ -1,15 +1,17 @@
+use std::io::{Read, Seek};
+use std::sync::Arc;
+
+use arrow::io::parquet::read;
+use polars_core::prelude::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::aggregations::ScanAggregation;
 use crate::mmap::MmapBytesReader;
 use crate::parquet::read_impl::read_parquet;
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::*;
 use crate::RowCount;
-use arrow::io::parquet::read;
-use polars_core::prelude::*;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::io::{Read, Seek};
-use std::sync::Arc;
 
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -1,3 +1,16 @@
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use arrow::array::new_empty_array;
+use arrow::io::parquet::read;
+use arrow::io::parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
+use polars_core::prelude::*;
+use polars_core::utils::accumulate_dataframes_vertical;
+use polars_core::POOL;
+use rayon::prelude::*;
+
 use crate::aggregations::{apply_aggregations, ScanAggregation};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 use crate::parquet::mmap::mmap_columns;
@@ -6,17 +19,6 @@ use crate::parquet::{mmap, ParallelStrategy};
 use crate::predicates::{apply_predicate, arrow_schema_to_empty_df, PhysicalIoExpr};
 use crate::utils::apply_projection;
 use crate::RowCount;
-use arrow::array::new_empty_array;
-use arrow::io::parquet::read;
-use arrow::io::parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
-use polars_core::prelude::*;
-use polars_core::utils::accumulate_dataframes_vertical;
-use polars_core::POOL;
-use rayon::prelude::*;
-use std::borrow::Cow;
-use std::convert::TryFrom;
-use std::ops::Deref;
-use std::sync::Arc;
 
 fn column_idx_to_series(
     column_i: usize,

--- a/polars/polars-io/src/parquet/write.rs
+++ b/polars/polars-io/src/parquet/write.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use arrow::array::Array;
 use arrow::chunk::Chunk;
 use arrow::datatypes::DataType as ArrowDataType;
@@ -7,10 +9,8 @@ use arrow::io::parquet::read::ParquetError;
 use arrow::io::parquet::write::{self, FileWriter, *};
 use arrow::io::parquet::write::{DynIter, DynStreamingIterator, Encoding};
 use polars_core::prelude::*;
-use rayon::prelude::*;
-use std::io::Write;
-
 use polars_core::utils::{accumulate_dataframes_vertical_unchecked, split_df};
+use rayon::prelude::*;
 pub use write::{BrotliLevel, CompressionOptions as ParquetCompression, GzipLevel, ZstdLevel};
 
 /// Write a DataFrame to parquet format

--- a/polars/polars-io/src/partition.rs
+++ b/polars/polars-io/src/partition.rs
@@ -1,12 +1,14 @@
-use crate::{utils::resolve_homedir, WriterFactory};
-use polars_core::prelude::*;
-use polars_core::POOL;
-use rayon::prelude::*;
 use std::{
     fs::File,
     io::BufWriter,
     path::{Path, PathBuf},
 };
+
+use polars_core::prelude::*;
+use polars_core::POOL;
+use rayon::prelude::*;
+
+use crate::{utils::resolve_homedir, WriterFactory};
 
 /// partition_df must be created by the same way of partition_by
 fn resolve_partition_dir<I, S>(rootdir: &Path, by: I, partition_df: &DataFrame) -> PathBuf
@@ -128,13 +130,13 @@ mod test {
     #[test]
     #[cfg(feature = "ipc")]
     fn test_ipc_partition() -> Result<()> {
-        use crate::ipc::IpcReader;
-        use crate::SerReader;
         use std::{io::BufReader, path::PathBuf};
 
         use tempdir::TempDir;
 
+        use crate::ipc::IpcReader;
         use crate::prelude::IpcWriterOption;
+        use crate::SerReader;
 
         let tempdir = TempDir::new("ipc-partition")?;
 

--- a/polars/polars-io/src/prelude.rs
+++ b/polars/polars-io/src/prelude.rs
@@ -1,4 +1,5 @@
-pub use crate::{SerReader, SerWriter};
+#[cfg(test)]
+use polars_core::prelude::*;
 
 #[cfg(feature = "csv-file")]
 pub use crate::csv::*;
@@ -10,11 +11,8 @@ pub use crate::json::*;
 pub use crate::ndjson_core::ndjson::*;
 #[cfg(feature = "parquet")]
 pub use crate::parquet::*;
-
 pub use crate::utils::*;
-
-#[cfg(test)]
-use polars_core::prelude::*;
+pub use crate::{SerReader, SerWriter};
 #[cfg(test)]
 pub(crate) fn create_df() -> DataFrame {
     let s0 = Series::new("days", [0, 1, 2, 3, 4].as_ref());

--- a/polars/polars-io/src/tests.rs
+++ b/polars/polars-io/src/tests.rs
@@ -1,9 +1,10 @@
 //! tests that require parsing a csv
 //!
 
+use polars_core::prelude::*;
+
 use crate::csv::CsvReader;
 use crate::SerReader;
-use polars_core::prelude::*;
 
 #[test]
 fn test_filter() -> Result<()> {

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -1,3 +1,9 @@
+use std::path::{Path, PathBuf};
+
+use dirs::home_dir;
+use polars_core::frame::DataFrame;
+use polars_core::prelude::*;
+
 #[cfg(any(
     feature = "ipc",
     feature = "ipc_streaming",
@@ -5,10 +11,6 @@
     feature = "avro"
 ))]
 use crate::ArrowSchema;
-use dirs::home_dir;
-use polars_core::frame::DataFrame;
-use polars_core::prelude::*;
-use std::path::{Path, PathBuf};
 
 // used by python polars
 pub fn resolve_homedir(path: &Path) -> PathBuf {
@@ -97,8 +99,9 @@ pub(crate) fn update_row_counts(dfs: &mut [(DataFrame, IdxSize)]) {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_homedir;
     use std::path::PathBuf;
+
+    use super::resolve_homedir;
 
     #[cfg(not(target_os = "windows"))]
     #[test]

--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -1,8 +1,10 @@
-use crate::prelude::*;
-use crate::utils::expr_to_root_column_names;
+use std::fmt::Write;
+
 use polars_core::prelude::*;
 use polars_utils::arena::Arena;
-use std::fmt::Write;
+
+use crate::prelude::*;
+use crate::utils::expr_to_root_column_names;
 
 impl LazyFrame {
     /// Get a dot language representation of the LogicalPlan.

--- a/polars/polars-lazy/src/dsl/dt.rs
+++ b/polars/polars-lazy/src/dsl/dt.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_time::prelude::TemporalMethods;
+
+use super::*;
 
 /// Specialized expressions for [`Series`] with dates/datetimes.
 pub struct DateLikeNameSpace(pub(crate) Expr);

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -1,6 +1,7 @@
+use rayon::prelude::*;
+
 use super::*;
 use crate::physical_plan::state::ExecutionState;
-use rayon::prelude::*;
 
 #[cfg(feature = "list_eval")]
 pub(super) fn prepare_eval_expr(mut expr: Expr) -> Expr {

--- a/polars/polars-lazy/src/dsl/expr.rs
+++ b/polars/polars-lazy/src/dsl/expr.rs
@@ -1,13 +1,14 @@
-use crate::prelude::*;
-use polars_core::prelude::*;
-use polars_core::utils::get_supertype;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-use crate::dsl::function_expr::FunctionExpr;
+use polars_core::prelude::*;
+use polars_core::utils::get_supertype;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::dsl::function_expr::FunctionExpr;
+use crate::prelude::*;
 
 /// A wrapper trait for any closure `Fn(Vec<Series>) -> Result<Series>`
 pub trait SeriesUdf: Send + Sync {

--- a/polars/polars-lazy/src/dsl/function_expr/arg_where.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/arg_where.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_arrow::trusted_len::PushUnchecked;
+
+use super::*;
 
 pub(super) fn arg_where(s: &mut [Series]) -> Result<Series> {
     let predicate = s[0].bool()?;

--- a/polars/polars-lazy/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/mod.rs
@@ -21,15 +21,14 @@ mod temporal;
 #[cfg(feature = "trigonometry")]
 mod trigonometry;
 
-pub(super) use self::nan::NanFunction;
-
-#[cfg(feature = "strings")]
-pub(super) use self::strings::StringFunction;
-
-use super::*;
 use polars_core::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+pub(super) use self::nan::NanFunction;
+#[cfg(feature = "strings")]
+pub(super) use self::strings::StringFunction;
+use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]

--- a/polars/polars-lazy/src/dsl/function_expr/nan.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/nan.rs
@@ -1,9 +1,8 @@
-use crate::{map_owned_without_args, map_without_args};
-
-use super::*;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use super::*;
+use crate::{map_owned_without_args, map_without_args};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]

--- a/polars/polars-lazy/src/dsl/function_expr/pow.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/pow.rs
@@ -1,8 +1,9 @@
-use super::*;
 use num::pow::Pow;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::export::num;
 use polars_core::export::num::ToPrimitive;
+
+use super::*;
 
 fn pow_on_floats<T>(base: &ChunkedArray<T>, exponent: &Series) -> Result<Series>
 where

--- a/polars/polars-lazy/src/dsl/function_expr/shift_and_fill.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/shift_and_fill.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::downcast_as_macro_arg_physical;
+
+use super::*;
 
 fn shift_and_fill_numeric<T>(
     ca: &ChunkedArray<T>,

--- a/polars/polars-lazy/src/dsl/function_expr/sign.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/sign.rs
@@ -1,6 +1,7 @@
-use super::*;
 use polars_core::export::num;
 use DataType::*;
+
+use super::*;
 
 pub(super) fn sign(s: &Series) -> Result<Series> {
     match s.dtype() {

--- a/polars/polars-lazy/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/strings.rs
@@ -1,6 +1,7 @@
-use super::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]

--- a/polars/polars-lazy/src/dsl/function_expr/trigonometry.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/trigonometry.rs
@@ -1,6 +1,7 @@
-use super::*;
 use num::Float;
 use polars_core::export::num;
+
+use super::*;
 
 pub(super) fn apply_trigonometric_function(
     s: &Series,

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -2,22 +2,22 @@
 //!
 //! Functions on expressions that might be useful.
 //!
+use std::ops::{BitAnd, BitOr};
+
+use polars_core::export::arrow::temporal_conversions::NANOSECONDS;
+use polars_core::prelude::*;
+use polars_core::utils::arrow::temporal_conversions::SECONDS_IN_DAY;
+#[cfg(feature = "rank")]
+use polars_core::utils::coalesce_nulls_series;
+use polars_core::utils::get_supertype;
+#[cfg(feature = "list")]
+use polars_ops::prelude::ListNameSpaceImpl;
+use rayon::prelude::*;
+
 #[cfg(feature = "arg_where")]
 use crate::dsl::function_expr::FunctionExpr;
 use crate::prelude::*;
 use crate::utils::has_wildcard;
-use polars_core::export::arrow::temporal_conversions::NANOSECONDS;
-use polars_core::prelude::*;
-use polars_core::utils::arrow::temporal_conversions::SECONDS_IN_DAY;
-use polars_core::utils::get_supertype;
-
-#[cfg(feature = "rank")]
-use polars_core::utils::coalesce_nulls_series;
-
-#[cfg(feature = "list")]
-use polars_ops::prelude::ListNameSpaceImpl;
-use rayon::prelude::*;
-use std::ops::{BitAnd, BitOr};
 
 /// Compute the covariance between two columns.
 pub fn cov(a: Expr, b: Expr) -> Expr {

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -1,15 +1,15 @@
-#[cfg(feature = "list_eval")]
-use crate::dsl::eval::prepare_eval_expr;
-
-use crate::dsl::function_expr::FunctionExpr;
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
 use parking_lot::Mutex;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::prelude::*;
 use polars_core::series::ops::NullBehavior;
 use polars_ops::prelude::*;
 use rayon::prelude::*;
+
+#[cfg(feature = "list_eval")]
+use crate::dsl::eval::prepare_eval_expr;
+use crate::dsl::function_expr::FunctionExpr;
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 /// Specialized expressions for [`Series`] of [`DataType::List`].
 pub struct ListNameSpace(pub(crate) Expr);

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -19,41 +19,37 @@ pub mod string;
 #[cfg(feature = "dtype-struct")]
 mod struct_;
 
-#[cfg(feature = "rolling_window")]
-use polars_time::series::SeriesOpsTime;
-
-use crate::prelude::*;
-use crate::utils::has_expr;
-
-#[cfg(feature = "is_in")]
-use crate::utils::has_root_literal_expr;
-use polars_arrow::prelude::QuantileInterpolOptions;
-use polars_core::export::arrow::{array::BooleanArray, bitmap::MutableBitmap};
-use polars_core::prelude::*;
-
 use std::fmt::Debug;
 use std::{
     ops::{Add, Div, Mul, Rem, Sub},
     sync::Arc,
 };
-// reexport the lazy method
-pub use crate::frame::IntoLazy;
-pub use crate::logical_plan::lit;
+
 pub use expr::*;
 pub use functions::*;
 pub use options::*;
-
-use crate::dsl::function_expr::FunctionExpr;
-use crate::dsl::function_expr::NanFunction;
-
-#[cfg(feature = "trigonometry")]
-use crate::dsl::function_expr::TrigonometricFunction;
-
+use polars_arrow::prelude::QuantileInterpolOptions;
+use polars_core::export::arrow::{array::BooleanArray, bitmap::MutableBitmap};
+use polars_core::prelude::*;
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
 use polars_core::series::IsSorted;
 use polars_core::utils::{get_supertype, NoNull};
 use polars_ops::prelude::SeriesOps;
+#[cfg(feature = "rolling_window")]
+use polars_time::series::SeriesOpsTime;
+
+use crate::dsl::function_expr::FunctionExpr;
+use crate::dsl::function_expr::NanFunction;
+#[cfg(feature = "trigonometry")]
+use crate::dsl::function_expr::TrigonometricFunction;
+// reexport the lazy method
+pub use crate::frame::IntoLazy;
+pub use crate::logical_plan::lit;
+use crate::prelude::*;
+use crate::utils::has_expr;
+#[cfg(feature = "is_in")]
+use crate::utils::has_root_literal_expr;
 
 pub fn binary_expr(l: Expr, op: Operator, r: Expr) -> Expr {
     Expr::BinaryExpr {

--- a/polars/polars-lazy/src/dsl/options.rs
+++ b/polars/polars-lazy/src/dsl/options.rs
@@ -1,6 +1,5 @@
 use polars_core::datatypes::DataType;
 use polars_core::prelude::TimeUnit;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/polars/polars-lazy/src/dsl/string.rs
+++ b/polars/polars-lazy/src/dsl/string.rs
@@ -1,8 +1,9 @@
-use super::function_expr::StringFunction;
-use super::*;
 use polars_arrow::array::ValueSize;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array};
+
+use super::function_expr::StringFunction;
+use super::*;
 /// Specialized expressions for [`Series`] of [`DataType::Utf8`].
 pub struct StringNameSpace(pub(crate) Expr);
 

--- a/polars/polars-lazy/src/dummies.rs
+++ b/polars/polars-lazy/src/dummies.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
+use polars_core::prelude::*;
+
 use crate::dsl::{BinaryUdfOutputField, SeriesBinaryUdf, SpecialEq};
 use crate::logical_plan::Context;
-use polars_core::prelude::*;
-use std::sync::Arc;
 
 impl Default for SpecialEq<Arc<dyn SeriesBinaryUdf>> {
     fn default() -> Self {

--- a/polars/polars-lazy/src/frame/anonymous_scan.rs
+++ b/polars/polars-lazy/src/frame/anonymous_scan.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::RowCount;
+
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct ScanArgsAnonymous {

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::csv::utils::get_reader_bytes;
 use polars_io::csv::utils::infer_file_schema;
 use polars_io::csv::{CsvEncoding, NullValues};
 use polars_io::RowCount;
+
+use crate::prelude::*;
 
 #[derive(Clone)]
 #[cfg(feature = "csv-file")]

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::RowCount;
+
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct ScanArgsIpc {

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::parquet::ParallelStrategy;
 use polars_io::RowCount;
+
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct ScanArgsParquet {

--- a/polars/polars-lazy/src/frame/python.rs
+++ b/polars/polars-lazy/src/frame/python.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 impl LazyFrame {
     pub fn scan_from_python_function(schema: Schema, scan_fn: Vec<u8>) -> Self {

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -1,11 +1,13 @@
-use crate::dsl::function_expr::FunctionExpr;
-use crate::logical_plan::Context;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::prelude::*;
 use polars_core::utils::{get_supertype, get_time_units};
 use polars_utils::arena::{Arena, Node};
-use std::sync::Arc;
+
+use crate::dsl::function_expr::FunctionExpr;
+use crate::logical_plan::Context;
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum AAggExpr {

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -1,3 +1,12 @@
+use std::borrow::Cow;
+#[cfg(any(feature = "ipc", feature = "csv-file", feature = "parquet"))]
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use polars_core::frame::explode::MeltArgs;
+use polars_core::prelude::*;
+use polars_utils::arena::{Arena, Node};
+
 #[cfg(feature = "ipc")]
 use crate::logical_plan::IpcScanOptionsInner;
 #[cfg(feature = "parquet")]
@@ -5,13 +14,6 @@ use crate::logical_plan::ParquetOptions;
 use crate::logical_plan::{det_melt_schema, Context, CsvParserOptions};
 use crate::prelude::*;
 use crate::utils::{aexprs_to_schema, PushNode};
-use polars_core::frame::explode::MeltArgs;
-use polars_core::prelude::*;
-use polars_utils::arena::{Arena, Node};
-use std::borrow::Cow;
-#[cfg(any(feature = "ipc", feature = "csv-file", feature = "parquet"))]
-use std::path::PathBuf;
-use std::sync::Arc;
 
 /// ALogicalPlan is a representation of LogicalPlan with Nodes which are allocated in an Arena
 #[derive(Clone, Debug)]

--- a/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/src/logical_plan/anonymous_scan.rs
@@ -1,6 +1,8 @@
-use crate::prelude::AnonymousScanOptions;
-use polars_core::prelude::*;
 use std::fmt::{Debug, Formatter};
+
+use polars_core::prelude::*;
+
+use crate::prelude::AnonymousScanOptions;
 
 pub trait AnonymousScan: Send + Sync {
     /// Creates a dataframe from the supplied function & scan options.

--- a/polars/polars-lazy/src/logical_plan/apply.rs
+++ b/polars/polars-lazy/src/logical_plan/apply.rs
@@ -1,5 +1,6 @@
-use polars_core::prelude::*;
 use std::fmt::{Debug, Formatter};
+
+use polars_core::prelude::*;
 
 pub trait DataFrameUdf: Send + Sync {
     fn call_udf(&self, df: DataFrame) -> Result<DataFrame>;

--- a/polars/polars-lazy/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/src/logical_plan/builder.rs
@@ -1,7 +1,6 @@
-use crate::logical_plan::projection::rewrite_projections;
-use crate::prelude::*;
-use crate::utils;
-use crate::utils::{combine_predicates_expr, has_expr};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+
 use parking_lot::Mutex;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::prelude::*;
@@ -19,8 +18,11 @@ use polars_io::{
     csv::utils::{get_reader_bytes, is_compressed},
     csv::NullValues,
 };
-use std::io::{Read, Seek, SeekFrom};
-use std::path::PathBuf;
+
+use crate::logical_plan::projection::rewrite_projections;
+use crate::prelude::*;
+use crate::utils;
+use crate::utils::{combine_predicates_expr, has_expr};
 
 pub(crate) fn prepare_projection(exprs: Vec<Expr>, schema: &Schema) -> Result<(Vec<Expr>, Schema)> {
     let exprs = rewrite_projections(exprs, schema, &[]);

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 fn to_aexprs(input: Vec<Expr>, arena: &mut Arena<AExpr>) -> Vec<Node> {
     input.into_iter().map(|e| to_aexpr(e, arena)).collect()

--- a/polars/polars-lazy/src/logical_plan/format.rs
+++ b/polars/polars-lazy/src/logical_plan/format.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
+
+use crate::prelude::*;
 
 impl fmt::Debug for LogicalPlan {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -315,9 +315,10 @@ impl<'a> Iterator for AlpIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use polars_core::df;
     use polars_core::prelude::*;
+
+    use super::*;
 
     #[test]
     fn test_lp_iter() -> Result<()> {

--- a/polars/polars-lazy/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/src/logical_plan/lit.rs
@@ -1,10 +1,10 @@
-use crate::prelude::*;
 #[cfg(feature = "temporal")]
 use polars_core::export::chrono::{Duration as ChronoDuration, NaiveDate, NaiveDateTime};
 use polars_core::prelude::*;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -1,9 +1,9 @@
-use parking_lot::Mutex;
 use std::borrow::Cow;
 #[cfg(any(feature = "ipc", feature = "csv-file", feature = "parquet"))]
 use std::path::PathBuf;
 use std::{cell::Cell, fmt::Debug, sync::Arc};
 
+use parking_lot::Mutex;
 use polars_core::prelude::*;
 
 use crate::logical_plan::LogicalPlan::DataFrameScan;
@@ -29,7 +29,6 @@ pub(crate) use apply::*;
 pub(crate) use builder::*;
 pub use lit::*;
 use polars_core::frame::explode::MeltArgs;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/delay_rechunk.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/delay_rechunk.rs
@@ -1,6 +1,7 @@
+use polars_utils::arena::{Arena, Node};
+
 use crate::prelude::stack_opt::OptimizationRule;
 use crate::prelude::*;
-use polars_utils::arena::{Arena, Node};
 
 pub(crate) struct DelayRechunk {}
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/drop_nulls.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/drop_nulls.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
+use polars_core::prelude::*;
+
 use crate::logical_plan::iterator::*;
 use crate::prelude::stack_opt::OptimizationRule;
 use crate::prelude::*;
 use crate::utils::aexpr_to_root_names;
-use polars_core::prelude::*;
-use std::sync::Arc;
 
 /// If we realize that a predicate drops nulls on a subset
 /// we replace it with an explicit df.drop_nulls call, as this

--- a/polars/polars-lazy/src/logical_plan/optimizer/fast_projection.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/fast_projection.rs
@@ -1,7 +1,8 @@
+use polars_core::prelude::*;
+
 use crate::logical_plan::alp::ALogicalPlan;
 use crate::prelude::stack_opt::OptimizationRule;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 /// Projection in the physical plan is done by selecting an expression per thread.
 /// In case of many projections and columns this can be expensive when the expressions are simple

--- a/polars/polars-lazy/src/logical_plan/optimizer/file_caching.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/file_caching.rs
@@ -1,10 +1,12 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use polars_core::datatypes::PlHashMap;
+use polars_core::prelude::*;
+
 use crate::logical_plan::optimizer::stack_opt::OptimizationRule;
 use crate::logical_plan::ALogicalPlanBuilder;
 use crate::prelude::*;
-use polars_core::datatypes::PlHashMap;
-use polars_core::prelude::*;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub(crate) struct FileFingerPrint {

--- a/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/mod.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use polars_core::{datatypes::PlHashMap, prelude::*};
+
+use crate::prelude::*;
 
 pub(crate) mod aggregate_pushdown;
 pub(crate) mod delay_rechunk;
@@ -15,9 +16,9 @@ pub mod slice_pushdown_lp;
 pub(crate) mod stack_opt;
 pub(crate) mod type_coercion;
 
-use crate::prelude::stack_opt::OptimizationRule;
-
 pub(crate) use slice_pushdown_lp::SlicePushDown;
+
+use crate::prelude::stack_opt::OptimizationRule;
 
 pub trait Optimize {
     fn optimize(&self, logical_plan: LogicalPlan) -> Result<LogicalPlan>;

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -1,11 +1,12 @@
 mod utils;
 
-use crate::logical_plan::{optimizer, Context};
-use crate::prelude::*;
-use crate::utils::{aexpr_to_root_names, aexprs_to_schema, check_input_node, has_aexpr};
 use polars_core::datatypes::PlHashMap;
 use polars_core::prelude::*;
 use utils::*;
+
+use crate::logical_plan::{optimizer, Context};
+use crate::prelude::*;
+use crate::utils::{aexpr_to_root_names, aexprs_to_schema, check_input_node, has_aexpr};
 
 #[derive(Default)]
 pub(crate) struct PredicatePushDown {}

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -1,8 +1,9 @@
+use polars_core::datatypes::PlHashMap;
+use polars_core::prelude::*;
+
 use crate::logical_plan::Context;
 use crate::prelude::*;
 use crate::utils::{aexpr_to_root_names, check_input_node, has_aexpr, rename_aexpr_root_names};
-use polars_core::datatypes::PlHashMap;
-use polars_core::prelude::*;
 
 trait Dsl {
     fn and(self, right: Node, arena: &mut Arena<AExpr>) -> Node;

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -1,3 +1,5 @@
+use polars_core::{datatypes::PlHashSet, prelude::*};
+
 use crate::logical_plan::Context;
 use crate::prelude::iterator::ArenaExprIter;
 use crate::prelude::*;
@@ -5,7 +7,6 @@ use crate::utils::{
     aexpr_assign_renamed_root, aexpr_to_root_names, aexpr_to_root_nodes, check_input_node,
     has_aexpr,
 };
-use polars_core::{datatypes::PlHashSet, prelude::*};
 
 fn init_vec() -> Vec<Node> {
     Vec::with_capacity(100)

--- a/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::prelude::*;
 use crate::utils::aexpr_is_simple_projection;
-use polars_core::prelude::*;
 
 pub(crate) struct SlicePushDown {}
 

--- a/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/type_coercion.rs
@@ -1,8 +1,9 @@
-use crate::dsl::function_expr::FunctionExpr;
-use polars_core::prelude::*;
-use polars_core::utils::get_supertype;
 use std::borrow::Cow;
 
+use polars_core::prelude::*;
+use polars_core::utils::get_supertype;
+
+use crate::dsl::function_expr::FunctionExpr;
 use crate::logical_plan::optimizer::stack_opt::OptimizationRule;
 use crate::logical_plan::Context;
 use crate::prelude::*;
@@ -479,10 +480,11 @@ fn early_escape(type_self: &DataType, type_other: &DataType) -> Option<()> {
 #[cfg(test)]
 #[cfg(feature = "dtype-categorical")]
 mod test {
+    use polars_core::prelude::*;
+
     use crate::logical_plan::optimizer::stack_opt::OptimizationRule;
     use crate::prelude::*;
     use crate::utils::test::optimize_expr;
-    use polars_core::prelude::*;
 
     #[test]
     fn test_categorical_utf8() {

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -1,9 +1,10 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::csv::{CsvEncoding, NullValues};
 use polars_io::RowCount;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 
 pub type FileCount = u32;
 

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -1,7 +1,8 @@
 //! this contains code used for rewriting projections, expanding wildcards, regex selection etc.
+use polars_arrow::index::IndexToUsize;
+
 use super::*;
 use crate::utils::has_nth;
-use polars_arrow::index::IndexToUsize;
 
 /// This replace the wildcard Expr with a Column Expr. It also removes the Exclude Expr from the
 /// expression chain.

--- a/polars/polars-lazy/src/physical_plan/executors/cache.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/cache.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub struct CacheExec {
     pub key: String,

--- a/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub(crate) struct DropDuplicatesExec {
     pub(crate) input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/explode.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/explode.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub(crate) struct ExplodeExec {
     pub(crate) input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/ext_context.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/ext_context.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub struct ExternalContext {
     pub input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/filter.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub struct FilterExec {
     pub(crate) predicate: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -1,6 +1,7 @@
-use super::*;
 use polars_core::POOL;
 use rayon::prelude::*;
+
+use super::*;
 
 /// Take an input Executor and a multiple expressions
 pub struct GroupByExec {

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -1,7 +1,8 @@
-use super::*;
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 use polars_core::POOL;
 use rayon::prelude::*;
+
+use super::*;
 
 /// Take an input Executor and a multiple expressions
 pub struct PartitionGroupByExec {

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
+
+use polars_core::prelude::*;
+use polars_core::POOL;
+
 use crate::logical_plan::FETCH_ROWS;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
-use polars_core::POOL;
-use std::borrow::Cow;
 
 pub struct JoinExec {
     input_left: Option<Box<dyn Executor>>,

--- a/polars/polars-lazy/src/physical_plan/executors/melt.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/melt.rs
@@ -1,7 +1,8 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::prelude::*;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct MeltExec {
     pub input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -19,21 +19,21 @@ mod stack;
 mod udf;
 mod union;
 
+use std::path::PathBuf;
+
+use polars_core::POOL;
+use rayon::prelude::*;
+
 #[cfg(feature = "python")]
 pub(super) use self::python_scan::*;
-
 pub(super) use self::{
     cache::*, drop_duplicates::*, explode::*, ext_context::*, filter::*, groupby::*,
     groupby_dynamic::*, groupby_partitioned::*, groupby_rolling::*, join::*, melt::*,
     projection::*, scan::*, slice::*, sort::*, stack::*, udf::*, union::*,
 };
-
 use super::*;
 use crate::logical_plan::FETCH_ROWS;
 use crate::physical_plan::state::StateFlags;
-use polars_core::POOL;
-use rayon::prelude::*;
-use std::path::PathBuf;
 
 fn set_n_rows(n_rows: Option<usize>) -> Option<usize> {
     let fetch_rows = FETCH_ROWS.with(|fetch_rows| fetch_rows.get());

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -1,7 +1,8 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::executors::evaluate_physical_expressions;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 /// Take an input Executor (creates the input DataFrame)
 /// and a multiple PhysicalExpressions (create the output Series)

--- a/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
@@ -1,7 +1,8 @@
-use super::*;
-use crate::prelude::*;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+
+use super::*;
+use crate::prelude::*;
 
 pub(crate) struct PythonScanExec {
     pub(crate) options: PythonOptions,

--- a/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -5,11 +5,6 @@ mod ipc;
 #[cfg(feature = "parquet")]
 mod parquet;
 
-use super::*;
-use crate::prelude::*;
-use polars_io::aggregations::ScanAggregation;
-use polars_io::csv::CsvEncoding;
-use polars_io::prelude::*;
 use std::fs::File;
 use std::mem;
 use std::path::Path;
@@ -20,6 +15,12 @@ pub(crate) use csv::CsvExec;
 pub(crate) use ipc::IpcExec;
 #[cfg(feature = "parquet")]
 pub(crate) use parquet::ParquetExec;
+use polars_io::aggregations::ScanAggregation;
+use polars_io::csv::CsvEncoding;
+use polars_io::prelude::*;
+
+use super::*;
+use crate::prelude::*;
 
 #[cfg(any(feature = "ipc", feature = "parquet"))]
 type Projection = Option<Vec<usize>>;

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub struct SliceExec {
     pub input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/sort.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub(crate) struct SortExec {
     pub(crate) input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -1,8 +1,9 @@
+use polars_core::{prelude::*, POOL};
+use rayon::prelude::*;
+
 use crate::physical_plan::executors::execute_projection_cached_window_fns;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::{prelude::*, POOL};
-use rayon::prelude::*;
 
 pub struct StackExec {
     pub(crate) input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/udf.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/udf.rs
@@ -1,6 +1,7 @@
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
 
 pub(crate) struct UdfExec {
     pub(crate) input: Box<dyn Executor>,

--- a/polars/polars-lazy/src/physical_plan/executors/union.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/union.rs
@@ -1,9 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::concat_df;
 use polars_core::POOL;
 use rayon::prelude::*;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub(crate) struct UnionExec {
     pub(crate) inputs: Vec<Box<dyn Executor>>,

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -1,14 +1,16 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::physical_plan::PartitionedAggregation;
-use crate::prelude::*;
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use polars_arrow::export::arrow::{array::*, compute::concatenate::concatenate};
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::{GroupByMethod, GroupsProxy};
 use polars_core::utils::NoNull;
 use polars_core::{prelude::*, POOL};
-use std::borrow::Cow;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::physical_plan::PartitionedAggregation;
+use crate::prelude::*;
 
 pub(crate) struct AggregationExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/alias.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/alias.rs
@@ -1,8 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct AliasExpr {
     pub(crate) physical_expr: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -1,11 +1,13 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct ApplyExpr {
     pub inputs: Vec<Arc<dyn PhysicalExpr>>,

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::{ExecutionState, StateFlags};
-use crate::prelude::*;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::series::unstable::UnstableSeries;
 use polars_core::{prelude::*, POOL};
-use std::convert::TryFrom;
-use std::sync::Arc;
+
+use crate::physical_plan::state::{ExecutionState, StateFlags};
+use crate::prelude::*;
 
 pub struct BinaryExpr {
     pub(crate) left: Arc<dyn PhysicalExpr>,
@@ -404,9 +406,10 @@ impl PhysicalExpr for BinaryExpr {
 
 #[cfg(feature = "parquet")]
 mod stats {
-    use super::*;
     use polars_io::parquet::predicates::BatchStats;
     use polars_io::predicates::StatsEvaluator;
+
+    use super::*;
 
     fn apply_operator_stats_rhs_lit(min_max: &Series, literal: &Series, op: Operator) -> bool {
         match op {

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -1,8 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct CastExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/column.rs
@@ -1,9 +1,11 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
-use polars_core::frame::groupby::GroupsProxy;
-use polars_core::prelude::*;
 use std::borrow::Cow;
 use std::sync::Arc;
+
+use polars_core::frame::groupby::GroupsProxy;
+use polars_core::prelude::*;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct ColumnExpr(Arc<str>, Expr);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/count.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/count.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
+use polars_core::prelude::*;
+
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_core::prelude::*;
-use std::borrow::Cow;
 
 const COUNT_NAME: &str = "count";
 

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::is_valid::IsValid;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::{prelude::*, POOL};
 use rayon::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct FilterExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
@@ -1,6 +1,8 @@
-use super::*;
-use polars_core::series::unstable::UnstableSeries;
 use std::pin::Pin;
+
+use polars_core::series::unstable::UnstableSeries;
+
+use super::*;
 
 impl<'a> AggregationContext<'a> {
     pub(super) fn iter_groups(

--- a/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_not_null.rs
@@ -1,8 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct IsNotNullExpr {
     physical_expr: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/is_null.rs
@@ -1,13 +1,15 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
-use crate::utils::expr_to_root_column_name;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 #[cfg(feature = "parquet")]
 use polars_io::predicates::StatsEvaluator;
 #[cfg(feature = "parquet")]
 use polars_io::prelude::predicates::BatchStats;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+use crate::utils::expr_to_root_column_name;
 
 pub struct IsNullExpr {
     physical_expr: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::borrow::Cow;
+use std::ops::Deref;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
-use std::borrow::Cow;
-use std::ops::Deref;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct LiteralExpr(pub LiteralValue, Expr);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -19,6 +19,14 @@ mod take;
 mod ternary;
 mod window;
 
+use std::borrow::Cow;
+
+use polars_arrow::export::arrow::array::ListArray;
+use polars_arrow::trusted_len::PushUnchecked;
+use polars_arrow::utils::CustomIterTools;
+use polars_core::frame::groupby::GroupsProxy;
+use polars_core::prelude::*;
+use polars_io::predicates::PhysicalIoExpr;
 pub(crate) use {
     aggregation::*, alias::*, apply::*, binary::*, cast::*, column::*, count::*, filter::*,
     is_not_null::*, is_null::*, literal::*, not::*, shift::*, slice::*, sort::*, sortby::*,
@@ -27,13 +35,6 @@ pub(crate) use {
 
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use polars_arrow::export::arrow::array::ListArray;
-use polars_arrow::trusted_len::PushUnchecked;
-use polars_arrow::utils::CustomIterTools;
-use polars_core::frame::groupby::GroupsProxy;
-use polars_core::prelude::*;
-use polars_io::predicates::PhysicalIoExpr;
-use std::borrow::Cow;
 
 #[derive(Clone, Debug)]
 pub(crate) enum AggState {

--- a/polars/polars-lazy/src/physical_plan/expressions/not.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/not.rs
@@ -1,8 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct NotExpr(Arc<dyn PhysicalExpr>, Expr);
 

--- a/polars/polars-lazy/src/physical_plan/expressions/shift.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/shift.rs
@@ -1,8 +1,10 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct ShiftExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -1,11 +1,13 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::{GroupsProxy, IdxItem};
 use polars_core::prelude::*;
 use polars_core::utils::{slice_offsets, CustomIterTools};
 use polars_core::POOL;
 use rayon::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct SliceExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -1,9 +1,11 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct SortExpr {
     pub(crate) physical_expr: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_core::frame::groupby::{GroupsIndicator, GroupsProxy};
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct SortByExpr {
     pub(crate) input: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
-use std::sync::Arc;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct TakeExpr {
     pub(crate) phys_expr: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -1,10 +1,12 @@
-use crate::physical_plan::state::{ExecutionState, StateFlags};
-use crate::prelude::*;
+use std::sync::Arc;
+
 use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::POOL;
-use std::sync::Arc;
+
+use crate::physical_plan::state::{ExecutionState, StateFlags};
+use crate::prelude::*;
 
 pub struct TernaryExpr {
     predicate: Arc<dyn PhysicalExpr>,

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -1,6 +1,5 @@
-use crate::logical_plan::Context;
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
+use std::fmt::Write;
+use std::sync::Arc;
 
 use polars_core::frame::groupby::{GroupBy, GroupsProxy};
 use polars_core::frame::hash_join::{
@@ -10,8 +9,10 @@ use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::POOL;
 use polars_utils::sort::perfect_sort;
-use std::fmt::Write;
-use std::sync::Arc;
+
+use crate::logical_plan::Context;
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 pub struct WindowExpr {
     /// the root column that the Function will be applied on.

--- a/polars/polars-lazy/src/physical_plan/file_cache.rs
+++ b/polars/polars-lazy/src/physical_plan/file_cache.rs
@@ -1,7 +1,8 @@
-use crate::prelude::file_caching::FileFingerPrint;
-use crate::prelude::*;
 use parking_lot::Mutex;
 use polars_core::prelude::*;
+
+use crate::prelude::file_caching::FileFingerPrint;
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub(crate) struct FileCache {

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -5,10 +5,11 @@ mod file_cache;
 pub mod planner;
 pub(crate) mod state;
 
-use crate::physical_plan::state::ExecutionState;
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;
+
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
 
 /// A type that implements this transforms a LogicalPlan to a physical plan.
 ///

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -1,9 +1,10 @@
-use super::super::expressions as phys_expr;
-use crate::prelude::*;
 use polars_core::frame::groupby::GroupByMethod;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::utils::parallel_op_series;
+
+use super::super::expressions as phys_expr;
+use crate::prelude::*;
 
 impl DefaultPlanner {
     pub fn create_physical_expr(

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -1,7 +1,8 @@
-use super::super::executors;
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_io::aggregations::ScanAggregation;
+
+use super::super::executors;
+use crate::prelude::*;
 
 #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
 fn aggregate_expr_to_scan_agg(

--- a/polars/polars-lazy/src/physical_plan/planner/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/mod.rs
@@ -1,10 +1,11 @@
 mod expr;
 mod lp;
 
-use crate::prelude::*;
 pub use expr::*;
 pub use lp::*;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 impl PhysicalPlanner for DefaultPlanner {
     fn create_physical_plan(

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,12 +1,13 @@
-#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
-use super::file_cache::FileCache;
-#[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
-use crate::prelude::file_caching::FileFingerPrint;
 use bitflags::bitflags;
 use parking_lot::Mutex;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::frame::hash_join::JoinOptIds;
 use polars_core::prelude::*;
+
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+use super::file_cache::FileCache;
+#[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
+use crate::prelude::file_caching::FileFingerPrint;
 
 pub type JoinTuplesCache = Arc<Mutex<PlHashMap<String, JoinOptIds>>>;
 pub type GroupsProxyCache = Arc<Mutex<PlHashMap<String, GroupsProxy>>>;

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -1,10 +1,8 @@
-pub(crate) use polars_utils::arena::{Arena, Node};
-
 #[cfg(feature = "temporal")]
 pub(crate) use polars_time::in_nanoseconds_window;
 #[cfg(feature = "dynamic_groupby")]
 pub(crate) use polars_time::{DynamicGroupOptions, PolarsTemporalGroupby, RollingGroupOptions};
-
+pub(crate) use polars_utils::arena::{Arena, Node};
 #[cfg(not(feature = "dynamic_groupby"))]
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -37,7 +35,6 @@ pub use crate::{
     },
     physical_plan::{expressions::*, planner::DefaultPlanner, Executor, PhysicalPlanner},
 };
-
 pub(crate) use crate::{
     logical_plan::{aexpr::*, alp::*, conversion::*, iterator::*},
     utils::*,

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_ops::prelude::ListNameSpaceImpl;
+
+use super::*;
 
 #[test]
 fn test_agg_exprs() -> Result<()> {

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_io::RowCount;
+
+use super::*;
 
 #[test]
 fn test_parquet_exec() -> Result<()> {

--- a/polars/polars-lazy/src/tests/logical.rs
+++ b/polars/polars-lazy/src/tests/logical.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
+
+use super::*;
 
 #[test]
 #[cfg(all(feature = "strings", feature = "temporal", feature = "dtype-duration"))]

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -25,24 +25,24 @@ fn load_df() -> DataFrame {
     .unwrap()
 }
 
-use optimization_checks::*;
+use std::io::Cursor;
+use std::iter::FromIterator;
 use std::sync::Mutex;
 
+use optimization_checks::*;
+use polars_core::chunked_array::builder::get_list_builder;
+use polars_core::df;
+#[cfg(feature = "temporal")]
+use polars_core::export::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use polars_core::prelude::*;
+pub(crate) use polars_core::SINGLE_LOCK;
 use polars_io::prelude::*;
-use std::io::Cursor;
 
 use crate::dsl::{argsort_by, pearson_corr};
 use crate::logical_plan::iterator::ArenaLpIter;
 use crate::logical_plan::optimizer::simplify_expr::SimplifyExprRule;
 use crate::logical_plan::optimizer::stack_opt::{OptimizationRule, StackOptimizer};
 use crate::prelude::*;
-use polars_core::chunked_array::builder::get_list_builder;
-use polars_core::df;
-#[cfg(feature = "temporal")]
-use polars_core::export::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-pub(crate) use polars_core::SINGLE_LOCK;
-use std::iter::FromIterator;
 
 static GLOB_PARQUET: &str = "../../examples/datasets/*.parquet";
 static GLOB_CSV: &str = "../../examples/datasets/*.csv";

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1,9 +1,10 @@
-use super::*;
-use crate::dsl::AggExpr::List;
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::series::ops::NullBehavior;
 use polars_time::prelude::DateMethods;
+
+use super::*;
+use crate::dsl::AggExpr::List;
 
 #[test]
 fn test_lazy_with_column() {

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -1,9 +1,11 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use polars_core::prelude::*;
+
 use crate::logical_plan::iterator::{ArenaExprIter, ArenaLpIter};
 use crate::logical_plan::Context;
 use crate::prelude::*;
-use polars_core::prelude::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 pub(crate) trait PushNode {
     fn push_node(&mut self, value: Node);
@@ -339,9 +341,10 @@ where
 
 #[cfg(test)]
 pub(crate) mod test {
+    use polars_core::prelude::*;
+
     use crate::prelude::stack_opt::{OptimizationRule, StackOptimizer};
     use crate::prelude::*;
-    use polars_core::prelude::*;
 
     pub fn optimize_lp(lp: LogicalPlan, rules: &mut [Box<dyn OptimizationRule>]) -> LogicalPlan {
         // initialize arena's

--- a/polars/polars-ops/src/chunked_array/list/hash.rs
+++ b/polars/polars-ops/src/chunked_array/list/hash.rs
@@ -1,11 +1,13 @@
-use super::*;
+use std::hash::Hash;
+
 use polars_core::export::{
     _boost_hash_combine,
     ahash::{self, CallHasher},
     rayon::prelude::*,
 };
 use polars_core::utils::NoNull;
-use std::hash::Hash;
+
+use super::*;
 
 fn hash_agg<T>(ca: &ChunkedArray<T>, random_state: &ahash::RandomState) -> u64
 where

--- a/polars/polars-ops/src/chunked_array/list/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/list/namespace.rs
@@ -1,11 +1,13 @@
-use super::*;
+use std::convert::TryFrom;
+use std::fmt::Write;
+
 use polars_arrow::kernels::list::sublist_get;
 use polars_arrow::prelude::ValueSize;
 use polars_core::chunked_array::builder::get_list_builder;
 use polars_core::series::ops::NullBehavior;
 use polars_core::utils::{get_supertype, CustomIterTools};
-use std::convert::TryFrom;
-use std::fmt::Write;
+
+use super::*;
 
 fn cast_rhs(
     other: &mut [Series],

--- a/polars/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/polars/polars-ops/src/chunked_array/list/to_struct.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::export::rayon::prelude::*;
+
+use super::*;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ListToStructWidthStrategy {

--- a/polars/polars-ops/src/chunked_array/mod.rs
+++ b/polars/polars-ops/src/chunked_array/mod.rs
@@ -4,14 +4,13 @@ mod strings;
 #[cfg(feature = "to_dummies")]
 mod to_dummies;
 
-#[allow(unused_imports)]
-use crate::prelude::*;
+pub use list::*;
 #[allow(unused_imports)]
 use polars_core::prelude::*;
-
+pub use set::ChunkedSet;
+pub use strings::*;
 #[cfg(feature = "to_dummies")]
 pub use to_dummies::*;
 
-pub use list::*;
-pub use set::ChunkedSet;
-pub use strings::*;
+#[allow(unused_imports)]
+use crate::prelude::*;

--- a/polars/polars-ops/src/chunked_array/strings/mod.rs
+++ b/polars/polars-ops/src/chunked_array/strings/mod.rs
@@ -4,7 +4,6 @@ mod namespace;
 
 #[cfg(feature = "strings")]
 pub use namespace::*;
-
 use polars_core::prelude::*;
 
 pub trait AsUtf8 {

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -1,11 +1,12 @@
-use super::*;
+use std::borrow::Cow;
 
 use polars_arrow::{
     export::arrow::{self, compute::substring::substring},
     kernels::string::*,
 };
 use polars_core::export::regex::{escape, Regex};
-use std::borrow::Cow;
+
+use super::*;
 
 fn f_regex_extract<'a>(reg: &Regex, input: &'a str, group_index: usize) -> Option<Cow<'a, str>> {
     reg.captures(input)

--- a/polars/polars-ops/src/chunked_array/to_dummies.rs
+++ b/polars/polars-ops/src/chunked_array/to_dummies.rs
@@ -1,6 +1,7 @@
-use super::*;
 use polars_core::frame::groupby::IntoGroupsProxy;
 use polars_core::utils::Wrap;
+
+use super::*;
 
 pub trait ToDummies<T> {
     fn to_dummies(&self) -> Result<DataFrame> {

--- a/polars/polars-ops/src/series/_trait.rs
+++ b/polars/polars-ops/src/series/_trait.rs
@@ -1,5 +1,6 @@
-use super::*;
 use std::ops::Deref;
+
+use super::*;
 
 #[cfg(feature = "to_dummies")]
 macro_rules! invalid_operation {

--- a/polars/polars-ops/src/series/implementations/date.rs
+++ b/polars/polars-ops/src/series/implementations/date.rs
@@ -1,5 +1,6 @@
-use super::*;
 use std::ops::Deref;
+
+use super::*;
 
 impl SeriesOps for Wrap<DateChunked> {
     fn dtype(&self) -> &DataType {

--- a/polars/polars-ops/src/series/implementations/datetime.rs
+++ b/polars/polars-ops/src/series/implementations/datetime.rs
@@ -1,6 +1,7 @@
-use super::*;
 #[cfg(feature = "to_dummies")]
 use std::ops::Deref;
+
+use super::*;
 
 impl SeriesOps for Wrap<DatetimeChunked> {
     fn dtype(&self) -> &DataType {

--- a/polars/polars-ops/src/series/implementations/duration.rs
+++ b/polars/polars-ops/src/series/implementations/duration.rs
@@ -1,5 +1,6 @@
-use super::*;
 use std::ops::Deref;
+
+use super::*;
 
 impl SeriesOps for Wrap<DurationChunked> {
     fn dtype(&self) -> &DataType {

--- a/polars/polars-ops/src/series/implementations/mod.rs
+++ b/polars/polars-ops/src/series/implementations/mod.rs
@@ -18,6 +18,7 @@ mod struct_;
 mod time;
 mod utf8;
 
-use crate::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::Wrap;
+
+use crate::prelude::*;

--- a/polars/polars-ops/src/series/implementations/time.rs
+++ b/polars/polars-ops/src/series/implementations/time.rs
@@ -1,6 +1,7 @@
-use super::*;
 #[cfg(feature = "to_dummies")]
 use std::ops::Deref;
+
+use super::*;
 
 impl SeriesOps for Wrap<TimeChunked> {
     fn dtype(&self) -> &DataType {

--- a/polars/polars-ops/src/series/mod.rs
+++ b/polars/polars-ops/src/series/mod.rs
@@ -2,10 +2,12 @@ mod _trait;
 mod implementations;
 mod ops;
 
-pub use self::_trait::*;
+use std::sync::Arc;
+
 use polars_core::prelude::*;
 use polars_core::utils::Wrap;
-use std::sync::Arc;
+
+pub use self::_trait::*;
 
 type SeriesOpsRef = Arc<dyn SeriesOps>;
 

--- a/polars/polars-ops/src/series/ops/log.rs
+++ b/polars/polars-ops/src/series/ops/log.rs
@@ -1,5 +1,6 @@
-use crate::series::ops::SeriesSealed;
 use polars_core::prelude::*;
+
+use crate::series::ops::SeriesSealed;
 
 fn log<T: PolarsNumericType>(ca: &ChunkedArray<T>, base: f64) -> Float64Chunked {
     ca.cast_and_apply_in_place(|v: f64| v.log(base))

--- a/polars/polars-ops/src/series/ops/mod.rs
+++ b/polars/polars-ops/src/series/ops/mod.rs
@@ -7,7 +7,6 @@ mod various;
 #[cfg(feature = "log")]
 pub use log::*;
 use polars_core::prelude::*;
-
 #[cfg(feature = "rolling_window")]
 pub use rolling::*;
 pub use various::*;

--- a/polars/polars-ops/src/series/ops/rolling.rs
+++ b/polars/polars-ops/src/series/ops/rolling.rs
@@ -1,9 +1,11 @@
-use crate::series::ops::SeriesSealed;
+use std::ops::SubAssign;
+
 use polars_core::export::num;
 use polars_core::export::num::{Float, FromPrimitive};
 use polars_core::prelude::*;
 use polars_core::utils::with_unstable_series;
-use std::ops::SubAssign;
+
+use crate::series::ops::SeriesSealed;
 
 #[cfg(feature = "moment")]
 fn rolling_skew<T>(ca: &ChunkedArray<T>, window_size: usize, bias: bool) -> Result<ChunkedArray<T>>

--- a/polars/polars-ops/src/series/ops/various.rs
+++ b/polars/polars-ops/src/series/ops/various.rs
@@ -1,8 +1,8 @@
-use crate::series::ops::SeriesSealed;
-use polars_core::prelude::*;
-
 #[cfg(feature = "hash")]
 use polars_core::export::ahash;
+use polars_core::prelude::*;
+
+use crate::series::ops::SeriesSealed;
 
 pub trait SeriesMethods: SeriesSealed {
     /// Create a [`DataFrame`] with the unique `values` of this [`Series`] and a column `"counts"`

--- a/polars/polars-time/src/chunkedarray/date.rs
+++ b/polars/polars-time/src/chunkedarray/date.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
+
+use super::*;
 
 pub(crate) fn naive_date_to_date(nd: NaiveDate) -> i32 {
     let nt = NaiveTime::from_hms(0, 0, 0);

--- a/polars/polars-time/src/chunkedarray/datetime.rs
+++ b/polars/polars-time/src/chunkedarray/datetime.rs
@@ -1,10 +1,11 @@
-use super::*;
 use arrow::array::{Array, PrimitiveArray};
 use arrow::compute::cast::CastOptions;
 use arrow::compute::{cast::cast, temporal};
 use arrow::error::Result as ArrowResult;
 use polars_arrow::export::arrow;
 use polars_core::prelude::*;
+
+use super::*;
 
 fn cast_and_apply<
     F: Fn(&dyn Array) -> ArrowResult<PrimitiveArray<T::Native>>,
@@ -149,8 +150,9 @@ impl DatetimeMethods for DatetimeChunked {}
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use chrono::NaiveDateTime;
+
+    use super::*;
 
     #[test]
     fn from_datetime() {

--- a/polars/polars-time/src/chunkedarray/duration.rs
+++ b/polars/polars-time/src/chunkedarray/duration.rs
@@ -1,7 +1,8 @@
-use super::*;
 use polars_arrow::export::arrow::temporal_conversions::{
     MICROSECONDS, MILLISECONDS, MILLISECONDS_IN_DAY, NANOSECONDS, SECONDS_IN_DAY,
 };
+
+use super::*;
 
 const NANOSECONDS_IN_MILLISECOND: i64 = 1_000_000;
 const SECONDS_IN_HOUR: i64 = 3600;

--- a/polars/polars-time/src/chunkedarray/kernels.rs
+++ b/polars/polars-time/src/chunkedarray/kernels.rs
@@ -1,6 +1,5 @@
 //! macros that define kernels for extracting
 //! `week`, `weekday`, `year`, `hour` etc. from primitive arrays.
-use super::*;
 use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
 use polars_arrow::export::arrow::array::PrimitiveArray;
 use polars_arrow::export::arrow::compute::arity::unary;
@@ -10,6 +9,8 @@ use polars_arrow::export::arrow::temporal_conversions::{
     date32_to_datetime, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
     timestamp_us_to_datetime,
 };
+
+use super::*;
 
 trait PolarsWeekDay {
     fn p_weekday(&self) -> u32;

--- a/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -1,6 +1,7 @@
-use super::*;
 use num::{pow::Pow, Float};
 use polars_core::export::num;
+
+use super::*;
 
 #[cfg(not(feature = "rolling_window"))]
 impl<T> RollingAgg for WrapFloat<ChunkedArray<T>>

--- a/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -3,8 +3,10 @@ mod ints;
 #[cfg(feature = "rolling_window")]
 mod rolling_kernels;
 
-use crate::prelude::*;
-use crate::series::WrapFloat;
+#[cfg(feature = "rolling_window")]
+use std::convert::TryFrom;
+use std::ops::SubAssign;
+
 #[cfg(feature = "rolling_window")]
 use arrow::array::{Array, PrimitiveArray};
 use polars_arrow::data_types::IsFloat;
@@ -15,9 +17,9 @@ use polars_arrow::kernels::rolling;
 #[cfg(feature = "rolling_window")]
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::prelude::*;
-#[cfg(feature = "rolling_window")]
-use std::convert::TryFrom;
-use std::ops::SubAssign;
+
+use crate::prelude::*;
+use crate::series::WrapFloat;
 
 #[derive(Clone)]
 pub struct RollingOptions {

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
@@ -1,5 +1,7 @@
 pub(super) mod no_nulls;
-use crate::prelude::*;
+use std::fmt::Debug;
+use std::ops::{AddAssign, Div, Mul, Sub, SubAssign};
+
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
 use polars_arrow::data_types::IsFloat;
@@ -8,5 +10,5 @@ use polars_arrow::index::IdxSize;
 use polars_arrow::trusted_len::TrustedLen;
 use polars_core::export::num::{Bounded, Float, NumCast, One};
 use polars_core::prelude::*;
-use std::fmt::Debug;
-use std::ops::{AddAssign, Div, Mul, Sub, SubAssign};
+
+use crate::prelude::*;

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -1,6 +1,7 @@
-use super::*;
 use polars_arrow::kernels::rolling::no_nulls::{self, RollingAggWindowNoNulls};
 use polars_core::export::num;
+
+use super::*;
 
 // Use an aggregation window that maintains the state
 pub(crate) fn rolling_apply_agg_window<'a, Agg, T, O>(values: &'a [T], offsets: O) -> ArrayRef

--- a/polars/polars-time/src/chunkedarray/time.rs
+++ b/polars/polars-time/src/chunkedarray/time.rs
@@ -1,8 +1,10 @@
-use super::*;
+use std::fmt::Write;
+
 use chrono::Timelike;
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array, Utf8Array};
 use polars_arrow::export::arrow::temporal_conversions::{time64ns_to_time, NANOSECONDS};
-use std::fmt::Write;
+
+use super::*;
 
 const SECONDS_IN_MINUTE: i64 = 60;
 const SECONDS_IN_HOUR: i64 = 3_600;

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -1,12 +1,13 @@
+use chrono::{NaiveDate, NaiveDateTime};
+use polars_arrow::export::arrow::array::PrimitiveArray;
+use polars_core::prelude::*;
+use polars_core::utils::arrow::types::NativeType;
+
 use super::patterns;
 #[cfg(feature = "dtype-date")]
 use crate::chunkedarray::date::naive_date_to_date;
 use crate::chunkedarray::utf8::patterns::Pattern;
 use crate::chunkedarray::utf8::strptime;
-use chrono::{NaiveDate, NaiveDateTime};
-use polars_arrow::export::arrow::array::PrimitiveArray;
-use polars_core::prelude::*;
-use polars_core::utils::arrow::types::NativeType;
 
 #[derive(Clone)]
 pub struct DatetimeInfer<T> {

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -2,13 +2,14 @@ pub mod infer;
 mod patterns;
 mod strptime;
 
+use chrono::ParseError;
+pub use patterns::Pattern;
+
 use super::*;
 #[cfg(feature = "dtype-date")]
 use crate::chunkedarray::date::naive_date_to_date;
 #[cfg(feature = "dtype-time")]
 use crate::chunkedarray::time::time_to_time64ns;
-use chrono::ParseError;
-pub use patterns::Pattern;
 
 #[cfg(feature = "dtype-time")]
 fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>

--- a/polars/polars-time/src/date_range.rs
+++ b/polars/polars-time/src/date_range.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use chrono::{Datelike, NaiveDateTime};
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
     // ~584 year around 1970

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -1,12 +1,12 @@
-use crate::prelude::*;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::export::rayon::prelude::*;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::POOL;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 
 #[repr(transparent)]
 struct Wrap<T>(pub T);
@@ -423,8 +423,9 @@ fn update_subgroups(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use chrono::prelude::*;
+
+    use super::*;
 
     #[test]
     fn test_rolling_groupby_tu() -> Result<()> {

--- a/polars/polars-time/src/lib.rs
+++ b/polars/polars-time/src/lib.rs
@@ -10,7 +10,6 @@ mod windows;
 
 #[cfg(any(feature = "dtype-date", feature = "dtype-datetime"))]
 pub use groupby::dynamic::*;
-
 pub use {
     date_range::*, truncate::*, upsample::*, windows::calendar::date_range as date_range_vec,
     windows::duration::Duration, windows::groupby::ClosedWindow, windows::window::Window,

--- a/polars/polars-time/src/prelude.rs
+++ b/polars/polars-time/src/prelude.rs
@@ -1,7 +1,7 @@
+pub use date_range::*;
+
 pub use crate::chunkedarray::*;
+pub use crate::series::SeriesOpsTime;
 pub use crate::series::TemporalMethods;
 pub use crate::windows::{bounds::*, duration::*, groupby::*, window::*};
 pub use crate::*;
-pub use date_range::*;
-
-pub use crate::series::SeriesOpsTime;

--- a/polars/polars-time/src/series/implementations/floats.rs
+++ b/polars/polars-time/src/series/implementations/floats.rs
@@ -1,6 +1,8 @@
-use super::*;
-use polars_arrow::data_types::IsFloat;
 use std::ops::SubAssign;
+
+use polars_arrow::data_types::IsFloat;
+
+use super::*;
 
 impl<T: PolarsFloatType> SeriesOpsTime for WrapFloat<ChunkedArray<T>>
 where

--- a/polars/polars-time/src/series/implementations/mod.rs
+++ b/polars/polars-time/src/series/implementations/mod.rs
@@ -18,7 +18,8 @@ mod struct_;
 mod time;
 mod utf8;
 
-use crate::prelude::*;
-use crate::series::*;
 use polars_core::prelude::*;
 use polars_core::utils::Wrap;
+
+use crate::prelude::*;
+use crate::series::*;

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -1,14 +1,14 @@
 mod _trait;
 mod implementations;
-use crate::chunkedarray::*;
-use polars_core::prelude::*;
 use std::ops::Deref;
-
-pub use self::_trait::*;
-use polars_core::utils::Wrap;
 use std::sync::Arc;
 
+use polars_core::prelude::*;
+use polars_core::utils::Wrap;
 pub use SeriesOpsTime;
+
+pub use self::_trait::*;
+use crate::chunkedarray::*;
 
 type SeriesOpsRef = Arc<dyn SeriesOpsTime>;
 

--- a/polars/polars-time/src/truncate.rs
+++ b/polars/polars-time/src/truncate.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 pub trait PolarsTruncate {
     #[must_use]

--- a/polars/polars-time/src/upsample.rs
+++ b/polars/polars-time/src/upsample.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 pub trait PolarsUpsample {
     /// Upsample a DataFrame at a regular frequency.

--- a/polars/polars-time/src/windows/calendar.rs
+++ b/polars/polars-time/src/windows/calendar.rs
@@ -1,5 +1,6 @@
-use crate::prelude::*;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 const LAST_DAYS_MONTH: [u32; 12] = [
     31, // January:   31,

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -1,7 +1,5 @@
-use super::calendar::{
-    is_leap_year, last_day_of_month, NS_DAY, NS_HOUR, NS_MICROSECOND, NS_MILLISECOND, NS_MINUTE,
-    NS_SECOND, NS_WEEK,
-};
+use std::ops::Mul;
+
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use polars_arrow::export::arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime, MILLISECONDS,
@@ -11,10 +9,13 @@ use polars_core::prelude::{
     datetime_to_timestamp_ms, datetime_to_timestamp_ns, datetime_to_timestamp_us,
 };
 use polars_core::utils::arrow::temporal_conversions::NANOSECONDS;
-use std::ops::Mul;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use super::calendar::{
+    is_leap_year, last_day_of_month, NS_DAY, NS_HOUR, NS_MICROSECOND, NS_MILLISECOND, NS_MINUTE,
+    NS_SECOND, NS_WEEK,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -1,4 +1,5 @@
-use crate::prelude::*;
+use std::cmp::Ordering;
+
 use polars_arrow::trusted_len::TrustedLen;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::prelude::*;
@@ -7,7 +8,8 @@ use polars_core::{export::rayon::prelude::*, utils::split_offsets};
 use polars_utils::flatten;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
+
+use crate::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -1,7 +1,8 @@
-use crate::prelude::*;
 use chrono::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::timestamp_ns_to_datetime;
 use polars_core::prelude::*;
+
+use crate::prelude::*;
 
 #[test]
 fn test_date_range() {

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -1,8 +1,9 @@
-use crate::prelude::*;
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, NANOSECONDS};
 use polars_core::export::arrow::temporal_conversions::MICROSECONDS;
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::SECONDS_IN_DAY;
+
+use crate::prelude::*;
 
 /// Represents a window in time
 #[derive(Copy, Clone)]

--- a/polars/polars-utils/src/contention_pool.rs
+++ b/polars/polars-utils/src/contention_pool.rs
@@ -1,5 +1,6 @@
-use parking_lot::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::Mutex;
 
 pub struct LowContentionPool<T> {
     stack: Vec<Mutex<T>>,

--- a/polars/polars-utils/src/sort.rs
+++ b/polars/polars-utils/src/sort.rs
@@ -1,5 +1,6 @@
-use crate::IdxSize;
 use rayon::{prelude::*, ThreadPool};
+
+use crate::IdxSize;
 
 /// This is a perfect sort particularly useful for an argsort of an argsort
 /// The second argsort sorts indices from `0` to `len` so can be just assigned to the

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -319,16 +319,14 @@ pub mod docs;
 pub mod export;
 pub mod prelude;
 
+pub use polars_core::apply_method_all_arrow_series;
+pub use polars_core::df;
 #[cfg(feature = "dtype-categorical")]
 pub use polars_core::toggle_string_cache;
 pub use polars_core::{chunked_array, datatypes, doc, error, frame, functions, series, testing};
-#[cfg(feature = "temporal")]
-pub use polars_time as time;
-
-pub use polars_core::apply_method_all_arrow_series;
-pub use polars_core::df;
-
 #[cfg(feature = "polars-io")]
 pub use polars_io as io;
 #[cfg(feature = "lazy")]
 pub use polars_lazy as lazy;
+#[cfg(feature = "temporal")]
+pub use polars_time as time;

--- a/polars/src/prelude.rs
+++ b/polars/src/prelude.rs
@@ -2,11 +2,8 @@ pub use polars_core::frame::groupby::*;
 pub use polars_core::{prelude::*, utils::NoNull};
 #[cfg(feature = "polars-io")]
 pub use polars_io::prelude::*;
-
 #[cfg(feature = "lazy")]
 pub use polars_lazy::prelude::*;
-
+pub use polars_ops::prelude::*;
 #[cfg(feature = "temporal")]
 pub use polars_time::prelude::*;
-
-pub use polars_ops::prelude::*;

--- a/polars/tests/it/core/groupby.rs
+++ b/polars/tests/it/core/groupby.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::series::IsSorted;
+
+use super::*;
 
 #[test]
 fn test_sorted_groupby() -> Result<()> {

--- a/polars/tests/it/core/joins.rs
+++ b/polars/tests/it/core/joins.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
+
+use super::*;
 
 #[test]
 fn test_chunked_left_join() -> Result<()> {

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -1,6 +1,8 @@
-use super::*;
-use polars::io::RowCount;
 use std::io::Cursor;
+
+use polars::io::RowCount;
+
+use super::*;
 
 const FOODS_CSV: &str = "../examples/datasets/foods1.csv";
 

--- a/polars/tests/it/io/ipc_stream.rs
+++ b/polars/tests/it/io/ipc_stream.rs
@@ -2,13 +2,15 @@ use super::*;
 
 #[cfg(test)]
 mod test {
-    use crate::io::create_df;
+    use std::io::Cursor;
+
     use polars::export::arrow::io::ipc::write;
     use polars_core::df;
     use polars_core::prelude::*;
     use polars_io::ipc::*;
     use polars_io::{SerReader, SerWriter};
-    use std::io::Cursor;
+
+    use crate::io::create_df;
 
     #[test]
     fn write_and_read_ipc_stream() {

--- a/polars/tests/it/io/parquet.rs
+++ b/polars/tests/it/io/parquet.rs
@@ -1,5 +1,6 @@
-use polars::prelude::*;
 use std::io::Cursor;
+
+use polars::prelude::*;
 
 #[test]
 fn test_vstack_empty_3220() -> Result<()> {

--- a/polars/tests/it/lazy/expressions/expand.rs
+++ b/polars/tests/it/lazy/expressions/expand.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars::export::chrono::NaiveDate;
+
+use super::*;
 
 #[test]
 fn test_expand_datetimes_3042() -> Result<()> {

--- a/polars/tests/it/lazy/expressions/slice.rs
+++ b/polars/tests/it/lazy/expressions/slice.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::prelude::*;
+
+use super::*;
 
 #[test]
 fn test_slice_args() -> Result<()> {

--- a/polars/tests/it/lazy/groupby.rs
+++ b/polars/tests/it/lazy/groupby.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::series::ops::NullBehavior;
+
+use super::*;
 
 #[test]
 fn test_filter_sort_diff_2984() -> Result<()> {

--- a/polars/tests/it/lazy/groupby_dynamic.rs
+++ b/polars/tests/it/lazy/groupby_dynamic.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars::export::chrono::prelude::*;
+
+use super::*;
 
 #[test]
 #[cfg(all(

--- a/polars/tests/it/lazy/predicate_queries.rs
+++ b/polars/tests/it/lazy/predicate_queries.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::{with_string_cache, SINGLE_LOCK};
+
+use super::*;
 
 #[test]
 fn test_predicate_after_renaming() -> Result<()> {

--- a/polars/tests/it/lazy/queries.rs
+++ b/polars/tests/it/lazy/queries.rs
@@ -1,5 +1,6 @@
-use super::*;
 use polars_core::series::IsSorted;
+
+use super::*;
 
 #[test]
 fn test_with_duplicate_column_empty_df() {

--- a/py-polars/src/apply/dataframe.rs
+++ b/py-polars/src/apply/dataframe.rs
@@ -1,13 +1,14 @@
-use super::*;
-use crate::conversion::Wrap;
-use crate::error::PyPolarsErr;
-use crate::series::PySeries;
-use crate::PyDataFrame;
 use polars::prelude::*;
 use polars_core::frame::row::{rows_to_schema, Row};
 use pyo3::conversion::{FromPyObject, IntoPy};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyString, PyTuple};
+
+use super::*;
+use crate::conversion::Wrap;
+use crate::error::PyPolarsErr;
+use crate::series::PySeries;
+use crate::PyDataFrame;
 
 // the return type is Union[PySeries, PyDataFrame] and a boolean indicating if it is a dataframe or not
 pub fn apply_lambda_unknown<'a>(

--- a/py-polars/src/apply/mod.rs
+++ b/py-polars/src/apply/mod.rs
@@ -1,14 +1,15 @@
 pub mod dataframe;
 pub mod series;
 
-use crate::prelude::ObjectValue;
-use crate::{PyPolarsErr, PySeries, Wrap};
 use polars::chunked_array::builder::get_list_builder;
 use polars::prelude::*;
 use polars_core::utils::CustomIterTools;
 use polars_core::{export::rayon::prelude::*, POOL};
 use pyo3::types::PyDict;
 use pyo3::{PyAny, PyResult};
+
+use crate::prelude::ObjectValue;
+use crate::{PyPolarsErr, PySeries, Wrap};
 
 pub trait PyArrowPrimitiveType: PolarsNumericType {}
 

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -1,12 +1,13 @@
+use polars::chunked_array::builder::get_list_builder;
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyCFunction, PyDict, PyFloat, PyList, PyString, PyTuple};
+
 use super::*;
 use crate::conversion::slice_to_wrapped;
 use crate::py_modules::SERIES;
 use crate::series::PySeries;
 use crate::{PyPolarsErr, Wrap};
-use polars::chunked_array::builder::get_list_builder;
-use polars::prelude::*;
-use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyCFunction, PyDict, PyFloat, PyList, PyString, PyTuple};
 
 /// Find the output type and dispatch to that implementation.
 fn infer_and_finish<'a, A: ApplyLambda<'a>>(

--- a/py-polars/src/arrow_interop/to_rust.rs
+++ b/py-polars/src/arrow_interop/to_rust.rs
@@ -1,4 +1,3 @@
-use crate::error::PyPolarsErr;
 use polars_core::export::rayon::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
@@ -7,6 +6,8 @@ use polars_core::POOL;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+
+use crate::error::PyPolarsErr;
 
 pub fn field_to_rust(obj: &PyAny) -> PyResult<Field> {
     let schema = Box::new(ffi::ArrowSchema::empty());

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -1,12 +1,13 @@
-use crate::dataframe::PyDataFrame;
-use crate::error::PyPolarsErr;
-use crate::lazy::dataframe::PyLazyFrame;
-use crate::prelude::*;
-use crate::py_modules::POLARS;
-use crate::series::PySeries;
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
+
 use polars::chunked_array::object::PolarsObjectSafe;
 use polars::frame::row::Row;
 use polars::frame::{groupby::PivotAgg, NullStrategy};
+#[cfg(feature = "avro")]
+use polars::io::avro::AvroCompression;
+#[cfg(feature = "ipc")]
+use polars::io::ipc::IpcCompression;
 use polars::prelude::AnyValue;
 use polars::series::ops::NullBehavior;
 use polars_core::prelude::QuantileInterpolOptions;
@@ -17,13 +18,13 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyList, PySequence};
 use pyo3::{PyAny, PyResult};
-use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
 
-#[cfg(feature = "avro")]
-use polars::io::avro::AvroCompression;
-#[cfg(feature = "ipc")]
-use polars::io::ipc::IpcCompression;
+use crate::dataframe::PyDataFrame;
+use crate::error::PyPolarsErr;
+use crate::lazy::dataframe::PyLazyFrame;
+use crate::prelude::*;
+use crate::py_modules::POLARS;
+use crate::series::PySeries;
 
 pub(crate) fn slice_to_wrapped<T>(slice: &[T]) -> &[Wrap<T>] {
     // Safety:

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1,16 +1,32 @@
-use numpy::IntoPyArray;
-use pyo3::types::{PyDict, PyList, PyTuple};
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
 use std::io::BufWriter;
 use std::ops::Deref;
 
+use numpy::IntoPyArray;
 use polars::frame::groupby::GroupBy;
+use polars::frame::row::{rows_to_schema, Row};
+#[cfg(feature = "avro")]
+use polars::io::avro::AvroCompression;
+#[cfg(feature = "ipc")]
+use polars::io::ipc::IpcCompression;
+use polars::io::mmap::ReaderBytes;
+use polars::io::RowCount;
 use polars::prelude::*;
+use polars_core::export::arrow::datatypes::IntegerType;
+use polars_core::frame::explode::MeltArgs;
+use polars_core::frame::groupby::PivotAgg;
+use polars_core::frame::ArrowChunk;
+use polars_core::prelude::QuantileInterpolOptions;
+use polars_core::utils::arrow::compute::cast::CastOptions;
+use polars_core::utils::get_supertype;
+use pyo3::types::{PyDict, PyList, PyTuple};
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use crate::apply::dataframe::{
     apply_lambda_unknown, apply_lambda_with_bool_out_type, apply_lambda_with_primitive_out_type,
     apply_lambda_with_utf8_out_type,
 };
+#[cfg(feature = "parquet")]
+use crate::conversion::parse_parquet_compression;
 use crate::conversion::{ObjectValue, Wrap};
 use crate::file::get_mmap_bytes_reader;
 use crate::lazy::dataframe::PyLazyFrame;
@@ -22,23 +38,6 @@ use crate::{
     py_modules,
     series::{to_pyseries_collection, to_series_collection, PySeries},
 };
-use polars::frame::row::{rows_to_schema, Row};
-use polars::io::mmap::ReaderBytes;
-use polars::io::RowCount;
-use polars_core::export::arrow::datatypes::IntegerType;
-use polars_core::frame::explode::MeltArgs;
-use polars_core::frame::groupby::PivotAgg;
-use polars_core::frame::ArrowChunk;
-use polars_core::prelude::QuantileInterpolOptions;
-use polars_core::utils::arrow::compute::cast::CastOptions;
-use polars_core::utils::get_supertype;
-
-#[cfg(feature = "parquet")]
-use crate::conversion::parse_parquet_compression;
-#[cfg(feature = "avro")]
-use polars::io::avro::AvroCompression;
-#[cfg(feature = "ipc")]
-use polars::io::ipc::IpcCompression;
 
 #[pyclass]
 #[repr(transparent)]

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -1,6 +1,7 @@
-use crate::Wrap;
 use polars::prelude::*;
 use pyo3::{FromPyObject, PyAny, PyResult};
+
+use crate::Wrap;
 
 // Don't change the order of these!
 #[repr(u8)]

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use polars::prelude::PolarsError;
 use polars_core::error::ArrowError;
 use pyo3::exceptions::{PyIOError, PyValueError};
@@ -6,7 +8,6 @@ use pyo3::{
     exceptions::{PyException, PyRuntimeError},
     prelude::*,
 };
-use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 
 #[derive(Error)]

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -1,14 +1,16 @@
 // Credits to https://github.com/omerbenamram/pyo3-file
-use crate::prelude::resolve_homedir;
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io;
+use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
+
 use polars::io::mmap::MmapBytesReader;
 use pyo3::exceptions::PyFileNotFoundError;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
-use std::borrow::Borrow;
-use std::fs::File;
-use std::io;
-use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
+
+use crate::prelude::resolve_homedir;
 
 #[derive(Clone)]
 pub struct PyFileLikeObject {

--- a/py-polars/src/lazy/apply.rs
+++ b/py-polars/src/lazy/apply.rs
@@ -1,9 +1,10 @@
-use crate::lazy::dsl::PyExpr;
-use crate::prelude::PyDataType;
-use crate::series::PySeries;
 use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+
+use crate::lazy::dsl::PyExpr;
+use crate::prelude::PyDataType;
+use crate::series::PySeries;
 
 trait ToSeries {
     fn to_series(&self, py: Python, py_polars_module: &PyObject, name: &str) -> Series;

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -1,10 +1,5 @@
-use crate::arrow_interop::to_rust::pyarrow_schema_to_rust;
-use crate::conversion::Wrap;
-use crate::dataframe::PyDataFrame;
-use crate::error::PyPolarsErr;
-use crate::file::get_file_like;
-use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
-use crate::prelude::*;
+use std::io::BufWriter;
+
 use polars::io::RowCount;
 use polars::lazy::frame::{AllowedOptimizations, LazyCsvReader, LazyFrame, LazyGroupBy};
 use polars::lazy::prelude::col;
@@ -16,7 +11,14 @@ use polars_core::prelude::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use std::io::BufWriter;
+
+use crate::arrow_interop::to_rust::pyarrow_schema_to_rust;
+use crate::conversion::Wrap;
+use crate::dataframe::PyDataFrame;
+use crate::error::PyPolarsErr;
+use crate::file::get_file_like;
+use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
+use crate::prelude::*;
 
 #[pyclass]
 #[repr(transparent)]

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1,10 +1,5 @@
-use super::apply::*;
-use crate::conversion::parse_fill_null_strategy;
-use crate::conversion::Wrap;
-use crate::lazy::map_single;
-use crate::lazy::utils::py_exprs_to_exprs;
-use crate::series::PySeries;
-use crate::utils::reinterpret;
+use std::borrow::Cow;
+
 use polars::lazy::dsl;
 use polars::lazy::dsl::Operator;
 use polars::prelude::*;
@@ -13,7 +8,14 @@ use polars_core::prelude::QuantileInterpolOptions;
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
-use std::borrow::Cow;
+
+use super::apply::*;
+use crate::conversion::parse_fill_null_strategy;
+use crate::conversion::Wrap;
+use crate::lazy::map_single;
+use crate::lazy::utils::py_exprs_to_exprs;
+use crate::series::PySeries;
+use crate::utils::reinterpret;
 
 #[pyclass]
 #[repr(transparent)]

--- a/py-polars/src/lazy/utils.rs
+++ b/py-polars/src/lazy/utils.rs
@@ -1,5 +1,6 @@
-use crate::lazy::dsl::PyExpr;
 use polars::lazy::dsl::Expr;
+
+use crate::lazy::dsl::PyExpr;
 
 pub fn py_exprs_to_exprs(py_exprs: Vec<PyExpr>) -> Vec<Expr> {
     // Safety:

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -34,15 +34,6 @@ pub mod series;
 mod set;
 pub mod utils;
 
-use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
-use crate::error::{
-    ArrowErrorException, ComputeError, DuplicateError, NoDataError, NotFoundError, PyPolarsErr,
-    SchemaError,
-};
-use crate::file::get_either_file;
-use crate::prelude::{
-    vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs,
-};
 use dsl::ToExprs;
 #[cfg(target_os = "linux")]
 use jemallocator::Jemalloc;
@@ -56,6 +47,16 @@ use polars_core::prelude::{DataFrame, IDX_DTYPE};
 use polars_core::POOL;
 use pyo3::panic::PanicException;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
+
+use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
+use crate::error::{
+    ArrowErrorException, ComputeError, DuplicateError, NoDataError, NotFoundError, PyPolarsErr,
+    SchemaError,
+};
+use crate::file::get_either_file;
+use crate::prelude::{
+    vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs,
+};
 
 #[global_allocator]
 #[cfg(target_os = "linux")]

--- a/py-polars/src/list_construction.rs
+++ b/py-polars/src/list_construction.rs
@@ -1,7 +1,8 @@
-use crate::conversion::get_pyseq;
 use polars::prelude::*;
 use polars_core::utils::CustomIterTools;
 use pyo3::{PyAny, PyResult};
+
+use crate::conversion::get_pyseq;
 
 pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &DataType) -> PyResult<Series> {
     let (seq, len) = get_pyseq(seq)?;

--- a/py-polars/src/npy.rs
+++ b/py-polars/src/npy.rs
@@ -1,3 +1,5 @@
+use std::{mem, ptr};
+
 use ndarray::IntoDimension;
 use numpy::{
     npyffi::{self, flags, types::npy_intp},
@@ -6,7 +8,6 @@ use numpy::{
 use numpy::{Element, PyArray1};
 use polars_core::utils::arrow::types::NativeType;
 use pyo3::prelude::*;
-use std::{mem, ptr};
 
 /// Create an empty numpy array arrows 64 byte alignment
 ///

--- a/py-polars/src/prelude.rs
+++ b/py-polars/src/prelude.rs
@@ -1,4 +1,5 @@
+pub use polars::prelude::*;
+
 pub use crate::conversion::*;
 pub use crate::datatypes::*;
 pub(crate) use crate::py_modules;
-pub use polars::prelude::*;

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1,3 +1,11 @@
+use numpy::PyArray1;
+use polars::series::ops::NullBehavior;
+use polars_core::prelude::QuantileInterpolOptions;
+use polars_core::series::IsSorted;
+use polars_core::utils::CustomIterTools;
+use pyo3::types::{PyBytes, PyList, PyTuple};
+use pyo3::{exceptions::PyRuntimeError, prelude::*, Python};
+
 use crate::apply::series::{call_lambda_and_extract, ApplyLambda};
 use crate::arrow_interop::to_rust::array_to_rust;
 use crate::dataframe::PyDataFrame;
@@ -10,13 +18,6 @@ use crate::{
     npy::{aligned_array, get_refcnt},
     prelude::*,
 };
-use numpy::PyArray1;
-use polars::series::ops::NullBehavior;
-use polars_core::prelude::QuantileInterpolOptions;
-use polars_core::series::IsSorted;
-use polars_core::utils::CustomIterTools;
-use pyo3::types::{PyBytes, PyList, PyTuple};
-use pyo3::{exceptions::PyRuntimeError, prelude::*, Python};
 #[pyclass]
 #[repr(transparent)]
 #[derive(Clone)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
Resolves #4402 
(let's close that issue for now until something specific comes up)

Changes:
* Add `rustfmt.toml`
  * Enable "PEP8" style import grouping
* Reformat all imports accordingly

Let me know if you think this is an improvement!