### PR TITLE
docs[python]: Improve docstrings for LazyFrame JSON methods

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1734,9 +1734,9 @@ class DataFrame:
         file: None = None,
         pretty: bool = ...,
         row_oriented: bool = ...,
-        json_lines: bool = ...,
+        json_lines: bool | None = ...,
         *,
-        to_string: bool = ...,
+        to_string: bool | None = ...,
     ) -> str:
         ...
 
@@ -1746,9 +1746,9 @@ class DataFrame:
         file: IOBase | str | Path,
         pretty: bool = ...,
         row_oriented: bool = ...,
-        json_lines: bool = ...,
+        json_lines: bool | None = ...,
         *,
-        to_string: bool = ...,
+        to_string: bool | None = ...,
     ) -> None:
         ...
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1776,7 +1776,7 @@ class DataFrame:
         json_lines
             Deprecated argument. Toggle between `JSON` and `NDJSON` format.
         to_string
-            Ignore file argument and return a string.
+            Deprecated argument. Ignore file argument and return a string.
 
         See Also
         --------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -288,22 +288,11 @@ class LazyFrame:
         """
         Read into a DataFrame from JSON format.
 
-        .. deprecated:: 0.14.8
-          `LazyFrame.read_json` will be removed in a future version.
-          Use the equivalent `pl.read_json(...).lazy()` instead.
-
         See Also
         --------
         polars.io.read_json
 
         """
-        warn(
-            "`LazyFrame.read_json` will be removed in a future version."
-            " Use the equivalent `pl.read_json(...).lazy()` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
         elif isinstance(file, (str, Path)):

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import typing
 from io import BytesIO, IOBase, StringIO
@@ -37,10 +36,6 @@ try:
 except ImportError:
     _PYARROW_AVAILABLE = False
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -441,35 +441,26 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     @overload
     def write_json(
         self,
-        file: IOBase | str | Path | None = ...,
+        file: None = None,
         *,
-        to_string: Literal[True],
+        to_string: bool | None = ...,
     ) -> str:
         ...
 
     @overload
     def write_json(
         self,
-        file: IOBase | str | Path | None = ...,
+        file: IOBase | str | Path,
         *,
-        to_string: Literal[False] = ...,
+        to_string: bool | None = ...,
     ) -> None:
-        ...
-
-    @overload
-    def write_json(
-        self,
-        file: IOBase | str | Path | None = ...,
-        *,
-        to_string: bool = ...,
-    ) -> str | None:
         ...
 
     def write_json(
         self,
         file: IOBase | str | Path | None = None,
         *,
-        to_string: bool = False,
+        to_string: bool | None = None,
     ) -> str | None:
         """
         Serialize LogicalPlan to JSON representation.
@@ -479,13 +470,23 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         file
             Write to this file instead of returning a string.
         to_string
-            Ignore file argument and return a string.
+            Deprecated argument. Ignore file argument and return a string.
 
         See Also
         --------
         read_json
 
         """
+        if to_string is not None:
+            warn(
+                "`to_string` argument for `LazyFrame.write_json` will be removed in a"
+                " future version. Remove the argument and set `file=None` (default).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            to_string = False
+
         if isinstance(file, (str, Path)):
             file = format_path(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -269,7 +269,12 @@ class LazyFrame:
     @classmethod
     def from_json(cls, json: str) -> LazyFrame:
         """
-        Create a DataFrame from a JSON string.
+        Read a logical plan from a JSON string to construct a LazyFrame.
+
+        Parameters
+        ----------
+        json
+            String in JSON format.
 
         See Also
         --------
@@ -286,11 +291,16 @@ class LazyFrame:
         file: str | Path | IOBase,
     ) -> LazyFrame:
         """
-        Read into a DataFrame from JSON format.
+        Read a logical plan from a JSON file to construct a LazyFrame.
+
+        Parameters
+        ----------
+        file
+            Path to a file or a file-like object.
 
         See Also
         --------
-        polars.io.read_json
+        LazyFrame.from_json, LazyFrame.write_json
 
         """
         if isinstance(file, StringIO):
@@ -452,18 +462,19 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         to_string: bool | None = None,
     ) -> str | None:
         """
-        Serialize LogicalPlan to JSON representation.
+        Write the logical plan of this LazyFrame to a file or string in JSON format.
 
         Parameters
         ----------
         file
-            Write to this file instead of returning a string.
+            File path to which the result should be written. If set to ``None``
+            (default), the output is returned as a string instead.
         to_string
             Deprecated argument. Ignore file argument and return a string.
 
         See Also
         --------
-        read_json
+        LazyFrame.read_json
 
         """
         if to_string is not None:


### PR DESCRIPTION
Minor docs clarification after discussion in #4395.

Changes:
* Un-deprecate `LazyFrame.read_json`. I misunderstood what this method does, and there is no alternative right now. We can deprecate this once we come up with a better name/approach.
* Deprecate `to_string` argument for `LazyFrame.write_json`, since we can just set `file=None`. Similar to change already made in `DataFrame.write_json`.
* Improve docstrings for `LazyFrame.from/read/write_json`.
* Fix some types for `DataFrame.write_json`.