### PR TITLE
Bumping arrow2 to version 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ package = "arrow2"
 # rev = "6c102a0c3e2dbeb185360dd3d5c3637b5e2028fd"
 # path = "../../../arrow2"
 # branch = "comparison_and_validity"
-version = "0.14"
+version = "0.14.1"
 default-features = false
 features = [
   "compute_aggregate",


### PR DESCRIPTION
This PR updates the arrow2 version to include recent fixes in 0.14.1. This includes jorgecarleitao/json-deserializer#13, which fixes a regression in `arrow2` where numbers were not able to be deserialized directly after the switch from `serde_json` to `json_deserializer`. This fix is needed to complete the typed JSON path support being developed in pola-rs/polars#3413.