### PR TITLE
fix test[rust]: test_cat_lexical_sort occasionally fails

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -142,7 +142,7 @@ impl CategoricalChunked {
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
-    use crate::{toggle_string_cache, SINGLE_LOCK};
+    use crate::{reset_string_cache, toggle_string_cache, SINGLE_LOCK};
 
     fn assert_order(ca: &CategoricalChunked, cmp: &[&str]) {
         let s = ca.cast(&DataType::Utf8).unwrap();
@@ -150,14 +150,13 @@ mod test {
         assert_eq!(ca.into_no_null_iter().collect::<Vec<_>>(), cmp);
     }
 
-    // TODO: Fix this test (occasionally fails during CI test job) - See issue #4707
     #[test]
-    #[ignore]
     fn test_cat_lexical_sort() -> PolarsResult<()> {
         let init = &["c", "b", "a", "d"];
 
         let _lock = SINGLE_LOCK.lock();
         for toggle in [true, false] {
+            reset_string_cache();
             toggle_string_cache(toggle);
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;


### PR DESCRIPTION
The test failed sometimes because the values were in a different. The string cache was set up in test_categorical_builder and filled in test_fast_unique with the same values in a different order. By first resetting the cache the problem does not occur any more.