### PR TITLE
feat[python]: allow ergonomic coalesce-like calls for "fill_null"

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4430,7 +4430,9 @@ class DataFrame:
         Parameters
         ----------
         value
-            Value used to fill null values.
+            Value used to fill null values; can also be a sequence of expressions,
+            in which case you will get "coalesce" behaviour, where the first not-null
+            value from the given input expressions is used.
         strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
             Strategy used to fill null values.
         limit

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2055,7 +2055,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Parameters
         ----------
         value
-            Value used to fill null values.
+            Value used to fill null values; can also be a sequence of expressions,
+            in which case you will get "coalesce" behaviour, where the first not-null
+            value from the given input expressions is used.
         strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
             Strategy used to fill null values.
         limit

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -118,8 +118,8 @@ def expr_dispatch(cls: type[T]) -> type[T]:
                 # note: `co_varnames` starts with the function args, but needs to be
                 # constrained by `co_argcount` as it also includes function-level consts
                 args = attr.__code__.co_varnames[: attr.__code__.co_argcount]
-                # if an expression method with compatible method exists, further check
-                # that the series implementation has an empty function body
+                # if an expression method with compatible signature exists, further
+                # check that the series implementation has an empty function body
                 if (namespace, name, args) in expr_lookup and _is_empty_method(attr):
                     setattr(cls, name, call_expr(attr))
     return cls


### PR DESCRIPTION
Closes #4888 

----

Doesn't seem worth a new/standalone function (?), but this does allow for clean [coalesce](https://www.sqlservertutorial.net/sql-server-basics/sql-server-coalesce/)-style calls, and fits into place neatly within `fill_null`. Enables a sequence of `n` expressions to be passed-in, chaining the calls together like so:

**Before:**
```python
pl.col("a").fill_null( 
    pl.col("b") 
).fill_null( 
    pl.col("c") 
).fill_null( 
    pl.col("d") 
).fill_null( 
    pl.col("e")
).fill_null( 
    pl.col("f")
).fill_null( 
    pl.col("g")
)
```
**After:**
```python
pl.col("a").fill_null( [pl.col(c) for c in "bcdefg"] )
```
And (of course ;) new test coverage for the extended behaviour.