### PR TITLE
fix(rust): Inline nightly-only APIs to relax nightly compiler requirements

### DIFF
--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -89,7 +89,8 @@ impl PyDataFrame {
         // don't use this anywhere else.
         let mut df = std::mem::take(&mut self.df);
         let cols = std::mem::take(df.get_columns_mut());
-        let (ptr, len, cap) = cols.into_raw_parts();
+        let mut cols_md = std::mem::ManuallyDrop::new(cols);
+        let (ptr, len, cap) = (cols_md.as_mut_ptr(), cols_md.len(), cols_md.capacity());
         (ptr as usize, len, cap)
     }
 

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(vec_into_raw_parts)]
 #![allow(clippy::nonstandard_macro_braces)] // needed because clippy does not understand proc macro of pyo3
 #![allow(clippy::transmute_undefined_repr)]
 extern crate core;


### PR DESCRIPTION
Inline Vec::into_raw_parts to allow building py-polars on stable rust.

Looks like this was only being used in one place, and the implementation is only one extra line.
Using stable rust is more important than nightly/SIMD for me.

Related to ongoing work for #1325.

