### PR TITLE
ci[python,rust]: Use working-directory

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,7 +20,8 @@ jobs:
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - name: "check"
-        run: cd examples && cargo check
+        working-directory: examples
+        run: cargo check
 
   features:
     name: Features
@@ -37,8 +38,8 @@ jobs:
         run: |
           cargo install cargo-hack
       - name: Feature test
-        run: |
-          cd polars && cargo hack check --each-feature --no-dev-deps --features private
+        working-directory: polars
+        run: cargo hack check --each-feature --no-dev-deps --features private
 
   test-rust:
     name: Build and test Rust
@@ -74,8 +75,9 @@ jobs:
       - name: Run linting checks
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+        working-directory: polars
         run : |
-          cd polars && cargo clippy --all-features \
+          cargo clippy --all-features \
           -p polars-core \
           -p polars-io \
           -p polars-lazy \
@@ -84,10 +86,11 @@ jobs:
       - name: Run tests
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
-        run: cd polars && make test && make integration-tests
+        working-directory: polars
+        run: make test && make integration-tests
       - name: Run miri
+        working-directory: polars
         run: |
-          cd polars
           cargo miri setup
           cargo clean
           make miri

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,9 +25,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r py-polars/docs/requirements-docs.txt
       - name: Build python reference
-        run: |
-          cd py-polars/docs
-          make html
+        working-directory: py-polars/docs
+        run: make html
       - name: deploy docs
         env:
           RUSTFLAGS: --cfg docsrs

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -27,6 +27,5 @@ jobs:
       - name: Build python reference
         env:
           SPHINXOPTS: -W
-        run: |
-          cd py-polars/docs
-          make html
+        working-directory: py-polars/docs
+        run: make html

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -19,6 +19,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.7', '3.10']
+    defaults:
+      run:
+        working-directory: py-polars
+
     steps:
       - uses: actions/checkout@v3
       - name: Install latest Rust nightly
@@ -34,32 +38,27 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r py-polars/build.requirements.txt
+          pip install -r build.requirements.txt
       - name: Run formatting checks
         run: |
-          cd py-polars
           black --check .
           blackdoc --check .
           isort --check .
           pyupgrade --py37-plus `find . -name "*.py" -type f`
           rustup override set nightly-2022-08-22 && cargo fmt --all -- --check
-          cd ..
       - name: Run linting
-        run: |
-          cd py-polars && flake8 && cd ..
+        run: flake8
       # Allow untyped calls for older Python versions
       - name: Run type checking
-        run: |
-          cd py-polars && mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }} && cd ..
+        run: mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
       - name: Run tests
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
-          cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
+          rustup override set nightly-2022-08-22 && make venv && make test-with-cov
           make clippy
       - name: Check doc examples
-        run: |
-          cd py-polars && make doctest
+        run: make doctest
       # test if we can import polars without any requirements
       - name: Import polars
         run: |

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -14,6 +14,10 @@ jobs:
   test-python:
     name: Build and test Python
     runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: py-polars
+
     steps:
       - uses: actions/checkout@v3
       - name: Install latest Rust nightly
@@ -29,12 +33,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r py-polars/build.requirements.txt
+          pip install -r build.requirements.txt
       - name: Run tests
         shell: bash
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
-        run: cd py-polars && rustup override set nightly-2022-08-22 && make build-and-test-no-venv
+        run: rustup override set nightly-2022-08-22 && make build-and-test-no-venv
       # test if we can import polars without any requirements
       - name: Import polars
         run: |

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -24,4 +24,5 @@ jobs:
       - name: Run tests
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
-        run: cd polars && make test && make integration-tests
+        working-directory: polars
+        run: make test && make integration-tests


### PR DESCRIPTION
Because of the way the project is structured, with a Rust and a Python part, the CI contains a lot of directory switching. This can be made more explicit with the `working-directory` command provided by GitHub Actions.

Changes:
* Replace `cd` commands by `working-directory` wherever applicable.