### PR TITLE
performance[rust]: don't execute unused with_column expressions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown.rs
@@ -1038,10 +1038,45 @@ impl ProjectionPushDown {
                 let builder = ALogicalPlanBuilder::new(root, expr_arena, lp_arena);
                 Ok(self.finish_node(local_projection, builder))
             }
-            HStack { input, exprs, .. } => {
-                // Make sure that columns selected with_columns are available
-                // only if not empty. If empty we already select everything.
+            HStack {
+                input,
+                mut exprs,
+                schema,
+            } => {
                 if !acc_projections.is_empty() {
+                    let mut pruned_with_cols = Vec::with_capacity(exprs.len());
+
+                    // Check if output names are used upstream
+                    // if not, we can prune the `with_column` expression
+                    // as it is not used in the output.
+                    for node in &exprs {
+                        let output_field = expr_arena
+                            .get(*node)
+                            .to_field(schema.as_ref(), Context::Default, expr_arena)
+                            .unwrap();
+                        let output_name = output_field.name();
+
+                        let is_used_upstream = projected_names.contains(output_name.as_str());
+
+                        if is_used_upstream {
+                            pruned_with_cols.push(*node);
+                        }
+                    }
+
+                    if pruned_with_cols.is_empty() {
+                        self.pushdown_and_assign(
+                            input,
+                            acc_projections,
+                            projected_names,
+                            projections_seen,
+                            lp_arena,
+                            expr_arena,
+                        )?;
+                        return Ok(lp_arena.take(input));
+                    }
+
+                    // Make sure that columns selected with_columns are available
+                    // only if not empty. If empty we already select everything.
                     for expression in &exprs {
                         add_expr_to_accumulated(
                             *expression,
@@ -1050,8 +1085,18 @@ impl ProjectionPushDown {
                             expr_arena,
                         );
                     }
-                }
 
+                    exprs = pruned_with_cols
+                }
+                // projections that select columns added by
+                // this `with_column` operation can be dropped
+                // For instance in:
+                //
+                //  q
+                //  .with_column(col("a").alias("b")
+                //  .select(["a", "b"])
+                //
+                // we can drop the "b" projection at this level
                 let (acc_projections, _, names) = split_acc_projections(
                     acc_projections,
                     &lp_arena.get(input).schema(lp_arena),


### PR DESCRIPTION
This will improve the projection pushdown optimizer by removing `with_column` expressions that are not selected in the upstream output.