### PR TITLE
feat(rust, python): add struct arithmetics

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -64,6 +64,13 @@ where
             DataType::Categorical(_) => {
                 Ok(CategoricalChunked::full_null(self.name(), self.len()).into_series())
             }
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(fields) => {
+                // cast to first field dtype
+                let dtype = &fields[0].dtype;
+                let s = cast_impl_inner(self.name(), &self.chunks, dtype, true)?;
+                Ok(StructChunked::new_unchecked(self.name(), &[s]).into_series())
+            }
             _ => cast_impl_inner(self.name(), &self.chunks, data_type, checked).map(|mut s| {
                 // maintain sorted if data types remain signed
                 // this may still fail with overflow?

--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -175,7 +175,7 @@ impl StructChunked {
 
     pub(crate) fn apply_fields<F>(&self, func: F) -> Self
     where
-        F: Fn(&Series) -> Series,
+        F: FnMut(&Series) -> Series,
     {
         let fields = self.fields.iter().map(func).collect::<Vec<_>>();
         Self::new_unchecked(self.field.name(), &fields)

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -148,6 +148,8 @@ impl DataType {
             DataType::Object(_) => false,
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => false,
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(_) => false,
             _ => true,
         }
     }

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -202,7 +202,7 @@ impl Series {
     }
 
     fn restore_logical(&self, out: Series) -> Series {
-        if self.is_logical() {
+        if self.dtype().is_logical() {
             out.cast(self.dtype()).unwrap()
         } else {
             out

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -262,8 +262,8 @@ pub(crate) fn left_join_multiple_keys(
     chunk_mapping_right: Option<&[ChunkId]>,
 ) -> LeftJoinIds {
     // we should not join on logical types
-    debug_assert!(!a.iter().any(|s| s.is_logical()));
-    debug_assert!(!b.iter().any(|s| s.is_logical()));
+    debug_assert!(!a.iter().any(|s| s.dtype().is_logical()));
+    debug_assert!(!b.iter().any(|s| s.dtype().is_logical()));
 
     let n_threads = POOL.current_num_threads();
     let dfs_a = split_df(a, n_threads).unwrap();
@@ -392,8 +392,8 @@ pub(crate) fn semi_anti_join_multiple_keys_impl<'a>(
     b: &'a mut DataFrame,
 ) -> impl ParallelIterator<Item = (IdxSize, bool)> + 'a {
     // we should not join on logical types
-    debug_assert!(!a.iter().any(|s| s.is_logical()));
-    debug_assert!(!b.iter().any(|s| s.is_logical()));
+    debug_assert!(!a.iter().any(|s| s.dtype().is_logical()));
+    debug_assert!(!b.iter().any(|s| s.dtype().is_logical()));
 
     let n_threads = POOL.current_num_threads();
     let dfs_a = split_df(a, n_threads).unwrap();

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -181,7 +181,7 @@ pub(super) fn sort_or_hash_inner(
     let size_factor_acceptable = std::env::var("POLARS_JOIN_SORT_FACTOR")
         .map(|s| s.parse::<f32>().unwrap())
         .unwrap_or(1.0);
-    let is_numeric = s_left.is_numeric_physical();
+    let is_numeric = s_left.dtype().to_physical().is_numeric();
     match (s_left.is_sorted(), s_right.is_sorted()) {
         (IsSorted::Ascending, IsSorted::Ascending) => {
             if verbose {
@@ -250,7 +250,7 @@ pub(super) fn sort_or_hash_left(s_left: &Series, s_right: &Series, verbose: bool
     let size_factor_acceptable = std::env::var("POLARS_JOIN_SORT_FACTOR")
         .map(|s| s.parse::<f32>().unwrap())
         .unwrap_or(1.0);
-    let is_numeric = s_left.is_numeric_physical();
+    let is_numeric = s_left.dtype().to_physical().is_numeric();
 
     match (s_left.is_sorted(), s_right.is_sorted()) {
         (IsSorted::Ascending, IsSorted::Ascending) => {

--- a/polars/polars-core/src/series/arithmetic/borrowed.rs
+++ b/polars/polars-core/src/series/arithmetic/borrowed.rs
@@ -396,12 +396,51 @@ fn coerce_time_units<'a>(
     }
 }
 
+#[cfg(feature = "dtype-struct")]
+fn struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
+    s: &Series,
+    rhs: &Series,
+    mut func: F,
+) -> Series {
+    let s = s.struct_().unwrap();
+    let rhs = rhs.struct_().unwrap();
+    let s_fields = s.fields();
+    let rhs_fields = rhs.fields();
+    match (s_fields.len(), rhs_fields.len()) {
+        (_, 1) => {
+            let rhs = &rhs.fields()[0];
+            s.apply_fields(|s| func(s, rhs)).into_series()
+        }
+        (1, _) => {
+            let s = &s.fields()[0];
+            rhs.apply_fields(|rhs| func(s, rhs)).into_series()
+        }
+        _ => {
+            let mut rhs_iter = rhs.fields().iter();
+
+            s.apply_fields(|s| match rhs_iter.next() {
+                Some(rhs) => func(s, rhs),
+                None => s.clone(),
+            })
+            .into_series()
+        }
+    }
+}
+
 impl ops::Sub for &Series {
     type Output = Series;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-        lhs.subtract(rhs.as_ref()).expect("data types don't match")
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                struct_arithmetic(self, rhs, |a, b| a.sub(b))
+            }
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
+                lhs.subtract(rhs.as_ref()).expect("data types don't match")
+            }
+        }
     }
 }
 
@@ -409,8 +448,16 @@ impl ops::Add for &Series {
     type Output = Series;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-        lhs.add_to(rhs.as_ref()).expect("data types don't match")
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                struct_arithmetic(self, rhs, |a, b| a.add(b))
+            }
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
+                lhs.add_to(rhs.as_ref()).expect("data types don't match")
+            }
+        }
     }
 }
 
@@ -423,8 +470,16 @@ impl ops::Mul for &Series {
     /// let out = &s * &s;
     /// ```
     fn mul(self, rhs: Self) -> Self::Output {
-        let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-        lhs.multiply(rhs.as_ref()).expect("data types don't match")
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                struct_arithmetic(self, rhs, |a, b| a.mul(b))
+            }
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
+                lhs.multiply(rhs.as_ref()).expect("data types don't match")
+            }
+        }
     }
 }
 
@@ -437,8 +492,16 @@ impl ops::Div for &Series {
     /// let out = &s / &s;
     /// ```
     fn div(self, rhs: Self) -> Self::Output {
-        let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-        lhs.divide(rhs.as_ref()).expect("data types don't match")
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                struct_arithmetic(self, rhs, |a, b| a.div(b))
+            }
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
+                lhs.divide(rhs.as_ref()).expect("data types don't match")
+            }
+        }
     }
 }
 
@@ -451,8 +514,16 @@ impl ops::Rem for &Series {
     /// let out = &s / &s;
     /// ```
     fn rem(self, rhs: Self) -> Self::Output {
-        let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-        lhs.remainder(rhs.as_ref()).expect("data types don't match")
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                struct_arithmetic(self, rhs, |a, b| a.rem(b))
+            }
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
+                lhs.remainder(rhs.as_ref()).expect("data types don't match")
+            }
+        }
     }
 }
 

--- a/polars/polars-core/src/series/arithmetic/owned.rs
+++ b/polars/polars-core/src/series/arithmetic/owned.rs
@@ -43,7 +43,10 @@ macro_rules! impl_operation {
                 #[cfg(feature = "performant")]
                 {
                     // only physical numeric values take the mutable path
-                    if !self.is_logical() && self.is_numeric_physical() {
+                    if !self.dtype().is_logical()
+                        && self.dtype().to_physical().is_numeric()
+                        && rhs.dtype().to_physical().is_numeric()
+                    {
                         let (lhs, rhs) = coerce_lhs_rhs_owned(self, rhs).unwrap();
                         let (lhs, rhs) = align_chunks_binary_owned_series(lhs, rhs);
                         use DataType::*;

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -781,25 +781,6 @@ impl Series {
         }
     }
 
-    /// Check if the underlying data is a logical type.
-    pub fn is_logical(&self) -> bool {
-        self.dtype().is_logical()
-    }
-
-    /// Check if underlying physical data is numeric.
-    ///
-    /// Date types and Categoricals are also considered numeric.
-    pub fn is_numeric_physical(&self) -> bool {
-        // allow because it cannot be replaced when object feature is activated
-        #[allow(clippy::match_like_matches_macro)]
-        match self.dtype() {
-            DataType::Utf8 | DataType::List(_) | DataType::Boolean | DataType::Null => false,
-            #[cfg(feature = "object")]
-            DataType::Object(_) => false,
-            _ => true,
-        }
-    }
-
     #[cfg(feature = "abs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "abs")))]
     /// convert numerical values to their absolute value

--- a/polars/polars-core/src/utils/supertype.rs
+++ b/polars/polars-core/src/utils/supertype.rs
@@ -270,6 +270,15 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
                     Some(Struct(new_fields))
                 }
             }
+            #[cfg(feature = "dtype-struct")]
+            (Struct(fields_a), rhs) if rhs.is_numeric() => {
+                let mut new_fields = Vec::with_capacity(fields_a.len());
+                for a in fields_a {
+                    let st = get_supertype(&a.dtype, rhs)?;
+                    new_fields.push(Field::new(&a.name, st))
+                }
+                Some(Struct(new_fields))
+            }
             _ => None,
         }
     }

--- a/polars/polars-ops/src/series/ops/search_sorted.rs
+++ b/polars/polars-ops/src/series/ops/search_sorted.rs
@@ -47,7 +47,7 @@ where
 }
 
 pub fn search_sorted(s: &Series, search_value: &AnyValue) -> PolarsResult<IdxSize> {
-    if s.is_logical() {
+    if s.dtype().is_logical() {
         let search_dtype: DataType = search_value.into();
         if &search_dtype != s.dtype() {
             return Err(PolarsError::ComputeError(

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -17,3 +17,33 @@ def test_sqrt_neg_inf() -> None:
 
 def test_arithmetic_with_logical_on_series_4920() -> None:
     assert (pl.Series([date(2022, 6, 3)]) - date(2022, 1, 1)).dtype == pl.Duration("ms")
+
+
+def test_struct_arithmetic() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [3, 4],
+            "c": [5, 6],
+        }
+    ).select(pl.cumsum(["a", "c"]))
+    assert df.select(pl.col("cumsum") * 2).to_dict(False) == {
+        "cumsum": [{"a": 2, "c": 12}, {"a": 4, "c": 16}]
+    }
+    assert df.select(pl.col("cumsum") - 2).to_dict(False) == {
+        "cumsum": [{"a": -1, "c": 4}, {"a": 0, "c": 6}]
+    }
+    assert df.select(pl.col("cumsum") + 2).to_dict(False) == {
+        "cumsum": [{"a": 3, "c": 8}, {"a": 4, "c": 10}]
+    }
+    assert df.select(pl.col("cumsum") / 2).to_dict(False) == {
+        "cumsum": [{"a": 0.5, "c": 3.0}, {"a": 1.0, "c": 4.0}]
+    }
+    assert df.select(pl.col("cumsum") // 2).to_dict(False) == {
+        "cumsum": [{"a": 0, "c": 3}, {"a": 1, "c": 4}]
+    }
+
+    # inline, this check cumsum reports the right output type
+    assert pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}).select(
+        pl.cumsum(["a", "c"]) * 3
+    ).to_dict(False) == {"cumsum": [{"a": 3, "c": 18}, {"a": 6, "c": 24}]}


### PR DESCRIPTION

```python
pl.DataFrame(
    {
        "a": [1, 2],
        "b": [3, 4],
        "c": [5, 6],
}).select(pl.cumsum(["a", "c"]) * 3)

```

```
shape: (2, 1)
┌───────────┐
│ cumsum    │
│ ---       │
│ struct[2] │
╞═══════════╡
│ {3,18}    │
├╌╌╌╌╌╌╌╌╌╌╌┤
│ {6,24}    │
└───────────┘

```