### PR TITLE
fix[rust]: handle NaNs in argsort

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -24,7 +24,7 @@ type Len = usize;
 
 pub fn compare_fn_nan_min<T>(a: &T, b: &T) -> Ordering
 where
-    T: PartialOrd + IsFloat + NativeType,
+    T: PartialOrd + IsFloat,
 {
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {
@@ -41,9 +41,9 @@ where
     }
 }
 
-fn compare_fn_nan_max<T>(a: &T, b: &T) -> Ordering
+pub fn compare_fn_nan_max<T>(a: &T, b: &T) -> Ordering
 where
-    T: PartialOrd + IsFloat + NativeType,
+    T: PartialOrd + IsFloat,
 {
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {

--- a/polars/polars-ops/src/series/ops/search_sorted.rs
+++ b/polars/polars-ops/src/series/ops/search_sorted.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use polars_arrow::kernels::rolling::compare_fn_nan_min;
+use polars_arrow::kernels::rolling::compare_fn_nan_max;
 use polars_arrow::prelude::*;
 use polars_core::downcast_as_macro_arg_physical;
 use polars_core::export::num::NumCast;
@@ -27,7 +27,7 @@ where
         // - `mid < size`: `mid` is limited by `[left; right)` bound.
         let cmp = match unsafe { taker.get_unchecked(mid as usize) } {
             None => Ordering::Less,
-            Some(value) => compare_fn_nan_min(&value, &search_value),
+            Some(value) => compare_fn_nan_max(&value, &search_value),
         };
 
         // The reason why we use if/else control flow rather than match

--- a/py-polars/tests/test_sort.py
+++ b/py-polars/tests/test_sort.py
@@ -209,3 +209,20 @@ def test_sorted_fast_paths() -> None:
     assert rev.to_list() == [None, 3, 2, 1]
     assert rev.sort(reverse=True).to_list() == [None, 3, 2, 1]
     assert rev.sort().to_list() == [None, 1, 2, 3]
+
+
+def test_argsort_rank_nans() -> None:
+    assert (
+        pl.DataFrame(
+            {
+                "val": [1.0, float("NaN")],
+            }
+        )
+        .with_columns(
+            [
+                pl.col("val").rank().alias("rank"),
+                pl.col("val").argsort().alias("argsort"),
+            ]
+        )
+        .select(["rank", "argsort"])
+    ).to_dict(False) == {"rank": [1.0, 2.0], "argsort": [0, 1]}


### PR DESCRIPTION
fixes #4492

This should also make `argsort` on integers faster as we have elided a branch on every comparison.