### PR TITLE
feat(python)!: Update `Expr.sample` signature and change random seeding

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import math
 import os
+import random
 import sys
 import typing
 from collections.abc import Sized
@@ -6196,7 +6197,7 @@ class DataFrame:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -6222,6 +6223,9 @@ class DataFrame:
         """
         if n is not None and frac is not None:
             raise ValueError("cannot specify both `n` and `frac`")
+
+        if seed is None:
+            seed = random.randint(0, 10000)
 
         if n is None and frac is not None:
             return self._from_pydf(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5565,7 +5565,7 @@ class Expr:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -5587,6 +5587,9 @@ class Expr:
         """
         if n is not None and frac is not None:
             raise ValueError("cannot specify both `n` and `frac`")
+
+        if seed is None:
+            seed = random.randint(0, 10000)
 
         if frac is not None:
             return wrap_expr(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5,8 +5,8 @@ import random
 import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, cast
-from warnings import warn
 
+from polars import internals as pli
 from polars.datatypes import (
     DataType,
     PolarsDataType,
@@ -23,8 +23,6 @@ from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
 from polars.utils import _timedelta_to_pl_duration, accessor, deprecated_alias
-
-from polars import internals as pli
 
 try:
     from polars.polars import PyExpr

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4014,7 +4014,7 @@ class Series:
             Shuffle the order of sampled data points.
         seed
             Seed for the random number generator. If set to None (default), a random
-            seed is used.
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -4028,15 +4028,6 @@ class Series:
         ]
 
         """
-        if n is not None and frac is not None:
-            raise ValueError("cannot specify both `n` and `frac`")
-
-        if n is None and frac is not None:
-            return wrap_s(self._s.sample_frac(frac, with_replacement, shuffle, seed))
-
-        if n is None:
-            n = 1
-        return wrap_s(self._s.sample_n(n, with_replacement, shuffle, seed))
 
     def peak_max(self) -> Series:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -566,34 +566,6 @@ impl PySeries {
         self.series.has_validity()
     }
 
-    pub fn sample_n(
-        &self,
-        n: usize,
-        with_replacement: bool,
-        shuffle: bool,
-        seed: Option<u64>,
-    ) -> PyResult<Self> {
-        let s = self
-            .series
-            .sample_n(n, with_replacement, shuffle, seed)
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
-    pub fn sample_frac(
-        &self,
-        frac: f64,
-        with_replacement: bool,
-        shuffle: bool,
-        seed: Option<u64>,
-    ) -> PyResult<Self> {
-        let s = self
-            .series
-            .sample_frac(frac, with_replacement, shuffle, seed)
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
-    }
-
     pub fn series_equal(&self, other: &PySeries, null_equal: bool, strict: bool) -> bool {
         if strict {
             self.series.eq(&other.series)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -122,6 +122,13 @@ def test_sample() -> None:
     assert out.to_list() != out.sort().to_list()
     assert out.unique().shape == (10,)
 
+    # Setting random.seed should lead to reproducible results
+    random.seed(1)
+    result1 = pl.select(pl.lit(a).sample(n=10)).to_series()
+    random.seed(1)
+    result2 = pl.select(pl.lit(a).sample(n=10)).to_series()
+    assert result1.series_equal(result2)
+
 
 def test_map_alias() -> None:
     out = pl.DataFrame({"foo": [1, 2, 3]}).select(

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -106,7 +106,6 @@ def test_shuffle() -> None:
     assert result1.series_equal(result2)
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_sample() -> None:
     a = pl.Series("a", range(0, 20))
     out = pl.select(


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

Following up on #4623

Changes:
* Update `Expr.sample` function signature to be in like with `Series/DataFrame.sample`
  * Move `n` to be the first argument
  * Set default for `with_replacement` to `False`.
  * Change default behaviour to `n=1` instead of `frac=1.0`
* Handle random seed generation on the Python side, to enable seeding with `random.seed()`. This brings `sample` in line with `shuffle`.
  * This is included as a breaking change, as people relying on `random.seed()` could now inadvertently seed this method.
* Dispatch `Series.sample` to `Expr.sample`.

We can just leave this PR lying around until we decide to go for version `0.15.0`.