### PR TITLE
refactor[rust]: `polars-lazy` readability improvements

### DIFF
--- a/polars/polars-lazy/src/dsl/expr.rs
+++ b/polars/polars-lazy/src/dsl/expr.rs
@@ -258,8 +258,7 @@ impl AsRef<Expr> for AggExpr {
     }
 }
 
-/// Queries consists of multiple ex
-/// pressions.
+/// Queries consists of multiple expressions.
 #[derive(Clone, PartialEq)]
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -273,7 +273,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, sep: &str) -> Expr {
 pub fn format_str<E: AsRef<[Expr]>>(format: &str, args: E) -> PolarsResult<Expr> {
     let mut args: std::collections::VecDeque<Expr> = args.as_ref().to_vec().into();
 
-    // Parse the format string, and seperate substrings between placeholders
+    // Parse the format string, and separate substrings between placeholders
     let segments: Vec<&str> = format.split("{}").collect();
 
     if segments.len() - 1 != args.len() {

--- a/polars/polars-lazy/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/src/logical_plan/projection.rs
@@ -429,7 +429,7 @@ pub(crate) fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema, keys: &[Exp
         }
 
         // has multiple column names
-        // the expanded columns are added to the reuslt
+        // the expanded columns are added to the result
         if multiple_columns {
             if let Some(e) = expr
                 .into_iter()

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -288,7 +288,7 @@ impl Executor for PartitionGroupByExec {
         #[cfg(debug_assertions)]
         {
             if state.verbose() {
-                println!("run PartititonGroupbyExec")
+                println!("run PartitionGroupbyExec")
             }
         }
         let original_df = self.input.execute(state)?;
@@ -299,7 +299,7 @@ impl Executor for PartitionGroupByExec {
                 .iter()
                 .map(|s| Ok(s.to_field(&self.input_schema)?.name))
                 .collect::<PolarsResult<Vec<_>>>()?;
-            let name = column_delimited("groupby_paritioned".to_string(), &by);
+            let name = column_delimited("groupby_partitioned".to_string(), &by);
             Cow::Owned(name)
         } else {
             Cow::Borrowed("")

--- a/polars/polars-lazy/src/physical_plan/executors/slice.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/slice.rs
@@ -14,7 +14,7 @@ impl Executor for SliceExec {
         #[cfg(debug_assertions)]
         {
             if state.verbose() {
-                println!("run SciceExec")
+                println!("run SliceExec")
             }
         }
         let df = self.input.execute(state)?;


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

#### Description
readability fixups in `polars-lazy`

##### Notes
Most interesting change is
```rust
let name = column_delimited("groupby_partitioned".to_string(), &by);
```

The rest are comment/stdout