### PR TITLE
refactor[python]: Dispatch more `Series` methods to `Expr`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -4658,7 +4658,7 @@ class Expr:
         Parameters
         ----------
         n
-            number of slots to shift
+            Number of slots to shift.
         null_behavior : {'ignore', 'drop'}
             How to handle null values.
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3495,7 +3495,7 @@ class Expr:
         k3 = seed_3 if seed_3 is not None else seed
         return wrap_expr(self._pyexpr.hash(k0, k1, k2, k3))
 
-    def reinterpret(self, signed: bool) -> Expr:
+    def reinterpret(self, signed: bool = True) -> Expr:
         """
         Reinterpret the underlying bits as a signed/unsigned integer.
 

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -68,8 +68,6 @@ class ListNameSpace:
             Columns to concat into a List Series
 
         """
-        s = pli.wrap_s(self._s)
-        return s.to_frame().select(pli.col(s.name).arr.concat(other)).to_series()
 
     def get(self, index: int) -> pli.Series:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4046,7 +4046,6 @@ class Series:
         Series
 
         """
-        return wrap_s(self._s.reshape(dims))
 
     def shuffle(self, seed: int | None = None) -> Series:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2119,8 +2119,6 @@ class Series:
         ]
 
         """
-        pl_dtype = py_type_to_dtype(dtype)
-        return wrap_s(self._s.cast(pl_dtype, strict))
 
     def to_physical(self) -> Series:
         """
@@ -2152,7 +2150,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.to_physical())
 
     def to_list(self, use_pyarrow: bool = False) -> list[Any | None]:
         """
@@ -2224,7 +2221,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.reverse())
 
     def is_numeric(self) -> bool:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2699,7 +2699,6 @@ class Series:
         Only works on floating point Series
 
         """
-        return wrap_s(self._s.floor())
 
     def ceil(self) -> Series:
         """
@@ -2732,7 +2731,6 @@ class Series:
             number of decimals to round by.
 
         """
-        return wrap_s(self._s.round(decimals))
 
     def dot(self, other: Series) -> float | None:
         """
@@ -2768,7 +2766,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.mode())
 
     def sign(self) -> Series:
         """
@@ -3085,7 +3082,6 @@ class Series:
             Number of places to shift (may be negative).
 
         """
-        return wrap_s(self._s.shift(periods))
 
     def shift_and_fill(self, periods: int, fill_value: int | pli.Expr) -> Series:
         """
@@ -3671,7 +3667,6 @@ class Series:
         3
 
         """
-        return self._s.n_unique()
 
     @overload
     def shrink_to_fit(self, in_place: Literal[False] = ...) -> Series:
@@ -3734,11 +3729,6 @@ class Series:
         ]
 
         """
-        k0 = seed
-        k1 = seed_1 if seed_1 is not None else seed
-        k2 = seed_2 if seed_2 is not None else seed
-        k3 = seed_3 if seed_3 is not None else seed
-        return wrap_s(self._s.hash(k0, k1, k2, k3))
 
     def reinterpret(self, signed: bool = True) -> Series:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3652,6 +3652,7 @@ class Series:
         3
 
         """
+        return self._s.n_unique()
 
     @overload
     def shrink_to_fit(self, in_place: Literal[False] = ...) -> Series:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4245,7 +4245,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.extend_constant(value, n))
 
     def set_sorted(self, reverse: bool = False) -> Series:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1757,7 +1757,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_null())
 
     def is_not_null(self) -> Series:
         """
@@ -1781,7 +1780,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_not_null())
 
     def is_finite(self) -> Series:
         """
@@ -1805,7 +1803,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_finite())
 
     def is_infinite(self) -> Series:
         """
@@ -1829,7 +1826,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_infinite())
 
     def is_nan(self) -> Series:
         """
@@ -1854,7 +1850,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_nan())
 
     def is_not_nan(self) -> Series:
         """
@@ -1879,7 +1874,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_not_nan())
 
     def is_in(self, other: Series | Sequence[Any]) -> Series:
         """
@@ -1931,7 +1925,6 @@ class Series:
         ]
 
         """
-        return self.to_frame().select(pli.col(self.name).is_in(other)).to_series()
 
     def arg_true(self) -> Series:
         """
@@ -1966,7 +1959,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_unique())
 
     def is_first(self) -> Series:
         """
@@ -1977,7 +1969,6 @@ class Series:
         Boolean Series
 
         """
-        return wrap_s(self._s.is_first())
 
     def is_duplicated(self) -> Series:
         """
@@ -2001,7 +1992,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.is_duplicated())
 
     def explode(self) -> Series:
         """
@@ -2029,7 +2019,6 @@ class Series:
         Exploded Series of same dtype
 
         """
-        return wrap_s(self._s.explode())
 
     def series_equal(
         self, other: Series, null_equal: bool = False, strict: bool = False

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3753,7 +3753,6 @@ class Series:
             If True, reinterpret as `pl.Int64`. Otherwise, reinterpret as `pl.UInt64`.
 
         """
-        return wrap_s(self._s.reinterpret(signed))
 
     def interpolate(self) -> Series:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3774,11 +3774,9 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.interpolate())
 
     def abs(self) -> Series:
         """Compute absolute values."""
-        return wrap_s(self._s.abs())
 
     def rank(self, method: RankMethod = "average", reverse: bool = False) -> Series:
         """
@@ -3838,7 +3836,6 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.rank(method, reverse))
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
@@ -3852,7 +3849,6 @@ class Series:
             How to handle null values.
 
         """
-        return wrap_s(self._s.diff(n, null_behavior))
 
     def pct_change(self, n: int = 1) -> Series:
         """
@@ -4010,7 +4006,6 @@ class Series:
             Minimum value.
 
         """
-        return self.to_frame().select(pli.col(self.name).clip_min(min_val))[self.name]
 
     def clip_max(self, max_val: int | float) -> Series:
         """
@@ -4027,7 +4022,6 @@ class Series:
             Maximum value.
 
         """
-        return self.to_frame().select(pli.col(self.name).clip_max(max_val))[self.name]
 
     def reshape(self, dims: tuple[int, ...]) -> Series:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -11,7 +11,6 @@ use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::list_construction::py_seq_to_list;
 use crate::set::set_at_idx;
-use crate::utils::reinterpret;
 use crate::{
     apply_method_all_arrow_series2, arrow_interop,
     npy::{aligned_array, get_refcnt},
@@ -1091,11 +1090,6 @@ impl PySeries {
         })
     }
 
-    pub fn shift(&self, periods: i64) -> Self {
-        let s = self.series.shift(periods);
-        PySeries::new(s)
-    }
-
     pub fn zip_with(&self, mask: &PySeries, other: &PySeries) -> PyResult<Self> {
         let mask = mask.series.bool().map_err(PyPolarsErr::from)?;
         let s = self
@@ -1127,11 +1121,6 @@ impl PySeries {
         self.series.peak_min().into_series().into()
     }
 
-    pub fn n_unique(&self) -> PyResult<usize> {
-        let n = self.series.n_unique().map_err(PyPolarsErr::from)?;
-        Ok(n)
-    }
-
     pub fn is_first(&self) -> PyResult<Self> {
         let out = self
             .series
@@ -1139,11 +1128,6 @@ impl PySeries {
             .map_err(PyPolarsErr::from)?
             .into_series();
         Ok(out.into())
-    }
-
-    pub fn round(&self, decimals: u32) -> PyResult<Self> {
-        let s = self.series.round(decimals).map_err(PyPolarsErr::from)?;
-        Ok(s.into())
     }
 
     pub fn floor(&self) -> PyResult<Self> {
@@ -1157,16 +1141,6 @@ impl PySeries {
 
     pub fn dot(&self, other: &PySeries) -> Option<f64> {
         self.series.dot(&other.series)
-    }
-
-    pub fn hash(&self, k0: u64, k1: u64, k2: u64, k3: u64) -> Self {
-        let hb = ahash::RandomState::with_seeds(k0, k1, k2, k3);
-        self.series.hash(hb).into_series().into()
-    }
-
-    pub fn mode(&self) -> PyResult<Self> {
-        let s = self.series.mode().map_err(PyPolarsErr::from)?;
-        Ok(s.into())
     }
 
     pub fn __getstate__(&self, py: Python) -> PyResult<PyObject> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1164,11 +1164,6 @@ impl PySeries {
         self.series.hash(hb).into_series().into()
     }
 
-    pub fn reinterpret(&self, signed: bool) -> PyResult<Self> {
-        let s = reinterpret(&self.series, signed).map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
     pub fn mode(&self) -> PyResult<Self> {
         let s = self.series.mode().map_err(PyPolarsErr::from)?;
         Ok(s.into())

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1242,15 +1242,6 @@ impl PySeries {
         Ok(out.into())
     }
 
-    pub fn extend_constant(&self, value: Wrap<AnyValue>, n: usize) -> PyResult<Self> {
-        let value = value.0;
-        let out = self
-            .series
-            .extend_constant(value, n)
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
-    }
-
     pub fn time_unit(&self) -> Option<&str> {
         if let DataType::Datetime(tu, _) | DataType::Duration(tu) = self.series.dtype() {
             Some(match tu {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -437,10 +437,6 @@ impl PySeries {
         self.series.cumprod(reverse).into()
     }
 
-    pub fn reverse(&self) -> Self {
-        self.series.reverse().into()
-    }
-
     pub fn chunk_lengths(&self) -> Vec<usize> {
         self.series.chunk_lengths().collect()
     }
@@ -739,11 +735,6 @@ impl PySeries {
 
     pub fn len(&self) -> usize {
         self.series.len()
-    }
-
-    pub fn to_physical(&self) -> Self {
-        let s = self.series.to_physical_repr().into_owned();
-        s.into()
     }
 
     pub fn to_list(&self) -> PyObject {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1,5 +1,4 @@
 use numpy::PyArray1;
-use polars::series::ops::NullBehavior;
 use polars_core::prelude::QuantileInterpolOptions;
 use polars_core::series::IsSorted;
 use polars_core::utils::CustomIterTools;
@@ -1175,11 +1174,6 @@ impl PySeries {
         Ok(s.into())
     }
 
-    pub fn interpolate(&self) -> Self {
-        let s = self.series.interpolate();
-        s.into()
-    }
-
     pub fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         // Used in pickle/pickling
         Ok(PyBytes::new(py, &bincode::serialize(&self.series).unwrap()).to_object(py))
@@ -1194,18 +1188,6 @@ impl PySeries {
             }
             Err(e) => Err(e),
         }
-    }
-
-    pub fn rank(&self, method: Wrap<RankMethod>, reverse: bool) -> PyResult<Self> {
-        let options = RankOptions {
-            method: method.0,
-            descending: reverse,
-        };
-        Ok(self.series.rank(options).into())
-    }
-
-    pub fn diff(&self, n: usize, null_behavior: Wrap<NullBehavior>) -> PyResult<Self> {
-        Ok(self.series.diff(n, null_behavior.0).into())
     }
 
     pub fn skew(&self, bias: bool) -> PyResult<Option<f64>> {
@@ -1229,11 +1211,6 @@ impl PySeries {
             self.series.cast(&dtype)
         };
         let out = out.map_err(PyPolarsErr::from)?;
-        Ok(out.into())
-    }
-
-    pub fn abs(&self) -> PyResult<Self> {
-        let out = self.series.abs().map_err(PyPolarsErr::from)?;
         Ok(out.into())
     }
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -606,39 +606,6 @@ impl PySeries {
         self.series.has_validity()
     }
 
-    pub fn is_null(&self) -> PySeries {
-        Self::new(self.series.is_null().into_series())
-    }
-
-    pub fn is_not_null(&self) -> PySeries {
-        Self::new(self.series.is_not_null().into_series())
-    }
-
-    pub fn is_not_nan(&self) -> PyResult<Self> {
-        let ca = self.series.is_not_nan().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
-    pub fn is_nan(&self) -> PyResult<Self> {
-        let ca = self.series.is_nan().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
-    pub fn is_finite(&self) -> PyResult<Self> {
-        let ca = self.series.is_finite().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
-    pub fn is_infinite(&self) -> PyResult<Self> {
-        let ca = self.series.is_infinite().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
-    pub fn is_unique(&self) -> PyResult<Self> {
-        let ca = self.series.is_unique().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
     pub fn sample_n(
         &self,
         n: usize,
@@ -664,16 +631,6 @@ impl PySeries {
             .series
             .sample_frac(frac, with_replacement, shuffle, seed)
             .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
-    pub fn is_duplicated(&self) -> PyResult<Self> {
-        let ca = self.series.is_duplicated().map_err(PyPolarsErr::from)?;
-        Ok(ca.into_series().into())
-    }
-
-    pub fn explode(&self) -> PyResult<Self> {
-        let s = self.series.explode().map_err(PyPolarsErr::from)?;
         Ok(s.into())
     }
 
@@ -1110,15 +1067,6 @@ impl PySeries {
 
     pub fn peak_min(&self) -> Self {
         self.series.peak_min().into_series().into()
-    }
-
-    pub fn is_first(&self) -> PyResult<Self> {
-        let out = self
-            .series
-            .is_first()
-            .map_err(PyPolarsErr::from)?
-            .into_series();
-        Ok(out.into())
     }
 
     pub fn floor(&self) -> PyResult<Self> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1069,6 +1069,11 @@ impl PySeries {
         self.series.peak_min().into_series().into()
     }
 
+    pub fn n_unique(&self) -> PyResult<usize> {
+        let n = self.series.n_unique().map_err(PyPolarsErr::from)?;
+        Ok(n)
+    }
+
     pub fn floor(&self) -> PyResult<Self> {
         let s = self.series.floor().map_err(PyPolarsErr::from)?;
         Ok(s.into())

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1237,11 +1237,6 @@ impl PySeries {
         Ok(out.into())
     }
 
-    pub fn reshape(&self, dims: Vec<i64>) -> PyResult<Self> {
-        let out = self.series.reshape(&dims).map_err(PyPolarsErr::from)?;
-        Ok(out.into())
-    }
-
     pub fn time_unit(&self) -> Option<&str> {
         if let DataType::Datetime(tu, _) | DataType::Duration(tu) = self.series.dtype() {
             Some(match tu {


### PR DESCRIPTION
Changes:
* Dispatch many more `Series` methods to an `Expr` equivalent. A few notable cases:
  * `Expr.reinterpret` now has a default `True` like its `Series` counterpart.

...more to come, haven't worked through all methods yet.