### PR TITLE
feat[python]: Allow use of builtin abs()

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -157,6 +157,9 @@ class Expr:
             "Hint: use '&' or '|' to chain Expr together, not and/or."
         )
 
+    def __abs__(self) -> Expr:
+        return wrap_expr(self._pyexpr.abs())
+
     def __invert__(self) -> Expr:
         return self.is_not()
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -4587,6 +4587,8 @@ class Expr:
         """
         Compute absolute values.
 
+        Same as `abs(expr)`.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3733,7 +3733,11 @@ class Series:
         """
 
     def abs(self) -> Series:
-        """Compute absolute values."""
+        """
+        Compute absolute values.
+
+        Same as `abs(series)`.
+        """
 
     __abs__ = call_expr(abs)
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -47,7 +47,7 @@ from polars.internals.series.datetime import DateTimeNameSpace
 from polars.internals.series.list import ListNameSpace
 from polars.internals.series.string import StringNameSpace
 from polars.internals.series.struct import StructNameSpace
-from polars.internals.series.utils import expr_dispatch, get_ffi_func
+from polars.internals.series.utils import call_expr, expr_dispatch, get_ffi_func
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
@@ -3734,6 +3734,8 @@ class Series:
 
     def abs(self) -> Series:
         """Compute absolute values."""
+
+    __abs__ = call_expr(abs)
 
     def rank(self, method: RankMethod = "average", reverse: bool = False) -> Series:
         """

--- a/py-polars/tests/test_exprs.py
+++ b/py-polars/tests/test_exprs.py
@@ -405,3 +405,10 @@ def test_search_sorted() -> None:
 
         for v in range(int(np.min(a)), int(np.max(a)), 20):
             assert np.searchsorted(a, v) == s.search_sorted(v)
+
+
+def test_abs_expr() -> None:
+    df = pl.DataFrame({"x": [-1, 0, 1]})
+    out = df.select(abs(pl.col("x")))
+
+    assert out["x"].to_list() == [1, 0, 1]

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1965,3 +1965,10 @@ def test_repr() -> None:
     assert "1001" in x_repr
     for n in x.to_list():
         assert str(n) in x_repr
+
+
+def test_abs() -> None:
+    s = pl.Series("s", [-1, 0, 1, None])
+    a = abs(s)
+
+    assert a.to_list() == [1, 0, 1, None]

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1967,7 +1967,7 @@ def test_repr() -> None:
         assert str(n) in x_repr
 
 
-def test_abs() -> None:
+def test_builtin_abs() -> None:
     s = pl.Series("s", [-1, 0, 1, None])
     a = abs(s)
 


### PR DESCRIPTION
1. [x] Add `Expr.__abs__` method to allow abs(expr).
2. [x] Add `Series.__abs__` method to allow abs(series).
3. [x] Update documentation.