### PR TITLE
 ci[python]: Disable `fail-fast` for Python test job

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -19,7 +19,7 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ['3.7', '3.10']
 
@@ -82,6 +82,7 @@ jobs:
   windows:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10']
 


### PR DESCRIPTION
At the request of @zundertj 

Changes:
* Disable `fail-fast` for Python test job.
  * An error in one of the matrix jobs will no longer cancel the other jobs
  * This helps debug version-specific issues.