### PR TITLE
feat[rust,python]: support nested StringCache scope, enabling clean composition

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -7,7 +7,7 @@ use polars_arrow::trusted_len::PushUnchecked;
 
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
 use crate::prelude::*;
-use crate::{datatypes::PlHashMap, use_string_cache, StrHashGlobal, StringCache, POOL};
+use crate::{datatypes::PlHashMap, using_string_cache, StrHashGlobal, StringCache, POOL};
 
 pub enum RevMappingBuilder {
     /// Hashmap: maps the indexes from the global cache/categorical array to indexes in the local Utf8Array
@@ -58,7 +58,7 @@ impl Default for RevMapping {
     fn default() -> Self {
         let slice: &[Option<&str>] = &[];
         let cats = Utf8Array::<i64>::from(slice);
-        if use_string_cache() {
+        if using_string_cache() {
             let cache = &mut crate::STRING_CACHE.lock_map();
             let id = cache.uuid;
             RevMapping::Global(Default::default(), cats, id)
@@ -388,7 +388,7 @@ impl CategoricalChunkedBuilder {
     where
         I: IntoIterator<Item = Option<&'a str>>,
     {
-        if use_string_cache() {
+        if using_string_cache() {
             self.build_global_map_contention(i)
         } else {
             let _ = self.build_local_map(i, false);

--- a/polars/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -3,7 +3,7 @@ use arrow::datatypes::IntegerType;
 use polars_arrow::compute::cast::cast;
 
 use super::*;
-use crate::use_string_cache;
+use crate::using_string_cache;
 
 impl From<&CategoricalChunked> for DictionaryArray<u32> {
     fn from(ca: &CategoricalChunked) -> Self {
@@ -91,7 +91,7 @@ impl CategoricalChunked {
         keys: &PrimitiveArray<u32>,
         values: &Utf8Array<i64>,
     ) -> Self {
-        if use_string_cache() {
+        if using_string_cache() {
             let mut builder = CategoricalChunkedBuilder::new(name, keys.len());
             builder.global_map_from_local(keys, values.clone());
             builder.finish()

--- a/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -26,7 +26,6 @@ pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
 /// This allows join operations on categorical types.
 pub fn toggle_string_cache(toggle: bool) {
     USE_STRING_CACHE.store(toggle, Ordering::Release);
-
     if !toggle {
         STRING_CACHE.clear()
     }
@@ -38,7 +37,7 @@ pub fn reset_string_cache() {
 }
 
 /// Check if string cache is set.
-pub(crate) fn use_string_cache() -> bool {
+pub fn using_string_cache() -> bool {
     USE_STRING_CACHE.load(Ordering::Acquire)
 }
 

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -687,9 +687,9 @@ impl LazyFrame {
     pub fn collect(self) -> Result<DataFrame> {
         let file_caching = self.opt_state.file_caching;
         #[cfg(feature = "dtype-categorical")]
-        let use_string_cache = self.opt_state.global_string_cache;
+        let using_string_cache = self.opt_state.global_string_cache;
         #[cfg(feature = "dtype-categorical")]
-        if use_string_cache {
+        if using_string_cache {
             eprint!("global string cache in combination with LazyFrames is deprecated; please set the global string cache globally.")
         }
         let mut expr_arena = Arena::with_capacity(256);
@@ -698,8 +698,8 @@ impl LazyFrame {
 
         // if string cache was already set, we skip this and global settings are respected
         #[cfg(feature = "dtype-categorical")]
-        if use_string_cache {
-            toggle_string_cache(use_string_cache);
+        if using_string_cache {
+            toggle_string_cache(using_string_cache);
         }
 
         let finger_prints = if file_caching {
@@ -729,8 +729,8 @@ impl LazyFrame {
             state.file_cache.assert_empty();
         }
         #[cfg(feature = "dtype-categorical")]
-        if use_string_cache {
-            toggle_string_cache(!use_string_cache);
+        if using_string_cache {
+            toggle_string_cache(!using_string_cache);
         }
         out
     }

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -344,9 +344,9 @@ pub mod prelude;
 
 pub use polars_core::apply_method_all_arrow_series;
 pub use polars_core::df;
-#[cfg(feature = "dtype-categorical")]
-pub use polars_core::toggle_string_cache;
 pub use polars_core::{chunked_array, datatypes, doc, error, frame, functions, series, testing};
+#[cfg(feature = "dtype-categorical")]
+pub use polars_core::{toggle_string_cache, using_string_cache};
 #[cfg(feature = "polars-io")]
 pub use polars_io as io;
 #[cfg(feature = "lazy")]

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -130,7 +130,7 @@ from polars.io import (
     scan_parquet,
 )
 from polars.show_versions import show_versions
-from polars.string_cache import StringCache, toggle_string_cache
+from polars.string_cache import StringCache, toggle_string_cache, using_string_cache
 from polars.utils import threadpool_size
 
 __all__ = [
@@ -191,6 +191,7 @@ __all__ = [
     # polars.stringcache
     "StringCache",
     "toggle_string_cache",
+    "using_string_cache",
     # polars.config
     "Config",
     # polars.internal.when

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -184,6 +184,11 @@ fn toggle_string_cache(toggle: bool) {
 }
 
 #[pyfunction]
+fn using_string_cache() -> bool {
+    polars::using_string_cache()
+}
+
+#[pyfunction]
 fn concat_str(s: Vec<dsl::PyExpr>, sep: &str) -> dsl::PyExpr {
     let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
     polars::lazy::dsl::concat_str(s, sep).into()
@@ -505,6 +510,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(version)).unwrap();
     m.add_wrapped(wrap_pyfunction!(toggle_string_cache))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(using_string_cache)).unwrap();
     m.add_wrapped(wrap_pyfunction!(concat_str)).unwrap();
     m.add_wrapped(wrap_pyfunction!(concat_lst)).unwrap();
     m.add_wrapped(wrap_pyfunction!(concat_df)).unwrap();


### PR DESCRIPTION
Rationale
-----

As we've gradually exposed more `polars` usage internally, and wanted to make more use of categoricals, we've had some issues appropriately scoping the global `StringCache`. This has become particularly acute now that we have pipeline units that may be called either independently _or_ nested within other units, as context exit invalidates the cache. So, currently the only option is to either turn the string cache on globally (for the duration of the session) and ensure nobody _ever_ uses the context manager or... do without categoricals. However, all is not lost!  :)

What the patch does
-----
Exposes the current state of the cache (active/inactive) up to python via `using_string_cache()`, so that `StringCache` contexts can now be nested while respecting the _outermost_ scope. This ensures that individual units can safely implement an inner cache (for when they are called independently) but can also cleanly participate in a larger scoped pipeline _without_ wiping out the global cache when they complete (thus causing errors with pipeline-level categorical ops).

Example
-----

_In use there is absolutely no change_... except that only exit from the **outermost** cache will invalidate. 
The test coverage added with this PR (below) illustrates the improved behavior:

```python
def test_nested_cache_composition() -> None:
    assert pl.using_string_cache() is False

    # function representing a composable stage of a pipeline; has 
    # an inner scope for the case where it is called by itself
    def create_lazy(data: dict) -> pl.LazyFrame:  # type: ignore[type-arg]
        with pl.StringCache():
            df = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
            lf = df.with_column(pl.col("a").cast(pl.Categorical)).lazy()

        # confirm inner function scope-exit does NOT invalidate 
        # the cache yet, as an outer context is still active
        assert pl.using_string_cache() is True
        return lf


    # THIS is the outer scope that controls when the cache is invalidated
    with pl.StringCache():
        lf1 = create_lazy({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
        lf2 = create_lazy({"a": ["spam", "foo", "eggs"], "c": [3, 2, 2]})

        res = lf1.join(lf2, on="a", how="inner").collect().rows()
        assert sorted(res) == [("bar", 2, 2), ("foo", 1, 1), ("ham", 3, 3)]


    # now that no scope is active; we expect the cache to have been invalidated
    assert pl.using_string_cache() is False
```
