### PR TITLE
Draft: feat(python)!: Change `DataFrame.__getitem__` semantics

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -24,7 +24,6 @@ from warnings import warn
 from polars import internals as pli
 from polars._html import NotebookFormatter
 from polars.datatypes import (
-    Boolean,
     ColumnsType,
     Int8,
     Int16,
@@ -49,7 +48,6 @@ from polars.internals.construction import (
     series_to_pydf,
 )
 from polars.internals.dataframe.groupby import DynamicGroupBy, GroupBy, RollingGroupBy
-from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
@@ -59,7 +57,6 @@ from polars.utils import (
     is_bool_sequence,
     is_int_sequence,
     is_str_sequence,
-    range_to_slice,
     scale_bytes,
 )
 
@@ -101,9 +98,9 @@ else:
     from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
-    from typing import TypeAlias
+    from typing import TypeAlias, TypeGuard
 else:
-    from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias, TypeGuard
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -129,11 +126,13 @@ if TYPE_CHECKING:
     # these aliases are used to annotate DataFrame.__getitem__()
     # MultiRowSelector indexes into the vertical axis and
     # MultiColSelector indexes into the horizontal axis
-    # NOTE: wrapping these as strings is necessary for Python <3.10
-
-    MultiRowSelector: TypeAlias = "slice | range | list[int] | pli.Series"
+    # NOTE: wrapping these as strings is necessary for Python <3.
+    MultiRowSelector: TypeAlias = (
+        "slice | range | list[int] | pli.Series | np.ndarray[Any, Any]"
+    )
     MultiColSelector: TypeAlias = (
-        "slice | range | list[int] | list[str] | list[bool] | pli.Series"
+        "slice | range | list[int] | list[str] | list[bool] "
+        "| pli.Series | np.ndarray[Any, Any]"
     )
 
 # A type variable used to refer to a polars.DataFrame or any subclass of it.
@@ -1129,115 +1128,34 @@ class DataFrame:
     def __iter__(self) -> Iterator[Any]:
         return self.get_columns().__iter__()
 
-    def _pos_idx(self, idx: int, dim: int) -> int:
-        if idx >= 0:
-            return idx
-        else:
-            return self.shape[dim] + idx
-
-    def _pos_idxs(
-        self, idxs: np.ndarray[Any, Any] | pli.Series, dim: int
-    ) -> pli.Series:
-        # pl.UInt32 (polars) or pl.UInt64 (polars_u64_idx).
-        idx_type = get_idx_type()
-
-        if isinstance(idxs, pli.Series):
-            if idxs.dtype == idx_type:
-                return idxs
-            if idxs.dtype in {
-                UInt8,
-                UInt16,
-                UInt64 if idx_type == UInt32 else UInt32,
-                Int8,
-                Int16,
-                Int32,
-                Int64,
-            }:
-                if idx_type == UInt32:
-                    if idxs.dtype in {Int64, UInt64}:
-                        if idxs.max() >= 2**32:  # type: ignore[operator]
-                            raise ValueError(
-                                "Index positions should be smaller than 2^32."
-                            )
-                    if idxs.dtype == Int64:
-                        if idxs.min() < -(2**32):  # type: ignore[operator]
-                            raise ValueError(
-                                "Index positions should be bigger than -2^32 + 1."
-                            )
-                if idxs.dtype in {Int8, Int16, Int32, Int64}:
-                    if idxs.min() < 0:  # type: ignore[operator]
-                        if idx_type == UInt32:
-                            if idxs.dtype in {Int8, Int16}:
-                                idxs = idxs.cast(Int32)
-                        else:
-                            if idxs.dtype in {Int8, Int16, Int32}:
-                                idxs = idxs.cast(Int64)
-
-                        idxs = pli.select(
-                            pli.when(pli.lit(idxs) < 0)
-                            .then(self.shape[dim] + pli.lit(idxs))
-                            .otherwise(pli.lit(idxs))
-                        ).to_series()
-
-                return idxs.cast(idx_type)
-
-        if _NUMPY_AVAILABLE and isinstance(idxs, np.ndarray):
-            if idxs.ndim != 1:
-                raise ValueError("Only 1D numpy array is supported as index.")
-            if idxs.dtype.kind in ("i", "u"):
-                # Numpy array with signed or unsigned integers.
-
-                if idx_type == UInt32:
-                    if idxs.dtype in {np.int64, np.uint64} and idxs.max() >= 2**32:
-                        raise ValueError("Index positions should be smaller than 2^32.")
-                    if idxs.dtype == np.int64 and idxs.min() < -(2**32):
-                        raise ValueError(
-                            "Index positions should be bigger than -2^32 + 1."
-                        )
-                if idxs.dtype.kind == "i" and idxs.min() < 0:
-                    if idx_type == UInt32:
-                        if idxs.dtype in (np.int8, np.int16):
-                            idxs = idxs.astype(np.int32)
-                    else:
-                        if idxs.dtype in (np.int8, np.int16, np.int32):
-                            idxs = idxs.astype(np.int64)
-
-                    # Update negative indexes to absolute indexes.
-                    idxs = np.where(idxs < 0, self.shape[dim] + idxs, idxs)
-
-                return pli.Series("", idxs, dtype=idx_type)
-
-        raise NotImplementedError("Unsupported idxs datatype.")
-
     @overload
-    def __getitem__(self: DF, item: str) -> pli.Series:
+    def __getitem__(self: DF, item: str | int) -> pli.Series:
         ...
 
     @overload
     def __getitem__(
         self: DF,
-        item: int
+        item: MultiColSelector
         | np.ndarray[Any, Any]
-        | MultiColSelector
         | tuple[int, MultiColSelector]
         | tuple[MultiRowSelector, MultiColSelector],
     ) -> DF:
         ...
 
     @overload
-    def __getitem__(self: DF, item: tuple[MultiRowSelector, int]) -> pli.Series:
+    def __getitem__(self, item: tuple[MultiRowSelector, int]) -> pli.Series:
         ...
 
     @overload
-    def __getitem__(self: DF, item: tuple[MultiRowSelector, str]) -> pli.Series:
+    def __getitem__(self, item: tuple[MultiRowSelector, str]) -> pli.Series:
         ...
 
     @overload
-    def __getitem__(self: DF, item: tuple[int, int]) -> Any:
+    def __getitem__(self, item: tuple[int, int]) -> Any:
         ...
 
     @overload
-    def __getitem__(self: DF, item: tuple[int, str]) -> Any:
+    def __getitem__(self, item: tuple[int, str]) -> Any:
         ...
 
     def __getitem__(
@@ -1245,7 +1163,6 @@ class DataFrame:
         item: (
             str
             | int
-            | np.ndarray[Any, Any]
             | MultiColSelector
             | tuple[int, MultiColSelector]
             | tuple[MultiRowSelector, MultiColSelector]
@@ -1255,210 +1172,276 @@ class DataFrame:
             | tuple[int, str]
         ),
     ) -> DataFrame | pli.Series:
-        """Get item. Does quite a lot. Read the comments."""
-        # select rows and columns at once
-        # every 2d selection, i.e. tuple is row column order, just like numpy
-        if isinstance(item, tuple) and len(item) == 2:
-            row_selection, col_selection = item
+        """
+        Select a subset of the ``DataFrame`` by specifying rows/columns.
 
-            # df[:, unknown]
-            if isinstance(row_selection, slice):
+        ``polars`` abides by the philosophy that columns represent the primary
+        logical unit of a ``DataFrame``. With this in mind, ``df[X]`` always
+        selects *columns*. For any ``X``, it is shorthand for ``df[:, X]``.
+        Rows should be accessed explicitly with``df[X, :]``.
 
-                # multiple slices
-                # df[:, :]
-                if isinstance(col_selection, slice):
-                    # slice can be
-                    # by index
-                    #   [1:8]
-                    # or by column name
-                    #   ["foo":"bar"]
-                    # first we make sure that the slice is by index
-                    start = col_selection.start
-                    stop = col_selection.stop
-                    if isinstance(col_selection.start, str):
-                        start = self.find_idx_by_name(col_selection.start)
-                    if isinstance(col_selection.stop, str):
-                        stop = self.find_idx_by_name(col_selection.stop) + 1
+        Note that when selecting by columns, the type of ``X`` fully determines the
+        return type of ``__getitem__``. If ``X`` is a scalar value (integer or
+        string) a ``Series`` is returned. Otherwise, a ``DataFrame`` is returned.
+        When selecting by rows, a ``DataFrame`` is always returned.
 
-                    col_selection = slice(start, stop, col_selection.step)
+        Additionally, ``df[X, int | str]`` is simply shorthand for ``df[int | str][X]``.
+        In other words, we first extract the column as a ``Series``, and then index
+        the row positions.
 
-                    df = self.__getitem__(self.columns[col_selection])
-                    return df[row_selection]
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": range(3), "b": range(3)})
+        >>> df["a"]
+        shape: (3,)
+        Series: 'a' [i64]
+        [
+            0
+            1
+            2
+        ]
 
-                # df[:, [True, False]]
-                if is_bool_sequence(col_selection) or (
-                    isinstance(col_selection, pli.Series)
-                    and col_selection.dtype == Boolean
-                ):
-                    if len(col_selection) != self.width:
-                        raise ValueError(
-                            f"Expected {self.width} values when selecting columns by"
-                            f" boolean mask. Got {len(col_selection)}."
-                        )
-                    series_list = []
-                    for (i, val) in enumerate(col_selection):
-                        if val:
-                            series_list.append(self.to_series(i))
+        >>> df[0]
+        shape: (3,)
+        Series: 'a' [i64]
+        [
+            0
+            1
+            2
+        ]
 
-                    df = self.__class__(series_list)
-                    return df[row_selection]
+        >>> df[["a"]]
+        shape: (3, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 0   │
+        ├╌╌╌╌╌┤
+        │ 1   │
+        ├╌╌╌╌╌┤
+        │ 2   │
+        └─────┘
 
-                # single slice
-                # df[:, unknown]
-                series = self.__getitem__(col_selection)
-                # s[:]
-                pli.wrap_s(series[row_selection])
+        >>> df[[0]]
+        shape: (3, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 0   │
+        ├╌╌╌╌╌┤
+        │ 1   │
+        ├╌╌╌╌╌┤
+        │ 2   │
+        └─────┘
 
-            # df[2, :] (select row as df)
-            if isinstance(row_selection, int):
-                if isinstance(col_selection, (slice, list)) or (
-                    _NUMPY_AVAILABLE and isinstance(col_selection, np.ndarray)
-                ):
-                    df = self[:, col_selection]
-                    return df.slice(row_selection, 1)
-                # df[2, "a"]
-                if isinstance(col_selection, str):
-                    return self[col_selection][row_selection]
+        >>> df[0, :]
+        shape: (1, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 0   ┆ 0   │
+        └─────┴─────┘
 
-            # column selection can be "a" and ["a", "b"]
-            if isinstance(col_selection, str):
-                col_selection = [col_selection]
+        >>> df[1:, "a":"b"]
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 1   │
+        ├╌╌╌╌╌┼╌╌╌╌╌┤
+        │ 2   ┆ 2   │
+        └─────┴─────┘
 
-            # df[:, 1]
-            if isinstance(col_selection, int):
-                series = self.to_series(col_selection)
-                return series[row_selection]
+        """
+        # df[X] == df[:, X]
+        if not isinstance(item, tuple):
+            return self[:, item]  # type: ignore[index]
 
-            if isinstance(col_selection, list):
-                # df[:, [1, 2]]
-                if is_int_sequence(col_selection):
-                    series_list = [self.to_series(i) for i in col_selection]
-                    df = self.__class__(series_list)
-                    return df[row_selection]
+        rows, cols = item
 
-            df = self.__getitem__(col_selection)
-            return df.__getitem__(row_selection)
+        # Select the requested columns, fast-path if we want all columns
+        if isinstance(cols, slice) and cols == slice(None, None, None):
+            df = self
+        else:
+            std_cols = self._standardize_col_accessor(cols)
+            df = self.select(std_cols)
 
-        # select single column
-        # df["foo"]
-        if isinstance(item, str):
-            return pli.wrap_s(self._df.column(item))
+        # NOTE: If we have selected just a single column, squeeze to
+        # a Series and delegate the row indexing to Series.__getitem__
+        if isinstance(cols, (int, str)):
+            return df.to_series()[rows]
+        else:
+            if isinstance(rows, slice) and rows == slice(None, None, None):
+                return df
+            else:
+                std_rows = self._standardize_row_accessor(rows)
+                return df._from_pydf(df._df.take_with_series(std_rows._s))
 
-        # df[idx]
-        if isinstance(item, int):
-            return self.slice(self._pos_idx(item, dim=0), 1)
+    def _standardize_row_accessor(self, rows: int | MultiRowSelector) -> pli.Series:
+        """
+        Transform any row accessors to a canonical type.
 
-        # df[range(n)]
-        if isinstance(item, range):
-            return self[range_to_slice(item)]
-
-        # df[:]
-        if isinstance(item, slice):
-            return PolarsSlice(self).apply(item)
-
-        # select rows by numpy mask or index
-        # df[np.array([1, 2, 3])]
-        # df[np.array([True, False, True])]
-        if _NUMPY_AVAILABLE and isinstance(item, np.ndarray):
-            if item.ndim != 1:
-                raise ValueError("Only a 1D-Numpy array is supported as index.")
-            if item.dtype.kind in ("i", "u"):
-                # Numpy array with signed or unsigned integers.
-                return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
+        The canonical type is Series with the dtype given by ``get_idx_type()``
+        """
+        if isinstance(rows, int):
+            return self._standardize_row_accessor(pli.Series([rows]))
+        if isinstance(rows, range):
+            return pli.Series(rows, dtype=get_idx_type())
+        if isinstance(rows, slice):
+            start, stop, step = rows.indices(self.__len__())
+            return pli.Series(range(start, stop, step), dtype=get_idx_type())
+        if isinstance(rows, list):
+            return self._standardize_row_accessor(pli.Series(rows))
+        if isinstance(rows, pli.Series):
+            if rows.dtype == get_idx_type():
+                return rows
+            if rows.dtype in [UInt8, UInt16, UInt32, UInt64]:
+                return rows.cast(get_idx_type(), strict=True)
+            if rows.dtype in [Int8, Int16, Int32, Int64]:
+                lit = pli.lit(rows)
+                n = self.__len__()
+                return (
+                    pli.select(pli.when(lit < 0).then(n + lit).otherwise(lit))
+                    .to_series()
+                    .cast(get_idx_type(), strict=True)
                 )
-            if isinstance(item[0], str):
-                return self._from_pydf(self._df.select(item))
+        if _NUMPY_AVAILABLE and isinstance(rows, np.ndarray):
+            if rows.ndim != 1:
+                raise TypeError("numpy row indexer must only have a single dimension")
+            if rows.dtype in [np.uint8, np.uint16, np.uint32]:
+                return pli.Series(rows, dtype=get_idx_type())
+            if rows.dtype in [np.int8, np.int16, np.int32, np.int64, np.uint64]:
+                return self._standardize_row_accessor(pli.Series(rows))
+        raise TypeError(f"unable to determine row indices from {rows}")
 
-        if is_str_sequence(item, allow_str=False):
-            # select multiple columns
-            # df[["foo", "bar"]]
-            return self._from_pydf(self._df.select(item))
-        elif is_int_sequence(item):
-            item = pli.Series("", item)  # fall through to next if isinstance
+    def _standardize_col_accessor(
+        self, cols: int | str | MultiColSelector
+    ) -> list[pli.Expr]:
+        """
+        Transform any column accessor to a canonical type.
 
-        if isinstance(item, pli.Series):
-            dtype = item.dtype
-            if dtype == Utf8:
-                return self._from_pydf(self._df.select(item))
-            if dtype == UInt32:
-                return self._from_pydf(self._df.take_with_series(item._s))
-            if dtype in {UInt8, UInt16, UInt64, Int8, Int16, Int32, Int64}:
-                return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
+        The canonical type is a list of ``pl.col`` expressions.
+        """
+        if isinstance(cols, (int, str)):
+            return self._standardize_col_accessor([cols])  # type: ignore[arg-type]
+        if isinstance(cols, slice):
+            # NOTE: the only valid combinations are
+            #   - slice(int | None, int | None, int | None)
+            #   - slice(str | None, str | None, int | None)
+            start, stop = self._standardize_slice_start_stop(cols.start, cols.stop)
+            rng_indices = slice(start, stop, cols.step).indices(self.width)
+            return self._standardize_col_accessor(range(*rng_indices))
+        if isinstance(cols, range):
+            return self._standardize_col_accessor([self.columns[i] for i in cols])
+        if _NUMPY_AVAILABLE and isinstance(cols, np.ndarray):
+            if cols.ndim != 1:
+                raise TypeError(
+                    "numpy column indexer must only have a single dimension"
                 )
+            return self._standardize_col_accessor(cols.tolist())
+        if isinstance(cols, list) and cols.__len__() == 0:
+            # Guard against an empty list, i.e. no columns selected
+            return []
+        if is_bool_sequence(cols):
+            if cols.__len__() != self.columns.__len__():
+                raise ValueError("boolean mask does not match DataFrame width")
+            masked = [x for x, flag in zip(self.columns, cols) if flag]
+            return self._standardize_col_accessor(masked)
+        if is_int_sequence(cols):
+            return self._standardize_col_accessor([self.columns[i] for i in cols])
+        if is_str_sequence(cols, allow_str=False):
+            return [pli.col(x) for x in cols]
+        if isinstance(cols, pli.Series):
+            return self._standardize_col_accessor(
+                cols.to_list()  # type: ignore[arg-type]
+            )
+        raise TypeError(f"unable to determine column indices from {cols}")
 
-        # if no data has been returned, the operation is not supported
-        raise ValueError(
-            f"Cannot __getitem__ on DataFrame with item: '{item}'"
-            f" of type: '{type(item)}'."
-        )
+    def _standardize_slice_start_stop(
+        self, start: int | str | None, stop: int | str | None
+    ) -> tuple[int | None, int | None]:
+        """Convert possible str indices to int indices."""
+
+        def _is_int_or_none(x: int | str | None) -> TypeGuard[int | None]:
+            return isinstance(x, int) or x is None
+
+        if _is_int_or_none(start) and _is_int_or_none(stop):
+            return start, stop
+
+        def _is_str_or_none(x: int | str | None) -> TypeGuard[str | None]:
+            return isinstance(x, str) or x is None
+
+        if _is_str_or_none(start) and _is_str_or_none(stop):
+            _start = start if start is None else self.columns.index(start)
+            _stop = stop if stop is None else self.columns.index(stop) + 1
+            return _start, _stop
+
+        raise TypeError(f"received invalid slice types {type(start), type(stop)}")
 
     def __setitem__(
-        self, key: str | list[int] | list[str] | tuple[Any, str | int], value: Any
-    ) -> None:  # pragma: no cover
-        # df["foo"] = series
-        if isinstance(key, str):
-            raise TypeError(
-                "'DataFrame' object does not support 'Series' assignment by index. "
-                "Use 'DataFrame.with_columns'"
-            )
+        self, key: list[int] | list[str] | tuple[Any, str | int], value: Any
+    ) -> None:
+        """
+        Assign values into the ``DataFrame``.
 
-        # df[["C", "D"]]
-        elif isinstance(key, list):
-            # TODO: Use python sequence constructors
-            if not _NUMPY_AVAILABLE:
-                raise ImportError("'numpy' is required for this functionality.")
-            value = np.array(value)
-            if value.ndim != 2:
-                raise ValueError("can only set multiple columns with 2D matrix")
-            if value.shape[1] != len(key):
-                raise ValueError(
-                    "matrix columns should be equal to list use to determine column"
-                    " names"
-                )
+        Generally, it is not advised to use ``__setitem__``. It is preferable
+        to use the expressions API and `with_columns``.
+        """
+        if isinstance(key, list):
+            if _NUMPY_AVAILABLE and isinstance(value, np.ndarray):
+                if value.ndim != 2:
+                    raise ValueError(
+                        "np.ndarray must be two-dimensional when setting "
+                        "multiple columns"
+                    )
 
-            # todo! we can parallelize this by calling from_numpy
+                def fetch_values_for_column(i: int) -> Any:
+                    return value[:, i]
+
+            else:
+                if not (isinstance(value, Sequence) and len(value) == len(key)):
+                    raise ValueError("provided values does not contain enough columns")
+
+                def fetch_values_for_column(i: int) -> Any:
+                    return value[i]
+
             columns = []
-            for (i, name) in enumerate(key):
-                columns.append(pli.Series(name, value[:, i]))
-            self._df = self.with_columns(columns)._df
+            for i, k in enumerate(key):
+                if isinstance(k, str):
+                    name = k
+                else:
+                    name = self.columns[k]  # type: ignore[call-overload]
+                columns.append(pli.Series(name, fetch_values_for_column(i)))
+                self._df = self.with_columns(columns)._df
 
-        # df[a, b]
         elif isinstance(key, tuple):
             row_selection, col_selection = key
 
-            if (
-                isinstance(row_selection, pli.Series) and row_selection.dtype == Boolean
-            ) or is_bool_sequence(row_selection):
-                raise ValueError(
-                    "Not allowed to set 'DataFrame' by boolean mask in the "
-                    "row position. Consider using 'DataFrame.with_columns'"
-                )
+            if not isinstance(col_selection, (str, int)):
+                raise ValueError(f"unsupported column indexer {col_selection}")
 
-            # get series column selection
-            if isinstance(col_selection, str):
-                s = self.__getitem__(col_selection)
-            elif isinstance(col_selection, int):
-                s = self[:, col_selection]
-            else:
-                raise ValueError(f"column selection not understood: {col_selection}")
+            # Dispatch to Series.__setitem__ to do the modification
+            series = self[col_selection]
+            series[row_selection] = value
 
-            # dispatch to __setitem__ of Series to do modification
-            s[row_selection] = value
-
-            # now find the location to place series
-            # df[idx]
+            # Now replace the column with the new Series
             if isinstance(col_selection, int):
-                self.replace_at_idx(col_selection, s)
-            # df["foo"]
+                self.replace_at_idx(col_selection, series)
             elif isinstance(col_selection, str):
-                self.replace(col_selection, s)
+                self.replace(col_selection, series)
+
         else:
             raise ValueError(
-                f"Cannot __setitem__ on DataFrame with key: '{key}' "
-                f"of type: '{type(key)}' and value: '{value}' "
-                f"of type: '{type(value)}'."
+                f"Cannot __setitem__ on DataFrame with key "
+                f"of type: {type(key)} and value of type: {type(value)}"
             )
 
     def __len__(self) -> int:

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -90,7 +90,7 @@ class GroupBy(Generic[DF]):
         groups = groups_df["groups"]
         df = self._dataframe_class._from_pydf(self._df)
         for i in range(groups_df.height):
-            yield df[groups[i]]
+            yield df[groups[i], :]
 
     def _select(self, columns: str | list[str]) -> GBSelection[DF]:  # pragma: no cover
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -672,9 +672,12 @@ class Series:
         if isinstance(item, range):
             return self[range_to_slice(item)]
 
-        # slice
+        # slice, with fast-path
         if isinstance(item, slice):
-            return PolarsSlice(self).apply(item)
+            if item == slice(None, None, None):
+                return self
+            else:
+                return PolarsSlice(self).apply(item)
 
         raise TypeError(f"unexpected type for Series.__getitem__, {type(item)}")
 

--- a/py-polars/polars/testing.py
+++ b/py-polars/polars/testing.py
@@ -882,7 +882,7 @@ if HYPOTHESIS_INSTALLED:
             # optionally generate frames with n_chunks > 1
             if series_size > 1 and chunked is True:
                 split_at = series_size // 2
-                df = df[:split_at].vstack(df[split_at:])
+                df = df[:split_at, :].vstack(df[split_at:, :])
 
             # optionally make lazy
             return df.lazy() if lazy else df

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -111,7 +111,12 @@ def is_dtype_sequence(val: object) -> TypeGuard[Sequence[PolarsDataType]]:
 
 def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
-    return isinstance(val, Sequence) and _is_iterable_of(val, int)
+    if isinstance(val, Sequence) and _is_iterable_of(val, int):
+        # NOTE: _is_iterable_of(val, int) returns True for a sequence
+        # of bools, so we additionally need to check for bools
+        return not is_bool_sequence(val)
+    else:
+        return False
 
 
 def is_expr_sequence(val: object) -> TypeGuard[Sequence[pli.Expr]]:

--- a/py-polars/tests/parametric/test_dataframe.py
+++ b/py-polars/tests/parametric/test_dataframe.py
@@ -86,7 +86,7 @@ def test_frame_slice(df: pl.DataFrame) -> None:
     for start, stop, step, _ in py_data:
         s = slice(start, stop, step)
         sliced_py_data = py_data[s]
-        sliced_df_data = df[s].rows()
+        sliced_df_data = df[s, :].rows()
 
         assert (
             sliced_py_data == sliced_df_data

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -126,26 +126,21 @@ def test_getitem_errs() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 
     with pytest.raises(
-        ValueError,
-        match=r"Cannot __getitem__ on DataFrame with item: "
-        r"'{'some'}' of type: '<class 'set'>'.",
+        TypeError,
+        match=r"unable to determine column indices from {'some'}",
     ):
         df[{"some"}]
 
     with pytest.raises(
-        ValueError,
-        match=r"Cannot __getitem__ on Series of dtype: "
-        r"'<class 'polars.datatypes.Int64'>' with argument: "
-        r"'{'strange'}' of type: '<class 'set'>'.",
+        TypeError,
+        match=r"unexpected type for Series.__getitem__, <class 'set'>",
     ):
         df["a"][{"strange"}]
 
     with pytest.raises(
         ValueError,
-        match=r"Cannot __setitem__ on "
-        r"DataFrame with key: '{'some'}' of "
-        r"type: '<class 'set'>' and value: "
-        r"'foo' of type: '<class 'str'>'",
+        match=r"Cannot __setitem__ on DataFrame with key of type: "
+        r"<class 'set'> and value of type: <class 'str'>",
     ):
         df[{"some"}] = "foo"
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -359,7 +359,7 @@ def test_inspect(capsys: CaptureFixture[str]) -> None:
 
 def test_fetch(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.lazy().select("*").fetch(2)
-    assert res.frame_equal(res[:2])
+    assert res.frame_equal(res[:2, :])
 
 
 def test_window_deadlock() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -388,12 +388,12 @@ def test_various() -> None:
 
 def test_filter_ops() -> None:
     a = pl.Series("a", range(20))
-    assert a[a > 1].len() == 18
-    assert a[a < 1].len() == 1
-    assert a[a <= 1].len() == 2
-    assert a[a >= 1].len() == 19
-    assert a[a == 1].len() == 1
-    assert a[a != 1].len() == 19
+    assert a.filter(a > 1).len() == 18
+    assert a.filter(a < 1).len() == 1
+    assert a.filter(a <= 1).len() == 2
+    assert a.filter(a >= 1).len() == 19
+    assert a.filter(a == 1).len() == 1
+    assert a.filter(a != 1).len() == 19
 
 
 def test_cast() -> None:
@@ -1198,7 +1198,7 @@ def test_range() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     assert s[2:5].series_equal(s[range(2, 5)])
     df = pl.DataFrame([s])
-    assert df[2:5].frame_equal(df[range(2, 5)])
+    assert df[2:5, :].frame_equal(df[range(2, 5), :])
 
 
 def test_strict_cast() -> None:


### PR DESCRIPTION
Closes #4924 

**BREAKING CHANGE**

There are a few changes bundled in here.

## `Series.__getitem__`
- Fully removes support for boolean masks. We had previously added a deprecation warning for this in #5075 
- Adds fast-path for `slice(None, None, None)`.

## `DataFrame.__getitem__`
- Semantically, the biggest change is that `df[int | list[int]]` no longer selects rows; it selects columns. 
- Documentation drastically improved.
- Refactor so that we normalize all row accessors to `pl.Series(dtype=UInt32 | UInt64)` and all col accessors to `list[pl.col]`. 
  - I think overall this reduces the complexity of the code. It completely decouples the row selection from the column selection, whereas previously we had it all mixed into the body of `DataFrame.__getitem__`.

## `DataFrame.__setitem__`
- General clean-up (for example, we had the function annotated to accept a `str` but then immediately raised an error).
- Loosened restriction for setting multiple columns -- we no longer require `numpy` to be installed.

IMO this function should be dumbed down even more. I would propose two simple rules

1. `df[X] = z` is semantically equivalent to `df[:, X] = z`. This would then be consistent with `DataFrame.__getitem__`.
2. `df[X, Y]` is semantically equivalent to `df[Y][X] = z`, ie. extract the `Y` column and then delegate to `s[X] = z`.

If this is agreeable, I am happy to add it to the PR. What we have now is a bit strange...

```python
df["col"] = range(5)        # disallowed
df[["col"]] = [range(5)]    # allowed
```

Marking this as a draft to allow time for people to leave feedback!