### PR TITLE
feat[python]: support np.datetime64 init for Series

### DIFF
--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -91,6 +91,7 @@ if _NUMPY_AVAILABLE and not _DOCUMENTING:
         np.uint64: PySeries.new_u64,
         np.str_: PySeries.new_str,
         np.bool_: PySeries.new_bool,
+        np.datetime64: PySeries.new_i64,
     }
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -101,9 +101,13 @@ def numpy_to_pyseries(
         if dtype == np.float16:
             values = values.astype(np.float32)
             dtype = values.dtype.type
+
         constructor = numpy_type_to_constructor(dtype)
+
         if dtype == np.float32 or dtype == np.float64:
             return constructor(name, values, nan_to_null)
+        elif dtype == np.datetime64:
+            return constructor(name, values.astype(np.int64), strict)
         else:
             return constructor(name, values, strict)
     else:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from polars import internals as pli
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Categorical,
     ColumnsType,
     Date,
@@ -101,6 +102,11 @@ def numpy_to_pyseries(
         if dtype == np.float16:
             values = values.astype(np.float32)
             dtype = values.dtype.type
+        elif (
+            dtype == np.datetime64
+            and np.datetime_data(values.dtype)[0] not in DTYPE_TEMPORAL_UNITS
+        ):
+            dtype = object
 
         constructor = numpy_type_to_constructor(dtype)
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence, Union, overload
 
 from polars import internals as pli
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Boolean,
     DataType,
     Date,
@@ -245,11 +246,12 @@ class Series:
                     dtype == Datetime and not getattr(dtype, "tu", None)
                 ):
                     tu = getattr(dtype, "tu", np.datetime_data(values.dtype)[0])
-                    dtype = Datetime(tu)  # type: ignore[arg-type]
+                    if tu in DTYPE_TEMPORAL_UNITS:
+                        dtype = Datetime(tu)
 
                 # handle NaT values
-                if np.isnan(values).any(0):
-                    nat: int = np.datetime64("NaT").astype(int)
+                if dtype is not None and np.isnan(values).any(0):
+                    nat = np.datetime64("NaT").astype(int)
                     scol = pli.col(self.name)
                     self._s = (
                         self.to_frame()

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -245,11 +245,11 @@ class Series:
                     dtype == Datetime and not getattr(dtype, "tu", None)
                 ):
                     tu = getattr(dtype, "tu", np.datetime_data(values.dtype)[0])
-                    dtype = Datetime(tu)
+                    dtype = Datetime(tu)  # type: ignore[arg-type]
 
                 # handle NaT values
                 if np.isnan(values).any(0):
-                    nat = np.datetime64("NaT").astype(np.int64)
+                    nat: int = np.datetime64("NaT").astype(int)
                     scol = pli.col(self.name)
                     self._s = (
                         self.to_frame()

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -251,15 +251,16 @@ class Series:
 
                 # handle NaT values
                 if dtype is not None and np.isnan(values).any(0):
-                    nat = np.datetime64("NaT").astype(int)
+                    nat: int = np.datetime64("NaT").astype(int)
                     scol = pli.col(self.name)
                     self._s = (
                         self.to_frame()
                         .with_column(
-                            pli.when(scol == nat).then(None).otherwise(scol).keep_name()
+                            (pli.when(scol == nat).then(None).otherwise(scol))
+                            .cast(dtype)
+                            .keep_name()
                         )
                         .to_series()
-                        .cast(dtype, strict=True)
                         ._s
                     )
                     return

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -922,17 +922,39 @@ def test_literal_series() -> None:
     df = pl.DataFrame(
         {
             "a": np.array([21.7, 21.8, 21], dtype=np.float32),
-            "b": np.array([1, 3, 2], dtype=np.int64),
+            "b": np.array([1, 3, 2], dtype=np.int8),
             "c": ["reg1", "reg2", "reg3"],
+            "d": np.array(
+                [datetime(2022, 8, 16), datetime(2022, 8, 17), datetime(2022, 8, 18)],
+                dtype="<M8[ns]",
+            ),
         }
     )
     out = (
         df.lazy()
-        .with_column(pl.Series("e", [2, 1, 3]))  # type: ignore[arg-type]
+        .with_column(pl.Series("e", [2, 1, 3], pl.Int32))  # type: ignore[arg-type]
         .with_column(pl.col("e").cast(pl.Float32))
         .collect()
     )
-    assert out["e"] == [2, 1, 3]
+    expected_schema = {
+        "a": pl.Float32,
+        "b": pl.Int8,
+        "c": pl.Utf8,
+        "d": pl.Datetime("ns"),
+        "e": pl.Float32,
+    }
+    assert_frame_equal(
+        pl.DataFrame(
+            [
+                (21.7, 1, "reg1", datetime(2022, 8, 16, 0), 2),
+                (21.8, 3, "reg2", datetime(2022, 8, 17, 0), 1),
+                (21.0, 2, "reg3", datetime(2022, 8, 18, 0), 3),
+            ],
+            columns=expected_schema,  # type: ignore[arg-type]
+        ),
+        out,
+        atol=0.00001,
+    )
 
 
 def test_to_html(df: pl.DataFrame) -> None:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import Date, Float64, Int32, Int64, UInt32, UInt64
+from polars.datatypes import Date, Datetime, Float64, Int32, Int64, UInt32, UInt64
 from polars.testing import assert_series_equal, verify_series_and_expr_api
 
 
@@ -45,6 +45,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
             == pl.List
         )
         assert pl.Series("a", [10000, 20000, 30000], dtype=pl.Time).dtype == pl.Time
+
         # 2d numpy array
         res = pl.Series(name="a", values=np.array([[1, 2], [3, 4]]))
         assert all(res[0] == np.array([1, 2]))
@@ -56,6 +57,21 @@ def test_init_inputs(monkeypatch: Any) -> None:
 
         # lists
         assert pl.Series("a", [[1, 2], [3, 4]]).dtype == pl.List
+
+    # datetime64: check timeunit (auto-detect, implicit/explcit) and NaT
+    d64 = pd.date_range(date(2021, 8, 1), date(2021, 8, 3)).values
+    d64[1] = None
+
+    expected = [datetime(2021, 8, 1, 0), None, datetime(2021, 8, 3, 0)]
+    for dtype in (None, Datetime, Datetime("ns")):
+        s = pl.Series("dates", d64, dtype)
+        assert s.to_list() == expected
+        assert Datetime == s.dtype
+        assert s.dtype.tu == "ns"  # type: ignore[attr-defined]
+
+    s = pl.Series(values=d64.astype("<M8[ms]"))
+    assert s.dtype.tu == "ms"  # type: ignore[attr-defined]
+    assert expected == s.to_list()
 
     # pandas
     assert pl.Series(pd.Series([1, 2])).dtype == pl.Int64

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -58,7 +58,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
         # lists
         assert pl.Series("a", [[1, 2], [3, 4]]).dtype == pl.List
 
-    # datetime64: check timeunit (auto-detect, implicit/explcit) and NaT
+    # datetime64: check timeunit (auto-detect, implicit/explicit) and NaT
     d64 = pd.date_range(date(2021, 8, 1), date(2021, 8, 3)).values
     d64[1] = None
 


### PR DESCRIPTION
Extends the existing numpy support for Series init to properly handle `np.datetime64` values, with autodetection of time units and handling of NaT values.
