### PR TITLE
chore[python]: Better Makefile

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := help
+
 SHELL=/bin/bash
 PYTHON=venv/bin/python
 PYTHON_BIN=venv/bin
@@ -64,3 +66,7 @@ build-and-test-no-venv:
 install-no-venv: build-no-venv install-wheel
 install-no-venv-release: build-no-venv-release install-wheel
 
+.PHONY: help
+help:  ## Display this help screen
+	@echo -e '\033[1mAvailable commands:\033[0m'
+	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -5,14 +5,14 @@ PYTHON=venv/bin/python
 PYTHON_BIN=venv/bin
 
 .PHONY: venv
-venv:
+venv:  ## Set up virtual environment
 	@python -m venv venv
 	@venv/bin/pip install -U pip
 	@venv/bin/pip install -r build.requirements.txt
 	@unset CONDA_PREFIX && source venv/bin/activate && maturin develop
 
 .PHONY: clean
-clean:
+clean:  ## Clean up caches and build artifacts
 	@rm -rf venv/
 	@rm -rf docs/build/
 	@rm -rf .hypothesis/
@@ -24,7 +24,7 @@ clean:
 	@cargo clean
 
 .PHONY: pre-commit
-pre-commit: venv
+pre-commit: venv  ## Run autoformatting and linting
 	$(PYTHON_BIN)/isort .
 	$(PYTHON_BIN)/black .
 	$(PYTHON_BIN)/blackdoc .
@@ -35,22 +35,22 @@ pre-commit: venv
 	cargo fmt --all
 
 .PHONY: test
-test: venv
+test: venv  ## Run fast unittests
 	$(PYTHON_BIN)/maturin develop
 	$(PYTHON) -m pytest tests/unit/
 
 .PHONY: test-all
-test-all: venv
+test-all: venv  ## Run all tests
 	$(PYTHON_BIN)/maturin develop
 	$(PYTHON) -m pytest
 	$(PYTHON) tests/docs/run_doc_examples.py
 
 .PHONY: test-with-cov
-test-with-cov: venv
+test-with-cov: venv  ## Run tests and report coverage
 	$(PYTHON) -m pytest --cov=polars --cov-report xml
 
 .PHONY: doctest
-doctest:
+doctest:  ## Run doctests
 	$(PYTHON) tests/docs/run_doc_examples.py
 
 .PHONY: install-wheel

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -4,8 +4,7 @@ SHELL=/bin/bash
 PYTHON=venv/bin/python
 PYTHON_BIN=venv/bin
 
-.PHONY: pre-commit test pip
-
+.PHONY: venv
 venv:
 	@python -m venv venv
 	@venv/bin/pip install -U pip
@@ -24,6 +23,7 @@ clean:
 	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
+.PHONY: pre-commit
 pre-commit: venv
 	$(PYTHON_BIN)/isort .
 	$(PYTHON_BIN)/black .
@@ -34,36 +34,47 @@ pre-commit: venv
 	make -C .. fmt_toml
 	cargo fmt --all
 
+.PHONY: test
 test: venv
 	$(PYTHON_BIN)/maturin develop
 	$(PYTHON) -m pytest tests/unit/
 
+.PHONY: test-all
 test-all: venv
 	$(PYTHON_BIN)/maturin develop
 	$(PYTHON) -m pytest
 	$(PYTHON) tests/docs/run_doc_examples.py
 
+.PHONY: test-with-cov
 test-with-cov: venv
 	$(PYTHON) -m pytest --cov=polars --cov-report xml
 
+.PHONY: doctest
 doctest:
 	$(PYTHON) tests/docs/run_doc_examples.py
 
+.PHONY: install-wheel
 install-wheel:
 	pip install --force-reinstall -U wheels/polars-*.whl
 
+.PHONY: build-no-venv
 build-no-venv:
 	maturin build -o wheels
 
+.PHONY: build-no-venv-release
 build-no-venv-release:
 	maturin build -o wheels --release
 
+.PHONY: build-and-test-no-venv
 build-and-test-no-venv:
 	maturin build -o wheels
 	pip install --force-reinstall -U wheels/polars-*.whl
 	pytest tests
 
+.PHONY: install-no-venv
 install-no-venv: build-no-venv install-wheel
+
+.PHONY: install-no-venv-release
 install-no-venv-release: build-no-venv-release install-wheel
 
 .PHONY: help

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 PYTHON=venv/bin/python
 PYTHON_BIN=venv/bin
 
-.PHONY: pre-commit test pip clean
+.PHONY: pre-commit test pip
 
 venv:
 	@python -m venv venv
@@ -10,8 +10,16 @@ venv:
 	@venv/bin/pip install -r build.requirements.txt
 	@unset CONDA_PREFIX && source venv/bin/activate && maturin develop
 
+.PHONY: clean
 clean:
-	@-rm -r venv
+	@rm -rf venv/
+	@rm -rf docs/build/
+	@rm -rf .hypothesis/
+	@rm -rf .mypy_cache/
+	@rm -rf .pytest_cache/
+	@rm -f .coverage
+	@rm -f coverage.xml
+	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
 pre-commit: venv


### PR DESCRIPTION
I plan on making more extensive changes in how the virtual environment is handled and deleting some commands - but since those changes may be more controversial, let's get these simple changes in first.

Changes:
* Add a `help` command. It lists available commands that include a help text. This command is set as the default. It looks quite pretty:

![image](https://user-images.githubusercontent.com/3502351/188266498-271df0d2-34cb-434d-8c26-e15427862d72.png)

* Update `make clean` to clean more thoroughly.
* Define the `.PHONY` line for each command; otherwise it's easy to miss one.

Notes for (possible) future work:
* We can probably remove all the commands that do not have a help text - I have never used them and they are not used in the CI (except for one)
* The way the venv is set up is unnecessarily restrictive. We can provide the `venv` command, but let people create their environments however they want to. I usually use `pyenv` but this doesn't work for Polars because of the way the Makefile is set up. So instead of pointing to `venv/bin/python` specifically, we should just use `python` and use whichever environment the user has built and activated for themselves.