### PR TITLE
ci: ensure db-benchmark runs on categorical dtypes

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'polars/**'
+      - 'py-polars/tests/db-benchmark/**'
       - '.github/workflows/benchmark.yaml'
 jobs:
   test:

--- a/py-polars/tests/db-benchmark/main.py
+++ b/py-polars/tests/db-benchmark/main.py
@@ -23,7 +23,7 @@ x = pl.read_csv(
 ON_STRINGS = sys.argv.pop() == "on_strings"
 
 if not ON_STRINGS:
-    x.with_columns([pl.col(["id1", "id2", "id3"]).cast(pl.Categorical)])
+    x = x.with_columns([pl.col(["id1", "id2", "id3"]).cast(pl.Categorical)])
 df = x.clone()
 x = df.lazy()
 


### PR DESCRIPTION
It ran on string dtypes.