### PR TITLE
ci[python]: Use maturin-action for Windows/macOS release

### DIFF
--- a/.github/workflows/create-py-mac-universal2-release.yaml
+++ b/.github/workflows/create-py-mac-universal2-release.yaml
@@ -2,38 +2,36 @@ name: Create macOs universal2/aarch64-apple-darwin python release
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-      - 'py-polars-v*' # Push events to matching py-polars-v*, i.e. py-polars-v1.0, py-polars-v20.15.10
+      - 'py-polars-v*'
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  build:
-    name: Create Release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["macos-latest"]
-        python-version: ["3.7"]
+  macos-aarch64:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2022-09-26
-      - name: Setup universal2 targets for Rust
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Prepare maturin publish
-        shell: bash
-        run: |
-          rm py-polars/README.md
-          cp README.md py-polars/README.md
-          cd py-polars
-      - name: maturin publish
+
+      - name: Set up Rust targets
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
@@ -45,4 +43,3 @@ jobs:
            # we don't run it because it is twice as big and not needed because we build
            # for both architectures separately
 #          args: -m py-polars/Cargo.toml --no-sdist --universal2 -o wheels -i python -u ritchie46
-

--- a/.github/workflows/create-py-release-windows-macos.yaml
+++ b/.github/workflows/create-py-release-windows-macos.yaml
@@ -2,43 +2,39 @@ name: Create Python release windows macos
 
 on:
   push:
-     # Sequence of patterns matched against refs/tags
     tags:
-      - 'py-polars-v*' # Push events to matching py-polars-v*, i.e. py-polars-v1.0, py-polars-v20.15.10
+      - 'py-polars-v*'
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  build:
-    name: Create Release
+  win-macos:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: ["macos-latest", "windows-latest"]
-        python-version: ["3.7"]
+        os: [macos-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/setup-python@v4
         with:
-          toolchain: nightly-2022-09-26
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install maturin==0.13.2
-      - name: Publish wheel
-        shell: bash
-        env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
+          python-version: '3.7'
+
+      - name: Fix README symlink
         run: |
           rm py-polars/README.md
           cp README.md py-polars/README.md
-          cd py-polars
-          maturin publish \
-          --no-sdist \
-          --skip-existing \
-          -o wheels \
-          -i python \
-          --username ritchie46
+
+      - name: Publish wheel
+        uses: messense/maturin-action@v1
+        env:
+          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
+        with:
+          rust-toolchain: nightly-2022-09-26
+          maturin-version: '0.13.2'
+          command: publish
+          args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46


### PR DESCRIPTION
Changes:
* Use `maturin-action` for the Windows/macOS workflow, rather than manually running commands.
  * I see no reason not to use the action, like we do in other release workflows. But maybe I am missing something?
* Some minor reformatting, also in the other macOS workflow

**This is untested**, as I don't really know how to test this without actually publishing the wheel. And I don't want to do that since I don't know enough yet about the release process / if that could potentially break something.