### PR TITLE
feat[rust]: more compact duration format (for table output)

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -513,45 +513,45 @@ const SIZES_NS: [i64; 4] = [
     60_000_000_000,
     1_000_000_000,
 ];
-const NAMES: [&str; 4] = ["day", "hour", "minute", "second"];
+const NAMES: [&str; 4] = ["d", "h", "m", "s"];
 const SIZES_US: [i64; 4] = [86_400_000_000, 3_600_000_000, 60_000_000, 1_000_000];
 const SIZES_MS: [i64; 4] = [86_400_000, 3_600_000, 60_000, 1_000];
 
 fn fmt_duration_ns(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
     if v == 0 {
-        return write!(f, "0 ns");
+        return write!(f, "0ns");
     }
     format_duration(f, v, SIZES_NS.as_slice(), NAMES.as_slice())?;
     if v % 1000 != 0 {
-        write!(f, "{} ns", v % 1_000_000_000)?;
+        write!(f, "{}ns", v % 1_000_000_000)?;
     } else if v % 1_000_000 != 0 {
-        write!(f, "{} µs", (v % 1_000_000_000) / 1000)?;
+        write!(f, "{}µs", (v % 1_000_000_000) / 1000)?;
     } else if v % 1_000_000_000 != 0 {
-        write!(f, "{} ms", (v % 1_000_000_000) / 1_000_000)?;
+        write!(f, "{}ms", (v % 1_000_000_000) / 1_000_000)?;
     }
     Ok(())
 }
 
 fn fmt_duration_us(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
     if v == 0 {
-        return write!(f, "0 µs");
+        return write!(f, "0µs");
     }
     format_duration(f, v, SIZES_US.as_slice(), NAMES.as_slice())?;
     if v % 1000 != 0 {
-        write!(f, "{} µs", (v % 1_000_000_000) / 1000)?;
+        write!(f, "{}µs", (v % 1_000_000_000) / 1000)?;
     } else if v % 1_000_000 != 0 {
-        write!(f, "{} ms", (v % 1_000_000_000) / 1_000_000)?;
+        write!(f, "{}ms", (v % 1_000_000_000) / 1_000_000)?;
     }
     Ok(())
 }
 
 fn fmt_duration_ms(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
     if v == 0 {
-        return write!(f, "0 ms");
+        return write!(f, "0ms");
     }
     format_duration(f, v, SIZES_MS.as_slice(), NAMES.as_slice())?;
     if v % 1_000 != 0 {
-        write!(f, "{} ms", (v % 1_000_000_000) / 1_000_000)?;
+        write!(f, "{}ms", (v % 1_000_000_000) / 1_000_000)?;
     }
     Ok(())
 }
@@ -564,10 +564,7 @@ fn format_duration(f: &mut Formatter, v: i64, sizes: &[i64], names: &[&str]) -> 
             (v % sizes[i - 1]) / sizes[i]
         };
         if whole_num <= -1 || whole_num >= 1 {
-            write!(f, "{} {}", whole_num, names[i])?;
-            if whole_num != 1 {
-                write!(f, "s")?;
-            }
+            write!(f, "{}{}", whole_num, names[i])?;
             if v % sizes[i] != 0 {
                 write!(f, " ")?;
             }

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -243,7 +243,7 @@ def date_range(
     if isinstance(interval, timedelta):
         interval = _timedelta_to_pl_duration(interval)
     elif " " in interval:
-        interval = interval.replace(" ","")
+        interval = interval.replace(" ", "")
 
     low, low_is_date = _ensure_datetime(low)
     high, high_is_date = _ensure_datetime(high)

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -242,6 +242,8 @@ def date_range(
     """
     if isinstance(interval, timedelta):
         interval = _timedelta_to_pl_duration(interval)
+    elif " " in interval:
+        interval = interval.replace(" ","")
 
     low, low_is_date = _ensure_datetime(low)
     high, high_is_date = _ensure_datetime(high)


### PR DESCRIPTION
I've been noticing that duration/timedelta columns frequently wrap in table output, and/or require "..." when doing interval math. This patch makes the table output a little more compact by using the unit abbreviations instead of the fully spelled-out unit name; remains highly readable but is now guaranteed never to inject a "..." or wrap (unless the duration is preposterously and enormously negative :)

```python
df = pl.DataFrame(
  {
    "x": [16618590123],
    "y": [16618590123456],
    "z": [16618590123456789],
  },
  columns=[("x", pl.Duration("ms")),("y", pl.Duration("us")),("z", pl.Duration("ns"))],
)
```

**Before**
```
┌────────────────────────────────┬────────────────────────────────┬────────────────────────────────┐
│ x                              ┆ y                              ┆ z                              │
│ ---                            ┆ ---                            ┆ ---                            │
│ duration[ms]                   ┆ duration[μs]                   ┆ duration[ns]                   │
╞════════════════════════════════╪════════════════════════════════╪════════════════════════════════╡
│ 192 days 8 hours 16 minutes 30 ┆ 192 days 8 hours 16 minutes 30 ┆ 192 days 8 hours 16 minutes 30 │
│ s...                           ┆ s...                           ┆ s...                           │
└────────────────────────────────┴────────────────────────────────┴────────────────────────────────┘
```
**After**
```
┌───────────────────────┬──────────────────────────┬─────────────────────────────┐
│ x                     ┆ y                        ┆ z                           │
│ ---                   ┆ ---                      ┆ ---                         │
│ duration[ms]          ┆ duration[μs]             ┆ duration[ns]                │
╞═══════════════════════╪══════════════════════════╪═════════════════════════════╡
│ 192d 8h 16m 30s 618ms ┆ 192d 8h 16m 30s 590123µs ┆ 192d 8h 16m 30s 123456789ns │
└───────────────────────┴──────────────────────────┴─────────────────────────────┘
```
For convenience, the same format is allowed as input to the `interval` param in the python `date_range` function (this only required stripping the spaces, as the shortcut form `1d2h3m4s` is already supported).

(I believe we should consider this for cast-to-string too, which currently returns a stringified int, but one thing at a time ;)