### PR TITLE
feat[python]: more detailed validation of EWM parameters

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -6100,22 +6100,37 @@ class Expr:
 
 
 def _prepare_alpha(
-    com: float | None = None,
-    span: float | None = None,
-    half_life: float | None = None,
-    alpha: float | None = None,
+    com: float | int | None = None,
+    span: float | int | None = None,
+    half_life: float | int | None = None,
+    alpha: float | int | None = None,
 ) -> float:
-    if com is not None and alpha is None:
-        assert com >= 0.0
+    """Normalise EWM decay specification in terms of smoothing factor 'alpha'."""
+    if sum((param is not None) for param in (com, span, half_life, alpha)) > 1:
+        raise ValueError(
+            "Parameters 'com', 'span', 'half_life', and 'alpha' are mutually exclusive"
+        )
+    if com is not None:
+        if com < 0.0:
+            raise ValueError(f"Require 'com' >= 0 (found {com})")
         alpha = 1.0 / (1.0 + com)
-    if span is not None and alpha is None:
-        assert span >= 1.0
+
+    elif span is not None:
+        if span < 1.0:
+            raise ValueError(f"Require 'span' >= 1 (found {span})")
         alpha = 2.0 / (span + 1.0)
-    if half_life is not None and alpha is None:
-        assert half_life > 0.0
+
+    elif half_life is not None:
+        if half_life <= 0.0:
+            raise ValueError(f"Require 'half_life' > 0 (found {half_life})")
         alpha = 1.0 - math.exp(-math.log(2.0) / half_life)
-    if alpha is None:
-        raise ValueError("at least one of {com, span, half_life, alpha} should be set")
+
+    elif alpha is None:
+        raise ValueError("One of 'com', 'span', 'half_life', or 'alpha' must be set")
+
+    elif not (0 < alpha <= 1):
+        raise ValueError(f"Require 0 < 'alpha' <= 1 (found {alpha})")
+
     return alpha
 
 
@@ -6129,4 +6144,4 @@ def _prepare_rolling_window_args(
         window_size = f"{window_size}i"
     if min_periods is None:
         min_periods = 1
-    return (window_size, min_periods)
+    return window_size, min_periods

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1871,6 +1871,32 @@ def test_ewm_std_var() -> None:
     assert np.allclose(var, std**2, rtol=1e-16)
 
 
+def test_ewm_param_validation() -> None:
+    s = pl.Series("values", range(10))
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        s.ewm_std(com=0.5, alpha=0.5)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        s.ewm_mean(span=1.5, half_life=0.75)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        s.ewm_var(alpha=0.5, span=1.5)
+
+    with pytest.raises(ValueError, match="Require 'com' >= 0"):
+        s.ewm_std(com=-0.5)
+
+    with pytest.raises(ValueError, match="Require 'span' >= 1"):
+        s.ewm_mean(span=0.5)
+
+    with pytest.raises(ValueError, match="Require 'half_life' > 0"):
+        s.ewm_var(half_life=0)
+
+    for alpha in (-0.5, -0.0000001, 0.0, 1.0000001, 1.5):
+        with pytest.raises(ValueError, match="Require 0 < 'alpha' <= 1"):
+            s.ewm_std(alpha=alpha)
+
+
 def test_extend_constant() -> None:
     a = pl.Series("a", [1, 2, 3])
     expected = pl.Series("a", [1, 2, 3, 1, 1, 1])


### PR DESCRIPTION
Currently it is possible to call the `ewm` methods with _all_ of the mutually-exclusive decay parameters set, without indication that this is technically an error:

```python
import polars as pl
s = pl.Series(range(10))

# which param wins? :)
s.ewm_std(com=0.5, span=1.5, half_life=0.75) 
```
This PR extends the common `_prepare_alpha` function such that it will raise an exception when mutually-exclusive parameters are set, and also provide slightly more detailed error messages when out-of-range values are given for those parameters.

Unit test coverage added to ensure that the expected exceptions are raised.

(Also updates the function signature to account for integer input).