### PR TITLE
(chore)Improve display versions Python issue report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -67,7 +67,9 @@ body:
       value: >
         <details>
 
+
         Replace this line with the output of pl.show_versions()
+
 
         </details>
     validations:


### PR DESCRIPTION
Adding additional newlines, so that when the user on paste replaces the line to be replaced, an empty line before and and empty line after the versions, versus the details tags, is maintained. This way, the GH markdown parser will display the line breaks properly.