### PR TITLE
style[python]: Disable pydocstyle lint D401

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -7,7 +7,7 @@ extend-ignore =
     E203,
     # pydocstyle: http://www.pydocstyle.org/en/stable/error_codes.html
     # numpy convention with a few additional lints
-    D107, D203, D212, D402, D415, D416,
+    D107, D203, D212, D401, D402, D415, D416,
     # TODO: Remove errors below to further improve docstring linting
     D1, D400, D205,
     # flake8-simplify


### PR DESCRIPTION
See discussion in #4601 

Declarative docstring wording is preferred. So this PR disables error code D401.