### PR TITLE
docs[python]: More docstring formatting

### DIFF
--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 88
 ban-relative-imports = true
-docstring-convention=all
+docstring-convention = all
 extend-ignore =
     # Satisfy black: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
     E203,
@@ -9,7 +9,7 @@ extend-ignore =
     # numpy convention with a few additional lints
     D107, D203, D212, D401, D402, D415, D416,
     # TODO: Remove errors below to further improve docstring linting
-    D1, D400, D205,
+    D1,
     # flake8-simplify
     SIM102, SIM117,
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -34,8 +34,9 @@ def from_dict(
     columns: Sequence[str] | None = None,
 ) -> DataFrame:
     """
-    Construct a DataFrame from a dictionary of sequences. This operation clones data,
-    unless you pass in a `dict[str, pl.Series]`.
+    Construct a DataFrame from a dictionary of sequences.
+
+    This operation clones data, unless you pass in a `dict[str, pl.Series]`.
 
     Parameters
     ----------
@@ -318,6 +319,7 @@ def from_pandas(
 ) -> DataFrame | Series:
     """
     Construct a Polars DataFrame or Series from a pandas DataFrame or Series.
+
     This operation clones data.
 
     This requires that pandas and pyarrow are installed.

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 def get_idx_type() -> type[DataType]:
     """
-    Get the datatype used for polars Indexing
+    Get the datatype used for polars Indexing.
 
     This is UInt32 in regulars polars and UInt64 in polars_u64_idx
 

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -1,4 +1,6 @@
 """
+Core Polars functionality.
+
 The modules within `polars.internals` are interdependent. To prevent cyclical imports,
 they all import from each other via this __init__ file using
 `import polars.internals as pli`. The imports below are being shared across this module.

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5807,6 +5807,7 @@ class DataFrame:
         Shrink DataFrame memory usage.
 
         Shrinks to fit the exact capacity needed to hold the data.
+
         """
         if in_place:
             self._df.shrink_to_fit()

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4801,10 +4801,7 @@ class DataFrame:
 
     def shift_and_fill(self, periods: int, fill_value: int | str | float) -> DataFrame:
         """
-        Shift values by the given period and fill resulting null values.
-
-        Fill the parts that will be empty due to this operation with the result of the
-        `fill_value` expression.
+        Shift the values by a given period and fill the resulting null values.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -846,8 +846,7 @@ class Expr:
 
     def is_null(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression contains null
-        values.
+        Returns a boolean Series indicating which values are null.
 
         Examples
         --------
@@ -880,8 +879,7 @@ class Expr:
 
     def is_not_null(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression does not
-        contain null values.
+        Returns a boolean Series indicating which values are not null.
 
         Examples
         --------
@@ -914,8 +912,7 @@ class Expr:
 
     def is_finite(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression values are
-        finite.
+        Returns a boolean Series indicating which values are finite.
 
         Returns
         -------
@@ -947,8 +944,7 @@ class Expr:
 
     def is_infinite(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression values are
-        infinite.
+        Returns a boolean Series indicating which values are infinite.
 
         Returns
         -------
@@ -980,8 +976,7 @@ class Expr:
 
     def is_nan(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression values are NaN
-        (Not A Number).
+        Returns a boolean Series indicating which values are NaN.
 
         Examples
         --------
@@ -1014,8 +1009,7 @@ class Expr:
 
     def is_not_nan(self) -> Expr:
         """
-        Create a boolean expression returning `True` where the expression values are not
-        NaN (Not A Number).
+        Returns a boolean Series indicating which values are not NaN.
 
         Examples
         --------
@@ -1170,8 +1164,9 @@ class Expr:
 
     def append(self, other: Expr, upcast: bool = True) -> Expr:
         """
-        Append expressions. This is done by adding the chunks of `other` to this
-        `Series`.
+        Append expressions.
+
+        This is done by adding the chunks of `other` to this `Series`.
 
         Parameters
         ----------
@@ -1497,10 +1492,9 @@ class Expr:
 
     def floor(self) -> Expr:
         """
-        Floor underlying floating point array to the lowest integers smaller or equal to
-        the float value.
+        Rounds down to the nearest integer value.
 
-        Only works on floating point Series
+        Only works on floating point Series.
 
         Examples
         --------
@@ -1526,10 +1520,9 @@ class Expr:
 
     def ceil(self) -> Expr:
         """
-        Ceil underlying floating point array to the highest integers smaller or equal to
-        the float value.
+        Rounds up to the nearest integer value.
 
-        Only works on floating point Series
+        Only works on floating point Series.
 
         Examples
         --------
@@ -2012,8 +2005,7 @@ class Expr:
 
     def shift(self, periods: int = 1) -> Expr:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with nulls.
+        Shift the values by a given period.
 
         Parameters
         ----------
@@ -2048,8 +2040,7 @@ class Expr:
         fill_value: int | float | bool | str | Expr | list[Any],
     ) -> Expr:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with the result of the ``fill_value`` expression.
+        Shift the values by a given period and fill the resulting null values.
 
         Parameters
         ----------
@@ -3376,8 +3367,9 @@ class Expr:
 
     def repeat_by(self, by: Expr | str) -> Expr:
         """
-        Repeat the elements in this Series `n` times by dictated by the number given by
-        `by`. The elements are expanded into a `List`
+        Repeat the elements in this Series as specified in the given expression.
+
+        The repeated elements are expanded into a `List`.
 
         Parameters
         ----------
@@ -4768,8 +4760,10 @@ class Expr:
 
     def pct_change(self, n: int = 1) -> Expr:
         """
+        Computes percentage change between values.
+
         Percentage change (as fraction) between current element and most-recent
-        non-null element at least n period(s) before the current element.
+        non-null element at least ``n`` period(s) before the current element.
 
         Computes the change from the previous row by default.
 
@@ -4898,10 +4892,9 @@ class Expr:
 
     def clip(self, min_val: int | float, max_val: int | float) -> Expr:
         """
-        Clip (limit) the values in an array to any value that fits in 64 floating point
-        range.
+        Clip (limit) the values in an array to a `min` and `max` boundary.
 
-        Only works for the following dtypes: {Int32, Int64, Float32, Float64, UInt32}.
+        Only works for numerical types.
 
         If you want to clip other dtypes, consider writing a "when, then, otherwise"
         expression. See :func:`when` for more information.

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1049,6 +1049,7 @@ class Expr:
     def agg_groups(self) -> Expr:
         """
         Get the group indexes of the group by operation.
+
         Should be used in aggregation context only.
 
         Examples
@@ -1083,7 +1084,7 @@ class Expr:
 
     def count(self) -> Expr:
         """
-        Count the number of values in this expression
+        Count the number of values in this expression.
 
         Examples
         --------
@@ -1103,8 +1104,9 @@ class Expr:
 
     def len(self) -> Expr:
         """
+        Count the number of values in this expression.
+
         Alias for :func:`count`.
-        Count the number of values in this expression
 
         Examples
         --------
@@ -1269,7 +1271,7 @@ class Expr:
 
     def drop_nans(self) -> Expr:
         """
-        Drop floating point NaN values
+        Drop floating point NaN values.
 
         Warnings
         --------
@@ -1458,6 +1460,7 @@ class Expr:
     def cumcount(self, reverse: bool = False) -> Expr:
         """
         Get an array with the cumulative count computed at every element.
+
         Counting from 0 to len
 
         Parameters
@@ -1583,7 +1586,7 @@ class Expr:
 
     def dot(self, other: Expr | str) -> Expr:
         """
-        Compute the dot/inner product between two Expressions
+        Compute the dot/inner product between two Expressions.
 
         Parameters
         ----------
@@ -1615,6 +1618,7 @@ class Expr:
     def mode(self) -> Expr:
         """
         Compute the most occurring value(s).
+
         Can return multiple Values.
 
         Examples
@@ -1686,6 +1690,7 @@ class Expr:
     def sort(self, reverse: bool = False, nulls_last: bool = False) -> Expr:
         """
         Sort this column. In projection/ selection context the whole column is sorted.
+
         If used in a groupby context, the groups are sorted.
 
         Parameters
@@ -1894,6 +1899,7 @@ class Expr:
     ) -> Expr:
         """
         Sort this column by the ordering of another column, or multiple other columns.
+
         In projection/ selection context the whole column is sorted.
         If used in a groupby context, the groups are sorted.
 
@@ -2083,6 +2089,7 @@ class Expr:
     ) -> Expr:
         """
         Fill null values using the specified value or strategy.
+
         To interpolate over null values see interpolate
 
         Parameters
@@ -2149,7 +2156,7 @@ class Expr:
 
     def fill_nan(self, fill_value: str | int | float | bool | Expr | None) -> Expr:
         """
-        Fill floating point NaN value with a fill value
+        Fill floating point NaN value with a fill value.
 
         Examples
         --------
@@ -2442,7 +2449,7 @@ class Expr:
 
     def product(self) -> Expr:
         """
-        Compute the product of an expression
+        Compute the product of an expression.
 
         Examples
         --------
@@ -2800,7 +2807,6 @@ class Expr:
         """
         Get quantile value.
 
-
         Parameters
         ----------
         quantile
@@ -2904,7 +2910,9 @@ class Expr:
 
     def where(self, predicate: Expr) -> Expr:
         """
-        Alias for filter
+        Filter a single column.
+
+        Alias for :func:`filter`.
 
         Parameters
         ----------
@@ -3614,6 +3622,7 @@ class Expr:
     def interpolate(self) -> Expr:
         """
         Fill nulls with linear interpolation over missing values.
+
         Can also be used to regrid data to a new grid - see examples below
 
         Examples
@@ -4928,7 +4937,7 @@ class Expr:
 
     def clip_min(self, min_val: int | float) -> Expr:
         """
-        Clip (limit) the values in an array to a `min` boundary
+        Clip (limit) the values in an array to a `min` boundary.
 
         Only works for numerical types.
 
@@ -4945,7 +4954,7 @@ class Expr:
 
     def clip_max(self, max_val: int | float) -> Expr:
         """
-        Clip (limit) the values in an array to a `max` boundary
+        Clip (limit) the values in an array to a `max` boundary.
 
         Only works for numerical types.
 
@@ -5324,19 +5333,20 @@ class Expr:
 
     def reshape(self, dims: tuple[int, ...]) -> Expr:
         """
-        Reshape this Expr to a flat series, shape: (len,)
-        or a List series, shape: (rows, cols)
-
-        if a -1 is used in any of the dimensions, that dimension is inferred.
+        Reshape this Expr to a flat Series or a Series of Lists.
 
         Parameters
         ----------
         dims
-            Tuple of the dimension sizes
+            Tuple of the dimension sizes. If a -1 is used in any of the dimensions, that
+            dimension is inferred.
 
         Returns
         -------
         Expr
+            If a single dimension is given, results in a flat Series of shape (len,).
+            If a multiple dimensions are given, results in a Series of Lists with shape
+            (rows, cols).
 
         Examples
         --------
@@ -5671,7 +5681,7 @@ class Expr:
 
     def value_counts(self, multithreaded: bool = False, sort: bool = False) -> Expr:
         """
-        Count all unique values and create a struct mapping value to count
+        Count all unique values and create a struct mapping value to count.
 
         Parameters
         ----------
@@ -5750,7 +5760,7 @@ class Expr:
 
     def log(self, base: float = math.e) -> Expr:
         """
-        Compute the logarithm to a given base
+        Compute the logarithm to a given base.
 
         Parameters
         ----------
@@ -5779,8 +5789,9 @@ class Expr:
 
     def entropy(self, base: float = math.e, normalize: bool = True) -> Expr:
         """
-        Compute the entropy as `-sum(pk * log(pk)`.
-        where `pk` are discrete probabilities.
+        Computes the entropy.
+
+        Uses the formula ``-sum(pk * log(pk)`` where ``pk`` are discrete probabilities.
 
         Parameters
         ----------
@@ -5873,8 +5884,9 @@ class Expr:
 
     def set_sorted(self, reverse: bool = False) -> Expr:
         """
-        Set this `Series` as `sorted` so that downstream code can use
-        fast paths for sorted arrays.
+        Flags the expression as 'sorted'.
+
+        Enables downstream code to user fast paths for sorted arrays.
 
         Parameters
         ----------
@@ -5968,6 +5980,7 @@ class Expr:
     def arr(self) -> ExprListNameSpace:
         """
         Create an object namespace of all list related methods.
+
         See the individual method pages for full details
 
         """
@@ -6004,6 +6017,7 @@ class Expr:
     def struct(self) -> ExprStructNameSpace:
         """
         Create an object namespace of all struct related methods.
+
         See the individual method pages for full details
 
         Examples
@@ -6039,6 +6053,7 @@ class Expr:
     def meta(self) -> ExprMetaNameSpace:
         """
         Create an object namespace of all meta related expression methods.
+
         This can be used to modify and traverse existing expressions
 
         """

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -130,7 +130,7 @@ class ExprListNameSpace:
 
     def sort(self, reverse: bool = False) -> pli.Expr:
         """
-        Sort the arrays in the list
+        Sort the arrays in the list.
 
         Examples
         --------
@@ -156,7 +156,7 @@ class ExprListNameSpace:
 
     def reverse(self) -> pli.Expr:
         """
-        Reverse the arrays in the list
+        Reverse the arrays in the list.
 
         Examples
         --------
@@ -253,6 +253,7 @@ class ExprListNameSpace:
     def get(self, index: int) -> pli.Expr:
         """
         Get the value by index in the sublists.
+
         So index `0` would return the first item of every sublist
         and index `-1` would return the last item of every sublist
         if an index is out of bounds, it will return a `None`.
@@ -370,6 +371,7 @@ class ExprListNameSpace:
     def join(self, separator: str) -> pli.Expr:
         """
         Join all string items in a sublist and place a separator between them.
+
         This errors if inner type of list `!= Utf8`.
 
         Parameters
@@ -401,7 +403,7 @@ class ExprListNameSpace:
 
     def arg_min(self) -> pli.Expr:
         """
-        Retrieve the index of the minimal value in every sublist
+        Retrieve the index of the minimal value in every sublist.
 
         Returns
         -------
@@ -431,7 +433,7 @@ class ExprListNameSpace:
 
     def arg_max(self) -> pli.Expr:
         """
-        Retrieve the index of the maximum value in every sublist
+        Retrieve the index of the maximum value in every sublist.
 
         Returns
         -------
@@ -627,7 +629,7 @@ class ExprListNameSpace:
 
     def eval(self, expr: pli.Expr, parallel: bool = False) -> pli.Expr:
         """
-        Run any polars expression against the lists' elements
+        Run any polars expression against the lists' elements.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -488,8 +488,7 @@ class ExprListNameSpace:
 
     def shift(self, periods: int = 1) -> pli.Expr:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with nulls.
+        Shift values by the given period.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -530,6 +530,7 @@ class ExprStringNameSpace:
     def json_path_match(self, json_path: str) -> pli.Expr:
         """
         Extract the first match of json string with provided JSONPath expression.
+
         Throw errors if encounter invalid json strings.
         All return value will be casted to Utf8 regardless of the original value.
 

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -813,8 +813,9 @@ class ExprStringNameSpace:
 
     def split_exact(self, by: str, n: int, inclusive: bool = False) -> pli.Expr:
         """
-        Split the string by a substring into a struct of ``n+1`` fields using
-        ``n`` splits.
+        Split the string by a substring using ``n`` splits.
+
+        Results in a struct of ``n+1`` fields.
 
         If it cannot make ``n`` splits, the remaining field elements will be null.
 

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -265,6 +265,8 @@ class ExprStringNameSpace:
 
     def zfill(self, alignment: int) -> pli.Expr:
         """
+        Fills the string with zeroes.
+
         Return a copy of the string left filled with ASCII '0' digits to make a string
         of length width.
 
@@ -705,7 +707,9 @@ class ExprStringNameSpace:
 
     def extract_all(self, pattern: str) -> pli.Expr:
         r"""
-        Extract each successive non-overlapping regex match in an individual string as
+        Extracts all matches for the given regex pattern.
+
+        Extracts each successive non-overlapping regex match in an individual string as
         an array.
 
         Parameters

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -179,7 +179,7 @@ def col(
 
 def element() -> pli.Expr:
     """
-    Alias for an element in evaluated in an `eval` expression
+    Alias for an element in evaluated in an `eval` expression.
 
     Examples
     --------
@@ -1051,7 +1051,10 @@ def arange(
     eager: bool = False,
 ) -> pli.Expr | pli.Series:
     """
-    Create a range expression. This can be used in a `select`, `with_column` etc.
+    Create a range expression.
+
+    This can be used in a `select`, `with_column` etc.
+
     Be sure that the range size is equal to the DataFrame you are collecting.
 
     Examples

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -752,8 +752,9 @@ def map(
     return_dtype: type[DataType] | None = None,
 ) -> pli.Expr:
     """
-    Map a custom function over multiple columns/expressions and produce a single Series
-    result.
+    Map a custom function over multiple columns/expressions.
+
+    Produces a single Series result.
 
     Parameters
     ----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1,7 +1,3 @@
-"""
-Module containing all expressions and classes needed for lazy computation/query
-execution.
-"""
 from __future__ import annotations
 
 import os
@@ -203,9 +199,12 @@ class LazyFrame:
         memory_map: bool = True,
     ) -> LDF:
         """
+        Lazily read from an Arrow IPC (Feather v2) file.
+
         See Also
         --------
         scan_parquet, scan_csv
+
         """
         if isinstance(file, (str, Path)):
             file = format_path(file)
@@ -267,9 +266,12 @@ class LazyFrame:
     @classmethod
     def from_json(cls, json: str) -> LazyFrame:
         """
+        Create a DataFrame from a JSON string.
+
         See Also
         --------
         read_json
+
         """
         f = StringIO(json)
         return cls.read_json(f)
@@ -546,9 +548,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def inspect(self: LDF, fmt: str = "{}") -> LDF:
         """
+        Inspect a node in the computation graph.
+
         Print the value that this node in the computation graph evaluates to and passes
         on the value.
 
+        Examples
+        --------
         >>> df = pl.DataFrame({"foo": [1, 1, -2, 3]}).lazy()
         >>> (
         ...     df.select(
@@ -576,11 +582,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         nulls_last: bool = False,
     ) -> LDF:
         """
-        Sort the DataFrame by:
+        Sort the DataFrame.
 
-            - A single column name
-            - An expression
-            - Multiple expressions
+        Sorting can be done by:
+
+        - A single column name
+        - An expression
+        - Multiple expressions
 
         Parameters
         ----------
@@ -671,6 +679,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         slice_pushdown: bool = True,
     ) -> pli.DataFrame:
         """
+        Collect a small number of rows for debugging purposes.
+
         Fetch is like a :func:`collect` operation, but it overwrites the number of rows
         read by every scan operation. This is a utility that helps debug a query on a
         smaller number of rows.
@@ -1009,8 +1019,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """
-        Create rolling groups based on a time column (or index value of type Int32,
-        Int64).
+        Create rolling groups based on a time column.
+
+        Also works for index values of type Int32 or Int64.
 
         Different from a rolling groupby the windows are now determined by the
         individual values and are not of constant intervals. For constant intervals use
@@ -1232,8 +1243,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         force_parallel: bool = False,
     ) -> LDF:
         """
-        Perform an asof join. This is similar to a left-join except that we
-        match on nearest key rather than equal keys.
+        Perform an asof join.
+
+        This is similar to a left-join except that we match on nearest key rather than
+        equal keys.
 
         Both DataFrames must be sorted by the join_asof key.
 
@@ -1687,8 +1700,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def shift(self: LDF, periods: int) -> LDF:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with `Nones`.
+        Shift the values by a given period.
 
         Parameters
         ----------
@@ -1739,8 +1751,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         fill_value: pli.Expr | int | str | float,
     ) -> LDF:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with the result of the `fill_value` expression.
+        Shift the values by a given period and fill the resulting null values.
 
         Parameters
         ----------
@@ -2224,8 +2235,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         value_name: str | None = None,
     ) -> LDF:
         """
-        Unpivot a DataFrame from wide to long format, optionally leaving identifiers
-        set.
+        Unpivot a DataFrame from wide to long format.
+
+        Optionally leaves identifiers set.
 
         This function is useful to massage a DataFrame into a format where one or more
         columns are identifier variables (id_vars), while all other columns, considered
@@ -2297,8 +2309,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         validate_output_schema: bool = True,
     ) -> LDF:
         """
-        Apply a custom function. It is important that the function returns a Polars
-        DataFrame.
+        Apply a custom function.
+
+        It is important that the function returns a Polars DataFrame.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -787,7 +787,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     @property
     def schema(self) -> Schema:
         """
-        Get a dict[column name, DataType]
+        Get a dict[column name, DataType].
 
         Examples
         --------
@@ -2108,6 +2108,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     ) -> LDF:
         """
         Drop duplicate rows from this DataFrame.
+
         Note that this fails if there is a column of type `List` in the DataFrame or
         subset.
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -242,8 +242,10 @@ class DateTimeNameSpace:
 
     def with_time_unit(self, tu: TimeUnit) -> pli.Series:
         """
-        Set time unit a Series of dtype Datetime or Duration. This does not modify
-        underlying data, and should be used to fix an incorrect time unit.
+        Set time unit a Series of dtype Datetime or Duration.
+
+        This does not modify underlying data, and should be used to fix an incorrect
+        time unit.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -48,7 +48,7 @@ class DateTimeNameSpace:
 
     def strftime(self, fmt: str) -> pli.Series:
         """
-        Format Date/datetime with a formatting rule:
+        Format Date/datetime with a formatting rule.
 
         See `chrono strftime/strptime
         <https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html>`_.
@@ -62,6 +62,7 @@ class DateTimeNameSpace:
     def year(self) -> pli.Series:
         """
         Extract the year from the underlying date representation.
+
         Can be performed on Date and Datetime.
 
         Returns the year number in the calendar date.
@@ -75,6 +76,7 @@ class DateTimeNameSpace:
     def quarter(self) -> pli.Series:
         """
         Extract quarter from underlying Date representation.
+
         Can be performed on Date and Datetime.
 
         Returns the quarter ranging from 1 to 4.
@@ -88,6 +90,7 @@ class DateTimeNameSpace:
     def month(self) -> pli.Series:
         """
         Extract the month from the underlying date representation.
+
         Can be performed on Date and Datetime
 
         Returns the month number starting from 1.
@@ -102,6 +105,7 @@ class DateTimeNameSpace:
     def week(self) -> pli.Series:
         """
         Extract the week from the underlying date representation.
+
         Can be performed on Date and Datetime
 
         Returns the ISO week number starting from 1.
@@ -116,6 +120,7 @@ class DateTimeNameSpace:
     def weekday(self) -> pli.Series:
         """
         Extract the week day from the underlying date representation.
+
         Can be performed on Date and Datetime.
 
         Returns the weekday number where monday = 0 and sunday = 6
@@ -129,6 +134,7 @@ class DateTimeNameSpace:
     def day(self) -> pli.Series:
         """
         Extract the day from the underlying date representation.
+
         Can be performed on Date and Datetime.
 
         Returns the day of month starting from 1.
@@ -143,6 +149,7 @@ class DateTimeNameSpace:
     def ordinal_day(self) -> pli.Series:
         """
         Extract ordinal day from underlying date representation.
+
         Can be performed on Date and Datetime.
 
         Returns the day of year starting from 1.
@@ -157,6 +164,7 @@ class DateTimeNameSpace:
     def hour(self) -> pli.Series:
         """
         Extract the hour from the underlying DateTime representation.
+
         Can be performed on Datetime.
 
         Returns the hour number from 0 to 23.
@@ -170,6 +178,7 @@ class DateTimeNameSpace:
     def minute(self) -> pli.Series:
         """
         Extract the minutes from the underlying DateTime representation.
+
         Can be performed on Datetime.
 
         Returns the minute number from 0 to 59.
@@ -183,6 +192,7 @@ class DateTimeNameSpace:
     def second(self) -> pli.Series:
         """
         Extract the seconds the from underlying DateTime representation.
+
         Can be performed on Datetime.
 
         Returns the second number from 0 to 59.
@@ -196,6 +206,7 @@ class DateTimeNameSpace:
     def nanosecond(self) -> pli.Series:
         """
         Extract the nanoseconds from the underlying DateTime representation.
+
         Can be performed on Datetime.
 
         Returns the number of nanoseconds since the whole non-leap second.
@@ -220,7 +231,7 @@ class DateTimeNameSpace:
 
     def epoch(self, tu: EpochTimeUnit = "us") -> pli.Series:
         """
-        Get the time passed since the Unix EPOCH in the give time unit
+        Get the time passed since the Unix EPOCH in the give time unit.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -72,6 +72,7 @@ class ListNameSpace:
     def get(self, index: int) -> pli.Series:
         """
         Get the value by index in the sublists.
+
         So index `0` would return the first item of every sublist
         and index `-1` would return the last item of every sublist
         if an index is out of bounds, it will return a `None`.
@@ -86,6 +87,7 @@ class ListNameSpace:
     def join(self, separator: str) -> pli.Series:
         """
         Join all string items in a sublist and place a separator between them.
+
         This errors if inner type of list `!= Utf8`.
 
         Parameters
@@ -133,7 +135,7 @@ class ListNameSpace:
 
     def arg_min(self) -> pli.Series:
         """
-        Retrieve the index of the minimal value in every sublist
+        Retrieve the index of the minimal value in every sublist.
 
         Returns
         -------
@@ -143,7 +145,7 @@ class ListNameSpace:
 
     def arg_max(self) -> pli.Series:
         """
-        Retrieve the index of the maximum value in every sublist
+        Retrieve the index of the maximum value in every sublist.
 
         Returns
         -------
@@ -269,7 +271,7 @@ class ListNameSpace:
 
     def eval(self, expr: pli.Expr, parallel: bool = False) -> pli.Series:
         """
-        Run any polars expression against the lists' elements
+        Run any polars expression against the lists' elements.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -179,8 +179,7 @@ class ListNameSpace:
 
     def shift(self, periods: int = 1) -> pli.Series:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with nulls.
+        Shift values by the given period.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1735,7 +1735,7 @@ class Series:
 
     def is_null(self) -> Series:
         """
-        Get mask of null values.
+        Returns a boolean Series indicating which values are null.
 
         Returns
         -------
@@ -1758,7 +1758,7 @@ class Series:
 
     def is_not_null(self) -> Series:
         """
-        Get mask of non null values.
+        Returns a boolean Series indicating which values are not null.
 
         Returns
         -------
@@ -1781,7 +1781,7 @@ class Series:
 
     def is_finite(self) -> Series:
         """
-        Get mask of finite values if Series dtype is Float.
+        Returns a boolean Series indicating which values are finite.
 
         Returns
         -------
@@ -1804,7 +1804,7 @@ class Series:
 
     def is_infinite(self) -> Series:
         """
-        Get mask of infinite values if Series dtype is Float.
+        Returns a boolean Series indicating which values are infinite.
 
         Returns
         -------
@@ -1827,7 +1827,7 @@ class Series:
 
     def is_nan(self) -> Series:
         """
-        Get mask of NaN values if Series dtype is Float.
+        Returns a boolean Series indicating which values are not NaN.
 
         Returns
         -------
@@ -1851,7 +1851,7 @@ class Series:
 
     def is_not_nan(self) -> Series:
         """
-        Get negated mask of NaN values if Series dtype is_not Float.
+        Returns a boolean Series indicating which values are not NaN.
 
         Returns
         -------
@@ -2651,19 +2651,17 @@ class Series:
 
     def floor(self) -> Series:
         """
-        Floor underlying floating point array to the lowest integers smaller or equal to
-        the float value.
+        Rounds down to the nearest integer value.
 
-        Only works on floating point Series
+        Only works on floating point Series.
 
         """
 
     def ceil(self) -> Series:
         """
-        Ceil underlying floating point array to the highest integers smaller or equal to
-        the float value.
+        Rounds up to the nearest integer value.
 
-        Only works on floating point Series
+        Only works on floating point Series.
 
         """
 
@@ -3013,8 +3011,7 @@ class Series:
 
     def shift(self, periods: int = 1) -> Series:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with `Nones`.
+        Shift the values by a given period.
 
         Examples
         --------
@@ -3045,8 +3042,7 @@ class Series:
 
     def shift_and_fill(self, periods: int, fill_value: int | pli.Expr) -> Series:
         """
-        Shift the values by a given period and fill the parts that will be empty due to
-        this operation with the result of the `fill_value` expression.
+        Shift the values by a given period and fill the resulting null values.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -630,7 +630,7 @@ class Series:
     @property
     def flags(self) -> dict[str, bool]:
         """
-        Get flags that are set on the Series
+        Get flags that are set on the Series.
 
         Returns
         -------
@@ -677,7 +677,7 @@ class Series:
 
     def sqrt(self) -> Series:
         """
-        Compute the square root of the elements
+        Compute the square root of the elements.
 
         Syntactic sugar for
 
@@ -693,7 +693,7 @@ class Series:
 
     def any(self) -> bool:
         """
-        Check if any boolean value in the column is `True`
+        Check if any boolean value in the column is `True`.
 
         Returns
         -------
@@ -704,7 +704,7 @@ class Series:
 
     def all(self) -> bool:
         """
-        Check if all boolean values in the column are `True`
+        Check if all boolean values in the column are `True`.
 
         Returns
         -------
@@ -773,7 +773,7 @@ class Series:
     @property
     def inner_dtype(self) -> type[DataType] | None:
         """
-        Get the inner dtype in of a List typed Series
+        Get the inner dtype in of a List typed Series.
 
         Returns
         -------
@@ -784,8 +784,10 @@ class Series:
 
     def describe(self) -> pli.DataFrame:
         """
-        Quick summary statistics of a series. Series with mixed datatypes will return
-        summary statistics for the datatype of the first value.
+        Quick summary statistics of a series.
+
+        Series with mixed datatypes will return summary statistics for the datatype of
+        the first value.
 
         Returns
         -------
@@ -1085,10 +1087,9 @@ class Series:
 
     def entropy(self, base: float = math.e, normalize: bool = False) -> float | None:
         """
-        Compute the entropy as `-sum(pk * log(pk)`.
-        where `pk` are discrete probabilities.
+        Computes the entropy.
 
-        This routine will normalize pk if they don’t sum to 1.
+        Uses the formula ``-sum(pk * log(pk)`` where ``pk`` are discrete probabilities.
 
         Parameters
         ----------
@@ -2691,7 +2692,7 @@ class Series:
 
     def dot(self, other: Series) -> float | None:
         """
-        Compute the dot/inner product between two Series
+        Compute the dot/inner product between two Series.
 
         Examples
         --------
@@ -2710,7 +2711,9 @@ class Series:
 
     def mode(self) -> Series:
         """
-        Compute the most occurring value(s). Can return multiple Values
+        Compute the most occurring value(s).
+
+        Can return multiple Values.
 
         Examples
         --------
@@ -3212,6 +3215,7 @@ class Series:
     ) -> Series:
         """
         Apply a rolling mean (moving mean) over the values in this array.
+
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
@@ -3263,6 +3267,7 @@ class Series:
     ) -> Series:
         """
         Apply a rolling sum (moving sum) over the values in this array.
+
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
@@ -3313,7 +3318,7 @@ class Series:
         center: bool = False,
     ) -> Series:
         """
-        Compute a rolling std dev
+        Compute a rolling std dev.
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
@@ -3439,7 +3444,7 @@ class Series:
         center: bool = False,
     ) -> Series:
         """
-        Compute a rolling median
+        Compute a rolling median.
 
         Parameters
         ----------
@@ -3478,7 +3483,7 @@ class Series:
         center: bool = False,
     ) -> Series:
         """
-        Compute a rolling quantile
+        Compute a rolling quantile.
 
         Parameters
         ----------
@@ -3513,7 +3518,7 @@ class Series:
 
     def rolling_skew(self, window_size: int, bias: bool = True) -> Series:
         """
-        Compute a rolling skew
+        Compute a rolling skew.
 
         Parameters
         ----------
@@ -3909,7 +3914,7 @@ class Series:
 
     def clip(self, min_val: int | float, max_val: int | float) -> Series:
         """
-        Clip (limit) the values in an array to a `min` and `max` boundary
+        Clip (limit) the values in an array to a `min` and `max` boundary.
 
         Only works for numerical types.
 
@@ -3940,7 +3945,7 @@ class Series:
 
     def clip_min(self, min_val: int | float) -> Series:
         """
-        Clip (limit) the values in an array to a `min` boundary
+        Clip (limit) the values in an array to a `min` boundary.
 
         Only works for numerical types.
 
@@ -3956,7 +3961,7 @@ class Series:
 
     def clip_max(self, max_val: int | float) -> Series:
         """
-        Clip (limit) the values in an array to a `max` boundary
+        Clip (limit) the values in an array to a `max` boundary.
 
         Only works for numerical types.
 
@@ -4264,7 +4269,7 @@ class SeriesIter:
 def _resolve_datetime_dtype(
     dtype: PolarsDataType | None, ndtype: np.datetime64
 ) -> PolarsDataType | None:
-    """Given polars/numpy datetime dtypes, resolve to an explicit unit"""
+    """Given polars/numpy datetime dtypes, resolve to an explicit unit."""
     if dtype is None or (dtype == Datetime and not getattr(dtype, "tu", None)):
         tu = getattr(dtype, "tu", np.datetime_data(ndtype)[0])
         # explicit formulation is verbose, but keeps mypy happy

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3972,19 +3972,20 @@ class Series:
 
     def reshape(self, dims: tuple[int, ...]) -> Series:
         """
-        Reshape this Series to a flat series, shape: (len,)
-        or a List series, shape: (rows, cols)
-
-        if a -1 is used in any of the dimensions, that dimension is inferred.
+        Reshape this Series to a flat Series or a Series of Lists.
 
         Parameters
         ----------
         dims
-            Tuple of the dimension sizes
+            Tuple of the dimension sizes. If a -1 is used in any of the dimensions, that
+            dimension is inferred.
 
         Returns
         -------
         Series
+            If a single dimension is given, results in a flat Series of shape (len,).
+            If a multiple dimensions are given, results in a Series of Lists with shape
+            (rows, cols).
 
         """
 
@@ -4188,8 +4189,9 @@ class Series:
 
     def set_sorted(self, reverse: bool = False) -> Series:
         """
-        Set this `Series` as `sorted` so that downstream code can use
-        fast paths for sorted arrays.
+        Flags the Series as 'sorted'.
+
+        Enables downstream code to user fast paths for sorted arrays.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -644,8 +644,9 @@ class Series:
 
     def estimated_size(self, unit: SizeUnit = "b") -> int | float:
         """
-        Return an estimation of the total (heap) allocated size of the `Series` in
-        bytes (pass `unit` to return estimated size in kilobytes, megabytes, etc).
+        Return an estimation of the total (heap) allocated size of the Series.
+
+        Estimated size is given in the specified unit (bytes by default).
 
         This estimation is the sum of the size of its buffers, validity, including
         nested arrays. Multiple arrays may share buffers and bitmaps. Therefore, the
@@ -1875,8 +1876,7 @@ class Series:
 
     def is_in(self, other: Series | Sequence[Any]) -> Series:
         """
-        Check if elements of this Series are in the other Series, or
-        if this Series is itself a member of the other Series.
+        Check if elements of this Series are in the other Series.
 
         Returns
         -------
@@ -2288,9 +2288,10 @@ class Series:
 
     def view(self, ignore_nulls: bool = False) -> SeriesView:
         """
-        Get a view into this Series data with a numpy array. This operation doesn't
-        clone data, but does not include missing values. Don't use this unless you know
-        what you are doing.
+        Get a view into this Series data with a numpy array.
+
+        This operation doesn't clone data, but does not include missing values.
+        Don't use this unless you know what you are doing.
 
         """
         if not ignore_nulls:
@@ -2451,8 +2452,9 @@ class Series:
 
     def to_arrow(self) -> pa.Array:
         """
-        Get the underlying Arrow Array. If the Series contains only a single chunk
-        this operation is zero copy.
+        Get the underlying Arrow Array.
+
+        If the Series contains only a single chunk this operation is zero copy.
 
         Examples
         --------
@@ -2555,8 +2557,9 @@ class Series:
 
     def cleared(self) -> Series:
         """
-        Create an empty copy of the current Series, with identical name/dtype but no
-        data.
+        Create an empty copy of the current Series.
+
+        The copy has identical name/dtype but no data.
 
         See Also
         --------
@@ -3055,6 +3058,8 @@ class Series:
 
     def zip_with(self, mask: Series, other: Series) -> Series:
         """
+        Take values from self or other based on the given mask.
+
         Where mask evaluates true, take values from self. Where mask evaluates false,
         take values from other.
 
@@ -3641,8 +3646,10 @@ class Series:
 
     def shrink_to_fit(self, in_place: bool = False) -> Series | None:
         """
-        Shrink memory usage of this Series to fit the exact capacity needed to hold the
-        data.
+        Shrink Series memory usage.
+
+        Shrinks to fit the exact capacity needed to hold the data.
+
         """
         if in_place:
             self._s.shrink_to_fit()
@@ -3800,8 +3807,10 @@ class Series:
 
     def pct_change(self, n: int = 1) -> Series:
         """
+        Computes percentage change between values.
+
         Percentage change (as fraction) between current element and most-recent
-        non-null element at least n period(s) before the current element.
+        non-null element at least ``n`` period(s) before the current element.
 
         Computes the change from the previous row by default.
 

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -368,6 +368,8 @@ class StringNameSpace:
 
     def extract_all(self, pattern: str) -> pli.Series:
         r"""
+        Extracts all matches for the given regex pattern.
+
         Extract each successive non-overlapping regex match in an individual string as
         an array
 
@@ -634,10 +636,14 @@ class StringNameSpace:
 
     def zfill(self, alignment: int) -> pli.Series:
         """
+        Fills the string with zeroes.
+
         Return a copy of the string left filled with ASCII '0' digits to make a string
-        of length width. A leading sign prefix ('+'/'-') is handled by inserting the
-        padding after the sign character rather than before.
-        The original string is returned if width is less than or equal to ``len(s)``.
+        of length width.
+
+        A leading sign prefix ('+'/'-') is handled by inserting the padding after the
+        sign character rather than before. The original string is returned if width is
+        less than or equal to ``len(s)``.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -442,8 +442,9 @@ class StringNameSpace:
 
     def split_exact(self, by: str, n: int, inclusive: bool = False) -> pli.Series:
         """
-        Split the string by a substring into a struct of ``n+1`` fields using
-        ``n`` splits.
+        Split the string by a substring using ``n`` splits.
+
+        Results in a struct of ``n+1`` fields.
 
         If it cannot make ``n`` splits, the remaining field elements will be null.
 

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -259,7 +259,7 @@ class StringNameSpace:
 
     def encode(self, encoding: TransferEncoding) -> pli.Series:
         """
-        Encode a value using the provided encoding
+        Encode a value using the provided encoding.
 
         Parameters
         ----------
@@ -287,6 +287,7 @@ class StringNameSpace:
     def json_path_match(self, json_path: str) -> pli.Series:
         """
         Extract the first match of json string with provided JSONPath expression.
+
         Throw errors if encounter invalid json strings.
         All return value will be casted to Utf8 regardless of the original value.
 

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -48,7 +48,7 @@ class StructNameSpace:
 
     def rename_fields(self, names: list[str]) -> pli.Series:
         """
-        Rename the fields of the struct
+        Rename the fields of the struct.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -44,9 +44,12 @@ _EMPTY_BYTECODE = _EmptyBytecodeHelper()
 
 def _is_empty_method(func: SeriesMethod) -> bool:
     """
-    Confirm that the given function has no implementation, eg:
-    * only has a docstring (body is empty)
-    * has no docstring and just contains 'pass' (or equivalent)
+    Confirm that the given function has no implementation.
+
+    Definitions of empty:
+
+    - only has a docstring (body is empty)
+    - has no docstring and just contains 'pass' (or equivalent)
     """
     fc = func.__code__
     return (fc.co_code in _EMPTY_BYTECODE) and (

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -55,7 +55,7 @@ def _is_empty_method(func: SeriesMethod) -> bool:
 
 
 def _expr_lookup(namespace: str | None) -> set[tuple[str | None, str, tuple[str, ...]]]:
-    """Create lookup of potential Expr methods (in the given namespace)"""
+    """Create lookup of potential Expr methods (in the given namespace)."""
     # dummy Expr object that we can introspect
     expr = pli.Expr()
     expr._pyexpr = None
@@ -98,6 +98,7 @@ def call_expr(func: SeriesMethod) -> SeriesMethod:
 def expr_dispatch(cls: type[T]) -> type[T]:
     """
     Series/NameSpace class decorator that sets up expression dispatch.
+
     * Applied to the Series class, and/or any Series 'NameSpace' classes.
     * Walks the class attributes, looking for methods that have empty function
       bodies, with signatures compatible with an existing Expr function.


### PR DESCRIPTION
Following up on #4601 

Changes:
* Enable pydocstyle lints D400 and D205.
* Fix all linting errors. Now all docstrings have a 1-line summary as required by numpydoc convention.