### PR TITLE
docs[python]: add favicon/touchicon

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -82,4 +82,16 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
     ],
+    "favicons": [
+        {
+            "rel": "icon",
+            "sizes": "32x32",
+            "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/favicon-32x32.png",  # noqa: E501
+        },
+        {
+            "rel": "apple-touch-icon",
+            "sizes": "180x180",
+            "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/touchicon-180x180.png",  # noqa: E501
+        },
+    ],
 }


### PR DESCRIPTION
Adds a favicon to the docs (hard to shrink the bear down cleanly, so I just took the head/shoulders - can revisit if it's non-obvious :) and a [touchicon](https://realfavicongenerator.net/blog/apple-touch-icon-the-good-the-bad-the-ugly/) (what iOS would use if anyone were to add the docs site to their iPad/etc homescreen).