### PR TITLE
chore: Use literal style for version instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -64,13 +64,13 @@ body:
       label: Installed versions
       description: >
         Please paste the output of ``pl.show_versions()``
-      value: >
+      value: |
         <details>
 
         ```
         Replace this line with the output of pl.show_versions(), leave the backticks in place
         ```
-
+        
         </details>
     validations:
       required: true


### PR DESCRIPTION
Using `values: |` instead of `values: >` in the bug report section retains newlines in the `version information` instructions. This should help the version information come out looking better by default when others submit bug reports.