### PR TITLE
fix[python, rust]: allow `expr+series` as well as `series+expr`, address some micros/millis timeunit debt

### DIFF
--- a/polars/polars-lazy/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/src/logical_plan/lit.rs
@@ -226,7 +226,7 @@ impl Literal for NaiveDateTime {
         if in_nanoseconds_window(&self) {
             Expr::Literal(LiteralValue::DateTime(self, TimeUnit::Nanoseconds))
         } else {
-            Expr::Literal(LiteralValue::DateTime(self, TimeUnit::Milliseconds))
+            Expr::Literal(LiteralValue::DateTime(self, TimeUnit::Microseconds))
         }
     }
 }

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1223,13 +1223,14 @@ def argsort_by(
 
 def duration(
     *,
-    days: pli.Expr | str | None = None,
-    seconds: pli.Expr | str | None = None,
-    nanoseconds: pli.Expr | str | None = None,
-    milliseconds: pli.Expr | str | None = None,
-    minutes: pli.Expr | str | None = None,
-    hours: pli.Expr | str | None = None,
-    weeks: pli.Expr | str | None = None,
+    days: pli.Expr | str | int | None = None,
+    seconds: pli.Expr | str | int | None = None,
+    nanoseconds: pli.Expr | str | int | None = None,
+    microseconds: pli.Expr | str | int | None = None,
+    milliseconds: pli.Expr | str | int | None = None,
+    minutes: pli.Expr | str | int | None = None,
+    hours: pli.Expr | str | int | None = None,
+    weeks: pli.Expr | str | int | None = None,
 ) -> pli.Expr:
     """
     Create polars `Duration` from distinct time components.
@@ -1281,25 +1282,37 @@ def duration(
         seconds = pli.expr_to_lit_or_expr(seconds, str_to_lit=False)._pyexpr
     if milliseconds is not None:
         milliseconds = pli.expr_to_lit_or_expr(milliseconds, str_to_lit=False)._pyexpr
+    if microseconds is not None:
+        microseconds = pli.expr_to_lit_or_expr(microseconds, str_to_lit=False)._pyexpr
     if nanoseconds is not None:
         nanoseconds = pli.expr_to_lit_or_expr(nanoseconds, str_to_lit=False)._pyexpr
     if days is not None:
         days = pli.expr_to_lit_or_expr(days, str_to_lit=False)._pyexpr
     if weeks is not None:
         weeks = pli.expr_to_lit_or_expr(weeks, str_to_lit=False)._pyexpr
+
     return pli.wrap_expr(
-        py_duration(days, seconds, nanoseconds, milliseconds, minutes, hours, weeks)
+        py_duration(
+            days,
+            seconds,
+            nanoseconds,
+            microseconds,
+            milliseconds,
+            minutes,
+            hours,
+            weeks,
+        )
     )
 
 
 def _datetime(
-    year: pli.Expr | str,
-    month: pli.Expr | str,
-    day: pli.Expr | str,
-    hour: pli.Expr | str | None = None,
-    minute: pli.Expr | str | None = None,
-    second: pli.Expr | str | None = None,
-    millisecond: pli.Expr | str | None = None,
+    year: pli.Expr | str | int,
+    month: pli.Expr | str | int,
+    day: pli.Expr | str | int,
+    hour: pli.Expr | str | int | None = None,
+    minute: pli.Expr | str | int | None = None,
+    second: pli.Expr | str | int | None = None,
+    microsecond: pli.Expr | str | int | None = None,
 ) -> pli.Expr:
     """
     Create polars `Datetime` from distinct time components.
@@ -1313,13 +1326,13 @@ def _datetime(
     day
         column or literal, ranging from 1-31.
     hour
-        column or literal, ranging from 1-24.
+        column or literal, ranging from 1-23.
     minute
-        column or literal, ranging from 1-60.
+        column or literal, ranging from 1-59.
     second
-        column or literal, ranging from 1-60.
-    millisecond
-        column or literal, ranging from 1-1000.
+        column or literal, ranging from 1-59.
+    microsecond
+        column or literal, ranging from 1-999999.
 
     Returns
     -------
@@ -1336,8 +1349,9 @@ def _datetime(
         minute = pli.expr_to_lit_or_expr(minute, str_to_lit=False)._pyexpr
     if second is not None:
         second = pli.expr_to_lit_or_expr(second, str_to_lit=False)._pyexpr
-    if millisecond is not None:
-        millisecond = pli.expr_to_lit_or_expr(millisecond, str_to_lit=False)._pyexpr
+    if microsecond is not None:
+        microsecond = pli.expr_to_lit_or_expr(microsecond, str_to_lit=False)._pyexpr
+
     return pli.wrap_expr(
         py_datetime(
             year_expr._pyexpr,
@@ -1346,15 +1360,15 @@ def _datetime(
             hour,
             minute,
             second,
-            millisecond,
+            microsecond,
         )
     )
 
 
 def _date(
-    year: pli.Expr | str,
-    month: pli.Expr | str,
-    day: pli.Expr | str,
+    year: pli.Expr | str | int,
+    month: pli.Expr | str | int,
+    day: pli.Expr | str | int,
 ) -> pli.Expr:
     """
     Create polars Date from distinct time components.

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -419,10 +419,13 @@ class Series:
         return self._comp(other, "lt_eq")
 
     def _arithmetic(self, other: Any, op_s: str, op_ffi: str) -> Series:
+        if isinstance(other, pli.Expr):
+            # expand pl.lit, pl.datetime, pl.duration Exprs to compatible Series
+            other = self.to_frame().select(other).to_series()
         if isinstance(other, Series):
             return wrap_s(getattr(self._s, op_s)(other._s))
-        # we recurse and the if statement above will
-        # ensure we return early
+
+        # recurse; the 'if' statement above will ensure we return early
         if isinstance(other, (date, datetime, timedelta, str)):
             other = Series("", [other])
             return self._arithmetic(other, op_s, op_ffi)

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -354,7 +354,10 @@ if HYPOTHESIS_INSTALLED:
         #  validate compatibility.
         Time: times(),
         Date: dates(),
-        Duration: timedeltas(),
+        Duration: timedeltas(
+            min_value=timedelta(microseconds=-(2**63)),
+            max_value=timedelta(microseconds=(2**63) - 1),
+        ),
         # TODO: confirm datetime min/max limits with different timeunit granularity.
         # TODO: specific strategies for temporal dtypes with timeunits.
         Datetime: datetimes(min_value=datetime(1970, 1, 1)),

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -219,12 +219,12 @@ fn py_datetime(
     hour: Option<dsl::PyExpr>,
     minute: Option<dsl::PyExpr>,
     second: Option<dsl::PyExpr>,
-    millisecond: Option<dsl::PyExpr>,
+    microsecond: Option<dsl::PyExpr>,
 ) -> dsl::PyExpr {
     let hour = hour.map(|e| e.inner);
     let minute = minute.map(|e| e.inner);
     let second = second.map(|e| e.inner);
-    let millisecond = millisecond.map(|e| e.inner);
+    let microsecond = microsecond.map(|e| e.inner);
 
     let args = DatetimeArgs {
         year: year.inner,
@@ -233,17 +233,19 @@ fn py_datetime(
         hour,
         minute,
         second,
-        millisecond,
+        microsecond,
     };
 
     polars::lazy::dsl::datetime(args).into()
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
 fn py_duration(
     days: Option<PyExpr>,
     seconds: Option<PyExpr>,
     nanoseconds: Option<PyExpr>,
+    microseconds: Option<PyExpr>,
     milliseconds: Option<PyExpr>,
     minutes: Option<PyExpr>,
     hours: Option<PyExpr>,
@@ -253,6 +255,7 @@ fn py_duration(
         days: days.map(|e| e.inner),
         seconds: seconds.map(|e| e.inner),
         nanoseconds: nanoseconds.map(|e| e.inner),
+        microseconds: microseconds.map(|e| e.inner),
         milliseconds: milliseconds.map(|e| e.inner),
         minutes: minutes.map(|e| e.inner),
         hours: hours.map(|e| e.inner),

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -3,7 +3,9 @@
 # -------------------------------------------------
 from __future__ import annotations
 
-from hypothesis import given, settings
+from decimal import Decimal
+
+from hypothesis import given, settings, seed, reproduce_failure
 from hypothesis.strategies import sampled_from
 
 import polars as pl
@@ -39,3 +41,33 @@ def test_series_slice(
 
     assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
     assert_series_equal(srs, srs, check_exact=True)
+
+
+@given(
+    s1=series(min_size=1, max_size=10, dtype=pl.Datetime),
+    s2=series(min_size=1, max_size=10, dtype=pl.Duration),
+)
+def test_series_timeunits(
+    s1: pl.Series,
+    s2: pl.Series,
+) -> None:
+    # datetime
+    assert s1.to_list() == list(s1)
+    assert list(s1.dt.millisecond()) == [v.microsecond // 1000 for v in s1]
+    assert list(s1.dt.nanosecond()) == [v.microsecond * 1000 for v in s1]
+    assert list(s1.dt.microsecond()) == [v.microsecond for v in s1]
+
+    # duration
+    millis: list[int] = s2.dt.milliseconds().to_list()
+    micros: list[int] = s2.dt.microseconds().to_list()
+
+    assert s1.to_list() == list(s1)
+    assert millis == [int(Decimal(v) / 1000) for v in s2.cast(int)]
+    assert micros == list(s2.cast(int))
+
+    # special handling for nanosecs (as we may generate a microsecs-based
+    # timedelta that results in 64bit overflow on conversion to nanosecs)
+    lbound, hbound = -(2**63), (2**63) - 1
+    if all((lbound <= (us * 1000) <= hbound) for us in micros):
+        for ns, us in zip(s2.dt.nanoseconds(), micros):
+            assert ns == (us * 1000)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1037,6 +1037,39 @@ def test_describe() -> None:
     pl.testing.assert_frame_equal(df.describe(), expected)
 
 
+def test_duration_arithmetic() -> None:
+    pl.Config.with_columns_kwargs = True
+
+    df = pl.DataFrame(
+        {"a": [datetime(2022, 1, 1, 0, 0, 0), datetime(2022, 1, 2, 0, 0, 0)]}
+    )
+    d1 = pl.duration(days=3, microseconds=987000)
+    d2 = pl.duration(days=6, milliseconds=987)
+
+    assert_frame_equal(
+        df.with_columns(
+            b=(df["a"] + d1),
+            c=(pl.col("a") + d2),
+        ),
+        pl.DataFrame(
+            {
+                "a": [
+                    datetime(2022, 1, 1, 0, 0, 0),
+                    datetime(2022, 1, 2, 0, 0, 0),
+                ],
+                "b": [
+                    datetime(2022, 1, 4, 0, 0, 0, 987000),
+                    datetime(2022, 1, 5, 0, 0, 0, 987000),
+                ],
+                "c": [
+                    datetime(2022, 1, 7, 0, 0, 0, 987000),
+                    datetime(2022, 1, 8, 0, 0, 0, 987000),
+                ],
+            }
+        ),
+    )
+
+
 def test_string_cache_eager_lazy() -> None:
     # tests if the global string cache is really global and not interfered by the lazy
     # execution. first the global settings was thread-local and this breaks with the


### PR DESCRIPTION
Closes #4979.

----
Several things addressed:

* Handle `expr+series` as well as `series+expr`.
* Extended `pl.duration` (py) and `DurationArgs` (rs) with a microsecond param.
* Changed `pl.datetime` (py) and `DatetimeArgs` (rs) to microsecond granularity.
* Fixed `pl.datetime` and `pl.date` typing (recognize "int" as valid parameter type).

Plenty of new test coverage for all of the above.
No existing tests needed adjustment/modification.

Also:
* Added a basic parametric test to probe duration/datetime timeunits; this uncovered the fact that the parametrically-generated (python-side) timedeltas could exceed 64bit bounds for microseconds (in rust/chrono) and cause overflow/wrap-around, so clipped the min/max accordingly -

   _parametric timedelta min:_ `-106751991d -4h -54s -854775µs`
   _parametric timedelta max:_ `106751991d 4h 54s 854775µs`
