### PR TITLE
fix[python]: add missing cse param to LazyFrame "profile" method

### DIFF
--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -755,6 +755,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         simplify_expression: bool = True,
         no_optimization: bool = False,
         slice_pushdown: bool = True,
+        common_subplan_elimination: bool = True,
     ) -> tuple[pli.DataFrame, pli.DataFrame]:
         """
         Profile a LazyFrame.
@@ -779,6 +780,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Turn off (certain) optimizations.
         slice_pushdown
             Slice pushdown optimization.
+        common_subplan_elimination
+            Will try to cache branching subplans that occur on self-joins or unions.
 
         Returns
         -------
@@ -795,6 +798,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             projection_pushdown,
             simplify_expression,
             slice_pushdown,
+            common_subplan_elimination,
         )
         df, timings = ldf.profile()
         return pli.wrap_df(df), pli.wrap_df(timings)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -34,6 +34,18 @@ def test_lazy() -> None:
     # test if pl.list is available, this is `to_list` re-exported as list
     df.groupby("a").agg(pl.list("b"))
 
+    # profile lazyframe operation/plan
+    df.lazy().groupby("a").agg(pl.list("b")).profile()
+    # ┌──────────────┬───────┬─────┐
+    # │ node         ┆ start ┆ end │
+    # │ ---          ┆ ---   ┆ --- │
+    # │ str          ┆ u64   ┆ u64 │
+    # ╞══════════════╪═══════╪═════╡
+    # │ optimization ┆ 0     ┆ 6   │
+    # ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌┤
+    # │ groupby(a)   ┆ 6     ┆ 230 │
+    # └──────────────┴───────┴─────┘
+
 
 def test_lazyframe_membership_operator() -> None:
     ldf = pl.DataFrame({"name": ["Jane", "John"], "age": [20, 30]}).lazy()


### PR DESCRIPTION
Closes #5053

---

Adds missing `common_subplan_elimination` param to the `LazyFrame.profile()` method (and a line of test coverage).