### PR TITLE
feat[rust, python]: support custom null value for csv output

### DIFF
--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -100,4 +100,12 @@ where
         self.options.quote = char;
         self
     }
+
+    /// Set the CSV file's null value representation
+    pub fn with_null_value(mut self, null_value: Option<String>) -> Self {
+        if let Some(null) = null_value {
+            self.options.null = null
+        }
+        self
+    }
 }

--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -102,10 +102,8 @@ where
     }
 
     /// Set the CSV file's null value representation
-    pub fn with_null_value(mut self, null_value: Option<String>) -> Self {
-        if let Some(null) = null_value {
-            self.options.null = null
-        }
+    pub fn with_null_value(mut self, null_value: String) -> Self {
+        self.options.null = null_value;
         self
     }
 }

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1794,6 +1794,7 @@ class DataFrame:
         date_format: str | None = None,
         time_format: str | None = None,
         float_precision: int | None = None,
+        null_value: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -1825,6 +1826,8 @@ class DataFrame:
         float_precision
             Number of decimal places to write, applied to both ``Float32`` and
             ``Float64`` datatypes.
+        null_value
+            A string representing null values (defaulting to the empty string).
 
         Examples
         --------
@@ -1843,8 +1846,11 @@ class DataFrame:
         """
         if len(sep) > 1:
             raise ValueError("only single byte separator is allowed")
-        if len(quote) > 1:
+        elif len(quote) > 1:
             raise ValueError("only single byte quote char is allowed")
+        elif null_value == "":
+            null_value = None
+
         if file is None:
             buffer = BytesIO()
             self._df.write_csv(
@@ -1857,6 +1863,7 @@ class DataFrame:
                 date_format,
                 time_format,
                 float_precision,
+                null_value,
             )
             return str(buffer.getvalue(), encoding="utf-8")
 
@@ -1873,6 +1880,7 @@ class DataFrame:
             date_format,
             time_format,
             float_precision,
+            null_value,
         )
         return None
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -430,6 +430,7 @@ impl PyDataFrame {
         date_format: Option<String>,
         time_format: Option<String>,
         float_precision: Option<usize>,
+        null_value: Option<String>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
@@ -443,6 +444,7 @@ impl PyDataFrame {
                 .with_date_format(date_format)
                 .with_time_format(time_format)
                 .with_float_precision(float_precision)
+                .with_null_value(null_value)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -456,6 +458,7 @@ impl PyDataFrame {
                 .with_date_format(date_format)
                 .with_time_format(time_format)
                 .with_float_precision(float_precision)
+                .with_null_value(null_value)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -432,6 +432,7 @@ impl PyDataFrame {
         float_precision: Option<usize>,
         null_value: Option<String>,
     ) -> PyResult<()> {
+        let null = null_value.unwrap_or(String::new());
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
             // no need for a buffered writer, because the csv writer does internal buffering
@@ -444,7 +445,7 @@ impl PyDataFrame {
                 .with_date_format(date_format)
                 .with_time_format(time_format)
                 .with_float_precision(float_precision)
-                .with_null_value(null_value)
+                .with_null_value(null)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
@@ -458,7 +459,7 @@ impl PyDataFrame {
                 .with_date_format(date_format)
                 .with_time_format(time_format)
                 .with_float_precision(float_precision)
-                .with_null_value(null_value)
+                .with_null_value(null)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }


### PR DESCRIPTION
**Rationale:**

We can already _read_ custom `null` values from CSV, so there is a symmetry in also being able to _write_ them; more importantly, it allows efficient output directly into the default format expected by of a number of database bulk-loaders (and probably a few other ingestion pipelines/etc), without requiring pre-projection (for example, the default NULL representation for the PostgreSQL COPY TEXT protocol is `\N`). While it's often possible to customise the expected `null` char in these cases, it's cleaner to be able to output the expected format from the start.

**In-use:**
```python
df.write_csv( output, null_value=r"\N" )
```
If not set, there is no change to existing behaviour.
Existing tests pass without modification, and some new test coverage was added.