### PR TITLE
style[python]: Clean up imports in PyO3 bindings

### DIFF
--- a/py-polars/src/apply/mod.rs
+++ b/py-polars/src/apply/mod.rs
@@ -3,8 +3,9 @@ pub mod series;
 
 use polars::chunked_array::builder::get_list_builder;
 use polars::prelude::*;
+use polars_core::export::rayon::prelude::*;
 use polars_core::utils::CustomIterTools;
-use polars_core::{export::rayon::prelude::*, POOL};
+use polars_core::POOL;
 use pyo3::types::PyDict;
 use pyo3::{PyAny, PyResult};
 

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -3,8 +3,9 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "object")]
 use polars::chunked_array::object::PolarsObjectSafe;
+use polars::frame::groupby::PivotAgg;
 use polars::frame::row::Row;
-use polars::frame::{groupby::PivotAgg, NullStrategy};
+use polars::frame::NullStrategy;
 #[cfg(feature = "avro")]
 use polars::io::avro::AvroCompression;
 #[cfg(feature = "ipc")]

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -19,8 +19,9 @@ use polars_core::prelude::QuantileInterpolOptions;
 use polars_core::utils::arrow::compute::cast::CastOptions;
 use polars_core::utils::get_supertype;
 use polars_lazy::frame::pivot::{pivot, pivot_stable};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use crate::apply::dataframe::{
     apply_lambda_unknown, apply_lambda_with_bool_out_type, apply_lambda_with_primitive_out_type,
@@ -29,17 +30,12 @@ use crate::apply::dataframe::{
 #[cfg(feature = "parquet")]
 use crate::conversion::parse_parquet_compression;
 use crate::conversion::{ObjectValue, Wrap};
-use crate::file::get_mmap_bytes_reader;
+use crate::error::PyPolarsErr;
+use crate::file::{get_either_file, get_file_like, get_mmap_bytes_reader, EitherRustPythonFile};
 use crate::lazy::dataframe::PyLazyFrame;
 use crate::prelude::dicts_to_rows;
-use crate::{
-    arrow_interop,
-    error::PyPolarsErr,
-    file::{get_either_file, get_file_like, EitherRustPythonFile},
-    py_modules,
-    series::{to_pyseries_collection, to_series_collection, PySeries},
-    PyExpr,
-};
+use crate::series::{to_pyseries_collection, to_series_collection, PySeries};
+use crate::{arrow_interop, py_modules, PyExpr};
 
 #[pyclass]
 #[repr(transparent)]

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -2,12 +2,9 @@ use std::fmt::{Debug, Formatter};
 
 use polars::prelude::PolarsError;
 use polars_core::error::ArrowError;
-use pyo3::exceptions::{PyIOError, PyValueError};
-use pyo3::{
-    create_exception,
-    exceptions::{PyException, PyRuntimeError},
-    prelude::*,
-};
+use pyo3::create_exception;
+use pyo3::exceptions::{PyException, PyIOError, PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
 use thiserror::Error;
 
 #[derive(Error)]

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -5,8 +5,7 @@ use std::io;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 
 use polars::io::mmap::MmapBytesReader;
-use pyo3::exceptions::PyFileNotFoundError;
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::{PyFileNotFoundError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -22,7 +22,8 @@ use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::file::get_file_like;
-use crate::lazy::{dsl::PyExpr, utils::py_exprs_to_exprs};
+use crate::lazy::dsl::PyExpr;
+use crate::lazy::utils::py_exprs_to_exprs;
 use crate::prelude::*;
 use crate::py_modules::POLARS;
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -10,8 +10,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
 
 use super::apply::*;
-use crate::conversion::parse_fill_null_strategy;
-use crate::conversion::Wrap;
+use crate::conversion::{parse_fill_null_strategy, Wrap};
 use crate::lazy::map_single;
 use crate::lazy::utils::py_exprs_to_exprs;
 use crate::series::PySeries;

--- a/py-polars/src/lazy/mod.rs
+++ b/py-polars/src/lazy/mod.rs
@@ -4,6 +4,7 @@ pub mod dsl;
 #[cfg(feature = "meta")]
 mod meta;
 pub mod utils;
+
 pub use apply::*;
 use dsl::*;
 use polars_lazy::prelude::*;

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -4,20 +4,6 @@
 extern crate core;
 extern crate polars;
 
-use pyo3::prelude::*;
-use pyo3::wrap_pyfunction;
-
-use crate::lazy::dsl::PyExpr;
-use crate::{
-    dataframe::PyDataFrame,
-    file::EitherRustPythonFile,
-    lazy::{
-        dataframe::{PyLazyFrame, PyLazyGroupBy},
-        dsl,
-    },
-    series::PySeries,
-};
-
 pub mod apply;
 pub mod arrow_interop;
 pub mod conversion;
@@ -46,7 +32,9 @@ use polars_core::prelude::IntoSeries;
 use polars_core::prelude::{DataFrame, IDX_DTYPE};
 use polars_core::POOL;
 use pyo3::panic::PanicException;
+use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
+use pyo3::wrap_pyfunction;
 
 use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
 use crate::error::{
@@ -54,8 +42,18 @@ use crate::error::{
     SchemaError,
 };
 use crate::file::get_either_file;
+use crate::lazy::dsl::PyExpr;
 use crate::prelude::{
     vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs,
+};
+use crate::{
+    dataframe::PyDataFrame,
+    file::EitherRustPythonFile,
+    lazy::{
+        dataframe::{PyLazyFrame, PyLazyGroupBy},
+        dsl,
+    },
+    series::PySeries,
 };
 
 #[global_allocator]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -28,8 +28,7 @@ use mimalloc::MiMalloc;
 use polars::functions::{diag_concat_df, hor_concat_df};
 use polars::prelude::Null;
 use polars_core::datatypes::TimeUnit;
-use polars_core::prelude::IntoSeries;
-use polars_core::prelude::{DataFrame, IDX_DTYPE};
+use polars_core::prelude::{DataFrame, IntoSeries, IDX_DTYPE};
 use polars_core::POOL;
 use pyo3::panic::PanicException;
 use pyo3::prelude::*;
@@ -37,24 +36,19 @@ use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
 use pyo3::wrap_pyfunction;
 
 use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
+use crate::dataframe::PyDataFrame;
 use crate::error::{
     ArrowErrorException, ComputeError, DuplicateError, NoDataError, NotFoundError, PyPolarsErr,
     SchemaError,
 };
-use crate::file::get_either_file;
+use crate::file::{get_either_file, EitherRustPythonFile};
+use crate::lazy::dataframe::{PyLazyFrame, PyLazyGroupBy};
+use crate::lazy::dsl;
 use crate::lazy::dsl::PyExpr;
 use crate::prelude::{
     vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs,
 };
-use crate::{
-    dataframe::PyDataFrame,
-    file::EitherRustPythonFile,
-    lazy::{
-        dataframe::{PyLazyFrame, PyLazyGroupBy},
-        dsl,
-    },
-    series::PySeries,
-};
+use crate::series::PySeries;
 
 #[global_allocator]
 #[cfg(target_os = "linux")]
@@ -254,7 +248,8 @@ fn py_duration(
 
 #[pyfunction]
 fn concat_df(dfs: &PyAny, py: Python) -> PyResult<PyDataFrame> {
-    use polars_core::{error::Result, utils::rayon::prelude::*};
+    use polars_core::error::Result;
+    use polars_core::utils::rayon::prelude::*;
 
     let (seq, _len) = get_pyseq(dfs)?;
     let mut iter = seq.iter()?;

--- a/py-polars/src/npy.rs
+++ b/py-polars/src/npy.rs
@@ -1,11 +1,9 @@
 use std::{mem, ptr};
 
 use ndarray::IntoDimension;
-use numpy::{
-    npyffi::{self, flags, types::npy_intp},
-    ToNpyDims, PY_ARRAY_API,
-};
-use numpy::{Element, PyArray1};
+use numpy::npyffi::types::npy_intp;
+use numpy::npyffi::{self, flags};
+use numpy::{Element, PyArray1, ToNpyDims, PY_ARRAY_API};
 use polars_core::utils::arrow::types::NativeType;
 use pyo3::prelude::*;
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -2,20 +2,20 @@ use numpy::PyArray1;
 use polars_core::prelude::QuantileInterpolOptions;
 use polars_core::series::IsSorted;
 use polars_core::utils::CustomIterTools;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList, PyTuple};
-use pyo3::{exceptions::PyRuntimeError, prelude::*, Python};
+use pyo3::Python;
 
 use crate::apply::series::{call_lambda_and_extract, ApplyLambda};
 use crate::arrow_interop::to_rust::array_to_rust;
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::list_construction::py_seq_to_list;
+use crate::npy::{aligned_array, get_refcnt};
+use crate::prelude::*;
 use crate::set::set_at_idx;
-use crate::{
-    apply_method_all_arrow_series2, arrow_interop,
-    npy::{aligned_array, get_refcnt},
-    prelude::*,
-};
+use crate::{apply_method_all_arrow_series2, arrow_interop};
 #[pyclass]
 #[repr(transparent)]
 #[derive(Clone)]


### PR DESCRIPTION
Changes:
*  `rustfmt` doesn't gather `use` statements when there are `mod` statements in between. I manually fixed this in `lib.rs` by moving the `mod` statements above the `use` statements.
* I ran `rustfmt` with `imports_granularity = "Module"`. See [here](https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#imports_granularity). I think it is a HUGE improvement in readability. I suggest we do this for the main Rust code base too by adding this setting to `rustfmt.toml`. The default setting is to do nothing (leave user style intact), which leads to a lot of inconsistency/ugliness.