### PR TITLE
fix[rust]: overlapping groups should not explode data in groupby

### DIFF
--- a/polars/polars-core/src/chunked_array/iterator/par/list.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/list.rs
@@ -28,4 +28,15 @@ impl ListChunked {
             })
             .flatten()
     }
+
+    // Get an indexed parallel iterator over the [`Series`] in this [`ListChunked`].
+    pub fn par_iter_indexed(&mut self) -> impl IndexedParallelIterator<Item = Option<Series>> + '_ {
+        *self = self.rechunk();
+        let arr = self.downcast_iter().next().unwrap();
+
+        let dtype = self.inner_dtype();
+        (0..arr.len())
+            .into_par_iter()
+            .map(move |idx| unsafe { idx_to_array(idx, arr, &dtype) })
+    }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -29,6 +29,13 @@ impl Executor for GroupByDynamicExec {
         let mut df = self.input.execute(state)?;
         df.as_single_chunk_par();
         state.set_schema(self.input_schema.clone());
+
+        // if the periods are larger than the intervals,
+        // the groups overlap
+        if self.options.every < self.options.period {
+            state.flags |= StateFlags::OVERLAPPING_GROUPS
+        }
+
         let keys = self
             .keys
             .iter()

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -57,6 +57,9 @@ impl Executor for GroupByRollingExec {
             }
         };
 
+        // a rolling groupby has overlapping windows
+        state.flags |= StateFlags::OVERLAPPING_GROUPS;
+
         let agg_columns = POOL.install(|| {
                     self.aggs
                         .par_iter()

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -134,7 +134,10 @@ impl<'a> AggregationContext<'a> {
                         })
                     }
                     // sliced groups are already in correct order
-                    GroupsProxy::Slice { .. } => {}
+                    GroupsProxy::Slice { groups, .. } => {
+                        dbg!(groups);
+                        dbg!("hree");
+                    }
                 }
                 self.update_groups = UpdateGroups::No;
             }

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -155,9 +155,8 @@ impl WindowExpr {
                     if let GroupsProxy::Idx(g) = gb.get_groups() {
                         debug_assert!(g.is_sorted())
                     }
-                    else {
-                        debug_assert!(false)
-                    }
+                    // GroupsProxy::Slice is always sorted
+
                     // Note that group columns must be sorted for this to make sense!!!
                     Ok(MapStrategy::Explode)
                 } else {

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -14,9 +14,14 @@ pub type GroupsProxyCache = Arc<Mutex<PlHashMap<String, GroupsProxy>>>;
 
 bitflags! {
     pub(super) struct StateFlags: u8 {
+        /// More verbose logging
         const VERBOSE = 0x01;
+        /// Indicates that window expression's [`GroupTuples`] may be cached.
         const CACHE_WINDOW_EXPR = 0x02;
-        const FILTER_NODE = 0x03;
+        /// Indicates that a groupby operations groups may overlap.
+        /// If this is the case, an `explode` will yield more values than rows in original `df`,
+        /// this breaks some assumptions
+        const OVERLAPPING_GROUPS = 0x03;
     }
 }
 
@@ -152,10 +157,19 @@ impl ExecutionState {
         lock.clear();
     }
 
+    /// Indicates that window expression's [`GroupTuples`] may be cached.
     pub(super) fn cache_window(&self) -> bool {
         self.flags.contains(StateFlags::CACHE_WINDOW_EXPR)
     }
 
+    /// Indicates that a groupby operations groups may overlap.
+    /// If this is the case, an `explode` will yield more values than rows in original `df`,
+    /// this breaks some assumptions
+    pub(super) fn overlapping_groups(&self) -> bool {
+        self.flags.contains(StateFlags::OVERLAPPING_GROUPS)
+    }
+
+    /// More verbose logging
     pub(super) fn verbose(&self) -> bool {
         self.flags.contains(StateFlags::VERBOSE)
     }

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::ops::Mul;
 
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
@@ -28,6 +29,18 @@ pub struct Duration {
     pub(crate) negative: bool,
     // indicates if an integer string was passed. e.g. "2i"
     pub parsed_int: bool,
+}
+
+impl PartialOrd<Self> for Duration {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.duration_ns().partial_cmp(&other.duration_ns())
+    }
+}
+
+impl Ord for Duration {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.duration_ns().cmp(&other.duration_ns())
+    }
 }
 
 impl Duration {


### PR DESCRIPTION
fixes #4628 

There is more to do here. We did many optimizations on the assumption that we could exploded/flatten an aggregated list for free. This is not the case if groups are overlapping. An explode an a groupby rolling `col().list()` increases `n` elements to `n * avg(group_len)` which can be a lot!.

I shall see if we can change strategies in more operations for overlapping groups. 