### PR TITLE
chore[python]: Fix typo in docs reference

### DIFF
--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -12,7 +12,7 @@ Attributes
 ----------
 
 .. autosummary::
-   :toctree: apimut /
+   :toctree: api/
 
     LazyFrame.columns
     LazyFrame.dtypes


### PR DESCRIPTION
This seems to be a small mistake that slipped in somewhere... causes these `.rst` files to be created in a new folder `apimut ` instead of `api`. Doesn't really impact anything as far as I can see, except that this folder is not in the `.gitignore` so I get annoying diffs on this when I build the docs locally 😄 

See #4908 for why the tests fail for Python 3.10.