### PR TITLE
feat(python, rust)!: Implement `expanding_count` via `cumcount`

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -135,6 +135,97 @@ where
         ca.rename(self.name());
         ca
     }
+
+    fn cumcount(&self, reverse: bool, count_nulls: bool) -> UInt32Chunked {
+        let mut initial_value = 0u32;
+        let mut chunked_array: UInt32Chunked = match reverse {
+            false => self
+                .into_iter()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_trusted(),
+            true => self
+                .into_iter()
+                .rev()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_reversed(),
+        };
+        chunked_array.rename(self.name());
+        chunked_array
+    }
+}
+
+impl ChunkCumAgg<BooleanType> for ChunkedArray<BooleanType>
+where
+    ChunkedArray<BooleanType>: FromIterator<Option<bool>>,
+{
+    fn cumcount(&self, reverse: bool, count_nulls: bool) -> UInt32Chunked {
+        let mut initial_value = 0u32;
+        let mut chunked_array: UInt32Chunked = match reverse {
+            false => self
+                .into_iter()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_trusted(),
+            true => self
+                .into_iter()
+                .rev()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_reversed(),
+        };
+        chunked_array.rename(self.name());
+        chunked_array
+    }
+}
+
+impl ChunkCumAgg<Utf8Type> for ChunkedArray<Utf8Type>
+where
+    ChunkedArray<Utf8Type>: FromIterator<Option<String>>,
+{
+    fn cumcount(&self, reverse: bool, count_nulls: bool) -> UInt32Chunked {
+        let mut initial_value = 0u32;
+        let mut chunked_array: UInt32Chunked = match reverse {
+            false => self
+                .into_iter()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_trusted(),
+            true => self
+                .into_iter()
+                .rev()
+                .map(|x| {
+                    if x.is_some() || count_nulls {
+                        initial_value += 1;
+                    }
+                    Some(initial_value)
+                })
+                .collect_reversed(),
+        };
+        chunked_array.rename(self.name());
+        chunked_array
+    }
 }
 
 #[cfg(test)]

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -115,6 +115,10 @@ pub trait ChunkCumAgg<T: PolarsDataType> {
     fn cumprod(&self, _reverse: bool) -> ChunkedArray<T> {
         panic!("operation cumprod not supported for this dtype")
     }
+    /// Get an array with the cumulative count at every element.
+    fn cumcount(&self, _reverse: bool, _count_nulls: bool) -> UInt32Chunked {
+        panic!("operation cumcount not supported for this dtype")
+    }
 }
 
 /// Traverse and collect every nth element

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -552,7 +552,7 @@ impl Series {
         {
             use DataType::*;
             match self.dtype() {
-                Boolean => self.cast(&DataType::UInt32).unwrap().cumsum(reverse),
+                Boolean => self.cast(&UInt32).unwrap().cumsum(reverse),
                 Int8 | UInt8 | Int16 | UInt16 => {
                     let s = self.cast(&Int64).unwrap();
                     s.cumsum(reverse)
@@ -601,7 +601,7 @@ impl Series {
         {
             use DataType::*;
             match self.dtype() {
-                Boolean => self.cast(&DataType::Int64).unwrap().cumprod(reverse),
+                Boolean => self.cast(&Int64).unwrap().cumprod(reverse),
                 Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 => {
                     let s = self.cast(&Int64).unwrap();
                     s.cumprod(reverse)
@@ -623,6 +623,82 @@ impl Series {
                     ca.cumprod(reverse).into_series()
                 }
                 dt => panic!("cumprod not supported for dtype: {:?}", dt),
+            }
+        }
+        #[cfg(not(feature = "cum_agg"))]
+        {
+            panic!("activate 'cum_agg' feature")
+        }
+    }
+
+    /// Count the number of elements elements over an expanding window.
+    #[allow(unused_variables)]
+    pub fn cumcount(&self, reverse: bool, count_nulls: bool) -> Series {
+        #[cfg(feature = "cum_agg")]
+        {
+            match self.dtype() {
+                DataType::Float32 => self
+                    .f32()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Float64 => self
+                    .f64()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Int8 => self
+                    .i8()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Int16 => self
+                    .i16()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Int32 => self
+                    .i32()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Int64 => self
+                    .i64()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::UInt8 => self
+                    .u8()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::UInt16 => self
+                    .u16()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::UInt32 => self
+                    .u32()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::UInt64 => self
+                    .u64()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Utf8 => self
+                    .utf8()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                DataType::Boolean => self
+                    .bool()
+                    .unwrap()
+                    .cumcount(reverse, count_nulls)
+                    .into_series(),
+                // Handle Date, Datetime, Time, Categorical
+                _ => self.to_physical_repr().cumcount(reverse, count_nulls),
             }
         }
         #[cfg(not(feature = "cum_agg"))]

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1,7 +1,6 @@
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::series::ops::NullBehavior;
-use polars_core::utils::concat_df;
 use polars_time::prelude::DateMethods;
 
 use super::*;
@@ -1886,7 +1885,7 @@ fn empty_df() -> PolarsResult<()> {
             col("A").shift_and_fill(1, lit(1)).alias("2"),
             col("A").shift_and_fill(-1, lit(1)).alias("3"),
             col("A").fill_null(lit(1)).alias("4"),
-            col("A").cumcount(false).alias("5"),
+            col("A").cumcount(false, true).alias("5"),
             col("A").diff(1, NullBehavior::Ignore).alias("6"),
             col("A").cummax(false).alias("7"),
             col("A").cummin(false).alias("8"),

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -119,6 +119,7 @@ Computations
     Series.cummin
     Series.cumprod
     Series.cumsum
+    Series.cumcount
     Series.cumulative_eval
     Series.diff
     Series.dot

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1297,7 +1297,7 @@ class Expr:
         Parameters
         ----------
         reverse
-            Reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Notes
         -----
@@ -1338,7 +1338,7 @@ class Expr:
         Parameters
         ----------
         reverse
-            Reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Notes
         -----
@@ -1379,7 +1379,7 @@ class Expr:
         Parameters
         ----------
         reverse
-            Reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Examples
         --------
@@ -1415,7 +1415,7 @@ class Expr:
         Parameters
         ----------
         reverse
-            Reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Examples
         --------
@@ -1444,16 +1444,16 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.cummax(reverse))
 
-    def cumcount(self, reverse: bool = False) -> Expr:
+    def cumcount(self, reverse: bool = False, count_nulls: bool = False) -> Expr:
         """
         Get an array with the cumulative count computed at every element.
-
-        Counting from 0 to len
 
         Parameters
         ----------
         reverse
-            Reverse the operation.
+            When ``True``, instead count from the tail to the head.
+        count_nulls
+            Whether to include null values in the count.
 
         Examples
         --------
@@ -1470,17 +1470,17 @@ class Expr:
         │ --- ┆ ---       │
         │ u32 ┆ u32       │
         ╞═════╪═══════════╡
-        │ 0   ┆ 3         │
+        │ 1   ┆ 4         │
         ├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 1   ┆ 2         │
+        │ 2   ┆ 3         │
         ├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 2   ┆ 1         │
+        │ 3   ┆ 2         │
         ├╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 3   ┆ 0         │
+        │ 4   ┆ 1         │
         └─────┴───────────┘
 
         """
-        return wrap_expr(self._pyexpr.cumcount(reverse))
+        return wrap_expr(self._pyexpr.cumcount(reverse, count_nulls))
 
     def floor(self) -> Expr:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1348,7 +1348,7 @@ class Series:
         Parameters
         ----------
         reverse
-            reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Notes
         -----
@@ -1376,7 +1376,7 @@ class Series:
         Parameters
         ----------
         reverse
-            reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Examples
         --------
@@ -1399,7 +1399,7 @@ class Series:
         Parameters
         ----------
         reverse
-            reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Examples
         --------
@@ -1422,7 +1422,7 @@ class Series:
         Parameters
         ----------
         reverse
-            reverse the operation.
+            When ``True``, instead move from the tail to the head.
 
         Notes
         -----
@@ -1439,6 +1439,30 @@ class Series:
             1
             2
             6
+        ]
+
+        """
+
+    def cumcount(self, reverse: bool = False, count_nulls: bool = False) -> Series:
+        """
+        Get an array with the cumulative count computed at every element.
+
+        Parameters
+        ----------
+        reverse
+            When ``True``, instead count from the tail to the head.
+        count_nulls
+            Whether to include null values in the count.
+
+        Examples
+        --------
+        >>> pl.Series([8, 6, None]).cumcount(reverse=True, count_nulls=False)
+        shape: (3,)
+        Series: '' [u32]
+        [
+            2
+            1
+            0
         ]
 
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -493,15 +493,21 @@ impl PyExpr {
     pub fn cumsum(&self, reverse: bool) -> PyExpr {
         self.clone().inner.cumsum(reverse).into()
     }
+
     pub fn cummax(&self, reverse: bool) -> PyExpr {
         self.clone().inner.cummax(reverse).into()
     }
+
     pub fn cummin(&self, reverse: bool) -> PyExpr {
         self.clone().inner.cummin(reverse).into()
     }
 
     pub fn cumprod(&self, reverse: bool) -> PyExpr {
         self.clone().inner.cumprod(reverse).into()
+    }
+
+    pub fn cumcount(&self, reverse: bool, count_nulls: bool) -> Self {
+        self.inner.clone().cumcount(reverse, count_nulls).into()
     }
 
     pub fn product(&self) -> PyExpr {
@@ -1443,10 +1449,6 @@ impl PyExpr {
 
     pub fn reshape(&self, dims: Vec<i64>) -> Self {
         self.inner.clone().reshape(&dims).into()
-    }
-
-    pub fn cumcount(&self, reverse: bool) -> Self {
-        self.inner.clone().cumcount(reverse).into()
     }
 
     pub fn to_physical(&self) -> Self {

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -38,8 +38,8 @@ def test_cumcount() -> None:
         [pl.col("A").cumcount(reverse=False).alias("foo")]
     )
 
-    assert out["foo"][0].to_list() == [0, 1, 2, 3]
-    assert out["foo"][1].to_list() == [0, 1]
+    assert out["foo"][0].to_list() == [1, 2, 3, 4]
+    assert out["foo"][1].to_list() == [1, 2]
 
 
 def test_filter_where() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -26,6 +26,31 @@ def test_cum_agg() -> None:
     verify_series_and_expr_api(s, pl.Series("a", [1, 2, 6, 12]), "cumprod")
 
 
+@pytest.mark.parametrize(
+    "series",
+    [
+        pl.Series([8, 6, None], dtype=pl.Float32),
+        pl.Series([8, 6, None], dtype=pl.Float64),
+        pl.Series([8, 6, None], dtype=pl.Int8),
+        pl.Series([8, 6, None], dtype=pl.Int16),
+        pl.Series([8, 6, None], dtype=pl.Int32),
+        pl.Series([8, 6, None], dtype=pl.Int64),
+        pl.Series([8, 6, None], dtype=pl.UInt8),
+        pl.Series([8, 6, None], dtype=pl.UInt16),
+        pl.Series([8, 6, None], dtype=pl.UInt32),
+        pl.Series([8, 6, None], dtype=pl.UInt64),
+        pl.Series(["a", "b", None], dtype=pl.Utf8),
+        pl.Series([True, False, None], dtype=pl.Boolean),
+        pl.Series([date(2020, 1, 1), date(2020, 1, 2), None], dtype=pl.Date),
+    ],
+)
+def test_cumcount(series: pl.Series) -> None:
+    assert series.cumcount(reverse=False, count_nulls=False).to_list() == [1, 2, 2]
+    assert series.cumcount(reverse=False, count_nulls=True).to_list() == [1, 2, 3]
+    assert series.cumcount(reverse=True, count_nulls=False).to_list() == [2, 1, 0]
+    assert series.cumcount(reverse=True, count_nulls=True).to_list() == [3, 2, 1]
+
+
 def test_init_inputs(monkeypatch: Any) -> None:
     for flag in [False, True]:
         monkeypatch.setattr(pl.internals.construction, "_PYARROW_AVAILABLE", flag)


### PR DESCRIPTION
BREAKING CHANGE!

As part of the work to introduce more "expanding" functionality, I thought I would introduce an `expanding_count` function that counts the number of non-null values observed. 

As I went to implement it though, I realized the functionality was _very_ similar to the existing `cumcount` functionality, albeit some notable differences.

1. `cumcount` starts its count at 0. So in truth, `cumcount` generates _indices_ not _counts_.
2. `cumcount` does not have any options for ignoring null values.

I decided that instead of adding an entirely new function, it would be better to give `cumcount` a `count_nulls` parameter. With this addition, I also think it makes much more sense for `cumcount` to generate real counts, rather than indices (consider what happens otherwise)

```python
pl.Series([None]).cumcount(count_nulls=True)
# [0]

pl.Series([None]).cumcount(count_nulls=False)
# [0]
```

The breaking change is that `cumcount` now starts at **1**, instead of **0**. There are still plenty of ways to generate indices if need be, for example `.cumcount(count_nulls=True) - 1`.

Some additional features that accompany this MR:
- enable a `reverse` parameter for `cumcount`
- add `cumcount` as a `Series` method (previously it was only an `Expr`)