### PR TITLE
ci: Caching for docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,44 +1,57 @@
-name: Docs
+name: Deploy documentation
 
 on:
   push:
     branches:
       - master
-      - docs
+
 jobs:
-  test:
-    name: Docs
+  main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2022-09-26
-          components: rust-docs
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
-      - name: Install dependencies
+
+      - name: Install Python dependencies
         working-directory: py-polars/docs
         run: |
           pip install --upgrade pip
           pip install -r requirements-docs.txt
-      - name: Build python reference
+
+      - name: Build Python documentation
         working-directory: py-polars/docs
         run: make html
-      - name: deploy docs
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-09-26
+          components: rust-docs
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build Rust documentation
         env:
           RUSTFLAGS: --cfg docsrs
+        run: cargo doc --features=docs-selection --package polars
+
+      - name: Prepare deployment
         run: |
-          set -e
-          cargo doc --features=docs-selection --package polars && \
-          echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html && \
+          echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html
           mkdir target/doc/py-polars
-          cp -r py-polars/docs/build/html target/doc/py-polars
-          echo ghp-import step
-          ghp-import -n target/doc && \
+          mv py-polars/docs/build/html target/doc/py-polars
+
+      - name: Deploy
+        run: |
+          ghp-import -n target/doc
           git push -qf https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git gh-pages
+
+      # Make sure documentation artifacts are not cached
+      - name: Clean up documentation artifacts
+        run: rm -rf target/doc


### PR DESCRIPTION
After some debugging I found the issue with the previous attempt (#4832): the `mkdir` step is required before the `mv` step; otherwise the `html` subfolder is not created.

Also, the cleanup step before the caching targeted the wrong folder (`target/docs` instead of `target/doc`).

Now I have verified everything works by running this workflow on my fork. I added a small change in both Rust/Python code and this change is properly published to GitHub Pages.

Changes:
* Split the docs-deploy workflow into logical steps
* Add rust-cache step
  * This saves about 3 minutes per workflow run on the "Build Rust documentation" step.
  * The documentation artifacts should not be cached, these are removed in a final clean up step before caching occurs.
* No longer trigger on push to `docs` branch - this branch doesn't exist, so that was probably some old way of working.

