### PR TITLE
feat[rust, python]: add missing `millisecond` and `microsecond` accessors

### DIFF
--- a/polars/polars-lazy/src/dsl/dt.rs
+++ b/polars/polars-lazy/src/dsl/dt.rs
@@ -132,16 +132,19 @@ impl DateLikeNameSpace {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Day))
     }
+
     /// Get the ordinal_day of a Date/Datetime
     pub fn ordinal_day(self) -> Expr {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::OrdinalDay))
     }
+
     /// Get the hour of a Datetime/Time64
     pub fn hour(self) -> Expr {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Hour))
     }
+
     /// Get the minute of a Datetime/Time64
     pub fn minute(self) -> Expr {
         self.0
@@ -153,10 +156,23 @@ impl DateLikeNameSpace {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Second))
     }
-    /// Get the nanosecond of a Time64
+
+    /// Get the millisecond of a Time64 (scaled from nanosecs)
+    pub fn millisecond(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Millisecond))
+    }
+
+    /// Get the microsecond of a Time64 (scaled from nanosecs)
+    pub fn microsecond(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Microsecond))
+    }
+
+    /// Get the nanosecond part of a Time64
     pub fn nanosecond(self) -> Expr {
         self.0
-            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::NanoSecond))
+            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::Nanosecond))
     }
 
     pub fn timestamp(self, tu: TimeUnit) -> Expr {

--- a/polars/polars-lazy/src/dsl/function_expr/datetime.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/datetime.rs
@@ -17,7 +17,9 @@ pub enum TemporalFunction {
     Hour,
     Minute,
     Second,
-    NanoSecond,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
     TimeStamp(TimeUnit),
 }
 
@@ -36,7 +38,9 @@ impl Display for TemporalFunction {
             Hour => "hour",
             Minute => "minute",
             Second => "second",
-            NanoSecond => "nanosecond",
+            Millisecond => "millisecond",
+            Microsecond => "microsecond",
+            Nanosecond => "nanosecond",
             TimeStamp(tu) => return write!(f, "dt.timestamp({})", tu),
         };
         write!(f, "dt.{}", s)
@@ -76,10 +80,15 @@ pub(super) fn minute(s: &Series) -> PolarsResult<Series> {
 pub(super) fn second(s: &Series) -> PolarsResult<Series> {
     s.second().map(|ca| ca.into_series())
 }
+pub(super) fn millisecond(s: &Series) -> PolarsResult<Series> {
+    s.nanosecond().map(|ca| (ca / 1_000_000).into_series())
+}
+pub(super) fn microsecond(s: &Series) -> PolarsResult<Series> {
+    s.nanosecond().map(|ca| (ca / 1_000).into_series())
+}
 pub(super) fn nanosecond(s: &Series) -> PolarsResult<Series> {
     s.nanosecond().map(|ca| ca.into_series())
 }
-
 pub(super) fn timestamp(s: &Series, tu: TimeUnit) -> PolarsResult<Series> {
     s.timestamp(tu).map(|ca| ca.into_series())
 }

--- a/polars/polars-lazy/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/mod.rs
@@ -407,7 +407,9 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Hour => map!(datetime::hour),
             Minute => map!(datetime::minute),
             Second => map!(datetime::second),
-            NanoSecond => map!(datetime::nanosecond),
+            Millisecond => map!(datetime::millisecond),
+            Microsecond => map!(datetime::microsecond),
+            Nanosecond => map!(datetime::nanosecond),
             TimeStamp(tu) => map!(datetime::timestamp, tu),
         }
     }

--- a/polars/polars-lazy/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/src/dsl/function_expr/schema.rs
@@ -113,7 +113,7 @@ impl FunctionExpr {
                 let dtype = match fun {
                     Year | IsoYear => DataType::Int32,
                     Month | Quarter | Week | WeekDay | Day | OrdinalDay | Hour | Minute
-                    | NanoSecond | Second => DataType::UInt32,
+                    | Millisecond | Microsecond | Nanosecond | Second => DataType::UInt32,
                     TimeStamp(_) => DataType::Int64,
                 };
                 with_dtype(dtype)

--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -283,6 +283,9 @@ The following methods are available under the `expr.dt` attribute.
     ExprDateTimeNameSpace.epoch
     ExprDateTimeNameSpace.hour
     ExprDateTimeNameSpace.hours
+    ExprDateTimeNameSpace.microsecond
+    ExprDateTimeNameSpace.microseconds
+    ExprDateTimeNameSpace.millisecond
     ExprDateTimeNameSpace.milliseconds
     ExprDateTimeNameSpace.minute
     ExprDateTimeNameSpace.minutes

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -235,6 +235,9 @@ The following methods are available under the `Series.dt` attribute.
     DateTimeNameSpace.max
     DateTimeNameSpace.mean
     DateTimeNameSpace.median
+    DateTimeNameSpace.microsecond
+    DateTimeNameSpace.microseconds
+    DateTimeNameSpace.millisecond
     DateTimeNameSpace.milliseconds
     DateTimeNameSpace.min
     DateTimeNameSpace.minute

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -146,7 +146,7 @@ class ExprDateTimeNameSpace:
         """
         Extract year from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the year number in the calendar date.
 
@@ -198,9 +198,9 @@ class ExprDateTimeNameSpace:
         """
         Extract iso-year from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
-        Returns the year number in the iso standard.
+        Returns the year number in the ISO standard.
         This may not correspond with the calendar year.
 
         Returns
@@ -214,7 +214,7 @@ class ExprDateTimeNameSpace:
         """
         Extract quarter from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the quarter ranging from 1 to 4.
 
@@ -262,7 +262,7 @@ class ExprDateTimeNameSpace:
         """
         Extract month from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the month number starting from 1.
         The return value ranges from 1 to 12.
@@ -311,7 +311,7 @@ class ExprDateTimeNameSpace:
         """
         Extract the week from the underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the ISO week number starting from 1.
         The return value ranges from 1 to 53. (The last week of year differs by years.)
@@ -360,7 +360,7 @@ class ExprDateTimeNameSpace:
         """
         Extract the week day from the underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the weekday number where monday = 0 and sunday = 6
 
@@ -414,7 +414,7 @@ class ExprDateTimeNameSpace:
         """
         Extract day from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the day of month starting from 1.
         The return value ranges from 1 to 31. (The last day of month differs by months.)
@@ -469,7 +469,7 @@ class ExprDateTimeNameSpace:
         """
         Extract ordinal day from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the day of year starting from 1.
         The return value ranges from 1 to 366. (The last day of year differs by years.)
@@ -524,7 +524,7 @@ class ExprDateTimeNameSpace:
         """
         Extract hour from underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the hour number from 0 to 23.
 
@@ -572,7 +572,7 @@ class ExprDateTimeNameSpace:
         """
         Extract minutes from underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the minute number from 0 to 59.
 
@@ -622,7 +622,7 @@ class ExprDateTimeNameSpace:
         """
         Extract seconds from underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the integer second number from 0 to 59, or a floating
         point number from 0 < 60 if ``fractional=True`` that includes
@@ -693,18 +693,41 @@ class ExprDateTimeNameSpace:
             else sec
         )
 
-    def nanosecond(self) -> pli.Expr:
+    def millisecond(self) -> pli.Expr:
         """
-        Extract seconds from underlying DateTime representation.
+        Extract milliseconds from underlying DateTime representation.
 
-        Can be performed on Datetime columns.
-
-        Returns the number of nanoseconds since the whole non-leap second.
-        The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
+        Applies to Datetime columns.
 
         Returns
         -------
-        Nanosecond as UInt32
+        Milliseconds as UInt32
+
+        """
+        return pli.wrap_expr(self._pyexpr.millisecond())
+
+    def microsecond(self) -> pli.Expr:
+        """
+        Extract microseconds from underlying DateTime representation.
+
+        Applies to Datetime columns.
+
+        Returns
+        -------
+        Microseconds as UInt32
+
+        """
+        return pli.wrap_expr(self._pyexpr.microsecond())
+
+    def nanosecond(self) -> pli.Expr:
+        """
+        Extract nanoseconds from underlying DateTime representation.
+
+        Applies to Datetime columns.
+
+        Returns
+        -------
+        Nanoseconds as UInt32
 
         """
         return pli.wrap_expr(self._pyexpr.nanosecond())

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -63,13 +63,13 @@ class DateTimeNameSpace:
         """
         Extract the year from the underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the year number in the calendar date.
 
         Returns
         -------
-        Year as Int32
+        Year part as Int32
 
         """
 
@@ -77,14 +77,14 @@ class DateTimeNameSpace:
         """
         Extract iso-year from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the year number in the iso standard.
         This may not correspond with the calendar year.
 
         Returns
         -------
-        Year as Int32
+        ISO year as Int32
 
         """
 
@@ -92,7 +92,7 @@ class DateTimeNameSpace:
         """
         Extract quarter from underlying Date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the quarter ranging from 1 to 4.
 
@@ -106,14 +106,14 @@ class DateTimeNameSpace:
         """
         Extract the month from the underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the month number starting from 1.
         The return value ranges from 1 to 12.
 
         Returns
         -------
-        Month as UInt32
+        Month part as UInt32
 
         """
 
@@ -121,7 +121,7 @@ class DateTimeNameSpace:
         """
         Extract the week from the underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the ISO week number starting from 1.
         The return value ranges from 1 to 53. (The last week of year differs by years.)
@@ -136,13 +136,13 @@ class DateTimeNameSpace:
         """
         Extract the week day from the underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the weekday number where monday = 0 and sunday = 6
 
         Returns
         -------
-        Week day as UInt32
+        Weekday as UInt32
 
         """
 
@@ -150,14 +150,14 @@ class DateTimeNameSpace:
         """
         Extract the day from the underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the day of month starting from 1.
         The return value ranges from 1 to 31. (The last day of month differs by months.)
 
         Returns
         -------
-        Day as UInt32
+        Day part as UInt32
 
         """
 
@@ -165,14 +165,14 @@ class DateTimeNameSpace:
         """
         Extract ordinal day from underlying date representation.
 
-        Can be performed on Date and Datetime columns.
+        Applies to Date and Datetime columns.
 
         Returns the day of year starting from 1.
         The return value ranges from 1 to 366. (The last day of year differs by years.)
 
         Returns
         -------
-        Day as UInt32
+        Ordinaly day as UInt32
 
         """
 
@@ -180,13 +180,13 @@ class DateTimeNameSpace:
         """
         Extract the hour from the underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the hour number from 0 to 23.
 
         Returns
         -------
-        Hour as UInt32
+        Hour part as UInt32
 
         """
 
@@ -194,13 +194,13 @@ class DateTimeNameSpace:
         """
         Extract the minutes from the underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the minute number from 0 to 59.
 
         Returns
         -------
-        Minute as UInt32
+        Minute part as UInt32
 
         """
 
@@ -208,7 +208,7 @@ class DateTimeNameSpace:
         """
         Extract seconds from underlying DateTime representation.
 
-        Can be performed on Datetime columns.
+        Applies to Datetime columns.
 
         Returns the integer second number from 0 to 59, or a floating
         point number from 0 < 60 if ``fractional=True`` that includes
@@ -216,7 +216,31 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Second as UInt32 (or Float64)
+        Second part as UInt32 (or Float64)
+
+        """
+
+    def millisecond(self) -> pli.Series:
+        """
+        Extract the milliseconds from the underlying DateTime representation.
+
+        Applies to Datetime columns.
+
+        Returns
+        -------
+        Millisecond part as UInt32
+
+        """
+
+    def microsecond(self) -> pli.Series:
+        """
+        Extract the microseconds from the underlying DateTime representation.
+
+        Applies to Datetime columns.
+
+        Returns
+        -------
+        Microsecond part as UInt32
 
         """
 
@@ -224,14 +248,11 @@ class DateTimeNameSpace:
         """
         Extract the nanoseconds from the underlying DateTime representation.
 
-        Can be performed on Datetime columns.
-
-        Returns the number of nanoseconds since the whole non-leap second.
-        The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
+        Applies to Datetime columns.
 
         Returns
         -------
-        Nanosecond as UInt32
+        Nanosecond part as UInt32
 
         """
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -809,6 +809,12 @@ impl PyExpr {
     pub fn second(&self) -> PyExpr {
         self.clone().inner.dt().second().into()
     }
+    pub fn millisecond(&self) -> PyExpr {
+        self.clone().inner.dt().millisecond().into()
+    }
+    pub fn microsecond(&self) -> PyExpr {
+        self.clone().inner.dt().microsecond().into()
+    }
     pub fn nanosecond(&self) -> PyExpr {
         self.clone().inner.dt().nanosecond().into()
     }

--- a/py-polars/tests/db-benchmark/main.py
+++ b/py-polars/tests/db-benchmark/main.py
@@ -296,8 +296,8 @@ out = (
     .select([pl.sum("id6"), pl.sum("v3")])
     .collect()
 )
-assert out["id6"] == 430957682
-assert np.isclose(out["v3"], 4.724150165888001e6)
+assert out["id6"].to_list() == [430957682]
+assert np.isclose(out["v3"].to_list(), 4.724150165888001e6).all()
 print(out)
 
 out = (
@@ -307,8 +307,8 @@ out = (
 )
 print(out)
 
-assert out["id6"] == 2137755425
-assert np.isclose(out["v3"], 4.7040828499563754e8)
+assert out["id6"].to_list() == [2137755425]
+assert np.isclose(out["v3"].to_list(), 4.7040828499563754e8).all()
 
 if not ON_STRINGS:
     if total_time > 12:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1567,10 +1567,16 @@ def test_dt_datetimes() -> None:
     s = pl.Series(["2020-01-01 00:00:00.000000000", "2020-02-02 03:20:10.987654321"])
     s = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
 
-    # hours, minutes, seconds and nanoseconds
+    # hours, minutes, seconds, milliseconds, microseconds, and nanoseconds
     verify_series_and_expr_api(s, pl.Series("", [0, 3], dtype=UInt32), "dt.hour")
     verify_series_and_expr_api(s, pl.Series("", [0, 20], dtype=UInt32), "dt.minute")
     verify_series_and_expr_api(s, pl.Series("", [0, 10], dtype=UInt32), "dt.second")
+    verify_series_and_expr_api(
+        s, pl.Series("", [0, 987], dtype=UInt32), "dt.millisecond"
+    )
+    verify_series_and_expr_api(
+        s, pl.Series("", [0, 987654], dtype=UInt32), "dt.microsecond"
+    )
     verify_series_and_expr_api(
         s, pl.Series("", [0, 987654321], dtype=UInt32), "dt.nanosecond"
     )


### PR DESCRIPTION
Closes #4760 

----

Returning to this; exposes `dt.millisecond` and `dt.microsecond` attrs for Expr and Series, and adds some test coverage for the same. 

Also, some minor doc updates - removed the note in the accessors about leap-seconds, as it doesn't seem possible to generate/load any that would meet the required conditions (reading into the [chrono docs](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html#leap-second-handling) it seems that you need to instantiate one specially - I tried as hard as I could with a list of known leap-seconds and was unable to make anything visible to our layer from real data; attempting to parse something that _would_ make it work at the chrono level just -quite reasonably- raises an error about strict conversion of dates).

----

_Example: definition of a chrono-level leap-second - note the number of nanoseconds ;)
`let dt = Utc.ymd(2015, 6, 30).and_hms_nano(23, 59, 59, 1_000_000_000)`_