### PR TITLE
feat[python]!: Update `Expr.sample` signature and change random seeding

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import random
 import sys
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
@@ -5614,7 +5615,7 @@ class DataFrame:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -5640,6 +5641,9 @@ class DataFrame:
         """
         if n is not None and frac is not None:
             raise ValueError("cannot specify both `n` and `frac`")
+
+        if seed is None:
+            seed = random.randint(0, 10000)
 
         if n is None and frac is not None:
             return self._from_pydf(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5417,7 +5417,7 @@ class Expr:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -5439,6 +5439,9 @@ class Expr:
         """
         if n is not None and frac is not None:
             raise ValueError("cannot specify both `n` and `frac`")
+
+        if seed is None:
+            seed = random.randint(0, 10000)
 
         if frac is not None:
             return wrap_expr(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -4,7 +4,6 @@ import math
 import random
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Callable, Sequence
-from warnings import warn
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -5394,20 +5393,22 @@ class Expr:
             seed = random.randint(0, 10000)
         return wrap_expr(self._pyexpr.shuffle(seed))
 
-    @deprecated_alias(fraction="frac")
     def sample(
         self,
+        n: int | None = None,
         frac: float | None = None,
-        with_replacement: bool = True,
+        with_replacement: bool = False,
         shuffle: bool = False,
         seed: int | None = None,
-        n: int | None = None,
     ) -> Expr:
         """
         Sample from this expression.
 
         Parameters
         ----------
+        n
+            Number of items to return. Cannot be used with `frac`. Defaults to 1 if
+            `frac` is None.
         frac
             Fraction of items to return. Cannot be used with `n`.
         with_replacement
@@ -5417,8 +5418,6 @@ class Expr:
         seed
             Seed for the random number generator. If set to None (default), a random
             seed is used.
-        n
-            Number of items to return. Cannot be used with `frac`.
 
         Examples
         --------
@@ -5438,25 +5437,17 @@ class Expr:
         └─────┘
 
         """
-        warn(
-            "The function signature for Expr.sample will change in a future"
-            " version. Explicitly set `frac` and `with_replacement` using keyword"
-            " arguments to retain the same behaviour.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
         if n is not None and frac is not None:
             raise ValueError("cannot specify both `n` and `frac`")
 
-        if n is not None and frac is None:
-            return wrap_expr(self._pyexpr.sample_n(n, with_replacement, shuffle, seed))
+        if frac is not None:
+            return wrap_expr(
+                self._pyexpr.sample_frac(frac, with_replacement, shuffle, seed)
+            )
 
-        if frac is None:
-            frac = 1.0
-        return wrap_expr(
-            self._pyexpr.sample_frac(frac, with_replacement, shuffle, seed)
-        )
+        if n is None:
+            n = 1
+        return wrap_expr(self._pyexpr.sample_n(n, with_replacement, shuffle, seed))
 
     def ewm_mean(
         self,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3554,7 +3554,7 @@ class Series:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -3568,15 +3568,6 @@ class Series:
         ]
 
         """
-        if n is not None and frac is not None:
-            raise ValueError("cannot specify both `n` and `frac`")
-
-        if n is None and frac is not None:
-            return wrap_s(self._s.sample_frac(frac, with_replacement, shuffle, seed))
-
-        if n is None:
-            n = 1
-        return wrap_s(self._s.sample_n(n, with_replacement, shuffle, seed))
 
     def peak_max(self) -> Series:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -558,34 +558,6 @@ impl PySeries {
         self.series.has_validity()
     }
 
-    pub fn sample_n(
-        &self,
-        n: usize,
-        with_replacement: bool,
-        shuffle: bool,
-        seed: Option<u64>,
-    ) -> PyResult<Self> {
-        let s = self
-            .series
-            .sample_n(n, with_replacement, shuffle, seed)
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
-    pub fn sample_frac(
-        &self,
-        frac: f64,
-        with_replacement: bool,
-        shuffle: bool,
-        seed: Option<u64>,
-    ) -> PyResult<Self> {
-        let s = self
-            .series
-            .sample_frac(frac, with_replacement, shuffle, seed)
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
     pub fn series_equal(&self, other: &PySeries, null_equal: bool, strict: bool) -> bool {
         if strict {
             self.series.eq(&other.series)

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import random
 from typing import cast
 
 import numpy as np
-import pytest
 
 import polars as pl
 from polars.testing import assert_series_equal, verify_series_and_expr_api
@@ -94,7 +94,6 @@ def test_count_expr() -> None:
     assert out["count"].to_list() == [4, 1]
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_sample() -> None:
     a = pl.Series("a", range(0, 20))
     out = pl.select(

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -108,6 +108,13 @@ def test_sample() -> None:
     assert out.to_list() != out.sort().to_list()
     assert out.unique().shape == (10,)
 
+    # Setting random.seed should lead to reproducible results
+    random.seed(1)
+    result1 = pl.select(pl.lit(a).sample(n=10)).to_series()
+    random.seed(1)
+    result2 = pl.select(pl.lit(a).sample(n=10)).to_series()
+    assert result1.series_equal(result2)
+
 
 def test_map_alias() -> None:
     out = pl.DataFrame({"foo": [1, 2, 3]}).select(


### PR DESCRIPTION
Following up on #4623

Changes:
* Update `Expr.sample` function signature to be in like with `Series/DataFrame.sample`
  * Move `n` to be the first argument
  * Set default for `with_replacement` to `False`.
  * Change default behaviour to `n=1` instead of `frac=1.0`
* Handle random seed generation on the Python side, to enable seeding with `random.seed()`. This brings `sample` in line with `shuffle`.
  * This is included as a breaking change, as people relying on `random.seed()` could now inadvertently seed this method.
* Dispatch `Series.sample` to `Expr.sample`.

We can just leave this PR lying around until we decide to go for version `0.15.0`.