### PR TITLE
ci[python]: Separate docs requirements

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r py-polars/build.requirements.txt
+          pip install -r py-polars/docs/requirements-docs.txt
       - name: Build python reference
         run: |
           cd py-polars/docs

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r py-polars/build.requirements.txt
+          pip install -r py-polars/docs/requirements-docs.txt
       - name: Build python reference
         run: |
           cd py-polars/docs

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,7 @@ You have to follow these steps:
   - from [./py-polars](./py-polars) run `$ pip3 install -r build.requirements.txt`
   - **tests:** from [./py-polars](./py-polars) run `$ make test`
   - **formatting + linting:** from [./py-polars](./py-polars) run `$ make pre-commit` before committing.
+  - **docs:** from [./py-polars/docs](./py-polars/docs) run `$ pip3 install -r requirements-docs.txt` followed by `make html`
 
 `make test` installs a (slow) development build in your current environment and runs `pytest`.
 

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -14,6 +14,7 @@ venv:  ## Set up virtual environment
 clean:  ## Clean up caches and build artifacts
 	@rm -rf venv/
 	@rm -rf docs/build/
+	@rm -rf docs/source/reference/api/
 	@rm -rf .hypothesis/
 	@rm -rf .mypy_cache/
 	@rm -rf .pytest_cache/

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -25,18 +25,6 @@ flake8-docstrings==1.6.0
 flake8-simplify==0.19.3
 flake8-tidy-imports==4.8.0
 pyupgrade==2.37.3
-ghp-import==2.1.0
-sphinx==5.1.1
-pydata-sphinx-theme==0.10.1
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.0
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
-sphinxcontrib-napoleon==0.7
-commonmark==0.9.1
-numpydoc==1.4.0
 
 # Stub files
 pandas-stubs==1.2.0.61

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -26,8 +26,8 @@ flake8-simplify==0.19.3
 flake8-tidy-imports==4.8.0
 pyupgrade==2.37.3
 ghp-import==2.1.0
-sphinx==4.3.2
-pydata-sphinx-theme==0.9.0
+sphinx==5.1.1
+pydata-sphinx-theme==0.10.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -10,16 +10,16 @@ pytz
 types-pytz
 
 # Tooling
-maturin==0.13.0
-pytest==7.1.2
+maturin==0.13.2
+pytest==7.1.3
 pytest-cov==3.0.0
-hypothesis==6.49.1
-black==22.6.0
-blackdoc==0.3.5
+hypothesis==6.54.5
+black==22.8.0
+blackdoc==0.3.6
 isort==5.10.1
 mypy==0.971
-flake8==5.0.2
-flake8-bugbear==22.7.1
+flake8==5.0.4
+flake8-bugbear==22.8.23
 flake8-comprehensions==3.10.0
 flake8-docstrings==1.6.0
 flake8-simplify==0.19.3

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,0 +1,14 @@
+hypothesis==6.54.5
+
+ghp-import==2.1.0
+sphinx==4.3.2
+pydata-sphinx-theme==0.10.1
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-napoleon==0.7
+commonmark==0.9.1
+numpydoc==1.4.0


### PR DESCRIPTION
Currently, we cannot use the latest version of Sphinx because it is not compatible with some package versions we need to run while testing on Python 3.7. This illustrates some problematic aspects of the existing setup of defining our development dependencies.

In this PR, I will do a first attempt at improving this.

Changes:
* Update build dependency versions
* Update Python version for docs workflows to 3.10.
* Separate documentation dependencies into a separate file.
  * Docs requirements are not required in any of the CI/testing pipelines; only in two docs-specific CI pipelines
  * This speeds the CI pipelines we run many times, as well as make the initial venv setup for users lighter.
  * This will allow us to upgrade Sphinx version (keeping this for a later PR because it affects the API UI)
* Update `make clean` to also remove `py-polars/docs/source/reference/api` (generated by Sphinx)
* Added a line to `CONTRIBUTING.md` to indicate how to build the docs. I will overhaul this soon; for now this should do.