### PR TITLE
feat[python]: support np.datetime64 init for Series

### DIFF
--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -91,6 +91,7 @@ if _NUMPY_AVAILABLE and not _DOCUMENTING:
         np.uint64: PySeries.new_u64,
         np.str_: PySeries.new_str,
         np.bool_: PySeries.new_bool,
+        np.datetime64: PySeries.new_i64,
     }
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from polars import internals as pli
 from polars.datatypes import (
+    DTYPE_TEMPORAL_UNITS,
     Categorical,
     ColumnsType,
     Date,
@@ -101,9 +102,18 @@ def numpy_to_pyseries(
         if dtype == np.float16:
             values = values.astype(np.float32)
             dtype = values.dtype.type
+        elif (
+            dtype == np.datetime64
+            and np.datetime_data(values.dtype)[0] not in DTYPE_TEMPORAL_UNITS
+        ):
+            dtype = object
+
         constructor = numpy_type_to_constructor(dtype)
+
         if dtype == np.float32 or dtype == np.float64:
             return constructor(name, values, nan_to_null)
+        elif dtype == np.datetime64:
+            return constructor(name, values.astype(np.int64), strict)
         else:
             return constructor(name, values, strict)
     else:

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import Date, Float64, Int32, Int64, UInt32, UInt64
+from polars.datatypes import Date, Datetime, Float64, Int32, Int64, UInt32, UInt64
 from polars.testing import assert_series_equal, verify_series_and_expr_api
 
 
@@ -45,6 +45,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
             == pl.List
         )
         assert pl.Series("a", [10000, 20000, 30000], dtype=pl.Time).dtype == pl.Time
+
         # 2d numpy array
         res = pl.Series(name="a", values=np.array([[1, 2], [3, 4]]))
         assert all(res[0] == np.array([1, 2]))
@@ -56,6 +57,21 @@ def test_init_inputs(monkeypatch: Any) -> None:
 
         # lists
         assert pl.Series("a", [[1, 2], [3, 4]]).dtype == pl.List
+
+    # datetime64: check timeunit (auto-detect, implicit/explicit) and NaT
+    d64 = pd.date_range(date(2021, 8, 1), date(2021, 8, 3)).values
+    d64[1] = None
+
+    expected = [datetime(2021, 8, 1, 0), None, datetime(2021, 8, 3, 0)]
+    for dtype in (None, Datetime, Datetime("ns")):
+        s = pl.Series("dates", d64, dtype)
+        assert s.to_list() == expected
+        assert Datetime == s.dtype
+        assert s.dtype.tu == "ns"  # type: ignore[attr-defined]
+
+    s = pl.Series(values=d64.astype("<M8[ms]"))
+    assert s.dtype.tu == "ms"  # type: ignore[attr-defined]
+    assert expected == s.to_list()
 
     # pandas
     assert pl.Series(pd.Series([1, 2])).dtype == pl.Int64


### PR DESCRIPTION
Extends the existing numpy support for `Series` init to properly handle `np.datetime64` values, with autodetection of time units ('ms', 'us', 'ns') and handling of `NaT` values.

**[update]**

Also added various improvements to `set_at_idx`:
* allow setting None/null values.
* allow use of single integer index.
* early-exit if given empty sequence of indexes (no-op).
* tweak typing ("Sequence[int]", vs "List[int] | Tuple[int]").
* ensure index Series is cast to correct integer type.
* additional/explicit test coverage.