### PR TITLE
fix[rust]: specialize sqrt as power behavior of infinite values is wrong

### DIFF
--- a/py-polars/tests/test_arithmetic.py
+++ b/py-polars/tests/test_arithmetic.py
@@ -1,0 +1,13 @@
+import polars as pl
+
+
+def test_sqrt_neg_inf() -> None:
+    out = pl.DataFrame(
+        {
+            "val": [float("-Inf"), -9, 0, 9, float("Inf")],
+        }
+    ).with_column(pl.col("val").sqrt().alias("sqrt"))
+    # comparing nans and infinities by string value as they are not cmp
+    assert str(out["sqrt"].to_list()) == str(
+        [float("NaN"), float("NaN"), 0.0, 3.0, float("Inf")]
+    )


### PR DESCRIPTION
This probably is also faster as we now call a specialized `f32::sqrt`.