### PR TITLE
feat[rust, python]: struct access ergonomics

### DIFF
--- a/polars/polars-lazy/src/dsl/function_expr/struct_.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/struct_.rs
@@ -1,0 +1,23 @@
+use polars_core::utils::slice_offsets;
+
+use super::*;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum StructFunction {
+    FieldByIndex(i64),
+    FieldByName(Arc<str>),
+}
+
+pub(super) fn get_by_index(s: &Series, index: i64) -> Result<Series> {
+    let s = s.struct_()?;
+    let (index, _) = slice_offsets(index, 0, s.fields().len());
+    s.fields()
+        .get(index)
+        .cloned()
+        .ok_or_else(|| PolarsError::ComputeError("index out of bounds in 'struct.field'".into()))
+}
+pub(super) fn get_by_name(s: &Series, name: Arc<str>) -> Result<Series> {
+    let ca = s.struct_()?;
+    ca.field_by_name(name.as_ref())
+}

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -220,9 +220,8 @@ pub fn argsort_by<E: AsRef<[Expr]>>(by: E, reverse: &[bool]) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            auto_explode: false,
             fmt_str: "argsort_by",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }
@@ -245,7 +244,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, sep: &str) -> Expr {
             input_wildcard_expansion: true,
             auto_explode: true,
             fmt_str: "concat_by",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }
@@ -262,9 +261,8 @@ pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: false,
             fmt_str: "concat_list",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }
@@ -450,9 +448,8 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: false,
             fmt_str: "datetime",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
     .alias("datetime")
@@ -528,9 +525,8 @@ pub fn duration(args: DurationArgs) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: false,
             fmt_str: "duration",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
     .alias("duration")
@@ -731,7 +727,7 @@ where
                 input_wildcard_expansion: true,
                 auto_explode: true,
                 fmt_str: "",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     } else {
@@ -904,10 +900,8 @@ pub fn arg_where<E: Into<Expr>>(condition: E) -> Expr {
         function: FunctionExpr::ArgWhere,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
-            auto_explode: false,
             fmt_str: "arg_where",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -352,7 +352,7 @@ impl ListNameSpace {
                 input_wildcard_expansion: true,
                 auto_explode: true,
                 fmt_str: "arr.contains",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -474,10 +474,9 @@ impl Expr {
     pub fn arg_min(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
             auto_explode: true,
             fmt_str: "arg_min",
-            cast_to_supertypes: false,
+            ..Default::default()
         };
 
         self.function_with_options(
@@ -491,10 +490,9 @@ impl Expr {
     pub fn arg_max(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
             auto_explode: true,
             fmt_str: "arg_max",
-            cast_to_supertypes: false,
+            ..Default::default()
         };
 
         self.function_with_options(
@@ -508,10 +506,8 @@ impl Expr {
     pub fn arg_sort(self, reverse: bool) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
-            auto_explode: false,
             fmt_str: "arg_sort",
-            cast_to_supertypes: false,
+            ..Default::default()
         };
 
         self.function_with_options(
@@ -536,10 +532,9 @@ impl Expr {
             function: FunctionExpr::SearchSorted,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                input_wildcard_expansion: false,
                 auto_explode: true,
                 fmt_str: "search_sorted",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -620,6 +615,7 @@ impl Expr {
                 auto_explode: false,
                 fmt_str: "map",
                 cast_to_supertypes: false,
+                allow_rename: false,
             },
         }
     }
@@ -634,6 +630,7 @@ impl Expr {
                 auto_explode: false,
                 fmt_str,
                 cast_to_supertypes: false,
+                allow_rename: false,
             },
         }
     }
@@ -654,10 +651,8 @@ impl Expr {
             output_type,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -681,10 +676,8 @@ impl Expr {
             output_type,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyList,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "map_list",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -730,10 +723,8 @@ impl Expr {
             output_type,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -744,10 +735,8 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str,
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -768,10 +757,9 @@ impl Expr {
             output_type,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                input_wildcard_expansion: false,
-                auto_explode: true,
                 fmt_str: "",
-                cast_to_supertypes: false,
+                auto_explode: true,
+                ..Default::default()
             },
         }
     }
@@ -793,10 +781,10 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                input_wildcard_expansion: false,
                 auto_explode,
                 fmt_str,
                 cast_to_supertypes,
+                ..Default::default()
             },
         }
     }
@@ -817,10 +805,10 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
                 auto_explode: true,
                 fmt_str,
                 cast_to_supertypes,
+                ..Default::default()
             },
         }
     }
@@ -933,10 +921,9 @@ impl Expr {
     pub fn product(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
             auto_explode: true,
             fmt_str: "product",
-            cast_to_supertypes: false,
+            ..Default::default()
         };
 
         self.function_with_options(
@@ -1127,10 +1114,9 @@ impl Expr {
             },
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "fill_null",
                 cast_to_supertypes: true,
+                ..Default::default()
             },
         }
     }
@@ -1204,6 +1190,7 @@ impl Expr {
                 auto_explode: false,
                 fmt_str: "pow",
                 cast_to_supertypes: false,
+                allow_rename: false,
             },
         }
     }
@@ -1216,10 +1203,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Sin),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "sin",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1232,10 +1217,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Cos),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "cos",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1248,10 +1231,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Tan),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "tan",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1264,10 +1245,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcSin),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arcsin",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1280,10 +1259,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcCos),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arccos",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1296,10 +1273,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcTan),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arctan",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1312,10 +1287,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Sinh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "sinh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1328,10 +1301,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Cosh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "cosh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1344,10 +1315,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::Tanh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "tanh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1360,10 +1329,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcSinh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arcsinh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1376,10 +1343,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcCosh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arccosh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1392,10 +1357,8 @@ impl Expr {
             function: FunctionExpr::Trigonometry(TrigonometricFunction::ArcTanh),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "arctanh",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -1408,10 +1371,8 @@ impl Expr {
             function: FunctionExpr::Sign,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                input_wildcard_expansion: false,
-                auto_explode: false,
                 fmt_str: "sign",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }
@@ -2372,10 +2333,8 @@ where
         output_type,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
-            input_wildcard_expansion: false,
-            auto_explode: false,
             fmt_str: "",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }
@@ -2400,10 +2359,9 @@ where
         output_type,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyList,
-            input_wildcard_expansion: false,
             auto_explode: true,
             fmt_str: "",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }
@@ -2430,10 +2388,9 @@ where
         output_type,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: false,
             auto_explode: true,
             fmt_str: "",
-            cast_to_supertypes: false,
+            ..Default::default()
         },
     }
 }

--- a/polars/polars-lazy/src/dsl/string.rs
+++ b/polars/polars-lazy/src/dsl/string.rs
@@ -124,7 +124,7 @@ impl StringNameSpace {
                 input_wildcard_expansion: false,
                 auto_explode: true,
                 fmt_str: "str.concat",
-                cast_to_supertypes: false,
+                ..Default::default()
             },
         }
     }

--- a/polars/polars-lazy/src/dsl/struct_.rs
+++ b/polars/polars-lazy/src/dsl/struct_.rs
@@ -1,34 +1,33 @@
 use super::*;
+use crate::dsl::function_expr::StructFunction;
 
 /// Specialized expressions for Struct dtypes.
 pub struct StructNameSpace(pub(crate) Expr);
 
 impl StructNameSpace {
+    pub fn field_by_index(self, index: i64) -> Expr {
+        self.0
+            .map_private(
+                FunctionExpr::StructExpr(StructFunction::FieldByIndex(index)),
+                "struct.field_by_index",
+            )
+            .with_function_options(|mut options| {
+                options.allow_rename = true;
+                options
+            })
+    }
+
     /// Retrieve one of the fields of this [`StructChunked`] as a new Series.
     pub fn field_by_name(self, name: &str) -> Expr {
-        let name1 = name.to_string();
-        let name2 = name.to_string();
-
         self.0
-            .map(
-                move |s| {
-                    let ca = s.struct_()?;
-                    ca.field_by_name(&name1)
-                },
-                GetOutput::map_dtype(move |dtype| {
-                    if let DataType::Struct(flds) = dtype {
-                        let fld = flds
-                            .iter()
-                            .find(|fld| fld.name() == &name2)
-                            .unwrap_or_else(|| panic!("{} not found", name2));
-                        fld.data_type().clone()
-                    } else {
-                        panic!("not a struct type: {}", dtype);
-                    }
-                }),
+            .map_private(
+                FunctionExpr::StructExpr(StructFunction::FieldByName(Arc::from(name))),
+                "struct.field_by_name",
             )
-            .with_fmt("struct.field_by_name")
-            .alias(name)
+            .with_function_options(|mut options| {
+                options.allow_rename = true;
+                options
+            })
     }
 
     /// Rename the fields of the [`StructChunked`].

--- a/polars/polars-lazy/src/logical_plan/options.rs
+++ b/polars/polars-lazy/src/logical_plan/options.rs
@@ -166,6 +166,20 @@ pub struct FunctionOptions {
 
     // if the expression and its inputs should be cast to supertypes
     pub(crate) cast_to_supertypes: bool,
+    pub(crate) allow_rename: bool,
+}
+
+impl Default for FunctionOptions {
+    fn default() -> Self {
+        FunctionOptions {
+            collect_groups: ApplyOptions::ApplyGroups,
+            input_wildcard_expansion: false,
+            auto_explode: false,
+            fmt_str: "",
+            cast_to_supertypes: false,
+            allow_rename: false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -174,13 +174,12 @@ impl PhysicalPlanner {
                                     }
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -204,13 +203,12 @@ impl PhysicalPlanner {
                                     }
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -226,13 +224,12 @@ impl PhysicalPlanner {
                                     parallel_op_series(|s| Ok(s.sum_as_series()), s, None)
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -249,13 +246,12 @@ impl PhysicalPlanner {
                                     Ok(s.std_as_series(ddof))
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -272,13 +268,12 @@ impl PhysicalPlanner {
                                     Ok(s.var_as_series(ddof))
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -294,13 +289,12 @@ impl PhysicalPlanner {
                                     Ok(s.mean_as_series())
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -316,13 +310,12 @@ impl PhysicalPlanner {
                                     Ok(s.median_as_series())
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -338,13 +331,12 @@ impl PhysicalPlanner {
                                     Ok(s.head(Some(1)))
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -360,13 +352,12 @@ impl PhysicalPlanner {
                                     Ok(s.tail(Some(1)))
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -382,13 +373,12 @@ impl PhysicalPlanner {
                                     s.to_list().map(|ca| ca.into_series())
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -408,13 +398,12 @@ impl PhysicalPlanner {
                                     })
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -435,13 +424,12 @@ impl PhysicalPlanner {
                                     s.quantile_as_series(quantile, interpol)
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -469,13 +457,12 @@ impl PhysicalPlanner {
                                         .into_series())
                                 })
                                     as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr {
-                                    inputs: vec![input],
+                                Ok(Arc::new(ApplyExpr::new_minimal(
+                                    vec![input],
                                     function,
-                                    expr: node_to_expr(expression, expr_arena),
-                                    collect_groups: ApplyOptions::ApplyFlat,
-                                    auto_explode: false,
-                                }))
+                                    node_to_expr(expression, expr_arena),
+                                    ApplyOptions::ApplyFlat,
+                                )))
                             }
                         }
                     }
@@ -523,6 +510,7 @@ impl PhysicalPlanner {
                     expr: node_to_expr(expression, expr_arena),
                     collect_groups: options.collect_groups,
                     auto_explode: options.auto_explode,
+                    allow_rename: options.allow_rename,
                 }))
             }
             Function {
@@ -539,6 +527,7 @@ impl PhysicalPlanner {
                     expr: node_to_expr(expression, expr_arena),
                     collect_groups: options.collect_groups,
                     auto_explode: options.auto_explode,
+                    allow_rename: options.allow_rename,
                 }))
             }
             Shift { input, periods } => {
@@ -570,13 +559,12 @@ impl PhysicalPlanner {
                     let s = std::mem::take(&mut s[0]);
                     Ok(s.reverse())
                 }) as Arc<dyn SeriesUdf>);
-                Ok(Arc::new(ApplyExpr {
-                    inputs: vec![input],
+                Ok(Arc::new(ApplyExpr::new_minimal(
+                    vec![input],
                     function,
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyGroups,
-                    auto_explode: false,
-                }))
+                    node_to_expr(expression, expr_arena),
+                    ApplyOptions::ApplyGroups,
+                )))
             }
             Duplicated(expr) => {
                 let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
@@ -584,13 +572,12 @@ impl PhysicalPlanner {
                     let s = std::mem::take(&mut s[0]);
                     s.is_duplicated().map(|ca| ca.into_series())
                 }) as Arc<dyn SeriesUdf>);
-                Ok(Arc::new(ApplyExpr {
-                    inputs: vec![input],
+                Ok(Arc::new(ApplyExpr::new_minimal(
+                    vec![input],
                     function,
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyGroups,
-                    auto_explode: false,
-                }))
+                    node_to_expr(expression, expr_arena),
+                    ApplyOptions::ApplyGroups,
+                )))
             }
             IsUnique(expr) => {
                 let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
@@ -598,13 +585,12 @@ impl PhysicalPlanner {
                     let s = std::mem::take(&mut s[0]);
                     s.is_unique().map(|ca| ca.into_series())
                 }) as Arc<dyn SeriesUdf>);
-                Ok(Arc::new(ApplyExpr {
-                    inputs: vec![input],
+                Ok(Arc::new(ApplyExpr::new_minimal(
+                    vec![input],
                     function,
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyGroups,
-                    auto_explode: false,
-                }))
+                    node_to_expr(expression, expr_arena),
+                    ApplyOptions::ApplyGroups,
+                )))
             }
             Explode(expr) => {
                 let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
@@ -612,13 +598,12 @@ impl PhysicalPlanner {
                     let s = std::mem::take(&mut s[0]);
                     s.explode()
                 }) as Arc<dyn SeriesUdf>);
-                Ok(Arc::new(ApplyExpr {
-                    inputs: vec![input],
+                Ok(Arc::new(ApplyExpr::new_minimal(
+                    vec![input],
                     function,
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: ApplyOptions::ApplyFlat,
-                    auto_explode: false,
-                }))
+                    node_to_expr(expression, expr_arena),
+                    ApplyOptions::ApplyFlat,
+                )))
             }
             Wildcard => panic!("should be no wildcard at this point"),
             Nth(_) => panic!("should be no nth at this point"),

--- a/py-polars/polars/internals/expr/struct.py
+++ b/py-polars/polars/internals/expr/struct.py
@@ -9,6 +9,14 @@ class ExprStructNameSpace:
     def __init__(self, expr: pli.Expr):
         self._pyexpr = expr._pyexpr
 
+    def __getitem__(self, item: str | int) -> pli.Expr:
+        if isinstance(item, str):
+            return self.field(item)
+        elif isinstance(item, int):
+            return pli.wrap_expr(self._pyexpr.struct_field_by_index(item))
+        else:
+            raise ValueError(f"expected type 'int | str', got {type(item)}")
+
     def field(self, name: str) -> pli.Expr:
         """
         Retrieve one of the fields of this `Struct` as a new Series.

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -7,6 +7,14 @@ class StructNameSpace:
     def __init__(self, s: pli.Series):
         self.s = s
 
+    def __getitem__(self, item: int | str) -> pli.Series:
+        if isinstance(item, int):
+            return self.field(self.fields[item])
+        elif isinstance(item, str):
+            return self.field(item)
+        else:
+            raise ValueError(f"expected type 'int | str', got {type(item)}")
+
     def to_frame(self) -> pli.DataFrame:
         """Convert this Struct Series to a DataFrame."""
         return pli.wrap_df(self.s._s.struct_to_frame())

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1474,6 +1474,10 @@ impl PyExpr {
         self.inner.clone().struct_().field_by_name(name).into()
     }
 
+    pub fn struct_field_by_index(&self, index: i64) -> PyExpr {
+        self.inner.clone().struct_().field_by_index(index).into()
+    }
+
     pub fn struct_rename_fields(&self, names: Vec<String>) -> PyExpr {
         self.inner.clone().struct_().rename_fields(names).into()
     }

--- a/py-polars/tests/test_struct.py
+++ b/py-polars/tests/test_struct.py
@@ -622,3 +622,13 @@ def test_struct_groupby_field_agg_4216() -> None:
     assert df.groupby("c").agg(pl.col("a").struct.field("b").count()).to_dict(
         False
     ) == {"c": [0], "b": [1]}
+
+
+def test_struct_getitem() -> None:
+    assert pl.Series([{"a": 1, "b": 2}]).struct["b"].name == "b"
+    assert pl.Series([{"a": 1, "b": 2}]).struct[0].name == "a"
+    assert pl.Series([{"a": 1, "b": 2}]).struct[1].name == "b"
+    assert pl.Series([{"a": 1, "b": 2}]).struct[-1].name == "b"
+    assert pl.Series([{"a": 1, "b": 2}]).to_frame().select(
+        [pl.col("").struct[0]]
+    ).to_dict(False) == {"a": [1]}


### PR DESCRIPTION
Implements `__getitem__` for the struct namespace. Also makes `struct.field_by_index` and `struct.field_by_name` serializable.