### PR TITLE
perf(rust): Removed some clones

### DIFF
--- a/polars-sql/src/lib.rs
+++ b/polars-sql/src/lib.rs
@@ -5,8 +5,9 @@ mod sql_expr;
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use polars::prelude::*;
+
+    use super::*;
 
     fn create_sample_df() -> Result<DataFrame> {
         let a = Series::new("a", (1..10000i64).map(|i| i / 100).collect::<Vec<_>>());
@@ -32,7 +33,7 @@ mod test {
         let df_pl = df
             .lazy()
             .filter(col("a").gt(lit(10)).and(col("a").lt(lit(20))))
-            .select(&[col("a"), col("b"), (col("a") + col("b")).alias("c")])
+            .select([col("a"), col("b"), (col("a") + col("b")).alias("c")])
             .limit(100)
             .collect()?;
         assert_eq!(df_sql, df_pl);

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -396,7 +396,7 @@ impl<'df> GroupBy<'df> {
     /// ```rust
     /// # use polars_core::prelude::*;
     /// fn example(df: DataFrame) -> Result<DataFrame> {
-    ///     df.groupby(["date"])?.select(&["temp", "rain"]).mean()
+    ///     df.groupby(["date"])?.select(["temp", "rain"]).mean()
     /// }
     /// ```
     /// Returns:
@@ -967,7 +967,7 @@ mod test {
         // Select multiple
         let out = df
             .groupby_stable(["date"])?
-            .select(&["temp", "rain"])
+            .select(["temp", "rain"])
             .mean()?;
         assert_eq!(
             out.column("temp_mean")?,

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1246,7 +1246,7 @@ impl DataFrame {
     ///     "2" => &[2, 2, 2]
     /// }?;
     ///
-    /// assert!(df.select(&["0", "1"])?.frame_equal(&df.select_by_range(0..=1)?));
+    /// assert!(df.select(["0", "1"])?.frame_equal(&df.select_by_range(0..=1)?));
     /// assert!(df.frame_equal(&df.select_by_range(..)?));
     /// # Ok::<(), PolarsError>(())
     /// ```

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -282,7 +282,7 @@ impl<'a> LazyCsvReader<'a> {
                     builder.finish_impl()
                 })
                 .collect::<Result<Vec<_>>>()?;
-            concat(&lfs, self.rechunk)
+            concat(lfs, self.rechunk)
                 .map_err(|_| PolarsError::ComputeError("no matching files found".into()))
                 .map(|lf| {
                     if self.skip_rows != 0 || self.n_rows.is_some() {

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -67,7 +67,7 @@ impl LazyFrame {
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            concat(&lfs, args.rechunk)
+            concat(lfs, args.rechunk)
                 .map_err(|_| PolarsError::ComputeError("no matching files found".into()))
                 .map(|mut lf| {
                     if let Some(n_rows) = args.n_rows {

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -61,7 +61,7 @@ impl LazyFrame {
     }
 
     fn concat_impl(lfs: Vec<LazyFrame>, args: ScanArgsParquet) -> Result<LazyFrame> {
-        concat(&lfs, args.rechunk).map(|mut lf| {
+        concat(lfs, args.rechunk).map(|mut lf| {
             if let Some(n_rows) = args.n_rows {
                 lf = lf.slice(0, n_rows as IdxSize)
             };

--- a/polars/polars-lazy/src/frame/pivot.rs
+++ b/polars/polars-lazy/src/frame/pivot.rs
@@ -39,11 +39,11 @@ pub fn pivot<I0, S0, I1, S1, I2, S2>(
 ) -> Result<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
+    S0: Into<String>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
+    S1: Into<String>,
     I2: IntoIterator<Item = S2>,
-    S2: AsRef<str>,
+    S2: Into<String>,
 {
     // make sure that the root column is replaced
     let expr = prepare_eval_expr(agg_expr);
@@ -67,11 +67,11 @@ pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
 ) -> Result<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
+    S0: Into<String>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
+    S1: Into<String>,
     I2: IntoIterator<Item = S2>,
-    S2: AsRef<str>,
+    S2: Into<String>,
 {
     // make sure that the root column is replaced
     let expr = prepare_eval_expr(agg_expr);

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -167,7 +167,7 @@
 //!     .agg(
 //!         vec![col("b").first(), col("c").first()]
 //!      )
-//!     .select(&[col("b"), col("c_first")])
+//!     .select([col("b"), col("c_first")])
 //! }
 //! ```
 //!

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -295,7 +295,7 @@ mod test {
         let df = get_df();
         let lf = df
             .lazy()
-            .select(&[((col("sepal.width") * lit(100)).alias("super_wide"))])
+            .select([((col("sepal.width") * lit(100)).alias("super_wide"))])
             .sort("super_wide", SortOptions::default());
 
         print_plans(&lf);
@@ -315,7 +315,7 @@ mod test {
         let lf = df
             .lazy()
             .filter(col("sepal.width").lt(lit(3.5)))
-            .select(&[col("variety").alias("foo")]);
+            .select([col("variety").alias("foo")]);
 
         print_plans(&lf);
         let df = lf.collect().unwrap();
@@ -328,7 +328,7 @@ mod test {
         let lp = df
             .clone()
             .lazy()
-            .select(&[col("variety").alias("foo")])
+            .select([col("variety").alias("foo")])
             .logical_plan;
 
         assert!(lp.schema().unwrap().get("foo").is_some());
@@ -373,7 +373,7 @@ mod test {
                 .clone()
                 .lazy()
                 .left_join(right.clone().lazy(), col("days"), col("days"))
-                .select(&[col("temp")]);
+                .select([col("temp")]);
 
             let _df = lf.collect().unwrap();
         }
@@ -383,7 +383,7 @@ mod test {
             let lf = left
                 .lazy()
                 .left_join(right.lazy(), col("days"), col("days"))
-                .select(&[col("temp"), col("rain_right")]);
+                .select([col("temp"), col("rain_right")]);
 
             print_plans(&lf);
             let _df = lf.collect().unwrap();
@@ -400,7 +400,7 @@ mod test {
         .unwrap();
         let mut s = String::new();
         left.lazy()
-            .select(&[col("days")])
+            .select([col("days")])
             .logical_plan
             .dot(&mut s, (0, 0), "")
             .unwrap();

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -450,7 +450,7 @@ fn test_lazy_query_10() {
     let df = DataFrame::new(vec![x, y]).unwrap();
     let out = df
         .lazy()
-        .select(&[(col("x") - col("y")).alias("z")])
+        .select([(col("x") - col("y")).alias("z")])
         .collect()
         .unwrap();
     let z: Series = DurationChunked::from_duration(
@@ -487,7 +487,7 @@ fn test_lazy_query_10() {
     let df = DataFrame::new(vec![x, y]).unwrap();
     let out = df
         .lazy()
-        .select(&[(col("x") - col("y")).alias("z")])
+        .select([(col("x") - col("y")).alias("z")])
         .collect()
         .unwrap();
     assert!(out
@@ -566,7 +566,7 @@ fn test_simplify_expr() {
 
     let plan = df
         .lazy()
-        .select(&[lit(1.0f32) + lit(1.0f32) + col("sepal.width")])
+        .select([lit(1.0f32) + lit(1.0f32) + col("sepal.width")])
         .logical_plan;
 
     let mut expr_arena = Arena::new();

--- a/polars/polars-ops/src/pivot/mod.rs
+++ b/polars/polars-ops/src/pivot/mod.rs
@@ -53,24 +53,15 @@ pub fn pivot<I0, S0, I1, S1, I2, S2>(
 ) -> Result<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
+    S0: Into<String>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
+    S1: Into<String>,
     I2: IntoIterator<Item = S2>,
-    S2: AsRef<str>,
+    S2: Into<String>,
 {
-    let values = values
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
-    let index = index
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
-    let columns = columns
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
+    let values = values.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+    let index = index.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+    let columns = columns.into_iter().map(|s| s.into()).collect::<Vec<_>>();
     pivot_impl(
         pivot_df,
         &values,
@@ -97,24 +88,15 @@ pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
 ) -> Result<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
+    S0: Into<String>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
+    S1: Into<String>,
     I2: IntoIterator<Item = S2>,
-    S2: AsRef<str>,
+    S2: Into<String>,
 {
-    let values = values
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
-    let index = index
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
-    let columns = columns
-        .into_iter()
-        .map(|s| s.as_ref().to_string())
-        .collect::<Vec<_>>();
+    let values = values.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+    let index = index.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+    let columns = columns.into_iter().map(|s| s.into()).collect::<Vec<_>>();
 
     pivot_impl(
         pivot_df,

--- a/polars/tests/it/lazy/expressions/window.rs
+++ b/polars/tests/it/lazy/expressions/window.rs
@@ -22,7 +22,7 @@ fn test_lazy_window_functions() {
     let _ = df
         .clone()
         .lazy()
-        .select(&[avg("values").over([col("groups")]).alias("part")])
+        .select([avg("values").over([col("groups")]).alias("part")])
         .collect()
         .unwrap();
     // test if partition aggregation is correct


### PR DESCRIPTION
This PR removes unnecessary clones during planning.

The idea is to replace `AsRef<[Expr]>` by `Into<Vec<Expr>>`. The main benefits are:

* API no longer requires passing by ref e.g. (`.select(&[col("a")])) -> .select([col("a")]))`)
* Internals no longer need to clone when not needed
