### PR TITLE
feat[python]: re-implement DataFrame.__setitem__

### DIFF
--- a/py-polars/tests/test_errors.py
+++ b/py-polars/tests/test_errors.py
@@ -140,6 +140,10 @@ def test_getitem_errs() -> None:
         df["a"][{"strange"}]
 
     with pytest.raises(
-        TypeError, match="'DataFrame' object does not support item assignment"
+        ValueError,
+        match=r"Cannot __setitem__ on "
+        r"DataFrame with key: '{'some'}' of "
+        r"type: '<class 'set'>' and value: "
+        r"'foo' of type: '<class 'str'>'",
     ):
         df[{"some"}] = "foo"


### PR DESCRIPTION
We've made valid things unnecessary hard to do that had no clear mapping in the expression API. This reintroduces the logic in `DataFrame.__setitem__` and raises an error for operations that should be done in `with_columns`. 

We should not throw the baby out with the bath water. 