### PR TITLE
chore[python]: Deprecate `Series.inner`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1865,7 +1865,7 @@ class DataFrame:
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
                 return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0).inner())
+                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
                 )
             if isinstance(item[0], str):
                 return self._from_pydf(self._df.select(item))
@@ -1882,10 +1882,10 @@ class DataFrame:
             if dtype == Utf8:
                 return self._from_pydf(self._df.select(item))
             if dtype == UInt32:
-                return self._from_pydf(self._df.take_with_series(item.inner()))
+                return self._from_pydf(self._df.take_with_series(item._s))
             if dtype in {UInt8, UInt16, UInt64, Int8, Int16, Int32, Int64}:
                 return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0).inner())
+                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
                 )
 
         # if no data has been returned, the operation is not supported
@@ -2578,7 +2578,7 @@ class DataFrame:
         └─────┴─────┘
 
         """
-        self._df.replace(column, new_col.inner())
+        self._df.replace(column, new_col._s)
 
     def slice(self: DF, offset: int, length: int | None = None) -> DF:
         """
@@ -3976,10 +3976,10 @@ class DataFrame:
         if not isinstance(columns, list):
             columns = columns.get_columns()
         if in_place:
-            self._df.hstack_mut([s.inner() for s in columns])
+            self._df.hstack_mut([s._s for s in columns])
             return None
         else:
-            return self._from_pydf(self._df.hstack([s.inner() for s in columns]))
+            return self._from_pydf(self._df.hstack([s._s for s in columns]))
 
     @overload
     def vstack(self, df: DataFrame, in_place: Literal[True]) -> None:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -270,15 +270,6 @@ class Series:
             pandas_to_pyseries(name, values, nan_to_none=nan_to_none)
         )
 
-    def inner(self) -> PySeries:
-        warn(
-            "Series.inner will be removed in a future version. Use the public Polars"
-            " API instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._s
-
     def __getstate__(self) -> Any:
         return self._s.__getstate__()
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -271,6 +271,12 @@ class Series:
         )
 
     def inner(self) -> PySeries:
+        warn(
+            "Series.inner will be removed in a future version. Use the public Polars"
+            " API instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._s
 
     def __getstate__(self) -> Any:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -574,9 +574,9 @@ class Series:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
-                return wrap_s(self._s.take_with_series(self._pos_idxs(item).inner()))
+                return wrap_s(self._s.take_with_series(self._pos_idxs(item)._s))
             if item.dtype == bool:
-                return wrap_s(self._s.filter(pli.Series("", item).inner()))
+                return wrap_s(self._s.filter(pli.Series("", item)._s))
 
         if is_bool_sequence(item) or is_int_sequence(item):
             item = Series("", item)  # fall through to next if isinstance
@@ -585,9 +585,9 @@ class Series:
             if item.dtype == Boolean:
                 return wrap_s(self._s.filter(item._s))
             if item.dtype == UInt32:
-                return wrap_s(self._s.take_with_series(item.inner()))
+                return wrap_s(self._s.take_with_series(item._s))
             if item.dtype in {UInt8, UInt16, UInt64, Int8, Int16, Int32, Int64}:
-                return wrap_s(self._s.take_with_series(self._pos_idxs(item).inner()))
+                return wrap_s(self._s.take_with_series(self._pos_idxs(item)._s))
 
         if isinstance(item, range):
             return self[range_to_slice(item)]


### PR DESCRIPTION
`Series.inner` is a public method that exposes the underlying `PySeries`. This is problematic for a number of reasons:

* We do not want users to interact directly with the underlying PyO3 object.
* It's a public method, but it is not listed in the Polars API reference.
* Internally we mostly use `Series._s` to get the underlying `PySeries` object (similar to `DataFrame._df`, `LazyFrame._ldf`, `Expr._pyexpr`). Using `.inner()` could be seen as non-idiomatic.

I think it makes most sense to remove the `Series.inner` method completely.

The alternative would be to make the method private (`_inner`), define it for `DataFrame`, `LazyFrame`, and `Expr` too, and change all the direct references to the underlying objects with `_inner()` calls. I don't feel that is a big improvement - `Series._s` is nice and short.

Changes:
* Add deprecation message to the `Series.inner` method
* Replace `inner()` calls with `_s`

_(Maybe we could just remove this method altogether, without deprecating it? I doubt people are using it)_