### PR TITLE
feat[python]: Support `Series` init as struct from `@dataclass` and annotated `NamedTuple`

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    ForwardRef,
     Mapping,
     Optional,
     Sequence,
@@ -35,6 +36,8 @@ except ImportError:
     _DOCUMENTING = True
 
 UnionType: type
+OptionType = type(Optional[type])
+
 if sys.version_info >= (3, 10):
     from types import UnionType
 else:
@@ -409,6 +412,9 @@ _PY_TYPE_TO_DTYPE: dict[type, PolarsDataType] = {
     Decimal: Float64,
 }
 
+_PY_STR_TO_DTYPE: dict[str, PolarsDataType] = {
+    str(tp.__name__): dtype for tp, dtype in _PY_TYPE_TO_DTYPE.items()
+}
 
 _DTYPE_TO_PY_TYPE: dict[PolarsDataType, type] = {
     Float64: float,
@@ -539,13 +545,23 @@ def is_polars_dtype(data_type: Any) -> bool:
 
 
 def py_type_to_dtype(data_type: Any, raise_unmatched: bool = True) -> PolarsDataType:
-    """Convert a Python dtype to a Polars dtype."""
-    # when the passed in is already a Polars datatype, return that
+    """Convert a Python dtype (or type annotation) to a Polars dtype."""
+    if isinstance(data_type, ForwardRef):
+        dtype = data_type.__forward_arg__
+        data_type = (
+            _PY_STR_TO_DTYPE.get(
+                dtype.removeprefix("None | ").removesuffix(" | None").strip(), data_type
+            )
+            if isinstance(dtype, str)  # type: ignore[redundant-expr]
+            else data_type
+        )
+
     if is_polars_dtype(data_type):
         return data_type
-    elif isinstance(data_type, UnionType):
-        # not exhaustive; currently handles the common "type | None" case,
-        # but ideally would pick appropriate supertype when n_types > 1
+
+    elif isinstance(data_type, (OptionType, UnionType)):
+        # not exhaustive; handles the common "type | None" case, but
+        # should probably pick appropriate supertype when n_types > 1?
         possible_types = [tp for tp in get_args(data_type) if tp is not NoneType]
         if len(possible_types) == 1:
             data_type = possible_types[0]

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import re
 import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -547,13 +548,13 @@ def is_polars_dtype(data_type: Any) -> bool:
 def py_type_to_dtype(data_type: Any, raise_unmatched: bool = True) -> PolarsDataType:
     """Convert a Python dtype (or type annotation) to a Polars dtype."""
     if isinstance(data_type, ForwardRef):
-        dtype = data_type.__forward_arg__
+        annotation = data_type.__forward_arg__
         data_type = (
             _PY_STR_TO_DTYPE.get(
-                dtype.removeprefix("None | ").removesuffix(" | None").strip(), data_type
+                re.sub(r"(^None \|)|(\| None$)", "", annotation).strip(), data_type
             )
-            if isinstance(dtype, str)  # type: ignore[redundant-expr]
-            else data_type
+            if isinstance(annotation, str)  # type: ignore[redundant-expr]
+            else annotation
         )
 
     if is_polars_dtype(data_type):

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -123,17 +123,17 @@ def test_init_dataclass_namedtuple() -> None:
         exporter: str
         importer: str
         product: str
-        weight: float | None
+        tonnes: int | None
 
     class TeaShipmentNT(NamedTuple):
         exporter: str
         importer: str
         product: str
-        weight: None | float
+        tonnes: None | int
 
     for Tea in (TeaShipmentDC, TeaShipmentNT):
-        t0 = Tea(exporter="Sri Lanka", importer="USA", product="Ceylon", weight=100)
-        t1 = Tea(exporter="India", importer="UK", product="Darjeeling", weight=250)
+        t0 = Tea(exporter="Sri Lanka", importer="USA", product="Ceylon", tonnes=10)
+        t1 = Tea(exporter="India", importer="UK", product="Darjeeling", tonnes=25)
 
         s = pl.Series("t", [t0, t1])
 
@@ -142,20 +142,20 @@ def test_init_dataclass_namedtuple() -> None:
             Field("exporter", pl.Utf8),
             Field("importer", pl.Utf8),
             Field("product", pl.Utf8),
-            Field("weight", pl.Float64),
+            Field("tonnes", pl.Int64),
         ]
         assert s.to_list() == [
             {
                 "exporter": "Sri Lanka",
                 "importer": "USA",
                 "product": "Ceylon",
-                "weight": 100.0,
+                "tonnes": 10,
             },
             {
                 "exporter": "India",
                 "importer": "UK",
                 "product": "Darjeeling",
-                "weight": 250.0,
+                "tonnes": 25,
             },
         ]
         assert_frame_equal(s.to_frame(), pl.DataFrame({"t": [t0, t1]}))


### PR DESCRIPTION
Closes #5022 

----

**New functionality**
* Extends existing polars DataFrame support for `@dataclass` and `NamedTuple` init to Series . 
* Improves type-inference from annotations (specifically from `ForwardRef` and explicit `Optional`).

**Setup** _(example)_
```python
from dataclasses import dataclass
from datetime import datetime

@dataclass
class Trade:
    timestamp: datetime
    ticker: str
    price: float
    size: int | None = None

trades = [
    Trade(datetime(2022, 10, 1, 14, 30, 45), "AAPL", 138.20, 250),
    Trade(datetime(2022, 10, 2, 10, 15, 12), "FSLY", 9.16, 2000),
    Trade(datetime(2022, 10, 3, 15, 30), "MU", 50.10, 600),
]
```

**Initialise series**
```python
import polars as pl
s = pl.Series( trades )
```

**Before** _(object)_
```python
# shape: (3,)
# Series: '' [o][object]
# [
#     Trade(timestamp=datetime.datetime(2022, 10, 1, 14, 30, 45), ticker='AAPL', price=138.2, size=250)
#     Trade(timestamp=datetime.datetime(2022, 10, 2, 10, 15, 12), ticker='FSLY', price=9.16, size=2000)
#     Trade(timestamp=datetime.datetime(2022, 10, 3, 15, 30), ticker='MU', price=50.1, size=600)
# ]
```

**After** _(struct)_
```python
# shape: (3,)
# Series: '' [struct[4]]
# [
#     {2022-10-01 14:30:45,"AAPL",138.2,250}
#     {2022-10-02 10:15:12,"FSLY",9.16,2000}
#     {2022-10-03 15:30:00,"MU",50.1,600}
# ]
```
Suitable test coverage added for all the above.