### PR TITLE
chore(rust): Constant instead of literal

### DIFF
--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -185,7 +185,7 @@ impl<'a> CoreJsonReader<'a> {
             self.sample_size,
             NEWLINE,
             self.schema.len(),
-            b',',
+            SEP,
             None,
         ) {
             let line_length_upper_bound = mean + 1.1 * std;


### PR DESCRIPTION
Just using the constant rather than a literal. Noticed whilst looking at the json parsing bug.