### PR TITLE
feat[python]: a new frame-alignment utility function

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -63,7 +63,13 @@ from polars.exceptions import (
 from polars.internals.dataframe import wrap_df  # noqa: F401
 from polars.internals.dataframe import DataFrame
 from polars.internals.expr import Expr
-from polars.internals.functions import concat, cut, date_range, get_dummies
+from polars.internals.functions import (
+    align_frames,
+    concat,
+    cut,
+    date_range,
+    get_dummies,
+)
 from polars.internals.io import read_ipc_schema, read_parquet_schema
 from polars.internals.lazy_functions import _date as date
 from polars.internals.lazy_functions import _datetime as datetime
@@ -196,11 +202,12 @@ __all__ = [
     "using_string_cache",
     # polars.config
     "Config",
-    # polars.internal.when
+    # polars.internals.whenthen
     "when",
-    # polars.internal.expr
+    # polars.internals.expr
     "Expr",
-    # polars.internal.functions
+    # polars.internals.functions
+    "align_frames",
     "arg_where",
     "concat",
     "date_range",
@@ -208,7 +215,7 @@ __all__ = [
     "repeat",
     "element",
     "cut",
-    # polars.internal.lazy_functions
+    # polars.internals.lazy_functions
     "col",
     "count",
     "std",

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -242,7 +242,7 @@ def from_arrow(
     a : Arrow Table or Array
         Data represented as Arrow Table or Array.
     rechunk : bool, default True
-        Make sure that all data is contiguous.
+        Make sure that all data is in contiguous memory.
 
     Returns
     -------
@@ -329,7 +329,7 @@ def from_pandas(
     df : pandas DataFrame, Series, or DatetimeIndex
         Data represented as a pandas DataFrame, Series, or DatetimeIndex.
     rechunk : bool, default True
-        Make sure that all data is contiguous.
+        Make sure that all data is in contiguous memory.
     nan_to_none : bool, default True
         If data contains NaN values PyArrow will convert the NaN to None
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -441,7 +441,7 @@ class DataFrame:
             If not specified, existing Array table columns are used, with missing names
             named as `column_0`, `column_1`, etc.
         rechunk : bool, default True
-            Make sure that all data is contiguous.
+            Make sure that all data is in contiguous memory.
 
         Returns
         -------
@@ -469,7 +469,7 @@ class DataFrame:
             Column labels to use for resulting DataFrame. If specified, overrides any
             labels already present in the data. Must match data dimensions.
         rechunk : bool, default True
-            Make sure that all data is contiguous.
+            Make sure that all data is in contiguous memory.
         nan_to_none : bool, default True
             If data contains NaN values PyArrow will convert the NaN to None
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -667,8 +667,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def sort(
         self: LDF,
-        by: str | pli.Expr | list[str] | list[pli.Expr],
-        reverse: bool | list[bool] = False,
+        by: str
+        | pli.Expr
+        | Sequence[str]
+        | Sequence[pli.Expr]
+        | Sequence[str | pli.Expr],
+        reverse: bool | Sequence[bool] = False,
         nulls_last: bool = False,
     ) -> LDF:
         """


### PR DESCRIPTION
This seems to fill a small gap in the function lineup and will be especially useful in helping users transition from pandas, where implicit alignment by index is used _constantly_ (eg: row-wise dot product across 'n' frames on a given index). This function makes that alignment explicit with respect to polars frames. It also leaves plenty of space for optimal/dedicated functions to emerge later; this is something I'll be keeping an eye on with our quant/research users.

To set the scene - this is neither an outer join, nor a concat/stack, though it contains elements of both.

Description
-----
`pl.align_frames( *frames, on=[keycol] )`
* Takes "n" frames.
* Takes one or more common columns containing the values to align on.
* Aligns the data in those frames by the unique set of those key/index values. 
* Frames which do not contain rows matching the key values have rows inserted (like an outer join).
* The output is the same number of frames as input, all now aligned by key/index, all having the same number of rows.
* Does not implement any specific functions that benefit from this type of alignment - remains general.
* The function works with both `DataFrame` _and_ `LazyFrame` input.

Visually
-----
_Before alignment_
```
# df1                              df2                              df3
# shape: (3, 3)                    shape: (3, 3)                    shape: (2, 3)
# ┌────────────┬─────┬──────┐      ┌────────────┬─────┬──────┐      ┌────────────┬─────┬─────┐
# │ dt         ┆ x   ┆ y    │      │ dt         ┆ x   ┆ y    │      │ dt         ┆ x   ┆ y   │
# │ ---        ┆ --- ┆ ---  │      │ ---        ┆ --- ┆ ---  │      │ ---        ┆ --- ┆ --- │
# │ date       ┆ f64 ┆ f64  │      │ date       ┆ f64 ┆ f64  │      │ date       ┆ f64 ┆ f64 │
# ╞════════════╪═════╪══════╡      ╞════════════╪═════╪══════╡      ╞════════════╪═════╪═════╡
# │ 2022-09-01 ┆ 3.5 ┆ 10.0 │      │ 2022-09-02 ┆ 8.0 ┆ 1.5  │      │ 2022-09-03 ┆ 2.0 ┆ 2.5 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤
# │ 2022-09-02 ┆ 4.0 ┆ 2.5  │      │ 2022-09-03 ┆ 1.0 ┆ 12.0 │      │ 2022-09-02 ┆ 5.0 ┆ 2.0 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      └────────────┴─────┴─────┘
# │ 2022-09-03 ┆ 1.0 ┆ 1.5  │      │ 2022-09-01 ┆ 3.5 ┆ 5.0  │
# └────────────┴─────┴──────┘      └────────────┴─────┴──────┘
``` 
_After alignment (on "dt")_
``` 
# df1                              df2                              df3
# shape: (3, 3)                    shape: (3, 3)                    shape: (3, 3)
# ┌────────────┬─────┬──────┐      ┌────────────┬─────┬──────┐      ┌────────────┬──────┬──────┐
# │ dt         ┆ x   ┆ y    │      │ dt         ┆ x   ┆ y    │      │ dt         ┆ x    ┆ y    │
# │ ---        ┆ --- ┆ ---  │      │ ---        ┆ --- ┆ ---  │      │ ---        ┆ ---  ┆ ---  │
# │ date       ┆ f64 ┆ f64  │      │ date       ┆ f64 ┆ f64  │      │ date       ┆ f64  ┆ f64  │
# ╞════════════╪═════╪══════╡      ╞════════════╪═════╪══════╡      ╞════════════╪══════╪══════╡
# │ 2022-09-01 ┆ 3.5 ┆ 10.0 │      │ 2022-09-01 ┆ 3.5 ┆ 5.0  │      │ 2022-09-01 ┆ null ┆ null │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ 2022-09-02 ┆ 4.0 ┆ 2.5  │      │ 2022-09-02 ┆ 8.0 ┆ 1.5  │      │ 2022-09-02 ┆ 5.0  ┆ 2.0  │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤      ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ 2022-09-03 ┆ 1.0 ┆ 1.5  │      │ 2022-09-03 ┆ 1.0 ┆ 12.0 │      │ 2022-09-03 ┆ 2.0  ┆ 2.5  │
# └────────────┴─────┴──────┘      └────────────┴─────┴──────┘      └────────────┴──────┴──────┘ 
```


Example
-----
```python
from datetime import date
import polars as pl

# setup some test frames with rows that are disjoint by date
df1 = pl.DataFrame( 
    data = [
        (date(2022,1,3), 1.0, 10.0),
        (date(2022,1,4), 2.0, 11.0),
        (date(2022,1,6), 4.0, 13.0),
        (date(2022,1,7), 5.0, 14.0),
        (date(2022,1,8), 6.0, 15.0),
        (date(2022,1,9), 7.0, 16.0),
    ],
    columns = ["date" ,"x", "y"],
)
df2 = pl.DataFrame(
    data = [
        (date(2022,1,4),  9.0, 10.0),
        (date(2022,1,5), 10.0, 11.0),
        (date(2022,1,6), 11.0, 12.0),
        (date(2022,1,7), 12.0, 13.0),
        (date(2022,1,8), 13.0, 14.0),
        (date(2022,1,9), 14.0, 15.0),
    ],
    columns = ["date" ,"x", "y"],
)

# align the frames on "date", selecting-out only cols "x" and "y"
df1, df2 = pl.align_frames( df1, df2, on=["date"], select=["x", "y"] )

# now the frames have been aligned, can easily get the row-wise dot product
df_dot = ( df1 * df2 ).fill_null( 0 ).select( pl.sum(pl.col("*")).alias("dot") )

# shape: (8, 1)
# ┌───────┐
# │ dot   │
# │ ---   │
# │ f64   │
# ╞═══════╡
# │ 0.0   │
# ├╌╌╌╌╌╌╌┤
# │ 128.0 │
# ├╌╌╌╌╌╌╌┤
# │ 0.0   │
# ├╌╌╌╌╌╌╌┤
# │ 200.0 │
# ├╌╌╌╌╌╌╌┤
# │ 242.0 │
# ├╌╌╌╌╌╌╌┤
# │ 288.0 │
# ├╌╌╌╌╌╌╌┤
# │ 338.0 │
# └───────┘
```
The last line above is now closer to the compact pandas-equivalent (which assumes -and relies on- an index)...
```python
( df1 * df2 ).sum( axis="columns" ).to_frame( "dot" )

#               dot
# date             
# 2022-01-03    0.0
# 2022-01-04  128.0
# 2022-01-05    0.0
# 2022-01-06  200.0
# 2022-01-07  242.0
# 2022-01-08  288.0
# 2022-01-09  338.0
```
...and doesn't require explicitly constructing joins (which would have to be chained for n > 2) or managing renames (to avoid column name collisions in the joins) or anything more involved; the alignment setup is sufficient, and is an approach that is transferable to a lot of other use-cases, in-lieu of future optimal/dedicated functions.
