### PR TITLE
fix[python]: default numpy array keep dimensions

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -563,13 +563,24 @@ def numpy_to_pydf(
         n_columns = 1
 
     elif len(shape) == 2:
-        # Infer orientation
-        if orient is None and columns is not None:
-            orient = "col" if len(columns) == shape[0] else "row"
-
-        if orient == "row":
+        # default convention
+        # first axis is rows, second axis is columns
+        if orient is None and columns is None:
             n_columns = shape[1]
-        elif orient == "col" or orient is None:
+            orient = "row"
+
+        # Infer orientation if columns argument is given
+        elif orient is None and columns is not None:
+            if len(columns) == shape[0]:
+                orient = "col"
+                n_columns = shape[0]
+            else:
+                orient = "row"
+                n_columns = shape[1]
+
+        elif orient == "row":
+            n_columns = shape[1]
+        elif orient == "col":
             n_columns = shape[0]
         else:
             raise ValueError(

--- a/py-polars/tests/test_constructors.py
+++ b/py-polars/tests/test_constructors.py
@@ -126,8 +126,12 @@ def test_init_ndarray(monkeypatch: Any) -> None:
 
     # 2D array - default to column orientation
     df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
-    truth = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
+    truth = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
     assert df.frame_equal(truth)
+
+    # no orientation is numpy convention
+    df = pl.DataFrame(np.ones((3, 1)))
+    assert df.shape == (3, 1)
 
     # 2D array - row orientation inferred
     df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), columns=["a", "b", "c"])


### PR DESCRIPTION
I think this was an unintended side effect from earlier numpy refactors. In any case a 2D numpy array should always keep the `row, column` shape orientation if not set by us.

I found this in this [SO](https://stackoverflow.com/questions/72669537/performance-improvements-for-python-polars-df-select-operations/72669737?noredirect=1#comment129662311_72669737_) indicating a regression.

It turns out that passing a (n, 1) matrix turned out to be a (1, n) matrix. This fixes that whilst keeping the other behavior as similar as possible.