### PR TITLE
fix[python]: Fix datatype pickling

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -46,6 +46,15 @@ def get_idx_type() -> type[DataType]:
     return _get_idx_type()
 
 
+def _custom_reconstruct(cls, base, state):
+    if state:
+        obj = base.__new__(cls, state)
+        if base.__init__ != object.__init__:
+            base.__init__(obj, state)
+    else:
+        return object.__new__(cls)
+
+
 class DataType:
     """Base class for all Polars data types."""
 
@@ -55,6 +64,9 @@ class DataType:
         if args or kwargs:
             return super().__new__(cls)
         return cls
+
+    def __reduce__(self) -> Any:
+        return (_custom_reconstruct, (type(cls), object, None), self.__dict__)
 
     @classmethod
     def string_repr(cls) -> str:

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -46,7 +46,9 @@ def get_idx_type() -> type[DataType]:
     return _get_idx_type()
 
 
-def _custom_reconstruct(cls, base, state):
+def _custom_reconstruct(
+    cls: type[DataType], base: type[Any], state: Any
+) -> PolarsDataType:
     if state:
         obj = base.__new__(cls, state)
         if base.__init__ != object.__init__:
@@ -66,7 +68,7 @@ class DataType:
         return cls
 
     def __reduce__(self) -> Any:
-        return (_custom_reconstruct, (type(cls), object, None), self.__dict__)
+        return (_custom_reconstruct, (type(self), object, None), self.__dict__)
 
     @classmethod
     def string_repr(cls) -> str:

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -46,15 +46,14 @@ def get_idx_type() -> type[DataType]:
     return _get_idx_type()
 
 
-def _custom_reconstruct(
-    cls: type[DataType], base: type[Any], state: Any
-) -> PolarsDataType:
+def _custom_reconstruct(cls: type[Any], base: type[Any], state: Any) -> PolarsDataType:
     if state:
         obj = base.__new__(cls, state)
         if base.__init__ != object.__init__:
             base.__init__(obj, state)
     else:
-        return object.__new__(cls)
+        obj = object.__new__(cls)
+    return obj
 
 
 class DataType:

--- a/py-polars/tests/test_datatypes.py
+++ b/py-polars/tests/test_datatypes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-
+import pickle
 import polars as pl
 from polars import datatypes
 
@@ -32,3 +32,11 @@ def test_dtype_temporal_units() -> None:
 
 def test_get_idx_type() -> None:
     assert datatypes.get_idx_type() == datatypes.UInt32
+
+
+def test_dtypes_picklable() -> None:
+    parametric_type = pl.Datetime("ns")
+    singleton_type = pl.Float64
+    assert pickle.loads(pickle.dumps(parametric_type)) == parametric_type
+    assert pickle.loads(pickle.dumps(singleton_type)) == singleton_type
+

--- a/py-polars/tests/test_datatypes.py
+++ b/py-polars/tests/test_datatypes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import pickle
+
 import polars as pl
 from polars import datatypes
 
@@ -39,4 +40,3 @@ def test_dtypes_picklable() -> None:
     singleton_type = pl.Float64
     assert pickle.loads(pickle.dumps(parametric_type)) == parametric_type
     assert pickle.loads(pickle.dumps(singleton_type)) == singleton_type
-


### PR DESCRIPTION
During the `__reduce__` phase of a parametric dtype like `pl.Datatime("ns")` pickling we get:

```
(<function copyreg._reconstructor(cls, base, state)>,
 (polars.datatypes.Datetime, object, None),
 {'tu': 'ns', 'tz': None})
```

,but `copyreg`'s reconstructor calls `__new__` which we changed to make sure we can support singleton type objects:

```
def _reconstructor(cls, base, state):
    if base is object:
        obj = object.__new__(cls)
    else:
        obj = base.__new__(cls, state)
        if base.__init__ != object.__init__:
            base.__init__(obj, state)
    return obj
```

here, `object.__new__(cls)` returns the cls itself not an instance. We need to have a custom reconstructor in order to get this to work.