### PR TITLE
docs[rust] fix some minor typos

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -242,7 +242,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.iter_validities().any(|valid| valid.is_some())
     }
 
-    /// Shrink the capacity of this array to fit it's length.
+    /// Shrink the capacity of this array to fit its length.
     pub fn shrink_to_fit(&mut self) {
         self.chunks = vec![arrow::compute::concatenate::concatenate(
             self.chunks

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -22,7 +22,7 @@ where
 {
     /// Extend the memory backed by this array with the values from `other`.
     ///
-    /// Different from [`ChunkedArray::append`] which adds chunks to this [`ChunkedArray`] `extent`
+    /// Different from [`ChunkedArray::append`] which adds chunks to this [`ChunkedArray`] `extend`
     /// appends the data from `other` to the underlying `PrimitiveArray` and thus may cause a reallocation.
     ///
     /// However if this does not cause a reallocation, the resulting data structure will not have any extra chunks

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -411,7 +411,7 @@ impl DataFrame {
         DataFrame::new_no_checks(cols)
     }
 
-    /// Shrink the capacity of this DataFrame to fit it's length.
+    /// Shrink the capacity of this DataFrame to fit its length.
     pub fn shrink_to_fit(&mut self) {
         // Don't parallelize this. Memory overhead
         for s in &mut self.columns {
@@ -938,7 +938,7 @@ impl DataFrame {
     /// Extend the memory backed by this [`DataFrame`] with the values from `other`.
     ///
     /// Different from [`vstack`](Self::vstack) which adds the chunks from `other` to the chunks of this [`DataFrame`]
-    /// `extent` appends the data from `other` to the underlying memory locations and thus may cause a reallocation.
+    /// `extend` appends the data from `other` to the underlying memory locations and thus may cause a reallocation.
     ///
     /// If this does not cause a reallocation, the resulting data structure will not have any extra chunks
     /// and thus will yield faster queries.

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -191,7 +191,7 @@ impl Series {
         self
     }
 
-    /// Shrink the capacity of this array to fit it's length.
+    /// Shrink the capacity of this array to fit its length.
     pub fn shrink_to_fit(&mut self) {
         self._get_inner_mut().shrink_to_fit()
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -264,7 +264,7 @@ pub trait SeriesTrait:
         self.chunks().len()
     }
 
-    /// Shrink the capacity of this array to fit it's length.
+    /// Shrink the capacity of this array to fit its length.
     fn shrink_to_fit(&mut self) {
         panic!("shrink to fit not supported for dtype {:?}", self.dtype())
     }


### PR DESCRIPTION
Just replacing a few _"it's"_ with _"its"_, and _"extent"_ with _"extend"_. 
(Purely a docstring/comment update, no functional code touched).