### PR TITLE
fix[python]: prevent invalid use of `Series`, `DataFrame`, and `LazyFrame` in logical boolean context

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Iterator,
     Mapping,
+    NoReturn,
     Sequence,
     TextIO,
     TypeVar,
@@ -1051,6 +1052,12 @@ class DataFrame:
             return self.select(pli.all() <= other)
         else:
             raise ValueError(f"got unexpected comparison operator: {op}")
+
+    def __bool__(self) -> NoReturn:
+        raise ValueError(
+            "The truth value of a DataFrame is ambiguous. "
+            "Hint: to check if a DataFrame contains any values, use 'is_empty()'"
+        )
 
     def __eq__(self, other: Any) -> DataFrame:  # type: ignore[override]
         return self._comp(other, "eq")

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -120,7 +120,8 @@ class ExprDateTimeNameSpace:
             2001-01-01 23:00:00
             2001-01-02 00:00:00
         ]
-        >>> assert s.dt.truncate("1h") == s.dt.truncate(timedelta(hours=1))
+        >>> s.dt.truncate("1h").series_equal(s.dt.truncate(timedelta(hours=1)))
+        True
 
         """
         if offset is None:

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import random
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence
 from warnings import warn
 
 from polars import internals as pli
@@ -140,7 +140,7 @@ class Expr:
     def __str__(self) -> str:
         return self._pyexpr.to_str()
 
-    def __bool__(self) -> Expr:
+    def __bool__(self) -> NoReturn:
         raise ValueError(
             "Since Expr are lazy, the truthiness of an Expr is ambiguous. "
             "Hint: use '&' or '|' to chain Expr together, not and/or."

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -7,7 +7,7 @@ import tempfile
 import typing
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, TypeVar, overload
 from warnings import warn
 
 from polars import internals as pli
@@ -389,6 +389,12 @@ class LazyFrame:
 
         """  # noqa: E501
         return self._ldf.schema()
+
+    def __bool__(self) -> NoReturn:
+        raise ValueError(
+            "The truth value of a LazyFrame is ambiguous; consequently it "
+            "cannot be used in boolean context with and/or/not operators. "
+        )
 
     def __contains__(self: LDF, key: str) -> bool:
         return key in self.columns

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -500,6 +500,7 @@ class DateTimeNameSpace:
             2001-01-01 23:00:00
             2001-01-02 00:00:00
         ]
-        >>> assert s.dt.truncate("1h") == s.dt.truncate(timedelta(hours=1))
+        >>> s.dt.truncate("1h").series_equal(s.dt.truncate(timedelta(hours=1)))
+        True
 
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, Union
 from warnings import warn
 
 from polars import internals as pli
@@ -321,6 +321,13 @@ class Series:
     def time_unit(self) -> TimeUnit | None:
         """Get the time unit of underlying Datetime Series as {"ns", "us", "ms"}."""
         return self._s.time_unit()
+
+    def __bool__(self) -> NoReturn:
+        raise ValueError(
+            "The truth value of a Series is ambiguous. Hint: use '&' or '|' to chain "
+            "Series boolean results together, not and/or; to check if a Series "
+            "contains any values, use 'is_empty()'"
+        )
 
     def __getstate__(self) -> Any:
         return self._s.__getstate__()

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -13,7 +13,7 @@ import pytest
 import polars as pl
 from polars import DataType
 from polars.internals.type_aliases import TimeUnit
-from polars.testing import assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal_local_categoricals, assert_series_equal
 
 
 def test_quoted_date() -> None:
@@ -230,12 +230,13 @@ def test_read_csv_encoding() -> None:
     for use_pyarrow in (False, True):
         for file in (file_path, file_str, bts, bytesio):
             print(type(file))
-            assert pl.read_csv(
-                file,  # type: ignore[arg-type]
-                encoding="big5",
-                use_pyarrow=use_pyarrow,
-            ).get_column("Region") == pl.Series(
-                "Region", ["台北", "台中", "新竹", "高雄", "美國"]
+            assert_series_equal(
+                pl.read_csv(
+                    file,  # type: ignore[arg-type]
+                    encoding="big5",
+                    use_pyarrow=use_pyarrow,
+                ).get_column("Region"),
+                pl.Series("Region", ["台北", "台中", "新竹", "高雄", "美國"]),
             )
 
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -17,7 +17,7 @@ else:
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, TemporalDataType
-from polars.testing import verify_series_and_expr_api
+from polars.testing import assert_series_equal, verify_series_and_expr_api
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit
@@ -83,7 +83,7 @@ def test_series_add_datetime() -> None:
     out = pl.Series(
         [datetime(2027, 5, 19), datetime(2054, 10, 4), datetime(2082, 2, 19)]
     )
-    assert (deltas + pl.Series([datetime(2000, 1, 1)])) == out
+    assert_series_equal(deltas + pl.Series([datetime(2000, 1, 1)]), out)
 
 
 def test_diff_datetime() -> None:
@@ -102,7 +102,7 @@ def test_diff_datetime() -> None:
             ]
         ).with_columns([pl.col("timestamp").diff().list().over("char")])
     )["timestamp"]
-    assert out[0] == out[1]
+    assert (out[0] == out[1]).all()
 
 
 def test_from_pydatetime() -> None:
@@ -379,7 +379,7 @@ def test_date_range() -> None:
     assert result.name == "drange"
 
     result = pl.date_range(date(2022, 1, 1), date(2022, 1, 2), "1h30m")
-    assert result == [
+    assert list(result) == [
         datetime(2022, 1, 1, 0, 0),
         datetime(2022, 1, 1, 1, 30),
         datetime(2022, 1, 1, 3, 0),

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -412,3 +412,13 @@ def test_abs_expr() -> None:
     out = df.select(abs(pl.col("x")))
 
     assert out["x"].to_list() == [1, 0, 1]
+
+
+def test_logical_boolean() -> None:
+    # note, cannot use expressions in logical
+    # boolean context (eg: and/or/not operators)
+    with pytest.raises(ValueError, match="ambiguous"):
+        pl.col("colx") and pl.col("coly")
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        pl.col("colx") or pl.col("coly")

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -229,13 +229,12 @@ def test_from_dicts() -> None:
     assert df.shape == (3, 2)
 
 
-@pytest.mark.skip("not implemented yet")
 def test_from_dicts_struct() -> None:
     data = [{"a": {"b": 1, "c": 2}, "d": 5}, {"a": {"b": 3, "c": 4}, "d": 6}]
     df = pl.from_dicts(data)
     assert df.shape == (2, 2)
-    assert df["a"][0] == (1, 2)
-    assert df["a"][1] == (3, 4)
+    assert df["a"][0] == {"b": 1, "c": 2}
+    assert df["a"][1] == {"b": 3, "c": 4}
 
 
 def test_from_records() -> None:

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -166,7 +166,6 @@ def test_zfill() -> None:
             "num": [-10, -1, 0, 1, 10, 100, 1000, 10000, 100000, 1000000, None],
         }
     )
-
     out = [
         "-0010",
         "-0001",
@@ -184,7 +183,7 @@ def test_zfill() -> None:
         df.with_column(pl.col("num").cast(str).str.zfill(5)).to_series().to_list()
         == out
     )
-    assert df["num"].cast(str).str.zfill(5) == out
+    assert df["num"].cast(str).str.zfill(5).to_list() == out
 
 
 def test_ljust_and_rjust() -> None:


### PR DESCRIPTION
Closes #4926 

---

We already have this for Expr, but as the linked issue shows (incorrect usage of the logical operator `and` instead of the binary operator `&`) Series, DataFrame, and LazyFrame should have the same protection and raise a similarly helpful Exception.

Turns out this is not just a helpful convenience for users - making this change showed that our own test suite had **37**(!) potential errors in it, directly linked to invalid asserts against Series, and several of those tests were actively asserting incorrect values.

For instance - the following pattern _always_ passes the `assert`, no matter what data the Series contains, because the result from `==` is a Series, but the assert infers a logical boolean:

```python
# this did *not* raise an AssertionError, 
# but the pattern was found in unit tests
s = pl.Series([0, 0, 0, 0, 0, 0])
assert s == [999,999,999]
```

Depending on the form of the test, I have updated them to use one of the following correct patterns instead:

```python
assert (s == [999,999,999]).all()
assert s.to_list() == [999,999,999]
assert_series_equal(s, pl.Series([999,999,999]))
```

The test suite is now in good shape again, and I _very_ carefully checked over the incorrect values being asserted; the good news is that all of the functionality appears to be fine (so no bugs slipped through while the asserts weren't working), and I have updated all of the incorrect test values to assert the correct behaviour.

----
_Example of incorrect values in unit test assert (now fixed):_
```python
def test_multiple_column_sort() -> None:
    df = pl.DataFrame({
        "a": ["foo", "bar", "2"], 
        "b": [2, 2, 3],   
        "c": [1.0, 2.0, 3.0],
    })
    out = df.sort([pl.col("b"), pl.col("c").reverse()])
    assert out["c"] == [2, 3, 1]
    assert out["b"] == [2, 2, 3]
```
The values asserted for `out["c"]` are both in the wrong order, _and_ are the wrong type, but the test still passed; has now been updated to the following:
```python
assert list(out["c"]) == [2.0, 1.0, 3.0]
assert list(out["b"]) == [2, 2, 3]
```

