### PR TITLE
feat[python]: Add `Expr.limit` alias

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -202,6 +202,7 @@ Manipulation/ selection
     Expr.head
     Expr.inspect
     Expr.interpolate
+    Expr.limit
     Expr.lower_bound
     Expr.rechunk
     Expr.reinterpret

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2617,18 +2617,17 @@ class DataFrame:
             length = self.height - offset + length
         return self._from_pydf(self._df.slice(offset, length))
 
-    def limit(self: DF, length: int = 5) -> DF:
+    @deprecated_alias(length="n")
+    def limit(self: DF, n: int = 5) -> DF:
         """
-        Get first N rows as DataFrame.
+        Get the first `n` rows.
 
-        See Also
-        --------
-        head, tail, slice
+        Alias for :func:`head`.
 
         Parameters
         ----------
-        length
-            Amount of rows to take.
+        n
+            Number of rows to return.
 
         Examples
         --------
@@ -2652,7 +2651,7 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return self.head(length)
+        return self.head(n)
 
     @deprecated_alias(length="n")
     def head(self: DF, n: int = 5) -> DF:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2629,27 +2629,6 @@ class DataFrame:
         n
             Number of rows to return.
 
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "foo": [1, 2, 3],
-        ...         "bar": [6, 7, 8],
-        ...         "ham": ["a", "b", "c"],
-        ...     }
-        ... )
-        >>> df.limit(2)
-        shape: (2, 3)
-        ┌─────┬─────┬─────┐
-        │ foo ┆ bar ┆ ham │
-        │ --- ┆ --- ┆ --- │
-        │ i64 ┆ i64 ┆ str │
-        ╞═════╪═════╪═════╡
-        │ 1   ┆ 6   ┆ a   │
-        ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
-        │ 2   ┆ 7   ┆ b   │
-        └─────┴─────┴─────┘
-
         """
         return self.head(n)
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3259,6 +3259,20 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.tail(n))
 
+    def limit(self, n: int = 10) -> Expr:
+        """
+        Get the first `n` rows.
+
+        Alias for :func:`head`.
+
+        Parameters
+        ----------
+        n
+            Number of rows to return.
+
+        """
+        return self.head(n)
+
     def pow(self, exponent: int | float | pli.Series | Expr) -> Expr:
         """
         Raise expression to the power of exponent.

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1836,15 +1836,16 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Alias for :func:`head`.
 
-        .. note::
-            Consider using the :func:`fetch` operation if you only want to test your
-            query. The :func:`fetch` operation will load the first `n` rows at the scan
-            level, whereas the :func:`head`/:func:`limit` are applied at the end.
-
         Parameters
         ----------
         n
             Number of rows to return.
+
+        Notes
+        -----
+        Consider using the :func:`fetch` operation if you only want to test your
+        query. The :func:`fetch` operation will load the first `n` rows at the scan
+        level, whereas the :func:`head`/:func:`limit` are applied at the end.
 
         """
         return self.head(n)
@@ -1853,18 +1854,16 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         Get the first `n` rows.
 
-        .. note::
-            Consider using the :func:`fetch` operation if you only want to test your
-            query. The :func:`fetch` operation will load the first `n` rows at the scan
-            level, whereas the :func:`head`/:func:`limit` are applied at the end.
-
-        This operation instead loads all the rows and only applies the ``head`` at the
-        end.
-
         Parameters
         ----------
         n
             Number of rows to return.
+
+        Notes
+        -----
+        Consider using the :func:`fetch` operation if you only want to test your
+        query. The :func:`fetch` operation will load the first `n` rows at the scan
+        level, whereas the :func:`head`/:func:`limit` are applied at the end.
 
         """
         return self.slice(0, n)

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1832,10 +1832,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def limit(self: LDF, n: int = 5) -> LDF:
         """
-        Limit the LazyFrame to the first `n` rows.
+        Get the first `n` rows.
+
+        Alias for :func:`head`.
 
         .. note::
-            Consider using the :func:`fetch` operation when you only want to test your
+            Consider using the :func:`fetch` operation if you only want to test your
             query. The :func:`fetch` operation will load the first `n` rows at the scan
             level, whereas the :func:`head`/:func:`limit` are applied at the end.
 
@@ -1845,7 +1847,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Number of rows to return.
 
         """
-        return self.slice(0, n)
+        return self.head(n)
 
     def head(self: LDF, n: int = 5) -> LDF:
         """
@@ -1865,11 +1867,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Number of rows to return.
 
         """
-        return self.limit(n)
+        return self.slice(0, n)
 
     def tail(self: LDF, n: int = 5) -> LDF:
         """
-        Get the last `n` rows of the DataFrame.
+        Get the last `n` rows.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1338,17 +1338,6 @@ class Series:
         n
             Number of rows to return.
 
-        Examples
-        --------
-        >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.limit(2)
-        shape: (2,)
-        Series: 'a' [i64]
-        [
-                1
-                2
-        ]
-
         """
         return self.to_frame().select(pli.col(self.name).limit(n)).to_series()
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1326,14 +1326,17 @@ class Series:
 
         """
 
-    def limit(self, num_elements: int = 10) -> Series:
+    @deprecated_alias(num_elements="n")
+    def limit(self, n: int = 10) -> Series:
         """
-        Take n elements from this Series.
+        Get the first `n` rows.
+
+        Alias for :func:`head`.
 
         Parameters
         ----------
-        num_elements
-            Amount of elements to take.
+        n
+            Number of rows to return.
 
         Examples
         --------
@@ -1347,7 +1350,7 @@ class Series:
         ]
 
         """
-        return wrap_s(self._s.limit(num_elements))
+        return self.to_frame().select(pli.col(self.name).limit(n)).to_series()
 
     def slice(self, offset: int, length: int | None = None) -> Series:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -480,11 +480,6 @@ impl PySeries {
         self.series.n_chunks()
     }
 
-    pub fn limit(&self, num_elements: usize) -> Self {
-        let series = self.series.limit(num_elements);
-        series.into()
-    }
-
     pub fn slice(&self, offset: i64, length: Option<usize>) -> Self {
         let series = self
             .series


### PR DESCRIPTION
Changes:
* Add `Expr.limit` method, as an alias for `Expr.head`. This alias already exists for Series/DataFrame/LazyFrame.
  * I didn't add tests - since it's just an alias for `Expr.head`, and there are already tests in place for that method.
* Improve consistency in arg names / docstrings across `limit` methods
  * Removed docstring examples here, as it's simply an alias for `head`. I think it's fair to redirect people there to find examples.
* Dispatch `Series.limit` to `Expr.limit`