### PR TITLE
perf[rust]: improve `pivot ~2.2x` and `groupby_stable` performance.

### DIFF
--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -23,6 +23,13 @@ fn finish_group_order(mut out: Vec<Vec<IdxItem>>, sorted: bool) -> GroupsProxy {
         let mut out = if out.len() == 1 {
             out.pop().unwrap()
         } else {
+            // pre-sort every array
+            // this will make the final single threaded sort much faster
+            POOL.install(|| {
+                out.par_iter_mut()
+                    .for_each(|g| g.sort_unstable_by_key(|g| g.0))
+            });
+
             flatten(&out, None)
         };
         out.sort_unstable_by_key(|g| g.0);

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -3,7 +3,7 @@ use polars_arrow::prelude::*;
 use polars_utils::flatten;
 
 use super::*;
-use crate::utils::{copy_from_slice_unchecked, split_offsets};
+use crate::utils::{_split_offsets, copy_from_slice_unchecked};
 
 /// Used to create the tuples for a groupby operation.
 pub trait IntoGroupsProxy {
@@ -239,7 +239,7 @@ impl IntoGroupsProxy for Utf8Chunked {
         if multithreaded {
             let n_partitions = set_partition_size();
 
-            let split = split_offsets(self.len(), n_partitions);
+            let split = _split_offsets(self.len(), n_partitions);
 
             let str_hashes = POOL.install(|| {
                 split
@@ -415,7 +415,7 @@ pub(super) fn pack_utf8_columns(
     n_partitions: usize,
     sorted: bool,
 ) -> GroupsProxy {
-    let splits = split_offsets(lhs.len(), n_partitions);
+    let splits = _split_offsets(lhs.len(), n_partitions);
     let hb = RandomState::default();
     let null_h = get_null_hash_value(hb.clone());
 

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -10,7 +10,7 @@ use self::hashing::*;
 use crate::prelude::*;
 #[cfg(feature = "groupby_list")]
 use crate::utils::Wrap;
-use crate::utils::{accumulate_dataframes_vertical, set_partition_size, split_offsets};
+use crate::utils::{_split_offsets, accumulate_dataframes_vertical, set_partition_size};
 use crate::vector_hasher::{get_null_hash_value, AsU64, StrHash};
 use crate::POOL;
 
@@ -69,7 +69,7 @@ impl DataFrame {
                 // pack the bit values together and add a final byte that will be 0
                 // when there are no null values.
                 // otherwise we use two bits of this byte to represent null values.
-                let splits = split_offsets($ca0.len(), n_partitions);
+                let splits = _split_offsets($ca0.len(), n_partitions);
 
                 let keys = POOL.install(|| {
                     splits

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -5,7 +5,7 @@ use polars_utils::flatten;
 
 use super::*;
 #[cfg(feature = "performant")]
-use crate::utils::split_offsets;
+use crate::utils::_split_offsets;
 
 pub(super) fn use_sort_merge(s_left: &Series, s_right: &Series) -> bool {
     // only use for numeric data for now
@@ -32,7 +32,7 @@ fn par_sorted_merge_left_impl<T>(
 where
     T: PolarsNumericType,
 {
-    let offsets = split_offsets(s_left.len(), POOL.current_num_threads());
+    let offsets = _split_offsets(s_left.len(), POOL.current_num_threads());
     let s_left = s_left.rechunk();
     let s_right = s_right.rechunk();
 
@@ -99,7 +99,7 @@ fn par_sorted_merge_inner_impl<T>(
 where
     T: PolarsNumericType,
 {
-    let offsets = split_offsets(s_left.len(), POOL.current_num_threads());
+    let offsets = _split_offsets(s_left.len(), POOL.current_num_threads());
     let s_left = s_left.rechunk();
     let s_right = s_right.rechunk();
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -31,7 +31,7 @@ pub use series_trait::{IsSorted, *};
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "zip_with")]
 use crate::series::arithmetic::coerce_lhs_rhs;
-use crate::utils::{split_ca, split_offsets, split_series, Wrap};
+use crate::utils::{_split_offsets, split_ca, split_series, Wrap};
 use crate::POOL;
 
 /// # Series
@@ -404,7 +404,7 @@ impl Series {
         func: &(dyn Fn(usize, usize) -> Result<Series> + Send + Sync),
     ) -> Result<Series> {
         let n_threads = POOL.current_num_threads();
-        let offsets = split_offsets(len, n_threads);
+        let offsets = _split_offsets(len, n_threads);
 
         let series: Result<Vec<_>> = POOL.install(|| {
             offsets

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -110,8 +110,9 @@ where
 }
 
 // prefer this one over split_ca, as this can push the null_count into the thread pool
+// returns an `(offset, length)` tuple
 #[doc(hidden)]
-pub fn split_offsets(len: usize, n: usize) -> Vec<(usize, usize)> {
+pub fn _split_offsets(len: usize, n: usize) -> Vec<(usize, usize)> {
     if n == 1 {
         vec![(0, len)]
     } else {
@@ -809,7 +810,7 @@ where
     F: Fn(Series) -> Result<Series> + Send + Sync,
 {
     let n_threads = n_threads.unwrap_or_else(|| POOL.current_num_threads());
-    let splits = split_offsets(s.len(), n_threads);
+    let splits = _split_offsets(s.len(), n_threads);
 
     let chunks = POOL.install(|| {
         splits

--- a/polars/polars-ops/src/pivot/positioning.rs
+++ b/polars/polars-ops/src/pivot/positioning.rs
@@ -1,0 +1,281 @@
+use std::hash::Hash;
+
+use polars_core::prelude::*;
+
+use super::*;
+
+pub(super) fn position_aggregates(
+    n_rows: usize,
+    n_cols: usize,
+    row_locations: &[IdxSize],
+    col_locations: &[IdxSize],
+    value_agg_phys: &Series,
+    logical_type: &DataType,
+    headers: &Utf8Chunked,
+) -> Vec<Series> {
+    let mut buf = vec![AnyValue::Null; n_rows * n_cols];
+    let start_ptr = buf.as_mut_ptr() as usize;
+
+    let n_threads = POOL.current_num_threads();
+    let split = _split_offsets(row_locations.len(), n_threads);
+
+    POOL.install(|| {
+        split.into_par_iter().for_each(|(offset, len)| {
+            let start_ptr = start_ptr as *mut AnyValue;
+            let row_locations = &row_locations[offset..offset + len];
+            let col_locations = &col_locations[offset..offset + len];
+            let value_agg_phys = value_agg_phys.slice(offset as i64, len);
+
+            for ((row_idx, col_idx), val) in row_locations
+                .iter()
+                .zip(col_locations)
+                .zip(value_agg_phys.iter())
+            {
+                // Safety:
+                // in bounds
+                unsafe {
+                    let idx = *row_idx as usize + *col_idx as usize * n_rows;
+                    debug_assert!(idx < buf.len());
+                    let pos = start_ptr.add(idx);
+                    std::ptr::write(pos, val)
+                }
+            }
+        });
+
+        let headers_iter = headers.par_iter_indexed();
+
+        (0..n_cols)
+            .into_par_iter()
+            .zip(headers_iter)
+            .map(|(i, opt_name)| {
+                let offset = i * n_rows;
+                let avs = &buf[offset..offset + n_rows];
+                let name = opt_name.unwrap_or("null");
+                let mut out = Series::new(name, avs);
+                finish_logical_type(&mut out, logical_type);
+                out
+            })
+            .collect::<Vec<_>>()
+    })
+}
+
+pub(super) fn position_aggregates_numeric<T>(
+    n_rows: usize,
+    n_cols: usize,
+    row_locations: &[IdxSize],
+    col_locations: &[IdxSize],
+    value_agg_phys: &ChunkedArray<T>,
+    logical_type: &DataType,
+    headers: &Utf8Chunked,
+) -> Vec<Series>
+where
+    T: PolarsNumericType,
+    ChunkedArray<T>: IntoSeries,
+{
+    let mut buf = vec![None; n_rows * n_cols];
+    let start_ptr = buf.as_mut_ptr() as usize;
+
+    let n_threads = POOL.current_num_threads();
+
+
+    let split = _split_offsets(row_locations.len(), n_threads);
+
+    POOL.install(|| {
+        split.into_par_iter().for_each(|(offset, len)| {
+            let start_ptr = start_ptr as *mut Option<T::Native>;
+            let row_locations = &row_locations[offset..offset + len];
+            let col_locations = &col_locations[offset..offset + len];
+            let value_agg_phys = value_agg_phys.slice(offset as i64, len);
+
+            for ((row_idx, col_idx), val) in row_locations
+                .iter()
+                .zip(col_locations)
+                .zip(value_agg_phys.into_iter())
+            {
+                // Safety:
+                // in bounds
+                unsafe {
+                    let idx = *row_idx as usize + *col_idx as usize * n_rows;
+                    debug_assert!(idx < buf.len());
+                    let pos = start_ptr.add(idx);
+                    std::ptr::write(pos, val)
+                }
+            }
+        });
+        let headers_iter = headers.par_iter_indexed();
+
+        (0..n_cols)
+            .into_par_iter()
+            .zip(headers_iter)
+            .map(|(i, opt_name)| {
+                let offset = i * n_rows;
+                let opt_values = &buf[offset..offset + n_rows];
+                let name = opt_name.unwrap_or("null");
+                let mut out = ChunkedArray::<T>::from_slice_options(name, opt_values).into_series();
+
+                finish_logical_type(&mut out, logical_type);
+                out
+            })
+            .collect::<Vec<_>>()
+    })
+}
+
+fn compute_col_idx_numeric<T>(column_agg_physical: &ChunkedArray<T>) -> Vec<IdxSize>
+where
+    T: PolarsNumericType,
+    T::Native: Hash + Eq,
+{
+    let mut col_to_idx = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+    let mut idx = 0 as IdxSize;
+    column_agg_physical
+        .into_iter()
+        .map(|v| {
+            let idx = *col_to_idx.entry(v).or_insert_with(|| {
+                let old_idx = idx;
+                idx += 1;
+                old_idx
+            });
+            idx
+        })
+        .collect()
+}
+
+pub(super) fn compute_col_idx(
+    pivot_df: &DataFrame,
+    column: &str,
+    groups: &GroupsProxy,
+) -> Result<(Vec<IdxSize>, Series)> {
+    let column_s = pivot_df.column(column)?;
+    let column_agg = unsafe { column_s.agg_first(groups) };
+    let column_agg_physical = column_agg.to_physical_repr();
+
+    use DataType::*;
+    let col_locations = match column_agg_physical.dtype() {
+        Int32 | UInt32 | Float32 => {
+            let ca = column_agg_physical.bit_repr_small();
+            compute_col_idx_numeric(&ca)
+        }
+        Int64 | UInt64 | Float64 => {
+            let ca = column_agg_physical.bit_repr_large();
+            compute_col_idx_numeric(&ca)
+        }
+        _ => {
+            let mut col_to_idx = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
+            let mut idx = 0 as IdxSize;
+            column_agg_physical
+                .iter()
+                .map(|v| {
+                    let idx = *col_to_idx.entry(v).or_insert_with(|| {
+                        let old_idx = idx;
+                        idx += 1;
+                        old_idx
+                    });
+                    idx
+                })
+                .collect()
+        }
+    };
+
+    Ok((col_locations, column_agg))
+}
+
+// TODO! Also create a specialized version for numerics.
+pub(super) fn compute_row_idx(
+    pivot_df: &DataFrame,
+    index: &[String],
+    groups: &GroupsProxy,
+    count: usize,
+) -> Result<(Vec<IdxSize>, usize, Option<Vec<Series>>)> {
+    let (row_locations, n_rows, row_index) = if index.len() == 1 {
+        let index_s = pivot_df.column(&index[0])?;
+        let index_agg = unsafe { index_s.agg_first(groups) };
+        let index_agg_physical = index_agg.to_physical_repr();
+
+        let mut row_to_idx =
+            PlIndexMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
+        let mut idx = 0 as IdxSize;
+        let row_locations = index_agg_physical
+            .iter()
+            .map(|v| {
+                let idx = *row_to_idx.entry(v).or_insert_with(|| {
+                    let old_idx = idx;
+                    idx += 1;
+                    old_idx
+                });
+                idx
+            })
+            .collect::<Vec<_>>();
+
+        let row_index = match count {
+            0 => {
+                let s = Series::new(
+                    &index[0],
+                    row_to_idx.into_iter().map(|(k, _)| k).collect::<Vec<_>>(),
+                );
+                let s = restore_logical_type(&s, index_s.dtype());
+                Some(vec![s])
+            }
+            _ => None,
+        };
+
+        (row_locations, idx as usize, row_index)
+    } else {
+        let index_s = pivot_df.columns(index)?;
+        let index_agg_physical = index_s
+            .iter()
+            .map(|s| unsafe { s.agg_first(groups).to_physical_repr().into_owned() })
+            .collect::<Vec<_>>();
+        let mut iters = index_agg_physical
+            .iter()
+            .map(|s| s.iter())
+            .collect::<Vec<_>>();
+        let mut row_to_idx =
+            PlIndexMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
+        let mut idx = 0 as IdxSize;
+
+        let mut row_locations = Vec::with_capacity(groups.len());
+        loop {
+            match iters
+                .iter_mut()
+                .map(|it| it.next())
+                .collect::<Option<Vec<_>>>()
+            {
+                None => break,
+                Some(items) => {
+                    let idx = *row_to_idx.entry(items).or_insert_with(|| {
+                        let old_idx = idx;
+                        idx += 1;
+                        old_idx
+                    });
+                    row_locations.push(idx)
+                }
+            }
+        }
+        let row_index = match count {
+            0 => Some(
+                index
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| {
+                        let s = Series::new(
+                            name,
+                            row_to_idx
+                                .iter()
+                                .map(|(k, _)| {
+                                    debug_assert!(i < k.len());
+                                    unsafe { k.get_unchecked(i).clone() }
+                                })
+                                .collect::<Vec<_>>(),
+                        );
+                        restore_logical_type(&s, index_s[i].dtype())
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        };
+
+        (row_locations, idx as usize, row_index)
+    };
+
+    Ok((row_locations, n_rows, row_index))
+}

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -4,7 +4,7 @@ use polars_arrow::trusted_len::TrustedLen;
 use polars_arrow::utils::CustomIterTools;
 use polars_core::export::rayon::prelude::*;
 use polars_core::prelude::*;
-use polars_core::utils::split_offsets;
+use polars_core::utils::_split_offsets;
 use polars_core::POOL;
 use polars_utils::flatten;
 #[cfg(feature = "serde")]
@@ -387,7 +387,7 @@ pub fn groupby_values(
     tu: TimeUnit,
 ) -> GroupsSlice {
     partially_check_sorted(time);
-    let thread_offsets = split_offsets(time.len(), POOL.current_num_threads());
+    let thread_offsets = _split_offsets(time.len(), POOL.current_num_threads());
 
     // we have a (partial) lookbehind window
     if offset.negative {


### PR DESCRIPTION
Done a thorough pass through our pivot code on the algorithm described [here](https://github.com/pola-rs/polars/issues/4678#issuecomment-1236129744). Made sure that numeric code uses specialized functions instead of `AnyValue`. 

One of the biggest performance gains was presorting the groups on a thread before running the final sort of the `groupby_stable`. 

I have benchmarked on 10M rows and went from `19425ms` on master to `8568ms` on this PR.