### PR TITLE
feat[rust, python]: if datetime format not specified for "write_csv", infer the required precision

### DIFF
--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -20,7 +20,6 @@ where
         // 9f: all nanoseconds
         let options = write_impl::SerializeOptions {
             time_format: Some("%T%.9f".to_string()),
-            datetime_format: Some("%FT%H:%M:%S.%9f".to_string()),
             ..Default::default()
         };
 
@@ -38,7 +37,7 @@ where
         if self.header {
             write_impl::write_header(&mut self.buffer, &names, &self.options)?;
         }
-        write_impl::write(&mut self.buffer, df, self.batch_size, &self.options)
+        write_impl::write(&mut self.buffer, df, self.batch_size, &mut self.options)
     }
 }
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1814,7 +1814,9 @@ class DataFrame:
         datetime_format
             A format string, with the specifiers defined by the
             `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
-            Rust crate.
+            Rust crate. If no format specified, the default fractional-second
+            precision is inferred from the maximum timeunit found in the frame's
+            Datetime cols (if any).
         date_format
             A format string, with the specifiers defined by the
             `chrono <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -425,7 +425,7 @@ impl PyDataFrame {
         sep: u8,
         quote: u8,
         batch_size: usize,
-        mut datetime_format: Option<String>,
+        datetime_format: Option<String>,
         date_format: Option<String>,
         time_format: Option<String>,
         float_precision: Option<usize>,
@@ -433,25 +433,6 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         let null = null_value.unwrap_or(String::new());
 
-        // if datetime format not specified, infer the maximum required precision
-        if datetime_format.is_none() {
-            for col in self.df.get_columns() {
-                match col.dtype() {
-                    DataType::Datetime(TimeUnit::Microseconds, _) if datetime_format.is_none() => {
-                        datetime_format = Some("%FT%H:%M:%S.%6f".to_string());
-                    }
-                    DataType::Datetime(TimeUnit::Nanoseconds, _) => {
-                        datetime_format = Some("%FT%H:%M:%S.%9f".to_string());
-                        break; // highest precision; no need to check further
-                    }
-                    _ => {}
-                }
-            }
-            if datetime_format.is_none() {
-                // if still not set, no cols require higher precision than "ms" (or no datetime cols)
-                datetime_format = Some("%FT%H:%M:%S.%3f".to_string());
-            }
-        }
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();
             // no need for a buffered writer, because the csv writer does internal buffering

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -710,16 +710,30 @@ def test_datetime_format(fmt: str, expected: str) -> None:
 @pytest.mark.parametrize(
     "tu1,tu2,expected",
     [
-        ("ns", "ns", "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n"),
-        ("ns", "us", "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n"),
-        ("ns", "ms", "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n"),
+        (
+            "ns",
+            "ns",
+            "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n",
+        ),
+        (
+            "ns",
+            "us",
+            "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n",
+        ),
+        (
+            "ns",
+            "ms",
+            "x,y\n2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000\n",
+        ),
         ("us", "us", "x,y\n2022-09-04T10:30:45.123000,2022-09-04T10:30:45.123000\n"),
         ("us", "ms", "x,y\n2022-09-04T10:30:45.123000,2022-09-04T10:30:45.123000\n"),
         ("ms", "us", "x,y\n2022-09-04T10:30:45.123000,2022-09-04T10:30:45.123000\n"),
         ("ms", "ms", "x,y\n2022-09-04T10:30:45.123,2022-09-04T10:30:45.123\n"),
     ],
 )
-def test_datetime_format_inferred_precision(tu1: TimeUnit, tu2: TimeUnit, expected: str) -> None:
+def test_datetime_format_inferred_precision(
+    tu1: TimeUnit, tu2: TimeUnit, expected: str
+) -> None:
     df = pl.DataFrame(
         data={
             "x": [datetime(2022, 9, 4, 10, 30, 45, 123000)],
@@ -731,6 +745,7 @@ def test_datetime_format_inferred_precision(tu1: TimeUnit, tu2: TimeUnit, expect
         ],
     )
     assert expected == df.write_csv()
+
 
 @pytest.mark.parametrize(
     "fmt,expected",


### PR DESCRIPTION
If the `datetime_format` parameter is _not_ set by the caller, the `CSVWriter` defaults to nanosecond precision, even when not required. This patch allows the `write_csv` call to infer the required output precision so that unnecessary decimals aren't written, and the precision of the output matches the precision of the frame.

(If the `datetime_format` parameter _is_ set, it is of course respected, and no inference is done).

Example
----

```python
from datetime import datetime, date
import polars as pl

# frame with millisecond-precision datetime cols
df = pl.DataFrame(
    data = {
        "colx": [datetime(2022,9,4,10,30,45,123000)],
        "coly": [datetime(2022,9,4,10,30,45,123000)],
    },
    columns = [
        ("colx", pl.Datetime("ms")),
        ("coly", pl.Datetime("ms")),
    ],
)
print( df.write_csv() )
```
**Before** _(forces "ns" precision on output)_
```
colx,coly
2022-09-04T10:30:45.123000000,2022-09-04T10:30:45.123000000
```

**After** _(infers actual "ms" precision: 20% more compact)_
```
colx,coly
2022-09-04T10:30:45.123,2022-09-04T10:30:45.123
```


FYI: I did consider trying per-column precision on output, but it felt like an unnecessarily heavyweight approach, and was more intrusive in the code; given that most frames are likely to have consistent time units this seemed more reasonable.