### PR TITLE
test[python]: Fix type indexing py3.7 test error

### DIFF
--- a/py-polars/tests/io/test_csv.py
+++ b/py-polars/tests/io/test_csv.py
@@ -7,7 +7,6 @@ import textwrap
 import zlib
 from datetime import date, datetime, time
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -510,10 +509,8 @@ def test_fallback_chrono_parser() -> None:
     2021-10-10,2021-10-10
     """
     )
-    assert cast(
-        tuple[int, int],
-        pl.read_csv(data.encode(), parse_dates=True).null_count().row(0),
-    ) == (0, 0)
+    df = pl.read_csv(data.encode(), parse_dates=True)
+    assert df.null_count().row(0) == (0, 0)  # type: ignore[comparison-overlap]
 
 
 def test_csv_string_escaping() -> None:


### PR DESCRIPTION
In #4058, I enforce strict type equality checks in mypy. Most cases can be fixed with `typing.cast`. For generic types such as tuple, we cannot use this yet, because py3.7 does not allow this, and thus we need a `type: ignore`. This one case of using the cast slipped through, fixing this here.

As noted by https://github.com/pola-rs/polars/pull/4413#issuecomment-1214400239