### PR TITLE
ci: Fix docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -46,10 +46,13 @@ jobs:
       - name: Prepare deployment
         run: |
           echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html
-          mkdir target/doc/py-polars
-          cp -r py-polars/docs/build/html target/doc/py-polars
+          mv py-polars/docs/build/html target/doc/py-polars
 
       - name: Deploy
         run: |
           ghp-import -n target/doc
           git push -qf https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git gh-pages
+
+      # Make sure documentation artifacts are not cached
+      - name: Clean up docs
+        run: rm -rf target/docs


### PR DESCRIPTION
Fixes breaking issue introduced by #4806

The issue was introduced by adding the rust cache. The `target/` folder is cached, which is why the `target/docs/py-polars` folder already existed when it was supposed to be created.

I still think the cache is worthwhile; I fixed this issue by removing the `target/docs` folder at the end of the workflow, so that it's not cached.

Changes:
* Add final step removing the `target/docs` folder.
* Removed unnecessary `mkdir` command
* Changed `cp -r` into `mv` (should theoretically be faster; and there is no reason to keep the docs in the old location).

It's hard to verify this, but I tried [here](https://github.com/pola-rs/polars/runs/8294705974?check_suite_focus=true). I propose we merge this, and if there's trouble, I'll come up with another fix 😄 

If after merging this it fails on copying the Python docs to the `target/doc` folder, that can probably be fixed by [clearing the existing cache](https://docs.github.com/en/rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id).