### PR TITLE
ci: Update PR labeler version

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,11 +1,12 @@
-name: "Pull Request Labeler"
-on:
-- pull_request_target
+name: Pull request labeler
+
+on: pull_request_target
 
 jobs:
-  labeler:
+  main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - name: Label pull request
+      uses: actions/labeler@v4
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes:
* Updated from `@v3` to [`@v4`](https://github.com/actions/labeler/releases)
* Minor formatting changes to match the other workflows.

Because the trigger for this workflow is `pull_request_target`, the check showing up on this PR still uses the 'old' workflow. I verified the changes by temporarily changing the trigger to `pull_request`; see [here](https://github.com/pola-rs/polars/runs/8286978496?check_suite_focus=true).