### PR TITLE
chore[python]: Makefile venv rule should not be .PHONY

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -4,7 +4,6 @@ SHELL=/bin/bash
 PYTHON=venv/bin/python
 PYTHON_BIN=venv/bin
 
-.PHONY: venv
 venv:  ## Set up virtual environment
 	@python -m venv venv
 	@venv/bin/pip install -U pip


### PR DESCRIPTION
@stinodego FYI.

The `venv` target is a real folder and should not be run when it already exists. This saves wasteful venv initialization and even worse recompiling the whole project from start.