### PR TITLE
feat[rust, python]: run expressions in pivot

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -122,6 +122,7 @@ meta = ["polars-lazy/meta"]
 date_offset = ["polars-lazy/date_offset"]
 trigonometry = ["polars-lazy/trigonometry"]
 sign = ["polars-lazy/sign"]
+pivot = ["polars-lazy/pivot"]
 
 test = [
   "lazy",

--- a/polars/polars-core/src/frame/groupby/expr.rs
+++ b/polars/polars-core/src/frame/groupby/expr.rs
@@ -1,0 +1,8 @@
+use crate::prelude::*;
+
+pub trait PhysicalAggExpr {
+    #[allow(clippy::ptr_arg)]
+    fn evaluate<'a>(&self, df: &DataFrame, groups: &'a GroupsProxy) -> Result<Series>;
+
+    fn root_name(&self) -> Result<&str>;
+}

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -15,6 +15,7 @@ use crate::vector_hasher::{get_null_hash_value, AsU64, StrHash};
 use crate::POOL;
 
 pub mod aggregations;
+pub mod expr;
 pub(crate) mod hashing;
 mod into_groups;
 #[cfg(feature = "rows")]

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -75,6 +75,7 @@ string_justify = ["polars-ops/string_justify"]
 arg_where = []
 search_sorted = ["polars-ops/search_sorted"]
 meta = []
+pivot = ["polars-core/rows"]
 
 # no guarantees whatsoever
 private = ["polars-time/private"]

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -3,22 +3,6 @@ use rayon::prelude::*;
 use super::*;
 use crate::physical_plan::state::ExecutionState;
 
-#[cfg(feature = "list_eval")]
-pub(super) fn prepare_eval_expr(mut expr: Expr) -> Expr {
-    expr.mutate().apply(|e| match e {
-        Expr::Column(name) => {
-            *name = Arc::from("");
-            true
-        }
-        Expr::Nth(_) => {
-            *e = Expr::Column(Arc::from(""));
-            true
-        }
-        _ => true,
-    });
-    expr
-}
-
 impl Expr {
     /// Run an expression over a sliding window that increases `1` slot every iteration.
     ///

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -5,9 +5,11 @@ use polars_core::series::ops::NullBehavior;
 use polars_ops::prelude::*;
 use rayon::prelude::*;
 
-#[cfg(feature = "list_eval")]
-use crate::dsl::eval::prepare_eval_expr;
 use crate::dsl::function_expr::FunctionExpr;
+#[cfg(feature = "list_eval")]
+use crate::physical_plan::exotic::prepare_eval_expr;
+#[cfg(feature = "list_eval")]
+use crate::physical_plan::exotic::prepare_expression_for_context;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
 
@@ -223,24 +225,8 @@ impl ListNameSpace {
         let func = move |s: Series| {
             let lst = s.list()?;
 
-            let mut lp_arena = Arena::with_capacity(8);
-            let mut expr_arena = Arena::with_capacity(10);
-
-            // create a dummy lazyframe and run a very simple optimization run so that
-            // type coercion and simplify expression optimizations run.
-            let column = Series::full_null("", 0, &lst.inner_dtype());
-            let lf = DataFrame::new_no_checks(vec![column])
-                .lazy()
-                .without_optimizations()
-                .with_simplify_expr(true)
-                .select([expr.clone()]);
-            let optimized = lf.optimize(&mut lp_arena, &mut expr_arena).unwrap();
-            let lp = lp_arena.get(optimized);
-            let aexpr = lp.get_exprs().pop().unwrap();
-
-            let planner = PhysicalPlanner::default();
             let phys_expr =
-                planner.create_physical_expr(aexpr, Context::Default, &mut expr_arena)?;
+                prepare_expression_for_context("", &expr, &lst.inner_dtype(), Context::Default)?;
 
             let state = ExecutionState::new();
 

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -11,6 +11,8 @@ mod parquet;
 mod python;
 
 mod anonymous_scan;
+#[cfg(feature = "pivot")]
+pub mod pivot;
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/polars/polars-lazy/src/frame/pivot.rs
+++ b/polars/polars-lazy/src/frame/pivot.rs
@@ -1,0 +1,83 @@
+//! Polars lazy does not implement a pivot because it is impossible to know the schema without
+//! materializing the whole dataset. This makes a pivot quite a terrible operation for performant
+//! workflows. An optimization can never be pushed down passed a pivot.
+//!
+//! We can do a pivot on an eager `DataFrame` as that is already materialized. The code for the
+//! pivot is here, because we want to be able to pass expressions to the pivot operation.
+//!
+
+use polars_core::frame::groupby::PivotAgg;
+use polars_core::{frame::groupby::expr::PhysicalAggExpr, prelude::*};
+
+use crate::physical_plan::exotic::{prepare_eval_expr, prepare_expression_for_context};
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+
+impl PhysicalAggExpr for Expr {
+    fn evaluate<'a>(&self, df: &DataFrame, groups: &'a GroupsProxy) -> Result<Series> {
+        let state = ExecutionState::new();
+        let dtype = df.get_columns()[0].dtype();
+        let phys_expr = prepare_expression_for_context("", self, dtype, Context::Aggregation)?;
+        phys_expr
+            .evaluate_on_groups(df, groups, &state)
+            .map(|mut ac| ac.aggregated())
+    }
+
+    fn root_name(&self) -> Result<&str> {
+        Ok("")
+    }
+}
+
+pub fn pivot<I0, S0, I1, S1, I2, S2>(
+    df: &DataFrame,
+    values: I0,
+    index: I1,
+    columns: I2,
+    agg_expr: Expr,
+    sort_columns: bool,
+) -> Result<DataFrame>
+where
+    I0: IntoIterator<Item = S0>,
+    S0: AsRef<str>,
+    I1: IntoIterator<Item = S1>,
+    S1: AsRef<str>,
+    I2: IntoIterator<Item = S2>,
+    S2: AsRef<str>,
+{
+    // make sure that the root column is replaced
+    let expr = prepare_eval_expr(agg_expr);
+    df.pivot(
+        values,
+        index,
+        columns,
+        PivotAgg::Expr(Arc::new(expr)),
+        sort_columns,
+    )
+}
+
+pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
+    df: &DataFrame,
+    values: I0,
+    index: I1,
+    columns: I2,
+    agg_expr: Expr,
+    sort_columns: bool,
+) -> Result<DataFrame>
+where
+    I0: IntoIterator<Item = S0>,
+    S0: AsRef<str>,
+    I1: IntoIterator<Item = S1>,
+    S1: AsRef<str>,
+    I2: IntoIterator<Item = S2>,
+    S2: AsRef<str>,
+{
+    // make sure that the root column is replaced
+    let expr = prepare_eval_expr(agg_expr);
+    df.pivot_stable(
+        values,
+        index,
+        columns,
+        PivotAgg::Expr(Arc::new(expr)),
+        sort_columns,
+    )
+}

--- a/polars/polars-lazy/src/physical_plan/exotic.rs
+++ b/polars/polars-lazy/src/physical_plan/exotic.rs
@@ -1,0 +1,43 @@
+use polars_core::prelude::*;
+
+use crate::prelude::*;
+
+pub(crate) fn prepare_eval_expr(mut expr: Expr) -> Expr {
+    expr.mutate().apply(|e| match e {
+        Expr::Column(name) => {
+            *name = Arc::from("");
+            true
+        }
+        Expr::Nth(_) => {
+            *e = Expr::Column(Arc::from(""));
+            true
+        }
+        _ => true,
+    });
+    expr
+}
+
+pub(crate) fn prepare_expression_for_context(
+    name: &str,
+    expr: &Expr,
+    dtype: &DataType,
+    ctxt: Context,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    let mut lp_arena = Arena::with_capacity(8);
+    let mut expr_arena = Arena::with_capacity(10);
+
+    // create a dummy lazyframe and run a very simple optimization run so that
+    // type coercion and simplify expression optimizations run.
+    let column = Series::full_null(name, 0, dtype);
+    let lf = DataFrame::new_no_checks(vec![column])
+        .lazy()
+        .without_optimizations()
+        .with_simplify_expr(true)
+        .select([expr.clone()]);
+    let optimized = lf.optimize(&mut lp_arena, &mut expr_arena).unwrap();
+    let lp = lp_arena.get(optimized);
+    let aexpr = lp.get_exprs().pop().unwrap();
+
+    let planner = PhysicalPlanner::default();
+    planner.create_physical_expr(aexpr, ctxt, &mut expr_arena)
+}

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -1,4 +1,6 @@
 pub mod executors;
+#[cfg(any(feature = "list_eval", feature = "pivot"))]
+pub(crate) mod exotic;
 pub mod expressions;
 #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
 mod file_cache;

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -57,6 +57,7 @@ lazy_regex = ["polars/lazy_regex"]
 csv-file = ["polars/csv-file"]
 object = ["polars/object"]
 extract_jsonpath = ["polars/extract_jsonpath"]
+pivot = ["polars/pivot"]
 
 all = [
   "json",
@@ -78,6 +79,7 @@ all = [
   "extract_jsonpath",
   "polars/timezones",
   "object",
+  "pivot",
 ]
 
 # we cannot conditionaly activate simd

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4496,7 +4496,7 @@ class DataFrame:
         values: list[str] | str,
         index: list[str] | str,
         columns: list[str] | str,
-        aggregate_fn: PivotAgg = "first",
+        aggregate_fn: PivotAgg | pli.Expr = "first",
         maintain_order: bool = True,
         sort_columns: bool = False,
     ) -> DF:
@@ -4513,7 +4513,7 @@ class DataFrame:
         columns
             Columns whose values will be used as the header of the output DataFrame
         aggregate_fn : {'first', 'sum', 'max', 'min', 'mean', 'median', 'last', 'count'}
-            Aggregate function.
+            A predefined aggregate function str or an expression.
         maintain_order
             Sort the grouped keys so that the output order is predictable.
         sort_columns
@@ -4551,6 +4551,18 @@ class DataFrame:
             index = [index]
         if isinstance(columns, str):
             columns = [columns]
+        if isinstance(aggregate_fn, pli.Expr):
+            return self._from_pydf(
+                self._df.pivot_expr(
+                    values,
+                    index,
+                    columns,
+                    aggregate_fn._pyexpr,
+                    maintain_order,
+                    sort_columns,
+                )
+            )
+
         return self._from_pydf(
             self._df.pivot2(
                 values, index, columns, aggregate_fn, maintain_order, sort_columns

--- a/py-polars/tests/test_pivot.py
+++ b/py-polars/tests/test_pivot.py
@@ -83,9 +83,21 @@ def test_pivot_categorical_index() -> None:
         columns=[("A", pl.Categorical), ("B", pl.Categorical)],
     )
 
-    assert df.pivot(values="B", index=["A"], columns="B", aggregate_fn="count").to_dict(
-        False
-    ) == {"A": ["Fire", "Water"], "Car": [1, 2], "Ship": [1, None]}
+    expected = {"A": ["Fire", "Water"], "Car": [1, 2], "Ship": [1, None]}
+    assert (
+        df.pivot(values="B", index=["A"], columns="B", aggregate_fn="count").to_dict(
+            False
+        )
+        == expected
+    )
+
+    # test expression dispatch
+    assert (
+        df.pivot(values="B", index=["A"], columns="B", aggregate_fn=pl.count()).to_dict(
+            False
+        )
+        == expected
+    )
 
     df = pl.DataFrame(
         {


### PR DESCRIPTION
I dislike pivots, but if we have them, let's make them powerful. :)


```python
url = "https://raw.githubusercontent.com/pola-rs/polars/master/examples/datasets/foods1.csv"
df = pl.read_csv(url)

df.pivot(
    values="fats_g", 
    index="sugars_g", 
    columns="category", 
    aggregate_fn=(pl.element().where(pl.element() > 0) ** 2).ewm_mean(com=0.5).last()
)
```

```
shape: (8, 5)
┌──────────┬────────────┬───────────┬───────┬───────┐
│ sugars_g ┆ vegetables ┆ seafood   ┆ meat  ┆ fruit │
│ ---      ┆ ---        ┆ ---       ┆ ---   ┆ ---   │
│ i64      ┆ f64        ┆ f64       ┆ f64   ┆ f64   │
╞══════════╪════════════╪═══════════╪═══════╪═══════╡
│ 2        ┆ 0.25       ┆ 49.0      ┆ null  ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 0        ┆ null       ┆ 26.506198 ┆ 48.4  ┆ 20.25 │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 11       ┆ null       ┆ null      ┆ null  ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 1        ┆ null       ┆ 25.0      ┆ 100.0 ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 5        ┆ null       ┆ null      ┆ null  ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 3        ┆ null       ┆ null      ┆ null  ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 4        ┆ null       ┆ null      ┆ null  ┆ null  │
├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 25       ┆ null       ┆ null      ┆ null  ┆ null  │
└──────────┴────────────┴───────────┴───────┴───────┘

```