### PR TITLE
ci[rust,python]: Improve benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -33,7 +33,7 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Set up R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: '3.5.3'
       - name: Generate data

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -16,39 +16,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'py-polars/requirements-dev.txt'
+
       - name: Create virtual environment
         working-directory: py-polars
         run: |
           python -m venv venv
           echo "$GITHUB_WORKSPACE/py-polars/venv/bin" >> $GITHUB_PATH
+
       - name: Install Python dependencies
         working-directory: py-polars
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.txt
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: '3.5.3'
+
       - name: Generate data
         working-directory: py-polars/tests/db-benchmark
         run: |
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-08-22
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: py-polars
+
       - name: Install Polars
         env:
           RUSTFLAGS: -C embed-bitcode
@@ -56,15 +64,19 @@ jobs:
         run: |
           source activate
           maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+
       - name: Run benchmark tests - lazy versus eager
         working-directory: py-polars/tests/db-benchmark
         run: python lazy_vs_eager.py
+
       - name: Run benchmark tests - various
         working-directory: py-polars/tests/db-benchmark
         run: python various.py
+
       - name: Run benchmark tests - on strings
         working-directory: py-polars/tests/db-benchmark
         run: python main.py on_strings
+
       - name: Run benchmark tests - on categoricals
         working-directory: py-polars/tests/db-benchmark
         run: python main.py

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -12,42 +12,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2022-08-22
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'py-polars/requirements-dev.txt'
+      - name: Create virtual environment
+        working-directory: py-polars
+        run: |
+          python -m venv venv
+          echo "$GITHUB_WORKSPACE/py-polars/venv/bin" >> $GITHUB_PATH
+      - name: Install Python dependencies
+        working-directory: py-polars
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-dev.txt
       - name: Set up R
         uses: r-lib/actions/setup-r@v1
         with:
           r-version: '3.5.3'
-      - name: Run benchmark tests
-        env:
-          RUSTFLAGS: -C embed-bitcode
+      - name: Generate data
+        working-directory: py-polars/tests/db-benchmark
         run: |
-          pip install --upgrade pip
-          python -m venv venv
-          source venv/bin/activate
-          pip install -r py-polars/requirements-dev.txt
-          cd py-polars
-          maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
-          cd tests/db-benchmark
           Rscript -e 'install.packages("data.table", repos="https://Rdatatable.github.io/data.table")'
           Rscript groupby-datagen.R 1e7 1e2 5 0
-          echo "LAZY vs EAGER tests"
-          python lazy_vs_eager.py
-          echo "run various.py tests"
-          python various.py
-          echo "ON STRINGS"
-          python main.py on_strings
-          echo "ON CATEGORICALS"
-          python main.py
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-08-22
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: py-polars
+      - name: Install Polars
+        env:
+          RUSTFLAGS: -C embed-bitcode
+        working-directory: py-polars
+        run: |
+          source activate
+          maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+      - name: Run benchmark tests - lazy versus eager
+        working-directory: py-polars/tests/db-benchmark
+        run: python lazy_vs_eager.py
+      - name: Run benchmark tests - various
+        working-directory: py-polars/tests/db-benchmark
+        run: python various.py
+      - name: Run benchmark tests - on strings
+        working-directory: py-polars/tests/db-benchmark
+        run: python main.py on_strings
+      - name: Run benchmark tests - on categoricals
+        working-directory: py-polars/tests/db-benchmark
+        run: python main.py


### PR DESCRIPTION
Continuing my crusade to optimize our GitHub Actions 😄 

Changes:
* Split up the long run script into logical steps.
  * Makes it easier to view the logs and see how long each step/benchmark took.
* Add a cache step for Rust
  * Reduces the time it takes to install Polars by about 5 minutes on cache hit
* Update R action
  * Updating the R version from `3.5.3` to a later version resulted in an error - I'm guessing the generated data is different. Keeping this at `3.5.3` for now.