### PR TITLE
refactor[rust]: Fix some warnings

### DIFF
--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -10,7 +10,9 @@ use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
-use crate::frame::hash_join::{check_categorical_src, ZipOuterJoinColumn};
+#[cfg(feature = "is_in")]
+use crate::frame::hash_join::check_categorical_src;
+use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 

--- a/polars/polars-lazy/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/mod.rs
@@ -34,7 +34,6 @@ use std::fmt::{Display, Formatter};
 #[cfg(feature = "list")]
 pub(super) use list::ListFunction;
 use polars_core::prelude::*;
-use polars_core::utils::slice_offsets;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/polars/polars-lazy/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/schema.rs
@@ -131,6 +131,7 @@ impl FunctionExpr {
             }
             #[cfg(feature = "dtype-struct")]
             StructExpr(s) => {
+                use polars_core::utils::slice_offsets;
                 use StructFunction::*;
                 match s {
                     FieldByIndex(index) => {

--- a/polars/polars-lazy/src/dsl/function_expr/shift_and_fill.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/shift_and_fill.rs
@@ -15,7 +15,15 @@ where
     ca.shift_and_fill(periods, fill_value)
 }
 
+#[cfg(any(
+    feature = "object",
+    feature = "dtype-struct",
+    feature = "dtype-categorical"
+))]
 fn shift_and_fill_with_mask(s: &Series, periods: i64, fill_value: &Series) -> Result<Series> {
+    use polars_core::export::arrow::array::BooleanArray;
+    use polars_core::export::arrow::bitmap::MutableBitmap;
+
     let mask: BooleanChunked = if periods > 0 {
         let len = s.len();
         let mut bits = MutableBitmap::with_capacity(s.len());

--- a/polars/polars-lazy/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/temporal.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "date_offset")]
 use super::*;
 
 #[cfg(feature = "date_offset")]

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -30,8 +30,6 @@ pub use expr::*;
 pub use functions::*;
 pub use options::*;
 use polars_arrow::prelude::QuantileInterpolOptions;
-use polars_core::export::arrow::array::BooleanArray;
-use polars_core::export::arrow::bitmap::MutableBitmap;
 use polars_core::prelude::*;
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;

--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -8,6 +8,7 @@ use polars_arrow::utils::CustomIterTools;
 use polars_core::frame::groupby::{GroupByMethod, GroupsProxy};
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
+#[cfg(feature = "dtype-struct")]
 use polars_core::POOL;
 
 use crate::physical_plan::state::ExecutionState;
@@ -305,7 +306,6 @@ impl PartitionedAggregation for AggregationExpr {
             GroupByMethod::Mean => {
                 let new_name = partitioned.name();
                 match partitioned.dtype() {
-                    #[cfg(feature = "dtype-struct")]
                     DataType::Struct(_) => {
                         let ca = partitioned.struct_().unwrap();
                         let sum = &ca.fields()[0];

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -71,21 +71,17 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> Result<Ser
         Operator::Minus => Ok(left - right),
         Operator::Multiply => Ok(left * right),
         Operator::Divide => Ok(left / right),
-        Operator::TrueDivide => {
-            use DataType::*;
-            match left.dtype() {
-                Date | Datetime(_, _) | Float32 | Float64 => Ok(left / right),
-                _ => Ok(&left.cast(&Float64)? / &right.cast(&Float64)?),
+        Operator::TrueDivide => match left.dtype() {
+            DataType::Date | DataType::Datetime(_, _) | DataType::Float32 | DataType::Float64 => {
+                Ok(left / right)
             }
-        }
-        Operator::FloorDivide => {
-            use DataType::*;
-            match left.dtype() {
-                #[cfg(feature = "round_series")]
-                Float32 | Float64 => (left / right).floor(),
-                _ => Ok(left / right),
-            }
-        }
+            _ => Ok(&left.cast(&DataType::Float64)? / &right.cast(&DataType::Float64)?),
+        },
+        Operator::FloorDivide => match left.dtype() {
+            #[cfg(feature = "round_series")]
+            DataType::Float32 | DataType::Float64 => (left / right).floor(),
+            _ => Ok(left / right),
+        },
         Operator::And => left.bitand(right),
         Operator::Or => left.bitor(right),
         Operator::Xor => left.bitxor(right),

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -6,6 +6,7 @@ use polars_core::prelude::*;
 
 use crate::logical_plan::iterator::{ArenaExprIter, ArenaLpIter};
 use crate::logical_plan::Context;
+#[cfg(feature = "meta")]
 use crate::prelude::names::COUNT;
 use crate::prelude::*;
 
@@ -148,6 +149,7 @@ pub(crate) fn has_null(current_expr: &Expr) -> bool {
 }
 
 /// output name of expr
+#[cfg(feature = "meta")]
 pub(crate) fn expr_output_name(expr: &Expr) -> Result<Arc<str>> {
     for e in expr {
         match e {


### PR DESCRIPTION
Changes:
* Fixed a few 'unused import' warnings caused by feature flags.

I'm sure there is a better / more consistent way to handle this, but at least the warnings are gone 😄 

Still pondering a warning about the field 'cache' never being read...