### PR TITLE
feat[rust, python]: Add profiling to lazy execution

### DIFF
--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -32,8 +32,6 @@ use polars_core::datatypes::PlHashMap;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::frame::hash_join::JoinType;
 use polars_core::prelude::*;
-#[cfg(feature = "dtype-categorical")]
-use polars_core::toggle_string_cache;
 use polars_io::RowCount;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -127,7 +125,6 @@ pub struct OptState {
     pub simplify_expr: bool,
     pub file_caching: bool,
     pub aggregate_pushdown: bool,
-    pub global_string_cache: bool,
     pub slice_pushdown: bool,
 }
 
@@ -138,7 +135,6 @@ impl Default for OptState {
             predicate_pushdown: true,
             type_coercion: true,
             simplify_expr: true,
-            global_string_cache: false,
             slice_pushdown: true,
             // will be toggled by a scan operation such as csv scan or parquet scan
             file_caching: false,
@@ -185,7 +181,6 @@ impl LazyFrame {
             predicate_pushdown: false,
             type_coercion: true,
             simplify_expr: false,
-            global_string_cache: false,
             slice_pushdown: false,
             // will be toggled by a scan operation such as csv scan or parquet scan
             file_caching: false,
@@ -220,12 +215,6 @@ impl LazyFrame {
     /// Toggle aggregate pushdown.
     pub fn with_aggregate_pushdown(mut self, toggle: bool) -> Self {
         self.opt_state.aggregate_pushdown = toggle;
-        self
-    }
-
-    /// Toggle global string cache.
-    pub fn with_string_cache(mut self, toggle: bool) -> Self {
-        self.opt_state.global_string_cache = toggle;
         self
     }
 
@@ -680,39 +669,11 @@ impl LazyFrame {
         Ok(lp_top)
     }
 
-    /// Execute all the lazy operations and collect them into a [DataFrame](polars_core::frame::DataFrame).
-    /// Before execution the query is being optimized.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use polars_core::prelude::*;
-    /// use polars_lazy::prelude::*;
-    ///
-    /// fn example(df: DataFrame) -> Result<DataFrame> {
-    ///     df.lazy()
-    ///       .groupby([col("foo")])
-    ///       .agg([col("bar").sum(), col("ham").mean().alias("avg_ham")])
-    ///       .collect()
-    /// }
-    /// ```
-    pub fn collect(self) -> Result<DataFrame> {
+    fn prepare_collect(self) -> Result<(ExecutionState, Box<dyn Executor>)> {
         let file_caching = self.opt_state.file_caching;
-        #[cfg(feature = "dtype-categorical")]
-        let using_string_cache = self.opt_state.global_string_cache;
-        #[cfg(feature = "dtype-categorical")]
-        if using_string_cache {
-            eprint!("global string cache in combination with LazyFrames is deprecated; please set the global string cache globally.")
-        }
         let mut expr_arena = Arena::with_capacity(256);
         let mut lp_arena = Arena::with_capacity(128);
         let lp_top = self.optimize(&mut lp_arena, &mut expr_arena)?;
-
-        // if string cache was already set, we skip this and global settings are respected
-        #[cfg(feature = "dtype-categorical")]
-        if using_string_cache {
-            toggle_string_cache(using_string_cache);
-        }
 
         let finger_prints = if file_caching {
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
@@ -730,21 +691,47 @@ impl LazyFrame {
         };
 
         let planner = PhysicalPlanner::default();
-        let mut physical_plan =
+        let physical_plan =
             planner.create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
 
-        let mut state = ExecutionState::with_finger_prints(finger_prints);
+        let state = ExecutionState::with_finger_prints(finger_prints);
+        Ok((state, physical_plan))
+
+    }
+
+    /// Execute all the lazy operations and collect them into a [DataFrame](polars_core::frame::DataFrame).
+    /// Before execution the query is being optimized.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::prelude::*;
+    /// use polars_lazy::prelude::*;
+    ///
+    /// fn example(df: DataFrame) -> Result<DataFrame> {
+    ///     df.lazy()
+    ///       .groupby([col("foo")])
+    ///       .agg([col("bar").sum(), col("ham").mean().alias("avg_ham")])
+    ///       .collect()
+    /// }
+    /// ```
+    pub fn collect(self) -> Result<DataFrame> {
+        let (mut state, mut physical_plan) = self.prepare_collect()?;
         let out = physical_plan.execute(&mut state);
         #[cfg(debug_assertions)]
         {
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             state.file_cache.assert_empty();
         }
-        #[cfg(feature = "dtype-categorical")]
-        if using_string_cache {
-            toggle_string_cache(!using_string_cache);
-        }
         out
+    }
+
+    pub fn collect_and_time(self) -> Result<(DataFrame, DataFrame)> {
+        let (mut state, mut physical_plan) = self.prepare_collect()?;
+        state.time_nodes();
+        let out = physical_plan.execute(&mut state)?;
+        let timer_df = state.finish_timer()?;
+        Ok((out, timer_df))
     }
 
     /// Filter by some predicate expression.

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -691,12 +691,10 @@ impl LazyFrame {
         };
 
         let planner = PhysicalPlanner::default();
-        let physical_plan =
-            planner.create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
+        let physical_plan = planner.create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
 
         let state = ExecutionState::with_finger_prints(finger_prints);
         Ok((state, physical_plan))
-
     }
 
     /// Execute all the lazy operations and collect them into a [DataFrame](polars_core::frame::DataFrame).
@@ -726,7 +724,7 @@ impl LazyFrame {
         out
     }
 
-    pub fn collect_and_time(self) -> Result<(DataFrame, DataFrame)> {
+    pub fn profile(self) -> Result<(DataFrame, DataFrame)> {
         let (mut state, mut physical_plan) = self.prepare_collect()?;
         state.time_nodes();
         let out = physical_plan.execute(&mut state)?;

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -724,6 +724,13 @@ impl LazyFrame {
         out
     }
 
+    //// Profile a LazyFrame.
+    ////
+    //// This will run the query and return a tuple
+    //// containing the materialized DataFrame and a DataFrame that contains profiling information
+    //// of each node that is executed.
+    ////
+    //// The units of the timings are microseconds.
     pub fn profile(self) -> Result<(DataFrame, DataFrame)> {
         let (mut state, mut physical_plan) = self.prepare_collect()?;
         state.time_nodes();

--- a/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
@@ -20,9 +20,11 @@ impl Executor for DropDuplicatesExec {
         let subset = self.options.subset.as_ref().map(|v| &***v);
         let keep = self.options.keep_strategy;
 
-        match self.options.maintain_order {
-            true => df.unique_stable(subset, keep),
-            false => df.unique(subset, keep),
-        }
+        state.record(|| {
+            match self.options.maintain_order {
+                true => df.unique_stable(subset, keep),
+                false => df.unique(subset, keep),
+            }
+        }, "unique_node")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/drop_duplicates.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use polars_core::prelude::*;
 
 use crate::physical_plan::state::ExecutionState;
@@ -20,11 +22,12 @@ impl Executor for DropDuplicatesExec {
         let subset = self.options.subset.as_ref().map(|v| &***v);
         let keep = self.options.keep_strategy;
 
-        state.record(|| {
-            match self.options.maintain_order {
+        state.record(
+            || match self.options.maintain_order {
                 true => df.unique_stable(subset, keep),
                 false => df.unique(subset, keep),
-            }
-        }, "unique_node")
+            },
+            Cow::Borrowed("unique()"),
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/explode.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/explode.rs
@@ -17,6 +17,8 @@ impl Executor for ExplodeExec {
             }
         }
         let df = self.input.execute(state)?;
-        df.explode(&self.columns)
+        state.record(|| {
+            df.explode(&self.columns)
+        }, "explode")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/explode.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/explode.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use polars_core::prelude::*;
 
 use crate::physical_plan::state::ExecutionState;
@@ -17,8 +19,6 @@ impl Executor for ExplodeExec {
             }
         }
         let df = self.input.execute(state)?;
-        state.record(|| {
-            df.explode(&self.columns)
-        }, "explode")
+        state.record(|| df.explode(&self.columns), Cow::Borrowed("explode()"))
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/filter.rs
@@ -25,10 +25,13 @@ impl Executor for FilterExec {
         let df = self.input.execute(state)?;
         let s = self.predicate.evaluate(&df, state)?;
         let mask = s.bool().expect("filter predicate wasn't of type boolean");
-        let df = df.filter(mask)?;
-        if state.verbose() {
-            eprintln!("dataframe filtered");
-        }
-        Ok(df)
+
+        state.record(|| {
+            let df = df.filter(mask)?;
+            if state.verbose() {
+                eprintln!("dataframe filtered");
+            }
+            Ok(df)
+        }, "filter")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -91,18 +91,9 @@ pub(super) fn groupby_helper(
     DataFrame::new(columns)
 }
 
-impl Executor for GroupByExec {
-    fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
-        #[cfg(debug_assertions)]
-        {
-            if state.verbose() {
-                println!("run GroupbyExec")
-            }
-        }
-        if state.verbose() {
-            eprintln!("keys/aggregates are not partitionable: running default HASH AGGREGATION")
-        }
-        let df = self.input.execute(state)?;
+impl GroupByExec {
+    fn execute_impl(&mut self, state: &mut ExecutionState, df: DataFrame) -> Result<DataFrame> {
+
         state.set_schema(self.input_schema.clone());
         let keys = self
             .keys
@@ -118,5 +109,31 @@ impl Executor for GroupByExec {
             self.maintain_order,
             self.slice,
         )
+
+    }
+}
+
+impl Executor for GroupByExec {
+    fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run GroupbyExec")
+            }
+        }
+        if state.verbose() {
+            eprintln!("keys/aggregates are not partitionable: running default HASH AGGREGATION")
+        }
+        let df = self.input.execute(state)?;
+
+        if state.has_node_timer() {
+            let new_state = state.clone();
+            new_state.record(|| {
+                self.execute_impl(state, df)
+            }, "groupby")
+        } else {
+            self.execute_impl(state, df)
+        }
+
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -12,21 +12,10 @@ pub(crate) struct GroupByDynamicExec {
     pub(crate) slice: Option<(i64, usize)>,
 }
 
-impl Executor for GroupByDynamicExec {
-    #[cfg(not(feature = "dynamic_groupby"))]
-    fn execute(&mut self, _state: &mut ExecutionState) -> Result<DataFrame> {
-        panic!("activate feature dynamic_groupby")
-    }
-
+impl GroupByDynamicExec {
     #[cfg(feature = "dynamic_groupby")]
-    fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
-        #[cfg(debug_assertions)]
-        {
-            if state.verbose() {
-                println!("run GroupbyDynamicExec")
-            }
-        }
-        let mut df = self.input.execute(state)?;
+    fn execute_impl(&mut self, state: &mut ExecutionState, mut df: DataFrame) -> Result<DataFrame> {
+
         df.as_single_chunk_par();
         state.set_schema(self.input_schema.clone());
 
@@ -46,8 +35,8 @@ impl Executor for GroupByDynamicExec {
 
         let mut groups = &groups;
         #[allow(unused_assignments)]
-        // it is unused because we only use it to keep the lifetime of sliced_group valid
-        let mut sliced_groups = None;
+            // it is unused because we only use it to keep the lifetime of sliced_group valid
+            let mut sliced_groups = None;
 
         if let Some((offset, len)) = self.slice {
             sliced_groups = Some(groups.slice(offset, len));
@@ -63,21 +52,21 @@ impl Executor for GroupByDynamicExec {
         }
 
         let agg_columns = POOL.install(|| {
-                self.aggs
-                    .par_iter()
-                    .map(|expr| {
-                        let agg = expr.evaluate_on_groups(&df, groups, state)?.finalize();
-                        if agg.len() != groups.len() {
-                            return Err(PolarsError::ComputeError(
-                                format!("returned aggregation is a different length: {} than the group lengths: {}",
-                                        agg.len(),
-                                        groups.len()).into()
-                            ))
-                        }
-                        Ok(agg)
-                    })
-                    .collect::<Result<Vec<_>>>()
-            })?;
+            self.aggs
+                .par_iter()
+                .map(|expr| {
+                    let agg = expr.evaluate_on_groups(&df, groups, state)?.finalize();
+                    if agg.len() != groups.len() {
+                        return Err(PolarsError::ComputeError(
+                            format!("returned aggregation is a different length: {} than the group lengths: {}",
+                                    agg.len(),
+                                    groups.len()).into()
+                        ))
+                    }
+                    Ok(agg)
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
 
         state.clear_schema_cache();
         let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
@@ -86,5 +75,35 @@ impl Executor for GroupByDynamicExec {
         columns.extend_from_slice(&agg_columns);
 
         DataFrame::new(columns)
+
+    }
+
+}
+
+impl Executor for GroupByDynamicExec {
+    #[cfg(not(feature = "dynamic_groupby"))]
+    fn execute(&mut self, _state: &mut ExecutionState) -> Result<DataFrame> {
+        panic!("activate feature dynamic_groupby")
+    }
+
+    #[cfg(feature = "dynamic_groupby")]
+    fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
+        #[cfg(debug_assertions)]
+        {
+            if state.verbose() {
+                println!("run GroupbyDynamicExec")
+            }
+        }
+        let df = self.input.execute(state)?;
+
+
+        if state.has_node_timer() {
+            let new_state = state.clone();
+            new_state.record(|| {
+                self.execute_impl(state, df)
+            }, "groupby_partitioned")
+        } else {
+            self.execute_impl(state, df)
+        }
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/join.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/join.rs
@@ -78,81 +78,85 @@ impl Executor for JoinExec {
             (input_left.execute(state), input_right.execute(state))
         };
 
-        let mut df_left = df_left?;
-        let mut df_right = df_right?;
+        state.record(|| {
+            let mut df_left = df_left?;
+            let mut df_right = df_right?;
 
-        let left_on_series = self
-            .left_on
-            .iter()
-            .map(|e| e.evaluate(&df_left, state))
-            .collect::<Result<Vec<_>>>()?;
+            let left_on_series = self
+                .left_on
+                .iter()
+                .map(|e| e.evaluate(&df_left, state))
+                .collect::<Result<Vec<_>>>()?;
 
-        let right_on_series = self
-            .right_on
-            .iter()
-            .map(|e| e.evaluate(&df_right, state))
-            .collect::<Result<Vec<_>>>()?;
+            let right_on_series = self
+                .right_on
+                .iter()
+                .map(|e| e.evaluate(&df_right, state))
+                .collect::<Result<Vec<_>>>()?;
 
-        // make sure that we can join on evaluated expressions
-        for s in &left_on_series {
-            df_left.with_column(s.clone())?;
-        }
-        for s in &right_on_series {
-            df_right.with_column(s.clone())?;
-        }
+            // make sure that we can join on evaluated expressions
+            for s in &left_on_series {
+                df_left.with_column(s.clone())?;
+            }
+            for s in &right_on_series {
+                df_right.with_column(s.clone())?;
+            }
 
-        // prepare the tolerance
-        // we must ensure that we use the right units
-        #[cfg(feature = "asof_join")]
-        {
-            if let JoinType::AsOf(options) = &mut self.how {
-                use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
-                if let Some(tol) = &options.tolerance_str {
-                    let duration = polars_time::Duration::parse(tol);
-                    if duration.months() != 0 {
-                        return Err(PolarsError::ComputeError("Cannot use month offset in timedelta of an asof join. Consider using 4 weeks".into()));
-                    }
-                    let left_asof = df_left.column(left_on_series[0].name())?;
-                    use DataType::*;
-                    match left_asof.dtype() {
-                        Datetime(tu, _) | Duration(tu) => {
-                            let tolerance = match tu {
-                                TimeUnit::Nanoseconds => duration.duration_ns(),
-                                TimeUnit::Microseconds => duration.duration_us(),
-                                TimeUnit::Milliseconds => duration.duration_ms(),
-                            };
-                            options.tolerance = Some(AnyValue::from(tolerance))
+            // prepare the tolerance
+            // we must ensure that we use the right units
+            #[cfg(feature = "asof_join")]
+            {
+                if let JoinType::AsOf(options) = &mut self.how {
+                    use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
+                    if let Some(tol) = &options.tolerance_str {
+                        let duration = polars_time::Duration::parse(tol);
+                        if duration.months() != 0 {
+                            return Err(PolarsError::ComputeError("Cannot use month offset in timedelta of an asof join. Consider using 4 weeks".into()));
                         }
-                        Date => {
-                            let days = (duration.duration_ms() / MILLISECONDS_IN_DAY) as i32;
-                            options.tolerance = Some(AnyValue::from(days))
-                        }
-                        Time => {
-                            let tolerance = duration.duration_ns();
-                            options.tolerance = Some(AnyValue::from(tolerance))
-                        }
-                        _ => {
-                            panic!("can only use timedelta string language with Date/Datetime/Duration/Time dtypes")
+                        let left_asof = df_left.column(left_on_series[0].name())?;
+                        use DataType::*;
+                        match left_asof.dtype() {
+                            Datetime(tu, _) | Duration(tu) => {
+                                let tolerance = match tu {
+                                    TimeUnit::Nanoseconds => duration.duration_ns(),
+                                    TimeUnit::Microseconds => duration.duration_us(),
+                                    TimeUnit::Milliseconds => duration.duration_ms(),
+                                };
+                                options.tolerance = Some(AnyValue::from(tolerance))
+                            }
+                            Date => {
+                                let days = (duration.duration_ms() / MILLISECONDS_IN_DAY) as i32;
+                                options.tolerance = Some(AnyValue::from(days))
+                            }
+                            Time => {
+                                let tolerance = duration.duration_ns();
+                                options.tolerance = Some(AnyValue::from(tolerance))
+                            }
+                            _ => {
+                                panic!("can only use timedelta string language with Date/Datetime/Duration/Time dtypes")
+                            }
                         }
                     }
                 }
             }
-        }
 
-        let df = df_left._join_impl(
-            &df_right,
-            left_on_series,
-            right_on_series,
-            self.how.clone(),
-            Some(self.suffix.clone().into_owned()),
-            self.slice,
-            true,
-            state.verbose(),
-        );
+            let df = df_left._join_impl(
+                &df_right,
+                left_on_series,
+                right_on_series,
+                self.how.clone(),
+                Some(self.suffix.clone().into_owned()),
+                self.slice,
+                true,
+                state.verbose(),
+            );
 
-        if state.verbose() {
-            eprintln!("{:?} join dataframes finished", self.how);
-        };
-        df
+            if state.verbose() {
+                eprintln!("{:?} join dataframes finished", self.how);
+            };
+            df
+
+        }, "join")
+
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/melt.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/melt.rs
@@ -20,8 +20,6 @@ impl Executor for MeltExec {
         let df = self.input.execute(state)?;
         let args = std::mem::take(Arc::make_mut(&mut self.args));
 
-        state.record(|| {
-            df.melt2(args)
-        }, "melt")
+        state.record(|| df.melt2(args), "melt()".into())
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/melt.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/melt.rs
@@ -19,6 +19,9 @@ impl Executor for MeltExec {
         }
         let df = self.input.execute(state)?;
         let args = std::mem::take(Arc::make_mut(&mut self.args));
-        df.melt2(args)
+
+        state.record(|| {
+            df.melt2(args)
+        }, "melt")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -19,6 +19,7 @@ mod stack;
 mod udf;
 mod union;
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use polars_core::POOL;

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use polars_core::prelude::*;
 
 use crate::physical_plan::executors::evaluate_physical_expressions;
@@ -16,7 +18,6 @@ pub struct ProjectionExec {
 }
 
 impl ProjectionExec {
-
     fn execute_impl(&mut self, state: &mut ExecutionState, df: DataFrame) -> Result<DataFrame> {
         state.set_schema(self.input_schema.clone());
 
@@ -49,14 +50,23 @@ impl Executor for ProjectionExec {
         }
         let df = self.input.execute(state)?;
 
+        let profile_name = if state.has_node_timer() {
+            let by = self
+                .expr
+                .iter()
+                .map(|s| Ok(s.to_field(&self.input_schema)?.name))
+                .collect::<Result<Vec<_>>>()?;
+            let name = column_delimited("projection".to_string(), &by);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
         if state.has_node_timer() {
             let new_state = state.clone();
-            new_state.record(|| {
-                self.execute_impl(state, df)
-            }, "projection")
+            new_state.record(|| self.execute_impl(state, df), profile_name)
         } else {
             self.execute_impl(state, df)
         }
-
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -68,10 +68,25 @@ impl Executor for CsvExec {
                 .map(|ae| ae.as_expression().unwrap().clone()),
             slice: (self.options.skip_rows, self.options.n_rows),
         };
-        state.record(|| {
-            state
-                .file_cache
-                .read(finger_print, self.options.file_counter, &mut || self.read())
-        }, "csv_scan")
+
+        let profile_name = if state.has_node_timer() {
+            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            if self.predicate.is_some() {
+                ids.push("predicate".to_string())
+            }
+            let name = column_delimited("csv".to_string(), &ids);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
+        state.record(
+            || {
+                state
+                    .file_cache
+                    .read(finger_print, self.options.file_counter, &mut || self.read())
+            },
+            profile_name,
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -68,8 +68,10 @@ impl Executor for CsvExec {
                 .map(|ae| ae.as_expression().unwrap().clone()),
             slice: (self.options.skip_rows, self.options.n_rows),
         };
-        state
-            .file_cache
-            .read(finger_print, self.options.file_counter, &mut || self.read())
+        state.record(|| {
+            state
+                .file_cache
+                .read(finger_print, self.options.file_counter, &mut || self.read())
+        }, "csv_scan")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -39,10 +39,15 @@ impl Executor for IpcExec {
                 .map(|ae| ae.as_expression().unwrap().clone()),
             slice: (0, self.options.n_rows),
         };
-        state
-            .file_cache
-            .read(finger_print, self.options.file_counter, &mut || {
-                self.read(state.verbose())
-            })
+
+        state.record(|| {
+
+            state
+                .file_cache
+                .read(finger_print, self.options.file_counter, &mut || {
+                    self.read(state.verbose())
+                })
+
+        }, "ipc_scan")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -40,14 +40,26 @@ impl Executor for IpcExec {
             slice: (0, self.options.n_rows),
         };
 
-        state.record(|| {
+        let profile_name = if state.has_node_timer() {
+            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            if self.predicate.is_some() {
+                ids.push("predicate".to_string())
+            }
+            let name = column_delimited("ipc".to_string(), &ids);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
 
-            state
-                .file_cache
-                .read(finger_print, self.options.file_counter, &mut || {
-                    self.read(state.verbose())
-                })
-
-        }, "ipc_scan")
+        state.record(
+            || {
+                state
+                    .file_cache
+                    .read(finger_print, self.options.file_counter, &mut || {
+                        self.read(state.verbose())
+                    })
+            },
+            profile_name,
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -112,16 +112,19 @@ pub(crate) struct AnonymousScanExec {
 
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
-        state.record(|| {
-            let mut df = self.function.scan(self.options.clone())?;
-            if let Some(predicate) = &self.predicate {
-                let s = predicate.evaluate(&df, state)?;
-                let mask = s.bool().map_err(|_| {
-                    PolarsError::ComputeError("filter predicate was not of type boolean".into())
-                })?;
-                df = df.filter(mask)?;
-            }
-            Ok(df)
-        }, "anonymous_scan")
+        state.record(
+            || {
+                let mut df = self.function.scan(self.options.clone())?;
+                if let Some(predicate) = &self.predicate {
+                    let s = predicate.evaluate(&df, state)?;
+                    let mask = s.bool().map_err(|_| {
+                        PolarsError::ComputeError("filter predicate was not of type boolean".into())
+                    })?;
+                    df = df.filter(mask)?;
+                }
+                Ok(df)
+            },
+            "anonymous_scan".into(),
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -112,14 +112,16 @@ pub(crate) struct AnonymousScanExec {
 
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &mut ExecutionState) -> Result<DataFrame> {
-        let mut df = self.function.scan(self.options.clone())?;
-        if let Some(predicate) = &self.predicate {
-            let s = predicate.evaluate(&df, state)?;
-            let mask = s.bool().map_err(|_| {
-                PolarsError::ComputeError("filter predicate was not of type boolean".into())
-            })?;
-            df = df.filter(mask)?;
-        }
-        Ok(df)
+        state.record(|| {
+            let mut df = self.function.scan(self.options.clone())?;
+            if let Some(predicate) = &self.predicate {
+                let s = predicate.evaluate(&df, state)?;
+                let mask = s.bool().map_err(|_| {
+                    PolarsError::ComputeError("filter predicate was not of type boolean".into())
+                })?;
+                df = df.filter(mask)?;
+            }
+            Ok(df)
+        }, "anonymous_scan")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -60,11 +60,25 @@ impl Executor for ParquetExec {
                 .map(|ae| ae.as_expression().unwrap().clone()),
             slice: (0, self.options.n_rows),
         };
-        state.record(|| {
-            state
-                .file_cache
-                .read(finger_print, self.options.file_counter, &mut || self.read())
 
-        }, "parquet_scan")
+        let profile_name = if state.has_node_timer() {
+            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            if self.predicate.is_some() {
+                ids.push("predicate".to_string())
+            }
+            let name = column_delimited("parquet".to_string(), &ids);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
+        state.record(
+            || {
+                state
+                    .file_cache
+                    .read(finger_print, self.options.file_counter, &mut || self.read())
+            },
+            profile_name,
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -60,8 +60,11 @@ impl Executor for ParquetExec {
                 .map(|ae| ae.as_expression().unwrap().clone()),
             slice: (0, self.options.n_rows),
         };
-        state
-            .file_cache
-            .read(finger_print, self.options.file_counter, &mut || self.read())
+        state.record(|| {
+            state
+                .file_cache
+                .read(finger_print, self.options.file_counter, &mut || self.read())
+
+        }, "parquet_scan")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -18,6 +18,9 @@ impl Executor for SliceExec {
             }
         }
         let df = self.input.execute(state)?;
-        Ok(df.slice(self.offset, self.len as usize))
+
+        state.record(|| {
+            Ok(df.slice(self.offset, self.len as usize))
+        }, "slice")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -19,8 +19,9 @@ impl Executor for SliceExec {
         }
         let df = self.input.execute(state)?;
 
-        state.record(|| {
-            Ok(df.slice(self.offset, self.len as usize))
-        }, "slice")
+        state.record(
+            || Ok(df.slice(self.offset, self.len as usize)),
+            "slice".into(),
+        )
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/sort.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use polars_core::prelude::*;
 
 use crate::physical_plan::state::ExecutionState;
@@ -10,7 +12,6 @@ pub(crate) struct SortExec {
 }
 
 impl SortExec {
-
     fn execute_impl(&mut self, state: &mut ExecutionState, mut df: DataFrame) -> Result<DataFrame> {
         df.as_single_chunk_par();
 
@@ -37,9 +38,7 @@ impl SortExec {
             self.args.nulls_last,
             self.args.slice,
         )
-
     }
-
 }
 
 impl Executor for SortExec {
@@ -52,11 +51,21 @@ impl Executor for SortExec {
         }
         let df = self.input.execute(state)?;
 
+        let profile_name = if state.has_node_timer() {
+            let by = self
+                .by_column
+                .iter()
+                .map(|s| Ok(s.to_field(&df.schema())?.name))
+                .collect::<Result<Vec<_>>>()?;
+            let name = column_delimited("sort".to_string(), &by);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
         if state.has_node_timer() {
             let new_state = state.clone();
-            new_state.record(|| {
-                self.execute_impl(state, df)
-            }, "sort")
+            new_state.record(|| self.execute_impl(state, df), profile_name)
         } else {
             self.execute_impl(state, df)
         }

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
@@ -14,7 +16,6 @@ pub struct StackExec {
 }
 
 impl StackExec {
-
     fn execute_impl(&mut self, state: &mut ExecutionState, mut df: DataFrame) -> Result<DataFrame> {
         state.set_schema(self.input_schema.clone());
         let res = if self.has_windows {
@@ -44,7 +45,6 @@ impl StackExec {
         }
 
         Ok(df)
-
     }
 }
 
@@ -58,11 +58,21 @@ impl Executor for StackExec {
         }
         let df = self.input.execute(state)?;
 
+        let profile_name = if state.has_node_timer() {
+            let by = self
+                .expr
+                .iter()
+                .map(|s| Ok(s.to_field(&self.input_schema)?.name))
+                .collect::<Result<Vec<_>>>()?;
+            let name = column_delimited("with_column".to_string(), &by);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
         if state.has_node_timer() {
             let new_state = state.clone();
-            new_state.record(|| {
-                self.execute_impl(state, df)
-            }, "stack")
+            new_state.record(|| self.execute_impl(state, df), profile_name)
         } else {
             self.execute_impl(state, df)
         }

--- a/polars/polars-lazy/src/physical_plan/executors/udf.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/udf.rs
@@ -17,6 +17,9 @@ impl Executor for UdfExec {
             }
         }
         let df = self.input.execute(state)?;
-        self.function.call_udf(df)
+
+        state.record(|| {
+            self.function.call_udf(df)
+        }, "udf")
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/udf.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/udf.rs
@@ -18,8 +18,6 @@ impl Executor for UdfExec {
         }
         let df = self.input.execute(state)?;
 
-        state.record(|| {
-            self.function.call_udf(df)
-        }, "udf")
+        state.record(|| self.function.call_udf(df), "udf".into())
     }
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -16,6 +16,7 @@ mod ternary;
 mod window;
 
 use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
 
 pub(crate) use aggregation::*;
 pub(crate) use alias::*;
@@ -590,6 +591,15 @@ pub trait PhysicalExpr: Send + Sync {
 
     fn is_literal(&self) -> bool {
         false
+    }
+}
+
+impl Display for &dyn PhysicalExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.as_expression() {
+            None => Ok(()),
+            Some(e) => write!(f, "{}", e),
+        }
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -6,6 +6,7 @@ pub mod expressions;
 mod file_cache;
 pub mod planner;
 pub(crate) mod state;
+mod node_timer;
 
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -4,9 +4,9 @@ pub(crate) mod exotic;
 pub mod expressions;
 #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
 mod file_cache;
+mod node_timer;
 pub mod planner;
 pub(crate) mod state;
-mod node_timer;
 
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;

--- a/polars/polars-lazy/src/physical_plan/node_timer.rs
+++ b/polars/polars-lazy/src/physical_plan/node_timer.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+use std::time::Instant;
+use parking_lot::Mutex;
+use polars_core::prelude::*;
+use polars_core::utils::NoNull;
+
+type StartInstant = Instant;
+type EndInstant = Instant;
+
+type Nodes= Vec<String>;
+type Ticks= Vec<(StartInstant, EndInstant)>;
+
+#[derive(Clone)]
+pub(super) struct NodeTimer {
+    query_start: Instant,
+    data: Arc<Mutex<(Nodes, Ticks)>>
+}
+
+impl NodeTimer {
+    pub(super) fn new() -> Self {
+        Self {
+            query_start: Instant::now(),
+            data: Arc::new(Mutex::new((
+                Vec::with_capacity(16),
+                Vec::with_capacity(16),
+                )))
+        }
+    }
+
+    pub(super) fn store(&self, start: StartInstant, end: EndInstant, name: String) {
+        let mut data = self.data.lock();
+        let nodes = &mut data.0;
+        nodes.push(name);
+        let ticks = &mut data.1;
+        ticks.push((start, end))
+    }
+
+    pub(super) fn finish(self) -> Result<DataFrame> {
+        let mut data = self.data.lock();
+        let mut nodes = std::mem::take(&mut data.0);
+        nodes.push("optimization".to_string());
+
+        let mut ticks = std::mem::take(&mut data.1);
+        // first value is end of optimization
+        if ticks.is_empty() {
+            return Err(PolarsError::ComputeError("no data to time".into()))
+        } else {
+            let start = ticks[0].0;
+            ticks.push((self.query_start, start))
+        }
+        let nodes_s = Series::new("node", nodes);
+        let start: NoNull<UInt64Chunked> = ticks.iter().map(|(start, _)| {
+            (start.duration_since(self.query_start)).as_micros() as u64
+        }).collect();
+        let mut start = start.into_inner();
+        start.rename("start");
+
+        let end: NoNull<UInt64Chunked> = ticks.iter().map(|(_, end)| {
+            (end.duration_since(self.query_start)).as_micros() as u64
+        }).collect();
+        let mut end = end.into_inner();
+        end.rename("end");
+
+        DataFrame::new(vec![
+            nodes_s,
+            start.into_series(),
+            end.into_series()
+        ])
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/node_timer.rs
+++ b/polars/polars-lazy/src/physical_plan/node_timer.rs
@@ -52,16 +52,16 @@ impl NodeTimer {
             .map(|(start, _)| (start.duration_since(self.query_start)).as_micros() as u64)
             .collect();
         let mut start = start.into_inner();
-        start.rename("start[us]");
+        start.rename("start");
 
         let end: NoNull<UInt64Chunked> = ticks
             .iter()
             .map(|(_, end)| (end.duration_since(self.query_start)).as_micros() as u64)
             .collect();
         let mut end = end.into_inner();
-        end.rename("end[us]");
+        end.rename("end");
 
         DataFrame::new_no_checks(vec![nodes_s, start.into_series(), end.into_series()])
-            .sort(vec!["start[us]"], vec![false])
+            .sort(vec!["start"], vec![false])
     }
 }

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -3,6 +3,7 @@ use parking_lot::Mutex;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::frame::hash_join::JoinOptIds;
 use polars_core::prelude::*;
+use crate::physical_plan::node_timer::NodeTimer;
 
 #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
 use super::file_cache::FileCache;
@@ -58,9 +59,36 @@ pub struct ExecutionState {
     pub(super) branch_idx: usize,
     pub(super) flags: StateFlags,
     pub(super) ext_contexts: Arc<Vec<DataFrame>>,
+    node_timer: Option<NodeTimer>
 }
 
 impl ExecutionState {
+    /// Toggle this to measure execution times.
+    pub(crate) fn time_nodes(&mut self) {
+        self.node_timer = Some(NodeTimer::new())
+    }
+    pub(super) fn has_node_timer(&self) -> bool {
+        self.node_timer.is_some()
+    }
+
+    pub(crate) fn finish_timer(self) -> Result<DataFrame> {
+        self.node_timer.unwrap().finish()
+    }
+
+    pub(super) fn record<T, F: FnOnce() -> T>(&self, func: F, name: &str) -> T{
+        match &self.node_timer {
+            None => func(),
+            Some(timer) => {
+                let start = std::time::Instant::now();
+                let out = func();
+                let end = std::time::Instant::now();
+
+                timer.store(start, end, name.to_string());
+                out
+            }
+        }
+    }
+
     /// Partially clones and partially clears state
     pub(super) fn split(&self) -> Self {
         Self {
@@ -73,6 +101,23 @@ impl ExecutionState {
             branch_idx: self.branch_idx,
             flags: self.flags,
             ext_contexts: self.ext_contexts.clone(),
+            node_timer: self.node_timer.clone(),
+        }
+    }
+
+    /// clones and partially clears state
+    pub(super) fn clone(&self) -> Self {
+        Self {
+            df_cache: self.df_cache.clone(),
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            file_cache: self.file_cache.clone(),
+            schema_cache: self.schema_cache.clone(),
+            group_tuples: self.group_tuples.clone(),
+            join_tuples: self.join_tuples.clone(),
+            branch_idx: self.branch_idx,
+            flags: self.flags,
+            ext_contexts: self.ext_contexts.clone(),
+            node_timer: self.node_timer.clone(),
         }
     }
 
@@ -92,6 +137,7 @@ impl ExecutionState {
             branch_idx: 0,
             flags: StateFlags::init(),
             ext_contexts: Default::default(),
+            node_timer: None
         }
     }
 
@@ -102,15 +148,16 @@ impl ExecutionState {
             flags |= StateFlags::VERBOSE;
         }
         Self {
-            df_cache: Arc::new(Mutex::new(PlHashMap::default())),
+            df_cache: Default::default(),
             schema_cache: Default::default(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: FileCache::new(None),
-            group_tuples: Arc::new(Mutex::new(PlHashMap::default())),
-            join_tuples: Arc::new(Mutex::new(PlHashMap::default())),
+            group_tuples: Default::default(),
+            join_tuples: Default::default(),
             branch_idx: 0,
             flags: StateFlags::init(),
             ext_contexts: Default::default(),
+            node_timer: None
         }
     }
     pub(crate) fn set_schema(&mut self, schema: SchemaRef) {

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -8,6 +8,19 @@ use crate::logical_plan::Context;
 use crate::prelude::names::COUNT;
 use crate::prelude::*;
 
+// write some thing
+pub(crate) fn column_delimited(mut s: String, items: &[String]) -> String {
+    s.push('(');
+    for c in items {
+        s.push_str(c);
+        s.push_str(", ");
+    }
+    s.pop();
+    s.pop();
+    s.push(')');
+    s
+}
+
 pub(crate) trait PushNode {
     fn push_node(&mut self, value: Node);
 }

--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -12,7 +12,7 @@ Attributes
 ----------
 
 .. autosummary::
-   :toctree: api/
+   :toctree: apimut /
 
     LazyFrame.columns
     LazyFrame.dtypes
@@ -107,6 +107,7 @@ Various
     LazyFrame.collect
     LazyFrame.fetch
     LazyFrame.pipe
+    LazyFrame.profile
 
 GroupBy
 -------

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1538,12 +1538,7 @@ def collect_all(
     simplify_expression
         Run simplify expressions optimization.
     string_cache
-        Use a global string cache in this query.
-        This is needed if you want to join on categorical columns.
-
-        Caution!
-            If you already have set a global string cache, set this to `False` as this
-            will reset the global cache when the query is finished.
+        This argument is deprecated and will be ignored
     no_optimization
         Turn off optimizations.
     slice_pushdown
@@ -1567,7 +1562,6 @@ def collect_all(
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
-            string_cache,
             slice_pushdown,
         )
         prepared.append(ldf)

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -559,7 +559,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
-            string_cache=False,
             slice_pushdown=slice_pushdown,
         )
 
@@ -698,6 +697,55 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by = pli.selection_to_pyexpr_list(by)
         return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse, nulls_last))
 
+    def collect_and_time(
+            self,
+            type_coercion: bool = True,
+            predicate_pushdown: bool = True,
+            projection_pushdown: bool = True,
+            simplify_expression: bool = True,
+            no_optimization: bool = False,
+            slice_pushdown: bool = True,
+    ) -> tuple[pli.DataFrame, pli.DataFrame]:
+        """
+        Collect into a DataFrame.
+
+        Note: use :func:`fetch` if you want to run your query on the first `n` rows
+        only. This can be a huge time saver in debugging queries.
+
+        Parameters
+        ----------
+        type_coercion
+            Do type coercion optimization.
+        predicate_pushdown
+            Do predicate pushdown optimization.
+        projection_pushdown
+            Do projection pushdown optimization.
+        simplify_expression
+            Run simplify expressions optimization.
+        no_optimization
+            Turn off (certain) optimizations.
+        slice_pushdown
+            Slice pushdown optimization.
+
+        Returns
+        -------
+        DataFrame
+
+        """
+        if no_optimization:
+            predicate_pushdown = False
+            projection_pushdown = False
+
+        ldf = self._ldf.optimization_toggle(
+            type_coercion,
+            predicate_pushdown,
+            projection_pushdown,
+            simplify_expression,
+            slice_pushdown,
+        )
+        df, timings = ldf.collect_and_time()
+        return pli.wrap_df(df), pli.wrap_df(timings)
+
     def collect(
         self,
         type_coercion: bool = True,
@@ -726,13 +774,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Run simplify expressions optimization.
         string_cache
             This argument is deprecated. Please set the string cache globally.
-
-            Use a global string cache in this query.
-            This is needed if you want to join on categorical columns.
-
-            Caution!
-                If you already have set a global string cache, set this to `False` as
-                this will reset the global cache when the query is finished.
+            The argument will be ignored
         no_optimization
             Turn off (certain) optimizations.
         slice_pushdown
@@ -752,7 +794,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
-            string_cache,
             slice_pushdown,
         )
         return pli.wrap_df(ldf.collect())
@@ -793,9 +834,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Run simplify expressions optimization.
         string_cache
             This argument is deprecated. Please set the string cache globally.
-
-            Use a global string cache in this query.
-            This is needed if you want to join on categorical columns.
+            The argument will be ignored
         no_optimization
             Turn off optimizations.
         slice_pushdown
@@ -816,7 +855,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
-            string_cache,
             slice_pushdown,
         )
         return pli.wrap_df(ldf.fetch(n_rows))

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -707,10 +707,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         slice_pushdown: bool = True,
     ) -> tuple[pli.DataFrame, pli.DataFrame]:
         """
-        Collect into a DataFrame.
+        Profile a LazyFrame.
 
-        Note: use :func:`fetch` if you want to run your query on the first `n` rows
-        only. This can be a huge time saver in debugging queries.
+        This will run the query and return a tuple
+        containing the materialized DataFrame and a DataFrame that
+        contains profiling information of each node that is executed.
+
+        The units of the timings are microseconds.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -697,14 +697,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by = pli.selection_to_pyexpr_list(by)
         return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse, nulls_last))
 
-    def collect_and_time(
-            self,
-            type_coercion: bool = True,
-            predicate_pushdown: bool = True,
-            projection_pushdown: bool = True,
-            simplify_expression: bool = True,
-            no_optimization: bool = False,
-            slice_pushdown: bool = True,
+    def profile(
+        self,
+        type_coercion: bool = True,
+        predicate_pushdown: bool = True,
+        projection_pushdown: bool = True,
+        simplify_expression: bool = True,
+        no_optimization: bool = False,
+        slice_pushdown: bool = True,
     ) -> tuple[pli.DataFrame, pli.DataFrame]:
         """
         Collect into a DataFrame.
@@ -743,7 +743,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
         )
-        df, timings = ldf.collect_and_time()
+        df, timings = ldf.profile()
         return pli.wrap_df(df), pli.wrap_df(timings)
 
     def collect(

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -347,7 +347,6 @@ impl PyLazyFrame {
         predicate_pushdown: bool,
         projection_pushdown: bool,
         simplify_expr: bool,
-        string_cache: bool,
         slice_pushdown: bool,
     ) -> PyLazyFrame {
         let ldf = self.ldf.clone();
@@ -355,7 +354,6 @@ impl PyLazyFrame {
             .with_type_coercion(type_coercion)
             .with_predicate_pushdown(predicate_pushdown)
             .with_simplify_expr(simplify_expr)
-            .with_string_cache(string_cache)
             .with_slice_pushdown(slice_pushdown)
             .with_projection_pushdown(projection_pushdown);
         ldf.into()
@@ -386,6 +384,16 @@ impl PyLazyFrame {
     pub fn cache(&self) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         ldf.cache().into()
+    }
+
+    pub fn collect_and_time(&self, py: Python) -> PyResult<(PyDataFrame, PyDataFrame)> {
+        // if we don't allow threads and we have udfs trying to acquire the gil from different
+        // threads we deadlock.
+        let (df, time_df) = py.allow_threads(|| {
+            let ldf = self.ldf.clone();
+            ldf.collect_and_time().map_err(PyPolarsErr::from)
+        })?;
+        Ok((df.into(), time_df.into()))
     }
 
     pub fn collect(&self, py: Python) -> PyResult<PyDataFrame> {

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -386,12 +386,12 @@ impl PyLazyFrame {
         ldf.cache().into()
     }
 
-    pub fn collect_and_time(&self, py: Python) -> PyResult<(PyDataFrame, PyDataFrame)> {
+    pub fn profile(&self, py: Python) -> PyResult<(PyDataFrame, PyDataFrame)> {
         // if we don't allow threads and we have udfs trying to acquire the gil from different
         // threads we deadlock.
         let (df, time_df) = py.allow_threads(|| {
             let ldf = self.ldf.clone();
-            ldf.collect_and_time().map_err(PyPolarsErr::from)
+            ldf.profile().map_err(PyPolarsErr::from)
         })?;
         Ok((df.into(), time_df.into()))
     }


### PR DESCRIPTION
With this you can call `profile` on a `LazyFrame` and get a result dataframe and a dataframe that contains the duration of each node.

This can help understanding which parts of a query take up the run time. I hope we can add the plotting logic later as well. I tried a little bit with plotly, but it requires a bit more knowledge/patience to get the a proper plot.

![image](https://user-images.githubusercontent.com/3023000/188885033-882076d1-f558-4a36-a8e4-42a87f4df151.png)


This work also convinces me that we should reuse much of the `Executor` architecture similar to what we already do with expressions.