### PR TITLE
feat(rust, python): Add metadata to DataFrame and wire it into parquet

### DIFF
--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_btree_new)]
+
 #![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate core;
 

--- a/polars/polars-io/src/parquet/write.rs
+++ b/polars/polars-io/src/parquet/write.rs
@@ -80,7 +80,7 @@ where
             compression: self.compression,
             version: write::Version::V2,
         };
-        let schema = ArrowSchema::from(fields);
+        let schema = ArrowSchema::from(fields).with_metadata(df.metadata().clone());
         let parquet_schema = write::to_parquet_schema(&schema)?;
         // declare encodings
         let encoding_map = |data_type: &ArrowDataType| {

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -41,6 +41,16 @@ def test_init_empty() -> None:
         not empty_df
 
 
+def test_metadata_empty() -> None:
+    df = pl.DataFrame({})
+    assert df.metadata() == {}
+
+
+def test_metadata_populated() -> None:
+    df = pl.DataFrame({}, {"key", "value"})
+    assert df.metadata() == {"key", "value"}
+
+
 def test_special_char_colname_init() -> None:
     from string import punctuation
 


### PR DESCRIPTION
This is an initial prototype for #5117. For my specific use case, I only need metadata persisted through Parquet, but I would be happy to add functionality for other supported formats.