### PR TITLE
ci[python]: Separate linting from testing

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: 'py-polars/build.requirements.txt'
+          cache-dependency-path: 'py-polars/requirements-dev.txt'
       - name: Set up R
         uses: r-lib/actions/setup-r@v1
         with:
@@ -37,7 +37,7 @@ jobs:
           pip install --upgrade pip
           python -m venv venv
           source venv/bin/activate
-          pip install -r py-polars/build.requirements.txt
+          pip install -r py-polars/requirements-dev.txt
           cd py-polars
           maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
           cd tests/db-benchmark

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -1,0 +1,47 @@
+name: Lint Python
+
+on:
+  pull_request:
+    paths:
+      - 'py-polars/**'
+      - '.github/workflows/lint-python.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: py-polars
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'py-polars/requirements-lint.txt'
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-lint.txt
+      - name: Lint Python
+        run: |
+          black --check .
+          blackdoc --check .
+          isort --check .
+          pyupgrade --py37-plus `find . -name "*.py" -type f`
+          flake8
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-08-22
+          components: rustfmt, clippy
+      - name: Lint Rust
+        run: |
+          cargo fmt --all -- --check
+          make clippy

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -41,7 +41,8 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: py-polars
       - name: Lint Rust

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -41,6 +41,9 @@ jobs:
         with:
           toolchain: nightly-2022-08-22
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: py-polars
       - name: Lint Rust
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -35,20 +35,26 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'py-polars/requirements-dev.txt'
+      - name: Create virtual environment
+        run: |
+          python -m venv venv
+          echo "$GITHUB_WORKSPACE/py-polars/venv/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.txt
       # Allow untyped calls for older Python versions
       - name: Run type checking
-        run: mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
       - name: Run tests
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
-          make venv && make test-with-cov
+          source activate
+          maturin develop
+          pytest --cov=polars
       - name: Check doc examples
-        run: make doctest
+        run: python tests/docs/run_doc_examples.py
       # Test whether Polars can be imported without optional dependencies
       - name: Check optional dependencies
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -24,10 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2022-08-22
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -45,13 +41,21 @@ jobs:
       # Allow untyped calls for older Python versions
       - name: Run mypy
         run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
-      - name: Run tests and report coverage
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-08-22
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: py-polars
+      - name: Install Polars
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
           source activate
           maturin develop
-          pytest --cov=polars
+      - name: Run tests and report coverage
+        run: pytest --cov=polars
       - name: Run doctests
         run: python tests/docs/run_doc_examples.py
       - name: Check import without optional dependencies

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -45,7 +45,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
         with:
           workspaces: py-polars
       - name: Install Polars

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -35,11 +35,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'py-polars/build.requirements.txt'
+          cache-dependency-path: 'py-polars/requirements-dev.txt'
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r build.requirements.txt
+          pip install -r requirements-dev.txt
       - name: Run formatting checks
         run: |
           black --check .

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -1,4 +1,4 @@
-name: Test python
+name: Test Python
 
 on:
   pull_request:
@@ -12,8 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-python:
-    name: Build and test Python
+  main:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -44,23 +43,22 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-dev.txt
       # Allow untyped calls for older Python versions
-      - name: Run type checking
+      - name: Run mypy
         run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
-      - name: Run tests
+      - name: Run tests and report coverage
         env:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
           source activate
           maturin develop
           pytest --cov=polars
-      - name: Check doc examples
+      - name: Run doctests
         run: python tests/docs/run_doc_examples.py
-      # Test whether Polars can be imported without optional dependencies
-      - name: Check optional dependencies
+      - name: Check import without optional dependencies
         run: |
           pip uninstall pandas -y
-          python -c "import polars"
+          python -c 'import polars'
           pip uninstall numpy -y
-          python -c "import polars"
+          python -c 'import polars'
           pip uninstall pyarrow -y
-          python -c "import polars"
+          python -c 'import polars'

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
-          components: rustfmt, clippy
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -40,15 +39,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.txt
-      - name: Run formatting checks
-        run: |
-          black --check .
-          blackdoc --check .
-          isort --check .
-          pyupgrade --py37-plus `find . -name "*.py" -type f`
-          cargo fmt --all -- --check
-      - name: Run linting
-        run: flake8
       # Allow untyped calls for older Python versions
       - name: Run type checking
         run: mypy  ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
@@ -57,11 +47,10 @@ jobs:
           RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
         run: |
           make venv && make test-with-cov
-          make clippy
       - name: Check doc examples
         run: make doctest
-      # test if we can import polars without any requirements
-      - name: Import polars
+      # Test whether Polars can be imported without optional dependencies
+      - name: Check optional dependencies
         run: |
           pip uninstall pandas -y
           python -c "import polars"

--- a/.github/workflows/test-windows-python.yaml
+++ b/.github/workflows/test-windows-python.yaml
@@ -29,11 +29,11 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: 'py-polars/build.requirements.txt'
+          cache-dependency-path: 'py-polars/requirements-dev.txt'
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r build.requirements.txt
+          pip install -r requirements-dev.txt
       - name: Run tests
         shell: bash
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ You have to follow these steps:
 
   - Install Rust nightly via [rustup](https://www.rust-lang.org/tools/install)
   - run `$ rustup override set nightly` from the root of the repo.
-  - from [./py-polars](./py-polars) run `$ pip3 install -r build.requirements.txt`
+  - from [./py-polars](./py-polars) run `$ make venv`
   - **tests:** from [./py-polars](./py-polars) run `$ make test`
   - **formatting + linting:** from [./py-polars](./py-polars) run `$ make pre-commit` before committing.
   - **docs:** from [./py-polars/docs](./py-polars/docs) run `$ pip3 install -r requirements-docs.txt` followed by `make html`

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -6,8 +6,9 @@ PYTHON_BIN=venv/bin
 
 venv:  ## Set up virtual environment
 	@python -m venv venv
-	@venv/bin/pip install -U pip
-	@venv/bin/pip install -r build.requirements.txt
+	@venv/bin/pip install --upgrade pip
+	@venv/bin/pip install -r requirements-dev.txt
+	@venv/bin/pip install -r requirements-lint.txt
 	@unset CONDA_PREFIX && source venv/bin/activate && maturin develop
 
 .PHONY: clean

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -14,6 +14,7 @@ venv:  ## Set up virtual environment
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts
 	@rm -rf venv/
+	@rm -rf target/
 	@rm -rf docs/build/
 	@rm -rf docs/source/reference/api/
 	@rm -rf .hypothesis/
@@ -21,6 +22,7 @@ clean:  ## Clean up caches and build artifacts
 	@rm -rf .pytest_cache/
 	@rm -f .coverage
 	@rm -f coverage.xml
+	@rm -f polars/polars.abi3.so
 	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -4,28 +4,18 @@
 
 # Dependencies
 numpy
-pyarrow
 pandas
+pyarrow
 pytz
-types-pytz
 xlsx2csv
 
 # Tooling
+hypothesis==6.54.5
 maturin==0.13.2
+mypy==0.971
 pytest==7.1.3
 pytest-cov==3.0.0
-hypothesis==6.54.5
-black==22.8.0
-blackdoc==0.3.6
-isort==5.10.1
-mypy==0.971
-flake8==5.0.4
-flake8-bugbear==22.8.23
-flake8-comprehensions==3.10.0
-flake8-docstrings==1.6.0
-flake8-simplify==0.19.3
-flake8-tidy-imports==4.8.0
-pyupgrade==2.37.3
 
 # Stub files
 pandas-stubs==1.2.0.61
+types-pytz==2022.2.1.0

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,0 +1,10 @@
+black==22.8.0
+blackdoc==0.3.6
+flake8==5.0.4
+flake8-bugbear==22.8.23
+flake8-comprehensions==3.10.0
+flake8-docstrings==1.6.0
+flake8-simplify==0.19.3
+flake8-tidy-imports==4.8.0
+isort==5.10.1
+pyupgrade==2.37.3


### PR DESCRIPTION
We are currently installing and running our Python linting for every Python version we test. This is wasteful, and also unnecessarily restrictive on what linting tools we can use, since they must run on Python 3.7 (I ran into this issue before with a certain flake8 extension).

Changes:
* Split `build.requirements.txt` into `requirements-dev.txt` and `requirements-lint.txt`
  * Updated `make venv` to install both dev and lint, so that the end result is the same as before.
* Add new "Lint Python" workflow
  * Uses `requirements-lint.txt`
  * Runs all lints except `mypy`, as we want `mypy` to work in multiple environments and it requires build dependencies to be installed.
  * Runs in about 2 minutes when hitting the Rust cache, otherwise ~4 minutes.
  * Triggers on changes to the `py-polars` folder
* Update "Test Python" workflow
  * Uses `requirements-dev.txt`
  * No longer relies on `make` commands, due to the weird way these are entangled with `make venv` which will install the lint dependencies. I plan on revisiting this once I improve the Makefile.
  * Added a separate step "Create virtual environment", which creates and activates an environment by adding it to the GITHUB_PATH.
    * I'd rather not use a virtual environment at all, but `maturin develop` requires it. We could use `maturin build`, but then we cannot compute test coverage. Wasted many hours down that rabbithole 🙃 
  * Adding it to the path saves having to type `source venv/bin/activate` before every step. However, `maturin develop` still requires an explicit `source activate`, for some reason.
  * Added Rust caching. I have verified that the cache hits, but speed-up appears to be minimal.
  * Improved ordering and naming of the various steps.
  * Execution time down from 10-13 minutes to 8-9 minutes.