### PR TITLE
ci[python]: Merge test-python jobs

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -16,8 +16,9 @@ jobs:
     name: Build and test Python
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
-        python-version: [ "3.10" ]
+        python-version: ['3.7', '3.10']
     steps:
       - uses: actions/checkout@v3
       - name: Install latest Rust nightly
@@ -46,61 +47,10 @@ jobs:
       - name: Run linting
         run: |
           cd py-polars && flake8 && cd ..
+      # Allow untyped calls for older Python versions
       - name: Run type checking
         run: |
-          cd py-polars && mypy && cd ..
-      - name: Run tests
-        run: |
-          export RUSTFLAGS="-C debuginfo=0"
-          cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
-          make clippy
-      - name: Check doc examples
-        run: |
-          cd py-polars && make doctest
-      # test if we can import polars without any requirements
-      - name: Import polars
-        run: |
-          pip uninstall pandas -y
-          python -c "import polars"
-
-  test-python-37:
-    name: Build and test Python 3.7
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.7" ]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-08-22
-          override: true
-          components: rustfmt, clippy
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r py-polars/build.requirements.txt
-      - name: Run formatting checks
-        run: |
-          cd py-polars
-          black --check .
-          blackdoc --check .
-          isort --check .
-          pyupgrade --py37-plus `find . -name "*.py" -type f`
-          rustup override set nightly-2022-08-22 && cargo fmt --all -- --check
-          cd ..
-      - name: Run linting
-        run: |
-          cd py-polars && flake8 && cd ..
-      # this step is different, note the flag
-      - name: Run type checking
-        run: |
-          cd py-polars && mypy --allow-untyped-calls && cd ..
+          cd py-polars && mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }} && cd ..
       - name: Run tests
         run: |
           export RUSTFLAGS="-C debuginfo=0"


### PR DESCRIPTION
Changes:
* Use an expression to set the mypy `--allow-untyped-calls` dynamically based on Python version
* Merge the two jobs into a single matrix job.
  * The jobs in this workflow matrix are set to fail-fast, which means that if one fails, the others will be cancelled. This can be disabled if desired.