### PR TITLE
fix[rust]: don't unnecessarily truncate datetime values on string cast

### DIFF
--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -378,8 +378,16 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     }
 
     fn cast(&self, data_type: &DataType) -> Result<Series> {
-        match data_type {
-            DataType::Utf8 => Ok(self.0.strftime("%F %T").into_series()),
+        match (data_type, self.0.time_unit()) {
+            (DataType::Utf8, TimeUnit::Milliseconds) => {
+                Ok(self.0.strftime("%F %T%.3f").into_series())
+            }
+            (DataType::Utf8, TimeUnit::Microseconds) => {
+                Ok(self.0.strftime("%F %T%.6f").into_series())
+            }
+            (DataType::Utf8, TimeUnit::Nanoseconds) => {
+                Ok(self.0.strftime("%F %T%.9f").into_series())
+            }
             _ => self.0.cast(data_type),
         }
     }

--- a/py-polars/tests/test_datelike.py
+++ b/py-polars/tests/test_datelike.py
@@ -1426,3 +1426,29 @@ def test_date_timedelta() -> None:
         "date_plus_one": [date(2001, 1, 2), date(2001, 1, 3), date(2001, 1, 4)],
         "date_min_one": [date(2000, 12, 31), date(2001, 1, 1), date(2001, 1, 2)],
     }
+
+
+def test_datetime_string_casts() -> None:
+    df = pl.DataFrame(
+        {
+            "x": [1661855445123],
+            "y": [1661855445123456],
+            "z": [1661855445123456789],
+        },
+        columns=[
+            ("x", pl.Datetime("ms")),
+            ("y", pl.Datetime("us")),
+            ("z", pl.Datetime("ns")),
+        ],
+    )
+    assert df.select(
+        [pl.col("x").dt.strftime("%F %T").alias("w")]
+        + [pl.col(d).cast(str) for d in df.columns]
+    ).rows() == [
+        (
+            "2022-08-30 10:30:45",
+            "2022-08-30 10:30:45.123",
+            "2022-08-30 10:30:45.123456",
+            "2022-08-30 10:30:45.123456789",
+        )
+    ]


### PR DESCRIPTION
No need to lose `Datetime` precision on cast to string (this bit us earlier today :)
Can use timeunit to infer the appropriate format and avoid losing data/precision.

```python
from datetime import datetime
import polars as pl

# setup test frame with various datetime units
df = pl.DataFrame(
  {
    "x": [1661855445123],
    "y": [1661855445123456],
    "z": [1661855445123456789],
  },
  columns=[("x", pl.Datetime("ms")),("y", pl.Datetime("us")),("z", pl.Datetime("ns"))],
)
# ┌─────────────────────────┬────────────────────────────┬───────────────────────────────┐
# │ x                       ┆ y                          ┆ z                             │
# │ ---                     ┆ ---                        ┆ ---                           │
# │ datetime[ms]            ┆ datetime[μs]               ┆ datetime[ns]                  │
# ╞═════════════════════════╪════════════════════════════╪═══════════════════════════════╡
# │ 2022-08-30 10:30:45.123 ┆ 2022-08-30 10:30:45.123456 ┆ 2022-08-30 10:30:45.123456789 │
# └─────────────────────────┴────────────────────────────┴───────────────────────────────┘
```
**Before** _(truncates fractional seconds)_
```python
df.select( [pl.col(d).cast(str) for d in df.columns] ).rows()
# [('2022-08-30 10:30:45',
#   '2022-08-30 10:30:45',
#   '2022-08-30 10:30:45')]
```
**After** _(preserves fractional seconds, based on timeunit/precision)_
```python
df.select( [pl.col(d).cast(str) for d in df.columns] ).rows()
# [('2022-08-30 10:30:45.123',
#   '2022-08-30 10:30:45.123456',
#   '2022-08-30 10:30:45.123456789')]
```
And if it's desirable to ignore the underlying timeunit, there's always `strftime`, for complete control over the output:
```python
pl.col('dtcol').dt.strftime('%F %T')
```