### PR TITLE
refactor[python]: Some minor stuff

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -47,6 +47,7 @@ JSON
    :toctree: api/
 
    read_json
+   scan_ndjson
    DataFrame.write_json
 
 AVRO

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -128,8 +128,7 @@ def wrap_expr(pyexpr: PyExpr) -> Expr:
 class Expr:
     """Expressions that can be used in various contexts."""
 
-    def __init__(self) -> None:
-        self._pyexpr: PyExpr  # pragma: no cover
+    _pyexpr: PyExpr
 
     @classmethod
     def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -76,7 +76,7 @@ class LazyFrame:
         return self
 
     @classmethod
-    def scan_csv(
+    def _scan_csv(
         cls: type[LDF],
         file: str,
         has_header: bool = True,
@@ -143,7 +143,7 @@ class LazyFrame:
         return self
 
     @classmethod
-    def scan_parquet(
+    def _scan_parquet(
         cls: type[LDF],
         file: str,
         n_rows: int | None = None,
@@ -187,7 +187,7 @@ class LazyFrame:
         return self
 
     @classmethod
-    def scan_ipc(
+    def _scan_ipc(
         cls: type[LDF],
         file: str | Path,
         n_rows: int | None = None,
@@ -201,9 +201,11 @@ class LazyFrame:
         """
         Lazily read from an Arrow IPC (Feather v2) file.
 
+        Use ``pl.scan_ipc`` to dispatch to this method.
+
         See Also
         --------
-        scan_parquet, scan_csv
+        polars.io.scan_ipc
 
         """
         if isinstance(file, (str, Path)):
@@ -230,7 +232,7 @@ class LazyFrame:
         return self
 
     @classmethod
-    def scan_ndjson(
+    def _scan_ndjson(
         cls: type[LDF],
         file: str,
         infer_schema_length: int | None = None,

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -564,7 +564,7 @@ def scan_csv(
     if isinstance(file, (str, Path)):
         file = format_path(file)
 
-    return LazyFrame.scan_csv(
+    return LazyFrame._scan_csv(
         file=file,
         has_header=has_header,
         sep=sep,
@@ -631,7 +631,7 @@ def scan_ipc(
         Only uncompressed IPC files can be memory mapped.
 
     """
-    return LazyFrame.scan_ipc(
+    return LazyFrame._scan_ipc(
         file=file,
         n_rows=n_rows,
         cache=cache,
@@ -691,7 +691,7 @@ def scan_parquet(
     if isinstance(file, (str, Path)):
         file = format_path(file)
 
-    return LazyFrame.scan_parquet(
+    return LazyFrame._scan_parquet(
         file=file,
         n_rows=n_rows,
         cache=cache,
@@ -744,7 +744,7 @@ def scan_ndjson(
     if isinstance(file, (str, Path)):
         file = format_path(file)
 
-    return LazyFrame.scan_ndjson(
+    return LazyFrame._scan_ndjson(
         file=file,
         infer_schema_length=infer_schema_length,
         batch_size=batch_size,

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -61,9 +61,6 @@ class StringCache:
 
     """
 
-    def __init__(self) -> None:
-        pass
-
     def __enter__(self) -> StringCache:
         self._already_enabled = _using_string_cache()
         if not self._already_enabled:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1176,9 +1176,6 @@ def test_hashing_on_python_objects() -> None:
     df = pl.DataFrame({"a": [1, 1, 3, 4], "b": [1, 1, 2, 2]})
 
     class Foo:
-        def __init__(self) -> None:
-            pass
-
         def __hash__(self) -> int:
             return 0
 


### PR DESCRIPTION
Changes:
* Remove empty init methods. Python doesn't require these.
* Make the `LazyFrame.scan_x` methods private. This is consistent with `DataFrame`, and encourages use of `pl.scan_x` instead. These methods were not documented in the API, so this doesn't have to be considered 'breaking'.
  * `LazyFrame.from_json/read_json` are outliers, as these are not available through an IO function. Can we improve the consistency here somehow?
* Add `scan_ndjson` to the API docs.