### PR TITLE
ci[rust]: Use new Rust toolchain action

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -38,7 +38,7 @@ jobs:
           source venv/bin/activate
           pip install -r py-polars/build.requirements.txt
           cd py-polars
-          rustup override set nightly-2022-08-22 && maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+          maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
           cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,11 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install dependencies
         run: |
@@ -46,11 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
           components: rustfmt, clippy, miri
       - name: Cache Cargo
         uses: actions/cache@v3

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,11 +23,10 @@ jobs:
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "py-polars/build.requirements.txt"
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
-          profile: minimal
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -16,11 +16,10 @@ jobs:
         python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - name: Setup universal2 targets for Rust
         run: |
           rustup target add aarch64-apple-darwin

--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -33,7 +33,6 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
           cd py-polars
-          rustup override set nightly-2022-08-22
       - name: maturin publish
         uses: messense/maturin-action@v1
         env:

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -15,11 +15,10 @@ jobs:
         python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -36,7 +36,6 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
           cd py-polars
-          rustup override set nightly-2022-08-22
           maturin publish \
           --no-sdist \
           --skip-existing \

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -14,33 +14,33 @@ jobs:
         os: ["macos-latest", "windows-latest"]
         python-version: ["3.7"]
     steps:
-        - uses: actions/checkout@v3
-        - name: Install latest Rust nightly
-          uses: actions-rs/toolchain@v1
-          with:
-            toolchain: nightly-2022-08-22
-            override: true
-        - name: Set up Python
-          uses: actions/setup-python@v3
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install maturin==0.13.2
-        - name: Publish wheel
-          shell: bash
-          env:
-            MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-            RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
-          run: |
-            rm py-polars/README.md
-            cp README.md py-polars/README.md
-            cd py-polars
-            rustup override set nightly-2022-08-22
-            maturin publish \
-            --no-sdist \
-            --skip-existing \
-            -o wheels \
-            -i python \
-            --username ritchie46
+      - uses: actions/checkout@v3
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-08-22
+          override: true
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install maturin==0.13.2
+      - name: Publish wheel
+        shell: bash
+        env:
+          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+          cd py-polars
+          rustup override set nightly-2022-08-22
+          maturin publish \
+          --no-sdist \
+          --skip-existing \
+          -o wheels \
+          -i python \
+          --username ritchie46

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
+          components: rust-docs
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,11 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -44,7 +44,7 @@ jobs:
           blackdoc --check .
           isort --check .
           pyupgrade --py37-plus `find . -name "*.py" -type f`
-          rustup override set nightly-2022-08-22 && cargo fmt --all -- --check
+          cargo fmt --all -- --check
       - name: Run linting
         run: flake8
       # Allow untyped calls for older Python versions
@@ -54,7 +54,7 @@ jobs:
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
-          rustup override set nightly-2022-08-22 && make venv && make test-with-cov
+          make venv && make test-with-cov
           make clippy
       - name: Check doc examples
         run: make doctest

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -25,11 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
           components: rustfmt, clippy
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -20,12 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
-          components: rustfmt
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
-        run: rustup override set nightly-2022-08-22 && make build-and-test-no-venv
+        run: make build-and-test-no-venv
       # test if we can import polars without any requirements
       - name: Import polars
         run: |

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -14,11 +14,10 @@ jobs:
   test-rust:
     runs-on: windows-latest
     steps:
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          override: true
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Run tests


### PR DESCRIPTION
While working on the CI, I discovered that the action we currently use to install the Rust toolchain [is unmaintained](https://github.com/actions-rs/toolchain/issues/216), and hasn't been updated in 2 years.

Most people seem to be moving to [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain), and I propose we do so too.

Changes:
* Replace `actions-rs/toolchain` by `dtolnay/rust-toolchain`
  * Profile is set to 'minimal' by default, which is nice!
* Removed `rustup override set nightly-2022-08-22` commands from various steps - the `rust-toolchain.toml` should take care of this.