### PR TITLE
Add serde for `Duration` type

### DIFF
--- a/polars/polars-core/src/serde/mod.rs
+++ b/polars/polars-core/src/serde/mod.rs
@@ -39,6 +39,7 @@ enum DeDataType<'a> {
     Utf8,
     Date,
     Datetime(TimeUnit, Option<TimeZone>),
+    Duration(TimeUnit),
     #[serde(with = "TimeUnitDef")]
     Time64(ArrowTimeUnit),
     List,
@@ -56,6 +57,7 @@ impl From<&DataType> for DeDataType<'_> {
             DataType::UInt64 => DeDataType::UInt64,
             DataType::Date => DeDataType::Date,
             DataType::Datetime(tu, tz) => DeDataType::Datetime(*tu, tz.clone()),
+            DataType::Duration(tu) => DeDataType::Duration(*tu),
             DataType::Float32 => DeDataType::Float32,
             DataType::Float64 => DeDataType::Float64,
             DataType::Utf8 => DeDataType::Utf8,

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -163,7 +163,8 @@ impl<'de> Deserialize<'de> for Series {
                     DeDataType::Duration(tu) => {
                         let values: Vec<Option<i64>> = map.next_value()?;
                         Ok(Series::new(&name, values)
-                            .cast(&DataType::Duration(tu)).unwrap())
+                            .cast(&DataType::Duration(tu))
+                            .unwrap())
                     }
                     DeDataType::Boolean => {
                         let values: Vec<Option<bool>> = map.next_value()?;

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -50,6 +50,11 @@ impl Serialize for Series {
                     let ca = self.categorical().unwrap();
                     ca.serialize(serializer)
                 }
+                #[cfg(feature = "dtype-duration")]
+                DataType::Duration(_) => {
+                    let ca = self.duration().unwrap();
+                    ca.serialize(serializer)
+                }
                 _ => {
                     // cast small integers to i32
                     self.cast(&DataType::Int32).unwrap().serialize(serializer)
@@ -153,6 +158,12 @@ impl<'de> Deserialize<'de> for Series {
                         Ok(Series::new(&name, values)
                             .cast(&DataType::Datetime(tu, tz))
                             .unwrap())
+                    }
+                    #[cfg(feature = "dtype-duration")]
+                    DeDataType::Duration(tu) => {
+                        let values: Vec<Option<i64>> = map.next_value()?;
+                        Ok(Series::new(&name, values)
+                            .cast(&DataType::Duration(tu)).unwrap())
                     }
                     DeDataType::Boolean => {
                         let values: Vec<Option<bool>> = map.next_value()?;

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -33,18 +33,25 @@ def test_serde_time_unit() -> None:
         )
     ).dtype == pl.Datetime("ns")
 
+
 def test_serde_duration() -> None:
-    df = pl.DataFrame(
-        {
-            "a": [
-                datetime(2021, 2, 1, 9, 20),
-                datetime(2021, 2, 2, 9, 20),
-            ],
-            "b": [4, 5],
-        }
-    ).with_columns([pl.col("a").cast(pl.Datetime("ns")).alias("a")]).select(pl.all())
+    df = (
+        pl.DataFrame(
+            {
+                "a": [
+                    datetime(2021, 2, 1, 9, 20),
+                    datetime(2021, 2, 2, 9, 20),
+                ],
+                "b": [4, 5],
+            }
+        )
+        .with_columns([pl.col("a").cast(pl.Datetime("ns")).alias("a")])
+        .select(pl.all())
+    )
     df = df.with_columns([pl.col("a").diff(n=1).alias("a_td")])
     serde_df = pickle.loads(pickle.dumps(df))
     assert serde_df["a_td"].dtype == pl.Duration("ns")
-    pl.testing.assert_series_equal(serde_df["a_td"], pl.Series("a_td", [None, timedelta(days=1)], dtype=pl.Duration("ns")))
-
+    pl.testing.assert_series_equal(
+        serde_df["a_td"],
+        pl.Series("a_td", [None, timedelta(days=1)], dtype=pl.Duration("ns")),
+    )


### PR DESCRIPTION
Duration types weren't supported for serialization so I added them here. I found this from:

```python
import datetime

df = (
    pl.DataFrame(
        {
            "a": [
                datetime.datetime(2021, 2, 1, 9, 20),
                datetime.datetime(2021, 2, 2, 9, 20),
                datetime.datetime(2021, 2, 3, 9, 20),
            ],
            "b": [4, 5, 6],
        }
    )
    .with_columns([pl.col("a").cast(pl.Datetime("ns")).alias("a")])
    .select(pl.all())
)
df = df.with_columns([pl.col("a").diff(n=1).alias("atd")])
print(df)
```

Which gave:

```
shape: (3, 3)
┌─────────────────────┬─────┬──────────────┐
│ a                   ┆ b   ┆ atd          │
│ ---                 ┆ --- ┆ ---          │
│ datetime[ns]        ┆ i64 ┆ duration[ns] │
╞═════════════════════╪═════╪══════════════╡
│ 2021-02-01 09:20:00 ┆ 4   ┆ null         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2021-02-02 09:20:00 ┆ 5   ┆ 1 day        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2021-02-03 09:20:00 ┆ 6   ┆ 1 day        │
└─────────────────────┴─────┴──────────────┘
```

But after serialization & deserialization:

```
import pickle

print(pickle.loads(pickle.dumps(df)))
```

It prints:

```
shape: (3, 3)
┌─────────────────────┬─────┬──────┐
│ a                   ┆ b   ┆ atd  │
│ ---                 ┆ --- ┆ ---  │
│ datetime[ns]        ┆ i64 ┆ i32  │
╞═════════════════════╪═════╪══════╡
│ 2021-02-01 09:20:00 ┆ 4   ┆ null │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤
│ 2021-02-02 09:20:00 ┆ 5   ┆ null │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┤
│ 2021-02-03 09:20:00 ┆ 6   ┆ null │
└─────────────────────┴─────┴──────┘
```

This PR fixes that (see test).