### PR TITLE
chore(python, rust): Small update to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_nodejs.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_nodejs.yml
@@ -1,5 +1,5 @@
-name: Bug Report - NodeJS
-description: An issue with NodeJS polars
+name: Bug report - Node.js
+description: An issue with Node.js Polars
 labels: [bug, nodejs]
 
 body:
@@ -13,22 +13,22 @@ body:
           required: true
         - label: >
             I have confirmed this bug exists on the
-            [latest version](https://www.npmjs.com/package/nodejs-polars) of polars.
+            [latest version](https://www.npmjs.com/package/nodejs-polars) of Polars.
           required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: Issue Description
+      label: Issue description
       description: >
-        Please provide a high-level description of the issue
+        Please provide a high-level description of the issue.
     validations:
       required: true
 
   - type: textarea
     id: example
     attributes:
-      label: Reproducible Example
+      label: Reproducible example
       description: >
         Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
         provide a minimal, copy-pastable example. Include the (wrong) output if applicable.
@@ -39,7 +39,7 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: Expected Behavior
+      label: Expected behavior
       description: >
         Please describe or show a code example of the expected behavior.
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report_nodejs.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_nodejs.yml
@@ -1,4 +1,4 @@
-name: Bug report - Node.js
+name: '🐞 Bug report - Node.js'
 description: An issue with Node.js Polars
 labels: [bug, nodejs]
 

--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -1,5 +1,5 @@
-name: Bug Report - Python
-description: An issue with python polars
+name: Bug report - Python
+description: An issue with Python Polars
 labels: [bug, python]
 
 body:
@@ -13,22 +13,22 @@ body:
           required: true
         - label: >
             I have confirmed this bug exists on the
-            [latest version](https://pypi.org/project/polars/) of polars.
+            [latest version](https://pypi.org/project/polars/) of Polars.
           required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: Issue Description
+      label: Issue description
       description: >
-        Please provide a high-level description of the issue
+        Please provide a high-level description of the issue.
     validations:
       required: true
 
   - type: textarea
     id: example
     attributes:
-      label: Reproducible Example
+      label: Reproducible example
       description: >
         Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
         provide a minimal, copy-pastable example. Include the (wrong) output if applicable.
@@ -52,7 +52,7 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: Expected Behavior
+      label: Expected behavior
       description: >
         Please describe or show a code example of the expected behavior.
     validations:
@@ -61,7 +61,7 @@ body:
   - type: textarea
     id: version
     attributes:
-      label: Installed Versions
+      label: Installed versions
       description: >
         Please paste the output of ``pl.show_versions()``
       value: >

--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -1,4 +1,4 @@
-name: Bug report - Python
+name: '🐞 Bug report - Python'
 description: An issue with Python Polars
 labels: [bug, python]
 

--- a/.github/ISSUE_TEMPLATE/bug_report_rust.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_rust.yml
@@ -1,4 +1,4 @@
-name: Bug report - Rust
+name: '🐞 Bug report - Rust'
 description: An issue with Rust Polars
 labels: [bug, rust]
 

--- a/.github/ISSUE_TEMPLATE/bug_report_rust.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_rust.yml
@@ -1,5 +1,5 @@
-name: Bug Report - Rust
-description: An issue with Rust polars
+name: Bug report - Rust
+description: An issue with Rust Polars
 labels: [bug, rust]
 
 body:
@@ -13,22 +13,22 @@ body:
           required: true
         - label: >
             I have confirmed this bug exists on the
-            [latest version](https://crates.io/crates/polars) of polars.
+            [latest version](https://crates.io/crates/polars) of Polars.
           required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: Issue Description
+      label: Issue description
       description: >
-        Please provide a high-level description of the issue
+        Please provide a high-level description of the issue.
     validations:
       required: true
 
   - type: textarea
     id: example
     attributes:
-      label: Reproducible Example
+      label: Reproducible example
       description: >
         Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
         provide a minimal, copy-pastable example. Include the (wrong) output if applicable.
@@ -38,7 +38,7 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: Expected Behavior
+      label: Expected behavior
       description: >
         Please describe or show a code example of the expected behavior.
     validations:
@@ -47,9 +47,9 @@ body:
   - type: textarea
     id: version
     attributes:
-      label: Installed Versions
+      label: Installed versions
       description: >
-        Please tell us which feature gates you used
+        Please tell us which feature gates you used.
       value: >
         <details>
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: true
 contact_links:
-- name: 'Discord server'
+- name: '💬 Discord server'
   url: https://discord.gg/4UfP5cfBE7
   about: |
     Chat with the community and Polars maintainers about both the usage of and development of the project.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+- name: 'Discord server'
+  url: https://discord.gg/4UfP5cfBE7
+  about: |
+    Chat with the community and Polars maintainers about both the usage of and development of the project.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,20 +1,19 @@
 name: Feature request
-description: Suggest a new feature for polars
-labels: [feature]
-
+description: Suggest a new feature or enhancement for Polars
+labels: [enhancement]
 
 body:
   - type: textarea
     id: description
     attributes:
-      label: Problem Description
+      label: Problem description
       description: >
         Please describe the behavior you want and the motivation. Please also provide
-        examples of how polars would be used if your feature request were added.
+        examples of how Polars would be used if your feature were added.
 
-        If you're not sure what to write here, then try imagining what the ideal
+        If you're not sure what to write here, try imagining what the ideal
         documentation of your new feature would look like. Then try to write it.
       placeholder: >
-        I wish I could use polars to ...
+        I wish I could use Polars to ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature request
+name: '✨ Feature request'
 description: Suggest a new feature or enhancement for Polars
 labels: [enhancement]
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,4 +1,4 @@
-name: Question
+name: '❓ Question'
 description: Ask a question about the Polars library
 labels: [question]
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,5 +1,5 @@
 name: Question
-description: Ask a question about the polars library
+description: Ask a question about the Polars library
 labels: [question]
 
 body:
@@ -7,7 +7,7 @@ body:
     attributes:
       value: >
         Is your question related to syntax or how you could do something with the polars library?
-        Please use [stackoverflow](https://stackoverflow.com/) and one of the following tags:
+        Please use [Stack Overflow](https://stackoverflow.com/) and one of the following tags:
 
         * [python-polars](https://stackoverflow.com/questions/tagged/python-polars)
 
@@ -15,25 +15,25 @@ body:
 
         * [nodejs-polars](https://stackoverflow.com/questions/tagged/nodejs-polars)
 
+
         This allows us to create high quality answers that remain updated and will save us from
         answering the same questions over and over again.
 
-
-        If a question is not yet on stackoverflow, please create a new question and post the link here, so we are noted.
+        If a question is not yet on Stack Overflow, please create a new question and post the link here, so we are notified.
   - type: checkboxes
     attributes:
       label: Research
       options:
         - label: >
-            I have searched the above polars tags on StackOverflow for similar questions.
+            I have searched the above polars tags on Stack Overflow for similar questions.
           required: true
         - label: >
-            I have asked my usage related question on [StackOverflow](https://stackoverflow.com).
+            I have asked my usage related question on [Stack Overflow](https://stackoverflow.com).
           required: false
   - type: input
     id: question-link
     attributes:
-      label: Link to question on StackOverflow
+      label: Link to question on Stack Overflow
     validations:
       required: false
   - type: markdown
@@ -42,7 +42,7 @@ body:
   - type: textarea
     id: question
     attributes:
-      label: Question about polars
+      label: Question about Polars
       description: >
         **Note**: If you'd still like to submit a question, please read [this guide](
         https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) detailing


### PR DESCRIPTION
Changes:
* Apply the `enhancement` label instead of `feature` to feature requests/enhancement suggestions. This change is done to be consistent with the new release-drafter autolabeler setup.
* Add link to the discord when opening an issue. See [here](https://github.com/python-poetry/poetry/issues/new/choose) for an example how that will look.
* Some minor improvements in capitalization, punctuation etc.
* Add emojis 😄 