### PR TITLE
feat[python]: allow ".row(idx)" to index with a predicate

### DIFF
--- a/py-polars/docs/source/reference/exceptions.rst
+++ b/py-polars/docs/source/reference/exceptions.rst
@@ -12,6 +12,9 @@ Exceptions
     DuplicateError
     NoDataError
     NotFoundError
+    NoRowsReturned
     PanicException
+    RowsException
     SchemaError
     ShapeError
+    TooManyRowsReturned

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -38,6 +38,18 @@ except ImportError:
         """Exception raised when an unexpected state causes a panic in the underlying Rust library."""  # noqa: E501
 
 
+class RowsException(Exception):
+    """Exception raised when the number of returned rows does not match expectation."""
+
+
+class NoRowsReturned(RowsException):
+    """Exception raised when no rows are returned, but at least one row is expected."""
+
+
+class TooManyRowsReturned(RowsException):
+    """Exception raised when more rows than expected are returned."""
+
+
 __all__ = [
     "ArrowError",
     "ComputeError",
@@ -47,4 +59,7 @@ __all__ = [
     "ShapeError",
     "DuplicateError",
     "PanicException",
+    "RowsException",
+    "NoRowsReturned",
+    "TooManyRowsReturned",
 ]

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -133,9 +133,9 @@ def test_strategy_null_probability(
     assert df2.null_count().fold(sum).sum() < df3.null_count().fold(sum).sum()
 
     nulls_col0, nulls_col1 = df2.null_count().rows()[0]
-    assert nulls_col0 > nulls_col1  # type: ignore[operator]
-    assert nulls_col0 < 50  # type: ignore[operator]
+    assert nulls_col0 > nulls_col1
+    assert nulls_col0 < 50
 
     nulls_col0, nulls_colx = df3.null_count().rows()[0]
-    assert nulls_col0 > nulls_colx  # type: ignore[operator]
+    assert nulls_col0 > nulls_colx
     assert nulls_col0 == 50

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -472,8 +472,8 @@ def test_csv_globbing(examples_dir: str) -> None:
 
     df = pl.read_csv(path, columns=["category", "sugars_g"])
     assert df.shape == (135, 2)
-    assert df.row(-1) == ("seafood", 1)  # type: ignore[comparison-overlap]
-    assert df.row(0) == ("vegetables", 2)  # type: ignore[comparison-overlap]
+    assert df.row(-1) == ("seafood", 1)
+    assert df.row(0) == ("vegetables", 2)
 
     with pytest.raises(ValueError):
         _ = pl.read_csv(path, dtypes=[pl.Utf8, pl.Int64, pl.Int64, pl.Int64])
@@ -581,7 +581,7 @@ def test_fallback_chrono_parser() -> None:
     """
     )
     df = pl.read_csv(data.encode(), parse_dates=True)
-    assert df.null_count().row(0) == (0, 0)  # type: ignore[comparison-overlap]
+    assert df.null_count().row(0) == (0, 0)
 
 
 def test_csv_string_escaping() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+from polars.exceptions import NoRowsReturned, TooManyRowsReturned
 from polars.testing import assert_frame_equal, assert_series_equal, columns
 
 if TYPE_CHECKING:
@@ -795,9 +796,38 @@ def test_df_fold() -> None:
 
 def test_row_tuple() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
-    assert df.row(0) == ("foo", 1, 1.0)  # type: ignore[comparison-overlap]
-    assert df.row(1) == ("bar", 2, 2.0)  # type: ignore[comparison-overlap]
-    assert df.row(-1) == ("2", 3, 3.0)  # type: ignore[comparison-overlap]
+
+    # return row by index
+    assert df.row(0) == ("foo", 1, 1.0)
+    assert df.row(1) == ("bar", 2, 2.0)
+    assert df.row(-1) == ("2", 3, 3.0)
+
+    # return row by predicate
+    assert df.row(by_predicate=pl.col("a") == "bar") == ("bar", 2, 2.0)
+    assert df.row(by_predicate=pl.col("b").is_in([2, 4, 6])) == ("bar", 2, 2.0)
+
+    # expected error conditions
+    with pytest.raises(TooManyRowsReturned):
+        df.row(by_predicate=pl.col("b").is_in([1, 3, 5]))
+
+    with pytest.raises(NoRowsReturned):
+        df.row(by_predicate=pl.col("a") == "???")
+
+    # cannot set both 'index' and 'by_predicate'
+    with pytest.raises(ValueError):
+        df.row(0, by_predicate=pl.col("a") == "bar")
+
+    # must call 'by_predicate' by keyword
+    with pytest.raises(TypeError):
+        df.row(None, pl.col("a") == "bar")  # type: ignore[misc]
+
+    # cannot pass predicate into 'index'
+    with pytest.raises(TypeError):
+        df.row(pl.col("a") == "bar")  # type: ignore[arg-type]
+
+    # at least one of 'index' and 'by_predicate' must be set
+    with pytest.raises(ValueError):
+        df.row()
 
 
 def test_df_apply() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -352,7 +352,7 @@ def test_regex_in_filter() -> None:
         pl.fold(acc=False, f=lambda acc, s: acc | s, exprs=(pl.col("^nrs|flt*$") < 3))
     ).row(0)
     expected = (1, "foo", 1.0)
-    assert res == expected  # type: ignore[comparison-overlap]
+    assert res == expected
 
 
 def test_arr_contains() -> None:


### PR DESCRIPTION
Closes #4675.

---
This patch allows `row(idx)` to additionally use a matching predicate - seems this functionality is widely implemented/used elsewhere (there's a good explanation/rationale in the linked issue), and implementing it here too is both straightforward and causes no issues.

```python
df.row( by_predicate=(pl.col("id") == 999) )
```

Specific exceptions are raised in the case of `TooManyRowsReturned` or `NoRowsReturned`, as it is useful to be able to distinguish between the two cases (but if you don't want to, they both inherit from `RowsException`).

**Also:** 
Was able to remove a number of `type: ignore[comparison-overlap]` directives by fixing typing on the return signature of the related `rows()` method.

**Update:**
The option to use a predicate now _requires_ use of the kw-only param `by_predicate` to ensure clarity of implementation, and comprehension when reading the code.