### PR TITLE
fix[rust]: rolling_groupby extrema fixed

### DIFF
--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -159,7 +159,7 @@ pub(crate) fn groupby_values_iter_full_lookbehind(
         .enumerate()
         .map(move |(mut i, lower)| {
             if *lower < last {
-                panic!("index column of 'groupby_rolling' must be sorted!")
+                panic!("index column of 'groupby_rolling' must be sorted in ascending order!")
             }
             last = *lower;
             i += start_offset;

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -25,6 +25,7 @@ Attributes
    Series.shape
    Series.str
    Series.time_unit
+   Series.flags
 
 Conversion
 ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -636,6 +636,21 @@ class Series:
         else:
             raise ValueError(f'cannot use "{key}" for indexing')
 
+    @property
+    def flags(self) -> dict[str, bool]:
+        """
+        Get flags that are set on the Series
+
+        Returns
+        -------
+        Dictionary containing the flag name and the value
+
+        """
+        return {
+            "SORTED_ASC": self._s.is_sorted_flag(),
+            "SORTED_DESC": self._s.is_sorted_reverse_flag(),
+        }
+
     def estimated_size(self) -> int:
         """
         Return an estimation of the total (heap) allocated size of the `Series` in

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -115,6 +115,13 @@ impl PySeries {
 
 #[pymethods]
 impl PySeries {
+    pub fn is_sorted_flag(&self) -> bool {
+        matches!(self.series.is_sorted(), IsSorted::Ascending)
+    }
+    pub fn is_sorted_reverse_flag(&self) -> bool {
+        matches!(self.series.is_sorted(), IsSorted::Descending)
+    }
+
     #[staticmethod]
     pub fn new_opt_bool(name: &str, obj: &PyAny, strict: bool) -> PyResult<PySeries> {
         let (seq, len) = get_pyseq(obj)?;

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -189,3 +189,9 @@ def test_sorted_join_and_dtypes() -> None:
         "row_nr": [0, 1, 2, 3, 4, 5],
         "a": [-5, -2, 3, 3, 9, 10],
     }
+
+
+def test_sorted_flag_reverse() -> None:
+    s = pl.arange(0, 7, eager=True)
+    assert s.flags["SORTED_ASC"]
+    assert s.reverse().flags["SORTED_DESC"]


### PR DESCRIPTION
fixes #4450 

Added tests that carefully contstruct the `sorted` flags such that we hit different branches. An invalid branch was removed for `agg_min` and `agg_max`.