### PR TITLE
feat[python] support np.datetime64 init for Series

### DIFF
--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -91,6 +91,7 @@ if _NUMPY_AVAILABLE and not _DOCUMENTING:
         np.uint64: PySeries.new_u64,
         np.str_: PySeries.new_str,
         np.bool_: PySeries.new_bool,
+        np.datetime64: PySeries.new_i64,
     }
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -101,9 +101,13 @@ def numpy_to_pyseries(
         if dtype == np.float16:
             values = values.astype(np.float32)
             dtype = values.dtype.type
+
         constructor = numpy_type_to_constructor(dtype)
+
         if dtype == np.float32 or dtype == np.float64:
             return constructor(name, values, nan_to_null)
+        elif dtype == np.datetime64:
+            return constructor(name, values.astype(np.int64), strict)
         else:
             return constructor(name, values, strict)
     else:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -244,7 +244,7 @@ class Series:
                     dtype == Datetime and not getattr(dtype, "tu", None)
                 ):
                     tu = getattr(dtype, "tu", np.datetime_data(values.dtype)[0])
-                    dtype = Datetime(tu)  # type: ignore[arg-type]
+                    dtype = Datetime(tu)
             if dtype is not None:
                 self._s = self.cast(dtype, strict=True)._s
         elif isinstance(values, Sequence):

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -239,6 +239,12 @@ class Series:
             self._s = arrow_to_pyseries(name, values)
         elif _NUMPY_AVAILABLE and isinstance(values, np.ndarray):
             self._s = numpy_to_pyseries(name, values, strict, nan_to_null)
+            if values.dtype.type == np.datetime64:
+                if dtype is None or (
+                    dtype == Datetime and not getattr(dtype, "tu", None)
+                ):
+                    tu = getattr(dtype, "tu", np.datetime_data(values.dtype)[0])
+                    dtype = Datetime(tu)  # type: ignore[arg-type]
             if dtype is not None:
                 self._s = self.cast(dtype, strict=True)._s
         elif isinstance(values, Sequence):

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import Date, Float64, Int32, Int64, UInt32, UInt64
+from polars.datatypes import Date, Datetime, Float64, Int32, Int64, UInt32, UInt64
 from polars.testing import assert_series_equal, verify_series_and_expr_api
 
 
@@ -45,6 +45,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
             == pl.List
         )
         assert pl.Series("a", [10000, 20000, 30000], dtype=pl.Time).dtype == pl.Time
+
         # 2d numpy array
         res = pl.Series(name="a", values=np.array([[1, 2], [3, 4]]))
         assert all(res[0] == np.array([1, 2]))
@@ -56,6 +57,18 @@ def test_init_inputs(monkeypatch: Any) -> None:
 
         # lists
         assert pl.Series("a", [[1, 2], [3, 4]]).dtype == pl.List
+
+    # datetime64
+    values = pd.date_range(date(2021, 8, 1), date(2021, 8, 3)).values
+    for dtype in (None, Datetime, Datetime("ns")):
+        s = pl.Series("dates", values, dtype)
+        assert s.to_list() == [
+            datetime(2021, 8, 1, 0),
+            datetime(2021, 8, 2, 0),
+            datetime(2021, 8, 3, 0),
+        ]
+        assert Datetime == s.dtype
+        assert s.dtype.tu == "ns"  # type: ignore[attr-defined]
 
     # pandas
     assert pl.Series(pd.Series([1, 2])).dtype == pl.Int64


### PR DESCRIPTION
Handle numpy arrays with `np.datetime64` dtype on `pl.Series` init, auto-detecting timeunit (if not explicitly supplied).

```python
from datetime import date
import pandas as pd
import polars as pl

d64 = pd.date_range(date(2021, 8, 1), date(2021, 8, 3)).values

pl.Series( 'dates', d64 )
# shape: (3,)
# Series: 'dates' [datetime[ns]]
# [
# 	2021-08-01 00:00:00
# 	2021-08-02 00:00:00
# 	2021-08-03 00:00:00
# ]
```