### PR TITLE
ci[python]: Improved clippy

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
           override: true
-          components: rustfmt, clippy
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -21,7 +21,6 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
           override: true
-          components: rustfmt, clippy
       - name: Setup universal2 targets for Rust
         run: |
           rustup target add aarch64-apple-darwin

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -20,7 +20,6 @@ jobs:
           with:
             toolchain: nightly-2022-08-22
             override: true
-            components: rustfmt, clippy
         - name: Set up Python
           uses: actions/setup-python@v3
           with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
           override: true
-          components: rustfmt, clippy
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
-          cargo clippy -- -D warnings -A clippy::borrow_deref_ref
+          make clippy
       - name: Check doc examples
         run: |
           cd py-polars && make doctest
@@ -105,7 +105,7 @@ jobs:
         run: |
           export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
-          cargo clippy -- -D warnings -A clippy::borrow_deref_ref
+          make clippy
       - name: Check doc examples
         run: |
           cd py-polars && make doctest

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
-          cargo clippy
+          cargo clippy -- -D warnings -A clippy::borrow_deref_ref
       - name: Check doc examples
         run: |
           cd py-polars && make doctest
@@ -105,7 +105,7 @@ jobs:
         run: |
           export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
-          cargo clippy
+          cargo clippy -- -D warnings -A clippy::borrow_deref_ref
       - name: Check doc examples
         run: |
           cd py-polars && make doctest

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -34,6 +34,10 @@ pre-commit: venv  ## Run autoformatting and linting
 	make -C .. fmt_toml
 	cargo fmt --all
 
+.PHONY: clippy
+clippy:  ## Run clippy
+	cargo clippy -- -D warnings -A clippy::borrow_deref_ref
+
 .PHONY: test
 test: venv  ## Run fast unittests
 	$(PYTHON_BIN)/maturin develop

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -238,7 +238,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         let mut null_count = 0;
         for opt_v in self.into_iter() {
             if let Some(v) = opt_v {
-                let arg = PyTuple::new(py, &[v]);
+                let arg = PyTuple::new(py, [v]);
                 let out = lambda.call1(arg)?;
                 if out.is_none() {
                     null_count += 1;
@@ -534,7 +534,7 @@ where
         let mut null_count = 0;
         for opt_v in self.into_iter() {
             if let Some(v) = opt_v {
-                let arg = PyTuple::new(py, &[v]);
+                let arg = PyTuple::new(py, [v]);
                 let out = lambda.call1(arg)?;
                 if out.is_none() {
                     null_count += 1;
@@ -825,7 +825,7 @@ impl<'a> ApplyLambda<'a> for Utf8Chunked {
         let mut null_count = 0;
         for opt_v in self.into_iter() {
             if let Some(v) = opt_v {
-                let arg = PyTuple::new(py, &[v]);
+                let arg = PyTuple::new(py, [v]);
                 let out = lambda.call1(arg)?;
                 if out.is_none() {
                     null_count += 1;
@@ -1651,7 +1651,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         let mut null_count = 0;
         for opt_v in self.into_iter() {
             if let Some(v) = opt_v {
-                let arg = PyTuple::new(py, &[v]);
+                let arg = PyTuple::new(py, [v]);
                 let out = lambda.call1(arg)?;
                 if out.is_none() {
                     null_count += 1;

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -455,7 +455,7 @@ impl PyDataFrame {
         float_precision: Option<usize>,
         null_value: Option<String>,
     ) -> PyResult<()> {
-        let null = null_value.unwrap_or(String::new());
+        let null = null_value.unwrap_or_default();
 
         if let Ok(s) = py_f.extract::<&str>(py) {
             let f = std::fs::File::create(s).unwrap();

--- a/py-polars/src/lazy/apply.rs
+++ b/py-polars/src/lazy/apply.rs
@@ -127,7 +127,7 @@ pub fn map_single(
     let output_type2 = output_type.clone();
     let function = move |s: Series| {
         Python::with_gil(|py| {
-            let output_type = output_type2.clone().unwrap_or_else(|| DataType::Unknown);
+            let output_type = output_type2.clone().unwrap_or(DataType::Unknown);
 
             // this is a python Series
             let out = call_lambda_with_series(py, s.clone(), &lambda, &POLARS)

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1695,18 +1695,16 @@ pub fn lit(value: &PyAny, allow_object: bool) -> PyResult<PyExpr> {
         Ok(dsl::lit(series.series).into())
     } else if value.is_none() {
         Ok(dsl::lit(Null {}).into())
+    } else if allow_object {
+        let s = Python::with_gil(|py| {
+            PySeries::new_object("", vec![ObjectValue::from(value.into_py(py))], false).series
+        });
+        Ok(dsl::lit(s).into())
     } else {
-        if allow_object {
-            let s = Python::with_gil(|py| {
-                PySeries::new_object("", vec![ObjectValue::from(value.into_py(py))], false).series
-            });
-            Ok(dsl::lit(s).into())
-        } else {
-            Err(PyValueError::new_err(format!(
-                "could not convert value {:?} as a Literal",
-                value.str()?
-            )))
-        }
+        Err(PyValueError::new_err(format!(
+            "could not convert value {:?} as a Literal",
+            value.str()?
+        )))
     }
 }
 

--- a/py-polars/src/set.rs
+++ b/py-polars/src/set.rs
@@ -78,19 +78,15 @@ pub(crate) fn set_at_idx(mut s: Series, idx: &Series, values: &Series) -> Result
             let ca = s.bool()?;
             let values = values.bool()?;
             let value = values.get(0);
-            let out = ca
-                .set_at_idx(idx.into_iter().copied(), value)
-                .map(|ca| ca.into_series())?;
-            out
+            ca.set_at_idx(idx.iter().copied(), value)
+                .map(|ca| ca.into_series())?
         }
         DataType::Utf8 => {
             let ca = s.utf8()?;
             let values = values.utf8()?;
             let value = values.get(0);
-            let out = ca
-                .set_at_idx(idx.into_iter().copied(), value)
-                .map(|ca| ca.into_series())?;
-            out
+            ca.set_at_idx(idx.iter().copied(), value)
+                .map(|ca| ca.into_series())?
         }
         _ => panic!("not yet implemented for dtype: {}", logical_dtype),
     };


### PR DESCRIPTION
Changes:
* Add a `make` command for running `clippy`
* Set `clippy` to fail on warnings and ignore the `borrow_deref_ref` lint that results from a PyO3 issue.
* Fix all `clippy` errors
* Update the "Install Rust" Action in various workflows not to include the clippy component when it isn't being used