### PR TITLE
fix[python, rust]: categorical-related edge cases with init from empty Arrow arrays

### DIFF
--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -194,7 +194,7 @@ impl Series {
             #[cfg(feature = "dtype-categorical")]
             ArrowDataType::Dictionary(key_type, value_type, _) => {
                 use arrow::datatypes::IntegerType;
-                // don't spuriously call this. This triggers a read on mmaped data
+                // don't spuriously call this; triggers a read on mmapped data
                 let arr = if chunks.len() > 1 {
                     let chunks = chunks.iter().map(|arr| &**arr).collect::<Vec<_>>();
                     arrow::compute::concatenate::concatenate(&chunks)?
@@ -204,10 +204,10 @@ impl Series {
 
                 if !matches!(
                     value_type.as_ref(),
-                    ArrowDataType::Utf8 | ArrowDataType::LargeUtf8
+                    ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 | ArrowDataType::Null
                 ) {
                     return Err(PolarsError::ComputeError(
-                        "polars only support dictionaries with string like values".into(),
+                        "polars only supports dictionaries with string-like values".into(),
                     ));
                 }
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -84,7 +84,22 @@ def series_to_pyseries(name: str, values: pli.Series) -> PySeries:
 def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySeries:
     """Construct a PySeries from an Arrow array."""
     array = coerce_arrow(values)
-    if hasattr(array, "num_chunks"):
+
+    # special handling of empty categorical arrays
+    if (
+        len(array) == 0
+        and isinstance(array.type, pa.DictionaryType)
+        and array.type.value_type
+        in (
+            pa.utf8(),
+            pa.large_utf8(),
+        )
+    ):
+        pys = pli.Series(name, [], dtype=Categorical)._s
+
+    elif not hasattr(array, "num_chunks"):
+        pys = PySeries.from_arrow(name, array)
+    else:
         if array.num_chunks > 1:
             it = array.iterchunks()
             pys = PySeries.from_arrow(name, next(it))
@@ -98,8 +113,7 @@ def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySe
         if rechunk:
             pys.rechunk(in_place=True)
 
-        return pys
-    return PySeries.from_arrow(name, array)
+    return pys
 
 
 def numpy_to_pyseries(


### PR DESCRIPTION
Fixes two additional edge-cases with empty pyarrow arrays that are specific to Categorical.

**Example 1:** (fixed)
```python
import pyarrow as pa
import polars as pl

arr = pa.array( ["a","a",None,"b"] ).dictionary_encode()
arr_chunked = pa.chunked_array( [],arr.type )
s = pl.Series( "arr",arr_chunked )

# ArrowErrorException: OutOfSpec("An array of type 
#  Dictionary(Int32, Utf8, false) must have a non-null buffer 1")
```
Specific to empty categorical arrays (chunked or otherwise).

**Example 2:** (fixed)
```python
arr = pa.array( [] ).dictionary_encode()
s = pl.Series( "arr",arr )

# ComputeError: polars only supports dictionaries with string-like values
```
This one requires the caller not to have set the dictionary dtype explicitly, and for there to be no data to introspect. This results in a dictionary value_type of null. Permitting `ArrowDataType::Null` on the Rust side here (in addition to `Utf8` and `LargeUtf8`) does allow us to successfully init though. While certainly odd, I can't see any likely negative impact from doing so.

Added bonus test coverage for all cases.