### PR TITLE
feat[rust]: allow io functions to take `AsRef<Path>`s instead of `String` for path arguments

### DIFF
--- a/examples/read_csv/src/main.rs
+++ b/examples/read_csv/src/main.rs
@@ -1,7 +1,7 @@
 use polars::prelude::*;
 
 fn main() -> Result<()> {
-    let mut df = LazyCsvReader::new("../datasets/foods1.csv".into())
+    let mut df = LazyCsvReader::new("../datasets/foods1.csv")
         .finish()?
         .select([
             // select all columns

--- a/examples/read_parquet/src/main.rs
+++ b/examples/read_parquet/src/main.rs
@@ -1,17 +1,14 @@
 use polars::prelude::*;
 
 fn main() -> Result<()> {
-    let df = LazyFrame::scan_parquet(
-        "../datasets/foods1.parquet".into(),
-        ScanArgsParquet::default(),
-    )?
-    .select([
-        // select all columns
-        all(),
-        // and do some aggregations
-        cols(["fats_g", "sugars_g"]).sum().suffix("_summed"),
-    ])
-    .collect()?;
+    let df = LazyFrame::scan_parquet("../datasets/foods1.parquet", ScanArgsParquet::default())?
+        .select([
+            // select all columns
+            all(),
+            // and do some aggregations
+            cols(["fats_g", "sugars_g"]).sum().suffix("_summed"),
+        ])
+        .collect()?;
 
     dbg!(df);
     Ok(())

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -61,10 +61,9 @@ impl LazyFrame {
             let lfs = paths
                 .map(|r| {
                     let path = r.map_err(|e| PolarsError::ComputeError(format!("{}", e).into()))?;
-                    let path_string = path.to_string_lossy().into_owned();
                     let mut args = args.clone();
                     args.row_count = None;
-                    Self::scan_ipc_impl(path_string, args)
+                    Self::scan_ipc_impl(path, args)
                 })
                 .collect::<Result<Vec<_>>>()?;
 

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use polars_core::prelude::*;
 use polars_io::RowCount;
 
@@ -25,7 +27,7 @@ impl Default for ScanArgsIpc {
 }
 
 impl LazyFrame {
-    fn scan_ipc_impl(path: String, args: ScanArgsIpc) -> Result<Self> {
+    fn scan_ipc_impl(path: impl AsRef<Path>, args: ScanArgsIpc) -> Result<Self> {
         let options = IpcScanOptions {
             n_rows: args.n_rows,
             cache: args.cache,
@@ -35,7 +37,9 @@ impl LazyFrame {
             memmap: args.memmap,
         };
         let row_count = args.row_count;
-        let mut lf: LazyFrame = LogicalPlanBuilder::scan_ipc(path, options)?.build().into();
+        let mut lf: LazyFrame = LogicalPlanBuilder::scan_ipc(path.as_ref(), options)?
+            .build()
+            .into();
         lf.opt_state.file_caching = true;
 
         // it is a bit hacky, but this row_count function updates the schema
@@ -48,9 +52,11 @@ impl LazyFrame {
 
     /// Create a LazyFrame directly from a ipc scan.
     #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
-    pub fn scan_ipc(path: String, args: ScanArgsIpc) -> Result<Self> {
-        if path.contains('*') {
-            let paths = glob::glob(&path)
+    pub fn scan_ipc(path: impl AsRef<Path>, args: ScanArgsIpc) -> Result<Self> {
+        let path = path.as_ref();
+        let path_str = path.to_string_lossy();
+        if path_str.contains('*') {
+            let paths = glob::glob(&path_str)
                 .map_err(|_| PolarsError::ComputeError("invalid glob pattern given".into()))?;
             let lfs = paths
                 .map(|r| {

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -1,3 +1,6 @@
+use std::io;
+use std::path::Path;
+
 use polars_core::prelude::*;
 use polars_io::parquet::ParallelStrategy;
 use polars_io::RowCount;
@@ -29,7 +32,7 @@ impl Default for ScanArgsParquet {
 
 impl LazyFrame {
     fn scan_parquet_impl(
-        path: String,
+        path: impl AsRef<Path>,
         n_rows: Option<usize>,
         cache: bool,
         parallel: ParallelStrategy,
@@ -38,7 +41,13 @@ impl LazyFrame {
         low_memory: bool,
     ) -> Result<Self> {
         let mut lf: LazyFrame = LogicalPlanBuilder::scan_parquet(
-            path, n_rows, cache, parallel, None, rechunk, low_memory,
+            path.as_ref(),
+            n_rows,
+            cache,
+            parallel,
+            None,
+            rechunk,
+            low_memory,
         )?
         .build()
         .into();
@@ -67,12 +76,15 @@ impl LazyFrame {
     /// Create a LazyFrame directly from a parquet scan.
     #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     #[deprecated(note = "please use `concat_lf` instead")]
-    pub fn scan_parquet_files(paths: Vec<String>, args: ScanArgsParquet) -> Result<Self> {
+    pub fn scan_parquet_files<P: AsRef<Path>>(
+        paths: Vec<P>,
+        args: ScanArgsParquet,
+    ) -> Result<Self> {
         let lfs = paths
             .iter()
             .map(|p| {
                 Self::scan_parquet_impl(
-                    p.to_string(),
+                    p,
                     args.n_rows,
                     args.cache,
                     args.parallel,
@@ -88,9 +100,11 @@ impl LazyFrame {
 
     /// Create a LazyFrame directly from a parquet scan.
     #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
-    pub fn scan_parquet(path: String, args: ScanArgsParquet) -> Result<Self> {
-        if path.contains('*') {
-            let paths = glob::glob(&path)
+    pub fn scan_parquet(path: impl AsRef<Path>, args: ScanArgsParquet) -> Result<Self> {
+        let path = path.as_ref();
+        let path_str = path.to_string_lossy();
+        if path_str.contains('*') {
+            let paths = glob::glob(&path_str)
                 .map_err(|_| PolarsError::ComputeError("invalid glob pattern given".into()))?;
             let lfs = paths
                 .map(|r| {

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::path::Path;
 
 use polars_core::prelude::*;

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -109,9 +109,8 @@ impl LazyFrame {
             let lfs = paths
                 .map(|r| {
                     let path = r.map_err(|e| PolarsError::ComputeError(format!("{}", e).into()))?;
-                    let path_string = path.to_string_lossy().into_owned();
                     Self::scan_parquet_impl(
-                        path_string,
+                        path,
                         args.n_rows,
                         args.cache,
                         ParallelStrategy::None,

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -256,7 +256,7 @@ fn test_union_and_agg_projections() -> Result<()> {
     // hashmap, if that doesn't set them sorted the vstack will panic.
     let lf1 = LazyFrame::scan_parquet(GLOB_PARQUET, Default::default())?;
     let lf2 = LazyFrame::scan_ipc(GLOB_IPC, Default::default())?;
-    let lf3 = LazyCsvReader::new(GLOB_CSV.into()).finish()?;
+    let lf3 = LazyCsvReader::new(GLOB_CSV).finish()?;
 
     for lf in [lf1, lf2, lf3] {
         let lf = lf.filter(col("category").eq(lit("vegetables"))).select([
@@ -386,7 +386,7 @@ fn test_row_count_on_files() -> Result<()> {
 
 #[test]
 fn scan_predicate_on_set_null_values() -> Result<()> {
-    let df = LazyCsvReader::new(FOODS_CSV.into())
+    let df = LazyCsvReader::new(FOODS_CSV)
         .with_null_values(Some(NullValues::Named(vec![("fats_g".into(), "0".into())])))
         .with_infer_schema_length(Some(0))
         .finish()?

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -254,8 +254,8 @@ fn test_union_and_agg_projections() -> Result<()> {
     let _guard = SINGLE_LOCK.lock().unwrap();
     // a union vstacks columns and aggscan optimization determines columns to aggregate in a
     // hashmap, if that doesn't set them sorted the vstack will panic.
-    let lf1 = LazyFrame::scan_parquet(GLOB_PARQUET.into(), Default::default())?;
-    let lf2 = LazyFrame::scan_ipc(GLOB_IPC.into(), Default::default())?;
+    let lf1 = LazyFrame::scan_parquet(GLOB_PARQUET, Default::default())?;
+    let lf2 = LazyFrame::scan_ipc(GLOB_IPC, Default::default())?;
     let lf3 = LazyCsvReader::new(GLOB_CSV.into()).finish()?;
 
     for lf in [lf1, lf2, lf3] {
@@ -352,7 +352,7 @@ fn test_row_count_on_files() -> Result<()> {
             (offset..27 + offset).collect::<Vec<_>>()
         );
 
-        let lf = LazyFrame::scan_parquet(FOODS_PARQUET.to_string(), Default::default())?
+        let lf = LazyFrame::scan_parquet(FOODS_PARQUET, Default::default())?
             .with_row_count("rc", Some(offset));
         assert!(row_count_at_scan(lf.clone()));
         let df = lf.collect()?;
@@ -362,8 +362,8 @@ fn test_row_count_on_files() -> Result<()> {
             (offset..27 + offset).collect::<Vec<_>>()
         );
 
-        let lf = LazyFrame::scan_ipc(FOODS_IPC.to_string(), Default::default())?
-            .with_row_count("rc", Some(offset));
+        let lf =
+            LazyFrame::scan_ipc(FOODS_IPC, Default::default())?.with_row_count("rc", Some(offset));
 
         assert!(row_count_at_scan(lf.clone()));
         let df = lf.clone().collect()?;

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -52,7 +52,7 @@ static FOODS_IPC: &str = "../../examples/datasets/foods1.ipc";
 static FOODS_PARQUET: &str = "../../examples/datasets/foods1.parquet";
 
 fn scan_foods_csv() -> LazyFrame {
-    LazyCsvReader::new(FOODS_CSV.to_string()).finish().unwrap()
+    LazyCsvReader::new(FOODS_CSV).finish().unwrap()
 }
 
 fn scan_foods_ipc() -> LazyFrame {

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -56,7 +56,7 @@ fn scan_foods_csv() -> LazyFrame {
 }
 
 fn scan_foods_ipc() -> LazyFrame {
-    LazyFrame::scan_ipc(FOODS_IPC.to_string(), Default::default()).unwrap()
+    LazyFrame::scan_ipc(FOODS_IPC, Default::default()).unwrap()
 }
 
 fn init_files() {
@@ -89,7 +89,7 @@ fn init_files() {
 #[cfg(feature = "parquet")]
 fn scan_foods_parquet(parallel: bool) -> LazyFrame {
     init_files();
-    let out_path = FOODS_PARQUET.to_string();
+    let out_path = FOODS_PARQUET;
     let parallel = if parallel {
         ParallelStrategy::Auto
     } else {

--- a/polars/src/docs/lazy.rs
+++ b/polars/src/docs/lazy.rs
@@ -29,12 +29,12 @@
 //! let lf: LazyFrame = df.lazy();
 //!
 //! // scan a csv file lazily
-//! let lf: LazyFrame = LazyCsvReader::new("some_path".into())
+//! let lf: LazyFrame = LazyCsvReader::new("some_path")
 //!     .has_header(true)
 //!     .finish()?;
 //!
 //! // scan a parquet file lazily
-//! let lf: LazyFrame = LazyFrame::scan_parquet("some_path".into(), Default::default())?;
+//! let lf: LazyFrame = LazyFrame::scan_parquet("some_path", Default::default())?;
 //!
 //! # Ok(())
 //! # }
@@ -114,7 +114,7 @@
 //! use polars::prelude::*;
 //! # fn example() -> Result<()> {
 //!
-//!  let df = LazyCsvReader::new("reddit.csv".into())
+//!  let df = LazyCsvReader::new("reddit.csv")
 //!     .has_header(true)
 //!     .with_delimiter(b',')
 //!     .finish()?

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -13,7 +13,7 @@
 //! use polars::prelude::*;
 //! # fn example() -> Result<()> {
 //!
-//! let lf1 = LazyFrame::scan_parquet("myfile_1.parquet".into(), Default::default())?
+//! let lf1 = LazyFrame::scan_parquet("myfile_1.parquet", Default::default())?
 //!     .groupby([col("ham")])
 //!     .agg([
 //!         // expressions can be combined into powerful aggregations
@@ -27,7 +27,7 @@
 //!         col("foo").reverse().list().alias("reverse_group"),
 //!     ]);
 //!
-//! let lf2 = LazyFrame::scan_parquet("myfile_2.parquet".into(), Default::default())?
+//! let lf2 = LazyFrame::scan_parquet("myfile_2.parquet", Default::default())?
 //!     .select([col("ham"), col("spam")]);
 //!
 //! let df = lf1


### PR DESCRIPTION
This is a breaking change. Closes #3501.