### PR TITLE
docs[python]: Fix broken part of read_excel docstring

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1141,8 +1141,6 @@ def read_excel(
     ...     read_csv_options={"infer_schema_length": None},
     ... )  # doctest: +SKIP
 
-    Alternative
-    -----------
     If :func:`read_excel` does not work or you need to read other types of spreadsheet
     files, you can try pandas ``pd.read_excel()``
     (supports `xls`, `xlsx`, `xlsm`, `xlsb`, `odf`, `ods` and `odt`).


### PR DESCRIPTION
Sphinx gave a warning that the `Alternatives` section is an unknown section. This section did not show up in the docs:
https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_excel.html

I removed the section header - now it should show up properly as a doc example.