### PR TITLE
chore[python]: Remove outdated TODO

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -228,7 +228,6 @@ class Series:
             else:
                 raise ValueError("Series name must be a string.")
 
-        # TODO: Remove if-statement below once Series name is allowed to be None
         if name is None:
             name = ""
 


### PR DESCRIPTION
I can't find the corresponding issue, but we've decided not to support `None` as a Series name.