### PR TITLE
fix[python]: subtly incorrect `Series` values on init from python datetimes (unit/precision issue)

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -216,7 +216,14 @@ def sequence_to_pyseries(
 
     else:
         if python_dtype is None:
-            python_dtype = float if (value is None) else type(value)
+            if value is None:
+                # generic default dtype
+                python_dtype = float
+            else:
+                python_dtype = type(value)
+                if datetime == python_dtype:
+                    # note: python-native datetimes have microsecond precision
+                    temporal_unit = "us"
 
         # temporal branch
         if python_dtype in py_temporal_types:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -244,6 +244,22 @@ def test_datetime_consistency() -> None:
         )
     ]
 
+    test_data = [
+        datetime(2000, 1, 1, 1, 1, 1, 555555),
+        datetime(2514, 5, 30, 1, 53, 4, 986754),
+        datetime(3099, 12, 31, 23, 59, 59, 123456),
+        datetime(9999, 12, 31, 23, 59, 59, 999999),
+    ]
+    ddf = pl.DataFrame({"dtm": test_data}).with_column(
+        pl.col("dtm").dt.nanosecond().alias("ns")
+    )
+    assert ddf.rows() == [
+        (test_data[0], 555555000),
+        (test_data[1], 986754000),
+        (test_data[2], 123456000),
+        (test_data[3], 999999000),
+    ]
+
 
 def test_timezone() -> None:
     ts = pa.timestamp("s")


### PR DESCRIPTION
Tracked down an issue with _very_ slightly wrong datetime values (apparently starting a few hundred years in the future) in `Series` initialized from python. 

This means python's `datetime.max` value (sometimes used as a sentinel) wasn't being represented accurately in polars frames, and would cause an `OverflowError` panic if trying to read the data back into python-space (eg: via `rows()`) or an `ArrowInvalid` exception (if exporting to pandas).

**Example / repro:**
```python
from datetime import datetime
import polars as pl

pl.DataFrame({
    "dtm": [
        datetime(2000,1,1,1,1,1,555555),
        datetime(2514,5,30,1,53,4,986754),
        datetime(3099,12,31,23,59,59,123456),
        datetime(9999,12,31,23,59,59,999999),  # << aka: datetime.max
    ]
}).with_column( 
    pl.col("dtm").dt.nanosecond().alias("ns")
)
```
**Before:** 
Datetime values greater than `datetime(2514,5,30,1,53,4,0)` are slightly wrong (on the order of 1-5 microsecs for tested values). The above example shows the following - both the datetime value itself and the associated nanoseconds are slightly off. 
```python
# ┌────────────────────────────┬───────────┐
# │ dtm                        ┆ ns        │
# │ ---                        ┆ ---       │
# │ datetime[μs]               ┆ u32       │
# ╞════════════════════════════╪═══════════╡
# │ 2000-01-01 01:01:01.555555 ┆ 555555000 │  # << correct
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ 2514-05-30 01:53:04.986756 ┆ 986756000 │  # << wrong: expect 986754000
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ 3099-12-31 23:59:59.123460 ┆ 123460000 │  # << wrong: expect 123456000
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ +10000-01-01 00:00:00      ┆ 0         │  # << wrong: in many ways :)
# └────────────────────────────┴───────────┘
```
**After:**
Microsecond precision explicitly identified/applied earlier, values are now correct.
```python
# ┌────────────────────────────┬───────────┐
# │ dtm                        ┆ ns        │
# │ ---                        ┆ ---       │
# │ datetime[μs]               ┆ u32       │
# ╞════════════════════════════╪═══════════╡
# │ 2000-01-01 01:01:01.555555 ┆ 555555000 │  # << correct
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ 2514-05-30 01:53:04.986754 ┆ 986754000 │  # << correct
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ 3099-12-31 23:59:59.123456 ┆ 123456000 │  # << correct
# ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
# │ 9999-12-31 23:59:59.999999 ┆ 999999000 │  # << correct
# └────────────────────────────┴───────────┘
```
As well as the fix (apply correct dtype precision earlier), have added new test coverage.