### PR TITLE
Fix type annotations for `fill_nan()`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4239,7 +4239,7 @@ class DataFrame:
         """
         return self.select(pli.all().fill_null(value, strategy, limit))
 
-    def fill_nan(self, fill_value: pli.Expr | int | float) -> DataFrame:
+    def fill_nan(self, fill_value: pli.Expr | int | float | None) -> DataFrame:
         """
         Fill floating point NaN values by an Expression evaluation.
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1987,7 +1987,7 @@ class Expr:
         else:
             return wrap_expr(self._pyexpr.fill_null_with_strategy(strategy, limit))
 
-    def fill_nan(self, fill_value: str | int | float | bool | Expr) -> Expr:
+    def fill_nan(self, fill_value: str | int | float | bool | Expr | None) -> Expr:
         """
         Fill floating point NaN value with a fill value
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1937,7 +1937,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         return self.select(pli.all().fill_null(value, strategy, limit))
 
-    def fill_nan(self: LDF, fill_value: int | str | float | pli.Expr) -> LDF:
+    def fill_nan(self: LDF, fill_value: int | str | float | pli.Expr | None) -> LDF:
         """
         Fill floating point NaN values.
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2600,7 +2600,9 @@ class Series:
     def __deepcopy__(self, memo: None = None) -> Series:
         return self.clone()
 
-    def fill_nan(self, fill_value: str | int | float | bool | pli.Expr) -> Series:
+    def fill_nan(
+        self, fill_value: str | int | float | bool | pli.Expr | None
+    ) -> Series:
         """Fill floating point NaN value with a fill value."""
         return (
             self.to_frame().select(pli.col(self.name).fill_nan(fill_value)).to_series()

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1465,6 +1465,7 @@ def test_fill_null() -> None:
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("nan")]})
     assert df.fill_nan(4).frame_equal(pl.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    assert df.fill_nan(None).frame_equal(pl.DataFrame({"a": [1, 2], "b": [3, None]}))
     assert df["b"].fill_nan(5.0).to_list() == [3.0, 5.0]
     df = pl.DataFrame(
         {

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -589,6 +589,12 @@ def test_fill_nan() -> None:
         .collect()["a"]
         .series_equal(pl.Series("a", [1.0, 2.0, 3.0]))
     )
+    assert (
+        df.lazy()
+        .fill_nan(None)
+        .collect()["a"]
+        .series_equal(pl.Series("a", [1.0, None, 3.0]), null_equal=True)
+    )
     assert df.select(pl.col("a").fill_nan(2))["a"].series_equal(
         pl.Series("a", [1.0, 2.0, 3.0])
     )

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -570,6 +570,13 @@ def test_fill_null() -> None:
     )
 
 
+def test_fill_nan() -> None:
+    a = pl.Series("a", [1.0, 2.1, float("nan")])
+    assert a.fill_nan(None).series_equal(
+        pl.Series("a", [1.0, 2.1, None]), null_equal=True
+    )
+
+
 def test_apply() -> None:
     a = pl.Series("a", [1, 2, None])
     b = a.apply(lambda x: x**2)


### PR DESCRIPTION
I added the types as suggested in https://github.com/pola-rs/polars/issues/3066#issuecomment-1216751600 for series, data frame and expression. tested it but for some reason, when comparing series and expressions with their reference, I could not get them to be equal. I had to convert to a tuple to pass the equality check. E.g. check this:
```
import polars as pl
lazy = pl.DataFrame({"a": [1.0, np.nan, 3.0]}).lazy().fill_nan(None).collect()["a"]
assert lazy.series_equal(pl.Series("a", [1.0, None, 3.0]))
```
They have the same printed output but they are not identical. 
For eager, it works:
```
lazy = pl.DataFrame({"a": [1.0, np.nan, 3.0]}).fill_nan(None)
assert lazy.frame_equal(pl.DataFrame({"a": [1.0, None, 3.0]}))
```
Not sure the comparison method needs to be adapted too, but I considered that out of scope for this PR.