### PR TITLE
feat[python]: df.__getitem__ allow boolean sequence in column position

### DIFF
--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -146,6 +146,19 @@ def test_selection() -> None:
     expect = pl.DataFrame({"a": [1, 3], "b": [1.0, 3.0], "c": ["a", "c"]})
     assert df[::2].frame_equal(expect)
 
+    # only allow boolean values in column position
+    df = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [2, 3],
+            "c": [3, 4],
+        }
+    )
+
+    assert df[:, [False, True, True]].columns == ["b", "c"]
+    assert df[:, pl.Series([False, True, True])].columns == ["b", "c"]
+    assert df[:, pl.Series([False, False, False])].columns == []
+
 
 def test_mixed_sequence_selection() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})


### PR DESCRIPTION
This allows getitem with a mask at column position. The reason for introducing this again is that we don't have a clear way of doing this in the expression API and I also don't think we should want that.

There are legitimate cases for selecting columns by a mask and currently we've made it too hard to do.

```python
df = pl.DataFrame({
    "a": [1, 2],
    "b": [2, 3],
    "c": [3, 4],
})

assert df[:, [False, True, True]].columns == ["b", "c"]
assert df[:, pl.Series([False, True, True])].columns == ["b", "c"]
assert df[:, pl.Series([False, False, False])].columns == []
```