### PR TITLE
ci[python,rust]: Use `env` keyword instead of export

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,20 +25,21 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
-      - name: Install dependencies
-        shell: bash
-        run: |
-      - uses: r-lib/actions/setup-r@v1
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
         with:
-          r-version: '3.5.3' # The R version to download (if necessary) and use.
-      - run: |
+          r-version: '3.5.3'
+      - name: Run benchmark tests
+        env:
+          RUSTFLAGS: -C embed-bitcode
+        run: |
           python -m pip install --upgrade pip
           pip install virtualenv
           python -m venv venv
           source venv/bin/activate
           pip install -r py-polars/build.requirements.txt
           cd py-polars
-          rustup override set nightly-2022-08-22 && RUSTFLAGS="-C embed-bitcode" maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+          rustup override set nightly-2022-08-22 && maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
           cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -72,9 +72,9 @@ jobs:
         run: |
           cargo fmt --all -- --check
       - name: Run linting checks
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run : |
-          # do not produce debug symbols to keep memory usage down
-          export RUSTFLAGS="-C debuginfo=0"
           cd polars && cargo clippy --all-features \
           -p polars-core \
           -p polars-io \
@@ -82,9 +82,9 @@ jobs:
           -- -D warnings
           cargo clippy -- -D warnings
       - name: Run tests
-        run: |
-          export RUSTFLAGS="-C debuginfo=0"
-          cd polars && make test && make integration-tests
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+        run: cd polars && make test && make integration-tests
       - name: Run miri
         run: |
           cd polars

--- a/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
+++ b/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: '-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt'
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
         with:
           rust-toolchain: nightly-2022-08-22
           maturin-version: '0.13.2'

--- a/.github/workflows/create-py-release-manylinux.yaml
+++ b/.github/workflows/create-py-release-manylinux.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: '-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma'
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
           rust-toolchain: nightly-2022-08-22
           maturin-version: '0.13.2'
@@ -55,7 +55,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: '-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma'
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
           rust-toolchain: nightly-2022-08-22
           maturin-version: '0.13.2'

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -32,15 +32,15 @@ jobs:
           shell: bash
           env:
             MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+            RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
           run: |
             rm py-polars/README.md
             cp README.md py-polars/README.md
             cd py-polars
             rustup override set nightly-2022-08-22
-            export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2'
             maturin publish \
             --no-sdist \
             --skip-existing \
             -o wheels \
             -i python \
-            --username ritchie46 \
+            --username ritchie46

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,9 +29,11 @@ jobs:
           cd py-polars/docs
           make html
       - name: deploy docs
+        env:
+          RUSTFLAGS: --cfg docsrs
         run: |
           set -e
-          RUSTFLAGS="--cfg docsrs" cargo doc --features=docs-selection --package polars && \
+          cargo doc --features=docs-selection --package polars && \
           echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html && \
           mkdir target/doc/py-polars
           cp -r py-polars/docs/build/html target/doc/py-polars

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -25,6 +25,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r py-polars/docs/requirements-docs.txt
       - name: Build python reference
+        env:
+          SPHINXOPTS: -W
         run: |
           cd py-polars/docs
-          make html SPHINXOPTS="-W"
+          make html

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -52,8 +52,9 @@ jobs:
         run: |
           cd py-polars && mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }} && cd ..
       - name: Run tests
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
-          export RUSTFLAGS="-C debuginfo=0"
           cd py-polars && rustup override set nightly-2022-08-22 && make venv && make test-with-cov
           make clippy
       - name: Check doc examples

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -32,9 +32,9 @@ jobs:
           pip install -r py-polars/build.requirements.txt
       - name: Run tests
         shell: bash
-        run: |
-          export RUSTFLAGS="-C debuginfo=0"
-          cd py-polars && rustup override set nightly-2022-08-22 && make build-and-test-no-venv
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+        run: cd py-polars && rustup override set nightly-2022-08-22 && make build-and-test-no-venv
       # test if we can import polars without any requirements
       - name: Import polars
         run: |

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
-        run: |
-          set RUSTFLAGS="-C debuginfo=0"
-          cd polars && make test && make integration-tests
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+        run: cd polars && make test && make integration-tests


### PR DESCRIPTION
We were already using the `env` keyword in a lot of places - this just make usage consistent across workflows.

Added benefit: this works cross-platform!