### PR TITLE
feat[python]: add new (optional) "name" param to `Series.to_frame`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -26,7 +26,6 @@ from polars._html import NotebookFormatter
 from polars.datatypes import (
     Boolean,
     ColumnsType,
-    DataType,
     Int8,
     Int16,
     Int32,
@@ -3922,7 +3921,7 @@ class DataFrame:
     def apply(
         self: DF,
         f: Callable[[tuple[Any, ...]], Any],
-        return_dtype: type[DataType] | None = None,
+        return_dtype: PolarsDataType | None = None,
         inference_size: int = 256,
     ) -> DF:
         """

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -196,7 +196,7 @@ class ExprDateTimeNameSpace:
 
     def iso_year(self) -> pli.Expr:
         """
-        Extract iso-year from underlying Date representation.
+        Extract ISO year from underlying Date representation.
 
         Applies to Date and Datetime columns.
 
@@ -205,7 +205,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Year as Int32
+        ISO Year as Int32
 
         """
         return pli.wrap_expr(self._pyexpr.iso_year())

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1856,12 +1856,12 @@ def coalesce(
     ],
 ) -> pli.Expr:
     """
-    Folds the expressions from left to right keeping the first no null values.
+    Folds the expressions from left to right, keeping the first non-null value.
 
     Parameters
     ----------
     exprs
-        Expression to coalesce.
+        Expressions to coalesce.
 
     """
     exprs = pli.selection_to_pyexpr_list(exprs)

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -75,11 +75,11 @@ class DateTimeNameSpace:
 
     def iso_year(self) -> pli.Series:
         """
-        Extract iso-year from underlying Date representation.
+        Extract ISO year from underlying Date representation.
 
         Applies to Date and Datetime columns.
 
-        Returns the year number in the iso standard.
+        Returns the year number according to the ISO standard.
         This may not correspond with the calendar year.
 
         Returns
@@ -172,7 +172,7 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Ordinaly day as UInt32
+        Ordinal day as UInt32
 
         """
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -879,16 +879,21 @@ class Series:
     def drop_nans(self) -> Series:
         """Drop NaN values."""
 
-    def to_frame(self) -> pli.DataFrame:
+    def to_frame(self, name: str | None = None) -> pli.DataFrame:
         """
         Cast this Series to a DataFrame.
 
+        Parameters
+        ----------
+        name
+            optionally name/rename the Series column in the new DataFrame.
+
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s = pl.Series("a", [1, 2])
         >>> df = s.to_frame()
         >>> df
-        shape: (3, 1)
+        shape: (2, 1)
         ┌─────┐
         │ a   │
         │ --- │
@@ -897,15 +902,29 @@ class Series:
         │ 1   │
         ├╌╌╌╌╌┤
         │ 2   │
-        ├╌╌╌╌╌┤
-        │ 3   │
         └─────┘
 
-        >>> type(df)
-        <class 'polars.internals.dataframe.frame.DataFrame'>
+        >>> df = s.to_frame("xyz")
+        >>> df
+        shape: (2, 1)
+        ┌─────┐
+        │ xyz │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        ├╌╌╌╌╌┤
+        │ 2   │
+        └─────┘
+
+        >>> isinstance(df, pl.DataFrame)
+        True
 
         """
-        return pli.wrap_df(PyDataFrame([self._s]))
+        df = pli.wrap_df(PyDataFrame([self._s]))
+        if name:
+            return df.rename({self.name: name})
+        return df
 
     def describe(self) -> pli.DataFrame:
         """
@@ -1189,7 +1208,7 @@ class Series:
 
         Parameters
         ----------
-        sort:
+        sort
             Ensure the output is sorted from most values to least.
 
         Examples
@@ -2500,12 +2519,13 @@ class Series:
         filter
             Boolean mask.
         value
-            Value to replace the the masked values with.
+            Value with which to replace the masked values.
 
         Notes
         -----
-        Using this is an anti-pattern.
-        Always prefer: `pl.when(predicate).then(value).otherwise(self)`
+        Use of this function is frequently an anti-pattern, as it can
+        block optimisation (predicate pushdown, etc). Consider using
+        `pl.when(predicate).then(value).otherwise(self)` instead.
 
         """
         f = get_ffi_func("set_with_mask_<>", self.dtype, self._s)
@@ -2547,8 +2567,9 @@ class Series:
 
         Notes
         -----
-        Using this is considered an anti-pattern.
-        Always prefer: `pl.when(predicate).then(value).otherwise(self)`
+        Use of this function is frequently an anti-pattern, as it can
+        block optimisation (predicate pushdown, etc). Consider using
+        `pl.when(predicate).then(value).otherwise(self)` instead.
 
         """
         if isinstance(idx, int):

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -890,7 +890,7 @@ class Series:
 
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2])
+        >>> s = pl.Series("a", [123, 456])
         >>> df = s.to_frame()
         >>> df
         shape: (2, 1)
@@ -899,9 +899,9 @@ class Series:
         │ --- │
         │ i64 │
         ╞═════╡
-        │ 1   │
+        │ 123 │
         ├╌╌╌╌╌┤
-        │ 2   │
+        │ 456 │
         └─────┘
 
         >>> df = s.to_frame("xyz")
@@ -912,17 +912,14 @@ class Series:
         │ --- │
         │ i64 │
         ╞═════╡
-        │ 1   │
+        │ 123 │
         ├╌╌╌╌╌┤
-        │ 2   │
+        │ 456 │
         └─────┘
-
-        >>> isinstance(df, pl.DataFrame)
-        True
 
         """
         df = pli.wrap_df(PyDataFrame([self._s]))
-        if name:
+        if name is not None:
             return df.rename({self.name: name})
         return df
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -122,6 +122,10 @@ def test_to_frame() -> None:
         assert df.rows() == [(1,), (2,)]
         assert df.columns == [name]
 
+    # note: the empty string IS technically a valid column name
+    assert s2.to_frame("").columns == [""]
+    assert s2.name == "s"
+
 
 def test_bitwise_ops() -> None:
     a = pl.Series([True, False, True])

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -109,8 +109,18 @@ def test_concat() -> None:
 
 
 def test_to_frame() -> None:
-    s = pl.Series([1, 2])
-    assert s.to_frame().shape == (2, 1)
+    s1 = pl.Series([1, 2])
+    s2 = pl.Series("s", [1, 2])
+
+    df1 = s1.to_frame()
+    df2 = s2.to_frame()
+    df3 = s1.to_frame("xyz")
+    df4 = s2.to_frame("xyz")
+
+    for df, name in ((df1, ""), (df2, "s"), (df3, "xyz"), (df4, "xyz")):
+        assert isinstance(df, pl.DataFrame)
+        assert df.rows() == [(1,), (2,)]
+        assert df.columns == [name]
 
 
 def test_bitwise_ops() -> None:


### PR DESCRIPTION
Handy minor addition; matches the [equivalent function](https://pandas.pydata.org/docs/reference/api/pandas.Series.to_frame.html) in pandas.

* if series has no name, can provide one.
* if series already has a name, can override it.

```python
import polars as pl
s = pl.Series([123, 456])

s.to_frame()
# ┌─────┐
# │     │
# │ --- │
# │ i64 │
# ╞═════╡
# │ 123 │
# ├╌╌╌╌╌┤
# │ 456 │
# └─────┘

s.to_frame("xyz")
# ┌─────┐
# │ xyz │
# │ --- │
# │ i64 │
# ╞═════╡
# │ 123 │
# ├╌╌╌╌╌┤
# │ 456 │
# └─────┘
```
Also: miscellaneous minor docstring updates.