### PR TITLE
feat[python]: improve frame init from `@dataclass` and `namedtuple` rows

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import sys
 from datetime import date, datetime, time, timedelta
+from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -13,6 +14,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    get_args,
 )
 
 try:
@@ -84,6 +86,7 @@ ColumnsType = Union[
     Mapping[str, PolarsDataType],
     Sequence[Tuple[str, Optional[PolarsDataType]]],
 ]
+NoneType = type(None)
 
 
 class Int8(DataType):
@@ -498,6 +501,11 @@ def py_type_to_dtype(data_type: Any) -> PolarsDataType:
     # when the passed in is already a Polars datatype, return that
     if is_polars_dtype(data_type):
         return data_type
+    elif isinstance(data_type, UnionType):
+        # extract bare 'type' from "'type' | None" dataclass definitions
+        possible_types = [tp for tp in get_args(data_type) if tp is not NoneType]
+        if len(possible_types) == 1:
+            data_type = possible_types[0]
     try:
         return _PY_TYPE_TO_DTYPE[data_type]
     except KeyError:  # pragma: no cover

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import ctypes
 import sys
 from datetime import date, datetime, time, timedelta
-from types import UnionType
+from decimal import Decimal
+from inspect import isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,7 +15,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    get_args,
 )
 
 try:
@@ -34,11 +34,28 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
+UnionType: type
+if sys.version_info >= (3, 10):
+    from types import UnionType
+else:
+    # infer equivalent class
+    UnionType = type(Union[int, float])
+
+if sys.version_info >= (3, 8):
+    from typing import get_args
+else:
+
+    # pass-through (only impact is that under 3.7 we'll end-up doing
+    # standard inference for dataclass fields with an option/union)
+    def get_args(tp: Any) -> Any:
+        return tp
+
+
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit
 
 
-def get_idx_type() -> type[DataType]:
+def get_idx_type() -> PolarsDataType:
     """
     Get the datatype used for polars Indexing.
 
@@ -79,6 +96,8 @@ class DataType:
         return dtype_str_repr(self)
 
 
+# note: defined this way as some types can have instances that
+# act as specialisations (eg: "List" and "List[Int32]")
 PolarsDataType = Union[Type[DataType], DataType]
 
 ColumnsType = Union[
@@ -146,7 +165,9 @@ class Unknown(DataType):
 
 
 class List(DataType):
-    def __init__(self, inner: type[DataType]):
+    inner: PolarsDataType | None = None
+
+    def __init__(self, inner: PolarsDataType):
         """
         Nested list/array type.
 
@@ -158,7 +179,7 @@ class List(DataType):
         """
         self.inner = py_type_to_dtype(inner)
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
+    def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # The comparison allows comparing objects to classes
         # and specific inner types to none specific.
         # if one of the arguments is not specific about its inner type
@@ -180,7 +201,7 @@ class List(DataType):
             return False
 
     def __hash__(self) -> int:
-        return hash(List)
+        return hash((List, self.inner))
 
 
 class Date(DataType):
@@ -205,7 +226,7 @@ class Datetime(DataType):
         self.tu = time_unit
         self.tz = time_zone
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
+    def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Datetime):
             return True
@@ -233,7 +254,7 @@ class Duration(DataType):
         """
         self.tu = time_unit
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
+    def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is type and issubclass(other, Duration):
             return True
@@ -259,7 +280,7 @@ class Categorical(DataType):
 
 
 class Field:
-    def __init__(self, name: str, dtype: type[DataType]):
+    def __init__(self, name: str, dtype: PolarsDataType):
         """
         Definition of a single field within a `Struct` DataType.
 
@@ -298,19 +319,17 @@ class Struct(DataType):
         """
         self.fields = fields
 
-    def __eq__(self, other: type[DataType]) -> bool:  # type: ignore[override]
-        # The comparison allows comparing objects to classes
-        # and specific inner types to none specific.
-        # if one of the arguments is not specific about its inner type
-        # we infer it as being equal.
-        # See the list type for more info
-        if type(other) is type and issubclass(other, Struct):
+    def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
+        # The comparison allows comparing objects to classes, and specific
+        # inner types to those without (eg: inner=None). if one of the
+        # arguments is not specific about its inner type we infer it
+        # as being equal. (See the List type for more info).
+        if isclass(other) and issubclass(other, Struct):
             return True
-        if isinstance(other, Struct):
-            if self.fields is None or other.fields is None:
-                return True
-            else:
-                return self.fields == other.fields
+        elif isinstance(other, Struct):
+            return any((f is None) for f in (self.fields, other.fields)) or (
+                self.fields == other.fields
+            )
         else:
             return False
 
@@ -368,7 +387,7 @@ for tu in DTYPE_TEMPORAL_UNITS:
     _DTYPE_TO_CTYPE[Duration(tu)] = ctypes.c_int64
 
 
-_PY_TYPE_TO_DTYPE: dict[type, type[DataType]] = {
+_PY_TYPE_TO_DTYPE: dict[type, PolarsDataType] = {
     float: Float64,
     int: Int64,
     str: Utf8,
@@ -379,6 +398,7 @@ _PY_TYPE_TO_DTYPE: dict[type, type[DataType]] = {
     time: Time,
     list: List,
     tuple: List,
+    Decimal: Float64,
 }
 
 
@@ -464,8 +484,16 @@ if _PYARROW_AVAILABLE:
     }
 
 
+def _lookup_type(dtype: PolarsDataType) -> PolarsDataType:
+    """Normalise type so it can be looked-up correctly."""
+    # (currently only List requires this, due to arbitrary 'inner')
+    return List if dtype == List else dtype
+
+
 def dtype_to_ctype(dtype: PolarsDataType) -> type[_SimpleCData]:
+    """Convert a Polars dtype to a ctype."""
     try:
+        dtype = _lookup_type(dtype)
         return _DTYPE_TO_CTYPE[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
@@ -474,7 +502,9 @@ def dtype_to_ctype(dtype: PolarsDataType) -> type[_SimpleCData]:
 
 
 def dtype_to_ffiname(dtype: PolarsDataType) -> str:
+    """Return FFI function name associated with the given Polars dtype."""
     try:
+        dtype = _lookup_type(dtype)
         return _DTYPE_TO_FFINAME[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
@@ -483,7 +513,9 @@ def dtype_to_ffiname(dtype: PolarsDataType) -> str:
 
 
 def dtype_to_py_type(dtype: PolarsDataType) -> type:
+    """Convert a Polars dtype to a Python dtype."""
     try:
+        dtype = _lookup_type(dtype)
         return _DTYPE_TO_PY_TYPE[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
@@ -492,23 +524,28 @@ def dtype_to_py_type(dtype: PolarsDataType) -> type:
 
 
 def is_polars_dtype(data_type: Any) -> bool:
+    """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     return isinstance(data_type, DataType) or (
         type(data_type) is type and issubclass(data_type, DataType)
     )
 
 
-def py_type_to_dtype(data_type: Any) -> PolarsDataType:
+def py_type_to_dtype(data_type: Any, raise_unmatched: bool = True) -> PolarsDataType:
+    """Convert a Python dtype to a Polars dtype."""
     # when the passed in is already a Polars datatype, return that
     if is_polars_dtype(data_type):
         return data_type
     elif isinstance(data_type, UnionType):
-        # extract bare 'type' from "'type' | None" dataclass definitions
+        # not exhaustive; currently handles the common "type | None" case,
+        # but ideally would pick appropriate supertype when n_types > 1
         possible_types = [tp for tp in get_args(data_type) if tp is not NoneType]
         if len(possible_types) == 1:
             data_type = possible_types[0]
     try:
         return _PY_TYPE_TO_DTYPE[data_type]
     except KeyError:  # pragma: no cover
+        if not raise_unmatched:
+            return None  # type: ignore[return-value]
         raise NotImplementedError(
             f"Conversion of Python data type {data_type} to Polars data type not"
             " implemented."
@@ -539,7 +576,8 @@ def supported_numpy_char_code(dtype: str) -> bool:
     return dtype in _NUMPY_CHAR_CODE_TO_DTYPE
 
 
-def numpy_char_code_to_dtype(dtype: str) -> type[DataType]:
+def numpy_char_code_to_dtype(dtype: str) -> PolarsDataType:
+    """Convert a numpy character dtype to a Polars dtype."""
     try:
         return _NUMPY_CHAR_CODE_TO_DTYPE[dtype]
     except KeyError:  # pragma: no cover
@@ -549,8 +587,8 @@ def numpy_char_code_to_dtype(dtype: str) -> type[DataType]:
 
 
 def maybe_cast(
-    el: type[DataType], dtype: type, time_unit: TimeUnit | None = None
-) -> type[DataType]:
+    el: PolarsDataType, dtype: type, time_unit: TimeUnit | None = None
+) -> PolarsDataType:
     # cast el if it doesn't match
     from polars.utils import _datetime_to_pl_timestamp, _timedelta_to_pl_timedelta
 
@@ -565,4 +603,4 @@ def maybe_cast(
 
 
 #: Mapping of `~polars.DataFrame` / `~polars.LazyFrame` column names to their `DataType`
-Schema = Dict[str, Type[DataType]]
+Schema = Dict[str, PolarsDataType]

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -6,7 +6,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import polars.internals as pli
-from polars.datatypes import DataType, dtype_to_ffiname
+from polars.datatypes import PolarsDataType, dtype_to_ffiname
 
 if TYPE_CHECKING:
     from polars.polars import PySeries
@@ -126,7 +126,7 @@ def expr_dispatch(cls: type[T]) -> type[T]:
 
 
 def get_ffi_func(
-    name: str, dtype: type[DataType], obj: PySeries
+    name: str, dtype: PolarsDataType, obj: PySeries
 ) -> Callable[..., Any] | None:
     """
     Dynamically obtain the proper ffi function/ method.

--- a/py-polars/tests/slow/test_csv.py
+++ b/py-polars/tests/slow/test_csv.py
@@ -7,5 +7,5 @@ def test_csv_statistics_offset() -> None:
     # this would fail if the statistics sample did not also sample
     # from the end of the file
     # the lines at the end have larger rows as the numbers increase
-    csv = "\n".join([str(x) for x in range(5_000)])
+    csv = "\n".join(str(x) for x in range(5_000))
     assert pl.read_csv(io.StringIO(csv), n_rows=5000).height == 4999

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -24,8 +24,8 @@ def test_dtype_temporal_units() -> None:
         assert pl.Datetime == pl.Datetime(tu)
         assert pl.Duration == pl.Duration(tu)
 
-        assert pl.Datetime(tu) == pl.Datetime()  # type: ignore[operator]
-        assert pl.Duration(tu) == pl.Duration()  # type: ignore[operator]
+        assert pl.Datetime(tu) == pl.Datetime()
+        assert pl.Duration(tu) == pl.Duration()
 
     assert pl.Datetime("ms") != pl.Datetime("ns")
     assert pl.Duration("ns") != pl.Duration("us")
@@ -40,3 +40,17 @@ def test_dtypes_picklable() -> None:
     singleton_type = pl.Float64
     assert pickle.loads(pickle.dumps(parametric_type)) == parametric_type
     assert pickle.loads(pickle.dumps(singleton_type)) == singleton_type
+
+
+def test_dtypes_hashable() -> None:
+    # ensure that all the types can be hashed, and that their hashes
+    # are sufficient to ensure distinct entries in a dictionary/set
+
+    all_dtypes = [
+        getattr(datatypes, d)
+        for d in dir(datatypes)
+        if isinstance(getattr(datatypes, d), datatypes.DataType)
+    ]
+    assert len(set(all_dtypes + all_dtypes)) == len(all_dtypes)
+    assert len({pl.Datetime("ms"), pl.Datetime("us"), pl.Datetime("ns")}) == 3
+    assert len({pl.List, pl.List(pl.Int16), pl.List(pl.Int32), pl.List(pl.Int64)}) == 4

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import typing
 from datetime import datetime, timedelta
+from decimal import Decimal
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Iterator
 
@@ -220,26 +221,26 @@ def test_dataclasses_and_namedtuple() -> None:
     class TradeDC:
         timestamp: datetime
         ticker: str
-        price: float
+        price: Decimal
         size: int | None = None
 
     class TradeNT(NamedTuple):
         timestamp: datetime
         ticker: str
-        price: float
+        price: Decimal
         size: int | None = None
 
     raw_data = [
-        (datetime(2022, 9, 8, 14, 30, 45), "AAPL", 157.5, 125),
-        (datetime(2022, 9, 9, 10, 15, 12), "FLSY", 10.0, 1500),
-        (datetime(2022, 9, 7, 15, 30), "MU", 55.5, 400),
+        (datetime(2022, 9, 8, 14, 30, 45), "AAPL", Decimal("157.5"), 125),
+        (datetime(2022, 9, 9, 10, 15, 12), "FLSY", Decimal("10.0"), 1500),
+        (datetime(2022, 9, 7, 15, 30), "MU", Decimal("55.5"), 400),
     ]
 
     for TradeClass in (TradeDC, TradeNT):
         trades = [TradeClass(*values) for values in raw_data]
 
-        for df_init in (pl.DataFrame, pl.from_records):
-            df = df_init(data=trades)  # type: ignore[operator]
+        for DF in (pl.DataFrame, pl.from_records):
+            df = DF(data=trades)  # type: ignore[operator]
             assert df.schema == {
                 "timestamp": pl.Datetime("us"),
                 "ticker": pl.Utf8,

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -212,6 +212,61 @@ def test_from_arrow() -> None:
     assert df.rows() == []
 
 
+def test_dataclasses_and_namedtuple() -> None:
+    from dataclasses import dataclass
+    from typing import NamedTuple
+
+    @dataclass
+    class TradeDC:
+        timestamp: datetime
+        ticker: str
+        price: float
+        size: int | None = None
+
+    class TradeNT(NamedTuple):
+        timestamp: datetime
+        ticker: str
+        price: float
+        size: int | None = None
+
+    raw_data = [
+        (datetime(2022, 9, 8, 14, 30, 45), "AAPL", 157.5, 125),
+        (datetime(2022, 9, 9, 10, 15, 12), "FLSY", 10.0, 1500),
+        (datetime(2022, 9, 7, 15, 30), "MU", 55.5, 400),
+    ]
+
+    for TradeClass in (TradeDC, TradeNT):
+        trades = [TradeClass(*values) for values in raw_data]
+
+        for df_init in (pl.DataFrame, pl.from_records):
+            df = df_init(data=trades)  # type: ignore[operator]
+            assert df.schema == {
+                "timestamp": pl.Datetime("us"),
+                "ticker": pl.Utf8,
+                "price": pl.Float64,
+                "size": pl.Int64,
+            }
+            assert df.rows() == raw_data
+
+        # in conjunction with 'columns' override (rename/downcast)
+        df = pl.DataFrame(
+            data=trades,
+            columns=[  # type: ignore[arg-type]
+                ("ts", pl.Datetime("ms")),
+                ("tk", pl.Utf8),
+                ("pc", pl.Float32),
+                ("sz", pl.UInt16),
+            ],
+        )
+        assert df.schema == {
+            "ts": pl.Datetime("ms"),
+            "tk": pl.Utf8,
+            "pc": pl.Float32,
+            "sz": pl.UInt16,
+        }
+        assert df.rows() == raw_data
+
+
 def test_dataframe_membership_operator() -> None:
     # cf. issue #4032
     df = pl.DataFrame({"name": ["Jane", "John"], "age": [20, 30]})
@@ -1979,7 +2034,7 @@ def test_list_of_list_of_struct() -> None:
     assert df.rows() == [([[{"a": 1}, {"a": 2}]],)]
     assert df.to_dicts() == expected
 
-    df = pl.from_arrow(pa_df)[:0]
+    df = pl.from_arrow(pa_df[:0])
     assert df.to_dicts() == []
 
 


### PR DESCRIPTION
Closes #4801 

----

Python's `dataclass` and `namedtuple` are native types with good performance which have the added bonus that we can infer the column names and data orientation (from both) and the expected schema (from `dataclass`). 

This PR allows `DataFrames` to be initialised from both types (matching `pandas`, which supports the same).

**Setup** _(example)_
```python
from dataclasses import dataclass
from datetime import datetime

@dataclass
class Trade:
    timestamp: datetime
    ticker: str
    price: float
    size: int | None = None

trades = [
    Trade(datetime(2022, 9, 8, 14, 30, 45), "AAPL", 157.5, 125),
    Trade(datetime(2022, 9, 9, 10, 15, 12), "FSLY", 10.0, 1500),
    Trade(datetime(2022, 9, 7, 15, 30), "MU", 55.5, 400),
]
```
**Initialise frame** _(no need to set 'columns' or 'orient'; they are automatically inferred)_
```python
import polars as pl
df = pl.DataFrame( trades )

# shape: (3, 4)
# ┌─────────────────────┬────────┬───────┬──────┐
# │ timestamp           ┆ ticker ┆ price ┆ size │
# │ ---                 ┆ ---    ┆ ---   ┆ ---  │
# │ datetime[μs]        ┆ str    ┆ f64   ┆ i64  │
# ╞═════════════════════╪════════╪═══════╪══════╡
# │ 2022-09-08 14:30:45 ┆ AAPL   ┆ 157.5 ┆ 125  │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ 2022-09-09 10:15:12 ┆ FSLY   ┆ 10.0  ┆ 1500 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
# │ 2022-09-07 15:30:00 ┆ MU     ┆ 55.5  ┆ 400  │
# └─────────────────────┴────────┴───────┴──────┘
```


**Note**
The [issue](https://github.com/pola-rs/polars/issues/4801) also mentioned classes derived from `pydantic`; however, I have _not_ integrated support for this - unlike dataclasses and namedtuple the package is not part of the standard Python distribution, and I don't see sufficient value in taking the extra dependency (given the added functionality above).

**Also**
Some additional minor typing improvements.