### PR TITLE
ci: release polars-lts-cpu; a more conservative binary

### DIFF
--- a/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
+++ b/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
@@ -1,0 +1,36 @@
+name: Create Python release manylinux LTS-CPU
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'py-polars-v*' # Push events to matching py-polars-v*, i.e. py-polars-v1.0, py-polars-v20.15.10
+jobs:
+  build_manylinux:
+    name: Create Release manylinux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare maturin publish
+        shell: bash
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+          cd py-polars
+
+      - name: Prepare lts-cpu
+        shell: bash
+        run: |
+          sed -i 's/name = "polars"/name = "polars-lts-cpu"/' py-polars/pyproject.toml
+      - name: publish x64_64 lts-cpu
+        uses: messense/maturin-action@main
+        env:
+          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+          RUSTFLAGS: '-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt'
+        with:
+          rust-toolchain: nightly-2022-08-22
+          # don't use `2_17` it does not work: https://github.com/pola-rs/polars/runs/6107328960
+          manylinux: '2_24'
+          maturin-version: '0.13.0'
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing -o wheels -i python -u ritchie46

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Or for python users install `$ pip install -U polars-u64-idx`.
 
 Don't use this unless you hit the row boundary as the default polars is faster and consumes less memory.
 
+# Legacy
+Do you want polars to run on an old CPU (e.g. dating from before 2011)? Install `$pip -U polars-lts-cpu`. This polars project is 
+compiled without [avx](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target features.
+
 ## Acknowledgements
 
 Development of Polars is proudly powered by


### PR DESCRIPTION
Very old CPUs cannot load polars. This will release a more conservative binary.