### PR TITLE
perf(rust): sort and unsort join key if other side is sorted

### DIFF
--- a/polars/polars-arrow/src/conversion.rs
+++ b/polars/polars-arrow/src/conversion.rs
@@ -20,5 +20,5 @@ pub fn primitive_to_vec<T: NativeType>(arr: ArrayRef) -> Option<Vec<T>> {
     let arr_ref = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
     let mut buffer = arr_ref.values().clone();
     drop(arr);
-    buffer.get_mut().map(|v| std::mem::take(v))
+    buffer.get_mut().map(std::mem::take)
 }

--- a/polars/polars-arrow/src/conversion.rs
+++ b/polars/polars-arrow/src/conversion.rs
@@ -1,10 +1,24 @@
-use arrow::array::StructArray;
+use arrow::array::{PrimitiveArray, StructArray};
 use arrow::chunk::Chunk;
 use arrow::datatypes::{DataType, Field};
+use arrow::types::NativeType;
 
 use crate::prelude::*;
 
 pub fn chunk_to_struct(chunk: Chunk<ArrayRef>, fields: Vec<Field>) -> StructArray {
     let dtype = DataType::Struct(fields);
     StructArray::from_data(dtype, chunk.into_arrays(), None)
+}
+
+/// Returns its underlying [`Vec`], if possible.
+///
+/// This operation returns [`Some`] iff this [`PrimitiveArray`]:
+/// * has not been sliced with an offset
+/// * has not been cloned (i.e. [`Arc`]`::get_mut` yields [`Some`])
+/// * has not been imported from the c data interface (FFI)
+pub fn primitive_to_vec<T: NativeType>(arr: ArrayRef) -> Option<Vec<T>> {
+    let arr_ref = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    let mut buffer = arr_ref.values().clone();
+    drop(arr);
+    buffer.get_mut().map(|v| std::mem::take(v))
 }

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -97,6 +97,7 @@ macro_rules! det_hash_prone_order {
 }
 
 pub(super) use det_hash_prone_order;
+use polars_arrow::conversion::primitive_to_vec;
 
 use crate::series::IsSorted;
 
@@ -420,7 +421,9 @@ impl DataFrame {
                 JoinType::Inner => {
                     self.inner_join_from_series(other, s_left, s_right, suffix, slice)
                 }
-                JoinType::Left => self.left_join_from_series(other, s_left, s_right, suffix, slice),
+                JoinType::Left => {
+                    self.left_join_from_series(other, s_left, s_right, suffix, slice, _verbose)
+                }
                 JoinType::Outer => {
                     self.outer_join_from_series(other, s_left, s_right, suffix, slice)
                 }
@@ -681,19 +684,7 @@ impl DataFrame {
     ) -> PolarsResult<DataFrame> {
         #[cfg(feature = "dtype-categorical")]
         check_categorical_src(s_left.dtype(), s_right.dtype())?;
-
-        let ((join_tuples_left, join_tuples_right), sorted) = if use_sort_merge(s_left, s_right) {
-            #[cfg(feature = "performant")]
-            {
-                (par_sorted_merge_inner(s_left, s_right), true)
-            }
-            #[cfg(not(feature = "performant"))]
-            {
-                s_left.hash_join_inner(s_right)
-            }
-        } else {
-            s_left.hash_join_inner(s_right)
-        };
+        let ((join_tuples_left, join_tuples_right), sorted) = sort_or_hash_inner(s_left, s_right);
 
         let mut join_tuples_left = &*join_tuples_left;
         let mut join_tuples_right = &*join_tuples_right;
@@ -854,32 +845,11 @@ impl DataFrame {
         s_right: &Series,
         suffix: Option<String>,
         slice: Option<(i64, usize)>,
+        verbose: bool,
     ) -> PolarsResult<DataFrame> {
         #[cfg(feature = "dtype-categorical")]
         check_categorical_src(s_left.dtype(), s_right.dtype())?;
-
-        let ids = if use_sort_merge(s_left, s_right) {
-            #[cfg(feature = "performant")]
-            {
-                let (left_idx, right_idx) = par_sorted_merge_left(s_left, s_right);
-                #[cfg(feature = "chunked_ids")]
-                {
-                    (Either::Left(left_idx), Either::Left(right_idx))
-                }
-
-                #[cfg(not(feature = "chunked_ids"))]
-                {
-                    (left_idx, right_idx)
-                }
-            }
-            #[cfg(not(feature = "performant"))]
-            {
-                s_left.hash_join_left(s_right)
-            }
-        } else {
-            s_left.hash_join_left(s_right)
-        };
-
+        let ids = sort_or_hash_left(s_left, s_right, verbose);
         self.finish_left_join(ids, &other.drop(s_right.name()).unwrap(), suffix, slice)
     }
 

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -390,7 +390,7 @@ impl DataFrame {
                     suffix,
                     slice,
                     false,
-                    false,
+                    _verbose,
                 );
             }
         }
@@ -419,7 +419,7 @@ impl DataFrame {
             let s_right = other.column(selected_right[0].name())?;
             return match how {
                 JoinType::Inner => {
-                    self.inner_join_from_series(other, s_left, s_right, suffix, slice)
+                    self.inner_join_from_series(other, s_left, s_right, suffix, slice, _verbose)
                 }
                 JoinType::Left => {
                     self.left_join_from_series(other, s_left, s_right, suffix, slice, _verbose)
@@ -681,10 +681,12 @@ impl DataFrame {
         s_right: &Series,
         suffix: Option<String>,
         slice: Option<(i64, usize)>,
+        verbose: bool,
     ) -> PolarsResult<DataFrame> {
         #[cfg(feature = "dtype-categorical")]
         check_categorical_src(s_left.dtype(), s_right.dtype())?;
-        let ((join_tuples_left, join_tuples_right), sorted) = sort_or_hash_inner(s_left, s_right);
+        let ((join_tuples_left, join_tuples_right), sorted) =
+            sort_or_hash_inner(s_left, s_right, verbose);
 
         let mut join_tuples_left = &*join_tuples_left;
         let mut join_tuples_right = &*join_tuples_right;

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -97,6 +97,7 @@ macro_rules! det_hash_prone_order {
 }
 
 pub(super) use det_hash_prone_order;
+#[cfg(feature = "performant")]
 use polars_arrow::conversion::primitive_to_vec;
 
 use crate::series::IsSorted;


### PR DESCRIPTION
If on side of a `left/inner` join is sorted we can JIT sort the right key to use a sorted-merge join instead of a hash join. 