### PR TITLE
docs[python]: configure intersphinx and create (some) hyperlinks

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 
@@ -19,8 +20,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = "Polars"
-copyright = "2021, Ritchie Vink"
 author = "Ritchie Vink"
+copyright = f"{datetime.date.today().year}, {author}"
 
 
 # -- General configuration ---------------------------------------------------
@@ -94,4 +95,11 @@ html_theme_options = {
             "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/touchicon-180x180.png",  # noqa: E501
         },
     ],
+}
+
+intersphinx_mapping = {
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "pyarrow": ("https://arrow.apache.org/docs/", None),
+    "python": ("https://docs.python.org/3", None),
 }

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -98,7 +98,7 @@ html_theme_options = {
 }
 
 intersphinx_mapping = {
-    "numpy": ("https://numpy.org/doc/stable/objects.inv", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "pyarrow": ("https://arrow.apache.org/docs/", None),
     "python": ("https://docs.python.org/3", None),

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -98,7 +98,7 @@ html_theme_options = {
 }
 
 intersphinx_mapping = {
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/objects.inv", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "pyarrow": ("https://arrow.apache.org/docs/", None),
     "python": ("https://docs.python.org/3", None),

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -324,8 +324,8 @@ def from_pandas(
 
     Parameters
     ----------
-    df : :class:`~pandas.DataFrame`, :class:`~pandas.Series`, or :class:`~pandas.DatetimeIndex`
-        Data represented as a pandas DataFrame`, Series or DatetimeIndex.
+    df : :class:`pandas.DataFrame`, :class:`pandas.Series` or :class:`pandas.DatetimeIndex`
+        Data represented as a pandas DataFrame, Series or DatetimeIndex.
     rechunk : bool, default True
         Make sure that all data is contiguous.
     nan_to_none : bool, default True

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -176,7 +176,7 @@ def from_numpy(
 
     Parameters
     ----------
-    data : numpy ndarray
+    data : :class:`numpy.ndarray`
         Two-dimensional data represented as a numpy ndarray.
     columns : Sequence of str, default None
         Column labels to use for resulting DataFrame. Must match data dimensions.
@@ -238,7 +238,7 @@ def from_arrow(
 
     Parameters
     ----------
-    a : Arrow Table or Array
+    a : :class:`pyarrow.Table` or :class:`pyarrow.Array`
         Data represented as Arrow Table or Array.
     rechunk : bool, default True
         Make sure that all data is contiguous.
@@ -320,12 +320,12 @@ def from_pandas(
     Construct a Polars DataFrame or Series from a pandas DataFrame or Series.
     This operation clones data.
 
-    This requires that pandas and pyarrow are installed.
+    This requires that :mod:`pandas` and :mod:`pyarrow` are installed.
 
     Parameters
     ----------
-    df : pandas DataFrame, Series, or DatetimeIndex
-        Data represented as a pandas DataFrame, Series, or DatetimeIndex.
+    df : :class:`~pandas.DataFrame`, :class:`~pandas.Series`, or :class:`~pandas.DatetimeIndex`
+        Data represented as a pandas DataFrame`, Series or DatetimeIndex.
     rechunk : bool, default True
         Make sure that all data is contiguous.
     nan_to_none : bool, default True

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -69,7 +69,7 @@ def series_to_pyseries(name: str, values: pli.Series) -> PySeries:
 
 
 def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySeries:
-    """Construct a PySeries from an Arrow array."""
+    """Construct a PySeries from a :class:`pa.Array`."""
     array = coerce_arrow(values)
     if hasattr(array, "num_chunks"):
         if array.num_chunks > 1:
@@ -93,7 +93,7 @@ def numpy_to_pyseries(
     strict: bool = True,
     nan_to_null: bool = False,
 ) -> PySeries:
-    """Construct a PySeries from a numpy array."""
+    """Construct a PySeries from a :class:`numpy.ndarray`."""
     if not values.flags["C_CONTIGUOUS"]:
         values = np.array(values)
 
@@ -337,11 +337,11 @@ def _pandas_series_to_arrow(
     min_len: int | None = None,
 ) -> pa.Array:
     """
-    Convert a pandas Series to an Arrow Array.
+    Convert a :class:`pandas.Series` to an :class:`pyarrow.Array`.
 
     Parameters
     ----------
-    values
+    values : :class:`pandas.Series`
         Series to convert to arrow
     nan_to_none
         Interpret `NaN` as missing values
@@ -351,7 +351,7 @@ def _pandas_series_to_arrow(
 
     Returns
     -------
-    Arrow Array
+    :class:`pyarrow.Array`
 
     """
     dtype = values.dtype
@@ -570,7 +570,7 @@ def numpy_to_pydf(
     columns: ColumnsType | None = None,
     orient: Orientation | None = None,
 ) -> PyDataFrame:
-    """Construct a PyDataFrame from a numpy ndarray."""
+    """Construct a PyDataFrame from a `:class:`numpy.ndarray`."""
     shape = data.shape
 
     # Unpack columns
@@ -641,7 +641,7 @@ def numpy_to_pydf(
 def arrow_to_pydf(
     data: pa.Table, columns: ColumnsType | None = None, rechunk: bool = True
 ) -> PyDataFrame:
-    """Construct a PyDataFrame from an Arrow Table."""
+    """Construct a PyDataFrame from a :class:`pyarrow.Table`."""
     if not _PYARROW_AVAILABLE:  # pragma: no cover
         raise ImportError(
             "'pyarrow' is required when constructing a PyDataFrame from an Arrow Table."
@@ -722,7 +722,7 @@ def pandas_to_pydf(
     rechunk: bool = True,
     nan_to_none: bool = True,
 ) -> PyDataFrame:
-    """Construct a PyDataFrame from a pandas DataFrame."""
+    """Construct a PyDataFrame from a :class:`pandas.DataFrame`."""
     if not _PYARROW_AVAILABLE:  # pragma: no cover
         raise ImportError(
             "'pyarrow' is required when constructing a PyDataFrame from a pandas"

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1076,11 +1076,15 @@ class DataFrame:
         Parameters
         ----------
         args
-            Arguments will be sent to pyarrow.Table.to_pandas.
+            Arguments will be sent to :meth:`pyarrow.Table.to_pandas`.
         date_as_object
-            Cast dates to objects. If False, convert to datetime64[ns] dtype.
+            Cast dates to objects. If False, convert to ``datetime64[ns]`` dtype.
         kwargs
-            Arguments will be sent to pyarrow.Table.to_pandas.
+            Arguments will be sent to :meth:`pyarrow.Table.to_pandas`.
+
+        Returns
+        -------
+        pd.DataFrame
 
         Examples
         --------


### PR DESCRIPTION
This is mostly a cosmetic change but I thought external links to pandas, pyarrow, numpy etc are generally quite useful. It configures the intersphinx extension to point to API inventory files which were previously not configured.