### PR TITLE
feat[python]: minor repr enhancement for Series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .mypy_cache/
 .pytest_cache/
 .python-version
+.yarn/
 .vscode/
 __pycache__/
 AUTO_CHANGELOG.md

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -314,7 +314,8 @@ class Series:
         self._s.__setstate__(state)
 
     def __str__(self) -> str:
-        return self._s.as_str()
+        s_repr: str = self._s.as_str()
+        return s_repr.replace("Series", f"{self.__class__.__name__}", 1)
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1871,3 +1871,26 @@ def test_set_at_idx() -> None:
     # expected error condition
     with pytest.raises(TypeError):
         s.set_at_idx([0, 2], 0.12345)
+
+
+def test_repr() -> None:
+    s = pl.Series("ints", [1001, 2002, 3003])
+    s_repr = repr(s)
+
+    assert "shape: (3,)" in s_repr
+    assert "Series: 'ints' [i64]" in s_repr
+    for n in s.to_list():
+        assert str(n) in s_repr
+
+    class XSeries(pl.Series):
+        """Custom Series class"""
+
+    # check custom class name reflected in repr ouput
+    x = XSeries("ints", [1001, 2002, 3003])
+    x_repr = repr(x)
+
+    assert "shape: (3,)" in x_repr
+    assert "XSeries: 'ints' [i64]" in x_repr
+    assert "1001" in x_repr
+    for n in x.to_list():
+        assert str(n) in x_repr


### PR DESCRIPTION
Include custom class name in the repr, when inheriting: 

```python
import polars as pl

class XSeries(pl.Series):
    """Custom Series class"""

s = XSeries("n", [1, 2, 3])

# shape: (3,)
# XSeries: 'n' [i64]          << note "XSeries" instead of "Series"
# [
# 	1
# 	2
# 	3
# ]
```
