### PR TITLE
fix(python): Fix empty method detection when PYTHONOPTIMIZE=2

### DIFF
--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -55,10 +55,7 @@ def _is_empty_method(func: SeriesMethod) -> bool:
     return (fc.co_code in _EMPTY_BYTECODE) and (
         (len(fc.co_consts) == 2 and fc.co_consts[1] is None)
         # account for potentially optimized-out docstrings
-        or (
-            sys.flags.optimize == 2
-            and fc.co_consts == (None,)
-        )
+        or (sys.flags.optimize == 2 and fc.co_consts == (None,))
     )
 
 

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -53,7 +53,13 @@ def _is_empty_method(func: SeriesMethod) -> bool:
     """
     fc = func.__code__
     return (fc.co_code in _EMPTY_BYTECODE) and (
-        len(fc.co_consts) == 2 and fc.co_consts[1] is None
+        (len(fc.co_consts) == 2 and fc.co_consts[1] is None)
+        # account for potentially optimized-out docstrings
+        or (
+            sys.flags.optimize == 2
+            and len(fc.co_consts) == 1
+            and fc.co_consts[0] is None
+        )
     )
 
 

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -57,8 +57,7 @@ def _is_empty_method(func: SeriesMethod) -> bool:
         # account for potentially optimized-out docstrings
         or (
             sys.flags.optimize == 2
-            and len(fc.co_consts) == 1
-            and fc.co_consts[0] is None
+            and fc.co_consts == (None,)
         )
     )
 


### PR DESCRIPTION
Fixing empty method detection (`_is_empty_method`, used in `expr_dispatch`) to handle optimized-out docstrings (`PYTHONOPTIMIZE=2`).

Tested by running `make test` with `PYTHONOPTIMIZE=0` and `PYTHONOPTIMIZE=2`.