### PR TITLE
fix[doc]: Render long method names on multiple lines (#4591)

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -16,3 +16,8 @@ dt em.sig-param:last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
+
+/* Display long method names over multiple lines in navbar. */
+.bd-toc-item {
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
Render long method names on multiple lines, so no sidewards
scrolling is needed to see them.