### PR TITLE
fix[python]: update test - slice input arrow table, not output frame

### DIFF
--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1979,7 +1979,7 @@ def test_list_of_list_of_struct() -> None:
     assert df.rows() == [([[{"a": 1}, {"a": 2}]],)]
     assert df.to_dicts() == expected
 
-    df = pl.from_arrow(pa_df)[:0]
+    df = pl.from_arrow(pa_df[:0])
     assert df.to_dicts() == []
 
 


### PR DESCRIPTION
As @ghuls [noticed](https://github.com/pola-rs/polars/pull/4792#discussion_r966982624) (thx!), I mistakenly sliced the frame, not the arrow table, in one of the new "empty Arrow data" tests. This just quickly fixes that (the test passes in both configurations).