### PR TITLE
refactor[python]: Replace pytz by stdlib zoneinfo

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements-dev.txt
       # Allow untyped calls for older Python versions
       - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' && '--no-warn-unused-ignores' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls --no-warn-unused-ignores' || '' }}
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements-dev.txt
       # Allow untyped calls for older Python versions
       - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls --no-warn-unused-ignores' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -40,7 +40,7 @@ jobs:
           pip install -r requirements-dev.txt
       # Allow untyped calls for older Python versions
       - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' && '--no-warn-unused-ignores' || '' }}
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ $ pip3 install -U 'polars[connectorx]'
 # Install Polars and xlsx2csv (read data from Excel).
 $ pip3 install -U 'polars[xlsx2csv]'
 
-# Install Polars and pytz (for timezone support).
-$ pip3 install -U 'polars[pytz]'
+# Install Polars and zoneinfo (for timezone support in Python < 3.9, Python 3.9+ has this in stdlib).
+$ pip3 install -U 'polars[zoneinfo]'
 ```
 
 Releases happen quite often (weekly / every few days) at the moment, so updating polars regularly to get the latest bugfixes / features might not be a bad idea.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ $ pip3 install -U 'polars[connectorx]'
 # Install Polars and xlsx2csv (read data from Excel).
 $ pip3 install -U 'polars[xlsx2csv]'
 
-# Install Polars and zoneinfo (for timezone support in Python < 3.9, Python 3.9+ has this in stdlib).
-$ pip3 install -U 'polars[zoneinfo]'
+# Install Polars with timezone support, only needed if
+#   1. you are on Python < 3.9, Python 3.9+ has this in stdlib
+#   2. you are on Windows
+$ pip3 install -U 'polars[timezone]'
 ```
 
 Releases happen quite often (weekly / every few days) at the moment, so updating polars regularly to get the latest bugfixes / features might not be a bad idea.

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -197,7 +197,7 @@ class Datetime(DataType):
             Time unit.
         time_zone
             Timezone string as defined in zoneinfo (run
-            `import zoneinfo; zoneinfo.available_timezones()` for a full list).
+            ``import zoneinfo; zoneinfo.available_timezones()`` for a full list).
 
         """
         self.tu = time_unit

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -196,7 +196,8 @@ class Datetime(DataType):
         time_unit : {'us', 'ns', 'ms'}
             Time unit.
         time_zone
-            Timezone string as defined in pytz.
+            Timezone string as defined in zoneinfo (run
+            `import zoneinfo; zoneinfo.available_timezones()` for a full list).
 
         """
         self.tu = time_unit

--- a/py-polars/polars/show_versions.py
+++ b/py-polars/polars/show_versions.py
@@ -55,7 +55,6 @@ def _get_dependency_info() -> dict[str, str]:
         "fsspec",
         "connectorx",
         "xlsx2csv",
-        "pytz",
     ]
     return {name: _get_dep_version(name) for name in opt_deps}
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -25,17 +25,18 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec, TypeGuard
 
-try:
+
+if sys.version_info >= (3, 9):
     import zoneinfo
 
-    ZONEINFO_AVAILABLE = True
-except ImportError:  # in Python 3.8 and earlier we would hit this
+    _ZONEINFO_AVAILABLE = True
+else:
     try:
-        from backports import zoneinfo  # type: ignore[no-redef]
+        from backports import zoneinfo
 
-        ZONEINFO_AVAILABLE = True
+        _ZONEINFO_AVAILABLE = True
     except ImportError:
-        ZONEINFO_AVAILABLE = False
+        _ZONEINFO_AVAILABLE = False
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import SizeUnit, TimeUnit
@@ -223,7 +224,7 @@ def _to_python_datetime(
 
 
 def _localize(dt: datetime, tz: str) -> datetime:
-    if not ZONEINFO_AVAILABLE:
+    if not _ZONEINFO_AVAILABLE:
         raise ImportError(
             "backports.zoneinfo is not installed. Please run "
             "`pip install backports.zoneinfo`."

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -204,17 +204,21 @@ def _to_python_datetime(
         else:
             raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
         if tz is not None and len(tz) > 0:
-            try:
-                import pytz
-            except ImportError:
-                raise ImportError(
-                    "pytz is not installed. Please run `pip install pytz`."
-                ) from None
-
-            return pytz.timezone(tz).localize(dt)
+            return _localize(dt, tz)
         return dt
     else:
         raise NotImplementedError  # pragma: no cover
+
+
+def _localize(dt: datetime, tz: str) -> datetime:
+    try:
+        import pytz
+    except ImportError:
+        raise ImportError(
+            "pytz is not installed. Please run `pip install pytz`."
+        ) from None
+
+    return pytz.timezone(tz).localize(dt, is_dst=None)
 
 
 def _in_notebook() -> bool:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -31,7 +31,7 @@ try:
     ZONEINFO_AVAILABLE = True
 except ImportError:  # in Python 3.8 and earlier we would hit this
     try:
-        from backports import zoneinfo  # type: ignore[import, no-redef]
+        from backports import zoneinfo
 
         ZONEINFO_AVAILABLE = True
     except ImportError:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -31,7 +31,7 @@ try:
     ZONEINFO_AVAILABLE = True
 except ImportError:  # in Python 3.8 and earlier we would hit this
     try:
-        from backports import zoneinfo
+        from backports import zoneinfo  # type: ignore[no-redef]
 
         ZONEINFO_AVAILABLE = True
     except ImportError:

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -19,7 +19,7 @@ numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
-pytz = ["pytz"]
+zoneinfo = ["backports.zoneinfo; python_version < '3.9'"]
 
 [tool.isort]
 profile = "black"

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -19,7 +19,7 @@ numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
-zoneinfo = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
+timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 
 [tool.isort]
 profile = "black"

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -36,7 +36,7 @@ enable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx", "IPython.*"]
+module = ["backports", "pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx", "IPython.*", "zoneinfo"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -19,7 +19,7 @@ numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
-zoneinfo = ["backports.zoneinfo; python_version < '3.9'"]
+zoneinfo = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 
 [tool.isort]
 profile = "black"

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -6,7 +6,7 @@
 numpy
 pandas
 pyarrow
-pytz
+backports.zoneinfo; python_version < '3.9'
 xlsx2csv
 
 # Tooling
@@ -18,4 +18,3 @@ pytest-cov==3.0.0
 
 # Stub files
 pandas-stubs==1.2.0.61
-types-pytz==2022.2.1.0

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -7,6 +7,7 @@ numpy
 pandas
 pyarrow
 backports.zoneinfo; python_version < '3.9'
+tzdata; platform_system == 'Windows'
 xlsx2csv
 
 # Tooling

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -488,9 +488,13 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let kwargs = PyDict::new(py);
                     kwargs.set_item("tzinfo", py.None())?;
                     let dt = ob.call_method("replace", (), Some(kwargs))?;
-                    
+
                     let pypolars = PyModule::import(py, "polars").unwrap();
-                    let localize = pypolars.getattr("utils").unwrap().getattr("_localize").unwrap();
+                    let localize = pypolars
+                        .getattr("utils")
+                        .unwrap()
+                        .getattr("_localize")
+                        .unwrap();
                     let loc_tz = localize.call1((dt, "UTC"));
 
                     loc_tz.call_method0("timestamp")?;

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -488,12 +488,11 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let kwargs = PyDict::new(py);
                     kwargs.set_item("tzinfo", py.None())?;
                     let dt = ob.call_method("replace", (), Some(kwargs))?;
+                    
+                    let pypolars = PyModule::import(py, "polars").unwrap();
+                    let localize = pypolars.getattr("utils").unwrap().getattr("_localize").unwrap();
+                    let loc_tz = localize.call1((dt, "UTC"));
 
-                    let pytz = PyModule::import(py, "pytz")?;
-                    let tz = pytz.call_method("timezone", ("UTC",), None)?;
-                    let kwargs = PyDict::new(py);
-                    kwargs.set_item("is_dst", py.None())?;
-                    let loc_tz = tz.call_method("localize", (dt,), Some(kwargs))?;
                     loc_tz.call_method0("timestamp")?;
                     // s to us
                     let v = (ts.extract::<f64>()? * 1000_000.0) as i64;

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -12,7 +12,7 @@ import pytest
 try:
     import zoneinfo
 except ImportError:  # in Python 3.8 and earlier we would hit this
-    from backports import zoneinfo  # type: ignore[import,no-redef]
+    from backports import zoneinfo
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -12,7 +12,7 @@ import pytest
 try:
     import zoneinfo
 except ImportError:  # in Python 3.8 and earlier we would hit this
-    from backports import zoneinfo
+    from backports import zoneinfo  # type: ignore[no-redef]
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -8,7 +8,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-import pytz
+
+try:
+    import zoneinfo
+except ImportError:  # in Python 3.8 and earlier we would hit this
+    from backports import zoneinfo  # type: ignore[import,no-redef]
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
@@ -660,8 +664,8 @@ def test_read_utc_times_parquet() -> None:
     df.to_parquet(f)
     f.seek(0)
     df_in = pl.read_parquet(f)
-    tz = pytz.timezone("UTC")
-    assert df_in["Timestamp"][0] == tz.localize(datetime(2022, 1, 1, 0, 0))
+    tz = zoneinfo.ZoneInfo("UTC")
+    assert df_in["Timestamp"][0] == datetime(2022, 1, 1, 0, 0).astimezone(tz)
 
 
 def test_epoch() -> None:
@@ -1369,7 +1373,7 @@ def test_weekday() -> None:
 
 
 def test_from_dict_tu_consistency() -> None:
-    tz = pytz.timezone("PRC")
+    tz = zoneinfo.ZoneInfo("PRC")
     dt = datetime(2020, 8, 1, 12, 0, 0, tzinfo=tz)
     from_dict = pl.from_dict({"dt": [dt]})
     from_dicts = pl.from_dicts([{"dt": dt}])

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import sys
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, no_type_check
 
@@ -9,10 +10,10 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-try:
+if sys.version_info >= (3, 9):
     import zoneinfo
-except ImportError:  # in Python 3.8 and earlier we would hit this
-    from backports import zoneinfo  # type: ignore[no-redef]
+else:
+    from backports import zoneinfo
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS


### PR DESCRIPTION
Dropping the third-party `pytz` package in favor of the Python stdlib `zoneinfo`. `zoneinfo` is a Python stdlib since Python 3.9. 
* For older Python versions we use `backports.zoneinfo` (https://github.com/pganssle/zoneinfo)
* `zoneinfo` relies on system timezone data. Windows does not provide that (or not in a format zoneinfo can use), so we need to install `tzdata` for that case.

See https://peps.python.org/pep-0431/ for a discussion of ZoneInfo and differences with `pytz`.