### PR TITLE
fix(rust,python): improve printing controls of DataFrame and Series

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -44,7 +44,22 @@ macro_rules! format_array {
         } else {
             15
         };
-        let limit = std::cmp::min(LIMIT, $a.len());
+        let limit: usize = {
+            let limit = std::env::var(FMT_MAX_ROWS)
+                .as_deref()
+                .unwrap_or("")
+                .parse()
+                .map_or(LIMIT, |n: i64| {
+                    if n < 0 {
+                        $a.len()
+                    } else if n < 2 {
+                        2
+                    } else {
+                        n as usize
+                    }
+                });
+            std::cmp::min(limit, $a.len())
+        };
 
         let write_fn = |v, f: &mut Formatter| {
             if truncate {
@@ -333,19 +348,15 @@ impl Display for DataFrame {
                 .as_deref()
                 .unwrap_or("")
                 .parse()
-                .unwrap_or(8);
+                .map_or(8, |n: i64| if n < 0 { self.width() } else { n as usize });
 
             let max_n_rows = {
                 let max_n_rows = std::env::var(FMT_MAX_ROWS)
                     .as_deref()
                     .unwrap_or("")
                     .parse()
-                    .unwrap_or(8);
-                if max_n_rows < 2 {
-                    2
-                } else {
-                    max_n_rows
-                }
+                    .map_or(8, |n: i64| if n < 0 { height } else { n as usize });
+                std::cmp::max(max_n_rows, 2)
             };
             let (n_first, n_last) = if self.width() > max_n_cols {
                 ((max_n_cols + 1) / 2, max_n_cols / 2)

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -68,7 +68,7 @@ clean:  ## Clean up caches and build artifacts
 	@rm -f .coverage
 	@rm -f coverage.xml
 	@rm -f polars/polars.abi3.so
-	@find -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
+	@find . -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
 	@cargo clean
 
 .PHONY: help

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -143,12 +143,13 @@ class Config:
     @classmethod
     def set_tbl_rows(cls, n: int) -> type[Config]:
         """
-        Set the number of rows used to print tables.
+        Set the number of rows used to print tables (Dataframe and Series).
 
         Parameters
         ----------
         n
-            number of rows to print
+            number of rows to print.
+            If n<0 print all rows (DataFrame) and all elements (Series).
 
         """
         os.environ["POLARS_FMT_MAX_ROWS"] = str(n)
@@ -162,7 +163,7 @@ class Config:
         Parameters
         ----------
         n
-            number of columns to print
+            number of columns to print. If n<0 print all the columns.
 
         Examples
         --------

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1482,7 +1482,12 @@ class DataFrame:
 
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
+        if max_cols < 0:
+            max_cols = self.shape[1]
         max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=25))
+        if max_rows < 0:
+            max_rows = self.shape[0]
+
         return "\n".join(NotebookFormatter(self, max_cols, max_rows).render())
 
     def to_arrow(self) -> pa.Table:

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -96,11 +96,14 @@ def test_set_tbl_cols(environ: None) -> None:
     assert str(df).split("\n")[2] == "│ a   ┆ ... ┆ d   │"
     pl.Config.set_tbl_cols(3)
     assert str(df).split("\n")[2] == "│ a   ┆ b   ┆ ... ┆ d   │"
+    pl.Config.set_tbl_cols(-1)
+    assert str(df).split("\n")[2] == "│ a   ┆ b   ┆ c   ┆ d   │"
 
 
 def test_set_tbl_rows(environ: None) -> None:
 
     df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8], "c": [9, 10, 11, 12]})
+    ser = pl.Series("ser", [1, 2, 3, 4, 5])
 
     pl.Config.set_tbl_rows(1)
     assert (
@@ -117,6 +120,15 @@ def test_set_tbl_rows(environ: None) -> None:
         "│ 4   ┆ 8   ┆ 12  │\n"
         "└─────┴─────┴─────┘"
     )
+    assert (
+        str(ser) == "shape: (5,)\n"
+        "Series: 'ser' [i64]\n"
+        "[\n"
+        "\t1\n"
+        "\t...\n"
+        "\t5\n"
+        "]"
+    )
 
     pl.Config.set_tbl_rows(2)
     assert (
@@ -132,6 +144,15 @@ def test_set_tbl_rows(environ: None) -> None:
         "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
         "│ 4   ┆ 8   ┆ 12  │\n"
         "└─────┴─────┴─────┘"
+    )
+    assert (
+        str(ser) == "shape: (5,)\n"
+        "Series: 'ser' [i64]\n"
+        "[\n"
+        "\t1\n"
+        "\t...\n"
+        "\t5\n"
+        "]"
     )
 
     pl.Config.set_tbl_rows(3)
@@ -151,6 +172,15 @@ def test_set_tbl_rows(environ: None) -> None:
         "│ 4   ┆ 8   ┆ 12  │\n"
         "└─────┴─────┴─────┘"
     )
+    assert (
+        str(ser) == "shape: (5,)\n"
+        "Series: 'ser' [i64]\n"
+        "[\n"
+        "\t1\n"
+        "\t...\n"
+        "\t5\n"
+        "]"
+    )
 
     pl.Config.set_tbl_rows(4)
     assert (
@@ -168,6 +198,17 @@ def test_set_tbl_rows(environ: None) -> None:
         "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
         "│ 4   ┆ 8   ┆ 12  │\n"
         "└─────┴─────┴─────┘"
+    )
+    assert (
+        str(ser) == "shape: (5,)\n"
+        "Series: 'ser' [i64]\n"
+        "[\n"
+        "\t1\n"
+        "\t2\n"
+        "\t...\n"
+        "\t4\n"
+        "\t5\n"
+        "]"
     )
 
     df = pl.DataFrame(
@@ -189,6 +230,37 @@ def test_set_tbl_rows(environ: None) -> None:
         "│ 1   ┆ 6   ┆ 11  │\n"
         "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
         "│ ... ┆ ... ┆ ... │\n"
+        "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
+        "│ 4   ┆ 9   ┆ 14  │\n"
+        "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
+        "│ 5   ┆ 10  ┆ 15  │\n"
+        "└─────┴─────┴─────┘"
+    )
+
+    pl.Config.set_tbl_rows(-1)
+    assert (
+        str(ser) == "shape: (5,)\n"
+        "Series: 'ser' [i64]\n"
+        "[\n"
+        "\t1\n"
+        "\t2\n"
+        "\t3\n"
+        "\t4\n"
+        "\t5\n"
+        "]"
+    )
+    assert (
+        str(df) == "shape: (5, 3)\n"
+        "┌─────┬─────┬─────┐\n"
+        "│ a   ┆ b   ┆ c   │\n"
+        "│ --- ┆ --- ┆ --- │\n"
+        "│ i64 ┆ i64 ┆ i64 │\n"
+        "╞═════╪═════╪═════╡\n"
+        "│ 1   ┆ 6   ┆ 11  │\n"
+        "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
+        "│ 2   ┆ 7   ┆ 12  │\n"
+        "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
+        "│ 3   ┆ 8   ┆ 13  │\n"
         "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"
         "│ 4   ┆ 9   ┆ 14  │\n"
         "├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┤\n"


### PR DESCRIPTION
fixes #5046

(1) Let polars.Config.set_tbl_rows to control maximum number of
    elements when printing Series (in general any Series => str conversion).
    Works the same way as when printing DataFrame.

(2) Calling polars.Config.set_tbl_rows or polars.Config.set_tbl_cols with
    any negative integer (-1 is recommended) will cause all the rows
    (DataFrame and Series) or all the columns (DataFrame) be printed.
