### PR TITLE
refactor[python]: `_from_pyexpr` as `@classmethod`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -137,11 +137,11 @@ class Expr:
     def _repr_html_(self) -> str:
         return self._pyexpr.to_str()
 
-    @staticmethod
-    def _from_pyexpr(pyexpr: PyExpr) -> Expr:
-        self = Expr.__new__(Expr)
-        self._pyexpr = pyexpr
-        return self
+    @classmethod
+    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+        expr = cls.__new__(cls)
+        expr._pyexpr = pyexpr
+        return expr
 
     def _to_pyexpr(self, other: Any) -> PyExpr:
         return self._to_expr(other)._pyexpr

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -131,17 +131,17 @@ class Expr:
     def __init__(self) -> None:
         self._pyexpr: PyExpr  # pragma: no cover
 
-    def __str__(self) -> str:
-        return self._pyexpr.to_str()
-
-    def _repr_html_(self) -> str:
-        return self._pyexpr.to_str()
-
     @classmethod
     def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
         expr = cls.__new__(cls)
         expr._pyexpr = pyexpr
         return expr
+
+    def __str__(self) -> str:
+        return self._pyexpr.to_str()
+
+    def _repr_html_(self) -> str:
+        return self._pyexpr.to_str()
 
     def _to_pyexpr(self, other: Any) -> PyExpr:
         return self._to_expr(other)._pyexpr


### PR DESCRIPTION
Just a small change to be more Pythonic and bring this in line with the other classes.

Changes:
* Refactor `Expr._from_pyexpr` to use `@classmethod` instead of `@staticmethod`