### PR TITLE
chore[rust]: Fix all clippy warnings except "clippy::borrow_deref_ref".

### DIFF
--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -1565,7 +1565,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
             let iter = self
                 .into_no_null_iter()
                 .skip(init_null_count + 1)
-                .map(|val| call_with_value(val));
+                .map(call_with_value);
             avs.extend(iter);
         }
         Ok(Series::new(self.name(), &avs))

--- a/py-polars/src/arrow_interop/to_rust.rs
+++ b/py-polars/src/arrow_interop/to_rust.rs
@@ -21,7 +21,7 @@ pub fn field_to_rust(obj: &PyAny) -> PyResult<Field> {
 
 // PyList<Field> which you get by calling `list(schema)`
 pub fn pyarrow_schema_to_rust(obj: &PyList) -> PyResult<Schema> {
-    obj.into_iter().map(|fld| field_to_rust(fld)).collect()
+    obj.into_iter().map(field_to_rust).collect()
 }
 
 pub fn array_to_rust(obj: &PyAny) -> PyResult<ArrayRef> {
@@ -42,7 +42,7 @@ pub fn array_to_rust(obj: &PyAny) -> PyResult<ArrayRef> {
     unsafe {
         let field = ffi::import_field_from_c(schema.as_ref()).map_err(PyPolarsErr::from)?;
         let array = ffi::import_array_from_c(*array, field.data_type).map_err(PyPolarsErr::from)?;
-        Ok(array.into())
+        Ok(array)
     }
 }
 
@@ -102,6 +102,5 @@ pub fn to_rust_df(rb: &[&PyAny]) -> PyResult<DataFrame> {
         })
         .collect::<PyResult<Vec<_>>>()?;
 
-    let out = Ok(accumulate_dataframes_vertical_unchecked(dfs));
-    out
+    Ok(accumulate_dataframes_vertical_unchecked(dfs))
 }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -417,6 +417,7 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn write_csv(
         &mut self,
         py: Python,
@@ -534,7 +535,7 @@ impl PyDataFrame {
             match st {
                 None => st = Some(dt_i.clone()),
                 Some(ref mut st) => {
-                    *st = get_supertype(&st, dt_i).ok()?;
+                    *st = get_supertype(st, dt_i).ok()?;
                 }
             }
         }
@@ -950,7 +951,7 @@ impl PyDataFrame {
     pub fn slice(&self, offset: usize, length: Option<usize>) -> Self {
         let df = self
             .df
-            .slice(offset as i64, length.unwrap_or(self.df.height()));
+            .slice(offset as i64, length.unwrap_or_else(|| self.df.height()));
         df.into()
     }
 

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -65,10 +65,10 @@ impl From<DataType> for PyDataType {
     }
 }
 
-impl Into<DataType> for PyDataType {
-    fn into(self) -> DataType {
+impl From<PyDataType> for DataType {
+    fn from(pdt: PyDataType) -> DataType {
         use DataType::*;
-        match self {
+        match pdt {
             PyDataType::Int8 => Int8,
             PyDataType::Int16 => Int16,
             PyDataType::Int32 => Int32,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1205,6 +1205,7 @@ impl PyExpr {
         self.inner.clone().rolling_median(options).into()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn rolling_quantile(
         &self,
         quantile: f64,

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -291,7 +291,7 @@ impl PySeries {
                 if fast_explode {
                     out.set_fast_explode()
                 }
-                return Ok(out.into_series().into());
+                Ok(out.into_series().into())
             }
             _ => {
                 let series: Series =
@@ -493,7 +493,7 @@ impl PySeries {
     pub fn slice(&self, offset: i64, length: Option<usize>) -> Self {
         let series = self
             .series
-            .slice(offset, length.unwrap_or(self.series.len()));
+            .slice(offset, length.unwrap_or_else(|| self.series.len()));
         series.into()
     }
 


### PR DESCRIPTION
Fix all clippy warnings except "clippy::borrow_deref_ref":

    cargo clippy -- -D warnings -A clippy::borrow_deref_ref