### PR TITLE
feat[rust, python]: various `str.strptime` enhancements/fixes, and new fractional seconds option for `dt.seconds`,

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -36,7 +36,6 @@ where
         "%y/%m/%d %H:%M:%S",
         //210319 23:58:50
         "%y%m%d %H:%M:%S",
-        // 2019-04-18T02:45:55
         // 2021/12/31 12:54:98
         "%Y/%m/%d %H:%M:%S",
         // 2021-12-31 24:58:01
@@ -45,13 +44,18 @@ where
         "%Y/%m/%d %H:%M:%S",
         // 20210319 23:58:50
         "%Y%m%d %H:%M:%S",
+        // note: '%F' cannot be parsed by polars native parser
         // 2019-04-18T02:45:55
-        // %F cannot be parse by polars native parser
         "%Y-%m-%dT%H:%M:%S",
-        // 2019-04-18T02:45:55.555000000
+        // 2019-04-18T02:45:55[...]
+        // milliseconds
+        "%Y-%m-%d %H:%M:%S.%3f",
+        "%Y-%m-%dT%H:%M:%S.%3f",
         // microseconds
+        "%Y-%m-%d %H:%M:%S.%6f",
         "%Y-%m-%dT%H:%M:%S.%6f",
         // nanoseconds
+        "%Y-%m-%d %H:%M:%S.%9f",
         "%Y-%m-%dT%H:%M:%S.%9f",
     ]
     .into_iter()

--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -69,11 +69,15 @@ pub(super) static DATETIME_Y_M_D: &[&str] = &[
     // 2019-04-18T02:45:55
     "%Y-%m-%dT%H:%M:%S",
     "%Y-%m-%dT%H:%M:%SZ",
-    // 2019-04-18T02:45:55.555000000
-    // microseconds
-    "%Y-%m-%dT%H:%M:%S.%6f",
+    // 2019-04-18T02:45:55.555[000000]
     // nanoseconds
+    "%Y-%m-%d %H:%M:%S.%9f",
     "%Y-%m-%dT%H:%M:%S.%9f",
+    // microseconds
+    "%Y-%m-%d %H:%M:%S.%6f",
+    "%Y-%m-%dT%H:%M:%S.%6f",
+    // milliseconds
+    "%Y-%m-%d %H:%M:%S.%3f",
     "%Y-%m-%dT%H:%M:%S.%3f",
     // no times
     "%Y-%m-%d",

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -187,6 +187,9 @@ class Date(DataType):
 class Datetime(DataType):
     """Calendar date and time type."""
 
+    tu: TimeUnit | None = None
+    tz: str | None = None
+
     def __init__(self, time_unit: TimeUnit = "us", time_zone: str | None = None):
         """
         Calendar date and time type.
@@ -217,6 +220,8 @@ class Datetime(DataType):
 
 class Duration(DataType):
     """Time duration/delta type."""
+
+    tu: TimeUnit | None = None
 
     def __init__(self, time_unit: TimeUnit = "us"):
         """
@@ -314,6 +319,8 @@ class Struct(DataType):
     def __hash__(self) -> int:
         return hash(Struct)
 
+
+TemporalDataType = Union[Type[Datetime], Datetime, Type[Date], Date, Type[Time], Time]
 
 DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
 
@@ -550,6 +557,7 @@ def maybe_cast(
         return _datetime_to_pl_timestamp(el, time_unit)
     elif isinstance(el, timedelta):
         return _timedelta_to_pl_timedelta(el, time_unit)
+
     py_type = dtype_to_py_type(dtype)
     if not isinstance(el, py_type):
         el = py_type(el)

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -63,7 +63,7 @@ class DateTimeNameSpace:
         """
         Extract the year from the underlying date representation.
 
-        Can be performed on Date and Datetime.
+        Can be performed on Date and Datetime columns.
 
         Returns the year number in the calendar date.
 
@@ -77,7 +77,7 @@ class DateTimeNameSpace:
         """
         Extract quarter from underlying Date representation.
 
-        Can be performed on Date and Datetime.
+        Can be performed on Date and Datetime columns.
 
         Returns the quarter ranging from 1 to 4.
 
@@ -91,7 +91,7 @@ class DateTimeNameSpace:
         """
         Extract the month from the underlying date representation.
 
-        Can be performed on Date and Datetime
+        Can be performed on Date and Datetime columns.
 
         Returns the month number starting from 1.
         The return value ranges from 1 to 12.
@@ -106,7 +106,7 @@ class DateTimeNameSpace:
         """
         Extract the week from the underlying date representation.
 
-        Can be performed on Date and Datetime
+        Can be performed on Date and Datetime columns.
 
         Returns the ISO week number starting from 1.
         The return value ranges from 1 to 53. (The last week of year differs by years.)
@@ -121,7 +121,7 @@ class DateTimeNameSpace:
         """
         Extract the week day from the underlying date representation.
 
-        Can be performed on Date and Datetime.
+        Can be performed on Date and Datetime columns.
 
         Returns the weekday number where monday = 0 and sunday = 6
 
@@ -135,7 +135,7 @@ class DateTimeNameSpace:
         """
         Extract the day from the underlying date representation.
 
-        Can be performed on Date and Datetime.
+        Can be performed on Date and Datetime columns.
 
         Returns the day of month starting from 1.
         The return value ranges from 1 to 31. (The last day of month differs by months.)
@@ -150,7 +150,7 @@ class DateTimeNameSpace:
         """
         Extract ordinal day from underlying date representation.
 
-        Can be performed on Date and Datetime.
+        Can be performed on Date and Datetime columns.
 
         Returns the day of year starting from 1.
         The return value ranges from 1 to 366. (The last day of year differs by years.)
@@ -165,7 +165,7 @@ class DateTimeNameSpace:
         """
         Extract the hour from the underlying DateTime representation.
 
-        Can be performed on Datetime.
+        Can be performed on Datetime columns.
 
         Returns the hour number from 0 to 23.
 
@@ -179,7 +179,7 @@ class DateTimeNameSpace:
         """
         Extract the minutes from the underlying DateTime representation.
 
-        Can be performed on Datetime.
+        Can be performed on Datetime columns.
 
         Returns the minute number from 0 to 59.
 
@@ -189,17 +189,19 @@ class DateTimeNameSpace:
 
         """
 
-    def second(self) -> pli.Series:
+    def second(self, fractional: bool = False) -> pli.Series:
         """
-        Extract the seconds the from underlying DateTime representation.
+        Extract seconds from underlying DateTime representation.
 
-        Can be performed on Datetime.
+        Can be performed on Datetime columns.
 
-        Returns the second number from 0 to 59.
+        Returns the integer second number from 0 to 59, or a floating
+        point number from 0 < 60 if ``fractional=True`` that includes
+        any milli/micro/nanosecond component.
 
         Returns
         -------
-        Second as UInt32
+        Second as UInt32 (or Float64)
 
         """
 
@@ -207,7 +209,7 @@ class DateTimeNameSpace:
         """
         Extract the nanoseconds from the underlying DateTime representation.
 
-        Can be performed on Datetime.
+        Can be performed on Datetime columns.
 
         Returns the number of nanoseconds since the whole non-leap second.
         The range from 1,000,000,000 to 1,999,999,999 represents the leap second.

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -368,6 +368,7 @@ class Series:
             f = get_ffi_func(op + "_<>", Int64, self._s)
             assert f is not None
             return wrap_s(f(ts))
+
         if isinstance(other, date) and self.dtype == Date:
             d = _date_to_pl_date(other)
             f = get_ffi_func(op + "_<>", Int32, self._s)
@@ -378,10 +379,13 @@ class Series:
             other = Series("", other, dtype_if_empty=self.dtype)
         if isinstance(other, Series):
             return wrap_s(getattr(self._s, op)(other._s))
-        other = maybe_cast(other, self.dtype, self.time_unit)
+
+        if other is not None:
+            other = maybe_cast(other, self.dtype, self.time_unit)
         f = get_ffi_func(op + "_<>", self.dtype, self._s)
         if f is None:
             return NotImplemented
+
         return wrap_s(f(other))
 
     def __eq__(self, other: Any) -> Series:  # type: ignore[override]
@@ -4237,7 +4241,7 @@ def _resolve_datetime_dtype(
 ) -> PolarsDataType | None:
     """Given polars/numpy datetime dtypes, resolve to an explicit unit."""
     if dtype is None or (dtype == Datetime and not getattr(dtype, "tu", None)):
-        tu = getattr(dtype, "tu", np.datetime_data(ndtype)[0])
+        tu = getattr(dtype, "tu", None) or np.datetime_data(ndtype)[0]
         # explicit formulation is verbose, but keeps mypy happy
         # (and avoids unsupported timeunits such as "s")
         if tu == "ns":

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import Date, Datetime, Time
+from polars.datatypes import TemporalDataType
 from polars.internals.series.utils import expr_dispatch
 from polars.utils import deprecated_alias
 
@@ -23,7 +23,7 @@ class StringNameSpace:
 
     def strptime(
         self,
-        datatype: type[Date] | type[Datetime] | type[Time],
+        datatype: TemporalDataType,
         fmt: str | None = None,
         strict: bool = True,
         exact: bool = True,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -514,11 +514,27 @@ impl PyExpr {
     }
 
     pub fn str_parse_datetime(&self, fmt: Option<String>, strict: bool, exact: bool) -> PyExpr {
+        let tu = match fmt {
+            Some(ref fmt) => {
+                if fmt.contains("%.9f")
+                    || fmt.contains("%9f")
+                    || fmt.contains("%f")
+                    || fmt.contains("%.f")
+                {
+                    TimeUnit::Nanoseconds
+                } else if fmt.contains("%.3f") || fmt.contains("%3f") {
+                    TimeUnit::Milliseconds
+                } else {
+                    TimeUnit::Microseconds
+                }
+            }
+            None => TimeUnit::Microseconds,
+        };
         self.inner
             .clone()
             .str()
             .strptime(StrpTimeOptions {
-                date_dtype: DataType::Datetime(TimeUnit::Microseconds, None),
+                date_dtype: DataType::Datetime(tu, None),
                 fmt,
                 strict,
                 exact,

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -372,12 +372,12 @@ def test_date_range() -> None:
     ]
 
     result = pl.date_range(
-        datetime(2022, 1, 1), datetime(2022, 1, 1, 0, 1), "987654321ns"
+        datetime(2022, 1, 1), datetime(2022, 1, 1, 0, 1), "987456321ns"
     )
     assert len(result) == 61
     assert result.dtype.tu == "ns"  # type: ignore[attr-defined]
     assert result.dt.second()[-1] == 59
-    assert result.dt.nanosecond()[-1] == 259259260
+    assert result.cast(pl.Utf8)[-1] == "2022-01-01 00:00:59.247379260"
 
 
 def test_date_comp() -> None:
@@ -710,6 +710,31 @@ def test_strptime_dates_datetimes() -> None:
     ]
 
 
+def test_strptime_precision() -> None:
+    s = pl.Series(
+        "date", ["2022-09-12 21:54:36.789321456", "2022-09-13 12:34:56.987456321"]
+    )
+    ds = s.str.strptime(pl.Datetime)
+    assert ds.cast(pl.Date) != None  # noqa: E711  (note: *deliberately* testing "!=")
+    assert getattr(ds.dtype, "tu", None) == "us"
+
+    time_units: list[TimeUnit] = ["ms", "us", "ns"]
+    suffixes = ["%.3f", "%.6f", "%.9f"]
+    test_data = zip(
+        time_units,
+        suffixes,
+        (
+            [789000000, 987000000],
+            [789321000, 987456000],
+            [789321456, 987456321],
+        ),
+    )
+    for precision, suffix, expected_values in test_data:
+        ds = s.str.strptime(pl.Datetime(precision), f"%Y-%m-%d %H:%M:%S{suffix}")
+        assert getattr(ds.dtype, "tu", None) == precision
+        assert ds.dt.nanosecond().to_list() == expected_values
+
+
 def test_asof_join_tolerance_grouper() -> None:
     from datetime import date
 
@@ -869,7 +894,6 @@ def test_asof_join() -> None:
             "bid": [720.5, 51.95, 51.97, 51.99, 720.50, 97.99, 720.50, 52.01],
         }
     )
-
     dates = [
         "2016-05-25 13:30:00.023",
         "2016-05-25 13:30:00.038",
@@ -891,10 +915,22 @@ def test_asof_join() -> None:
             "bid": [51.95, 51.95, 720.77, 720.92, 98.0],
         }
     )
-
+    assert trades.schema == {
+        "dates": pl.Datetime("ms"),
+        "ticker": pl.Utf8,
+        "bid": pl.Float64,
+    }
     out = trades.join_asof(quotes, on="dates", strategy="backward")
+
+    assert out.schema == {
+        "bid": pl.Float64,
+        "bid_right": pl.Float64,
+        "dates": pl.Datetime("ms"),
+        "ticker": pl.Utf8,
+        "ticker_right": pl.Utf8,
+    }
     assert out.columns == ["dates", "ticker", "bid", "ticker_right", "bid_right"]
-    assert (out["dates"].cast(int) / 1000).to_list() == [
+    assert (out["dates"].cast(int)).to_list() == [
         1464183000023,
         1464183000038,
         1464183000048,

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1486,7 +1486,6 @@ def test_str_strptime() -> None:
     verify_series_and_expr_api(
         s, expected, "str.strptime", pl.Datetime, "%Y-%m-%d %H:%M:%S"
     )
-
     s = pl.Series(["00:00:00", "03:20:10"])
     expected = pl.Series([0, 12010000000000], dtype=pl.Time)
     verify_series_and_expr_api(s, expected, "str.strptime", pl.Time, "%H:%M:%S")
@@ -1518,14 +1517,16 @@ def test_dt_year_month_week_day_ordinal_day() -> None:
 
 
 def test_dt_datetimes() -> None:
-    s = pl.Series(["2020-01-01 00:00:00", "2020-02-02 03:20:10"])
-    s = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S")
+    s = pl.Series(["2020-01-01 00:00:00.000000000", "2020-02-02 03:20:10.987654321"])
+    s = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
 
     # hours, minutes, seconds and nanoseconds
     verify_series_and_expr_api(s, pl.Series("", [0, 3], dtype=UInt32), "dt.hour")
     verify_series_and_expr_api(s, pl.Series("", [0, 20], dtype=UInt32), "dt.minute")
     verify_series_and_expr_api(s, pl.Series("", [0, 10], dtype=UInt32), "dt.second")
-    verify_series_and_expr_api(s, pl.Series("", [0, 0], dtype=UInt32), "dt.nanosecond")
+    verify_series_and_expr_api(
+        s, pl.Series("", [0, 987654321], dtype=UInt32), "dt.nanosecond"
+    )
 
     # epoch methods
     verify_series_and_expr_api(
@@ -1542,6 +1543,10 @@ def test_dt_datetimes() -> None:
         pl.Series("", [1_577_836_800_000, 1_580_613_610_000], dtype=Int64),
         "dt.epoch",
         tu="ms",
+    )
+    # fractional seconds
+    assert pl.Series("", [0.0, 10.987654321], dtype=Float64) == s.dt.second(
+        fractional=True
     )
 
 


### PR DESCRIPTION
* _Addressed some precision-related issues in `strptime`-derived cols:_

  The `strptime` formatting string, if set, is now used to infer the required time unit precision; was previously forcing microsecond precision, leading to unnecessary truncation of the fractional second component of input nanosecond strings, and unnecessary upcasting to microsecond precision for millisecond strings.

  ```python
  pl.Series(
    "date", ["2022-09-12 21:54:36.987654321", "2022-09-13 12:34:56.101010101"]
  ).str.strptime(
    datatype = pl.Datetime, 
    fmt = "%Y-%m-%d %H:%M:%S.%9f",   # << nanosecond precision inferred from "fmt"
  )

  # shape: (2,)
  # Series: 'date' [datetime[ns]].   # << "ns" (previously forced "us")
  # [
  #     2022-09-12 21:54:36.987654321
  #     2022-09-13 12:34:56.101010101
  # ]
  ```

* _Added `strptime` inference support for the common `%Y-%m-%d %H:%M:%S.%(3|6|9)f` patterns:_
 
  These are probably(?) more common than their `%Y-%m-%dT%H:%M:%S ...` equivalents, which are already supported (the new patterns just have a space instead of a "T").

  ```python
  # this would previously throw an error and require an explicit format string
  pl.Series(
    "dt", ["2022-09-12 21:54:36.654321", "2022-09-13 12:34:56.010101"]
  ).str.strptime(
    pl.Datetime
  )

  # shape: (2,)
  # Series: 'date' [datetime[μs]]
  # [
  #     2022-09-12 21:54:36.654321
  #     2022-09-13 12:34:56.010101
  # ]
  ```

* _The `strptime` method now respects the optional time unit in the input datatype:_

  For instance:
  ```python
  pl.Series(
    "date", ["2022-09-12 21:54:36", "2022-09-13 12:34:56"]
  ).str.strptime(
    pl.Datetime('ms')  # << timeunit now respected for final/output dtype
  )

  # shape: (2,)
  # Series: 'dt' [datetime[ms]]
  # [
  #     2022-09-12 21:54:36
  #     2022-09-13 12:34:56
  # ]
  ```

* _New "fractional" param for `dt.second` method (when not set only the integer component is returned, leaving it up to the caller to extract/combine the fractional part):_

  ```python
  df.select(pl.col("dt").dt.second(fractional=True).alias("secs"))
  shape: (3, 1)
  # ┌──────────┐
  # │ secs     │
  # │ ---      │
  # │ f64      │
  # ╞══════════╡
  # │ 0.456789 │
  # ├╌╌╌╌╌╌╌╌╌╌┤
  # │ 3.11111  │
  # ├╌╌╌╌╌╌╌╌╌╌┤
  # │ 5.765431 │
  # └──────────┘
  ```
----

**Update**
Splitting out the `dt.millisecond` and `dt.microsecond` addition to a future PR.