### PR TITLE
feat: Add support for reading non-utf8 encoded CSV files.

### DIFF
--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -25,9 +25,12 @@ except ImportError:
     pass
 
 
-def _process_http_file(path: str) -> BytesIO:
+def _process_http_file(path: str, encoding: str | None = None) -> BytesIO:
     with urlopen(path) as f:
-        return BytesIO(f.read())
+        if not encoding or encoding in {"utf8", "utf8-lossy"}:
+            return BytesIO(f.read())
+        else:
+            return BytesIO(f.read().decode(encoding).encode("utf8"))
 
 
 @overload
@@ -52,7 +55,10 @@ def _prepare_file_arg(
 
 
 def _prepare_file_arg(
-    file: str | list[str] | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+    file: str | list[str] | TextIO | Path | BinaryIO | bytes,
+    encoding: str | None = None,
+    use_pyarrow: bool | None = None,
+    **kwargs: Any,
 ) -> ContextManager[str | BinaryIO | list[str] | list[BinaryIO]]:
     """
     Prepare file argument.
@@ -64,8 +70,16 @@ def _prepare_file_arg(
     A local path is returned as a string.
     An http URL is read into a buffer and returned as a `BytesIO`.
 
+    When ``encoding`` is not ``utf8`` or ``utf8-lossy``, the whole file is
+    first read in python and decoded using the specified encoding and
+    returned as a `BytesIO` (for usage with ``read_csv``).
+
+    A `bytes` file is returned as a `BytesIO` if ``use_pyarrow=True``.
+
     When fsspec is installed, remote file(s) is (are) opened with
     `fsspec.open(file, **kwargs)` or `fsspec.open_files(file, **kwargs)`.
+    If encoding is not ``utf8`` or ``utf8-lossy``, decoding is handled by
+    fsspec too.
 
     """
     # Small helper to use a variable as context
@@ -76,29 +90,50 @@ def _prepare_file_arg(
         finally:
             pass
 
+    has_non_utf8_non_utf8_lossy_encoding = (
+        encoding not in {"utf8", "utf8-lossy"} if encoding else False
+    )
+    encoding_str = encoding if encoding else "utf8"
+
+    if isinstance(file, bytes):
+        if has_non_utf8_non_utf8_lossy_encoding:
+            return BytesIO(file.decode(encoding_str).encode("utf8"))
+        if use_pyarrow:
+            return BytesIO(file)
     if isinstance(file, StringIO):
-        return BytesIO(file.read().encode("utf8"))
+        return BytesIO(file.getvalue().encode("utf8"))
     if isinstance(file, BytesIO):
+        if has_non_utf8_non_utf8_lossy_encoding:
+            return BytesIO(file.getvalue().decode(encoding_str).encode("utf8"))
         return managed_file(file)
     if isinstance(file, Path):
+        if has_non_utf8_non_utf8_lossy_encoding:
+            return BytesIO(file.read_bytes().decode(encoding_str).encode("utf8"))
         return managed_file(format_path(file))
     if isinstance(file, str):
         # make sure that this is before fsspec
         # as fsspec needs requests to be installed
         # to read from http
         if file.startswith("http"):
-            return _process_http_file(file)
+            return _process_http_file(file, encoding_str)
         if _WITH_FSSPEC:
-            if infer_storage_options(file)["protocol"] == "file":
-                return managed_file(format_path(file))
+            if not has_non_utf8_non_utf8_lossy_encoding:
+                if infer_storage_options(file)["protocol"] == "file":
+                    return managed_file(format_path(file))
+            kwargs["encoding"] = encoding
             return fsspec.open(file, **kwargs)
     if isinstance(file, list) and bool(file) and all(isinstance(f, str) for f in file):
         if _WITH_FSSPEC:
-            if all(infer_storage_options(f)["protocol"] == "file" for f in file):
-                return managed_file([format_path(f) for f in file])
+            if not has_non_utf8_non_utf8_lossy_encoding:
+                if all(infer_storage_options(f)["protocol"] == "file" for f in file):
+                    return managed_file([format_path(f) for f in file])
+            kwargs["encoding"] = encoding
             return fsspec.open_files(file, **kwargs)
     if isinstance(file, str):
         file = format_path(file)
+        if has_non_utf8_non_utf8_lossy_encoding:
+            with open(file, encoding=encoding_str) as f:
+                return BytesIO(f.read().encode("utf8"))
     return managed_file(file)
 
 


### PR DESCRIPTION
Add support for reading non-utf8 encoded CSV files in read_csv.
  - Decode CSV files when encoding is not set to "utf8" or
    "utf8-lossy" in _prepare_file_arg if use_pyarrow=False.
    In that case, decoding is done by python, so fast path readers,
    of Polars are not used.
    If use_pyarrow=True, pass the encoding parameter directly to
    pa.csv.read_csv.

Other fixes/features:
  - Return BytesIO object for bytes input in _prepare_file_arg
    when using pyarrow (read_csv, read_ipc, read_parquet) as
    pyarrow only works with file like objects.
  - Check if eol_char argument value for read_csv is 1 byte.
  - Add quote_char support for read_csv:
    - Expand test_csv_quote_char: Check if fields surrounded
      by quotes keep the quotes with quote_char=None, both when
      reading with polars and with pyarrow.
  - Do no check the value of parse_dates when use_pyarrow=True
    as date parsing can't be disabled.