### PR TITLE
refactor[python]: dispatch `join` logic to `LazyFrame` side

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3765,9 +3765,9 @@ class DataFrame:
     def join(
         self,
         other: DataFrame,
-        left_on: str | pli.Expr | list[str | pli.Expr] | None = None,
-        right_on: str | pli.Expr | list[str | pli.Expr] | None = None,
-        on: str | pli.Expr | list[str | pli.Expr] | None = None,
+        left_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        right_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
         how: JoinStrategy = "inner",
         suffix: str = "_right",
     ) -> DataFrame:
@@ -3840,52 +3840,23 @@ class DataFrame:
         │ 3    ┆ 8.0  ┆ c   ┆ null  │
         └──────┴──────┴─────┴───────┘
 
-        **Joining on columns with categorical data**
-        See pl.StringCache().
+        Note
+        ----
+        For joining on columns with categorical data, see ``pl.StringCache()``.
 
         """
-        if how == "cross":
-            return self._from_pydf(self._df.join(other._df, [], [], how, suffix))
-
-        left_on_: list[str | pli.Expr] | None
-        if isinstance(left_on, (str, pli.Expr)):
-            left_on_ = [left_on]
-        else:
-            left_on_ = left_on
-
-        right_on_: list[str | pli.Expr] | None
-        if isinstance(right_on, (str, pli.Expr)):
-            right_on_ = [right_on]
-        else:
-            right_on_ = right_on
-
-        if isinstance(on, (str, pli.Expr)):
-            left_on_ = [on]
-            right_on_ = [on]
-        elif isinstance(on, list):
-            left_on_ = on
-            right_on_ = on
-
-        if left_on_ is None or right_on_ is None:
-            raise ValueError("You should pass the column to join on as an argument.")
-
-        if isinstance(left_on_[0], pli.Expr) or isinstance(right_on_[0], pli.Expr):
-            return (
-                self.lazy()
-                .join(
-                    other.lazy(),
-                    left_on,
-                    right_on,
-                    on=on,
-                    how=how,
-                    suffix=suffix,
-                )
-                .collect(no_optimization=True)
+        return (
+            self.lazy()
+            .join(
+                other=other.lazy(),
+                left_on=left_on,
+                right_on=right_on,
+                on=on,
+                how=how,
+                suffix=suffix,
             )
-        else:
-            return self._from_pydf(
-                self._df.join(other._df, left_on_, right_on_, how, suffix)
-            )
+            .collect(no_optimization=True)
+        )
 
     def apply(
         self: DF,

--- a/py-polars/polars/internals/expr/__init__.py
+++ b/py-polars/polars/internals/expr/__init__.py
@@ -1,6 +1,5 @@
 from polars.internals.expr.expr import (
     Expr,
-    ensure_list_of_pyexpr,
     expr_to_lit_or_expr,
     selection_to_pyexpr_list,
     wrap_expr,
@@ -8,7 +7,6 @@ from polars.internals.expr.expr import (
 
 __all__ = [
     "Expr",
-    "ensure_list_of_pyexpr",
     "expr_to_lit_or_expr",
     "selection_to_pyexpr_list",
     "wrap_expr",

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -22,7 +22,7 @@ from polars.internals.expr.list import ExprListNameSpace
 from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
-from polars.utils import deprecated_alias, is_expr_sequence, is_pyexpr_sequence
+from polars.utils import deprecated_alias
 
 try:
     from polars.polars import PyExpr
@@ -49,28 +49,12 @@ if TYPE_CHECKING:
 
 
 def selection_to_pyexpr_list(
-    exprs: str | Expr | Sequence[str | Expr | pli.Series] | pli.Series,
+    exprs: str | Expr | pli.Series | Sequence[str | Expr | pli.Series],
 ) -> list[PyExpr]:
     if isinstance(exprs, (str, Expr, pli.Series)):
         exprs = [exprs]
 
     return [expr_to_lit_or_expr(e, str_to_lit=False)._pyexpr for e in exprs]
-
-
-def ensure_list_of_pyexpr(exprs: object) -> list[PyExpr]:
-    if isinstance(exprs, PyExpr):
-        return [exprs]
-
-    if is_pyexpr_sequence(exprs):
-        return list(exprs)
-
-    if isinstance(exprs, Expr):
-        return [exprs._pyexpr]
-
-    if is_expr_sequence(exprs):
-        return [e._pyexpr for e in exprs]
-
-    raise TypeError(f"unexpected type '{type(exprs)}'")
 
 
 def expr_to_lit_or_expr(

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -540,7 +540,7 @@ def align_frames(
     aligned_frames = [
         alignment_frame.join(
             other=df.lazy(),
-            on=alignment_frame.columns,  # type: ignore[arg-type]
+            on=alignment_frame.columns,
             how="left",
         )
         .select(df.columns)

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -4,7 +4,7 @@ from typing import Callable, Generic, Sequence, TypeVar
 
 import polars.internals as pli
 from polars.datatypes import Schema
-from polars.internals.expr import ensure_list_of_pyexpr
+from polars.internals import selection_to_pyexpr_list
 from polars.utils import is_expr_sequence
 
 try:
@@ -54,7 +54,7 @@ class LazyGroupBy(Generic[LDF]):
             msg = f"expected 'Expr | Sequence[Expr]', got '{type(aggs)}'"
             raise TypeError(msg)
 
-        pyexprs = ensure_list_of_pyexpr(aggs)
+        pyexprs = selection_to_pyexpr_list(aggs)
         return self._lazyframe_class._from_pyldf(self.lgb.agg(pyexprs))
 
     def head(self, n: int = 5) -> LDF:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -304,3 +304,36 @@ def scale_bytes(sz: int, to: SizeUnit) -> int | float:
     if scaling_factor > 1:
         return sz / scaling_factor
     return sz
+
+
+def _convert_to_pyexpr(obj: str | pli.Expr | None) -> PyExpr | None:
+    """
+    Transform the passed argument to a PyExpr representation.
+
+    Performs the following transformations:
+        - obj: None -> None
+        - obj: str -> pl.col(obj)._pyexpr
+        - obj: Expr -> obj._pyexpr
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        return pli.col(obj)._pyexpr
+    if isinstance(obj, pli.Expr):
+        return obj._pyexpr
+    raise TypeError(f"encountered unexpected type: {type(obj)}")
+
+
+def _convert_to_pyexprs(
+    obj: str | pli.Expr | Sequence[str | pli.Expr] | None,
+) -> list[PyExpr] | None:
+    """Transform the passed argument to a list of PyExpr."""
+    if obj is None:
+        return None
+
+    if isinstance(obj, (str, pli.Expr)):
+        obj_as_seq = [obj]
+    else:
+        obj_as_seq = list(obj)
+
+    return [_convert_to_pyexpr(x) for x in obj_as_seq]

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -304,36 +304,3 @@ def scale_bytes(sz: int, to: SizeUnit) -> int | float:
     if scaling_factor > 1:
         return sz / scaling_factor
     return sz
-
-
-def _convert_to_pyexpr(obj: str | pli.Expr | None) -> PyExpr | None:
-    """
-    Transform the passed argument to a PyExpr representation.
-
-    Performs the following transformations:
-        - obj: None -> None
-        - obj: str -> pl.col(obj)._pyexpr
-        - obj: Expr -> obj._pyexpr
-    """
-    if obj is None:
-        return None
-    if isinstance(obj, str):
-        return pli.col(obj)._pyexpr
-    if isinstance(obj, pli.Expr):
-        return obj._pyexpr
-    raise TypeError(f"encountered unexpected type: {type(obj)}")
-
-
-def _convert_to_pyexprs(
-    obj: str | pli.Expr | Sequence[str | pli.Expr] | None,
-) -> list[PyExpr] | None:
-    """Transform the passed argument to a list of PyExpr."""
-    if obj is None:
-        return None
-
-    if isinstance(obj, (str, pli.Expr)):
-        obj_as_seq = [obj]
-    else:
-        obj_as_seq = list(obj)
-
-    return [_convert_to_pyexpr(x) for x in obj_as_seq]

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -785,21 +785,6 @@ impl PyDataFrame {
         format!("{:?}", self.df)
     }
 
-    pub fn join(
-        &self,
-        other: &PyDataFrame,
-        left_on: Vec<&str>,
-        right_on: Vec<&str>,
-        how: Wrap<JoinType>,
-        suffix: String,
-    ) -> PyResult<Self> {
-        let df = self
-            .df
-            .join(&other.df, left_on, right_on, how.0, Some(suffix))
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
-    }
-
     pub fn get_columns(&self) -> Vec<PySeries> {
         let cols = self.df.get_columns().clone();
         to_pyseries_collection(cols)


### PR DESCRIPTION
Similar to https://github.com/pola-rs/polars/pull/4787, this MR dispatches `DataFrame.join` to `LazyFrame.join`.

I also noticed that we had at least three ways of generating a list of `PyExpr` (I'm guilty of introducing one). I've removed two of them, and going forward we should make use of `selection_to_pyexpr_list`