### PR TITLE
fix[python]: init Series from empty arrow array (when no data/not chunked)

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -77,6 +77,8 @@ def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySe
             pys = PySeries.from_arrow(name, next(it))
             for a in it:
                 pys.append(PySeries.from_arrow(name, a))
+        elif array.num_chunks == 0:
+            pys = PySeries.from_arrow(name, pa.array([], array.type))
         else:
             pys = PySeries.from_arrow(name, array.combine_chunks())
 


### PR DESCRIPTION
Better-handle `pl.Series` init from empty `Arrow` arrays by _explicitly_ checking for the case where `num_chunks == 0` (0.14.10 somehow broke this, so I've added more testing for empty arrow data, as there wasn't any before).