### PR TITLE
chore(python): improve py-polars/Makefile

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -3,33 +3,83 @@
 SHELL=/bin/bash
 VENV ?= venv
 
+WHEELS_DEBUG   = wheels/debug
+WHEELS_RELEASE = wheels/release
+
 ifeq ($(OS),Windows_NT)
-	VENV_BIN=$(VENV)/Scripts
+    VENV_BIN=$(VENV)/Scripts
 else
-	VENV_BIN=$(VENV)/bin
+    VENV_BIN=$(VENV)/bin
 endif
 
-venv:  ## Set up virtual environment
-	python3 -m venv $(VENV)
-	$(VENV_BIN)/pip install --upgrade pip
-	$(VENV_BIN)/pip install -r requirements-dev.txt
-	$(VENV_BIN)/pip install -r requirements-lint.txt
-	$(MAKE) build
+ifneq ($(CONDA_EXE),)
+	CONDA_DEACT = . $(shell $(CONDA_EXE) info --base -q)/etc/profile.d/conda.sh; \
+		while [ -n "$$CONDA_PREFIX" ]; do conda deactivate; done;
+else
+	CONDA_DEACT =
+endif
 
-.PHONY: build
-build: venv  ## Set up virtual environment
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
+ifeq ($(VENV),) # no virtual environment
+	VENV_BIN     =
+	VENV_ACT_BIN =
+	CLEAN_VENV   = @:
+venv:
+	:
+else # use VENV
+	VENV_BIN    := $(abspath $(VENV_BIN))/# no space after trailing '/'
+	VENV_ACT_BIN = $(CONDA_DEACT) . $(VENV_BIN)activate; $(VENV_BIN)# no space after closing ')'
+	CLEAN_VENV   = -rm -rf $(VENV)
+ifeq ($(VENV),venv)
+venv:  ## Create virtual environment for building polars (optionally with VENV=<name>)
+else
+.PHONY: venv
+venv: $(VENV)
+$(VENV):
+endif
+	python -m venv  $(VENV)
+	$(VENV_ACT_BIN)pip install -U pip
+	$(VENV_ACT_BIN)pip install -r requirements-dev.txt
+	$(VENV_ACT_BIN)pip install -r requirements-lint.txt
+endif
+
+develop: $(VENV)  ## Build by running `maturin develop`
+	$(VENV_ACT_BIN)maturin develop
+
+develop-release: $(VENV)  ## Build by running `maturin develop --release`
+	$(VENV_ACT_BIN)maturin develop --release
+
+.PHONY: clean cleaner cleanest
+clean:  ## Just run `cargo clean`
+	-cargo clean
+
+cleaner: clean  ## clean + remove VENV and other auto-generated dirs & files
+	$(CLEAN_VENV)
+	-rm -rf target
+	-rm -rf docs/build
+	-rm -rf docs/source/reference/api
+	-rm -rf .hypothesis
+	-rm -rf .mypy_cache
+	-rm -rf .pytest_cache
+	-rm -f .coverage
+	-rm -f coverage.xml
+	-rm -f polars/polars.abi3.so
+	-find . \( -type f -name '*.py[co]' \) -or \( -type d -name __pycache__ \) -delete
+
+cleanest: cleaner  ## cleaner + remove the wheels
+	-rm -rf $(WHEELS_DEBUG)
+	-rm -rf $(WHEELS_RELEASE)
+	-rm -rf wheels
 
 .PHONY: fmt
-fmt: venv  ## Run autoformatting and linting
-	$(VENV_BIN)/isort .
-	$(VENV_BIN)/black .
-	$(VENV_BIN)/blackdoc .
-	$(VENV_BIN)/pyupgrade --py37-plus `find polars docs tests -name "*.py" -type f`
+fmt: $(VENV)  ## Run autoformatting and linting
+	$(VENV_ACT_BIN)isort .
+	$(VENV_ACT_BIN)black .
+	$(VENV_ACT_BIN)blackdoc .
+	$(VENV_ACT_BIN)pyupgrade --py37-plus `find polars docs tests -name "*.py" -type f`
 	cargo fmt --all
 	-dprint fmt
-	-$(VENV_BIN)/mypy
-	-$(VENV_BIN)/flake8
+	-$(VENV_ACT_BIN)mypy
+	-$(VENV_ACT_BIN)flake8 polars tests docs
 
 .PHONY: clippy
 clippy:  ## Run clippy
@@ -39,39 +89,53 @@ clippy:  ## Run clippy
 pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
-test: venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest tests/unit/
+test: # develop  ## Run fast unittests
+	$(VENV_ACT_BIN)pytest -v tests/unit/
 
 .PHONY: doctest
-doctest: venv build  ## Run doctests
-	$(VENV_BIN)/python tests/docs/run_doc_examples.py
+doctest: $(VENV) build  ## Run doctests
+	$(VENV_ACT_BIN)python tests/docs/run_doc_examples.py
 
 .PHONY: test-all
-test-all: venv build  ## Run all tests
-	$(VENV_BIN)/maturin develop
-	$(VENV_BIN)/pytest
-	$(VENV_BIN)/python tests/docs/run_doc_examples.py
+test-all: # develop  ## Run all tests
+	$(VENV_ACT_BIN)pytest -v
+	$(VENV_ACT_BIN)python tests/docs/run_doc_examples.py
 
 .PHONY: coverage
-coverage: venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov
+coverage:  ## Run tests and report coverage
+	$(VENV_ACT_BIN)pytest -v --cov
 
-.PHONY: clean
-clean:  ## Clean up caches and build artifacts
-	@rm -rf $(VENV)
-	@rm -rf target/
-	@rm -rf docs/build/
-	@rm -rf docs/source/reference/api/
-	@rm -rf .hypothesis/
-	@rm -rf .mypy_cache/
-	@rm -rf .pytest_cache/
-	@rm -f .coverage
-	@rm -f coverage.xml
-	@rm -f polars/polars.abi3.so
-	@find . -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
-	@cargo clean
+build-debug: $(VENV)  ## Build debug wheel
+	$(VENV_ACT_BIN)maturin build -o $(WHEELS_DEBUG)
+
+build: $(VENV)  ## Build release wheel
+	$(VENV_ACT_BIN)maturin build -o $(WHEELS_RELEASE) --release -- -C codegen-units=16 -C lto=thin -C target-cpu=native
+
+install-debug: $(VENV)  ## pip install debug wheel
+	$(VENV_ACT_BIN)pip install --no-deps --force-reinstall -U $(WHEELS_DEBUG)/polars-*.whl
+
+install: $(VENV)  ## pip install release wheel
+	$(VENV_ACT_BIN)pip install --no-deps --force-reinstall -U $(WHEELS_RELEASE)/polars-*.whl
+
+# Shortcut targets
+build-install-debug: build-debug install-debug  ## Build and install debug wheel
+build-install: build install  ## Build and install release wheel
 
 .PHONY: help
 help:  ## Display this help screen
+	@echo "Usage:"
+	@echo "* To run a make <comand> with venv, issue"
+	@echo "  > make <command>"
+	@echo "* To run a make <command> with alternative environement <name>, issue"
+	@echo "  > make VENV=<name> <command>"
+	@echo "* To run a make <command> without virtual environment (ex: conda), issue"
+	@echo "  > make VENV='' <command>"
+	@echo
+	@echo "Currently:"
+	@echo "  VENV = '$(VENV)'"
+	@echo
+
 	@echo -e '\033[1mAvailable commands:\033[0m'
-	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort
+
+#EOF


### PR DESCRIPTION
A recent commit (67219a86) removed bunch of useful functionality from `py-polars/Makefile`.
For instance, there are no `*-no-venv` targets anymore (without virtual environment) that
are useful for building in conda environment.  Targets for creating and installing
wheels were removed too.

This PR restores the missing functionality and improves the makefile's consistency.
Now one can run any makefile command with or without virtual environment.
If so desired, one can even alternate between different virtual environments
by giving `VENV=<name>` on the command-line (or set it in the shell environment).
To run without virtual environment issue `make VENV='' <command>`

Specifically, the following functionality is added/improved:

1. Making wheels (debug and release) with or without virtual environment.

2. pip install wheels (debug and release) inside or outside of a virtual environment.

3. Full parity between making targets with and without virtual environment
   (useful for conda development).
   `$ make <command>` # run with virtual environment named 'venv' (default)
   `$ make VENV=vfoo <command>` # run with virtual environment named 'vfoo'
   `$ make VENV='' <command>` # run without virtual environment (useful for conda)

4. Whenever needed properly deactivates conda environments
   (instead of a hacky way `unset CONDA_PREFIX`).

Call `make` with no parameters for a brief help message.
