### PR TITLE
feat[python]: api consistency; allow fluent calling pattern everywhere

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2295,7 +2295,7 @@ class DataFrame:
         """
         return self.select(pli.col("*").reverse())
 
-    def rename(self, mapping: dict[str, str]) -> DataFrame:
+    def rename(self: DF, mapping: dict[str, str]) -> DF | DataFrame:
         """
         Rename column names.
 
@@ -2326,7 +2326,7 @@ class DataFrame:
         """
         return self.lazy().rename(mapping).collect(no_optimization=True)
 
-    def insert_at_idx(self, index: int, series: pli.Series) -> None:
+    def insert_at_idx(self: DF, index: int, series: pli.Series) -> DF:
         """
         Insert a Series at a certain column index. This operation is in place.
 
@@ -2385,6 +2385,7 @@ class DataFrame:
         if index < 0:
             index = len(self.columns) + index
         self._df.insert_at_idx(index, series._s)
+        return self
 
     def filter(
         self,
@@ -2525,7 +2526,7 @@ class DataFrame:
         """
         return self._df.find_idx_by_name(name)
 
-    def replace_at_idx(self, index: int, series: pli.Series) -> None:
+    def replace_at_idx(self: DF, index: int, series: pli.Series) -> DF:
         """
         Replace a column at an index location.
 
@@ -2565,13 +2566,14 @@ class DataFrame:
         if index < 0:
             index = len(self.columns) + index
         self._df.replace_at_idx(index, series._s)
+        return self
 
     def sort(
-        self,
+        self: DF,
         by: str | pli.Expr | list[str] | list[pli.Expr],
         reverse: bool | list[bool] = False,
         nulls_last: bool = False,
-    ) -> DataFrame:
+    ) -> DF | DataFrame:
         """
         Sort the DataFrame by column.
 
@@ -2672,7 +2674,7 @@ class DataFrame:
         """
         return self._df.frame_equal(other._df, null_equal)
 
-    def replace(self, column: str, new_col: pli.Series) -> None:
+    def replace(self: DF, column: str, new_col: pli.Series) -> DF:
         """
         Replace a column by a new Series.
 
@@ -2704,6 +2706,7 @@ class DataFrame:
 
         """
         self._df.replace(column, new_col._s)
+        return self
 
     def slice(self: DF, offset: int, length: int | None = None) -> DF:
         """
@@ -4024,27 +4027,11 @@ class DataFrame:
         else:
             return self._from_pydf(self._df.with_column(column._s))
 
-    @overload
-    def hstack(
-        self: DF,
-        columns: list[pli.Series] | DataFrame,
-        in_place: Literal[False] = False,
-    ) -> DF:
-        ...
-
-    @overload
-    def hstack(
-        self: DF,
-        columns: list[pli.Series] | DataFrame,
-        in_place: Literal[True],
-    ) -> None:
-        ...
-
     def hstack(
         self: DF,
         columns: list[pli.Series] | DataFrame,
         in_place: bool = False,
-    ) -> DF | None:
+    ) -> DF:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
 
@@ -4084,23 +4071,11 @@ class DataFrame:
             columns = columns.get_columns()
         if in_place:
             self._df.hstack_mut([s._s for s in columns])
-            return None
+            return self
         else:
             return self._from_pydf(self._df.hstack([s._s for s in columns]))
 
-    @overload
-    def vstack(self, df: DataFrame, in_place: Literal[True]) -> None:
-        ...
-
-    @overload
-    def vstack(self: DF, df: DataFrame, in_place: Literal[False] = ...) -> DF:
-        ...
-
-    @overload
-    def vstack(self: DF, df: DataFrame, in_place: bool) -> DF | None:
-        ...
-
-    def vstack(self: DF, df: DataFrame, in_place: bool = False) -> DF | None:
+    def vstack(self: DF, df: DataFrame, in_place: bool = False) -> DF:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
 
@@ -4146,16 +4121,16 @@ class DataFrame:
         """
         if in_place:
             self._df.vstack_mut(df._df)
-            return None
+            return self
         else:
             return self._from_pydf(self._df.vstack(df._df))
 
-    def extend(self, other: DataFrame) -> None:
+    def extend(self: DF, other: DF) -> DF:
         """
         Extend the memory backed by this `DataFrame` with the values from `other`.
 
         Different from `vstack` which adds the chunks from `other` to the chunks of this
-        `DataFrame` `extent` appends the data from `other` to the underlying memory
+        `DataFrame` `extend` appends the data from `other` to the underlying memory
         locations and thus may cause a reallocation.
 
         If this does not cause a reallocation, the resulting data structure will not
@@ -4201,6 +4176,7 @@ class DataFrame:
 
         """
         self._df.extend(other._df)
+        return self
 
     def drop(self: DF, name: str | list[str]) -> DF:
         """
@@ -5943,19 +5919,7 @@ class DataFrame:
         """
         return self._df.row_tuples()
 
-    @overload
-    def shrink_to_fit(self: DF, in_place: Literal[False] = ...) -> DF:
-        ...
-
-    @overload
-    def shrink_to_fit(self, in_place: Literal[True]) -> None:
-        ...
-
-    @overload
-    def shrink_to_fit(self: DF, in_place: bool) -> DF | None:
-        ...
-
-    def shrink_to_fit(self: DF, in_place: bool = False) -> DF | None:
+    def shrink_to_fit(self: DF, in_place: bool = False) -> DF:
         """
         Shrink DataFrame memory usage.
 
@@ -5964,7 +5928,7 @@ class DataFrame:
         """
         if in_place:
             self._df.shrink_to_fit()
-            return None
+            return self
         else:
             df = self.clone()
             df._df.shrink_to_fit()

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2341,8 +2341,7 @@ class DataFrame:
         --------
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> s = pl.Series("baz", [97, 98, 99])
-        >>> df.insert_at_idx(1, s)  # returns None
-        >>> df
+        >>> df.insert_at_idx(1, s)
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ baz ┆ bar │
@@ -2365,7 +2364,6 @@ class DataFrame:
         ... )
         >>> s = pl.Series("d", [-2.5, 15, 20.5, 0])
         >>> df.insert_at_idx(3, s)
-        >>> df
         shape: (4, 4)
         ┌─────┬──────┬───────┬──────┐
         │ a   ┆ b    ┆ c     ┆ d    │
@@ -2546,9 +2544,8 @@ class DataFrame:
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... )
-        >>> x = pl.Series("apple", [10, 20, 30])
-        >>> df.replace_at_idx(0, x)
-        >>> df
+        >>> s = pl.Series("apple", [10, 20, 30])
+        >>> df.replace_at_idx(0, s)
         shape: (3, 3)
         ┌───────┬─────┬─────┐
         │ apple ┆ bar ┆ ham │
@@ -2690,7 +2687,6 @@ class DataFrame:
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> s = pl.Series([10, 20, 30])
         >>> df.replace("foo", s)  # works in-place!
-        >>> df
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
@@ -4153,8 +4149,7 @@ class DataFrame:
         --------
         >>> df1 = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> df2 = pl.DataFrame({"foo": [10, 20, 30], "bar": [40, 50, 60]})
-        >>> df1.extend(df2)  # returns None
-        >>> df1
+        >>> df1.extend(df2)
         shape: (6, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1492,7 +1492,6 @@ class Series:
         >>> s = pl.Series("a", [1, 2, 3])
         >>> s2 = pl.Series("b", [4, 5, 6])
         >>> s.append(s2)
-        >>> s
         shape: (6,)
         Series: 'a' [i64]
         [

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -214,20 +214,22 @@ def test_assignment() -> None:
 
 
 def test_insert_at_idx() -> None:
-    df = pl.DataFrame({"z": [3, 4, 5]})
-    df.insert_at_idx(0, pl.Series("x", [1, 2, 3]))
-    df.insert_at_idx(-1, pl.Series("y", [2, 3, 4]))
-
+    df = (
+        pl.DataFrame({"z": [3, 4, 5]})
+        .insert_at_idx(0, pl.Series("x", [1, 2, 3]))
+        .insert_at_idx(-1, pl.Series("y", [2, 3, 4]))
+    )
     expected_df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
     assert_frame_equal(expected_df, df)
 
 
 def test_replace_at_idx() -> None:
-    df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
-    df.replace_at_idx(0, pl.Series("a", [4, 5, 6]))
-    df.replace_at_idx(-2, pl.Series("b", [5, 6, 7]))
-    df.replace_at_idx(-1, pl.Series("c", [6, 7, 8]))
-
+    df = (
+        pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
+        .replace_at_idx(0, pl.Series("a", [4, 5, 6]))
+        .replace_at_idx(-2, pl.Series("b", [5, 6, 7]))
+        .replace_at_idx(-1, pl.Series("c", [6, 7, 8]))
+    )
     expected_df = pl.DataFrame({"a": [4, 5, 6], "b": [5, 6, 7], "c": [6, 7, 8]})
     assert_frame_equal(expected_df, df)
 
@@ -524,7 +526,7 @@ def test_vstack(in_place: bool) -> None:
     if in_place:
         assert df1.frame_equal(expected)
     else:
-        assert out.frame_equal(expected)  # type: ignore[union-attr]
+        assert out.frame_equal(expected)
 
 
 def test_extend() -> None:
@@ -1558,14 +1560,12 @@ def test_sample() -> None:
     assert df.sample(frac=0.4, seed=0).shape == (1, 3)
 
 
-@pytest.mark.parametrize("in_place", [True, False])
-def test_shrink_to_fit(in_place: bool) -> None:
+def test_shrink_to_fit() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]})
 
-    if in_place:
-        assert df.shrink_to_fit(in_place) is None
-    else:
-        assert df.shrink_to_fit(in_place).frame_equal(df)
+    assert df.shrink_to_fit(in_place=True) is df
+    assert df.shrink_to_fit(in_place=False) is not df
+    assert df.shrink_to_fit(in_place=False).frame_equal(df)
 
 
 def test_arithmetic() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1381,10 +1381,12 @@ def test_peak_max_peak_min() -> None:
 
 def test_shrink_to_fit() -> None:
     s = pl.Series("a", [4, 1, 3, 2, 5])
-    assert s.shrink_to_fit(in_place=True) is None
+    sf = s.shrink_to_fit(in_place=True)
+    assert sf is s
 
     s = pl.Series("a", [4, 1, 3, 2, 5])
-    assert isinstance(s.shrink_to_fit(in_place=False), pl.Series)
+    sf = s.shrink_to_fit(in_place=False)
+    assert s is not sf
 
 
 def test_str_concat() -> None:
@@ -1920,8 +1922,7 @@ def test_clip() -> None:
 
 def test_mutable_borrowed_append_3915() -> None:
     s = pl.Series("s", [1, 2, 3])
-    s.append(s)
-    assert s.to_list() == [1, 2, 3, 1, 2, 3]
+    assert s.append(s).to_list() == [1, 2, 3, 1, 2, 3]
 
 
 def test_set_at_idx() -> None:


### PR DESCRIPTION
A couple of Series and DataFrame functions returned `None` _iif_ their `in_place` param was `True`, leading to the inability to consistently use the API in the usual fluent/compositional style. Fixing this also simplifies some typing, as a consistent return type means that three additional `@overload` hints can be dropped (per method).

**Example:**

_Before (cannot compose as usual)_

```python
df.replace_at_idx( 0, pl.Series("a",[1, 2, 3]) )
df.replace_at_idx(-1, pl.Series("b",[3, 4, 5]) )
df.shrink_to_fit( in_place=True )
```

_After (fluent calling allowed again)_

```python
df.replace_at_idx( 0, pl.Series("a",[1, 2, 3]) )
  .replace_at_idx(-1, pl.Series("b",[3, 4, 5]) )
  .shrink_to_fit( in_place=True )
```

Note that there are no meaningful _advantages_ to returning `None`, despite various python builtin functions opting to do so when operating in-place; we just lose the ability to call the API in fluent/compositional form consistently.

Doesn't break any existing usage, and doesn't change any `in_place` defaults.