### PR TITLE
test[rust]: Ignore broken test

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -147,6 +147,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_cat_lexical_sort() -> Result<()> {
         let init = &["c", "b", "a", "d"];
 

--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -146,6 +146,7 @@ mod test {
         assert_eq!(ca.into_no_null_iter().collect::<Vec<_>>(), cmp);
     }
 
+    // TODO: Fix this test (occasionally fails during CI test job) - See issue #4707
     #[test]
     #[ignore]
     fn test_cat_lexical_sort() -> Result<()> {


### PR DESCRIPTION
The test `test_cat_lexical_sort` occasionally breaks and is unreliable. It should be fixed. Until then, let's ignore it.