### PR TITLE
docs[python]: Use numpydoc sections

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3731,8 +3731,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -3832,8 +3832,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -3933,8 +3933,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -4032,8 +4032,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -4133,8 +4133,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -4234,8 +4234,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -4331,8 +4331,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -4434,8 +4434,8 @@ class Expr:
 
         Warnings
         --------
-        The dynamic windows functionality is still experimental and may change
-        without it considered being a breaking change.
+        This functionality is experimental and may change without it being considered a
+        breaking change.
 
         Notes
         -----
@@ -5833,7 +5833,7 @@ class Expr:
 
         Warnings
         --------
-        This API is experimental and may change without it being considered a
+        This functionality is experimental and may change without it being considered a
         breaking change.
 
         This can be really slow as it can have `O(n^2)` complexity. Don't use this

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1237,9 +1237,10 @@ class Expr:
         """
         Drop null values.
 
-        .. warning::
-            Note that null values are not floating point NaN values!
-            To drop NaN values, use :func:`drop_nans`.
+        Warnings
+        --------
+        Note that null values are not floating point NaN values!
+        To drop NaN values, use :func:`drop_nans`.
 
         Examples
         --------
@@ -1270,9 +1271,10 @@ class Expr:
         """
         Drop floating point NaN values
 
-        .. warning::
-            Note that NaN values are not null values!
-            To drop null values, use :func:`drop_nulls`.
+        Warnings
+        --------
+        Note that NaN values are not null values!
+        To drop null values, use :func:`drop_nulls`.
 
         Examples
         --------
@@ -3727,15 +3729,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
-
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -3827,14 +3830,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -3926,14 +3931,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -4023,14 +4030,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -4122,14 +4131,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -4221,14 +4232,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -4316,14 +4329,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -4417,14 +4432,16 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define whether the temporal window interval is closed or not.
 
-        .. warning::
-            The dynamic windows functionality is still experimental and may change
-            without it considered being a breaking change
+        Warnings
+        --------
+        The dynamic windows functionality is still experimental and may change
+        without it considered being a breaking change.
 
-        .. note::
-            If you want to compute multiple aggregation statistics over the same dynamic
-            window, consider using `groupby_rolling` this method can cache the window
-            size computation.
+        Notes
+        -----
+        If you want to compute multiple aggregation statistics over the same dynamic
+        window, consider using `groupby_rolling` this method can cache the window size
+        computation.
 
         Examples
         --------
@@ -5803,14 +5820,6 @@ class Expr:
         """
         Run an expression over a sliding window that increases `1` slot every iteration.
 
-        .. warning::
-            This can be really slow as it can have `O(n^2)` complexity. Don't use this
-            for operations that visit all elements.
-
-        .. warning::
-            This API is experimental and may change without it being considered a
-            breaking change.
-
         Parameters
         ----------
         expr
@@ -5821,6 +5830,14 @@ class Expr:
         parallel
             Run in parallel. Don't do this in a groupby or another operation that
             already has much parallelization.
+
+        Warnings
+        --------
+        This API is experimental and may change without it being considered a
+        breaking change.
+
+        This can be really slow as it can have `O(n^2)` complexity. Don't use this
+        for operations that visit all elements.
 
         Examples
         --------
@@ -5859,14 +5876,15 @@ class Expr:
         Set this `Series` as `sorted` so that downstream code can use
         fast paths for sorted arrays.
 
-        .. warning::
-            This can lead to incorrect results if this `Series` is not sorted!!
-            Use with care!
-
         Parameters
         ----------
         reverse
             If the `Series` order is reversed, e.g. descending.
+
+        Warnings
+        --------
+        This can lead to incorrect results if this `Series` is not sorted!!
+        Use with care!
 
         Examples
         --------

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -280,10 +280,6 @@ def cut(
     """
     Bin values into discrete values.
 
-    .. warning::
-        This function is experimental and might change without it being considered a
-        breaking change.
-
     Parameters
     ----------
     s
@@ -301,6 +297,11 @@ def cut(
     Returns
     -------
     DataFrame
+
+    Warnings
+    --------
+    This function is experimental and might change without it being considered a
+    breaking change.
 
     Examples
     --------

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -300,7 +300,7 @@ def cut(
 
     Warnings
     --------
-    This function is experimental and might change without it being considered a
+    This functionality is experimental and may change without it being considered a
     breaking change.
 
     Examples

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1016,11 +1016,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         individual values and are not of constant intervals. For constant intervals use
         *groupby_dynamic*
 
-        .. seealso::
-
-            groupby_dynamic
-
-
         The `period` and `offset` arguments are created with
         the following string language:
 
@@ -1063,6 +1058,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
+
+        See Also
+        --------
+        groupby_dynamic
 
         Examples
         --------
@@ -1134,10 +1133,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         window could be seen as a rolling window, with a window size determined by
         dates/times/values instead of slots in the DataFrame.
 
-        .. seealso::
-
-            groupby_rolling
-
         A window is defined by:
 
         - every: interval of the window
@@ -1195,6 +1190,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Define whether the temporal window interval is closed or not.
         by
             Also group by this column/these columns
+
+        See Also
+        --------
+        groupby_rolling
 
         """
         if offset is None:

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1893,16 +1893,17 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         Add a column at index 0 that counts the rows.
 
-        .. warning::
-            This can have a negative effect on query performance.
-            This may, for instance, block predicate pushdown optimization.
-
         Parameters
         ----------
         name
             Name of the column to add.
         offset
             Start the row count at this offset.
+
+        Warnings
+        --------
+        This can have a negative effect on query performance.
+        This may, for instance, block predicate pushdown optimization.
 
         Examples
         --------
@@ -1977,14 +1978,15 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         Fill floating point NaN values.
 
-        .. warning::
-            Note that floating point NaN (Not a Number) are not missing values!
-            To replace missing values, use :func:`fill_null` instead.
-
         Parameters
         ----------
         fill_value
             Value to fill the NaN values with.
+
+        Warnings
+        --------
+        Note that floating point NaN (Not a Number) are not missing values!
+        To replace missing values, use :func:`fill_null` instead.
 
         """
         if not isinstance(fill_value, pli.Expr):
@@ -2298,18 +2300,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Apply a custom function. It is important that the function returns a Polars
         DataFrame.
 
-        .. warning::
-            The ``schema`` of a `LazyFrame` must always be correct.
-            It is up to the caller of this function to ensure that
-            this invariant is uphold.
-
-        .. warning::
-            It is important that the optimization flags are correct.
-            If the custom function for instance does an aggregation
-            of a column, ``predicate_pushdown`` should not be allowed,
-            as this prunes rows and will influence your aggregation
-            results.
-
         Parameters
         ----------
         f
@@ -2323,14 +2313,22 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         no_optimizations
             Turn off all optimizations past this point.
         schema
-            Output schema of the function, if set to ``None``
-            we assume that the schema will remain unchanged
-            by the applied function.
+            Output schema of the function, if set to ``None`` we assume that the schema
+            will remain unchanged by the applied function.
         validate_output_schema
-            It is paramount that polars' schema is correct. This flag
-            will ensure that the output schema of this function will
-            be checked with the expected schema. Setting this to ``False``
-            will not do this check, but may lead to hard to debug bugs.
+            It is paramount that polars' schema is correct. This flag will ensure that
+            the output schema of this function will be checked with the expected schema.
+            Setting this to ``False`` will not do this check, but may lead to hard to
+            debug bugs.
+
+        Warnings
+        --------
+        The ``schema`` of a `LazyFrame` must always be correct. It is up to the caller
+        of this function to ensure that this invariant is upheld.
+
+        It is important that the optimization flags are correct. If the custom function
+        for instance does an aggregation of a column, ``predicate_pushdown`` should not
+        be allowed, as this prunes rows and will influence your aggregation results.
 
         """
         if no_optimizations:

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -403,7 +403,7 @@ class DateTimeNameSpace:
 
         Warnings
         --------
-        This API is experimental and may change without it being considered a
+        This functionality is experimental and may change without it being considered a
         breaking change.
 
         Examples

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -372,10 +372,6 @@ class DateTimeNameSpace:
         offset: str | timedelta | None = None,
     ) -> pli.Series:
         """
-        .. warning::
-            This API is experimental and may change without it being considered a
-            breaking change.
-
         Divide the date/ datetime range into buckets.
 
         The `every` and `offset` argument are created with the
@@ -404,6 +400,11 @@ class DateTimeNameSpace:
         Returns
         -------
         Date/Datetime series
+
+        Warnings
+        --------
+        This API is experimental and may change without it being considered a
+        breaking change.
 
         Examples
         --------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1128,7 +1128,7 @@ class Series:
 
         Warnings
         --------
-        This API is experimental and may change without it being considered a
+        This functionality is experimental and may change without it being considered a
         breaking change.
 
         This can be really slow as it can have `O(n^2)` complexity. Don't use this

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1115,14 +1115,6 @@ class Series:
         """
         Run an expression over a sliding window that increases `1` slot every iteration.
 
-        .. warning::
-            This can be really slow as it can have `O(n^2)` complexity. Don't use this
-            for operations that visit all elements.
-
-        .. warning::
-            This API is experimental and may change without it being considered a
-            breaking change.
-
         Parameters
         ----------
         expr
@@ -1133,6 +1125,14 @@ class Series:
         parallel
             Run in parallel. Don't do this in a groupby or another operation that
             already has much parallelization.
+
+        Warnings
+        --------
+        This API is experimental and may change without it being considered a
+        breaking change.
+
+        This can be really slow as it can have `O(n^2)` complexity. Don't use this
+        for operations that visit all elements.
 
         Examples
         --------
@@ -4189,14 +4189,15 @@ class Series:
         Set this `Series` as `sorted` so that downstream code can use
         fast paths for sorted arrays.
 
-        .. warning::
-            This can lead to incorrect results if this `Series` is not sorted!!
-            Use with care!
-
         Parameters
         ----------
         reverse
             If the `Series` order is reversed, e.g. descending.
+
+        Warnings
+        --------
+        This can lead to incorrect results if this `Series` is not sorted!!
+        Use with care!
 
         """
         return wrap_s(self._s.set_sorted(reverse))

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2481,16 +2481,17 @@ class Series:
         """
         Set masked values.
 
-        .. note::
-            Using this is an anti-pattern.
-            Always prefer: `pl.when(predicate).then(value).otherwise(self)`
-
         Parameters
         ----------
         filter
             Boolean mask.
         value
             Value to replace the the masked values with.
+
+        Notes
+        -----
+        Using this is an anti-pattern.
+        Always prefer: `pl.when(predicate).then(value).otherwise(self)`
 
         """
         f = get_ffi_func("set_with_mask_<>", self.dtype, self._s)
@@ -2517,10 +2518,6 @@ class Series:
         """
         Set values at the index locations.
 
-        .. note::
-            Using this is an anti-pattern.
-            Always prefer: `pl.when(predicate).then(value).otherwise(self)`
-
         Parameters
         ----------
         idx
@@ -2531,6 +2528,11 @@ class Series:
         Returns
         -------
         the series mutated
+
+        Notes
+        -----
+        Using this is considered an anti-pattern.
+        Always prefer: `pl.when(predicate).then(value).otherwise(self)`
 
         """
         if isinstance(idx, int):

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -988,10 +988,6 @@ def read_sql(
     """
     Read a SQL query into a DataFrame.
 
-    .. note::
-        Make sure to install connectorx>=0.2.2. Read the documentation
-        `here <https://sfu-db.github.io/connector-x/intro.html>`_.
-
     Reading a SQL query from the following data sources are supported:
 
         * Postgres
@@ -1023,6 +1019,11 @@ def read_sql(
     protocol
         Backend-specific transfer protocol directive; see connectorx documentation for
         details.
+
+    Notes
+    -----
+    Make sure to install connectorx>=0.2.2. Read the documentation
+    `here <https://sfu-db.github.io/connector-x/intro.html>`_.
 
     Examples
     --------

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1185,14 +1185,15 @@ def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
 
     This can be useful to connect to cloud or partitioned datasets.
 
-    .. warning::
-        This API is experimental and may change without it being considered a breaking
-        change.
-
     Parameters
     ----------
     ds
         Pyarrow dataset to scan.
+
+    Warnings
+    --------
+    This API is experimental and may change without it being considered a breaking
+    change.
 
     Examples
     --------


### PR DESCRIPTION
Changes:
* Use numpydoc style sections `Warnings`, `Notes`, and `See Also` instead of sphinx reST formatting.
* Consistent wording for experimental feature warning.