### PR TITLE
fix[python]: keep column type of empty arrow table

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -687,7 +687,12 @@ def arrow_to_pydf(
 
         # path for table without rows that keeps datatype
         if tbl.shape[0] == 0:
-            pydf = pli.DataFrame._from_pandas(tbl.to_pandas())._df
+            pydf = pli.DataFrame(
+                [
+                    pli.Series(name, c)
+                    for (name, c) in zip(tbl.column_names, tbl.columns)
+                ]
+            )._df
         else:
             pydf = PyDataFrame.from_arrow_record_batches(tbl.to_batches())
     else:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -370,11 +370,17 @@ def test_from_empty_arrow() -> None:
     tbl = pa.Table.from_pandas(df1)
     out = pl.from_arrow(tbl)
     assert out.columns == ["b", "__index_level_0__"]
-    assert out.dtypes == [pl.Float64, pl.Utf8]
+    assert out.dtypes == [pl.Float64, pl.Int8]
     tbl = pa.Table.from_pandas(df1, preserve_index=False)
     out = pl.from_arrow(tbl)
     assert out.columns == ["b"]
     assert out.dtypes == [pl.Float64]
+
+    # 4568
+    tbl = pa.table({"l": []}, schema=pa.schema([("l", pa.large_list(pa.uint8()))]))
+
+    df = pl.from_arrow(tbl)
+    assert df.schema["l"] == pl.List(pl.UInt8)
 
 
 def test_from_null_column() -> None:


### PR DESCRIPTION
fixes #4568