### PR TITLE
ci(rust, python): Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,157 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+    labels: [ci, skip-changelog]
+    reviewers: [stinodego]
+
+  # Rust Polars
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-algo
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-arrow
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-core
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-io
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-lazy
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-lazy/polars-pipe
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-lazy/polars-plan
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-ops
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-sql
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-time
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  - package-ecosystem: cargo
+    directory: polars/polars-utils
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, rust, skip-changelog]
+
+  # Python Polars
+  - package-ecosystem: pip
+    directory: py-polars
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, python, skip-changelog]
+    reviewers: [stinodego]
+
+  - package-ecosystem: pip
+    directory: py-polars/docs
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, python, skip-changelog]
+    reviewers: [stinodego]
+
+  - package-ecosystem: cargo
+    directory: py-polars
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: [build, python, skip-changelog]


### PR DESCRIPTION
I've been messing around with Dependabot this week. I think it may be useful for Polars. It should help us keep dependencies up-to-date without having to remember to check for updates manually.

I'd also recommend enabling Dependabot security updates. Apparently there's an issue in `js-polars`; there might be others that pop up in the future.

Changes:
* Enable Dependabot for GitHub Actions, Python dependencies, and Rust dependencies.
* Put all dependencies on a monthly schedule. I'm skipping patch versions to avoid spam.
* I'll be pinged for reviewing Python dependencies. Rust dependencies will not ping anyone - I figured Ritchie gets enough notifications already 😄 