### PR TITLE
refactor[python]: Proper alias for `abs`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -158,7 +158,7 @@ class Expr:
         )
 
     def __abs__(self) -> Expr:
-        return wrap_expr(self._pyexpr.abs())
+        return self.abs()
 
     def __invert__(self) -> Expr:
         return self.is_not()

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -47,7 +47,7 @@ from polars.internals.series.datetime import DateTimeNameSpace
 from polars.internals.series.list import ListNameSpace
 from polars.internals.series.string import StringNameSpace
 from polars.internals.series.struct import StructNameSpace
-from polars.internals.series.utils import call_expr, expr_dispatch, get_ffi_func
+from polars.internals.series.utils import expr_dispatch, get_ffi_func
 from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
@@ -3739,7 +3739,8 @@ class Series:
         Same as `abs(series)`.
         """
 
-    __abs__ = call_expr(abs)
+    def __abs__(self) -> Series:
+        return self.abs()
 
     def rank(self, method: RankMethod = "average", reverse: bool = False) -> Series:
         """


### PR DESCRIPTION
This is just a small stylistic improvement on the nice contribution by @abalkin in #4650

In order to stay consistent with the rest of the code base, dunders that are an alias for a method should just call that method.

See also: `Expr.__invert__`, `Series.__len__`, ...

I prefer not to 'correct' other people's work, but in this case, setting a dunder method directly as an attribute by calling a decorator explicitly is a seriously dubious pattern that I would like to avoid.