### PR TITLE
ci: Cancel in-progress runs

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -6,6 +6,11 @@ on:
       - 'polars/**'
       - 'py-polars/tests/db-benchmark/**'
       - '.github/workflows/benchmark.yaml'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,8 +5,12 @@ on:
     paths:
       - 'polars/**'
       - '.github/workflows/build-test.yaml'
-jobs:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
   examples:
     name: Examples
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,10 @@ on:
       - 'py-polars/**'
       - '.github/workflows/coverage.yaml'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: Coverage for ${{ matrix.os }}

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -5,6 +5,11 @@ on:
     paths:
     - 'py-polars/**'
     - '.github/workflows/docs_check.yaml'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Docs check

--- a/.github/workflows/fmt_all.yaml
+++ b/.github/workflows/fmt_all.yaml
@@ -2,6 +2,11 @@ name: Check formatting
 
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-fmt-all:
     name: Test global formatting

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -6,6 +6,11 @@ on:
       - 'py-polars/**'
       - 'polars/**'
       - '.github/workflows/test-python.yaml'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-python:
     name: Build and test Python

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -5,6 +5,11 @@ on:
     paths:
       - 'py-polars/**'
       - '.github/workflows/test-windows-python.yaml'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-python:
     name: Build and test Python

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -5,6 +5,11 @@ on:
     paths:
       - 'polars/**'
       - '.github/workflows/test-windows.yaml'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-rust:
     runs-on: windows-latest


### PR DESCRIPTION
[Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run) works like a charm!

Saving the 🐻‍❄️ one PR at a time!

Changes:
* Use concurrency to cancel workflows that are already in progress on the same PR when the same workflow is triggered.