### PR TITLE
tests[python]: parametric test coverage for EWM functions

### DIFF
--- a/py-polars/tests/parametric/test_dataframe.py
+++ b/py-polars/tests/parametric/test_dataframe.py
@@ -11,12 +11,17 @@ from polars.testing import assert_frame_equal, column, dataframes
 
 
 @given(df=dataframes())
+@settings(max_examples=50)
 def test_repr(df: pl.DataFrame) -> None:
     assert isinstance(repr(df), str)
-    assert_frame_equal(df, df, check_exact=True)
+    assert_frame_equal(df, df, check_exact=True, nans_compare_equal=True)
 
 
-@given(df=dataframes(min_size=1, min_cols=1, max_size=10, null_probability=0.25))
+@given(
+    df=dataframes(
+        min_size=1, min_cols=1, null_probability=0.25, excluded_dtypes=[pl.Utf8]
+    )
+)
 @example(df=pl.DataFrame(columns=["x", "y", "z"]))
 @example(df=pl.DataFrame())
 def test_null_count(df: pl.DataFrame) -> None:
@@ -68,7 +73,6 @@ def test_null_count(df: pl.DataFrame) -> None:
     # │ null  ┆ 1    ┆ 2    ┆ 5865  │
     # └───────┴──────┴──────┴───────┘
 )
-@settings(max_examples=500)
 def test_frame_slice(df: pl.DataFrame) -> None:
     # take strategy-generated integer values from the frame as slice bounds.
     # use these bounds to slice the same frame, and then validate the result

--- a/py-polars/tests/parametric/test_lazyframe.py
+++ b/py-polars/tests/parametric/test_lazyframe.py
@@ -1,4 +1,7 @@
-from hypothesis import given, settings
+# ----------------------------------------------------
+# Validate LazyFrame behaviour with parametric tests
+# ----------------------------------------------------
+from hypothesis import given
 from hypothesis.strategies import integers
 
 import polars as pl
@@ -32,7 +35,6 @@ from polars.testing import column, dataframes
         ],
     )
 )
-@settings(max_examples=500)
 def test_lazyframe_slice(ldf: pl.LazyFrame) -> None:
     py_data = ldf.collect().rows()
 

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -4,20 +4,86 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import no_type_check
 
 from hypothesis import given, settings
-from hypothesis.strategies import sampled_from
+from hypothesis.strategies import booleans, floats, sampled_from
 
 import polars as pl
-from polars.testing import assert_series_equal, series  # , verify_series_and_expr_api
+from polars.internals.expr.expr import _prepare_alpha
+from polars.testing import assert_series_equal, series
 
-# # TODO: exclude obvious/known overflow inside the strategy before commenting back in
-# @given(s=series(allowed_dtypes=_NUMERIC_COL_TYPES, name="a"))
-# def test_cum_agg_extra(s: pl.Series) -> None:
-#     # confirm that ops on generated Series match equivalent Expr call
-#     # note: testing codepath-equivalence, not correctness.
-#     for op in ("cumsum", "cummin", "cummax", "cumprod"):
-#          verify_series_and_expr_api(s, None, op)
+
+def alpha_guard(**decay_param: float) -> bool:
+    """Protects against unnecessary noise in small number regime."""
+    if not list(decay_param.values())[0]:
+        return True
+    alpha = _prepare_alpha(**decay_param)
+    return ((1 - alpha) if round(alpha) else alpha) > 1e-6
+
+
+@given(
+    s=series(
+        min_size=4,
+        dtype=pl.Float64,
+        null_probability=0.05,
+        strategy=floats(min_value=-1e8, max_value=1e8),
+    ),
+    half_life=floats(min_value=0, max_value=4, exclude_min=True).filter(
+        lambda x: alpha_guard(half_life=x)
+    ),
+    com=floats(min_value=0, max_value=99).filter(lambda x: alpha_guard(com=x)),
+    span=floats(min_value=1, max_value=10).filter(lambda x: alpha_guard(span=x)),
+    adjust=booleans(),
+    bias=booleans(),
+)
+@no_type_check
+def test_ewm_methods(
+    s: pl.Series,
+    com: float | None,
+    span: float | None,
+    half_life: float | None,
+    adjust: bool,
+    bias: bool,
+) -> None:
+    # validate a large set of varied EWM calculations
+    for decay_param in ({"com": com}, {"span": span}, {"half_life": half_life}):
+        alpha = _prepare_alpha(**decay_param)
+
+        # convert parametrically-generated series to pandas, then use that as a
+        # reference implementation for comparison (after normalising NaN/None)
+        p = s.to_pandas()
+
+        # note: skip min_periods < 2, due to pandas-side inconsistency:
+        # https://github.com/pola-rs/polars/issues/5006#issuecomment-1259477178
+        for mp in range(2, len(s), len(s) // 3):
+            # consolidate ewm parameters
+            pl_params = {"min_periods": mp, "adjust": adjust}
+            pl_params.update(decay_param)
+
+            pd_params = pl_params.copy()
+            if "half_life" in pl_params:
+                pd_params["halflife"] = pd_params.pop("half_life")
+
+            # mean:
+            ewm_mean_pl = s.ewm_mean(**pl_params).fill_nan(None)
+            ewm_mean_pd = pl.Series(p.ewm(ignore_na=True, **pd_params).mean())
+            if alpha == 1:
+                # apply fill-forward to nulls to match pandas
+                # https://github.com/pola-rs/polars/pull/5011#issuecomment-1262318124
+                ewm_mean_pl = ewm_mean_pl.fill_null(strategy="forward")
+
+            assert_series_equal(ewm_mean_pl, ewm_mean_pd, atol=1e-07)
+
+            # std:
+            ewm_std_pl = s.ewm_std(bias=bias, **pl_params).fill_nan(None)
+            ewm_std_pd = pl.Series(p.ewm(ignore_na=True, **pd_params).std(bias=bias))
+            assert_series_equal(ewm_std_pl, ewm_std_pd, atol=1e-07)
+
+            # var:
+            ewm_var_pl = s.ewm_var(bias=bias, **pl_params).fill_nan(None)
+            ewm_var_pd = pl.Series(p.ewm(ignore_na=True, **pd_params).var(bias=bias))
+            assert_series_equal(ewm_var_pl, ewm_var_pd, atol=1e-07)
 
 
 @given(

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -24,13 +24,16 @@ def test_strategy_classes(df: pl.DataFrame, lf: pl.LazyFrame, srs: pl.Series) ->
 
 
 @given(
-    df1=dataframes(cols=5, size=5),
-    df2=dataframes(min_cols=2, max_cols=5, min_size=3, max_size=8),
-    s1=series(size=5),
-    s2=series(min_size=3, max_size=8, name="col"),
+    s1=series(dtype=pl.Boolean, size=5),
+    s2=series(dtype=pl.Boolean, min_size=3, max_size=8, name="col"),
+    df1=dataframes(allowed_dtypes=[pl.Boolean], cols=5, size=5),
+    df2=dataframes(
+        allowed_dtypes=[pl.Boolean], min_cols=2, max_cols=5, min_size=3, max_size=8
+    ),
 )
+@settings(max_examples=50)
 def test_strategy_shape(
-    df1: pl.DataFrame, df2: pl.DataFrame, s1: pl.Series, s2: pl.Series
+    s1: pl.Series, s2: pl.Series, df1: pl.DataFrame, df2: pl.DataFrame
 ) -> None:
     assert df1.shape == (5, 5)
     assert df1.columns == ["col0", "col1", "col2", "col3", "col4"]
@@ -82,13 +85,14 @@ def test_strategy_frame_columns(lf: pl.LazyFrame) -> None:
 
 
 @given(
-    df=dataframes(allowed_dtypes=TEMPORAL_DTYPES, max_size=1),
-    lf=dataframes(excluded_dtypes=TEMPORAL_DTYPES, max_size=1, lazy=True),
+    df=dataframes(allowed_dtypes=TEMPORAL_DTYPES, max_size=1, max_cols=5),
+    lf=dataframes(excluded_dtypes=TEMPORAL_DTYPES, max_size=1, max_cols=5, lazy=True),
     s1=series(max_size=1),
     s2=series(dtype=pl.Boolean, max_size=1),
     s3=series(allowed_dtypes=TEMPORAL_DTYPES, max_size=1),
     s4=series(excluded_dtypes=TEMPORAL_DTYPES, max_size=1),
 )
+@settings(max_examples=50)
 def test_strategy_dtypes(
     df: pl.DataFrame,
     lf: pl.LazyFrame,
@@ -166,7 +170,9 @@ def test_chunking(
 
 
 @given(
-    df=dataframes(allowed_dtypes=[pl.Float32, pl.Float64], allow_infinities=False),
+    df=dataframes(
+        allowed_dtypes=[pl.Float32, pl.Float64], max_cols=4, allow_infinities=False
+    ),
     s=series(dtype=pl.Float64, allow_infinities=False),
 )
 def test_infinities(


### PR DESCRIPTION
Massive expansion of EWM test coverage, using pandas (with `ignore_na=True`) as a reference implementation for comparison purposes. Over 2,000 actual tests get performed in ~2 secs, with all manner of data/parameter permutations.

**Parametric tests cover...**

* use of all three decay params: `com`, `span`, `half_life`.
* floating point values between -1e8 and 1e8.
* `null` values present / not present.
* different `min_period` values.
* chunked / unchunked series.
* series of different lengths
* `int` and `float` series.

**Result**

Both `ewm_std` and `ewm_var` tie-out perfectly under all conditions.🥇 

The only apparent difference is for some calculations at the extreme limit of float64 values (~1.8e308) where we can return `inf` and pandas returns `None` (I actually think we are more consistent here, based on other results). This is not a problem, but I constrained the generated float bounds to +/- 1e300 to avoid the unnecessary error report ;)

**Misc**

For the curious and detail-oriented, I also excluded [subnormal numbers](https://en.wikipedia.org/wiki/Subnormal_number) from the `half_life` param as they can cause an `overflow encountered in double_scalars` runtime warning (which is understood, so excluding them just reduces a bit of noise).

**Potential issue**

There appear to be some slight deviations in `ewm_mean`, so that test is currently commented out, pending review (will put sample data demonstrating some of the differences in a comment below shortly, so @matteosantama can tell me what myself -or pandas- are missing ;)

**Update**

Additional parameter permutations (now validating both `adjust` & `bias` as well) mean we're now looking at running approximately 4,000 tests per EWM type in ~4.5 secs (total).