### PR TITLE
fix[rust]: fix and test sorted fast paths

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -129,9 +129,10 @@ macro_rules! sort_with_fast_path {
             return $ca.clone();
         }
 
-        if $options.descending && $ca.is_sorted_reverse() || $ca.is_sorted() {
+        // we can clone if we sort in same order
+        if $options.descending && $ca.is_sorted_reverse() || ($ca.is_sorted() && !$options.descending) {
             // there are nulls
-            if $ca.has_validity() {
+            if $ca.null_count() > 0 {
                 // if the nulls are already last we can clone
                 if $options.nulls_last && $ca.get($ca.len() - 1).is_none()  ||
                 // if the nulls are already first we can clone
@@ -146,6 +147,10 @@ macro_rules! sort_with_fast_path {
                 return $ca.clone();
             }
         }
+        // we can reverse if we sort in other order
+        else if ($options.descending && $ca.is_sorted() || $ca.is_sorted_reverse()) && $ca.null_count() == 0 {
+            return $ca.reverse()
+        };
 
 
     }}

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -195,3 +195,17 @@ def test_sorted_flag_reverse() -> None:
     s = pl.arange(0, 7, eager=True)
     assert s.flags["SORTED_ASC"]
     assert s.reverse().flags["SORTED_DESC"]
+
+
+def test_sorted_fast_paths() -> None:
+    s = pl.Series([1, 2, 3]).sort()
+    rev = s.sort(reverse=True)
+
+    assert rev.to_list() == [3, 2, 1]
+    assert s.sort().to_list() == [1, 2, 3]
+
+    s = pl.Series([None, 1, 2, 3]).sort()
+    rev = s.sort(reverse=True)
+    assert rev.to_list() == [None, 3, 2, 1]
+    assert rev.sort(reverse=True).to_list() == [None, 3, 2, 1]
+    assert rev.sort().to_list() == [None, 1, 2, 3]


### PR DESCRIPTION
Also adds a `reverse` fast path for when we reverse sortedness.