### PR TITLE
feat[rust]: introduce `how="right"` parameter to join methods

### DIFF
--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -604,7 +604,7 @@ impl DataFrame {
             )
         };
 
-        self.finish_join(left, right_df, None)
+        self.assign_suffixes_and_hstack(left, right_df, None)
     }
 
     /// This is similar to a left-join except that we match on nearest key rather than equal keys.

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -198,7 +198,7 @@ impl DataFrame {
             )
         };
 
-        self.finish_join(left, right_df, suffix)
+        self.assign_suffixes_and_hstack(left, right_df, suffix)
     }
 
     /// This is similar to a left-join except that we match on nearest key rather than equal keys.

--- a/polars/polars-core/src/frame/cross_join.rs
+++ b/polars/polars-core/src/frame/cross_join.rs
@@ -81,7 +81,7 @@ impl DataFrame {
 
         let (l_df, r_df) = POOL.install(|| rayon::join(create_left_df, create_right_df));
 
-        self.finish_join(l_df, r_df, suffix)
+        self.assign_suffixes_and_hstack(l_df, r_df, suffix)
     }
 }
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3551,9 +3551,9 @@ class DataFrame:
     def join(
         self,
         other: DataFrame,
-        left_on: str | pli.Expr | list[str | pli.Expr] | None = None,
-        right_on: str | pli.Expr | list[str | pli.Expr] | None = None,
-        on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        left_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        right_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
         how: JoinStrategy = "inner",
         suffix: str = "_right",
     ) -> DataFrame:
@@ -3563,7 +3563,7 @@ class DataFrame:
         Parameters
         ----------
         other
-            DataFrame to join with.
+            ``DataFrame`` to join with.
         left_on
             Name(s) of the left join column(s).
         right_on
@@ -3577,7 +3577,7 @@ class DataFrame:
 
         Returns
         -------
-            Joined DataFrame
+            Joined ``DataFrame``
 
         See Also
         --------
@@ -3626,52 +3626,23 @@ class DataFrame:
         │ 3    ┆ 8.0  ┆ c   ┆ null  │
         └──────┴──────┴─────┴───────┘
 
-        **Joining on columns with categorical data**
-        See pl.StringCache().
+        Note
+        ----
+        For joining on columns with categorical data, see ``pl.StringCache()``.
 
         """
-        if how == "cross":
-            return self._from_pydf(self._df.join(other._df, [], [], how, suffix))
-
-        left_on_: list[str | pli.Expr] | None
-        if isinstance(left_on, (str, pli.Expr)):
-            left_on_ = [left_on]
-        else:
-            left_on_ = left_on
-
-        right_on_: list[str | pli.Expr] | None
-        if isinstance(right_on, (str, pli.Expr)):
-            right_on_ = [right_on]
-        else:
-            right_on_ = right_on
-
-        if isinstance(on, (str, pli.Expr)):
-            left_on_ = [on]
-            right_on_ = [on]
-        elif isinstance(on, list):
-            left_on_ = on
-            right_on_ = on
-
-        if left_on_ is None or right_on_ is None:
-            raise ValueError("You should pass the column to join on as an argument.")
-
-        if isinstance(left_on_[0], pli.Expr) or isinstance(right_on_[0], pli.Expr):
-            return (
-                self.lazy()
-                .join(
-                    other.lazy(),
-                    left_on,
-                    right_on,
-                    on=on,
-                    how=how,
-                    suffix=suffix,
-                )
-                .collect(no_optimization=True)
+        return (
+            self.lazy()
+            .join(
+                other.lazy(),
+                left_on,
+                right_on,
+                on=on,
+                how=how,
+                suffix=suffix,
             )
-        else:
-            return self._from_pydf(
-                self._df.join(other._df, left_on_, right_on_, how, suffix)
-            )
+            .collect(no_optimization=True)
+        )
 
     def apply(
         self: DF,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -23,7 +23,8 @@ from polars.utils import (
     _in_notebook,
     _prepare_row_count_args,
     _process_null_values,
-    format_path, _standardize_join_key,
+    _standardize_join_key,
+    format_path,
 )
 
 try:

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -58,7 +58,7 @@ InterpolationMethod: TypeAlias = Literal[
     "nearest", "higher", "lower", "midpoint", "linear"
 ]  # QuantileInterpolOptions
 JoinStrategy: TypeAlias = Literal[
-    "inner", "left", "outer", "semi", "anti", "cross"
+    "inner", "left", "outer", "semi", "anti", "cross", "right"
 ]  # JoinType
 ToStructStrategy: TypeAlias = Literal[
     "first_non_null", "max_width"

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -358,3 +358,26 @@ def scale_bytes(sz: int, to: SizeUnit) -> int | float:
     if scaling_factor > 1:
         return sz / scaling_factor
     return sz
+
+
+def _standardize_join_key(
+    key: str | pli.Expr | Sequence[str | pli.Expr] | None,
+) -> list[PyExpr] | None:
+    """Standardize the given join keys."""
+    if isinstance(key, str):
+        return [pli.col(key)._pyexpr]
+    elif isinstance(key, pli.Expr):
+        return [key._pyexpr]
+    elif isinstance(key, Sequence):
+        result = []
+        for k in key:
+            if isinstance(k, str):
+                expr = pli.col(k)
+            elif isinstance(k, pli.Expr):
+                expr = k
+            else:
+                raise TypeError(f"encountered unexpected key type, {type(k)}")
+            result.append(expr._pyexpr)
+        return result
+    else:
+        return key

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -824,6 +824,7 @@ impl FromPyObject<'_> for Wrap<JoinType> {
         let parsed = match ob.extract::<&str>()? {
             "inner" => JoinType::Inner,
             "left" => JoinType::Left,
+            "right" => JoinType::Right,
             "outer" => JoinType::Outer,
             "semi" => JoinType::Semi,
             "anti" => JoinType::Anti,
@@ -831,7 +832,7 @@ impl FromPyObject<'_> for Wrap<JoinType> {
             "cross" => JoinType::Cross,
             v => {
                 return Err(PyValueError::new_err(format!(
-                "how must be one of {{'inner', 'left', 'outer', 'semi', 'anti', 'cross'}}, got {}",
+                "how must be one of {{'inner', 'left', 'outer', 'semi', 'anti', 'cross', 'right}}, got {}",
                 v
             )))
             }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -757,21 +757,6 @@ impl PyDataFrame {
         format!("{:?}", self.df)
     }
 
-    pub fn join(
-        &self,
-        other: &PyDataFrame,
-        left_on: Vec<&str>,
-        right_on: Vec<&str>,
-        how: Wrap<JoinType>,
-        suffix: String,
-    ) -> PyResult<Self> {
-        let df = self
-            .df
-            .join(&other.df, left_on, right_on, how.0, Some(suffix))
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
-    }
-
     pub fn get_columns(&self) -> Vec<PySeries> {
         let cols = self.df.get_columns().clone();
         to_pyseries_collection(cols)

--- a/py-polars/tests/test_joins.py
+++ b/py-polars/tests/test_joins.py
@@ -263,6 +263,56 @@ def test_join() -> None:
     assert lazy_join.shape == eager_join.shape
 
 
+def test_join_right() -> None:
+    x = pl.DataFrame({"row_id": [1, 2, 3, 4, 5], "values": [5, 6, 7, 8, 9]})
+    y = pl.DataFrame({"row_id": [1, 2, 3, 4], "values": [10, 11, 12, 13]})
+
+    result = x.join(y, how="right", on="row_id", suffix="_y")
+    expected = pl.DataFrame(
+        {"values": [5, 6, 7, 8], "row_id": [1, 2, 3, 4], "values_y": [10, 11, 12, 13]}
+    )
+    assert result.frame_equal(expected)
+
+    result = y.join(x, how="right", on="row_id", suffix="_x")
+    expected = pl.DataFrame(
+        {
+            "values": [10, 11, 12, 13, None],
+            "row_id": [1, 2, 3, 4, 5],
+            "values_x": [5, 6, 7, 8, 9],
+        }
+    )
+    assert result.frame_equal(expected)
+
+    x = pl.DataFrame(
+        {"id_1": [1, 1, 2, 2, 3], "id_2": [1, 2, 1, 2, 1], "values": [5, 6, 7, 8, 9]}
+    )
+    y = pl.DataFrame(
+        {"id_1": [1, 1, 2, 2], "id_2": [1, 2, 1, 2], "values": [9, 10, 11, 12]}
+    )
+
+    result = x.join(y, how="right", on=["id_1", "id_2"], suffix="_y")
+    expected = pl.DataFrame(
+        {
+            "values": [5, 6, 7, 8],
+            "id_1": [1, 1, 2, 2],
+            "id_2": [1, 2, 1, 2],
+            "values_y": [9, 10, 11, 12],
+        }
+    )
+    assert result.frame_equal(expected)
+
+    result = y.join(x, how="right", on=["id_1", "id_2"], suffix="_x")
+    expected = pl.DataFrame(
+        {
+            "values": [9, 10, 11, 12, None],
+            "id_1": [1, 1, 2, 2, 3],
+            "id_2": [1, 2, 1, 2, 1],
+            "values_x": [5, 6, 7, 8, 9],
+        }
+    )
+    assert result.frame_equal(expected)
+
+
 def test_joins_dispatch() -> None:
     # this just flexes the dispatch a bit
 


### PR DESCRIPTION
Closes #3934 

This MR has two commits

1. Simplify `DataFrame.join` and `LazyFrame.join` by housing all the "business logic" within `LazyFrame.join`. `DataFrame.join` then becomes a wrapper to `LazyFrame.join`. @ritchie46 any red flags here?
2. Adds `how="right"` parameter to both join methods.

Question: we call `collect(no_optimization=True)`, is there a reason for this? Or can we turn it on?