### PR TITLE
docs[python]: Fix incorrect links

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2622,7 +2622,7 @@ class DataFrame:
         """
         Get the first `n` rows.
 
-        Alias for :func:`head`.
+        Alias for :func:`DataFrame.head`.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3264,7 +3264,7 @@ class Expr:
         """
         Get the first `n` rows.
 
-        Alias for :func:`head`.
+        Alias for :func:`Expr.head`.
 
         Parameters
         ----------
@@ -4572,7 +4572,7 @@ class Expr:
         """
         Get the index values that would sort this column.
 
-        Alias for `arg_sort`.
+        Alias for :func:`Expr.arg_sort`.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1834,7 +1834,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         Get the first `n` rows.
 
-        Alias for :func:`head`.
+        Alias for :func:`LazyFrame.head`.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1331,7 +1331,7 @@ class Series:
         """
         Get the first `n` rows.
 
-        Alias for :func:`head`.
+        Alias for :func:`Series.head`.
 
         Parameters
         ----------
@@ -1602,7 +1602,7 @@ class Series:
         """
         Get the index values that would sort this Series.
 
-        Alias for :func:`arg_sort`.
+        Alias for :func:`Series.arg_sort`.
 
         Parameters
         ----------


### PR DESCRIPTION
Apparently, these function links do not automatically link to the functions in the same scope. In this case, the `head` links would all link to `pl.head`. This should fix it.

_(Is there an easy way for me to check the resulting docs locally?)_