### PR TITLE
ci: Pin test Python version to 3.10.6

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.10.6']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,6 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: Change '3.10.6' to '3.10' after updating mypy version
+        # See issue: https://github.com/pola-rs/polars/issues/4957
         python-version: ['3.7', '3.10.6']
 
     steps:


### PR DESCRIPTION
Resolves #4957 

The workflow does not run when it selects Python 3.10.7. The runners seem to randomly select 3.10.6 or 3.10.7, resulting in the workflow failing only sometimes.

Changes:
* In the test Python job, change Python `3.10` to `3.10.6`. 

Note that we should revert this change once we update `mypy` to a version that contains a fix. I added a comment to this extent and will keep an eye on this.