### PR TITLE
ci[python,rust]: Minor improvements to docs workflows

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -1,18 +1,17 @@
-name: Docs check
+name: Check documentation
 
 on:
   pull_request:
     paths:
     - 'py-polars/**'
-    - '.github/workflows/docs_check.yaml'
+    - '.github/workflows/docs-check.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Docs check
+  main:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -20,17 +19,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
-      - name: Install dependencies
+
+      - name: Install Python dependencies
         run: |
           pip install --upgrade pip
           pip install -r requirements-docs.txt
-      - name: Build Python reference
+
+      - name: Build Python documentation
         env:
           SPHINXOPTS: -W
         run: make html

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,44 +1,55 @@
-name: Docs
+name: Deploy documentation
 
 on:
   push:
     branches:
       - master
       - docs
+
 jobs:
-  test:
-    name: Docs
+  main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2022-08-22
-          components: rust-docs
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
-      - name: Install dependencies
+
+      - name: Install Python dependencies
         working-directory: py-polars/docs
         run: |
           pip install --upgrade pip
           pip install -r requirements-docs.txt
-      - name: Build python reference
+
+      - name: Build Python documentation
         working-directory: py-polars/docs
         run: make html
-      - name: deploy docs
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-08-22
+          components: rust-docs
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build Rust documentation
         env:
           RUSTFLAGS: --cfg docsrs
+        run: cargo doc --features=docs-selection --package polars
+
+      - name: Prepare deployment
         run: |
-          set -e
-          cargo doc --features=docs-selection --package polars && \
-          echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html && \
+          echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html
           mkdir target/doc/py-polars
           cp -r py-polars/docs/build/html target/doc/py-polars
-          echo ghp-import step
-          ghp-import -n target/doc && \
+
+      - name: Deploy
+        run: |
+          ghp-import -n target/doc
           git push -qf https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git gh-pages


### PR DESCRIPTION
I checked if I could merge the two documentation workflows, since there is some duplication between the two. But after fiddling with this a lot, I concluded that there's no nice way to do it. Explicitly separating the two is just more clear.

I also tried adjusting the docs deployment workflow to build the Python and Rust docs in parallel, but again I had to conclude that this doesn't really improve things. Building the Rust docs takes less than a minute on cache hit and sharing files between jobs is just really cumbersome.

I ended up making some minor improvements.

Changes:
* Renamed workflows to reflect their purpose: `docs-check.yaml` and `docs-deploy.yaml`.
* Split the last step of the deploy workflow into smaller steps.
* Added a Rust cache for building the Rust docs.

Changes to deploy workflow were verified [here](https://github.com/pola-rs/polars/runs/8286839505?check_suite_focus=true) by letting it run on pull request and skipping the final deployment step.