### PR TITLE
chore(python): Improve Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,9 +134,9 @@ You have to follow these steps:
 
   - Install Rust nightly via [rustup](https://www.rust-lang.org/tools/install)
   - run `$ rustup override set nightly` from the root of the repo.
-  - from [./py-polars](./py-polars) run `$ make venv`
-  - **tests:** from [./py-polars](./py-polars) run `$ make test`
-  - **formatting + linting:** from [./py-polars](./py-polars) run `$ make pre-commit` before committing.
+  - Set up a virtual environment by running `$ python -m venv .venv`, followed by `$ source .venv/bin/activate`
+  - **tests:** from [./py-polars](./py-polars) run `$ pip install -r requirements-dev.txt` followed by `$ make test`
+  - **formatting + linting:** from [./py-polars](./py-polars) run `$ pip install -r requirements-lint.txt` followed by  `$ make pre-commit` before committing.
   - **docs:** from [./py-polars/docs](./py-polars/docs) run `$ pip3 install -r requirements-docs.txt` followed by `make html`
 
 `make test` installs a (slow) development build in your current environment and runs `pytest`.

--- a/py-polars/.flake8
+++ b/py-polars/.flake8
@@ -15,5 +15,5 @@ extend-ignore =
 
 extend-exclude =
     # Automatically generated test artifacts
-    venv/,
+    *venv/,
     target/,

--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -1,6 +1,6 @@
 wheels/
 !Cargo.lock
 target/
-venv/
+/*venv/
 .hypothesis
 .DS_Store

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -15,7 +15,7 @@ fmt:  ## Run autoformatting and linting
 	cargo fmt --all
 	-dprint fmt
 	-mypy
-	-flake8
+	-flake8 polars tests docs
 
 .PHONY: clippy
 clippy:  ## Lint Rust files
@@ -43,7 +43,7 @@ coverage: build  ## Run tests and report coverage
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts
-	@rm -rf venv/
+	@rm -rf *venv/
 	@rm -rf target/
 	@rm -rf docs/build/
 	@rm -rf docs/source/reference/api/

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -60,30 +60,6 @@ test-with-cov: venv  ## Run tests and report coverage
 doctest:  ## Run doctests
 	$(PYTHON) tests/docs/run_doc_examples.py
 
-.PHONY: install-wheel
-install-wheel:
-	pip install --force-reinstall -U wheels/polars-*.whl
-
-.PHONY: build-no-venv
-build-no-venv:
-	maturin build -o wheels
-
-.PHONY: build-no-venv-release
-build-no-venv-release:
-	maturin build -o wheels --release
-
-.PHONY: build-and-test-no-venv
-build-and-test-no-venv:
-	maturin build -o wheels
-	pip install --force-reinstall -U wheels/polars-*.whl
-	pytest tests
-
-.PHONY: install-no-venv
-install-no-venv: build-no-venv install-wheel
-
-.PHONY: install-no-venv-release
-install-no-venv-release: build-no-venv-release install-wheel
-
 .PHONY: help
 help:  ## Display this help screen
 	@echo -e '\033[1mAvailable commands:\033[0m'

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -48,7 +48,7 @@ test-all: build  ## Run all tests
 	pytest
 	python tests/docs/run_doc_examples.py
 
-.PHONY: test-with-cov
+.PHONY: coverage
 test-with-cov: build  ## Run tests and report coverage
 	pytest --cov
 

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -17,6 +17,10 @@ clean:  ## Clean up caches and build artifacts
 	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
+.PHONY: build
+build:  # Build and install Polars
+	maturin develop
+
 .PHONY: fmt
 fmt:  ## Run autoformatting and linting
 	isort .
@@ -36,22 +40,20 @@ clippy:  ## Lint Rust files
 pre-commit: fmt clippy ## Run all code quality checks
 
 .PHONY: test
-test:  ## Run fast unittests
-	maturin develop
+test: build  ## Run fast unittests
 	pytest tests/unit/
 
 .PHONY: test-all
-test-all:  ## Run all tests
-	maturin develop
+test-all: build  ## Run all tests
 	pytest
 	python tests/docs/run_doc_examples.py
 
 .PHONY: test-with-cov
-test-with-cov:  ## Run tests and report coverage
+test-with-cov: build  ## Run tests and report coverage
 	pytest --cov
 
 .PHONY: doctest
-doctest:  ## Run doctests
+doctest: build  ## Run doctests
 	python tests/docs/run_doc_examples.py
 
 .PHONY: help

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -26,20 +26,23 @@ clean:  ## Clean up caches and build artifacts
 	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
-.PHONY: pre-commit
-pre-commit: venv  ## Run autoformatting and linting
+.PHONY: fmt
+fmt: venv  ## Run autoformatting and linting
 	$(PYTHON_BIN)/isort .
 	$(PYTHON_BIN)/black .
 	$(PYTHON_BIN)/blackdoc .
 	$(PYTHON_BIN)/pyupgrade --py37-plus `find polars/ tests/ -name "*.py" -type f`
-	$(PYTHON_BIN)/mypy
-	$(PYTHON_BIN)/flake8
-	make -C .. fmt_toml
 	cargo fmt --all
+	-dprint fmt
+	-$(PYTHON_BIN)/mypy
+	-$(PYTHON_BIN)/flake8
 
 .PHONY: clippy
-clippy:  ## Run clippy
+clippy:  ## Lint Rust files
 	cargo clippy -- -D warnings -A clippy::borrow_deref_ref
+
+.PHONY: pre-commit
+pre-commit: fmt clippy ## Run all code quality checks
 
 .PHONY: test
 test: venv  ## Run fast unittests

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -2,21 +2,6 @@
 
 SHELL=/bin/bash
 
-.PHONY: clean
-clean:  ## Clean up caches and build artifacts
-	@rm -rf venv/
-	@rm -rf target/
-	@rm -rf docs/build/
-	@rm -rf docs/source/reference/api/
-	@rm -rf .hypothesis/
-	@rm -rf .mypy_cache/
-	@rm -rf .pytest_cache/
-	@rm -f .coverage
-	@rm -f coverage.xml
-	@rm -f polars/polars.abi3.so
-	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
-	@cargo clean
-
 .PHONY: build
 build:  # Build and install Polars
 	maturin develop
@@ -43,18 +28,33 @@ pre-commit: fmt clippy ## Run all code quality checks
 test: build  ## Run fast unittests
 	pytest tests/unit/
 
+.PHONY: doctest
+doctest: build  ## Run doctests
+	python tests/docs/run_doc_examples.py
+
 .PHONY: test-all
 test-all: build  ## Run all tests
 	pytest
 	python tests/docs/run_doc_examples.py
 
 .PHONY: coverage
-test-with-cov: build  ## Run tests and report coverage
+coverage: build  ## Run tests and report coverage
 	pytest --cov
 
-.PHONY: doctest
-doctest: build  ## Run doctests
-	python tests/docs/run_doc_examples.py
+.PHONY: clean
+clean:  ## Clean up caches and build artifacts
+	@rm -rf venv/
+	@rm -rf target/
+	@rm -rf docs/build/
+	@rm -rf docs/source/reference/api/
+	@rm -rf .hypothesis/
+	@rm -rf .mypy_cache/
+	@rm -rf .pytest_cache/
+	@rm -f .coverage
+	@rm -f coverage.xml
+	@rm -f polars/polars.abi3.so
+	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
+	@cargo clean
 
 .PHONY: help
 help:  ## Display this help screen

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -1,15 +1,6 @@
 .DEFAULT_GOAL := help
 
 SHELL=/bin/bash
-PYTHON=venv/bin/python
-PYTHON_BIN=venv/bin
-
-venv:  ## Set up virtual environment
-	@python -m venv venv
-	@venv/bin/pip install --upgrade pip
-	@venv/bin/pip install -r requirements-dev.txt
-	@venv/bin/pip install -r requirements-lint.txt
-	@unset CONDA_PREFIX && source venv/bin/activate && maturin develop
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts
@@ -27,15 +18,15 @@ clean:  ## Clean up caches and build artifacts
 	@cargo clean
 
 .PHONY: fmt
-fmt: venv  ## Run autoformatting and linting
-	$(PYTHON_BIN)/isort .
-	$(PYTHON_BIN)/black .
-	$(PYTHON_BIN)/blackdoc .
-	$(PYTHON_BIN)/pyupgrade --py37-plus `find polars/ tests/ -name "*.py" -type f`
+fmt:  ## Run autoformatting and linting
+	isort .
+	black .
+	blackdoc .
+	pyupgrade --py37-plus `find polars/ tests/ -name "*.py" -type f`
 	cargo fmt --all
 	-dprint fmt
-	-$(PYTHON_BIN)/mypy
-	-$(PYTHON_BIN)/flake8
+	-mypy
+	-flake8
 
 .PHONY: clippy
 clippy:  ## Lint Rust files
@@ -45,23 +36,23 @@ clippy:  ## Lint Rust files
 pre-commit: fmt clippy ## Run all code quality checks
 
 .PHONY: test
-test: venv  ## Run fast unittests
-	$(PYTHON_BIN)/maturin develop
-	$(PYTHON) -m pytest tests/unit/
+test:  ## Run fast unittests
+	maturin develop
+	pytest tests/unit/
 
 .PHONY: test-all
-test-all: venv  ## Run all tests
-	$(PYTHON_BIN)/maturin develop
-	$(PYTHON) -m pytest
-	$(PYTHON) tests/docs/run_doc_examples.py
+test-all:  ## Run all tests
+	maturin develop
+	pytest
+	python tests/docs/run_doc_examples.py
 
 .PHONY: test-with-cov
-test-with-cov: venv  ## Run tests and report coverage
-	$(PYTHON) -m pytest --cov
+test-with-cov:  ## Run tests and report coverage
+	pytest --cov
 
 .PHONY: doctest
 doctest:  ## Run doctests
-	$(PYTHON) tests/docs/run_doc_examples.py
+	python tests/docs/run_doc_examples.py
 
 .PHONY: help
 help:  ## Display this help screen


### PR DESCRIPTION
Following up on #4712

Some of these changes may be controversial - let me know what you think, I'll adjust as desired.

**Changes:**
* Removed the `make venv` command and all strict dependencies on the `venv` folder _(see further comments below)_.
  * This transfers the responsibility for managing the Python environment to the developer. We can include help for this in the Contributing guide.
  * This allows them to use a conda environment or put their virtual environment in a different location.
  * This enables developers on Windows to use the Makefile, since virtual environments on Windows do not have `venv/bin`, rather `venv/Scripts`.
  * In general, this just makes the Makefile more flexible for being used in various environments, such as the CI.
* Removed the 'no-venv' commands. I see no use for these as we should be using `maturin develop` for getting editable installs.
* Added the `make build` command, which runs `maturin develop`. We can define this as a prerequisite instead of explicitly running `maturin develop` before the `test` commands.
* Updated the `make pre-commit` command to also include running clippy.
* Added the `make fmt` command, which is the `make pre-commit` command without clippy. This is useful because it's faster than running `make pre-commit`.
* Renamed `make test-with-cov` to `make coverage`
* Updated `.gitignore` and `make clean` to handle a venv folder `.venv` in addition to `venv`. This is mentioned in the [official docs](https://docs.python.org/3/library/venv.html) as a common place for creating the virtual environment, so it makes sense to support this.
* Updated the CONTRIBUTING guide accordingly. Major revision of that file will come after we agree on the Makefile changes and this PR is merged.

## Regarding the `venv` change

In the previous PR, Ritchie remarked:

> Could we do something smart with an env var/path variable that users might override? I like the fact that we take the venv without activating the environment. This should be the default IMO, using something else should be opt-in as I hit make test a lot. :)

This is easily achieved by doing something like this:

```Makefile
VENV ?= venv  # Note the question mark - it can be overwritten by an env var
PYTHON = $(VENV)/bin/python

.PHONY: venv
venv:  ## Set up virtual environment
	@python -m venv $(VENV)
	@$(PYTHON) -m pip install --upgrade pip
	@$(PYTHON) -m pip install -r requirements-dev.txt
	@$(PYTHON) -m pip install -r requirements-lint.txt
	$(MAKE) build

.PHONY: build
build:  ## Set up virtual environment
	@unset CONDA_PREFIX && source $(VENV)/bin/activate && maturin develop

.PHONY: pre-commit
pre-commit: build  ## Run autoformatting and linting
	$(VENV)/bin/isort .
	...(etc)
```

Which allows people to set an environment variable VENV where the environment will be created. As long as the user sets up their IDE to always have that environment variable set, the make commands will work with the user-specified venv location.

**The problem is that it's counter-intuitive.** Python developers are used to have their active virtual environment be used whenever they do Python stuff. With this approach, the active environment is ignored. That leads to confusion (it sure confused me when I started working on Polars last year).

I have my IDE set up to activate the Polars venv whenever I open the project. I'm sure most people set up their IDE the same way; so all the make commands will be immediately available after the first time they set up their virtual environment. So I'm not sure what the added value would be of having the make commands work without an active virtual environment?