### PR TITLE
feat[rust]: show problematic values in failed cast

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -674,15 +674,12 @@ impl Series {
         let s = self.cast(data_type)?;
         if self.null_count() != s.null_count() {
             let failure_mask = !self.is_null() & s.is_null();
-            let failures = self
-                .filter_threaded(&failure_mask, false)?
-                .unique()?
-                .head(Some(10));
+            let failures = self.filter_threaded(&failure_mask, false)?.unique()?;
             Err(PolarsError::ComputeError(
                 format!(
                     "Strict conversion from {:?} to {:?} failed for values {}. \
                     If you were trying to cast Utf8 to Date, Time, or Datetime, \
-                    consider instead using `strptime`.",
+                    consider using `strptime`.",
                     self.dtype(),
                     data_type,
                     failures.fmt_list(),

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -675,12 +675,13 @@ impl Series {
         if self.null_count() != s.null_count() {
             Err(PolarsError::ComputeError(
                 format!(
-                    "strict conversion of cast from {:?} to {:?} failed. consider non-strict cast.\n
-                    If you were trying to cast Utf8 to Date,Time,Datetime, consider using `strptime`",
+                    "Strict conversion from {:?} to {:?} failed, consider a non-strict \
+                        cast instead. If you were trying to cast Utf8 to Date, Time, or \
+                        Datetime, consider using `strptime`.",
                     self.dtype(),
                     data_type
                 )
-                    .into(),
+                .into(),
             ))
         } else {
             Ok(s)

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -331,6 +331,10 @@ def test_cast() -> None:
     assert a.cast(pl.Datetime).dtype == pl.Datetime
     assert a.cast(pl.Date).dtype == pl.Date
 
+    # display failed values, GH#4706
+    with pytest.raises(pl.ComputeError, match="foobar"):
+        pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
+
 
 def test_to_python() -> None:
     a = pl.Series("a", range(20))


### PR DESCRIPTION
Closes #4706 

```python
import polars as pl

pl.DataFrame(['1','2','3','4','foobar']).select(pl.col('column_0').cast(int))
```

**Before:**
```
ComputeError: strict conversion of cast from Utf8 to Int64 failed. consider non-strict cast.

                    If you were trying to cast Utf8 to Date,Time,Datetime, consider using `strptime`
```

**After:**
```
ComputeError: Strict conversion from Utf8 to Int64 failed for values ["foobar"]. If you were trying to cast Utf8 to Date, Time, or Datetime, consider using `strptime`.
```