### PR TITLE
refactor(python): show_graph

### DIFF
--- a/py-polars/polars/show_versions.py
+++ b/py-polars/polars/show_versions.py
@@ -55,6 +55,7 @@ def _get_dependency_info() -> dict[str, str]:
         "fsspec",
         "connectorx",
         "xlsx2csv",
+        "matplotlib",
     ]
     return {name: _get_dep_version(name) for name in opt_deps}
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -20,8 +20,9 @@ fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
+matplotlib = ["matplotlib"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,timezone]",
+  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,timezone,matplotlib]",
 ]
 
 [tool.isort]

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -482,8 +482,6 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Utf8(v).into())
         } else if ob.get_type().name()?.contains("datetime") {
             Python::with_gil(|py| {
-                // windows
-                #[cfg(target_arch = "windows")]
                 {
                     let kwargs = PyDict::new(py);
                     kwargs.set_item("tzinfo", py.None())?;
@@ -497,23 +495,9 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                         .unwrap();
                     let loc_tz = localize.call1((dt, "UTC"));
 
-                    loc_tz.call_method0("timestamp")?;
+                    let ts = loc_tz.unwrap().call_method0("timestamp")?;
                     // s to us
                     let v = (ts.extract::<f64>()? * 1000_000.0) as i64;
-                    Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
-                }
-                // unix
-                #[cfg(not(target_arch = "windows"))]
-                {
-                    let datetime = PyModule::import(py, "datetime")?;
-                    let timezone = datetime.getattr("timezone")?;
-                    let kwargs = PyDict::new(py);
-                    kwargs.set_item("tzinfo", timezone.getattr("utc")?)?;
-                    let dt = ob.call_method("replace", (), Some(kwargs))?;
-                    let ts = dt.call_method0("timestamp")?;
-                    // s to us
-                    let v = (ts.extract::<f64>()? * 1_000_000.0) as i64;
-                    // we choose us as that is pythons default unit
                     Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
                 }
             })

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -482,6 +482,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Utf8(v).into())
         } else if ob.get_type().name()?.contains("datetime") {
             Python::with_gil(|py| {
+                // windows
+                #[cfg(target_arch = "windows")]
                 {
                     let kwargs = PyDict::new(py);
                     kwargs.set_item("tzinfo", py.None())?;
@@ -495,9 +497,23 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                         .unwrap();
                     let loc_tz = localize.call1((dt, "UTC"));
 
-                    let ts = loc_tz.unwrap().call_method0("timestamp")?;
+                    loc_tz.call_method0("timestamp")?;
                     // s to us
                     let v = (ts.extract::<f64>()? * 1000_000.0) as i64;
+                    Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
+                }
+                // unix
+                #[cfg(not(target_arch = "windows"))]
+                {
+                    let datetime = PyModule::import(py, "datetime")?;
+                    let timezone = datetime.getattr("timezone")?;
+                    let kwargs = PyDict::new(py);
+                    kwargs.set_item("tzinfo", timezone.getattr("utc")?)?;
+                    let dt = ob.call_method("replace", (), Some(kwargs))?;
+                    let ts = dt.call_method0("timestamp")?;
+                    // s to us
+                    let v = (ts.extract::<f64>()? * 1_000_000.0) as i64;
+                    // we choose us as that is pythons default unit
                     Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
                 }
             })


### PR DESCRIPTION
* Separate graph generation from display, so we can display the right error on missing imports.
* Avoid temporary file, we can just use the bytes in-memory as we need that anyways to display. Writing is now also in a single place

Closes #5042.
