### PR TITLE
fix[python]: ewm_mean better handling of min_periods

### DIFF
--- a/polars/polars-arrow/src/kernels/ewm/average.rs
+++ b/polars/polars-arrow/src/kernels/ewm/average.rs
@@ -1,184 +1,53 @@
-use std::fmt::Debug;
-use std::ops::AddAssign;
-
+use arrow::array::PrimitiveArray;
+use arrow::types::NativeType;
 use num::Float;
 
-use crate::trusted_len::{PushUnchecked, TrustedLen};
+use crate::trusted_len::PushUnchecked;
+
 // See:
 // https://github.com/pola-rs/polars/issues/2148
 // https://stackoverflow.com/a/51392341/6717054
 
-// this is the adjusted variant in pandas
-pub fn ewma_no_nulls<T, I>(vals: I, alpha: T) -> Vec<T>
+pub fn ewm_mean<T>(
+    xs: &PrimitiveArray<T>,
+    alpha: T,
+    adjust: bool,
+    min_periods: usize,
+) -> PrimitiveArray<T>
 where
-    T: Float + AddAssign,
-    I: IntoIterator<Item = T>,
-    I::IntoIter: TrustedLen,
+    T: Float + NativeType,
 {
-    let mut iter = vals.into_iter();
-    let len = iter.size_hint().1.unwrap();
-    if len == 0 {
-        return vec![];
-    }
-    let mut weight = T::one();
-    let mut out = Vec::with_capacity(len);
+    let n = xs.len();
+    let mut results = Vec::with_capacity(n);
 
-    let first = iter.next().unwrap();
-    out.push(first);
-    let mut ewma_old = first;
+    let mut denom = T::zero();
     let one_sub_alpha = T::one() - alpha;
+    let mut non_null_cnt = 0usize;
 
-    let mut i = T::from(out.len()).unwrap();
-    for val in iter {
-        weight += one_sub_alpha.powf(i);
-        ewma_old = ewma_old * (one_sub_alpha) + val;
-        // Safety:
-        // we allocated vals.len()
-        unsafe { out.push_unchecked(ewma_old / weight) };
-        i += T::one();
-    }
+    let mut opt_ewma = None;
 
-    out
-}
+    for opt_x in xs.iter() {
+        if let Some(&x) = opt_x {
+            non_null_cnt += 1;
 
-pub fn ewma<T, I>(vals: I, alpha: T) -> (usize, Vec<T>)
-where
-    T: Float + AddAssign,
-    I: IntoIterator<Item = Option<T>>,
-    I::IntoIter: TrustedLen,
-{
-    let mut iter = vals.into_iter();
-    let len = iter.size_hint().1.unwrap();
-    if len == 0 {
-        return (0, vec![]);
-    }
-    let mut weight = T::one();
-    let mut out = Vec::with_capacity(len);
+            let prev_ewma = opt_ewma.unwrap_or(x);
 
-    let leading_null_count = set_first_none_null(&mut iter, &mut out);
-    let mut ewma_old = out[out.len() - 1];
-    let one_sub_alpha = T::one() - alpha;
-
-    let mut i = T::one();
-    let mut prev = out[out.len() - 1];
-    for opt_val in iter {
-        prev = match opt_val {
-            Some(val) => {
-                weight += one_sub_alpha.powf(i);
-                ewma_old = ewma_old * (one_sub_alpha) + val;
-                i += T::one();
-                ewma_old / weight
-            }
-            None => prev,
-        };
-        // Safety:
-        // we allocated vals.len()
-        unsafe { out.push_unchecked(prev) };
-    }
-
-    (leading_null_count, out)
-}
-
-// this is the non-adjusted variant in pandas
-pub fn ewma_inf_hist_no_nulls<T, I>(vals: I, alpha: T) -> Vec<T>
-where
-    T: Float + AddAssign + Debug,
-    I: IntoIterator<Item = T>,
-    I::IntoIter: TrustedLen,
-{
-    let mut iter = vals.into_iter();
-    let len = iter.size_hint().1.unwrap();
-    if len == 0 {
-        return vec![];
-    }
-
-    let mut out = Vec::with_capacity(len);
-    let first = iter.next().unwrap();
-    out.push(first);
-    let one_sub_alpha = T::one() - alpha;
-
-    let mut prev = out[0];
-    for val in iter {
-        let output_val = val * alpha + prev * one_sub_alpha;
-        prev = output_val;
-
-        // Safety:
-        // we allocated vals.len()
-        unsafe { out.push_unchecked(output_val) }
-    }
-
-    out
-}
-
-// this is the non-adjusted variant in pandas
-/// # Arguments
-///
-/// * `vals` - Iterator of optional values
-/// * `alpha` - Smoothing factor
-///
-/// Returns the a tuple with:
-/// * `leading_null_count` - the amount of nulls that must be set by the caller
-/// * `smoothed values` - The result of the ewma
-///
-pub fn ewma_inf_hists<T, I>(vals: I, alpha: T) -> (usize, Vec<T>)
-where
-    T: Float + AddAssign + Debug,
-    I: IntoIterator<Item = Option<T>>,
-    I::IntoIter: TrustedLen,
-{
-    let mut iter = vals.into_iter();
-    let len = iter.size_hint().1.unwrap();
-    if len == 0 {
-        return (0, vec![]);
-    }
-
-    let mut out = Vec::with_capacity(len);
-
-    let leading_null_count = set_first_none_null(&mut iter, &mut out);
-    let one_sub_alpha = T::one() - alpha;
-    let mut prev = out[out.len() - 1];
-
-    for opt_val in iter {
-        let output_val = match opt_val {
-            Some(val) => {
-                // Safety:
-                // we add first, so i - 1 always exits
-                let output = val * alpha + prev * one_sub_alpha;
-                prev = output;
-                prev
-            }
-            None => prev,
-        };
-
-        // Safety:
-        // we allocated vals.len()
-        unsafe { out.push_unchecked(output_val) }
-    }
-
-    (leading_null_count, out)
-}
-
-pub fn set_first_none_null<T, I>(iter: &mut I, out: &mut Vec<T>) -> usize
-where
-    T: Float + AddAssign,
-    I: Iterator<Item = Option<T>>,
-{
-    let mut leading_null_count = 0;
-    // find first non null
-    for opt_val in iter {
-        match opt_val {
-            // these will be later masked out by the validity
-            None => {
-                leading_null_count += 1;
-                unsafe { out.push_unchecked(T::zero()) };
-            }
-            Some(val) => {
-                unsafe { out.push_unchecked(val) };
-                break;
-            }
+            let value = if adjust {
+                let numer = prev_ewma * denom * one_sub_alpha + x;
+                denom = T::one() + one_sub_alpha * denom;
+                numer / denom
+            } else {
+                x * alpha + prev_ewma * one_sub_alpha
+            };
+            opt_ewma = Some(value);
         }
+        let push_me = match non_null_cnt < min_periods {
+            true => None,
+            false => opt_ewma,
+        };
+        unsafe { results.push_unchecked(push_me) }
     }
-    leading_null_count
+    PrimitiveArray::from(results.as_slice())
 }
 
 #[cfg(test)]
@@ -186,85 +55,115 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_ewma() {
-        let vals = [2.0, 5.0, 3.0];
-        let out = ewma_no_nulls(vals.iter().copied(), 0.5);
-        let expected = [2.0, 4.0, 3.4285714285714284];
-        assert_eq!(out, expected);
+    fn test_ewm_mean_without_null() {
+        let xs = PrimitiveArray::from([Some(1.0f32), Some(2.0f32), Some(3.0f32)]);
 
-        let vals = [2.0, 5.0, 3.0];
-        let out = ewma_inf_hist_no_nulls(vals.iter().copied(), 0.5);
-        let expected = [2.0, 3.5, 3.25];
-        assert_eq!(out, expected);
+        for adjust in [false, true] {
+            let result = ewm_mean(&xs, 0.5, adjust, 0);
+
+            let expected = match adjust {
+                false => PrimitiveArray::from([Some(1.0f32), Some(1.5f32), Some(2.25f32)]),
+                true => PrimitiveArray::from([
+                    Some(1.0f32),
+                    Some(1.6666666666666667f32),
+                    Some(2.4285714285714284f32),
+                ]),
+            };
+            assert_eq!(result, expected);
+        }
     }
 
     #[test]
-    fn test_ewma_null() {
-        let vals = &[
-            Some(2.0),
-            Some(3.0),
-            Some(5.0),
-            Some(7.0),
-            None,
-            None,
-            None,
-            Some(4.0),
-        ];
-        let (cnt, out) = ewma_inf_hists(vals.into_iter().copied(), 0.5);
-        assert_eq!(cnt, 0);
-        let expected = [2.0, 2.5, 3.75, 5.375, 5.375, 5.375, 5.375, 4.6875];
-        assert_eq!(out, expected);
-        let vals = &[
-            None,
-            None,
-            Some(5.0),
-            Some(7.0),
-            None,
-            Some(2.0),
-            Some(1.0),
-            Some(4.0),
-        ];
-        let (cnt, out) = ewma_inf_hists(vals.into_iter().copied(), 0.5);
-        let expected = [0.0, 0.0, 5.0, 6.0, 6.0, 4.0, 2.5, 3.25];
-        assert_eq!(cnt, 2);
-        assert_eq!(out, expected);
+    fn test_ewm_mean_with_null() {
+        let xs = PrimitiveArray::from([Some(1.0f32), None, Some(1.0f32), Some(1.0f32)]);
+        let result = ewm_mean(&xs, 0.5, false, 2);
+        let expected = PrimitiveArray::from([None, None, Some(1.0f32), Some(1.0f32)]);
+        assert_eq!(result, expected);
 
-        let (cnt, out) = ewma(vals.into_iter().copied(), 0.5);
-        let expected = [
-            0.0,
-            0.0,
-            5.0,
-            6.333333333333333,
-            6.333333333333333,
-            3.857142857142857,
-            2.3333333333333335,
-            3.193548387096774,
-        ];
-        assert_eq!(cnt, 2);
-        assert_eq!(out, expected);
+        let xs = PrimitiveArray::from([None, None, Some(1.0f32), Some(1.0f32)]);
+        let result = ewm_mean(&xs, 0.5, false, 1);
+        let expected = PrimitiveArray::from([None, None, Some(1.0f32), Some(1.0f32)]);
+        assert_eq!(result, expected);
 
-        let vals = &[
+        let xs = PrimitiveArray::from([
+            Some(2.0f32),
+            Some(3.0f32),
+            Some(5.0f32),
+            Some(7.0f32),
             None,
-            Some(1.0),
-            Some(5.0),
-            Some(7.0),
             None,
-            Some(2.0),
-            Some(1.0),
-            Some(4.0),
-        ];
-        let (cnt, out) = ewma(vals.into_iter().copied(), 0.5);
-        let expected = [
-            0.0,
-            1.0,
-            3.6666666666666665,
-            5.571428571428571,
-            5.571428571428571,
-            3.6666666666666665,
-            2.2903225806451615,
-            3.1587301587301586,
-        ];
-        assert_eq!(cnt, 1);
-        assert_eq!(out, expected);
+            None,
+            Some(4.0f32),
+        ]);
+        let result = ewm_mean(&xs, 0.5, false, 0);
+        let expected = PrimitiveArray::from([
+            Some(2.0f32),
+            Some(2.5f32),
+            Some(3.75f32),
+            Some(5.375f32),
+            Some(5.375f32),
+            Some(5.375f32),
+            Some(5.375f32),
+            Some(4.6875f32),
+        ]);
+        assert_eq!(result, expected);
+
+        let xs = PrimitiveArray::from([
+            None,
+            None,
+            Some(5.0f32),
+            Some(7.0f32),
+            None,
+            Some(2.0f32),
+            Some(1.0f32),
+            Some(4.0f32),
+        ]);
+        let unadjusted_result = ewm_mean(&xs, 0.5, false, 1);
+        let unadjusted_expected = PrimitiveArray::from([
+            None,
+            None,
+            Some(5.0f32),
+            Some(6.0f32),
+            Some(6.0f32),
+            Some(4.0f32),
+            Some(2.5f32),
+            Some(3.25f32),
+        ]);
+        assert_eq!(unadjusted_result, unadjusted_expected);
+        let adjusted_result = ewm_mean(&xs, 0.5, true, 1);
+        let adjusted_expected = PrimitiveArray::from([
+            None,
+            None,
+            Some(5.0f32),
+            Some(6.333333333333333f32),
+            Some(6.333333333333333f32),
+            Some(3.857142857142857f32),
+            Some(2.3333333333333335f32),
+            Some(3.193548387096774f32),
+        ]);
+        assert_eq!(adjusted_result, adjusted_expected);
+
+        let xs = PrimitiveArray::from([
+            None,
+            Some(1.0f32),
+            Some(5.0f32),
+            Some(7.0f32),
+            None,
+            Some(2.0f32),
+            Some(1.0f32),
+            Some(4.0f32),
+        ]);
+        let result = ewm_mean(&xs, 0.5, true, 1);
+        let expected = PrimitiveArray::from([
+            None,
+            Some(1.0f32),
+            Some(3.6666666666666665f32),
+            Some(5.571428571428571f32),
+            Some(5.571428571428571f32),
+            Some(3.6666666666666665f32),
+            Some(2.2903225806451615f32),
+            Some(3.1587301587301586f32),
+        ]);
+        assert_eq!(result, expected);
     }
 }

--- a/polars/polars-core/src/series/ops/ewm.rs
+++ b/polars/polars-core/src/series/ops/ewm.rs
@@ -1,109 +1,33 @@
 use std::convert::TryFrom;
 
-use arrow::bitmap::MutableBitmap;
-use arrow::types::NativeType;
 pub use polars_arrow::kernels::ewm::EWMOptions;
-use polars_arrow::kernels::ewm::{
-    ewm_std, ewm_var, ewma, ewma_inf_hist_no_nulls, ewma_inf_hists, ewma_no_nulls,
-};
-use polars_arrow::prelude::FromData;
+use polars_arrow::kernels::ewm::{ewm_mean, ewm_std, ewm_var};
 use polars_utils::mem::to_mutable_slice;
 
 use crate::prelude::*;
 
-fn prepare_primitive_array<T: NativeType>(
-    vals: Vec<T>,
-    min_periods: usize,
-    leading_nulls: usize,
-) -> PrimitiveArray<T> {
-    let n = min_periods + leading_nulls;
-    if n > 1 {
-        let mut validity = MutableBitmap::with_capacity(vals.len());
-        validity.extend_constant(n - 1, false);
-        validity.extend_constant(vals.len() - (n - 1), true);
-
-        PrimitiveArray::from_data_default(vals.into(), Some(validity.into()))
-    } else {
-        PrimitiveArray::from_data_default(vals.into(), None)
-    }
-}
-
 impl Series {
     pub fn ewm_mean(&self, options: EWMOptions) -> Result<Self> {
-        match (self.dtype(), self.null_count()) {
-            (DataType::Float32, 0) => {
-                let ca = self.f32().unwrap();
-                match self.n_chunks() {
-                    1 => {
-                        let vals = ca.downcast_iter().next().unwrap();
-                        let vals = vals.values().as_slice();
-                        let out = if options.adjust {
-                            ewma_no_nulls(vals.iter().copied(), options.alpha as f32)
-                        } else {
-                            ewma_inf_hist_no_nulls(vals.iter().copied(), options.alpha as f32)
-                        };
-                        let arr = prepare_primitive_array(out, options.min_periods, 0);
-                        Series::try_from((self.name(), Box::new(arr) as ArrayRef))
-                    }
-                    _ => {
-                        let iter = ca.into_no_null_iter();
-                        let out = if options.adjust {
-                            ewma_no_nulls(iter, options.alpha as f32)
-                        } else {
-                            ewma_inf_hist_no_nulls(iter, options.alpha as f32)
-                        };
-                        let arr = prepare_primitive_array(out, options.min_periods, 0);
-                        Series::try_from((self.name(), Box::new(arr) as ArrayRef))
-                    }
-                }
+        match self.dtype() {
+            DataType::Float32 => {
+                let xs = self.f32().unwrap().downcast_iter().next().unwrap();
+                let result = ewm_mean(
+                    xs,
+                    options.alpha as f32,
+                    options.adjust,
+                    options.min_periods,
+                );
+                Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
-            (DataType::Float64, 0) => {
-                let ca = self.f64().unwrap();
-                match self.n_chunks() {
-                    1 => {
-                        let vals = ca.downcast_iter().next().unwrap();
-                        let vals = vals.values().as_slice();
-                        let out = if options.adjust {
-                            ewma_no_nulls(vals.iter().copied(), options.alpha)
-                        } else {
-                            ewma_inf_hist_no_nulls(vals.iter().copied(), options.alpha)
-                        };
-                        let arr = prepare_primitive_array(out, options.min_periods, 0);
-                        Series::try_from((self.name(), Box::new(arr) as ArrayRef))
-                    }
-                    _ => {
-                        let iter = ca.into_no_null_iter();
-                        let out = if options.adjust {
-                            ewma_no_nulls(iter, options.alpha)
-                        } else {
-                            ewma_inf_hist_no_nulls(iter, options.alpha)
-                        };
-                        let arr = prepare_primitive_array(out, options.min_periods, 0);
-                        Series::try_from((self.name(), Box::new(arr) as ArrayRef))
-                    }
-                }
-            }
-            (DataType::Float32, _) => {
-                let ca = self.f32().unwrap();
-                let iter = ca.into_iter();
-                let (leading_nulls, out) = if options.adjust {
-                    ewma(iter, options.alpha as f32)
-                } else {
-                    ewma_inf_hists(iter, options.alpha as f32)
-                };
-                let arr = prepare_primitive_array(out, options.min_periods, leading_nulls);
-                Series::try_from((self.name(), Box::new(arr) as ArrayRef))
-            }
-            (DataType::Float64, _) => {
-                let ca = self.f64().unwrap();
-                let iter = ca.into_iter();
-                let (leading_nulls, out) = if options.adjust {
-                    ewma(iter, options.alpha as f64)
-                } else {
-                    ewma_inf_hists(iter, options.alpha)
-                };
-                let arr = prepare_primitive_array(out, options.min_periods, leading_nulls);
-                Series::try_from((self.name(), Box::new(arr) as ArrayRef))
+            DataType::Float64 => {
+                let xs = self.f64().unwrap().downcast_iter().next().unwrap();
+                let result = ewm_mean(
+                    xs,
+                    options.alpha as f64,
+                    options.adjust,
+                    options.min_periods,
+                );
+                Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
             _ => self.cast(&DataType::Float64)?.ewm_mean(options),
         }

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -251,7 +251,6 @@ def test_append_extend() -> None:
     a.append(b, append_chunks=False)
     expected = pl.Series("a", [1, 2, 8, 9, None])
     assert a.series_equal(expected, null_equal=True)
-    print(a.chunk_lengths())
     assert a.n_chunks() == 1
 
 
@@ -1638,6 +1637,34 @@ def test_ewm_mean_leading_nulls() -> None:
     assert pl.Series([None, 1.0, 1.0, 1.0]).ewm_mean(
         alpha=0.5, min_periods=2
     ).to_list() == [None, None, 1.0, 1.0]
+
+
+def test_ewm_mean_min_periods() -> None:
+    series = pl.Series([1.0, None, None, None])
+
+    ewm_mean = series.ewm_mean(alpha=0.5, min_periods=1)
+    assert ewm_mean.to_list() == [1.0, 1.0, 1.0, 1.0]
+    ewm_mean = series.ewm_mean(alpha=0.5, min_periods=2)
+    assert ewm_mean.to_list() == [None, None, None, None]
+
+    series = pl.Series([1.0, None, 2.0, None, 3.0])
+
+    ewm_mean = series.ewm_mean(alpha=0.5, min_periods=1)
+    assert ewm_mean.to_list() == [
+        1.0,
+        1.0,
+        1.6666666666666667,
+        1.6666666666666667,
+        2.4285714285714284,
+    ]
+    ewm_mean = series.ewm_mean(alpha=0.5, min_periods=2)
+    assert ewm_mean.to_list() == [
+        None,
+        None,
+        1.6666666666666667,
+        1.6666666666666667,
+        2.4285714285714284,
+    ]
 
 
 def test_ewm_std_var() -> None:


### PR DESCRIPTION
fixes the issue I brought up [here](https://github.com/pola-rs/polars/issues/4463#issuecomment-1219384091)

This MR unifies the four different implementations we had for `ewm_mean`. The difference between the `adjusted` and `unadjusted` versions is a single line of code. And we shouldn't need separate implementations for "with null" and "without null" -- a "with null" version should be capable of handling data without nulls.