### PR TITLE
refactor[python]: Dispatch `Series.dt.with_time_zone` to `Expr`

### DIFF
--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -265,7 +265,6 @@ class DateTimeNameSpace:
 
         """
 
-    # TODO: Dispatch to Expr
     def with_time_zone(self, tz: str | None) -> pli.Series:
         """
         Set time zone a Series of type Datetime.
@@ -276,7 +275,6 @@ class DateTimeNameSpace:
             Time zone for the `Datetime` Series.
 
         """
-        return pli.wrap_s(self._s.with_time_zone(tz))
 
     def days(self) -> pli.Series:
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1082,12 +1082,6 @@ impl PySeries {
         }
     }
 
-    pub fn with_time_zone(&self, tz: Option<TimeZone>) -> PyResult<Self> {
-        let mut dt = self.series.datetime().map_err(PyPolarsErr::from)?.clone();
-        dt.set_time_zone(tz);
-        Ok(dt.into_series().into())
-    }
-
     pub fn set_at_idx(&mut self, idx: PySeries, values: PySeries) -> PyResult<()> {
         // we take the value because we want a ref count
         // of 1 so that we can have mutable access


### PR DESCRIPTION
There used to be a loop here (Expr.with_time_zone dispatching back to Series). I see this has been fixed, so we can safely tick off this TODO.

Changes:
* Dispatch `Series.dt.with_time_zone` to `Expr`