### PR TITLE
ci[python]: Upgrade setup-python actions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,9 +21,11 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/build.requirements.txt'
       - name: Set up R
         uses: r-lib/actions/setup-r@v1
         with:
@@ -32,8 +34,7 @@ jobs:
         env:
           RUSTFLAGS: -C embed-bitcode
         run: |
-          python -m pip install --upgrade pip
-          pip install virtualenv
+          pip install --upgrade pip
           python -m venv venv
           source venv/bin/activate
           pip install -r py-polars/build.requirements.txt
@@ -50,4 +51,3 @@ jobs:
           python main.py on_strings
           echo "ON CATEGORICALS"
           python main.py
-

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,11 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: "py-polars/build.requirements.txt"
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/build.requirements.txt'
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Prepare maturin publish

--- a/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
+++ b/.github/workflows/create-py-release-manylinux-lts-cpu.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.7'
           architecture: x64
       - name: Prepare maturin publish
         shell: bash

--- a/.github/workflows/create-py-release-manylinux.yaml
+++ b/.github/workflows/create-py-release-manylinux.yaml
@@ -17,9 +17,9 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.7'
           architecture: x64
 
       - name: publish x64_64

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -20,12 +20,12 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install maturin==0.13.2
       - name: Publish wheel
         shell: bash

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,13 +17,16 @@ jobs:
           toolchain: nightly-2022-08-22
           components: rust-docs
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
       - name: Install dependencies
+        working-directory: py-polars/docs
         run: |
-          python -m pip install --upgrade pip
-          pip install -r py-polars/docs/requirements-docs.txt
+          pip install --upgrade pip
+          pip install -r requirements-docs.txt
       - name: Build python reference
         working-directory: py-polars/docs
         run: make html

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -14,18 +14,23 @@ jobs:
   test:
     name: Docs check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: py-polars/docs
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r py-polars/docs/requirements-docs.txt
-      - name: Build python reference
+          pip install --upgrade pip
+          pip install -r requirements-docs.txt
+      - name: Build Python reference
         env:
           SPHINXOPTS: -W
-        working-directory: py-polars/docs
         run: make html

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -31,12 +31,14 @@ jobs:
           toolchain: nightly-2022-08-22
           components: rustfmt, clippy
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/build.requirements.txt'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install -r build.requirements.txt
       - name: Run formatting checks
         run: |

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -25,12 +25,14 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/build.requirements.txt'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install -r build.requirements.txt
       - name: Run tests
         shell: bash


### PR DESCRIPTION
Changes:
* Upgrade all the `actions/setup-python` actions to `@v4`.
* Leverage [caching](https://github.com/actions/setup-python#caching-packages-dependencies) to speed up installing Python dependencies
* Upgrade Python version from 3.9 to 3.10 for the benchmark and test-windows-python workflows