### PR TITLE
chore[python]: Add backticks to version details in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -67,9 +67,9 @@ body:
       value: >
         <details>
 
-
-        Replace this line with the output of pl.show_versions()
-
+        ```
+        Replace this line with the output of pl.show_versions(), leave the backticks in place
+        ```
 
         </details>
     validations:


### PR DESCRIPTION
Renders the versions as a code block, and hopefully does not have users remove the whitespace, causing the newlines to not being displayed.