### PR TITLE
chore[python]: Add coverage settings to pyproject.toml

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -65,7 +65,7 @@ jobs:
           maturin develop
 
       - name: Run tests and report coverage
-        run: pytest --cov=polars
+        run: pytest --cov
 
       - name: Run doctests
         run: python tests/docs/run_doc_examples.py

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -54,7 +54,7 @@ test-all: venv  ## Run all tests
 
 .PHONY: test-with-cov
 test-with-cov: venv  ## Run tests and report coverage
-	$(PYTHON) -m pytest --cov=polars --cov-report xml
+	$(PYTHON) -m pytest --cov
 
 .PHONY: doctest
 doctest:  ## Run doctests

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -53,8 +53,14 @@ addopts = [
   "--import-mode=importlib",
 ]
 
+[tool.coverage.run]
+source = ["polars"]
+branch = true
+
 [tool.coverage.report]
 fail_under = 85
+skip_covered = true
+show_missing = true
 exclude_lines = [
   "pragma: no cover",
   "@overload",


### PR DESCRIPTION
Changes:
* Enabled the following settings for `coverage.run`:
  * `source = ["polars"]` -> no longer have to specify this path on the command line.
  * `branch = true` -> checks if all branches are covered, e.g. all arms of an if-statement. Enabling this lowered our calculated coverage from ~91.6% to ~88.7%, but this is an important tool to discover uncovered cases.
* Enabled the following settings for `coverage.report`:
  * `skip_covered = true` -> Makes the coverage report include only the actionable items, files that are fully covered are not shown
  * `show_missing = true` -> Include the exact lines that are uncovered. Makes it easy to spot where extra tests are needed.
* Updated the `test-with-cov` command not to create an XML report, but instead write output to the terminal.

Calling `pytest --cov` now gets you something like:

![image](https://user-images.githubusercontent.com/3502351/189975438-17039a67-6bc3-4229-99b3-557327d57028.png)
