### PR TITLE
feat(rust, python): hybrid streaming query engine

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -91,7 +91,7 @@ dtype-i8 = []
 dtype-i16 = []
 dtype-u8 = []
 dtype-u16 = []
-dtype-categorical = ["smartstring"]
+dtype-categorical = []
 dtype-struct = []
 dtype-binary = []
 
@@ -170,7 +170,7 @@ regex = { version = "1.6", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-smartstring = { version = "1", optional = true }
+smartstring = { version = "1" }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -162,6 +162,10 @@ impl DataType {
         matches!(self, DataType::Float32 | DataType::Float64)
     }
 
+    pub fn is_integer(&self) -> bool {
+        self.is_numeric() && !matches!(self, DataType::Float32 | DataType::Float64)
+    }
+
     pub fn is_signed(&self) -> bool {
         // allow because it cannot be replaced when object feature is activated
         #[allow(clippy::match_like_matches_macro)]

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -306,7 +306,7 @@ pub enum AnyValue<'a> {
     #[cfg(feature = "dtype-struct")]
     StructOwned(Box<(Vec<AnyValue<'a>>, Vec<Field>)>),
     /// A UTF8 encoded string type.
-    Utf8Owned(String),
+    Utf8Owned(smartstring::alias::String),
     #[cfg(feature = "dtype-binary")]
     Binary(&'a [u8]),
     #[cfg(feature = "dtype-binary")]
@@ -337,7 +337,7 @@ impl Serialize for AnyValue<'_> {
             // both utf8 variants same number
             AnyValue::Utf8(v) => serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v),
             AnyValue::Utf8Owned(v) => {
-                serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v)
+                serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v.as_str())
             }
             #[cfg(feature = "dtype-binary")]
             AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v),
@@ -544,8 +544,8 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                         AnyValue::List(value)
                     }
                     (AvField::Utf8Owned, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Utf8Owned(value)
+                        let value: String = variant.newtype_variant()?;
+                        AnyValue::Utf8Owned(value.into())
                     }
                     #[cfg(feature = "dtype-binary")]
                     (AvField::BinaryOwned, variant) => {
@@ -775,7 +775,7 @@ impl<'a> AnyValue<'a> {
             #[cfg(feature = "dtype-time")]
             Time(v) => AnyValue::Time(v),
             List(v) => AnyValue::List(v),
-            Utf8(v) => AnyValue::Utf8Owned(v.to_string()),
+            Utf8(v) => AnyValue::Utf8Owned(v.into()),
             Utf8Owned(v) => AnyValue::Utf8Owned(v),
             #[cfg(feature = "dtype-binary")]
             Binary(v) => AnyValue::BinaryOwned(v.to_vec()),

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -745,6 +745,7 @@ impl<'a> AnyValue<'a> {
     #[inline]
     pub fn as_borrowed(&self) -> AnyValue<'_> {
         match self {
+            #[cfg(feature = "dtype-binary")]
             AnyValue::BinaryOwned(data) => AnyValue::Binary(data),
             AnyValue::Utf8Owned(data) => AnyValue::Utf8(data),
             av => av.clone(),

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -564,6 +564,7 @@ impl<'a> AnyValue<'a> {
     /// Extract a numerical value from the AnyValue
     #[doc(hidden)]
     #[cfg(feature = "private")]
+    #[inline]
     pub fn extract<T: NumCast>(&self) -> Option<T> {
         use AnyValue::*;
         match self {

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -39,7 +39,7 @@ where
     let group_size_hint = 0;
 
     if multithreaded && group_multithreaded(ca) {
-        let n_partitions = set_partition_size() as u64;
+        let n_partitions = _set_partition_size() as u64;
 
         // use the arrays as iterators
         if ca.chunks.len() == 1 {
@@ -240,7 +240,7 @@ impl IntoGroupsProxy for Utf8Chunked {
         let null_h = get_null_hash_value(hb.clone());
 
         let out = if multithreaded {
-            let n_partitions = set_partition_size();
+            let n_partitions = _set_partition_size();
 
             let split = _split_offsets(self.len(), n_partitions);
 
@@ -293,7 +293,7 @@ impl IntoGroupsProxy for BinaryChunked {
         let null_h = get_null_hash_value(hb.clone());
 
         let out = if multithreaded {
-            let n_partitions = set_partition_size();
+            let n_partitions = _set_partition_size();
 
             let split = _split_offsets(self.len(), n_partitions);
 
@@ -376,7 +376,7 @@ impl IntoGroupsProxy for ListChunked {
             };
 
             if multithreaded {
-                let n_partitions = set_partition_size();
+                let n_partitions = _set_partition_size();
                 let split = _split_offsets(self.len(), n_partitions);
 
                 let groups: PolarsResult<_> = POOL.install(|| {

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 
 use self::hashing::*;
 use crate::prelude::*;
-use crate::utils::{_split_offsets, accumulate_dataframes_vertical, set_partition_size};
+use crate::utils::{_split_offsets, accumulate_dataframes_vertical, _set_partition_size};
 use crate::vector_hasher::{get_null_hash_value, AsU64, BytesHash};
 use crate::POOL;
 
@@ -61,7 +61,7 @@ impl DataFrame {
 
         macro_rules! finish_packed_bit_path {
             ($ca0:expr, $ca1:expr, $pack_fn:expr) => {{
-                let n_partitions = set_partition_size();
+                let n_partitions = _set_partition_size();
 
                 // we split so that we can prepare the data over multiple threads.
                 // pack the bit values together and add a final byte that will be 0
@@ -100,7 +100,7 @@ impl DataFrame {
             ));
         };
 
-        let n_partitions = set_partition_size();
+        let n_partitions = _set_partition_size();
 
         let groups = match by.len() {
             1 => {

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -879,9 +879,9 @@ impl<'df> GroupBy<'df> {
     }
 
     /// Apply a closure over the groups as a new DataFrame.
-    pub fn apply<F>(&self, f: F) -> PolarsResult<DataFrame>
+    pub fn apply<F>(&self, mut f: F) -> PolarsResult<DataFrame>
     where
-        F: Fn(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
+        F: FnMut(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
     {
         let df = self.prepare_apply()?;
         let dfs = self

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 
 use self::hashing::*;
 use crate::prelude::*;
-use crate::utils::{_split_offsets, accumulate_dataframes_vertical, _set_partition_size};
+use crate::utils::{_set_partition_size, _split_offsets, accumulate_dataframes_vertical};
 use crate::vector_hasher::{get_null_hash_value, AsU64, BytesHash};
 use crate::POOL;
 

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -45,7 +45,7 @@ use crate::frame::hash_join::multiple_keys::{
 use crate::frame::hash_join::multiple_keys::{left_anti_multiple_keys, left_semi_multiple_keys};
 use crate::prelude::*;
 use crate::utils::series::to_physical_and_bit_repr;
-use crate::utils::{set_partition_size, slice_slice, split_ca};
+use crate::utils::{_set_partition_size, slice_slice, split_ca};
 use crate::vector_hasher::{
     create_hash_and_keys_threaded_vectorized, prepare_hashed_relation_threaded, this_partition,
     AsU64, BytesHash,

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -9,7 +9,7 @@ use crate::frame::hash_join::{
 };
 use crate::prelude::*;
 use crate::utils::series::to_physical_and_bit_repr;
-use crate::utils::{set_partition_size, split_df};
+use crate::utils::{_set_partition_size, split_df};
 use crate::vector_hasher::{df_rows_to_hashes_threaded, this_partition, IdBuildHasher, IdxHash};
 use crate::POOL;
 
@@ -33,7 +33,7 @@ pub(crate) fn create_probe_table(
     hashes: &[UInt64Chunked],
     keys: &DataFrame,
 ) -> Vec<HashMap<IdxHash, Vec<IdxSize>, IdBuildHasher>> {
-    let n_partitions = set_partition_size();
+    let n_partitions = _set_partition_size();
 
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
@@ -82,7 +82,7 @@ fn create_build_table_outer(
 ) -> Vec<HashMap<IdxHash, (bool, Vec<IdxSize>), IdBuildHasher>> {
     // Outer join equivalent of create_build_table() adds a bool in the hashmap values for tracking
     // whether a value in the hash table has already been matched to a value in the probe hashes.
-    let n_partitions = set_partition_size();
+    let n_partitions = _set_partition_size();
 
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
@@ -343,7 +343,7 @@ pub(crate) fn create_build_table_semi_anti(
     hashes: &[UInt64Chunked],
     keys: &DataFrame,
 ) -> Vec<HashMap<IdxHash, (), IdBuildHasher>> {
-    let n_partitions = set_partition_size();
+    let n_partitions = _set_partition_size();
 
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.

--- a/polars/polars-core/src/frame/hash_join/single_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys.rs
@@ -7,7 +7,7 @@ where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
     IntoSlice: AsRef<[T]> + Send + Sync,
 {
-    let n_partitions = set_partition_size();
+    let n_partitions = _set_partition_size();
 
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.

--- a/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
@@ -288,7 +288,7 @@ where
     fn hash_join_outer(&self, other: &ChunkedArray<T>) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
-        let n_partitions = set_partition_size();
+        let n_partitions = _set_partition_size();
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 
@@ -402,7 +402,7 @@ impl Utf8Chunked {
     fn hash_join_outer(&self, other: &Utf8Chunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
-        let n_partitions = set_partition_size();
+        let n_partitions = _set_partition_size();
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 
@@ -518,7 +518,7 @@ impl BinaryChunked {
     fn hash_join_outer(&self, other: &BinaryChunked) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
 
-        let n_partitions = set_partition_size();
+        let n_partitions = _set_partition_size();
         let splitted_a = split_ca(a, n_partitions).unwrap();
         let splitted_b = split_ca(b, n_partitions).unwrap();
 

--- a/polars/polars-core/src/frame/hash_join/single_keys_semi_anti.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_semi_anti.rs
@@ -6,7 +6,7 @@ where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
     IntoSlice: AsRef<[T]> + Send + Sync,
 {
-    let n_partitions = set_partition_size();
+    let n_partitions = _set_partition_size();
 
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -357,7 +357,7 @@ impl From<&Row<'_>> for Schema {
     }
 }
 
-pub(crate) enum AnyValueBuffer<'a> {
+pub enum AnyValueBuffer<'a> {
     Boolean(BooleanChunkedBuilder),
     Int32(PrimitiveChunkedBuilder<Int32Type>),
     Int64(PrimitiveChunkedBuilder<Int64Type>),
@@ -380,7 +380,8 @@ pub(crate) enum AnyValueBuffer<'a> {
 }
 
 impl<'a> AnyValueBuffer<'a> {
-    pub(crate) fn add(&mut self, val: AnyValue<'a>) -> Option<()> {
+    #[inline]
+    pub fn add(&mut self, val: AnyValue<'a>) -> Option<()> {
         use AnyValueBuffer::*;
         match (self, val) {
             (Boolean(builder), AnyValue::Boolean(v)) => builder.append_value(v),
@@ -437,7 +438,7 @@ impl<'a> AnyValueBuffer<'a> {
         })
     }
 
-    pub(crate) fn into_series(self) -> Series {
+    pub fn into_series(self) -> Series {
         use AnyValueBuffer::*;
         match self {
             Boolean(b) => b.finish().into_series(),
@@ -456,6 +457,10 @@ impl<'a> AnyValueBuffer<'a> {
             Utf8(b) => b.finish().into_series(),
             All(dtype, vals) => Series::from_any_values_and_dtype("", &vals, &dtype).unwrap(),
         }
+    }
+
+    pub fn new(dtype: &DataType, capacity: usize) -> AnyValueBuffer<'_> {
+        (dtype, capacity).into()
     }
 }
 

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -114,6 +114,11 @@ impl Schema {
         self.inner.get(name)
     }
 
+    pub fn try_get(&self, name: &str) -> PolarsResult<&DataType> {
+        self.get(name)
+            .ok_or_else(|| PolarsError::NotFound(name.to_string().into()))
+    }
+
     pub fn get_full(&self, name: &str) -> Option<(usize, &String, &DataType)> {
         self.inner.get_full(name)
     }

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -48,8 +48,9 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -50,8 +50,9 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -92,8 +92,9 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.logical().vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.logical().vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -74,8 +74,9 @@ macro_rules! impl_dyn_series {
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-                Ok(self.0.vec_hash(random_state))
+            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+                self.0.vec_hash(random_state, buf);
+                Ok(())
             }
 
             fn vec_hash_combine(

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -73,8 +73,9 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         })
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -77,8 +77,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -74,8 +74,9 @@ macro_rules! impl_dyn_series {
                 (&self.0).into_partial_ord_inner()
             }
 
-            fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-                Ok(self.0.vec_hash(random_state))
+            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+                self.0.vec_hash(random_state, buf);
+                Ok(())
             }
 
             fn vec_hash_combine(

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -131,8 +131,9 @@ macro_rules! impl_dyn_series {
                 (&self.0).into_partial_ord_inner()
             }
 
-            fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-                Ok(self.0.vec_hash(random_state))
+            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+                self.0.vec_hash(random_state, buf);
+                Ok(())
             }
 
             fn vec_hash_combine(

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -43,8 +43,9 @@ where
         (&self.0).into_partial_eq_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -48,8 +48,9 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState) -> PolarsResult<Vec<u64>> {
-        Ok(self.0.vec_hash(random_state))
+    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+        self.0.vec_hash(random_state, buf);
+        Ok(())
     }
 
     fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {

--- a/polars/polars-core/src/series/iterator.rs
+++ b/polars/polars-core/src/series/iterator.rs
@@ -87,6 +87,7 @@ pub struct SeriesIter<'a> {
 impl<'a> Iterator for SeriesIter<'a> {
     type Item = AnyValue<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let idx = self.idx;
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -145,7 +145,9 @@ impl Eq for Wrap<Series> {}
 impl Hash for Wrap<Series> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let rs = RandomState::with_seeds(0, 0, 0, 0);
-        let h = UInt64Chunked::from_vec("", self.0.vec_hash(rs).unwrap()).sum();
+        let mut h = vec![];
+        self.0.vec_hash(rs, &mut h).unwrap();
+        let h = UInt64Chunked::from_vec("", h).sum();
         h.hash(state)
     }
 }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -117,7 +117,7 @@ pub(crate) mod private {
         fn into_partial_ord_inner<'a>(&'a self) -> Box<dyn PartialOrdInner + 'a> {
             invalid_operation_panic!(self)
         }
-        fn vec_hash(&self, _build_hasher: RandomState) -> PolarsResult<Vec<u64>> {
+        fn vec_hash(&self, _build_hasher: RandomState, _buf: &mut Vec<u64>) -> PolarsResult<()> {
             invalid_operation!(self)
         }
         fn vec_hash_combine(

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -329,6 +329,51 @@ macro_rules! with_match_physical_numeric_type {(
     }
 })}
 
+#[macro_export]
+macro_rules! with_match_physical_numeric_polars_type {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    match $key_type {
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        _ => unimplemented!()
+    }
+})}
+
+#[macro_export]
+macro_rules! with_match_physical_integer_polars_type {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+    match $key_type {
+            #[cfg(feature = "dtype-i8")]
+        Int8 => __with_ty__! { Int8Type },
+            #[cfg(feature = "dtype-i16")]
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+            #[cfg(feature = "dtype-u8")]
+        UInt8 => __with_ty__! { UInt8Type },
+            #[cfg(feature = "dtype-u16")]
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        _ => unimplemented!()
+    }
+})}
+
 /// Apply a macro on the Downcasted ChunkedArray's of DataTypes that are logical numerics.
 /// So no logical.
 #[macro_export]

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -26,7 +26,7 @@ impl<T> Deref for Wrap<T> {
     }
 }
 
-pub(crate) fn set_partition_size() -> usize {
+pub fn _set_partition_size() -> usize {
     let mut n_partitions = POOL.current_num_threads();
     // set n_partitions to closes 2^n above the no of threads.
     loop {

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -308,6 +308,27 @@ macro_rules! match_arrow_data_type_apply_macro_ca {
     }};
 }
 
+#[macro_export]
+macro_rules! with_match_physical_numeric_type {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    match $key_type {
+        Int8 => __with_ty__! { i8 },
+        Int16 => __with_ty__! { i16 },
+        Int32 => __with_ty__! { i32 },
+        Int64 => __with_ty__! { i64 },
+        UInt8 => __with_ty__! { u8 },
+        UInt16 => __with_ty__! { u16 },
+        UInt32 => __with_ty__! { u32 },
+        UInt64 => __with_ty__! { u64 },
+        Float32 => __with_ty__! { f32 },
+        Float64 => __with_ty__! { f64 },
+        _ => unimplemented!()
+    }
+})}
+
 /// Apply a macro on the Downcasted ChunkedArray's of DataTypes that are logical numerics.
 /// So no logical.
 #[macro_export]

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -56,7 +56,7 @@ pub(crate) fn get_file_chunks(
     offsets
 }
 
-pub fn get_reader_bytes<R: Read + MmapBytesReader>(
+pub fn get_reader_bytes<R: Read + MmapBytesReader + ?Sized>(
     reader: &mut R,
 ) -> PolarsResult<ReaderBytes<'_>> {
     // we have a file so we can mmap

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -257,7 +257,7 @@ fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {
         Value::Static(StaticNode::U64(u)) => AnyValue::UInt64(*u),
         Value::Static(StaticNode::F64(f)) => AnyValue::Float64(*f),
         Value::Static(StaticNode::Null) => AnyValue::Null,
-        Value::String(s) => AnyValue::Utf8Owned(s.to_string()),
+        Value::String(s) => AnyValue::Utf8Owned(s.as_ref().into()),
         Value::Array(arr) => {
             let vals: Vec<AnyValue> = arr.iter().map(deserialize_all).collect();
 

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -278,6 +278,6 @@ fn deserialize_all<'a, 'b>(json: &'b Value) -> AnyValue<'a> {
             AnyValue::StructOwned(Box::new(vals))
         }
         #[cfg(not(feature = "dtype-struct"))]
-        val => AnyValue::Utf8Owned(format!("{:#?}", val)),
+        val => AnyValue::Utf8Owned(format!("{:#?}", val).into()),
     }
 }

--- a/polars/polars-io/src/parquet/read.rs
+++ b/polars/polars-io/src/parquet/read.rs
@@ -71,7 +71,6 @@ impl<R: MmapBytesReader> ParquetReader<R> {
             aggregate,
             self.parallel,
             self.row_count,
-            self.low_memory,
         )
         .map(|mut df| {
             if rechunk {
@@ -177,7 +176,6 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
             None,
             self.parallel,
             self.row_count,
-            self.low_memory,
         )
         .map(|mut df| {
             if self.rechunk {

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -173,7 +173,7 @@ fn rg_to_dfs_par(
         .iter()
         .enumerate()
         .skip(row_group_start)
-        .take(row_group_start - row_group_end)
+        .take(row_group_end - row_group_start)
         .map(|(rg_idx, rg_md)| {
             let row_count_start = *previous_row_count;
             let num_rows = rg_md.num_rows();

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -240,7 +240,6 @@ pub fn read_parquet<R: MmapBytesReader>(
     aggregate: Option<&[ScanAggregation]>,
     mut parallel: ParallelStrategy,
     row_count: Option<RowCount>,
-    low_memory: bool,
 ) -> PolarsResult<DataFrame> {
     let file_metadata = metadata
         .map(Ok)
@@ -307,11 +306,7 @@ pub fn read_parquet<R: MmapBytesReader>(
     } else {
         let mut df = accumulate_dataframes_vertical(dfs.into_iter())?;
         apply_aggregations(&mut df, aggregate)?;
-        Ok(if low_memory {
-            df._slice_and_realloc(0, limit)
-        } else {
-            df.slice_par(0, limit)
-        })
+        Ok(df)
     }
 }
 

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -17,6 +17,7 @@ polars-arrow = { version = "0.24.3", path = "../polars-arrow" }
 polars-core = { version = "0.24.3", path = "../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.24.3", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
 polars-ops = { version = "0.24.3", path = "../polars-ops", default-features = false }
+polars-pipe = { version = "0.24.3", path = "./polars-pipe" }
 polars-plan = { version = "0.24.3", path = "./polars-plan" }
 polars-time = { version = "0.24.3", path = "../polars-time", optional = true }
 polars-utils = { version = "0.24.3", path = "../polars-utils" }

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -27,10 +27,10 @@ rayon.workspace = true
 [features]
 compile = ["polars-plan/compile"]
 default = ["compile", "private"]
-parquet = ["polars-core/parquet", "polars-io/parquet", "polars-plan/parquet"]
+parquet = ["polars-core/parquet", "polars-io/parquet", "polars-plan/parquet", "polars-pipe/parquet"]
 ipc = ["polars-io/ipc", "polars-plan/ipc"]
 json = ["polars-io/json", "polars-plan/json"]
-csv-file = ["polars-io/csv-file", "polars-plan/csv-file"]
+csv-file = ["polars-io/csv-file", "polars-plan/csv-file", "polars-pipe/csv-file"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time", "dtype-duration", "polars-plan/temporal"]
 # debugging purposes
 fmt = ["polars-core/fmt", "polars-plan/fmt"]

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 polars-core = { version = "0.24.2", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.24.2", path = "../../polars-io", default-features = false }
 polars-plan = { version = "0.24.2", path = "../polars-plan", default-features = false, features = ["compile"] }
+polars-utils = { version = "0.24.2", path = "../../polars-utils"}
 rayon.workspace = true
 
 [features]

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hashbrown.workspace = true
 polars-core = { version = "0.24.2", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.24.2", path = "../../polars-io", default-features = false }
 polars-plan = { version = "0.24.2", path = "../polars-plan", default-features = false, features = ["compile"] }
-polars-utils = { version = "0.24.2", path = "../../polars-utils"}
+polars-utils = { version = "0.24.2", path = "../../polars-utils" }
 rayon.workspace = true
 
 [features]

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 hashbrown.workspace = true
+num.wokspace = true
 polars-core = { version = "0.24.2", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.24.2", path = "../../polars-io", default-features = false }
 polars-plan = { version = "0.24.2", path = "../polars-plan", default-features = false, features = ["compile"] }

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -16,3 +16,4 @@ rayon.workspace = true
 
 [features]
 csv-file = ["polars-plan/csv-file", "polars-io/csv-file"]
+parquet = ["polars-plan/parquet", "polars-io/parquet"]

--- a/polars/polars-lazy/polars-pipe/src/executors/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/mod.rs
@@ -1,2 +1,5 @@
-mod sources;
+pub(crate) mod operators;
+pub(crate) mod sinks;
+pub(crate) mod sources;
+
 use crate::operators::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
@@ -15,7 +15,9 @@ impl Operator for FilterOperator {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-        let s = self.predicate.evaluate(chunk, &context.execution_state)?;
+        let s = self
+            .predicate
+            .evaluate(chunk, context.execution_state.as_ref())?;
         let mask = s.bool().map_err(|e| {
             PolarsError::ComputeError(
                 format!("Filter predicate must be of type Boolean, got: {:?}", e).into(),

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
@@ -22,7 +22,7 @@ impl Operator for FilterOperator {
             )
         })?;
         // TODO! filter sequentially?
-        let df = chunk.data.filter(&mask)?;
+        let df = chunk.data.filter(mask)?;
 
         Ok(OperatorResult::Finished(chunk.with_data(df)))
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
+
 use polars_core::error::{PolarsError, PolarsResult};
+
 use crate::expressions::PhysicalPipedExpr;
 use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
 
 pub(crate) struct FilterOperator {
-    pub(crate) predicate: Arc<dyn PhysicalPipedExpr>
+    pub(crate) predicate: Arc<dyn PhysicalPipedExpr>,
 }
 
 impl Operator for FilterOperator {
@@ -13,7 +15,6 @@ impl Operator for FilterOperator {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-
         let s = self.predicate.evaluate(chunk, &context.execution_state)?;
         let mask = s.bool().map_err(|e| {
             PolarsError::ComputeError(

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/filter.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+use polars_core::error::{PolarsError, PolarsResult};
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
+
+pub(crate) struct FilterOperator {
+    pub(crate) predicate: Arc<dyn PhysicalPipedExpr>
+}
+
+impl Operator for FilterOperator {
+    fn execute(
+        &self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<OperatorResult> {
+
+        let s = self.predicate.evaluate(chunk, &context.execution_state)?;
+        let mask = s.bool().map_err(|e| {
+            PolarsError::ComputeError(
+                format!("Filter predicate must be of type Boolean, got: {:?}", e).into(),
+            )
+        })?;
+        // TODO! filter sequentially?
+        let df = chunk.data.filter(&mask)?;
+
+        Ok(OperatorResult::Finished(chunk.with_data(df)))
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
@@ -1,5 +1,5 @@
-mod projection;
 mod filter;
+mod projection;
 
-pub(crate) use projection::*;
 pub(crate) use filter::*;
+pub(crate) use projection::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
@@ -1,3 +1,5 @@
 mod projection;
+mod filter;
 
 pub(crate) use projection::*;
+pub(crate) use filter::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/mod.rs
@@ -1,0 +1,3 @@
+mod projection;
+
+pub(crate) use projection::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use polars_core::error::PolarsResult;
+use polars_core::frame::DataFrame;
+
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
+
+pub(crate) struct FastProjectionOperator {
+    pub(crate) columns: Arc<Vec<Arc<str>>>,
+}
+
+impl Operator for FastProjectionOperator {
+    fn execute(
+        &self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<OperatorResult> {
+        let chunk = chunk.with_data(chunk.data.select(self.columns.as_slice())?);
+        Ok(OperatorResult::Finished(chunk))
+    }
+}
+
+pub(crate) struct ProjectionOperator {
+    pub(crate) exprs: Vec<Arc<dyn PhysicalPipedExpr>>,
+}
+
+impl Operator for ProjectionOperator {
+    fn execute(
+        &self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<OperatorResult> {
+        let projected = self
+            .exprs
+            .iter()
+            .map(|e| e.evaluate(&chunk, context.execution_state.as_ref()))
+            .collect::<PolarsResult<Vec<_>>>()?;
+
+        let chunk = chunk.with_data(DataFrame::new_no_checks(projected));
+        Ok(OperatorResult::Finished(chunk))
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
@@ -13,7 +13,7 @@ pub(crate) struct FastProjectionOperator {
 impl Operator for FastProjectionOperator {
     fn execute(
         &self,
-        context: &PExecutionContext,
+        _context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
         let chunk = chunk.with_data(chunk.data.select(self.columns.as_slice())?);
@@ -34,7 +34,7 @@ impl Operator for ProjectionOperator {
         let projected = self
             .exprs
             .iter()
-            .map(|e| e.evaluate(&chunk, context.execution_state.as_ref()))
+            .map(|e| e.evaluate(chunk, context.execution_state.as_ref()))
             .collect::<PolarsResult<Vec<_>>>()?;
 
         let chunk = chunk.with_data(DataFrame::new_no_checks(projected));

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -50,7 +50,7 @@ pub fn can_convert_to_hash_agg(mut node: Node, expr_arena: &Arena<AExpr>) -> boo
             }
             ae
         })
-        .filter(|ae| matches!(ae, AExpr::Agg(_)))
+        .filter(|ae| matches!(ae, AExpr::Agg(_) | AExpr::Count))
         .count()
         == 1
         && can_run_partitioned
@@ -64,7 +64,11 @@ pub fn can_convert_to_hash_agg(mut node: Node, expr_arena: &Arena<AExpr>) -> boo
             AExpr::Agg(agg_fn) => {
                 matches!(
                     agg_fn,
-                    AAggExpr::Sum(_) | AAggExpr::First(_) | AAggExpr::Last(_) | AAggExpr::Mean(_)
+                    AAggExpr::Sum(_)
+                        | AAggExpr::First(_)
+                        | AAggExpr::Last(_)
+                        | AAggExpr::Mean(_)
+                        | AAggExpr::Count(_)
                 )
             }
             _ => false,

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -1,55 +1,84 @@
+use std::sync::Arc;
+
+use polars_core::error::PolarsResult;
 use polars_core::prelude::DataType;
 use polars_core::schema::Schema;
+use polars_plan::logical_plan::ArenaExprIter;
 use polars_plan::prelude::{AAggExpr, AExpr};
 use polars_utils::arena::{Arena, Node};
 
+use crate::executors::sinks::groupby::aggregates::first::FirstAgg;
 use crate::executors::sinks::groupby::aggregates::{AggregateFn, SumAgg};
+use crate::expressions::PhysicalPipedExpr;
 
 pub fn can_convert_to_hash_agg(node: Node, expr_arena: &Arena<AExpr>) -> bool {
-    match expr_arena.get(node) {
-        AExpr::Agg(agg) => match agg {
-            AAggExpr::Sum(input) => {
-                matches!(expr_arena.get(*input), AExpr::Column(_))
+    let mut agg_fn = None;
+    let mut can_run_partitioned = true;
+    if expr_arena
+        .iter(node)
+        .map(|(_, ae)| {
+            match ae {
+                AExpr::Agg(ae) => agg_fn = Some(ae.clone()),
+                AExpr::Cast { .. }
+                | AExpr::Literal(_)
+                | AExpr::Column(_)
+                | AExpr::BinaryExpr { .. }
+                | AExpr::Ternary { .. }
+                | AExpr::Alias(_, _) => {}
+                _ => {
+                    can_run_partitioned = false;
+                }
             }
+            ae
+        })
+        .filter(|ae| matches!(ae, AExpr::Agg(_)))
+        .count()
+        == 1
+        && can_run_partitioned
+    {
+        match agg_fn.unwrap() {
+            AAggExpr::Sum(_) => true,
+            AAggExpr::First(_) => true,
             _ => false,
-        },
-        _ => false,
+        }
+    } else {
+        false
     }
 }
 
-pub fn convert_to_hash_agg(
+pub fn convert_to_hash_agg<F>(
     node: Node,
     expr_arena: &Arena<AExpr>,
     schema: &Schema,
-) -> Option<(usize, Box<dyn AggregateFn>)> {
+    to_physical: &F,
+) -> (Arc<dyn PhysicalPipedExpr>, Box<dyn AggregateFn>)
+where
+    F: Fn(Node, &Arena<AExpr>) -> PolarsResult<Arc<dyn PhysicalPipedExpr>>,
+{
     match expr_arena.get(node) {
+        AExpr::Alias(input, _) => convert_to_hash_agg(*input, expr_arena, schema, to_physical),
         AExpr::Agg(agg) => match agg {
             AAggExpr::Sum(input) => {
-                if let AExpr::Column(name) = expr_arena.get(*input) {
-                    let (index, _, dtype) = schema.get_full(name).unwrap();
-                    let agg = match dtype.to_physical() {
-                        DataType::Int64 => {
-                            Some(Box::new(SumAgg::<i64>::new()) as Box<dyn AggregateFn>)
-                        }
-                        DataType::Int32 => {
-                            Some(Box::new(SumAgg::<i32>::new()) as Box<dyn AggregateFn>)
-                        }
-                        DataType::Float32 => {
-                            Some(Box::new(SumAgg::<f32>::new()) as Box<dyn AggregateFn>)
-                        }
-                        DataType::Float64 => {
-                            Some(Box::new(SumAgg::<f64>::new()) as Box<dyn AggregateFn>)
-                        }
-                        _ => None,
-                    }?;
-
-                    Some((index, agg))
-                } else {
-                    None
-                }
+                let phys_expr = to_physical(*input, expr_arena).unwrap();
+                let agg_fn = match phys_expr.field(schema).unwrap().dtype.to_physical() {
+                    DataType::Int64 => Box::new(SumAgg::<i64>::new()) as Box<dyn AggregateFn>,
+                    DataType::Int32 => Box::new(SumAgg::<i32>::new()) as Box<dyn AggregateFn>,
+                    DataType::Float32 => Box::new(SumAgg::<f32>::new()) as Box<dyn AggregateFn>,
+                    DataType::Float64 => Box::new(SumAgg::<f64>::new()) as Box<dyn AggregateFn>,
+                    _ => todo!(),
+                };
+                (phys_expr, agg_fn)
             }
-            _ => None,
+            AAggExpr::First(input) => {
+                let phys_expr = to_physical(*input, expr_arena).unwrap();
+                let dtype = phys_expr.field(schema).unwrap().dtype;
+                (
+                    phys_expr,
+                    Box::new(FirstAgg::new(dtype)) as Box<dyn AggregateFn>,
+                )
+            }
+            _ => todo!(),
         },
-        _ => None,
+        _ => todo!(),
     }
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -1,0 +1,32 @@
+use polars_core::prelude::DataType;
+use polars_core::schema::Schema;
+use polars_plan::prelude::{AAggExpr, AExpr};
+use polars_utils::arena::{Arena, Node};
+use crate::executors::sinks::groupby::aggregates::{AggregateFn, SumAgg};
+
+pub fn convert_to_hash_agg(node: Node, expr_arena: &Arena<AExpr>, schema: &Schema) -> Option<(usize, Box<dyn AggregateFn>)> {
+    match expr_arena.get(node) {
+        AExpr::Agg(agg) => {
+            match agg {
+                AAggExpr::Sum(input) => {
+                    if let AExpr::Column(name) = expr_arena.get(*input) {
+                        let (index, _, dtype) = schema.get_full(name).unwrap();
+                        let agg = match dtype.to_physical() {
+                            DataType::Int64 => Some(Box::new(SumAgg::<i64>::new()) as Box<dyn AggregateFn>),
+                            DataType::Int32 => Some(Box::new(SumAgg::<i32>::new())as Box<dyn AggregateFn>),
+                            DataType::Float32 => Some(Box::new(SumAgg::<f32>::new())as Box<dyn AggregateFn>),
+                            DataType::Float64 => Some(Box::new(SumAgg::<f64>::new())as Box<dyn AggregateFn>),
+                            _ => None
+                        }?;
+
+                        Some((index, agg))
+                    } else {
+                        None
+                    }
+                },
+                _ => None
+            }
+        },
+        _ => None
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -2,31 +2,54 @@ use polars_core::prelude::DataType;
 use polars_core::schema::Schema;
 use polars_plan::prelude::{AAggExpr, AExpr};
 use polars_utils::arena::{Arena, Node};
+
 use crate::executors::sinks::groupby::aggregates::{AggregateFn, SumAgg};
 
-pub fn convert_to_hash_agg(node: Node, expr_arena: &Arena<AExpr>, schema: &Schema) -> Option<(usize, Box<dyn AggregateFn>)> {
+pub fn can_convert_to_hash_agg(node: Node, expr_arena: &Arena<AExpr>) -> bool {
     match expr_arena.get(node) {
-        AExpr::Agg(agg) => {
-            match agg {
-                AAggExpr::Sum(input) => {
-                    if let AExpr::Column(name) = expr_arena.get(*input) {
-                        let (index, _, dtype) = schema.get_full(name).unwrap();
-                        let agg = match dtype.to_physical() {
-                            DataType::Int64 => Some(Box::new(SumAgg::<i64>::new()) as Box<dyn AggregateFn>),
-                            DataType::Int32 => Some(Box::new(SumAgg::<i32>::new())as Box<dyn AggregateFn>),
-                            DataType::Float32 => Some(Box::new(SumAgg::<f32>::new())as Box<dyn AggregateFn>),
-                            DataType::Float64 => Some(Box::new(SumAgg::<f64>::new())as Box<dyn AggregateFn>),
-                            _ => None
-                        }?;
-
-                        Some((index, agg))
-                    } else {
-                        None
-                    }
-                },
-                _ => None
+        AExpr::Agg(agg) => match agg {
+            AAggExpr::Sum(input) => {
+                matches!(expr_arena.get(*input), AExpr::Column(_))
             }
+            _ => false,
         },
-        _ => None
+        _ => false,
+    }
+}
+
+pub fn convert_to_hash_agg(
+    node: Node,
+    expr_arena: &Arena<AExpr>,
+    schema: &Schema,
+) -> Option<(usize, Box<dyn AggregateFn>)> {
+    match expr_arena.get(node) {
+        AExpr::Agg(agg) => match agg {
+            AAggExpr::Sum(input) => {
+                if let AExpr::Column(name) = expr_arena.get(*input) {
+                    let (index, _, dtype) = schema.get_full(name).unwrap();
+                    let agg = match dtype.to_physical() {
+                        DataType::Int64 => {
+                            Some(Box::new(SumAgg::<i64>::new()) as Box<dyn AggregateFn>)
+                        }
+                        DataType::Int32 => {
+                            Some(Box::new(SumAgg::<i32>::new()) as Box<dyn AggregateFn>)
+                        }
+                        DataType::Float32 => {
+                            Some(Box::new(SumAgg::<f32>::new()) as Box<dyn AggregateFn>)
+                        }
+                        DataType::Float64 => {
+                            Some(Box::new(SumAgg::<f64>::new()) as Box<dyn AggregateFn>)
+                        }
+                        _ => None,
+                    }?;
+
+                    Some((index, agg))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        },
+        _ => None,
     }
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/count.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/count.rs
@@ -1,0 +1,44 @@
+use std::any::Any;
+
+use polars_core::datatypes::{AnyValue, DataType};
+use polars_core::prelude::IDX_DTYPE;
+use polars_utils::unwrap::UnwrapUncheckedRelease;
+
+use super::*;
+use crate::operators::IdxSize;
+
+pub struct CountAgg {
+    count: IdxSize,
+}
+
+impl CountAgg {
+    pub(crate) fn new() -> Self {
+        CountAgg { count: 0 }
+    }
+}
+
+impl AggregateFn for CountAgg {
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, _item: &mut dyn ExactSizeIterator<Item = AnyValue>) {
+        self.count += 1;
+    }
+
+    fn dtype(&self) -> DataType {
+        IDX_DTYPE
+    }
+
+    fn combine(&mut self, other: &dyn Any) {
+        let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
+        self.count += other.count;
+    }
+
+    fn split(&self) -> Box<dyn AggregateFn> {
+        Box::new(Self::new())
+    }
+
+    fn finalize(&mut self) -> AnyValue<'static> {
+        AnyValue::from(self.count)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
-use polars_utils::debug_unwrap;
+use polars_utils::unwrap::UnwrapUncheckedRelease;
 
 use crate::executors::sinks::groupby::aggregates::AggregateFn;
 use crate::operators::IdxSize;
@@ -36,7 +36,7 @@ impl AggregateFn for FirstAgg {
     }
 
     fn combine(&mut self, other: &dyn Any) {
-        let other = unsafe { debug_unwrap(other.downcast_ref::<Self>()) };
+        let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
         if other.first.is_some() && other.chunk_idx < self.chunk_idx {
             self.first = other.first.clone();
             self.chunk_idx = other.chunk_idx;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
@@ -1,0 +1,52 @@
+use std::any::Any;
+
+use polars_core::datatypes::DataType;
+use polars_core::prelude::AnyValue;
+use polars_utils::debug_unwrap;
+
+use crate::executors::sinks::groupby::aggregates::AggregateFn;
+use crate::operators::IdxSize;
+
+pub struct FirstAgg {
+    chunk_idx: IdxSize,
+    first: Option<AnyValue<'static>>,
+    dtype: DataType,
+}
+
+impl FirstAgg {
+    pub(crate) fn new(dtype: DataType) -> Self {
+        Self {
+            chunk_idx: 0,
+            first: None,
+            dtype,
+        }
+    }
+}
+
+impl AggregateFn for FirstAgg {
+    fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue) {
+        if self.first.is_none() {
+            self.chunk_idx = chunk_idx;
+            self.first = Some(item.into_static().unwrap())
+        }
+    }
+
+    fn dtype(&self) -> DataType {
+        self.dtype.clone()
+    }
+
+    fn combine(&mut self, other: &dyn Any) {
+        let other = unsafe { debug_unwrap(other.downcast_ref::<Self>()) };
+        if other.first.is_some() && other.chunk_idx < self.chunk_idx {
+            self.first = other.first.clone()
+        };
+    }
+
+    fn split(&self) -> Box<dyn AggregateFn> {
+        Box::new(Self::new(self.dtype.clone()))
+    }
+
+    fn finalize(&mut self) -> AnyValue<'static> {
+        std::mem::take(&mut self.first).unwrap_or(AnyValue::Null)
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
@@ -24,7 +24,8 @@ impl FirstAgg {
 }
 
 impl AggregateFn for FirstAgg {
-    fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue) {
+    fn pre_agg(&mut self, chunk_idx: IdxSize, item: &mut dyn ExactSizeIterator<Item = AnyValue>) {
+        let item = unsafe { item.next().unwrap_unchecked_release() };
         if self.first.is_none() {
             self.chunk_idx = chunk_idx;
             self.first = Some(item.into_static().unwrap())

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/first.rs
@@ -7,6 +7,7 @@ use polars_utils::debug_unwrap;
 use crate::executors::sinks::groupby::aggregates::AggregateFn;
 use crate::operators::IdxSize;
 
+#[derive(Debug)]
 pub struct FirstAgg {
     chunk_idx: IdxSize,
     first: Option<AnyValue<'static>>,
@@ -48,5 +49,8 @@ impl AggregateFn for FirstAgg {
 
     fn finalize(&mut self) -> AnyValue<'static> {
         std::mem::take(&mut self.first).unwrap_or(AnyValue::Null)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -1,8 +1,10 @@
 use std::any::Any;
+
 use polars_core::prelude::AnyValue;
+
 use crate::operators::IdxSize;
 
-pub trait AggregateFn {
+pub trait AggregateFn: Send {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
 
     fn combine(&mut self, other: &dyn Any);

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 
+use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
 
 use crate::operators::IdxSize;
@@ -7,7 +8,11 @@ use crate::operators::IdxSize;
 pub trait AggregateFn: Send {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
 
+    fn dtype(&self) -> DataType;
+
     fn combine(&mut self, other: &dyn Any);
 
     fn split(&self) -> Box<dyn AggregateFn>;
+
+    fn finalize(&mut self) -> AnyValue<'static>;
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -8,4 +8,6 @@ pub trait AggregateFn: Send {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
 
     fn combine(&mut self, other: &dyn Any);
+
+    fn split(&self) -> Box<dyn AggregateFn>;
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -1,0 +1,9 @@
+use std::any::Any;
+use polars_core::prelude::AnyValue;
+use crate::operators::IdxSize;
+
+pub trait AggregateFn {
+    fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
+
+    fn combine(&mut self, other: &dyn Any);
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -1,12 +1,11 @@
 use std::any::Any;
-use std::fmt::Debug;
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
 
 use crate::operators::IdxSize;
 
-pub trait AggregateFn: Send + Debug {
+pub trait AggregateFn: Send + Sync {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
 
     fn dtype(&self) -> DataType;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -6,7 +6,7 @@ use polars_core::prelude::AnyValue;
 use crate::operators::IdxSize;
 
 pub trait AggregateFn: Send + Sync {
-    fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: &mut dyn ExactSizeIterator<Item = AnyValue>);
 
     fn dtype(&self) -> DataType;
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/interface.rs
@@ -1,11 +1,12 @@
 use std::any::Any;
+use std::fmt::Debug;
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
 
 use crate::operators::IdxSize;
 
-pub trait AggregateFn: Send {
+pub trait AggregateFn: Send + Debug {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue);
 
     fn dtype(&self) -> DataType;
@@ -15,4 +16,6 @@ pub trait AggregateFn: Send {
     fn split(&self) -> Box<dyn AggregateFn>;
 
     fn finalize(&mut self) -> AnyValue<'static>;
+
+    fn as_any(&self) -> &dyn Any;
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
@@ -7,28 +7,26 @@ use polars_utils::debug_unwrap;
 use crate::executors::sinks::groupby::aggregates::AggregateFn;
 use crate::operators::IdxSize;
 
-pub struct FirstAgg {
+pub struct LastAgg {
     chunk_idx: IdxSize,
-    first: Option<AnyValue<'static>>,
+    last: Option<AnyValue<'static>>,
     dtype: DataType,
 }
 
-impl FirstAgg {
+impl LastAgg {
     pub(crate) fn new(dtype: DataType) -> Self {
         Self {
-            chunk_idx: IdxSize::MAX,
-            first: None,
+            chunk_idx: 0,
+            last: None,
             dtype,
         }
     }
 }
 
-impl AggregateFn for FirstAgg {
+impl AggregateFn for LastAgg {
     fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue) {
-        if self.first.is_none() {
-            self.chunk_idx = chunk_idx;
-            self.first = Some(item.into_static().unwrap())
-        }
+        self.chunk_idx = chunk_idx;
+        self.last = Some(item.into_static().unwrap())
     }
 
     fn dtype(&self) -> DataType {
@@ -37,8 +35,8 @@ impl AggregateFn for FirstAgg {
 
     fn combine(&mut self, other: &dyn Any) {
         let other = unsafe { debug_unwrap(other.downcast_ref::<Self>()) };
-        if other.first.is_some() && other.chunk_idx < self.chunk_idx {
-            self.first = other.first.clone();
+        if other.last.is_some() && other.chunk_idx > self.chunk_idx {
+            self.last = other.last.clone();
             self.chunk_idx = other.chunk_idx;
         };
     }
@@ -48,7 +46,7 @@ impl AggregateFn for FirstAgg {
     }
 
     fn finalize(&mut self) -> AnyValue<'static> {
-        std::mem::take(&mut self.first).unwrap_or(AnyValue::Null)
+        std::mem::take(&mut self.last).unwrap_or(AnyValue::Null)
     }
     fn as_any(&self) -> &dyn Any {
         self

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
@@ -24,9 +24,9 @@ impl LastAgg {
 }
 
 impl AggregateFn for LastAgg {
-    fn pre_agg(&mut self, chunk_idx: IdxSize, item: AnyValue) {
-        self.chunk_idx = chunk_idx;
-        self.last = Some(item.into_static().unwrap())
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: &mut dyn ExactSizeIterator<Item = AnyValue>) {
+        let item = unsafe { item.next().unwrap_unchecked_release() };
+        self.last = unsafe { Some(item.into_static().unwrap_unchecked()) };
     }
 
     fn dtype(&self) -> DataType {

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/last.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
-use polars_utils::debug_unwrap;
+use polars_utils::unwrap::UnwrapUncheckedRelease;
 
 use crate::executors::sinks::groupby::aggregates::AggregateFn;
 use crate::operators::IdxSize;
@@ -34,7 +34,7 @@ impl AggregateFn for LastAgg {
     }
 
     fn combine(&mut self, other: &dyn Any) {
-        let other = unsafe { debug_unwrap(other.downcast_ref::<Self>()) };
+        let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
         if other.last.is_some() && other.chunk_idx > self.chunk_idx {
             self.last = other.last.clone();
             self.chunk_idx = other.chunk_idx;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
@@ -25,7 +25,8 @@ impl<K: NumericNative> MeanAgg<K> {
 }
 
 impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for MeanAgg<K> {
-    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: &mut dyn ExactSizeIterator<Item = AnyValue>) {
+        let item = unsafe { item.next().unwrap_unchecked_release() };
         match (item.extract::<K>(), self.sum) {
             (Some(val), Some(sum)) => {
                 self.sum = Some(sum + val);

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
@@ -26,9 +26,16 @@ impl<K: NumericNative> MeanAgg<K> {
 
 impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for MeanAgg<K> {
     fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
-        if let (Some(val), Some(sum)) = (item.extract::<K>(), self.sum) {
-            self.sum = Some(sum + val);
-            self.count += 1;
+        match (item.extract::<K>(), self.sum) {
+            (Some(val), Some(sum)) => {
+                self.sum = Some(sum + val);
+                self.count += 1;
+            }
+            (Some(val), None) => {
+                self.sum = Some(val);
+                self.count += 1;
+            }
+            _ => {}
         }
     }
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
@@ -1,0 +1,78 @@
+use std::any::Any;
+use std::ops::Add;
+
+use polars_core::datatypes::{AnyValue, DataType};
+use polars_core::export::arrow::datatypes::PrimitiveType;
+use polars_core::export::num::NumCast;
+use polars_core::prelude::NumericNative;
+use polars_utils::unwrap::UnwrapUncheckedRelease;
+
+use super::*;
+use crate::operators::{ArrowDataType, IdxSize};
+
+pub struct MeanAgg<K: NumericNative> {
+    sum: Option<K>,
+    count: IdxSize,
+}
+
+impl<K: NumericNative> MeanAgg<K> {
+    pub(crate) fn new() -> Self {
+        MeanAgg {
+            sum: None,
+            count: 0,
+        }
+    }
+}
+
+impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for MeanAgg<K> {
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
+        if let (Some(val), Some(sum)) = (item.extract::<K>(), self.sum) {
+            self.sum = Some(sum + val);
+            self.count += 1;
+        }
+    }
+
+    fn dtype(&self) -> DataType {
+        (&ArrowDataType::from(K::PRIMITIVE)).into()
+    }
+
+    fn combine(&mut self, other: &dyn Any) {
+        let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
+        match (self.sum, other.sum) {
+            (Some(lhs), Some(rhs)) => {
+                self.sum = Some(lhs + rhs);
+                self.count += other.count;
+            }
+            (None, Some(rhs)) => {
+                self.sum = Some(rhs);
+                self.count = other.count;
+            }
+            _ => {}
+        };
+    }
+
+    fn split(&self) -> Box<dyn AggregateFn> {
+        Box::new(Self::new())
+    }
+
+    fn finalize(&mut self) -> AnyValue<'static> {
+        if let Some(val) = self.sum {
+            unsafe {
+                match K::PRIMITIVE {
+                    PrimitiveType::Float32 => AnyValue::Float32(
+                        val.to_f32().unwrap_unchecked_release() / self.count as f32,
+                    ),
+                    PrimitiveType::Float64 => AnyValue::Float64(
+                        val.to_f64().unwrap_unchecked_release() / self.count as f64,
+                    ),
+                    _ => todo!(),
+                }
+            }
+        } else {
+            AnyValue::Null
+        }
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -3,5 +3,5 @@ use interface::*;
 mod interface;
 mod sum;
 
-pub(crate) use sum::SumAgg;
 pub(crate) use interface::AggregateFn;
+pub(crate) use sum::SumAgg;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -1,0 +1,7 @@
+use interface::*;
+
+mod interface;
+mod sum;
+
+pub(crate) use sum::SumAgg;
+pub(crate) use interface::AggregateFn;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -1,4 +1,5 @@
 mod convert;
+mod count;
 mod first;
 mod interface;
 mod last;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -1,8 +1,7 @@
-use interface::*;
-
 mod convert;
 mod first;
 mod interface;
+mod last;
 mod sum;
 
 pub use convert::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -2,6 +2,7 @@ mod convert;
 mod first;
 mod interface;
 mod last;
+mod mean;
 mod sum;
 
 pub use convert::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -1,10 +1,9 @@
 use interface::*;
 
+mod convert;
 mod interface;
 mod sum;
-mod convert;
 
+pub use convert::*;
 pub(crate) use interface::AggregateFn;
 pub(crate) use sum::SumAgg;
-pub(crate) use convert::*;
-

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -1,6 +1,7 @@
 use interface::*;
 
 mod convert;
+mod first;
 mod interface;
 mod sum;
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/mod.rs
@@ -2,6 +2,9 @@ use interface::*;
 
 mod interface;
 mod sum;
+mod convert;
 
 pub(crate) use interface::AggregateFn;
 pub(crate) use sum::SumAgg;
+pub(crate) use convert::*;
+

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -1,33 +1,37 @@
 use std::any::Any;
 use std::ops::{Add, AddAssign};
 
-use polars_core::datatypes::AnyValue;
+use polars_core::datatypes::{AnyValue, DataType};
+use polars_core::export::arrow::datatypes::PrimitiveType;
 use polars_core::export::num::NumCast;
+use polars_core::prelude::NumericNative;
 use polars_core::utils::arrow::types::NativeType;
 use polars_utils::debug_unwrap;
 
 use super::*;
-use crate::operators::IdxSize;
+use crate::operators::{ArrowDataType, IdxSize};
 
-pub struct SumAgg<K: NativeType> {
+pub struct SumAgg<K: NumericNative> {
     sum: Option<K>,
 }
 
-impl<K: NativeType> SumAgg<K> {
+impl<K: NumericNative> SumAgg<K> {
     pub(crate) fn new() -> Self {
-        SumAgg {
-            sum: None
-        }
+        SumAgg { sum: None }
     }
 }
 
-impl<K: NativeType + Add<Output=K> + NumCast> AggregateFn for SumAgg<K> {
+impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for SumAgg<K> {
     fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
         match (item.extract::<K>(), self.sum) {
             (Some(val), Some(sum)) => self.sum = Some(sum + val),
             (Some(val), None) => self.sum = Some(val),
             (None, _) => {}
         }
+    }
+
+    fn dtype(&self) -> DataType {
+        (&ArrowDataType::from(K::PRIMITIVE)).into()
     }
 
     fn combine(&mut self, other: &dyn Any) {
@@ -37,12 +41,32 @@ impl<K: NativeType + Add<Output=K> + NumCast> AggregateFn for SumAgg<K> {
             (Some(lhs), Some(rhs)) => Some(lhs + rhs),
             (Some(lhs), None) => Some(lhs),
             (None, Some(rhs)) => Some(rhs),
-            _ => None
+            (None, None) => None,
         };
         self.sum = sum;
     }
 
     fn split(&self) -> Box<dyn AggregateFn> {
         Box::new(Self::new())
+    }
+
+    fn finalize(&mut self) -> AnyValue<'static> {
+        if let Some(val) = self.sum {
+            match K::PRIMITIVE {
+                PrimitiveType::Int8 => AnyValue::Int8(NumCast::from(val).unwrap()),
+                PrimitiveType::Int16 => AnyValue::Int16(NumCast::from(val).unwrap()),
+                PrimitiveType::Int32 => AnyValue::Int32(NumCast::from(val).unwrap()),
+                PrimitiveType::Int64 => AnyValue::Int64(NumCast::from(val).unwrap()),
+                PrimitiveType::UInt8 => AnyValue::UInt8(NumCast::from(val).unwrap()),
+                PrimitiveType::UInt16 => AnyValue::UInt16(NumCast::from(val).unwrap()),
+                PrimitiveType::UInt32 => AnyValue::UInt32(NumCast::from(val).unwrap()),
+                PrimitiveType::UInt64 => AnyValue::UInt64(NumCast::from(val).unwrap()),
+                PrimitiveType::Float32 => AnyValue::Float32(NumCast::from(val).unwrap()),
+                PrimitiveType::Float64 => AnyValue::Float64(NumCast::from(val).unwrap()),
+                _ => todo!(),
+            }
+        } else {
+            AnyValue::Null
+        }
     }
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::fmt::Debug;
 use std::ops::{Add, AddAssign};
 
 use polars_core::datatypes::{AnyValue, DataType};
@@ -11,6 +12,7 @@ use polars_utils::debug_unwrap;
 use super::*;
 use crate::operators::{ArrowDataType, IdxSize};
 
+#[derive(Debug)]
 pub struct SumAgg<K: NumericNative> {
     sum: Option<K>,
 }
@@ -68,5 +70,8 @@ impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for SumAgg<K> {
         } else {
             AnyValue::Null
         }
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -1,12 +1,13 @@
 use std::any::Any;
 use std::ops::AddAssign;
+
 use polars_core::datatypes::AnyValue;
 use polars_core::export::num::NumCast;
 use polars_core::utils::arrow::types::NativeType;
 use polars_utils::debug_unwrap;
-use crate::operators::IdxSize;
-use super::*;
 
+use super::*;
+use crate::operators::IdxSize;
 
 pub struct SumAgg<K: NativeType> {
     sum: K,

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -1,18 +1,15 @@
 use std::any::Any;
-use std::fmt::Debug;
-use std::ops::{Add, AddAssign};
+use std::ops::Add;
 
 use polars_core::datatypes::{AnyValue, DataType};
 use polars_core::export::arrow::datatypes::PrimitiveType;
 use polars_core::export::num::NumCast;
 use polars_core::prelude::NumericNative;
-use polars_core::utils::arrow::types::NativeType;
 use polars_utils::debug_unwrap;
 
 use super::*;
 use crate::operators::{ArrowDataType, IdxSize};
 
-#[derive(Debug)]
 pub struct SumAgg<K: NumericNative> {
     sum: Option<K>,
 }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -5,7 +5,7 @@ use polars_core::datatypes::{AnyValue, DataType};
 use polars_core::export::arrow::datatypes::PrimitiveType;
 use polars_core::export::num::NumCast;
 use polars_core::prelude::NumericNative;
-use polars_utils::debug_unwrap;
+use polars_utils::unwrap::UnwrapUncheckedRelease;
 
 use super::*;
 use crate::operators::{ArrowDataType, IdxSize};
@@ -34,8 +34,7 @@ impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for SumAgg<K> {
     }
 
     fn combine(&mut self, other: &dyn Any) {
-        let other = other.downcast_ref::<Self>();
-        let other = unsafe { debug_unwrap(other) };
+        let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
         let sum = match (self.sum, other.sum) {
             (Some(lhs), Some(rhs)) => Some(lhs + rhs),
             (Some(lhs), None) => Some(lhs),
@@ -51,18 +50,40 @@ impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for SumAgg<K> {
 
     fn finalize(&mut self) -> AnyValue<'static> {
         if let Some(val) = self.sum {
-            match K::PRIMITIVE {
-                PrimitiveType::Int8 => AnyValue::Int8(NumCast::from(val).unwrap()),
-                PrimitiveType::Int16 => AnyValue::Int16(NumCast::from(val).unwrap()),
-                PrimitiveType::Int32 => AnyValue::Int32(NumCast::from(val).unwrap()),
-                PrimitiveType::Int64 => AnyValue::Int64(NumCast::from(val).unwrap()),
-                PrimitiveType::UInt8 => AnyValue::UInt8(NumCast::from(val).unwrap()),
-                PrimitiveType::UInt16 => AnyValue::UInt16(NumCast::from(val).unwrap()),
-                PrimitiveType::UInt32 => AnyValue::UInt32(NumCast::from(val).unwrap()),
-                PrimitiveType::UInt64 => AnyValue::UInt64(NumCast::from(val).unwrap()),
-                PrimitiveType::Float32 => AnyValue::Float32(NumCast::from(val).unwrap()),
-                PrimitiveType::Float64 => AnyValue::Float64(NumCast::from(val).unwrap()),
-                _ => todo!(),
+            unsafe {
+                match K::PRIMITIVE {
+                    PrimitiveType::Int8 => {
+                        AnyValue::Int8(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::Int16 => {
+                        AnyValue::Int16(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::Int32 => {
+                        AnyValue::Int32(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::Int64 => {
+                        AnyValue::Int64(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::UInt8 => {
+                        AnyValue::UInt8(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::UInt16 => {
+                        AnyValue::UInt16(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::UInt32 => {
+                        AnyValue::UInt32(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::UInt64 => {
+                        AnyValue::UInt64(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::Float32 => {
+                        AnyValue::Float32(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    PrimitiveType::Float64 => {
+                        AnyValue::Float64(NumCast::from(val).unwrap_unchecked_release())
+                    }
+                    _ => todo!(),
+                }
             }
         } else {
             AnyValue::Null

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -1,0 +1,27 @@
+use std::any::Any;
+use std::ops::AddAssign;
+use polars_core::datatypes::AnyValue;
+use polars_core::export::num::NumCast;
+use polars_core::utils::arrow::types::NativeType;
+use polars_utils::debug_unwrap;
+use crate::operators::IdxSize;
+use super::*;
+
+
+pub struct SumAgg<K: NativeType> {
+    sum: K,
+}
+
+impl<K: NativeType + AddAssign + NumCast> AggregateFn for SumAgg<K> {
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
+        let item = item.extract::<K>();
+        let item = unsafe { debug_unwrap(item) };
+        self.sum += item;
+    }
+
+    fn combine(&mut self, other: &dyn Any) {
+        let other = other.downcast_ref::<Self>();
+        let other = unsafe { debug_unwrap(other) };
+        self.sum += other.sum;
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -21,7 +21,8 @@ impl<K: NumericNative> SumAgg<K> {
 }
 
 impl<K: NumericNative + Add<Output = K> + NumCast> AggregateFn for SumAgg<K> {
-    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: AnyValue) {
+    fn pre_agg(&mut self, _chunk_idx: IdxSize, item: &mut dyn ExactSizeIterator<Item = AnyValue>) {
+        let item = unsafe { item.next().unwrap_unchecked_release() };
         match (item.extract::<K>(), self.sum) {
             (Some(val), Some(sum)) => self.sum = Some(sum + val),
             (Some(val), None) => self.sum = Some(val),

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
@@ -208,8 +208,7 @@ impl Sink for GenericGroupbySink {
                 let i = agg_idx as usize + i;
                 let agg_fn = unsafe { current_aggregators.get_unchecked_release_mut(i) };
 
-                let value = unsafe { agg_iter.next().unwrap_unchecked_release() };
-                agg_fn.pre_agg(chunk.chunk_index, value)
+                agg_fn.pre_agg(chunk.chunk_index, agg_iter.as_mut())
             }
         }
         drop(agg_iters);

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
@@ -1,0 +1,371 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use hashbrown::hash_map::RawEntryMut;
+use num::NumCast;
+use polars_core::export::ahash::RandomState;
+use polars_core::frame::row::AnyValueBuffer;
+use polars_core::prelude::*;
+use polars_core::utils::{_set_partition_size, accumulate_dataframes_vertical_unchecked};
+use polars_core::POOL;
+use polars_utils::option::UnwrapUncheckedRelease;
+use polars_utils::slice::GetSaferUnchecked;
+use polars_utils::{debug_unwrap, get_hash, hash_to_partition};
+use rayon::prelude::*;
+
+use super::aggregates::AggregateFn;
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{DataChunk, PExecutionContext, Sink, SinkResult};
+
+// We must strike a balance between cache coherence and resizing costs.
+// Overallocation seems a lot more expensive than resizing so we start reasonable small.
+pub(crate) const HASHMAP_INIT_SIZE: usize = 128;
+
+// This is the hash and the Index offset in the linear buffer
+type Key = (u64, IdxSize);
+
+pub struct GenericGroupbySink {
+    thread_no: usize,
+    // idx is the offset in the array with keys
+    // idx is the offset in the array with aggregators
+    pre_agg_partitions: Vec<PlHashMap<Key, IdxSize>>,
+    // the aggregations/keys are all tightly packed
+    // the aggregation function of a group can be found
+    // by:
+    // first get the correct vec by the partition index
+    //      * offset = (idx)
+    //      * end = (offset + n_aggs)
+    keys: Vec<Vec<AnyValue<'static>>>,
+    aggregators: Vec<Vec<Box<dyn AggregateFn>>>,
+    // the keys that will be aggregated on
+    key_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+    // the columns that will be aggregated
+    aggregation_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+    hb: RandomState,
+    // Aggregation functions
+    agg_fns: Vec<Box<dyn AggregateFn>>,
+    output_schema: SchemaRef,
+    // amortize allocations
+    aggregation_series: Vec<Series>,
+    keys_series: Vec<Series>,
+    hashes: Vec<u64>,
+}
+
+impl GenericGroupbySink {
+    pub fn new(
+        key_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+        aggregation_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+        agg_fns: Vec<Box<dyn AggregateFn>>,
+        output_schema: SchemaRef,
+    ) -> Self {
+        let hb = RandomState::default();
+        let partitions = _set_partition_size();
+
+        let mut pre_agg = Vec::with_capacity(partitions);
+        let mut keys = Vec::with_capacity(partitions);
+        let mut aggregators = Vec::with_capacity(partitions);
+
+        for _ in 0..partitions {
+            pre_agg.push(PlHashMap::with_capacity_and_hasher(
+                HASHMAP_INIT_SIZE,
+                hb.clone(),
+            ));
+            aggregators.push(Vec::with_capacity(
+                HASHMAP_INIT_SIZE * aggregation_columns.len(),
+            ));
+        }
+
+        Self {
+            thread_no: 0,
+            pre_agg_partitions: pre_agg,
+            keys,
+            aggregators,
+            key_columns,
+            aggregation_columns,
+            hb,
+            agg_fns,
+            output_schema,
+            aggregation_series: vec![],
+            keys_series: vec![],
+            hashes: vec![],
+        }
+    }
+
+    #[inline]
+    fn number_of_aggs(&self) -> usize {
+        self.aggregation_columns.len()
+    }
+}
+
+impl Sink for GenericGroupbySink {
+    fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
+        let num_aggs = self.number_of_aggs();
+
+        // todo! ammortize allocation
+        for phys_e in self.aggregation_columns.iter() {
+            let s = phys_e.evaluate(&chunk, context.execution_state.as_ref())?;
+            let s = s.to_physical_repr();
+            self.aggregation_series.push(s.rechunk());
+        }
+
+        let mut agg_iters = self
+            .aggregation_series
+            .iter()
+            .map(|s| s.phys_iter())
+            .collect::<Vec<_>>();
+
+        for phys_e in self.key_columns.iter() {
+            let s = phys_e.evaluate(&chunk, context.execution_state.as_ref())?;
+            let s = s.to_physical_repr();
+            self.keys_series.push(s.rechunk());
+        }
+
+        let mut key_iters = self
+            .keys_series
+            .iter()
+            .map(|s| s.phys_iter())
+            .collect::<Vec<_>>();
+
+        let mut iter_keys = self.keys_series.iter();
+        let first_key = iter_keys.next().unwrap();
+        first_key.vec_hash(self.hb.clone(), &mut self.hashes).unwrap();
+        for other_key in iter_keys {
+            other_key.vec_hash_combine(self.hb.clone(), &mut self.hashes).unwrap();
+        }
+
+        let mut current_keys_buf = Vec::with_capacity(self.keys.len());
+
+        for &h in &self.hashes {
+            // load the keys in the buffer
+            current_keys_buf.clear();
+            for key_iter in key_iters.iter_mut() {
+                unsafe { current_keys_buf.push(key_iter.next().unwrap_unchecked_release()) }
+            }
+
+            let partition = hash_to_partition(h, self.pre_agg_partitions.len());
+            let current_partition =
+                unsafe { self.pre_agg_partitions.get_unchecked_release_mut(partition) };
+            let current_aggregators =
+                unsafe { self.aggregators.get_unchecked_release_mut(partition) };
+            let current_key_values = unsafe { self.keys.get_unchecked_release_mut(partition) };
+
+            let mut entry = current_partition.raw_entry_mut().from_hash(h, |key| {
+                let idx = key.1 as usize;
+                if self.keys_series.len() > 1 {
+                    current_keys_buf.iter().enumerate().all(|(i, key)| unsafe {
+                        current_key_values.get_unchecked_release(i + idx) == key
+                    })
+                } else {
+                    unsafe {
+                        current_key_values.get_unchecked_release(idx)
+                            == current_keys_buf.get_unchecked_release(0)
+                    }
+                }
+            });
+
+            let agg_idx = match entry {
+                RawEntryMut::Vacant(entry) => {
+                    let value_offset = unsafe {
+                        NumCast::from(current_aggregators.len()).unwrap_unchecked_release()
+                    };
+                    let keys_offset = unsafe {
+                        (h, NumCast::from(current_key_values.len()).unwrap_unchecked_release())
+                    };
+                    entry.insert_with_hasher(h, keys_offset, value_offset, |_| h);
+
+                    unsafe {
+                        current_key_values.extend(
+                            current_keys_buf
+                                .iter()
+                                .map(|av| av.clone().into_static().unwrap_unchecked_release()),
+                        )
+                    };
+                    // initialize the aggregators
+                    for agg_fn in &self.agg_fns {
+                        current_aggregators.push(agg_fn.split())
+                    }
+                    value_offset
+                }
+                RawEntryMut::Occupied(entry) => *entry.get(),
+            };
+            for (i, agg_iter) in (0..num_aggs).zip(agg_iters.iter_mut()) {
+                let i = agg_idx as usize + i;
+                let agg_fn = unsafe { current_aggregators.get_unchecked_release_mut(i) };
+
+                let value = unsafe { agg_iter.next().unwrap_unchecked_release() };
+                agg_fn.pre_agg(chunk.chunk_index, value)
+            }
+        }
+        drop(agg_iters);
+        drop(key_iters);
+        self.aggregation_series.clear();
+        self.keys_series.clear();
+        self.hashes.clear();
+        Ok(SinkResult::CanHaveMoreInput)
+    }
+
+    fn combine(&mut self, other: Box<dyn Sink>) {
+        // don't parallel this as this is already done in parallel.
+
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        let n_partitions = self.pre_agg_partitions.len();
+
+        self.pre_agg_partitions
+            .iter_mut()
+            .zip(other.pre_agg_partitions.iter())
+            .zip(self.aggregators.iter_mut())
+            .zip(other.aggregators.iter())
+            .for_each(
+                |(((map_self, map_other), aggregators_self), aggregators_other)| {
+                    for (k_other, &agg_idx_other) in map_other.iter() {
+                        unsafe {
+                            // the hash value
+                            let h = k_other.0;
+                            // the partition where all keys and maps are located
+                            let partition = hash_to_partition(h, n_partitions);
+                            // get the key buffers
+                            let keys_buffer_self = self.keys.get_unchecked_release_mut(partition);
+                            let keys_buffer_other = other.keys.get_unchecked_release(partition);
+
+                            // the offset in the keys of other
+                            let idx_other = k_other.1 as usize;
+                            // slice to the keys of other
+                            let keys_other = keys_buffer_other
+                                .get_unchecked_release(idx_other..idx_other + self.keys_series.len());
+
+                            let entry = map_self.raw_entry_mut().from_hash(h, |k_self| {
+                                // the offset in the keys of self
+                                let idx_self = k_self.1 as usize;
+                                // slice to the keys of self
+                                let keys_self = keys_buffer_self
+                                    .get_unchecked_release(idx_self..idx_self + self.keys_series.len());
+                                // compare the keys
+                                keys_self == keys_other
+                            });
+
+                            let agg_idx_self = match entry {
+                                // the keys of other are not in this table, so we must update this table
+                                RawEntryMut::Vacant(entry) => {
+                                    // get the current offset in the values buffer
+                                    let values_offset = NumCast::from(aggregators_self.len()).unwrap_unchecked_release();
+                                    // get the key, comprised of the hash and the current offset in the keys buffer
+                                    let key = unsafe {
+                                        (h, NumCast::from(keys_buffer_self.len()).unwrap_unchecked_release())
+                                    };
+
+                                    // extend the keys buffer with the new keys from othger
+                                    unsafe {
+                                        keys_buffer_self.extend_from_slice(
+                                            keys_other
+                                        )
+                                    };
+
+                                    // inser the keys and values_offset
+                                    entry.insert_with_hasher(h, key, values_offset, |_| h);
+                                    // initialize the new aggregators
+                                    for agg_fn in &self.agg_fns {
+                                        aggregators_self.push(agg_fn.split())
+                                    }
+                                    values_offset
+                                }
+                                RawEntryMut::Occupied(entry) => *entry.get(),
+                            };
+
+                            // combine the aggregation functions
+                            for i in 0..self.aggregation_columns.len() {
+                                let agg_fn_other = aggregators_other
+                                    .get_unchecked_release(agg_idx_other as usize + i);
+                                let agg_fn_self = aggregators_self
+                                    .get_unchecked_release_mut(agg_idx_self as usize + i);
+                                agg_fn_self.combine(agg_fn_other.as_any())
+                            }
+                        }
+                    }
+                },
+            );
+    }
+
+    fn split(&self, thread_no: usize) -> Box<dyn Sink> {
+        let mut new = Self::new(
+            self.key_columns.clone(),
+            self.aggregation_columns.clone(),
+            self.agg_fns.iter().map(|func| func.split()).collect(),
+            self.output_schema.clone(),
+        );
+        new.hb = self.hb.clone();
+        new.thread_no = thread_no;
+        Box::new(new)
+    }
+
+    fn finalize(&mut self) -> PolarsResult<DataFrame> {
+        // TODO! parallel
+        let mut aggregators = std::mem::take(&mut self.aggregators);
+        let n_keys = self.keys_series.len();
+
+        POOL.install(|| {
+            let dfs = self
+                .pre_agg_partitions
+                .par_iter()
+                .zip(aggregators.par_iter_mut())
+                .zip(self.keys.par_iter())
+                .filter_map(|((agg_map, agg_fns), current_keys)| {
+                    if agg_map.is_empty() {
+                        return None;
+                    }
+                    let mut key_builders = self.keys_series.iter().map(|s|AnyValueBuffer::new(s.dtype(), agg_map.len())).collect::<Vec<_>>();
+                    let dtypes = agg_fns
+                        .iter()
+                        .take(self.number_of_aggs())
+                        .map(|func| func.dtype())
+                        .collect::<Vec<_>>();
+
+                    let mut buffers = dtypes
+                        .iter()
+                        .map(|dtype| AnyValueBuffer::new(dtype, agg_map.len()))
+                        .collect::<Vec<_>>();
+
+                    agg_map.into_iter().for_each(|(k, &offset)| {
+                        let keys_offset = k.1 as usize;
+                        let keys = unsafe { current_keys.get_unchecked_release(keys_offset..keys_offset + n_keys) };
+
+                        for (key, key_builder) in keys.iter().zip(key_builders.iter_mut()) {
+                            key_builder.add(key.as_borrowed());
+                        }
+
+                        for (i, buffer) in (offset as usize
+                            ..offset as usize + self.aggregation_columns.len())
+                            .zip(buffers.iter_mut())
+                        {
+                            unsafe {
+                                let agg_fn = agg_fns.get_unchecked_release_mut(i);
+                                let av = agg_fn.finalize();
+                                buffer.add(av);
+                            }
+                        }
+                    });
+
+                    let mut cols = Vec::with_capacity(n_keys + self.number_of_aggs());
+                    for key_builder in key_builders {
+                        cols.push(key_builder.into_series());
+                    }
+                    cols.extend(buffers.into_iter().map(|buf| buf.into_series()));
+                    for (s, (name, dtype)) in cols.iter_mut().zip(self.output_schema.iter()) {
+                        if s.name() != name {
+                            s.rename(name);
+                        }
+                        if s.dtype() != dtype {
+                            *s = s.cast(dtype).unwrap()
+                        }
+                    }
+                    Some(DataFrame::new_no_checks(cols))
+                })
+                .collect::<Vec<_>>();
+            Ok(accumulate_dataframes_vertical_unchecked(dfs))
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
@@ -110,7 +110,7 @@ impl Sink for GenericGroupbySink {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
         let num_aggs = self.number_of_aggs();
 
-        // todo! ammortize allocation
+        // todo! amortize allocation
         for phys_e in self.aggregation_columns.iter() {
             let s = phys_e.evaluate(&chunk, context.execution_state.as_ref())?;
             let s = s.to_physical_repr();

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -1,3 +1,2 @@
-mod primitive;
 mod aggregates;
-
+mod primitive;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod aggregates;
 mod generic;
 mod primitive;
 
+pub(crate) use generic::*;
 pub(crate) use primitive::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -1,2 +1,5 @@
-mod aggregates;
+pub(crate) mod aggregates;
 mod primitive;
+
+pub(crate) use primitive::*;
+

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod aggregates;
+mod generic;
 mod primitive;
 
 pub(crate) use primitive::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -1,0 +1,3 @@
+mod primitive;
+mod aggregates;
+

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -2,4 +2,3 @@ pub(crate) mod aggregates;
 mod primitive;
 
 pub(crate) use primitive::*;
-

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -265,5 +265,3 @@ where
         self
     }
 }
-
-unsafe impl<K: PolarsNumericType> Sync for PrimitiveGroupbySink<K> {}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -1,0 +1,51 @@
+use std::any::Any;
+use polars_core::prelude::*;
+use polars_core::export::arrow;
+use polars_core::utils::_set_partition_size;
+use polars_core::utils::arrow::types::NativeType;
+use crate::operators::{DataChunk, PExecutionContext, Sink, SinkResult};
+use super::aggregates::AggregateFn;
+
+
+type PartitionedHashMap<K> = PlHashMap<K, *mut [Box<dyn AggregateFn>]>;
+
+pub struct PrimitiveGroupbySink<K: NumericNative>{
+    thread_no: usize,
+    pre_agg: Vec<PartitionedHashMap<K>>
+}
+
+impl<K: NumericNative>  PrimitiveGroupbySink<K> {
+    pub fn new(thread_no: usize) -> Self {
+        Self {
+            thread_no,
+            pre_agg: Vec::with_capacity(_set_partition_size())
+        }
+    }
+
+}
+
+impl<K: NumericNative> Sink for PrimitiveGroupbySink<K> {
+    fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
+        todo!()
+    }
+
+    fn combine(&mut self, other: Box<dyn Sink>) {
+        todo!()
+    }
+
+    fn split(&self, thread_no: usize) -> Box<dyn Sink> {
+
+        todo!()
+    }
+
+    fn finalize(&mut self) -> PolarsResult<DataFrame> {
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        todo!()
+    }
+}
+
+unsafe impl<K: NumericNative> Send for PrimitiveGroupbySink<K> {}
+unsafe impl<K: NumericNative> Sync for PrimitiveGroupbySink<K> {}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -169,8 +169,7 @@ where
                 let i = (agg_idx + i) as usize;
                 let agg_fn = unsafe { current_aggregators.get_unchecked_release_mut(i) };
 
-                let value = unsafe { agg_iter.next().unwrap_unchecked_release() };
-                agg_fn.pre_agg(chunk.chunk_index, value)
+                agg_fn.pre_agg(chunk.chunk_index, agg_iter.as_mut())
             }
         }
         drop(agg_iters);

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -99,13 +99,14 @@ where
         // todo! ammortize allocation
         for phys_e in self.aggregation_columns.iter() {
             let s = phys_e.evaluate(&chunk, context.execution_state.as_ref())?;
+            let s = s.to_physical_repr();
             self.aggregation_series.push(s.rechunk());
         }
 
         let mut agg_iters = self
             .aggregation_series
             .iter()
-            .map(|s| s.iter())
+            .map(|s| s.phys_iter())
             .collect::<Vec<_>>();
 
         for arr in ca.downcast_iter() {
@@ -142,6 +143,7 @@ where
                 }
             }
         }
+        drop(agg_iters);
         self.aggregation_series.clear();
         Ok(SinkResult::CanHaveMoreInput)
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -1,31 +1,123 @@
 use std::any::Any;
-use polars_core::prelude::*;
+use std::hash::{BuildHasher, Hash, Hasher};
+
+use hashbrown::hash_map::RawEntryMut;
+use polars_core::export::ahash::RandomState;
 use polars_core::export::arrow;
+use polars_core::prelude::*;
 use polars_core::utils::_set_partition_size;
 use polars_core::utils::arrow::types::NativeType;
-use crate::operators::{DataChunk, PExecutionContext, Sink, SinkResult};
+use polars_utils::{debug_unwrap, get_hash, hash_to_partition};
+
 use super::aggregates::AggregateFn;
+use crate::operators::{DataChunk, PExecutionContext, Sink, SinkResult};
 
+// We must strike a balance between cache coherence and resizing costs.
+// Overallocation seems a lot more expensive than resizing so we start reasonable small.
+pub(crate) const HASHMAP_INIT_SIZE: usize = 128;
 
-type PartitionedHashMap<K> = PlHashMap<K, *mut [Box<dyn AggregateFn>]>;
-
-pub struct PrimitiveGroupbySink<K: NumericNative>{
+pub struct PrimitiveGroupbySink<K: PolarsNumericType> {
     thread_no: usize,
-    pre_agg: Vec<PartitionedHashMap<K>>
+    // idx is the offset in the array with aggregators
+    pre_agg: Vec<PlHashMap<Option<K::Native>, usize>>,
+    // the aggregations are all tightly packed
+    // the aggregation function of a group can be found
+    // by:
+    // first get the correct vec by the partition index
+    //      * offset = (idx)
+    //      * end = (offset + n_aggs)
+    aggregators: Vec<Vec<Box<dyn AggregateFn>>>,
+    key: Arc<str>,
+    aggs: Vec<usize>,
+    hb: RandomState,
+    // A function that generates the aggregation functions
+    agg_creator: Box<dyn Iterator<Item = Box<dyn AggregateFn>> + Send>,
 }
 
-impl<K: NumericNative>  PrimitiveGroupbySink<K> {
-    pub fn new(thread_no: usize) -> Self {
+impl<K: PolarsNumericType> PrimitiveGroupbySink<K> {
+    pub fn new(
+        thread_no: usize,
+        key: Arc<str>,
+        aggs: Vec<usize>,
+        agg_creator: Box<dyn Iterator<Item = Box<dyn AggregateFn>> + Send>,
+    ) -> Self {
+        let hb = RandomState::default();
+        let partitions = _set_partition_size();
+
+        let mut pre_agg = Vec::with_capacity(partitions);
+        let mut aggregators = Vec::with_capacity(partitions);
+
+        for _ in 0..partitions {
+            pre_agg.push(PlHashMap::with_capacity_and_hasher(
+                HASHMAP_INIT_SIZE,
+                hb.clone(),
+            ));
+            aggregators.push(Vec::with_capacity(HASHMAP_INIT_SIZE * aggs.len()));
+        }
+
         Self {
             thread_no,
-            pre_agg: Vec::with_capacity(_set_partition_size())
+            pre_agg,
+            aggregators,
+            key,
+            aggs,
+            hb,
+            agg_creator,
         }
     }
-
 }
 
-impl<K: NumericNative> Sink for PrimitiveGroupbySink<K> {
+impl<K: PolarsNumericType> Sink for PrimitiveGroupbySink<K>
+where
+    K::Native: Hash + Eq,
+{
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
+        let s = chunk.data.column(self.key.as_ref())?.to_physical_repr();
+        // cow -> &series -> &dyn series_trait -> &chunkedarray
+        let ca: &ChunkedArray<K> = s.as_ref().as_ref().as_ref();
+
+        // todo! ammortize allocation
+        let agg_s = self
+            .aggs
+            .iter()
+            .map(|i| chunk.data.select_at_idx(*i).unwrap().rechunk())
+            .collect::<Vec<_>>();
+
+        let mut agg_iters = agg_s.iter().map(|s| s.iter()).collect::<Vec<_>>();
+
+        for arr in ca.downcast_iter() {
+            for opt_v in arr {
+                let opt_v = opt_v.copied();
+                let h = get_hash(opt_v, &self.hb);
+                let part = hash_to_partition(h, self.pre_agg.len());
+                let mut current_part = unsafe { self.pre_agg.get_unchecked_mut(part) };
+                let mut current_aggregators = unsafe { self.aggregators.get_unchecked_mut(part) };
+
+                let entry = current_part
+                    .raw_entry_mut()
+                    .from_key_hashed_nocheck(h, &opt_v);
+                let agg_idx = match entry {
+                    RawEntryMut::Vacant(entry) => {
+                        entry.insert_with_hasher(h, opt_v, current_aggregators.len(), |_| h);
+                        // initialize the aggregators
+                        for _ in 0..self.aggs.len() {
+                            unsafe {
+                                current_aggregators.push(debug_unwrap(self.agg_creator.next()))
+                            };
+                        }
+                        0 as usize
+                    }
+                    RawEntryMut::Occupied(entry) => *entry.get(),
+                };
+                for (i, agg_iter) in (agg_idx..agg_idx + self.aggs.len()).zip(agg_iters.iter_mut())
+                {
+                    let agg_fn = unsafe { current_aggregators.get_unchecked_mut(i) };
+
+                    let value = unsafe { debug_unwrap(agg_iter.next()) };
+                    agg_fn.pre_agg(chunk.chunk_index, value)
+                }
+            }
+        }
         todo!()
     }
 
@@ -34,7 +126,6 @@ impl<K: NumericNative> Sink for PrimitiveGroupbySink<K> {
     }
 
     fn split(&self, thread_no: usize) -> Box<dyn Sink> {
-
         todo!()
     }
 
@@ -47,5 +138,4 @@ impl<K: NumericNative> Sink for PrimitiveGroupbySink<K> {
     }
 }
 
-unsafe impl<K: NumericNative> Send for PrimitiveGroupbySink<K> {}
-unsafe impl<K: NumericNative> Sync for PrimitiveGroupbySink<K> {}
+unsafe impl<K: PolarsNumericType> Sync for PrimitiveGroupbySink<K> {}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -1,12 +1,15 @@
 use std::any::Any;
+use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash, Hasher};
 
 use hashbrown::hash_map::RawEntryMut;
 use polars_core::export::ahash::RandomState;
 use polars_core::export::arrow;
+use polars_core::frame::row::AnyValueBuffer;
 use polars_core::prelude::*;
-use polars_core::utils::_set_partition_size;
+use polars_core::utils::{_set_partition_size, accumulate_dataframes_vertical, accumulate_dataframes_vertical_unchecked};
 use polars_core::utils::arrow::types::NativeType;
+use polars_utils::slice::GetSaferUnchecked;
 use polars_utils::{debug_unwrap, get_hash, hash_to_partition};
 
 use super::aggregates::AggregateFn;
@@ -19,7 +22,7 @@ pub(crate) const HASHMAP_INIT_SIZE: usize = 128;
 pub struct PrimitiveGroupbySink<K: PolarsNumericType> {
     thread_no: usize,
     // idx is the offset in the array with aggregators
-    pre_agg: Vec<PlHashMap<Option<K::Native>, usize>>,
+    pre_agg_partitions: Vec<PlHashMap<Option<K::Native>, usize>>,
     // the aggregations are all tightly packed
     // the aggregation function of a group can be found
     // by:
@@ -32,7 +35,7 @@ pub struct PrimitiveGroupbySink<K: PolarsNumericType> {
     aggregation_columns: Vec<usize>,
     hb: RandomState,
     // Aggregation functions
-    agg_fns: Vec<Box<dyn AggregateFn>>
+    agg_fns: Vec<Box<dyn AggregateFn>>,
 }
 
 impl<K: PolarsNumericType> PrimitiveGroupbySink<K> {
@@ -52,24 +55,31 @@ impl<K: PolarsNumericType> PrimitiveGroupbySink<K> {
                 HASHMAP_INIT_SIZE,
                 hb.clone(),
             ));
-            aggregators.push(Vec::with_capacity(HASHMAP_INIT_SIZE * aggregation_columns.len()));
+            aggregators.push(Vec::with_capacity(
+                HASHMAP_INIT_SIZE * aggregation_columns.len(),
+            ));
         }
 
         Self {
             thread_no: 0,
-            pre_agg,
+            pre_agg_partitions: pre_agg,
             aggregators,
             key,
             aggregation_columns,
             hb,
-            agg_fns
+            agg_fns,
         }
+    }
+
+    fn number_of_aggs(&self) -> usize {
+        self.aggregation_columns.len()
     }
 }
 
 impl<K: PolarsNumericType> Sink for PrimitiveGroupbySink<K>
 where
-    K::Native: Hash + Eq,
+    K::Native: Hash + Eq + Debug,
+    ChunkedArray<K>: IntoSeries
 {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
         let s = chunk.data.column(self.key.as_ref())?.to_physical_repr();
@@ -89,9 +99,11 @@ where
             for opt_v in arr {
                 let opt_v = opt_v.copied();
                 let h = get_hash(opt_v, &self.hb);
-                let part = hash_to_partition(h, self.pre_agg.len());
-                let mut current_part = unsafe { self.pre_agg.get_unchecked_mut(part) };
-                let mut current_aggregators = unsafe { self.aggregators.get_unchecked_mut(part) };
+                let part = hash_to_partition(h, self.pre_agg_partitions.len());
+                let mut current_part =
+                    unsafe { self.pre_agg_partitions.get_unchecked_release_mut(part) };
+                let mut current_aggregators =
+                    unsafe { self.aggregators.get_unchecked_release_mut(part) };
 
                 let entry = current_part
                     .raw_entry_mut()
@@ -102,37 +114,117 @@ where
                         // initialize the aggregators
                         for agg_fn in &self.agg_fns {
                             current_aggregators.push(agg_fn.split())
-                        };
+                        }
                         0 as usize
                     }
                     RawEntryMut::Occupied(entry) => *entry.get(),
                 };
-                for (i, agg_iter) in (agg_idx..agg_idx + self.aggregation_columns.len()).zip(agg_iters.iter_mut())
+                for (i, agg_iter) in
+                    (agg_idx..agg_idx + self.aggregation_columns.len()).zip(agg_iters.iter_mut())
                 {
-                    let agg_fn = unsafe { current_aggregators.get_unchecked_mut(i) };
+                    let agg_fn = unsafe { current_aggregators.get_unchecked_release_mut(i) };
 
                     let value = unsafe { debug_unwrap(agg_iter.next()) };
                     agg_fn.pre_agg(chunk.chunk_index, value)
                 }
             }
         }
-        todo!()
+        Ok(SinkResult::CanHaveMoreInput)
     }
 
     fn combine(&mut self, other: Box<dyn Sink>) {
-        todo!()
+        // TODO! parallel
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+
+        self.pre_agg_partitions
+            .iter_mut()
+            .zip(other.pre_agg_partitions.iter())
+            .zip(self.aggregators.iter_mut())
+            .zip(other.aggregators.iter())
+            .for_each(|(((map_self, map_other), agg_fn_self), agg_fn_other)| {
+                for (k, agg_idx_other) in map_other.iter() {
+                    let opt_v = *k;
+                    unsafe {
+                        let agg_fn_other = agg_fn_other.get_unchecked_release(*agg_idx_other);
+
+                        let h = get_hash(opt_v, &self.hb);
+                        let entry = map_self.raw_entry_mut().from_key_hashed_nocheck(h, &opt_v);
+
+                        let agg_idx_self = match entry {
+                            RawEntryMut::Vacant(entry) => {
+                                entry.insert_with_hasher(h, opt_v, agg_fn_self.len(), |_| h);
+                                // initialize the aggregators
+                                for agg_fn in &self.agg_fns {
+                                    agg_fn_self.push(agg_fn.split())
+                                }
+                                0 as usize
+                            }
+                            RawEntryMut::Occupied(entry) => *entry.get(),
+                        };
+                        for i in agg_idx_self..agg_idx_self + self.aggregation_columns.len() {
+                            let agg_fn_self = agg_fn_self.get_unchecked_release_mut(i);
+                            agg_fn_self.combine(agg_fn_other)
+                        }
+                    }
+                }
+            });
     }
 
     fn split(&self, thread_no: usize) -> Box<dyn Sink> {
-        todo!()
+        let mut new = Self::new(
+            self.key.clone(),
+            self.aggregation_columns.clone(),
+            self.agg_fns.iter().map(|func| func.split()).collect(),
+        );
+        new.thread_no = thread_no;
+        Box::new(new)
     }
 
     fn finalize(&mut self) -> PolarsResult<DataFrame> {
-        todo!()
+        // TODO! parallel
+        let mut aggregators = std::mem::take(&mut self.aggregators);
+        let dfs = self.pre_agg_partitions
+            .iter()
+            .zip(aggregators.iter_mut())
+            .filter_map(|(agg_map, agg_fns)| {
+                if agg_map.is_empty() {
+                    return None
+                }
+                let mut key_builder = PrimitiveChunkedBuilder::<K>::new(&self.key, agg_map.len());
+                let dtypes = agg_fns
+                    .iter()
+                    .take(self.number_of_aggs()).map(|func| func.dtype()).collect::<Vec<_>>();
+
+                let mut buffers = dtypes.iter()
+                    .map(|dtype| AnyValueBuffer::new(dtype, agg_map.len()))
+                    .collect::<Vec<_>>();
+
+                agg_map.into_iter().for_each(|(k, &offset)| {
+                    key_builder.append_option(*k);
+
+                    for (i, buffer) in
+                        (offset..offset + self.aggregation_columns.len()).zip(buffers.iter_mut())
+                    {
+                        unsafe {
+                            let agg_fn = agg_fns.get_unchecked_release_mut(i);
+                            let av = agg_fn.finalize();
+                            buffer.add(av);
+                        }
+                    }
+                });
+
+                let mut cols = Vec::with_capacity(1 + self.number_of_aggs());
+                cols.push(key_builder.finish().into_series());
+                cols.extend(
+                    buffers.into_iter().map(|buf| buf.into_series())
+                );
+                Some(DataFrame::new(cols))
+            }).collect::<PolarsResult<Vec<_>>>()?;
+        Ok(accumulate_dataframes_vertical_unchecked(dfs))
     }
 
     fn as_any(&self) -> &dyn Any {
-        todo!()
+        self
     }
 }
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
@@ -1,4 +1,4 @@
-mod groupby;
+pub(crate) mod groupby;
 mod ordered;
 
 pub(crate) use ordered::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
@@ -1,3 +1,4 @@
 mod ordered;
+mod groupby;
 
 pub(crate) use ordered::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
@@ -1,0 +1,3 @@
+mod ordered;
+
+pub(crate) use ordered::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/mod.rs
@@ -1,4 +1,4 @@
-mod ordered;
 mod groupby;
+mod ordered;
 
 pub(crate) use ordered::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/ordered.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/ordered.rs
@@ -25,7 +25,7 @@ impl OrderedSink {
 impl Sink for OrderedSink {
     fn sink(&mut self, _context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
         self.chunks.push(chunk);
-        Ok(SinkResult::NeedMoreInput)
+        Ok(SinkResult::CanHaveMoreInput)
     }
 
     fn combine(&mut self, other: Box<dyn Sink>) {

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/ordered.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/ordered.rs
@@ -1,0 +1,51 @@
+use std::any::Any;
+
+use polars_core::error::PolarsResult;
+use polars_core::frame::DataFrame;
+use polars_core::utils::accumulate_dataframes_vertical_unchecked;
+
+use crate::operators::{DataChunk, PExecutionContext, Sink, SinkResult};
+
+// Ensure the data is return in the order it was streamed
+#[derive(Clone)]
+pub struct OrderedSink {
+    chunks: Vec<DataChunk>,
+}
+
+impl OrderedSink {
+    pub fn new() -> Self {
+        OrderedSink { chunks: vec![] }
+    }
+
+    fn sort(&mut self) {
+        self.chunks.sort_unstable_by_key(|chunk| chunk.chunk_index);
+    }
+}
+
+impl Sink for OrderedSink {
+    fn sink(&mut self, _context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
+        self.chunks.push(chunk);
+        Ok(SinkResult::NeedMoreInput)
+    }
+
+    fn combine(&mut self, other: Box<dyn Sink>) {
+        let other = other.as_any().downcast_ref::<OrderedSink>().unwrap();
+        self.chunks.extend_from_slice(&other.chunks);
+        self.sort();
+    }
+
+    fn split(&self, _thread_no: usize) -> Box<dyn Sink> {
+        Box::new(self.clone())
+    }
+    fn finalize(&mut self) -> PolarsResult<DataFrame> {
+        self.sort();
+        Ok(accumulate_dataframes_vertical_unchecked(
+            std::mem::take(&mut self.chunks)
+                .into_iter()
+                .map(|chunk| chunk.data),
+        ))
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
@@ -8,14 +8,13 @@ use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::CsvParserOptions;
 
 use super::*;
-use crate::expressions::PhysicalPipedExpr;
 
 pub(crate) struct CsvSource {
+    #[allow(dead_code)]
+    // this exist because we need to keep ownership
     schema: SchemaRef,
-    predicate: Option<Arc<dyn PhysicalPipedExpr>>,
     reader: *mut CsvReader<'static, File>,
     batched_reader: *mut BatchedCsvReader<'static>,
-    stack: Vec<(IdxSize, DataFrame)>,
     n_threads: usize,
 }
 
@@ -24,7 +23,6 @@ impl CsvSource {
         path: PathBuf,
         schema: SchemaRef,
         options: CsvParserOptions,
-        predicate: Option<Arc<dyn PhysicalPipedExpr>>,
     ) -> PolarsResult<Self> {
         let mut with_columns = options.with_columns;
         let mut projected_len = 0;
@@ -73,10 +71,8 @@ impl CsvSource {
 
         Ok(CsvSource {
             schema,
-            predicate,
             reader,
             batched_reader,
-            stack: vec![],
             n_threads: POOL.current_num_threads(),
         })
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
@@ -60,6 +60,7 @@ impl CsvSource {
             .with_end_of_line_char(options.eol_char)
             .with_encoding(options.encoding)
             .with_rechunk(options.rechunk)
+            .with_chunk_size(50_000)
             .with_row_count(options.row_count)
             .with_parse_dates(options.parse_dates);
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
@@ -1,5 +1,13 @@
+#[cfg(feature = "csv-file")]
 mod csv;
+#[cfg(feature = "parquet")]
+mod parquet;
+mod union;
 
+#[cfg(feature = "csv-file")]
 pub(crate) use csv::CsvSource;
+#[cfg(feature = "parquet")]
+pub(crate) use parquet::*;
+pub(crate) use union::*;
 
 use super::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
@@ -1,3 +1,5 @@
 mod csv;
 
+pub(crate) use csv::CsvSource;
+
 use super::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/parquet.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/parquet.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use polars_core::error::PolarsResult;
+use polars_core::schema::*;
+use polars_core::POOL;
+use polars_io::parquet::{BatchedParquetReader, ParquetReader};
+use polars_io::SerReader;
+use polars_plan::prelude::ParquetOptions;
+
+use crate::operators::{DataChunk, PExecutionContext, Source, SourceResult};
+
+pub struct ParquetSource {
+    batched_reader: BatchedParquetReader,
+    n_threads: usize,
+}
+
+impl ParquetSource {
+    pub(crate) fn new(
+        path: PathBuf,
+        options: ParquetOptions,
+        schema: &Schema,
+    ) -> PolarsResult<Self> {
+        let projection: Option<Vec<_>> = options.with_columns.map(|with_columns| {
+            with_columns
+                .iter()
+                .map(|name| schema.index_of(name).unwrap())
+                .collect()
+        });
+
+        let file = std::fs::File::open(path).unwrap();
+        let batched_reader = ParquetReader::new(file)
+            .with_n_rows(options.n_rows)
+            .with_row_count(options.row_count)
+            .with_projection(projection)
+            .batched()?;
+
+        Ok(ParquetSource {
+            batched_reader,
+            n_threads: POOL.current_num_threads(),
+        })
+    }
+}
+
+impl Source for ParquetSource {
+    fn get_batches(&mut self, _context: &PExecutionContext) -> PolarsResult<SourceResult> {
+        let batches = self.batched_reader.next_batches(self.n_threads)?;
+        Ok(match batches {
+            None => SourceResult::Finished,
+            Some(batches) => SourceResult::GotMoreData(
+                batches
+                    .into_iter()
+                    .map(|(chunk_index, data)| DataChunk { chunk_index, data })
+                    .collect(),
+            ),
+        })
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/union.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/union.rs
@@ -1,0 +1,32 @@
+use polars_core::error::PolarsResult;
+
+use crate::operators::{PExecutionContext, Source, SourceResult};
+
+pub struct UnionSource {
+    sources: Vec<Box<dyn Source>>,
+    source_index: usize,
+}
+
+impl UnionSource {
+    pub(crate) fn new(sources: Vec<Box<dyn Source>>) -> Self {
+        Self {
+            sources,
+            source_index: 0,
+        }
+    }
+}
+
+impl Source for UnionSource {
+    fn get_batches(&mut self, context: &PExecutionContext) -> PolarsResult<SourceResult> {
+        // early return if we have data
+        // if no data we deplete the loop and are finished
+        while self.source_index < self.sources.len() {
+            let src = &mut self.sources[self.source_index];
+            match src.get_batches(context)? {
+                SourceResult::Finished => self.source_index += 1,
+                SourceResult::GotMoreData(chunks) => return Ok(SourceResult::GotMoreData(chunks)),
+            }
+        }
+        Ok(SourceResult::Finished)
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/expressions.rs
+++ b/polars/polars-lazy/polars-pipe/src/expressions.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use polars_core::prelude::*;
 
 use crate::operators::DataChunk;
@@ -5,5 +7,5 @@ use crate::operators::DataChunk;
 pub trait PhysicalPipedExpr: Send + Sync {
     /// Take a `DataFrame` and produces a boolean `Series` that serves
     /// as a predicate mask
-    fn evaluate(&self, chunk: DataChunk) -> PolarsResult<Series>;
+    fn evaluate(&self, chunk: &DataChunk, lazy_state: &dyn Any) -> PolarsResult<Series>;
 }

--- a/polars/polars-lazy/polars-pipe/src/expressions.rs
+++ b/polars/polars-lazy/polars-pipe/src/expressions.rs
@@ -8,4 +8,6 @@ pub trait PhysicalPipedExpr: Send + Sync {
     /// Take a `DataFrame` and produces a boolean `Series` that serves
     /// as a predicate mask
     fn evaluate(&self, chunk: &DataChunk, lazy_state: &dyn Any) -> PolarsResult<Series>;
+
+    fn field(&self, input_schema: &Schema) -> PolarsResult<Field>;
 }

--- a/polars/polars-lazy/polars-pipe/src/lib.rs
+++ b/polars/polars-lazy/polars-pipe/src/lib.rs
@@ -1,3 +1,4 @@
 mod executors;
-mod expressions;
-mod operators;
+pub mod expressions;
+pub mod operators;
+pub mod pipeline;

--- a/polars/polars-lazy/polars-pipe/src/operators/chunks.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/chunks.rs
@@ -1,6 +1,16 @@
 use super::*;
 
+#[derive(Clone, Debug)]
 pub struct DataChunk {
-    chunk_index: IdxSize,
-    data: DataFrame,
+    pub chunk_index: IdxSize,
+    pub data: DataFrame,
+}
+
+impl DataChunk {
+    pub(crate) fn with_data(&self, data: DataFrame) -> Self {
+        DataChunk {
+            chunk_index: self.chunk_index,
+            data,
+        }
+    }
 }

--- a/polars/polars-lazy/polars-pipe/src/operators/context.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/context.rs
@@ -2,11 +2,11 @@ use std::any::Any;
 
 pub struct PExecutionContext {
     // injected upstream in polars-lazy
-    pub(crate) execution_state: Box<dyn Any>,
+    pub(crate) execution_state: Box<dyn Any + Send + Sync>,
 }
 
 impl PExecutionContext {
-    pub(crate) fn new(state: Box<dyn Any>) -> Self {
+    pub(crate) fn new(state: Box<dyn Any + Send + Sync>) -> Self {
         PExecutionContext {
             execution_state: state,
         }

--- a/polars/polars-lazy/polars-pipe/src/operators/context.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/context.rs
@@ -1,1 +1,14 @@
-pub struct PExecutionContext {}
+use std::any::Any;
+
+pub struct PExecutionContext {
+    // injected upstream in polars-lazy
+    pub(crate) execution_state: Box<dyn Any>,
+}
+
+impl PExecutionContext {
+    pub(crate) fn new(state: Box<dyn Any>) -> Self {
+        PExecutionContext {
+            execution_state: state,
+        }
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/operators/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/mod.rs
@@ -1,4 +1,4 @@
-mod chunks;
+pub mod chunks;
 mod context;
 mod operator;
 mod sink;

--- a/polars/polars-lazy/polars-pipe/src/operators/operator.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/operator.rs
@@ -1,15 +1,15 @@
 use super::*;
 
 pub enum OperatorResult {
-    NeedMoreInput(Option<DataChunk>),
-    HaveMoreOutPut(Option<DataChunk>),
-    Finished(Option<DataChunk>),
+    NeedMoreInput,
+    HaveMoreOutPut(DataChunk),
+    Finished(DataChunk),
 }
 
-pub trait Operator {
+pub trait Operator: Send + Sync {
     fn execute(
         &self,
         context: &PExecutionContext,
-        chunk: DataChunk,
+        chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult>;
 }

--- a/polars/polars-lazy/polars-pipe/src/operators/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/sink.rs
@@ -5,7 +5,7 @@ use super::*;
 #[derive(Debug)]
 pub enum SinkResult {
     Finished,
-    NeedMoreInput,
+    CanHaveMoreInput,
 }
 
 pub trait Sink: Send + Sync {

--- a/polars/polars-lazy/polars-pipe/src/operators/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/sink.rs
@@ -1,10 +1,21 @@
+use std::any::Any;
+
 use super::*;
 
+#[derive(Debug)]
 pub enum SinkResult {
     Finished,
     NeedMoreInput,
 }
 
-pub trait Sink {
-    fn sink(context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult>;
+pub trait Sink: Send + Sync {
+    fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult>;
+
+    fn combine(&mut self, other: Box<dyn Sink>);
+
+    fn split(&self, thread_no: usize) -> Box<dyn Sink>;
+
+    fn finalize(&mut self) -> PolarsResult<DataFrame>;
+
+    fn as_any(&self) -> &dyn Any;
 }

--- a/polars/polars-lazy/polars-pipe/src/operators/source.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/source.rs
@@ -2,9 +2,9 @@ use super::*;
 
 pub enum SourceResult {
     Finished,
-    GotMoreData(DataChunk),
+    GotMoreData(Vec<DataChunk>),
 }
 
-pub trait Source {
-    fn get_batches(context: &PExecutionContext) -> PolarsResult<SourceResult>;
+pub trait Source: Send + Sync {
+    fn get_batches(&mut self, context: &PExecutionContext) -> PolarsResult<SourceResult>;
 }

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -72,13 +72,9 @@ where
                 };
                 Ok(Arc::new(op) as Arc<dyn Operator>)
             }
-            Selection {
-                predicate, ..
-            } => {
+            Selection { predicate, .. } => {
                 let predicate = to_physical(predicate, expr_arena)?;
-                let op = operators::FilterOperator{
-                    predicate
-                };
+                let op = operators::FilterOperator { predicate };
                 Ok(Arc::new(op) as Arc<dyn Operator>)
             }
             MapFunction {

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use polars_core::prelude::PolarsResult;
+use polars_plan::prelude::*;
+
+use crate::executors::sinks::OrderedSink;
+use crate::executors::{operators, sources};
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{Operator, Sink, Source};
+use crate::pipeline::Pipeline;
+
+fn exprs_to_physical<F>(
+    exprs: &[Node],
+    expr_arena: &mut Arena<AExpr>,
+    to_physical: &F,
+) -> PolarsResult<Vec<Arc<dyn PhysicalPipedExpr>>>
+where
+    F: Fn(Node, &mut Arena<AExpr>) -> PolarsResult<Arc<dyn PhysicalPipedExpr>>,
+{
+    exprs
+        .iter()
+        .map(|node| to_physical(*node, expr_arena))
+        .collect()
+}
+
+pub fn create_pipeline<F>(
+    sources: &[Node],
+    operators: &[Node],
+    sink: Option<Node>,
+    lp_arena: &mut Arena<ALogicalPlan>,
+    expr_arena: &mut Arena<AExpr>,
+    to_physical: F,
+) -> PolarsResult<Pipeline>
+where
+    F: Fn(Node, &mut Arena<AExpr>) -> PolarsResult<Arc<dyn PhysicalPipedExpr>>,
+{
+    use ALogicalPlan::*;
+    let mut source_objects = Vec::with_capacity(sources.len());
+
+    for node in sources {
+        match lp_arena.take(*node) {
+            ALogicalPlan::CsvScan {
+                path,
+                schema,
+                options,
+                predicate,
+                aggregate,
+                ..
+            } => {
+                // todo! remove aggregate pushdown
+                assert!(aggregate.is_empty());
+                let src = sources::CsvSource::new(
+                    path,
+                    schema,
+                    options,
+                    predicate.map(|node| to_physical(node, expr_arena).unwrap()),
+                )?;
+                source_objects.push(Arc::new(src) as Arc<dyn Source>)
+            }
+            lp => {
+                panic!("source {:?} not (yet) supported", lp)
+            }
+        }
+    }
+
+    let operators = operators
+        .iter()
+        .map(|node| match lp_arena.take(*node) {
+            ALogicalPlan::Projection { expr, .. } => {
+                let op = operators::ProjectionOperator {
+                    exprs: exprs_to_physical(&expr, expr_arena, &to_physical)?,
+                };
+                Ok(Arc::new(op) as Arc<dyn Operator>)
+            }
+            MapFunction {
+                function: FunctionNode::FastProjection { columns },
+                ..
+            } => {
+                let op = operators::FastProjectionOperator { columns };
+                Ok(Arc::new(op) as Arc<dyn Operator>)
+            }
+            lp => {
+                panic!("operator {:?} not (yet) supported", lp)
+            }
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let sink = match sink {
+        None => Box::new(OrderedSink::new()) as Box<dyn Sink>,
+        Some(node) => {
+            todo!()
+        }
+    };
+
+    Ok(Pipeline::new(source_objects, operators, sink))
+}

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
-use polars_core::error::PolarsError;
 
-use polars_core::prelude::{DataType, Int64Type, PolarsResult};
+use polars_core::error::PolarsError;
+use polars_core::prelude::{DataType, Int32Type, Int64Type, PolarsResult};
 use polars_plan::prelude::*;
 
+use crate::executors::sinks::groupby::aggregates::convert_to_hash_agg;
 use crate::executors::sinks::{groupby, OrderedSink};
 use crate::executors::{operators, sources};
-use crate::executors::sinks::groupby::aggregates::convert_to_hash_agg;
 use crate::expressions::PhysicalPipedExpr;
 use crate::operators::{Operator, Sink, Source};
 use crate::pipeline::Pipeline;
@@ -95,42 +95,49 @@ where
 
     let sink = match sink {
         None => Box::new(OrderedSink::new()) as Box<dyn Sink>,
-        Some(node) => {
-            match lp_arena.get(node) {
-                Aggregate {
-                    keys,
-                    aggs,
-                    schema,
-                    ..
-                } => {
-                    assert_eq!(keys.len(), 1);
-                    if let AExpr::Column(key) = expr_arena.get(keys[0]) {
+        Some(node) => match lp_arena.get(node) {
+            Aggregate {
+                keys, aggs, schema, ..
+            } => {
+                assert_eq!(keys.len(), 1);
+                if let AExpr::Column(key) = expr_arena.get(keys[0]) {
+                    let mut aggregation_columns = Vec::with_capacity(aggs.len());
+                    let mut agg_fns = Vec::with_capacity(aggs.len());
 
-                        let mut aggregation_columns = Vec::with_capacity(aggs.len());
-                        let mut agg_fns = Vec::with_capacity(aggs.len());
-
-                        for node in aggs {
-                            let (index, agg_fn) = convert_to_hash_agg(*node, expr_arena, schema).unwrap();
-                            aggregation_columns.push(index);
-                            agg_fns.push(agg_fn)
-                        }
-                        match schema.get(key).ok_or_else(|| PolarsError::NotFound(format!("{}", key.as_ref()).into()))? {
-                            DataType::Int64 => {
-                                Box::new(groupby::PrimitiveGroupbySink::<Int64Type>::new(key.clone(), aggregation_columns, agg_fns)) as Box<dyn Sink>
-                            }
-                            _ => todo!()
-                        }
-
-
-                    } else {
-                        unreachable!()
+                    for node in aggs {
+                        let (index, agg_fn) =
+                            convert_to_hash_agg(*node, expr_arena, schema).unwrap();
+                        aggregation_columns.push(index);
+                        agg_fns.push(agg_fn)
                     }
-                }
-                _ => {
-                    todo!()
+                    match schema
+                        .get(key)
+                        .ok_or_else(|| PolarsError::NotFound(format!("{}", key.as_ref()).into()))?
+                    {
+                        DataType::Int64 => {
+                            Box::new(groupby::PrimitiveGroupbySink::<Int64Type>::new(
+                                key.clone(),
+                                aggregation_columns,
+                                agg_fns,
+                            )) as Box<dyn Sink>
+                        }
+                        DataType::Int32 => {
+                            Box::new(groupby::PrimitiveGroupbySink::<Int32Type>::new(
+                                key.clone(),
+                                aggregation_columns,
+                                agg_fns,
+                            )) as Box<dyn Sink>
+                        }
+                        dt => panic!("dtype: '{}' not yet implemented in streaming", dt),
+                    }
+                } else {
+                    unreachable!()
                 }
             }
-        }
+            _ => {
+                todo!()
+            }
+        },
     };
 
     Ok(Pipeline::new(source_objects, operators, sink))

--- a/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
@@ -40,6 +40,7 @@ impl Pipeline {
         sink: &mut [Box<dyn Sink>],
         ec: &PExecutionContext,
     ) -> PolarsResult<Vec<SinkResult>> {
+        debug_assert!(chunks.len() <= sink.len());
         POOL.install(|| {
             chunks
                 .into_par_iter()

--- a/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
@@ -11,7 +11,7 @@ use crate::operators::{
 };
 
 pub struct Pipeline {
-    sources: Vec<Arc<dyn Source>>,
+    sources: Vec<Box<dyn Source>>,
     operators: Vec<Arc<dyn Operator>>,
     // a sink for every thread
     sink: Vec<Box<dyn Sink>>,
@@ -19,7 +19,7 @@ pub struct Pipeline {
 
 impl Pipeline {
     pub fn new(
-        sources: Vec<Arc<dyn Source>>,
+        sources: Vec<Box<dyn Source>>,
         operators: Vec<Arc<dyn Operator>>,
         sink: Box<dyn Sink>,
     ) -> Pipeline {
@@ -99,7 +99,6 @@ impl Pipeline {
         let mut sink = std::mem::take(&mut self.sink);
 
         for src in &mut std::mem::take(&mut self.sources) {
-            let src = Arc::get_mut(src).unwrap();
             while let SourceResult::GotMoreData(chunks) = src.get_batches(&ec)? {
                 let results = self.par_process_chunks(chunks, &mut sink, &ec)?;
 

--- a/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
@@ -1,9 +1,7 @@
-use crate::operators::{Operator, PExecutionContext, SinkResult, Source, SourceResult};
-
 mod convert;
-mod pipeline;
+mod dispatcher;
 
 pub use convert::create_pipeline;
-pub use pipeline::Pipeline;
+pub use dispatcher::Pipeline;
 
 pub use crate::executors::sinks::groupby::aggregates::can_convert_to_hash_agg;

--- a/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
@@ -1,0 +1,7 @@
+use crate::operators::{Operator, PExecutionContext, SinkResult, Source, SourceResult};
+
+mod convert;
+mod pipeline;
+
+pub use convert::create_pipeline;
+pub use pipeline::Pipeline;

--- a/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/mod.rs
@@ -5,3 +5,5 @@ mod pipeline;
 
 pub use convert::create_pipeline;
 pub use pipeline::Pipeline;
+
+pub use crate::executors::sinks::groupby::aggregates::can_convert_to_hash_agg;

--- a/polars/polars-lazy/polars-pipe/src/pipeline/pipeline.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/pipeline.rs
@@ -1,0 +1,115 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use polars_core::error::PolarsResult;
+use polars_core::frame::DataFrame;
+use polars_core::POOL;
+use rayon::prelude::*;
+
+use crate::operators::{
+    DataChunk, Operator, OperatorResult, PExecutionContext, Sink, SinkResult, Source, SourceResult,
+};
+
+pub struct Pipeline {
+    sources: Vec<Arc<dyn Source>>,
+    operators: Vec<Arc<dyn Operator>>,
+    // a sink for every thread
+    sink: Vec<Box<dyn Sink>>,
+    n_threads: usize,
+}
+
+impl Pipeline {
+    pub fn new(
+        sources: Vec<Arc<dyn Source>>,
+        operators: Vec<Arc<dyn Operator>>,
+        sink: Box<dyn Sink>,
+    ) -> Pipeline {
+        let n_threads = POOL.current_num_threads();
+
+        let sink = (0..n_threads).map(|i| sink.split(i)).collect();
+
+        Pipeline {
+            sources,
+            operators,
+            sink,
+            n_threads,
+        }
+    }
+
+    fn push_operators(
+        &self,
+        chunk: DataChunk,
+        ec: &PExecutionContext,
+    ) -> PolarsResult<OperatorResult> {
+        let mut in_process = vec![];
+        let mut op_iter = self.operators.iter();
+
+        if let Some(op) = op_iter.next() {
+            in_process.push((op, chunk))
+        }
+
+        while let Some((op, chunk)) = in_process.pop() {
+            match op.execute(&ec, &chunk)? {
+                OperatorResult::Finished(chunk) => {
+                    if let Some(op) = op_iter.next() {
+                        in_process.push((op, chunk))
+                    } else {
+                        return Ok(OperatorResult::Finished(chunk));
+                    }
+                }
+                OperatorResult::HaveMoreOutPut(output_chunk) => {
+                    if let Some(op) = op_iter.next() {
+                        in_process.push((op, output_chunk))
+                    }
+                    // this operator first at the top of the stack
+                    in_process.push((op, chunk))
+                }
+                OperatorResult::NeedMoreInput => {
+                    // current chunk will be used again
+                    in_process.push((op, chunk))
+                }
+            }
+        }
+
+        todo!()
+    }
+
+    pub fn execute(&mut self, state: Box<dyn Any>) -> PolarsResult<DataFrame> {
+        let ec = PExecutionContext::new(state);
+        let mut sink = std::mem::take(&mut self.sink);
+
+        for src in &mut std::mem::take(&mut self.sources) {
+            let src = Arc::get_mut(src).unwrap();
+            while let SourceResult::GotMoreData(chunks) = src.get_batches(&ec)? {
+                // linear:
+                let results = chunks
+                    .into_iter()
+                    .zip(&mut sink)
+                    .map(|(chunk, sink)| {
+                        let chunk = match self.push_operators(chunk, &ec)? {
+                            OperatorResult::Finished(chunk) => chunk,
+                            _ => todo!(),
+                        };
+                        sink.sink(&ec, chunk)
+                    })
+                    .collect::<PolarsResult<Vec<_>>>()?;
+
+                if results
+                    .iter()
+                    .any(|sink_result| matches!(sink_result, SinkResult::Finished))
+                {
+                    break;
+                }
+            }
+        }
+
+        let mut reduced_sink = sink
+            .into_par_iter()
+            .reduce_with(|mut a, b| {
+                a.combine(b);
+                a
+            })
+            .unwrap();
+        reduced_sink.finalize()
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/pipeline/pipeline.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/pipeline.rs
@@ -18,7 +18,6 @@ pub struct Pipeline {
     n_threads: usize,
 }
 
-
 impl Pipeline {
     pub fn new(
         sources: Vec<Arc<dyn Source>>,
@@ -37,14 +36,17 @@ impl Pipeline {
         }
     }
 
-    fn par_process_chunks(&self, chunks: Vec<DataChunk>, sink: &mut [Box<dyn Sink>], ec: &PExecutionContext) -> PolarsResult<Vec<SinkResult>> {
-
+    fn par_process_chunks(
+        &self,
+        chunks: Vec<DataChunk>,
+        sink: &mut [Box<dyn Sink>],
+        ec: &PExecutionContext,
+    ) -> PolarsResult<Vec<SinkResult>> {
         POOL.install(|| {
             chunks
                 .into_par_iter()
-                .zip( sink.par_iter_mut())
+                .zip(sink.par_iter_mut())
                 .map(|(chunk, sink)| {
-
                     let chunk = match self.push_operators(chunk, &ec)? {
                         OperatorResult::Finished(chunk) => chunk,
                         _ => todo!(),
@@ -100,7 +102,6 @@ impl Pipeline {
         for src in &mut std::mem::take(&mut self.sources) {
             let src = Arc::get_mut(src).unwrap();
             while let SourceResult::GotMoreData(chunks) = src.get_batches(&ec)? {
-
                 let results = self.par_process_chunks(chunks, &mut sink, &ec)?;
 
                 if results

--- a/polars/polars-lazy/polars-plan/src/frame/opt_state.rs
+++ b/polars/polars-lazy/polars-plan/src/frame/opt_state.rs
@@ -10,6 +10,7 @@ pub struct OptState {
     pub slice_pushdown: bool,
     #[cfg(feature = "cse")]
     pub common_subplan_elimination: bool,
+    pub streaming: bool,
 }
 
 impl Default for OptState {
@@ -25,6 +26,7 @@ impl Default for OptState {
             aggregate_pushdown: false,
             #[cfg(feature = "cse")]
             common_subplan_elimination: true,
+            streaming: false,
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -157,8 +157,8 @@ impl Default for ALogicalPlan {
         // the lp is should not be valid. By choosing a max value we'll likely panic indicating
         // a programming error early.
         ALogicalPlan::Selection {
-            input: Node(usize::max_value()),
-            predicate: Node(usize::max_value()),
+            input: Node(usize::MAX),
+            predicate: Node(usize::MAX),
         }
     }
 }
@@ -556,7 +556,7 @@ impl ALogicalPlan {
     /// Push inputs of the LP in of this node to an existing container.
     /// Most plans have typically one input. A join has two and a scan (CsvScan)
     /// or an in-memory DataFrame has none. A Union has multiple.
-    pub(crate) fn copy_inputs<T>(&self, container: &mut T)
+    pub fn copy_inputs<T>(&self, container: &mut T)
     where
         T: PushNode,
     {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/apply.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/apply.rs
@@ -3,14 +3,14 @@ use std::fmt::{Debug, Formatter};
 use polars_core::prelude::*;
 
 pub trait DataFrameUdf: Send + Sync {
-    fn call_udf(&self, df: DataFrame) -> PolarsResult<DataFrame>;
+    fn call_udf(&mut self, df: DataFrame) -> PolarsResult<DataFrame>;
 }
 
 impl<F> DataFrameUdf for F
 where
-    F: Fn(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
+    F: FnMut(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
 {
-    fn call_udf(&self, df: DataFrame) -> PolarsResult<DataFrame> {
+    fn call_udf(&mut self, df: DataFrame) -> PolarsResult<DataFrame> {
         self(df)
     }
 }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/apply.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/apply.rs
@@ -3,10 +3,23 @@ use std::fmt::{Debug, Formatter};
 use polars_core::prelude::*;
 
 pub trait DataFrameUdf: Send + Sync {
-    fn call_udf(&mut self, df: DataFrame) -> PolarsResult<DataFrame>;
+    fn call_udf(&self, df: DataFrame) -> PolarsResult<DataFrame>;
 }
 
 impl<F> DataFrameUdf for F
+where
+    F: Fn(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
+{
+    fn call_udf(&self, df: DataFrame) -> PolarsResult<DataFrame> {
+        self(df)
+    }
+}
+
+pub trait DataFrameUdfMut: Send + Sync {
+    fn call_udf(&mut self, df: DataFrame) -> PolarsResult<DataFrame>;
+}
+
+impl<F> DataFrameUdfMut for F
 where
     F: FnMut(DataFrame) -> PolarsResult<DataFrame> + Send + Sync,
 {
@@ -18,6 +31,11 @@ where
 impl Debug for dyn DataFrameUdf {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "dyn DataFrameUdf")
+    }
+}
+impl Debug for dyn DataFrameUdfMut {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dyn DataFrameUdfMut")
     }
 }
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
@@ -66,9 +66,7 @@ impl FunctionNode {
                     Ok(Cow::Owned(output_schema))
                 }
             },
-            Pipeline { .. } => {
-                unimplemented!()
-            }
+            Pipeline { schema, .. } => Ok(Cow::Owned(schema.clone())),
             FastProjection { columns } => {
                 let schema = columns
                     .iter()

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
@@ -130,10 +130,10 @@ impl FunctionNode {
         }
     }
 
-    pub fn evaluate(&self, mut df: DataFrame) -> PolarsResult<DataFrame> {
+    pub fn evaluate(&mut self, mut df: DataFrame) -> PolarsResult<DataFrame> {
         use FunctionNode::*;
         match self {
-            Opaque { function, .. } => function.call_udf(df),
+            Opaque { function, .. } => Arc::get_mut(function).unwrap().call_udf(df),
             FastProjection { columns } => df.select(columns.as_slice()),
             DropNulls { subset } => df.drop_nulls(Some(subset.as_slice())),
             Rechunk => {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
@@ -195,7 +195,7 @@ impl TryFrom<AnyValue<'_>> for LiteralValue {
             #[cfg(all(feature = "temporal", feature = "dtype-datetime"))]
             AnyValue::Time(nano_secs_sinds_midnight) => Ok(Self::Int64(nano_secs_sinds_midnight)),
             AnyValue::List(l) => Ok(Self::Series(SpecialEq::new(l))),
-            AnyValue::Utf8Owned(o) => Ok(Self::Utf8(o)),
+            AnyValue::Utf8Owned(o) => Ok(Self::Utf8(o.into())),
             #[cfg(feature = "dtype-categorical")]
             AnyValue::Categorical(c, rev_mapping) => Ok(Self::Utf8(rev_mapping.get(c).to_string())),
             _ => Err(PolarsError::ComputeError(

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
@@ -25,6 +25,7 @@ pub(super) fn collect_trails(
     // if trails should be collected
     collect: bool,
 ) -> Option<()> {
+    // TODO! remove recursion and use a stack
     if collect {
         trails.get_mut(id).unwrap().push(root);
     }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -266,7 +266,7 @@ impl FileCacher {
         scratch: &mut Vec<Node>,
     ) {
         scratch.clear();
-        let mut stack = Vec::with_capacity(lp_arena.len());
+        let mut stack = Vec::with_capacity(lp_arena.len() / 3 + 1);
         stack.push((root, false));
 
         // if behind cache we should not add a projection

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -305,6 +305,7 @@ impl SlicePushDown {
             | m @ (Cache {..}, _)
             | m @ (Distinct {..}, _)
             | m @ (HStack {..},_)
+            | m @ (Aggregate{..},_)
             => {
                 let (lp, state) = m;
                 self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -40,7 +40,7 @@ pub(crate) fn fmt_column_delimited<S: AsRef<str>>(
     write!(f, "{}", container_end)
 }
 
-pub(crate) trait PushNode {
+pub trait PushNode {
     fn push_node(&mut self, value: Node);
 }
 

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -21,7 +21,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
             let expr = expr.clone();
             let mut arena = Arena::with_capacity(10);
             let aexpr = to_aexpr(expr, &mut arena);
-            let phys_expr = create_physical_expr(aexpr, Context::Default, &mut arena)?;
+            let phys_expr = create_physical_expr(aexpr, Context::Default, &arena)?;
 
             let state = ExecutionState::new();
 

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -2,6 +2,7 @@ use polars_core::prelude::*;
 use rayon::prelude::*;
 
 use super::*;
+use crate::physical_plan::planner::create_physical_expr;
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
 
@@ -20,8 +21,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
             let expr = expr.clone();
             let mut arena = Arena::with_capacity(10);
             let aexpr = to_aexpr(expr, &mut arena);
-            let planner = PhysicalPlanner::default();
-            let phys_expr = planner.create_physical_expr(aexpr, Context::Default, &mut arena)?;
+            let phys_expr = create_physical_expr(aexpr, Context::Default, &mut arena)?;
 
             let state = ExecutionState::new();
 

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -39,6 +39,7 @@ use polars_plan::logical_plan::optimize;
 use polars_plan::utils::{combine_predicates_expr, expr_to_leaf_column_names};
 
 use crate::physical_plan::executors::Executor;
+use crate::physical_plan::planner::create_physical_plan;
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::streaming::insert_streaming_nodes;
 use crate::prelude::*;
@@ -554,8 +555,7 @@ impl LazyFrame {
             insert_streaming_nodes(lp_top, &mut lp_arena, &mut expr_arena, &mut scratch)?;
         }
 
-        let planner = PhysicalPlanner::default();
-        let physical_plan = planner.create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
+        let physical_plan = create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;
 
         let state = ExecutionState::with_finger_prints(finger_prints);
         Ok((state, physical_plan))

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -41,6 +41,7 @@ use polars_plan::utils::{combine_predicates_expr, expr_to_leaf_column_names};
 use crate::physical_plan::executors::Executor;
 use crate::physical_plan::planner::create_physical_plan;
 use crate::physical_plan::state::ExecutionState;
+#[cfg(any(feature = "csv-file", feature = "parquet"))]
 use crate::physical_plan::streaming::insert_streaming_nodes;
 use crate::prelude::*;
 
@@ -552,7 +553,14 @@ impl LazyFrame {
         };
 
         if streaming {
-            insert_streaming_nodes(lp_top, &mut lp_arena, &mut expr_arena, &mut scratch)?;
+            #[cfg(any(feature = "csv-file", feature = "parquet"))]
+            {
+                insert_streaming_nodes(lp_top, &mut lp_arena, &mut expr_arena, &mut scratch)?;
+            }
+            #[cfg(not(any(feature = "csv-file", feature = "parquet")))]
+            {
+                panic!("activate feature 'csv-file' or 'parquet'")
+            }
         }
 
         let physical_plan = create_physical_plan(lp_top, &mut lp_arena, &mut expr_arena)?;

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -47,9 +47,9 @@ pub(super) fn groupby_helper(
     df.as_single_chunk_par();
     let gb = df.groupby_with_series(keys, true, maintain_order)?;
 
-    if let Some(mut f) = apply {
+    if let Some(f) = apply {
         state.clear_schema_cache();
-        return gb.apply(move |df| Arc::get_mut(&mut f).unwrap().call_udf(df));
+        return gb.apply(move |df| f.call_udf(df));
     }
 
     let mut groups = gb.get_groups();

--- a/polars/polars-lazy/src/physical_plan/exotic.rs
+++ b/polars/polars-lazy/src/physical_plan/exotic.rs
@@ -39,5 +39,5 @@ pub(crate) fn prepare_expression_for_context(
     let lp = lp_arena.get(optimized);
     let aexpr = lp.get_exprs().pop().unwrap();
 
-    create_physical_expr(aexpr, ctxt, &mut expr_arena)
+    create_physical_expr(aexpr, ctxt, &expr_arena)
 }

--- a/polars/polars-lazy/src/physical_plan/exotic.rs
+++ b/polars/polars-lazy/src/physical_plan/exotic.rs
@@ -1,5 +1,6 @@
 use polars_core::prelude::*;
 
+use crate::physical_plan::planner::create_physical_expr;
 use crate::prelude::*;
 
 pub(crate) fn prepare_eval_expr(mut expr: Expr) -> Expr {
@@ -38,6 +39,5 @@ pub(crate) fn prepare_expression_for_context(
     let lp = lp_arena.get(optimized);
     let aexpr = lp.get_exprs().pop().unwrap();
 
-    let planner = PhysicalPlanner::default();
-    planner.create_physical_expr(aexpr, ctxt, &mut expr_arena)
+    create_physical_expr(aexpr, ctxt, &mut expr_arena)
 }

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -7,6 +7,7 @@ mod file_cache;
 mod node_timer;
 pub mod planner;
 pub(crate) mod state;
+pub(crate) mod streaming;
 
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -6,586 +6,593 @@ use polars_core::utils::parallel_op_series;
 use super::super::expressions as phys_expr;
 use crate::prelude::*;
 
-impl PhysicalPlanner {
-    pub fn create_physical_expr(
-        &self,
-        expression: Node,
-        ctxt: Context,
-        expr_arena: &mut Arena<AExpr>,
-    ) -> PolarsResult<Arc<dyn PhysicalExpr>> {
-        use AExpr::*;
+pub(crate) fn create_physical_expressions(
+    exprs: &[Node],
+    context: Context,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<Vec<Arc<dyn PhysicalExpr>>> {
+    exprs
+        .iter()
+        .map(|e| create_physical_expr(*e, context, expr_arena))
+        .collect()
+}
 
-        match expr_arena.get(expression).clone() {
-            Count => Ok(Arc::new(phys_expr::CountExpr::new())),
-            Window {
-                mut function,
-                partition_by,
-                order_by: _,
+pub(crate) fn create_physical_expr(
+    expression: Node,
+    ctxt: Context,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<Arc<dyn PhysicalExpr>> {
+    use AExpr::*;
+
+    match expr_arena.get(expression).clone() {
+        Count => Ok(Arc::new(phys_expr::CountExpr::new())),
+        Window {
+            mut function,
+            partition_by,
+            order_by: _,
+            options,
+        } => {
+            // TODO! Order by
+            let group_by =
+                create_physical_expressions(&partition_by, Context::Default, expr_arena)?;
+            let phys_function = create_physical_expr(function, Context::Aggregation, expr_arena)?;
+            let mut out_name = None;
+            let mut apply_columns = aexpr_to_leaf_names(function, expr_arena);
+            // sort and then dedup removes consecutive duplicates == all duplicates
+            apply_columns.sort();
+            apply_columns.dedup();
+
+            if apply_columns.is_empty() {
+                if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Literal(_))) {
+                    apply_columns.push(Arc::from("literal"))
+                } else if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Count)) {
+                    apply_columns.push(Arc::from("count"))
+                } else {
+                    let e = node_to_expr(function, expr_arena);
+                    return Err(PolarsError::ComputeError(
+                        format!(
+                            "Cannot apply a window function, did not find a root column. \
+                        This is likely due to a syntax error in this expression: {:?}",
+                            e
+                        )
+                        .into(),
+                    ));
+                }
+            }
+
+            if let Alias(expr, name) = expr_arena.get(function) {
+                function = *expr;
+                out_name = Some(name.clone());
+            };
+            let function = node_to_expr(function, expr_arena);
+
+            Ok(Arc::new(WindowExpr {
+                group_by,
+                apply_columns,
+                out_name,
+                function,
+                phys_function,
                 options,
-            } => {
-                // TODO! Order by
-                let group_by =
-                    self.create_physical_expressions(&partition_by, Context::Default, expr_arena)?;
-                let phys_function =
-                    self.create_physical_expr(function, Context::Aggregation, expr_arena)?;
-                let mut out_name = None;
-                let mut apply_columns = aexpr_to_leaf_names(function, expr_arena);
-                // sort and then dedup removes consecutive duplicates == all duplicates
-                apply_columns.sort();
-                apply_columns.dedup();
+                expr: node_to_expr(expression, expr_arena),
+            }))
+        }
+        Literal(value) => Ok(Arc::new(LiteralExpr::new(
+            value,
+            node_to_expr(expression, expr_arena),
+        ))),
+        BinaryExpr { left, op, right } => {
+            let lhs = create_physical_expr(left, ctxt, expr_arena)?;
+            let rhs = create_physical_expr(right, ctxt, expr_arena)?;
+            Ok(Arc::new(phys_expr::BinaryExpr::new(
+                lhs,
+                op,
+                rhs,
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        Column(column) => Ok(Arc::new(ColumnExpr::new(
+            column,
+            node_to_expr(expression, expr_arena),
+        ))),
+        Sort { expr, options } => {
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            Ok(Arc::new(SortExpr::new(
+                phys_expr,
+                options,
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        Take { expr, idx } => {
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            let phys_idx = create_physical_expr(idx, ctxt, expr_arena)?;
+            Ok(Arc::new(TakeExpr {
+                phys_expr,
+                idx: phys_idx,
+                expr: node_to_expr(expression, expr_arena),
+            }))
+        }
+        SortBy { expr, by, reverse } => {
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            let phys_by = create_physical_expressions(&by, ctxt, expr_arena)?;
+            Ok(Arc::new(SortByExpr::new(
+                phys_expr,
+                phys_by,
+                reverse,
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        Filter { input, by } => {
+            let phys_input = create_physical_expr(input, ctxt, expr_arena)?;
+            let phys_by = create_physical_expr(by, ctxt, expr_arena)?;
+            Ok(Arc::new(FilterExpr::new(
+                phys_input,
+                phys_by,
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        Alias(expr, name) => {
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            Ok(Arc::new(AliasExpr::new(
+                phys_expr,
+                name,
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        Agg(agg) => {
+            match agg {
+                AAggExpr::Min {
+                    input: expr,
+                    propagate_nans,
+                } => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            if propagate_nans {
+                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::NanMin)))
+                            } else {
+                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Min)))
+                            }
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
 
-                if apply_columns.is_empty() {
-                    if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Literal(_))) {
-                        apply_columns.push(Arc::from("literal"))
-                    } else if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Count)) {
-                        apply_columns.push(Arc::from("count"))
-                    } else {
-                        let e = node_to_expr(function, expr_arena);
-                        return Err(PolarsError::ComputeError(
-                            format!(
-                                "Cannot apply a window function, did not find a root column. \
-                            This is likely due to a syntax error in this expression: {:?}",
-                                e
-                            )
-                            .into(),
-                        ));
+                                if propagate_nans && s.dtype().is_float() {
+                                    #[cfg(feature = "propagate_nans")]
+                                    {
+                                        return parallel_op_series(
+                                            |s| {
+                                                Ok(polars_ops::prelude::nan_propagating_aggregate::nan_min_s(&s, s.name()))
+                                            },
+                                            s,
+                                            None,
+                                        );
+                                    }
+                                    #[cfg(not(feature = "propagate_nans"))]
+                                    {
+                                        panic!("activate 'propagate_nans' feature")
+                                    }
+                                }
+
+                                match s.is_sorted() {
+                                    IsSorted::Ascending | IsSorted::Descending => {
+                                        Ok(s.min_as_series())
+                                    }
+                                    IsSorted::Not => {
+                                        parallel_op_series(|s| Ok(s.min_as_series()), s, None)
+                                    }
+                                }
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
+                        }
                     }
                 }
+                AAggExpr::Max {
+                    input: expr,
+                    propagate_nans,
+                } => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            if propagate_nans {
+                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::NanMax)))
+                            } else {
+                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Max)))
+                            }
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
 
-                if let Alias(expr, name) = expr_arena.get(function) {
-                    function = *expr;
-                    out_name = Some(name.clone());
-                };
-                let function = node_to_expr(function, expr_arena);
-
-                Ok(Arc::new(WindowExpr {
-                    group_by,
-                    apply_columns,
-                    out_name,
-                    function,
-                    phys_function,
-                    options,
-                    expr: node_to_expr(expression, expr_arena),
-                }))
-            }
-            Literal(value) => Ok(Arc::new(LiteralExpr::new(
-                value,
-                node_to_expr(expression, expr_arena),
-            ))),
-            BinaryExpr { left, op, right } => {
-                let lhs = self.create_physical_expr(left, ctxt, expr_arena)?;
-                let rhs = self.create_physical_expr(right, ctxt, expr_arena)?;
-                Ok(Arc::new(phys_expr::BinaryExpr::new(
-                    lhs,
-                    op,
-                    rhs,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            Column(column) => Ok(Arc::new(ColumnExpr::new(
-                column,
-                node_to_expr(expression, expr_arena),
-            ))),
-            Sort { expr, options } => {
-                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                Ok(Arc::new(SortExpr::new(
-                    phys_expr,
-                    options,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            Take { expr, idx } => {
-                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                let phys_idx = self.create_physical_expr(idx, ctxt, expr_arena)?;
-                Ok(Arc::new(TakeExpr {
-                    phys_expr,
-                    idx: phys_idx,
-                    expr: node_to_expr(expression, expr_arena),
-                }))
-            }
-            SortBy { expr, by, reverse } => {
-                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                let phys_by = self.create_physical_expressions(&by, ctxt, expr_arena)?;
-                Ok(Arc::new(SortByExpr::new(
-                    phys_expr,
-                    phys_by,
-                    reverse,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            Filter { input, by } => {
-                let phys_input = self.create_physical_expr(input, ctxt, expr_arena)?;
-                let phys_by = self.create_physical_expr(by, ctxt, expr_arena)?;
-                Ok(Arc::new(FilterExpr::new(
-                    phys_input,
-                    phys_by,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            Alias(expr, name) => {
-                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                Ok(Arc::new(AliasExpr::new(
-                    phys_expr,
-                    name,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            Agg(agg) => {
-                match agg {
-                    AAggExpr::Min {
-                        input: expr,
-                        propagate_nans,
-                    } => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                if propagate_nans {
-                                    Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::NanMin)))
-                                } else {
-                                    Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Min)))
+                                if propagate_nans && s.dtype().is_float() {
+                                    #[cfg(feature = "propagate_nans")]
+                                    {
+                                        return parallel_op_series(
+                                            |s| {
+                                                Ok(polars_ops::prelude::nan_propagating_aggregate::nan_max_s(&s, s.name()))
+                                            },
+                                            s,
+                                            None,
+                                        );
+                                    }
+                                    #[cfg(not(feature = "propagate_nans"))]
+                                    {
+                                        panic!("activate 'propagate_nans' feature")
+                                    }
                                 }
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
 
-                                    if propagate_nans && s.dtype().is_float() {
-                                        #[cfg(feature = "propagate_nans")]
-                                        {
-                                            return parallel_op_series(
-                                                |s| {
-                                                    Ok(polars_ops::prelude::nan_propagating_aggregate::nan_min_s(&s, s.name()))
-                                                },
-                                                s,
-                                                None,
-                                            );
-                                        }
-                                        #[cfg(not(feature = "propagate_nans"))]
-                                        {
-                                            panic!("activate 'propagate_nans' feature")
-                                        }
+                                match s.is_sorted() {
+                                    IsSorted::Ascending | IsSorted::Descending => {
+                                        Ok(s.max_as_series())
                                     }
-
-                                    match s.is_sorted() {
-                                        IsSorted::Ascending | IsSorted::Descending => {
-                                            Ok(s.min_as_series())
-                                        }
-                                        IsSorted::Not => {
-                                            parallel_op_series(|s| Ok(s.min_as_series()), s, None)
-                                        }
+                                    IsSorted::Not => {
+                                        parallel_op_series(|s| Ok(s.max_as_series()), s, None)
                                     }
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
-                        }
-                    }
-                    AAggExpr::Max {
-                        input: expr,
-                        propagate_nans,
-                    } => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                if propagate_nans {
-                                    Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::NanMax)))
-                                } else {
-                                    Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Max)))
                                 }
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-
-                                    if propagate_nans && s.dtype().is_float() {
-                                        #[cfg(feature = "propagate_nans")]
-                                        {
-                                            return parallel_op_series(
-                                                |s| {
-                                                    Ok(polars_ops::prelude::nan_propagating_aggregate::nan_max_s(&s, s.name()))
-                                                },
-                                                s,
-                                                None,
-                                            );
-                                        }
-                                        #[cfg(not(feature = "propagate_nans"))]
-                                        {
-                                            panic!("activate 'propagate_nans' feature")
-                                        }
-                                    }
-
-                                    match s.is_sorted() {
-                                        IsSorted::Ascending | IsSorted::Descending => {
-                                            Ok(s.max_as_series())
-                                        }
-                                        IsSorted::Not => {
-                                            parallel_op_series(|s| Ok(s.max_as_series()), s, None)
-                                        }
-                                    }
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Sum(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Sum)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    parallel_op_series(|s| Ok(s.sum_as_series()), s, None)
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Sum(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Sum)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                parallel_op_series(|s| Ok(s.sum_as_series()), s, None)
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Std(expr, ddof) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
-                                input,
-                                GroupByMethod::Std(ddof),
-                            ))),
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.std_as_series(ddof))
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Std(expr, ddof) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
+                            input,
+                            GroupByMethod::Std(ddof),
+                        ))),
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.std_as_series(ddof))
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Var(expr, ddof) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
-                                input,
-                                GroupByMethod::Var(ddof),
-                            ))),
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.var_as_series(ddof))
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Var(expr, ddof) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
+                            input,
+                            GroupByMethod::Var(ddof),
+                        ))),
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.var_as_series(ddof))
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Mean(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Mean)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.mean_as_series())
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Mean(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Mean)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.mean_as_series())
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Median(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Median)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.median_as_series())
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Median(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Median)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.median_as_series())
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::First(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::First)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.head(Some(1)))
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::First(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::First)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.head(Some(1)))
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Last(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Last)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    Ok(s.tail(Some(1)))
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Last(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Last)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                Ok(s.tail(Some(1)))
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::List(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::List)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = &s[0];
-                                    s.to_list().map(|ca| ca.into_series())
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::List(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::List)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = &s[0];
+                                s.to_list().map(|ca| ca.into_series())
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::NUnique(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
-                                input,
-                                GroupByMethod::NUnique,
-                            ))),
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    s.n_unique().map(|count| {
-                                        UInt32Chunked::from_slice(s.name(), &[count as u32])
-                                            .into_series()
-                                    })
+                }
+                AAggExpr::NUnique(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
+                            input,
+                            GroupByMethod::NUnique,
+                        ))),
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                s.n_unique().map(|count| {
+                                    UInt32Chunked::from_slice(s.name(), &[count as u32])
+                                        .into_series()
                                 })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::Quantile {
-                        expr,
-                        quantile,
-                        interpol,
-                    } => {
-                        // todo! add schema to get correct output type
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggQuantileExpr::new(input, quantile, interpol)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    s.quantile_as_series(quantile, interpol)
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                }
+                AAggExpr::Quantile {
+                    expr,
+                    quantile,
+                    interpol,
+                } => {
+                    // todo! add schema to get correct output type
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggQuantileExpr::new(input, quantile, interpol)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                s.quantile_as_series(quantile, interpol)
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
-                    AAggExpr::AggGroups(expr) => {
-                        if let Context::Default = ctxt {
-                            panic!("agg groups expression only supported in aggregation context")
-                        }
-                        let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        Ok(Arc::new(AggregationExpr::new(
-                            phys_expr,
-                            GroupByMethod::Groups,
-                        )))
+                }
+                AAggExpr::AggGroups(expr) => {
+                    if let Context::Default = ctxt {
+                        panic!("agg groups expression only supported in aggregation context")
                     }
-                    AAggExpr::Count(expr) => {
-                        let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                        match ctxt {
-                            Context::Aggregation => {
-                                Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Count)))
-                            }
-                            Context::Default => {
-                                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                                    let s = std::mem::take(&mut s[0]);
-                                    let count = s.len();
-                                    Ok(UInt32Chunked::from_slice(s.name(), &[count as u32])
-                                        .into_series())
-                                })
-                                    as Arc<dyn SeriesUdf>);
-                                Ok(Arc::new(ApplyExpr::new_minimal(
-                                    vec![input],
-                                    function,
-                                    node_to_expr(expression, expr_arena),
-                                    ApplyOptions::ApplyFlat,
-                                )))
-                            }
+                    let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+                    Ok(Arc::new(AggregationExpr::new(
+                        phys_expr,
+                        GroupByMethod::Groups,
+                    )))
+                }
+                AAggExpr::Count(expr) => {
+                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    match ctxt {
+                        Context::Aggregation => {
+                            Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Count)))
+                        }
+                        Context::Default => {
+                            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                                let s = std::mem::take(&mut s[0]);
+                                let count = s.len();
+                                Ok(UInt32Chunked::from_slice(s.name(), &[count as u32])
+                                    .into_series())
+                            })
+                                as Arc<dyn SeriesUdf>);
+                            Ok(Arc::new(ApplyExpr::new_minimal(
+                                vec![input],
+                                function,
+                                node_to_expr(expression, expr_arena),
+                                ApplyOptions::ApplyFlat,
+                            )))
                         }
                     }
                 }
             }
-            Cast {
-                expr,
+        }
+        Cast {
+            expr,
+            data_type,
+            strict,
+        } => {
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            Ok(Arc::new(CastExpr {
+                input: phys_expr,
                 data_type,
+                expr: node_to_expr(expression, expr_arena),
                 strict,
-            } => {
-                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                Ok(Arc::new(CastExpr {
-                    input: phys_expr,
-                    data_type,
-                    expr: node_to_expr(expression, expr_arena),
-                    strict,
-                }))
-            }
-            Ternary {
+            }))
+        }
+        Ternary {
+            predicate,
+            truthy,
+            falsy,
+        } => {
+            let predicate = create_physical_expr(predicate, ctxt, expr_arena)?;
+            let truthy = create_physical_expr(truthy, ctxt, expr_arena)?;
+            let falsy = create_physical_expr(falsy, ctxt, expr_arena)?;
+            Ok(Arc::new(TernaryExpr::new(
                 predicate,
                 truthy,
                 falsy,
-            } => {
-                let predicate = self.create_physical_expr(predicate, ctxt, expr_arena)?;
-                let truthy = self.create_physical_expr(truthy, ctxt, expr_arena)?;
-                let falsy = self.create_physical_expr(falsy, ctxt, expr_arena)?;
-                Ok(Arc::new(TernaryExpr::new(
-                    predicate,
-                    truthy,
-                    falsy,
-                    node_to_expr(expression, expr_arena),
-                )))
-            }
-            AnonymousFunction {
-                input,
-                function,
-                output_type: _,
-                options,
-            } => {
-                let input = self.create_physical_expressions(&input, ctxt, expr_arena)?;
+                node_to_expr(expression, expr_arena),
+            )))
+        }
+        AnonymousFunction {
+            input,
+            function,
+            output_type: _,
+            options,
+        } => {
+            let input = create_physical_expressions(&input, ctxt, expr_arena)?;
 
-                Ok(Arc::new(ApplyExpr {
-                    inputs: input,
-                    function,
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: options.collect_groups,
-                    auto_explode: options.auto_explode,
-                    allow_rename: options.allow_rename,
-                }))
-            }
-            Function {
-                input,
+            Ok(Arc::new(ApplyExpr {
+                inputs: input,
                 function,
-                options,
-                ..
-            } => {
-                let input = self.create_physical_expressions(&input, ctxt, expr_arena)?;
+                expr: node_to_expr(expression, expr_arena),
+                collect_groups: options.collect_groups,
+                auto_explode: options.auto_explode,
+                allow_rename: options.allow_rename,
+            }))
+        }
+        Function {
+            input,
+            function,
+            options,
+            ..
+        } => {
+            let input = create_physical_expressions(&input, ctxt, expr_arena)?;
 
-                Ok(Arc::new(ApplyExpr {
-                    inputs: input,
-                    function: function.into(),
-                    expr: node_to_expr(expression, expr_arena),
-                    collect_groups: options.collect_groups,
-                    auto_explode: options.auto_explode,
-                    allow_rename: options.allow_rename,
-                }))
-            }
-            Slice {
+            Ok(Arc::new(ApplyExpr {
+                inputs: input,
+                function: function.into(),
+                expr: node_to_expr(expression, expr_arena),
+                collect_groups: options.collect_groups,
+                auto_explode: options.auto_explode,
+                allow_rename: options.allow_rename,
+            }))
+        }
+        Slice {
+            input,
+            offset,
+            length,
+        } => {
+            let input = create_physical_expr(input, ctxt, expr_arena)?;
+            let offset = create_physical_expr(offset, ctxt, expr_arena)?;
+            let length = create_physical_expr(length, ctxt, expr_arena)?;
+            Ok(Arc::new(SliceExpr {
                 input,
                 offset,
                 length,
-            } => {
-                let input = self.create_physical_expr(input, ctxt, expr_arena)?;
-                let offset = self.create_physical_expr(offset, ctxt, expr_arena)?;
-                let length = self.create_physical_expr(length, ctxt, expr_arena)?;
-                Ok(Arc::new(SliceExpr {
-                    input,
-                    offset,
-                    length,
-                    expr: node_to_expr(expression, expr_arena),
-                }))
-            }
-            Explode(expr) => {
-                let input = self.create_physical_expr(expr, ctxt, expr_arena)?;
-                let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-                    let s = std::mem::take(&mut s[0]);
-                    s.explode()
-                }) as Arc<dyn SeriesUdf>);
-                Ok(Arc::new(ApplyExpr::new_minimal(
-                    vec![input],
-                    function,
-                    node_to_expr(expression, expr_arena),
-                    ApplyOptions::ApplyGroups,
-                )))
-            }
-            Wildcard => panic!("should be no wildcard at this point"),
-            Nth(_) => panic!("should be no nth at this point"),
+                expr: node_to_expr(expression, expr_arena),
+            }))
         }
+        Explode(expr) => {
+            let input = create_physical_expr(expr, ctxt, expr_arena)?;
+            let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
+                let s = std::mem::take(&mut s[0]);
+                s.explode()
+            }) as Arc<dyn SeriesUdf>);
+            Ok(Arc::new(ApplyExpr::new_minimal(
+                vec![input],
+                function,
+                node_to_expr(expression, expr_arena),
+                ApplyOptions::ApplyGroups,
+            )))
+        }
+        Wildcard => panic!("should be no wildcard at this point"),
+        Nth(_) => panic!("should be no nth at this point"),
     }
 }

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 pub(crate) fn create_physical_expressions(
     exprs: &[Node],
     context: Context,
-    expr_arena: &mut Arena<AExpr>,
+    expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<Vec<Arc<dyn PhysicalExpr>>> {
     exprs
         .iter()
@@ -20,7 +20,7 @@ pub(crate) fn create_physical_expressions(
 pub(crate) fn create_physical_expr(
     expression: Node,
     ctxt: Context,
-    expr_arena: &mut Arena<AExpr>,
+    expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<Arc<dyn PhysicalExpr>> {
     use AExpr::*;
 

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -55,308 +55,301 @@ fn aggregate_expr_to_scan_agg(
         .collect()
 }
 
-#[derive(Default)]
-pub struct PhysicalPlanner {}
-
-impl PhysicalPlanner {
-    pub fn create_physical_plan(
-        &self,
-        root: Node,
-        lp_arena: &mut Arena<ALogicalPlan>,
-        expr_arena: &mut Arena<AExpr>,
-    ) -> PolarsResult<Box<dyn Executor>> {
-        use ALogicalPlan::*;
-        let logical_plan = lp_arena.take(root);
-        match logical_plan {
-            #[cfg(feature = "python")]
-            PythonScan { options } => Ok(Box::new(executors::PythonScanExec { options })),
-            Union { inputs, options } => {
-                let inputs = inputs
-                    .into_iter()
-                    .map(|node| self.create_physical_plan(node, lp_arena, expr_arena))
-                    .collect::<PolarsResult<Vec<_>>>()?;
-                Ok(Box::new(executors::UnionExec { inputs, options }))
-            }
-            Melt { input, args, .. } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::MeltExec { input, args }))
-            }
-            Slice { input, offset, len } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::SliceExec { input, offset, len }))
-            }
-            Selection { input, predicate } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let predicate = create_physical_expr(predicate, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::FilterExec::new(predicate, input)))
-            }
-            #[cfg(feature = "csv-file")]
-            CsvScan {
+pub fn create_physical_plan(
+    root: Node,
+    lp_arena: &mut Arena<ALogicalPlan>,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<Box<dyn Executor>> {
+    use ALogicalPlan::*;
+    let logical_plan = lp_arena.take(root);
+    match logical_plan {
+        #[cfg(feature = "python")]
+        PythonScan { options } => Ok(Box::new(executors::PythonScanExec { options })),
+        Union { inputs, options } => {
+            let inputs = inputs
+                .into_iter()
+                .map(|node| create_physical_plan(node, lp_arena, expr_arena))
+                .collect::<PolarsResult<Vec<_>>>()?;
+            Ok(Box::new(executors::UnionExec { inputs, options }))
+        }
+        Melt { input, args, .. } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::MeltExec { input, args }))
+        }
+        Slice { input, offset, len } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::SliceExec { input, offset, len }))
+        }
+        Selection { input, predicate } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let predicate = create_physical_expr(predicate, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::FilterExec::new(predicate, input)))
+        }
+        #[cfg(feature = "csv-file")]
+        CsvScan {
+            path,
+            schema,
+            output_schema: _,
+            options,
+            predicate,
+            aggregate,
+        } => {
+            let predicate = predicate
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map_or(Ok(None), |v| v.map(Some))?;
+            let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
+            Ok(Box::new(executors::CsvExec {
                 path,
                 schema,
-                output_schema: _,
                 options,
                 predicate,
                 aggregate,
-            } => {
-                let predicate = predicate
-                    .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
-                    .map_or(Ok(None), |v| v.map(Some))?;
-                let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
-                Ok(Box::new(executors::CsvExec {
-                    path,
-                    schema,
-                    options,
-                    predicate,
-                    aggregate,
-                }))
-            }
-            #[cfg(feature = "ipc")]
-            IpcScan {
+            }))
+        }
+        #[cfg(feature = "ipc")]
+        IpcScan {
+            path,
+            schema,
+            output_schema: _,
+            predicate,
+            aggregate,
+            options,
+        } => {
+            let predicate = predicate
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map_or(Ok(None), |v| v.map(Some))?;
+
+            let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
+            Ok(Box::new(executors::IpcExec {
                 path,
                 schema,
-                output_schema: _,
                 predicate,
                 aggregate,
                 options,
-            } => {
-                let predicate = predicate
-                    .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
-                    .map_or(Ok(None), |v| v.map(Some))?;
+            }))
+        }
+        #[cfg(feature = "parquet")]
+        ParquetScan {
+            path,
+            schema,
+            output_schema: _,
+            predicate,
+            aggregate,
+            options,
+        } => {
+            let predicate = predicate
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map_or(Ok(None), |v| v.map(Some))?;
 
-                let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
-                Ok(Box::new(executors::IpcExec {
-                    path,
-                    schema,
-                    predicate,
-                    aggregate,
-                    options,
-                }))
-            }
-            #[cfg(feature = "parquet")]
-            ParquetScan {
-                path,
-                schema,
-                output_schema: _,
-                predicate,
-                aggregate,
-                options,
-            } => {
-                let predicate = predicate
-                    .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
-                    .map_or(Ok(None), |v| v.map(Some))?;
-
-                let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
-                Ok(Box::new(executors::ParquetExec::new(
-                    path, schema, predicate, aggregate, options,
-                )))
-            }
-            Projection {
-                expr,
+            let aggregate = aggregate_expr_to_scan_agg(aggregate, expr_arena);
+            Ok(Box::new(executors::ParquetExec::new(
+                path, schema, predicate, aggregate, options,
+            )))
+        }
+        Projection {
+            expr,
+            input,
+            schema: _schema,
+            ..
+        } => {
+            let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
+            let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::ProjectionExec {
                 input,
-                schema: _schema,
-                ..
-            } => {
-                let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
-                let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::ProjectionExec {
-                    input,
-                    expr: phys_expr,
-                    has_windows,
-                    input_schema,
-                    #[cfg(test)]
-                    schema: _schema,
-                }))
-            }
-            LocalProjection {
-                expr,
-                input,
+                expr: phys_expr,
+                has_windows,
+                input_schema,
                 #[cfg(test)]
-                    schema: _schema,
-                ..
-            } => {
-                let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
+                schema: _schema,
+            }))
+        }
+        LocalProjection {
+            expr,
+            input,
+            #[cfg(test)]
+                schema: _schema,
+            ..
+        } => {
+            let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
 
-                let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::ProjectionExec {
-                    input,
-                    expr: phys_expr,
-                    has_windows,
-                    input_schema,
-                    #[cfg(test)]
-                    schema: _schema,
-                }))
-            }
-            DataFrameScan {
+            let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::ProjectionExec {
+                input,
+                expr: phys_expr,
+                has_windows,
+                input_schema,
+                #[cfg(test)]
+                schema: _schema,
+            }))
+        }
+        DataFrameScan {
+            df,
+            projection,
+            selection,
+            ..
+        } => {
+            let selection = selection
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map_or(Ok(None), |v| v.map(Some))?;
+            Ok(Box::new(executors::DataFrameExec {
                 df,
                 projection,
                 selection,
-                ..
-            } => {
-                let selection = selection
-                    .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
-                    .map_or(Ok(None), |v| v.map(Some))?;
-                Ok(Box::new(executors::DataFrameExec {
-                    df,
-                    projection,
-                    selection,
-                }))
-            }
-            AnonymousScan {
+            }))
+        }
+        AnonymousScan {
+            function,
+            predicate,
+            options,
+            ..
+        } => {
+            let predicate = predicate
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map_or(Ok(None), |v| v.map(Some))?;
+            Ok(Box::new(executors::AnonymousScanExec {
                 function,
                 predicate,
                 options,
-                ..
-            } => {
-                let predicate = predicate
-                    .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
-                    .map_or(Ok(None), |v| v.map(Some))?;
-                Ok(Box::new(executors::AnonymousScanExec {
-                    function,
-                    predicate,
-                    options,
-                }))
-            }
-            Sort {
+            }))
+        }
+        Sort {
+            input,
+            by_column,
+            args,
+        } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let by_column = create_physical_expressions(&by_column, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::SortExec {
                 input,
                 by_column,
                 args,
-            } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let by_column =
-                    create_physical_expressions(&by_column, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::SortExec {
+            }))
+        }
+        Explode { input, columns, .. } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::ExplodeExec { input, columns }))
+        }
+        Cache { input, id, count } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::CacheExec { id, input, count }))
+        }
+        Distinct { input, options } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::DropDuplicatesExec { input, options }))
+        }
+        Aggregate {
+            input,
+            keys,
+            aggs,
+            apply,
+            schema: _,
+            maintain_order,
+            options,
+        } => {
+            let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+
+            let phys_keys = create_physical_expressions(&keys, Context::Default, expr_arena)?;
+
+            let phys_aggs = create_physical_expressions(&aggs, Context::Aggregation, expr_arena)?;
+
+            let _slice = options.slice;
+            #[cfg(feature = "dynamic_groupby")]
+            if let Some(options) = options.dynamic {
+                return Ok(Box::new(executors::GroupByDynamicExec {
                     input,
-                    by_column,
-                    args,
-                }))
+                    keys: phys_keys,
+                    aggs: phys_aggs,
+                    options,
+                    input_schema,
+                    slice: _slice,
+                }));
             }
-            Explode { input, columns, .. } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::ExplodeExec { input, columns }))
-            }
-            Cache { input, id, count } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::CacheExec { id, input, count }))
-            }
-            Distinct { input, options } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::DropDuplicatesExec { input, options }))
-            }
-            Aggregate {
-                input,
-                keys,
-                aggs,
-                apply,
-                schema: _,
-                maintain_order,
-                options,
-            } => {
-                let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
 
-                let phys_keys = create_physical_expressions(&keys, Context::Default, expr_arena)?;
+            #[cfg(feature = "dynamic_groupby")]
+            if let Some(options) = options.rolling {
+                return Ok(Box::new(executors::GroupByRollingExec {
+                    input,
+                    keys: phys_keys,
+                    aggs: phys_aggs,
+                    options,
+                    input_schema,
+                    slice: _slice,
+                }));
+            }
 
-                let phys_aggs =
-                    create_physical_expressions(&aggs, Context::Aggregation, expr_arena)?;
+            // We first check if we can partition the groupby on the latest moment.
+            let mut partitionable = true;
 
-                let _slice = options.slice;
-                #[cfg(feature = "dynamic_groupby")]
-                if let Some(options) = options.dynamic {
-                    return Ok(Box::new(executors::GroupByDynamicExec {
-                        input,
-                        keys: phys_keys,
-                        aggs: phys_aggs,
-                        options,
-                        input_schema,
-                        slice: _slice,
-                    }));
+            // checks:
+            //      1. complex expressions in the groupby itself are also not partitionable
+            //          in this case anything more than col("foo")
+            //      2. a custom function cannot be partitioned
+            //      3. we don't bother with more than 2 keys, as the cardinality likely explodes
+            //         by the combinations
+            if !keys.is_empty() && keys.len() < 3 && apply.is_none() {
+                // complex expressions in the groupby itself are also not partitionable
+                // in this case anything more than col("foo")
+                for key in keys {
+                    if (&*expr_arena).iter(key).count() > 1 {
+                        partitionable = false;
+                        break;
+                    }
                 }
 
-                #[cfg(feature = "dynamic_groupby")]
-                if let Some(options) = options.rolling {
-                    return Ok(Box::new(executors::GroupByRollingExec {
-                        input,
-                        keys: phys_keys,
-                        aggs: phys_aggs,
-                        options,
-                        input_schema,
-                        slice: _slice,
-                    }));
-                }
+                if partitionable {
+                    for agg in &aggs {
+                        let aexpr = expr_arena.get(*agg);
+                        let depth = (&*expr_arena).iter(*agg).count();
 
-                // We first check if we can partition the groupby on the latest moment.
-                let mut partitionable = true;
-
-                // checks:
-                //      1. complex expressions in the groupby itself are also not partitionable
-                //          in this case anything more than col("foo")
-                //      2. a custom function cannot be partitioned
-                //      3. we don't bother with more than 2 keys, as the cardinality likely explodes
-                //         by the combinations
-                if !keys.is_empty() && keys.len() < 3 && apply.is_none() {
-                    // complex expressions in the groupby itself are also not partitionable
-                    // in this case anything more than col("foo")
-                    for key in keys {
-                        if (&*expr_arena).iter(key).count() > 1 {
+                        // col()
+                        // lit() etc.
+                        if depth == 1 {
                             partitionable = false;
                             break;
                         }
-                    }
 
-                    if partitionable {
-                        for agg in &aggs {
-                            let aexpr = expr_arena.get(*agg);
-                            let depth = (&*expr_arena).iter(*agg).count();
-
-                            // col()
-                            // lit() etc.
-                            if depth == 1 {
-                                partitionable = false;
-                                break;
-                            }
-
-                            // it should end with an aggregation
-                            if let AExpr::Alias(input, _) = aexpr {
-                                // col().agg().alias() is allowed: count of 3
-                                // col().alias() is not allowed: count of 2
-                                // count().alias() is allowed: count of 2
-                                if depth <= 2 {
-                                    match expr_arena.get(*input) {
-                                        AExpr::Count => {}
-                                        _ => {
-                                            partitionable = false;
-                                            break;
-                                        }
+                        // it should end with an aggregation
+                        if let AExpr::Alias(input, _) = aexpr {
+                            // col().agg().alias() is allowed: count of 3
+                            // col().alias() is not allowed: count of 2
+                            // count().alias() is allowed: count of 2
+                            if depth <= 2 {
+                                match expr_arena.get(*input) {
+                                    AExpr::Count => {}
+                                    _ => {
+                                        partitionable = false;
+                                        break;
                                     }
                                 }
                             }
+                        }
 
-                            let has_aggregation = |node: Node| {
-                                has_aexpr(node, expr_arena, |ae| matches!(ae, AExpr::Agg(_)))
-                            };
+                        let has_aggregation = |node: Node| {
+                            has_aexpr(node, expr_arena, |ae| matches!(ae, AExpr::Agg(_)))
+                        };
 
-                            // check if the aggregation type is partitionable
-                            // only simple aggregation like col().sum
-                            // that can be divided in to the aggregation of their partitions are allowed
-                            if !((&*expr_arena).iter(*agg).all(|(_, ae)| {
-                                use AExpr::*;
-                                match ae {
-                                    // struct is needed to keep both states
-                                    #[cfg(feature = "dtype-struct")]
-                                    Agg(AAggExpr::Mean(_)) => {
-                                        // only numeric means for now.
-                                        // logical types seem to break because of casts to float.
-                                        matches!(expr_arena.get(*agg).get_type(&input_schema, Context::Default, expr_arena).map(|dt| {
+                        // check if the aggregation type is partitionable
+                        // only simple aggregation like col().sum
+                        // that can be divided in to the aggregation of their partitions are allowed
+                        if !((&*expr_arena).iter(*agg).all(|(_, ae)| {
+                            use AExpr::*;
+                            match ae {
+                                // struct is needed to keep both states
+                                #[cfg(feature = "dtype-struct")]
+                                Agg(AAggExpr::Mean(_)) => {
+                                    // only numeric means for now.
+                                    // logical types seem to break because of casts to float.
+                                    matches!(expr_arena.get(*agg).get_type(&input_schema, Context::Default, expr_arena).map(|dt| {
                                         dt.is_numeric()}), Ok(true))
-                                    },
-                                    // only allowed expressions
-                                    Agg(agg_e) => {
-                                        matches!(
+                                },
+                                // only allowed expressions
+                                Agg(agg_e) => {
+                                    matches!(
                                             agg_e,
                                             AAggExpr::Min{..}
                                                 | AAggExpr::Max{..}
@@ -365,139 +358,137 @@ impl PhysicalPlanner {
                                                 | AAggExpr::First(_)
                                                 | AAggExpr::Count(_)
                                         )
-                                    },
-                                    Function {input, options, ..} => {
-                                        matches!(options.collect_groups, ApplyOptions::ApplyFlat) && input.len() == 1 &&
-                                            !has_aggregation(input[0])
-                                    }
-                                    BinaryExpr {left, right, ..} => {
-                                        !has_aggregation(*left) && !has_aggregation(*right)
-                                    }
-                                    Ternary {truthy, falsy, predicate,..} => {
-                                        !has_aggregation(*truthy) && !has_aggregation(*falsy) && !has_aggregation(*predicate)
-                                    }
-                                    Column(_) | Alias(_, _) | Count | Literal(_) | Cast {..} => {
-                                        true
-                                    }
-                                    _ => {
-                                        false
-                                    },
+                                },
+                                Function {input, options, ..} => {
+                                    matches!(options.collect_groups, ApplyOptions::ApplyFlat) && input.len() == 1 &&
+                                        !has_aggregation(input[0])
                                 }
-                            }) &&
-                                // we only allow expressions that end with an aggregation
-                                matches!(aexpr, AExpr::Alias(_, _) | AExpr::Agg(_)))
-                            {
-                                partitionable = false;
-                                break;
+                                BinaryExpr {left, right, ..} => {
+                                    !has_aggregation(*left) && !has_aggregation(*right)
+                                }
+                                Ternary {truthy, falsy, predicate,..} => {
+                                    !has_aggregation(*truthy) && !has_aggregation(*falsy) && !has_aggregation(*predicate)
+                                }
+                                Column(_) | Alias(_, _) | Count | Literal(_) | Cast {..} => {
+                                    true
+                                }
+                                _ => {
+                                    false
+                                },
                             }
+                        }) &&
+                            // we only allow expressions that end with an aggregation
+                            matches!(aexpr, AExpr::Alias(_, _) | AExpr::Agg(_)))
+                        {
+                            partitionable = false;
+                            break;
+                        }
 
-                            #[cfg(feature = "object")]
-                            {
-                                for name in aexpr_to_leaf_names(*agg, expr_arena) {
-                                    let dtype = input_schema.get(&name).unwrap();
+                        #[cfg(feature = "object")]
+                        {
+                            for name in aexpr_to_leaf_names(*agg, expr_arena) {
+                                let dtype = input_schema.get(&name).unwrap();
 
-                                    if let DataType::Object(_) = dtype {
-                                        partitionable = false;
-                                        break;
-                                    }
-                                }
-                                if !partitionable {
+                                if let DataType::Object(_) = dtype {
+                                    partitionable = false;
                                     break;
                                 }
                             }
+                            if !partitionable {
+                                break;
+                            }
                         }
                     }
-                } else {
-                    partitionable = false;
                 }
-                if partitionable {
-                    Ok(Box::new(executors::PartitionGroupByExec::new(
-                        input,
-                        phys_keys,
-                        phys_aggs,
-                        maintain_order,
-                        options.slice,
-                        input_schema,
-                    )))
-                } else {
-                    Ok(Box::new(executors::GroupByExec::new(
-                        input,
-                        phys_keys,
-                        phys_aggs,
-                        apply,
-                        maintain_order,
-                        input_schema,
-                        options.slice,
-                    )))
-                }
+            } else {
+                partitionable = false;
             }
-            Join {
-                input_left,
-                input_right,
-                left_on,
-                right_on,
-                options,
-                ..
-            } => {
-                let parallel = if options.force_parallel {
-                    true
-                } else if options.allow_parallel {
-                    // check if two DataFrames come from a separate source.
-                    // If they don't we can parallelize,
-                    // we may deadlock if we don't check this
-                    let mut sources_left = PlHashSet::new();
-                    agg_source_paths(input_left, &mut sources_left, lp_arena);
-                    let mut sources_right = PlHashSet::new();
-                    agg_source_paths(input_right, &mut sources_right, lp_arena);
-                    sources_left.intersection(&sources_right).next().is_none()
-                } else {
-                    false
-                };
-
-                let input_left = self.create_physical_plan(input_left, lp_arena, expr_arena)?;
-                let input_right = self.create_physical_plan(input_right, lp_arena, expr_arena)?;
-                let left_on = create_physical_expressions(&left_on, Context::Default, expr_arena)?;
-                let right_on =
-                    create_physical_expressions(&right_on, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::JoinExec::new(
-                    input_left,
-                    input_right,
-                    options.how,
-                    left_on,
-                    right_on,
-                    parallel,
-                    options.suffix,
+            if partitionable {
+                Ok(Box::new(executors::PartitionGroupByExec::new(
+                    input,
+                    phys_keys,
+                    phys_aggs,
+                    maintain_order,
+                    options.slice,
+                    input_schema,
+                )))
+            } else {
+                Ok(Box::new(executors::GroupByExec::new(
+                    input,
+                    phys_keys,
+                    phys_aggs,
+                    apply,
+                    maintain_order,
+                    input_schema,
                     options.slice,
                 )))
             }
-            HStack { input, exprs, .. } => {
-                let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
-                let has_windows = exprs.iter().any(|node| has_aexpr_window(*node, expr_arena));
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let phys_expr = create_physical_expressions(&exprs, Context::Default, expr_arena)?;
-                Ok(Box::new(executors::StackExec {
-                    input,
-                    has_windows,
-                    expr: phys_expr,
-                    input_schema,
-                }))
-            }
-            MapFunction {
-                input, function, ..
-            } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                Ok(Box::new(executors::UdfExec { input, function }))
-            }
-            ExtContext {
-                input, contexts, ..
-            } => {
-                let input = self.create_physical_plan(input, lp_arena, expr_arena)?;
-                let contexts = contexts
-                    .into_iter()
-                    .map(|node| self.create_physical_plan(node, lp_arena, expr_arena))
-                    .collect::<PolarsResult<_>>()?;
-                Ok(Box::new(executors::ExternalContext { input, contexts }))
-            }
+        }
+        Join {
+            input_left,
+            input_right,
+            left_on,
+            right_on,
+            options,
+            ..
+        } => {
+            let parallel = if options.force_parallel {
+                true
+            } else if options.allow_parallel {
+                // check if two DataFrames come from a separate source.
+                // If they don't we can parallelize,
+                // we may deadlock if we don't check this
+                let mut sources_left = PlHashSet::new();
+                agg_source_paths(input_left, &mut sources_left, lp_arena);
+                let mut sources_right = PlHashSet::new();
+                agg_source_paths(input_right, &mut sources_right, lp_arena);
+                sources_left.intersection(&sources_right).next().is_none()
+            } else {
+                false
+            };
+
+            let input_left = create_physical_plan(input_left, lp_arena, expr_arena)?;
+            let input_right = create_physical_plan(input_right, lp_arena, expr_arena)?;
+            let left_on = create_physical_expressions(&left_on, Context::Default, expr_arena)?;
+            let right_on = create_physical_expressions(&right_on, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::JoinExec::new(
+                input_left,
+                input_right,
+                options.how,
+                left_on,
+                right_on,
+                parallel,
+                options.suffix,
+                options.slice,
+            )))
+        }
+        HStack { input, exprs, .. } => {
+            let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
+            let has_windows = exprs.iter().any(|node| has_aexpr_window(*node, expr_arena));
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let phys_expr = create_physical_expressions(&exprs, Context::Default, expr_arena)?;
+            Ok(Box::new(executors::StackExec {
+                input,
+                has_windows,
+                expr: phys_expr,
+                input_schema,
+            }))
+        }
+        MapFunction {
+            input, function, ..
+        } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            Ok(Box::new(executors::UdfExec { input, function }))
+        }
+        ExtContext {
+            input, contexts, ..
+        } => {
+            let input = create_physical_plan(input, lp_arena, expr_arena)?;
+            let contexts = contexts
+                .into_iter()
+                .map(|node| create_physical_plan(node, lp_arena, expr_arena))
+                .collect::<PolarsResult<_>>()?;
+            Ok(Box::new(executors::ExternalContext { input, contexts }))
         }
     }
 }

--- a/polars/polars-lazy/src/physical_plan/planner/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/mod.rs
@@ -1,8 +1,6 @@
 mod expr;
 mod lp;
 
-pub use expr::*;
+pub(crate) use expr::*;
 pub use lp::*;
 use polars_plan::prelude::*;
-
-use super::expressions::*;

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -210,7 +210,7 @@ fn get_pipeline_node(
     });
 
     ALogicalPlan::MapFunction {
-        function: FunctionNode::Opaque {
+        function: FunctionNode::Pipeline {
             function: Arc::new(move |_df: DataFrame| {
                 let state = ExecutionState::new();
                 if state.verbose() {
@@ -219,10 +219,7 @@ fn get_pipeline_node(
                 let state = Box::new(state) as Box<dyn Any + Send + Sync>;
                 pipeline.execute(state)
             }),
-            schema: Some(Arc::new(move |_: &Schema| Ok(schema.clone()))),
-            predicate_pd: false,
-            projection_pd: false,
-            fmt_str: "",
+            schema,
         },
         input: dummy,
     }

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -1,9 +1,10 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use polars_core::datatypes::DataType;
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{SchemaRef, Series};
+use polars_core::prelude::{Field, SchemaRef, Series};
 use polars_core::schema::Schema;
 use polars_pipe::expressions::PhysicalPipedExpr;
 use polars_pipe::operators::chunks::DataChunk;
@@ -22,11 +23,14 @@ impl PhysicalPipedExpr for Wrap {
         let state = state.downcast_ref::<ExecutionState>().unwrap();
         self.0.evaluate(&chunk.data, state)
     }
+    fn field(&self, input_schema: &Schema) -> PolarsResult<Field> {
+        self.0.to_field(input_schema)
+    }
 }
 
 fn to_physical_piped_expr(
     node: Node,
-    expr_arena: &mut Arena<AExpr>,
+    expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<Arc<dyn PhysicalPipedExpr>> {
     // this is a double Arc<dyn> explore if we can create a single of it.
     create_physical_expr(node, Context::Default, expr_arena)

--- a/polars/polars-lazy/src/physical_plan/streaming/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/mod.rs
@@ -1,4 +1,3 @@
 mod convert;
-mod plan;
 
 pub(crate) use convert::insert_streaming_nodes;

--- a/polars/polars-lazy/src/physical_plan/streaming/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/mod.rs
@@ -1,0 +1,4 @@
+mod convert;
+mod plan;
+
+pub(crate) use convert::insert_streaming_nodes;

--- a/polars/polars-lazy/src/physical_plan/streaming/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/mod.rs
@@ -1,3 +1,4 @@
 mod convert;
 
+#[cfg(any(feature = "csv-file", feature = "parquet"))]
 pub(crate) use convert::insert_streaming_nodes;

--- a/polars/polars-lazy/src/physical_plan/streaming/plan.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/plan.rs
@@ -1,0 +1,1 @@
+fn find_pipelines() {}

--- a/polars/polars-lazy/src/physical_plan/streaming/plan.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/plan.rs
@@ -1,1 +1,0 @@
-fn find_pipelines() {}

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -10,4 +10,3 @@ pub(crate) use polars_utils::arena::{Arena, Node};
 pub use crate::dsl::*;
 pub use crate::frame::*;
 pub use crate::physical_plan::expressions::*;
-pub use crate::physical_plan::planner::PhysicalPlanner;

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod predicate_queries;
 mod projection_queries;
 #[cfg(feature = "test")]
 mod queries;
+mod streaming;
 #[cfg(feature = "strings")]
 mod tpch;
 

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -5,8 +5,14 @@ fn test_streaming_csv() -> PolarsResult<()> {
     let file = "../../examples/datasets/foods1.csv";
     let q = LazyCsvReader::new(file).finish()?;
 
+    // let out = q
+    //     .select([col("category"), col("calories")])
+    //     .collect_streaming()?;
+
     let out = q
-        .select([col("category"), col("calories")])
+        .select([col("sugars_g"), col("calories")])
+        .groupby([col("sugars_g")])
+        .agg([col("calories").sum()])
         .collect_streaming()?;
 
     dbg!(out);

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -80,7 +80,7 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
         .filter(col("sugars_g").gt(lit(10)))
         .groupby([col("sugars_g"), col("calories")])
         .agg([col("fats_g").sum() * lit(10)])
-        .sort("sugars_g", Default::default());
+        .sort_by_exprs([col("sugars_g"), col("calories")], [false, false], false);
 
     let q1 = q.clone().with_streaming(true);
     let q2 = q.clone();

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -1,9 +1,13 @@
 use super::*;
 
+fn get_file() -> LazyFrame {
+    let file = "../../examples/datasets/foods1.csv";
+    LazyCsvReader::new(file).finish().unwrap()
+}
+
 #[test]
 fn test_streaming_csv() -> PolarsResult<()> {
-    let file = "../../examples/datasets/foods1.csv";
-    let q = LazyCsvReader::new(file).finish()?;
+    let q = get_file();
 
     let q = q
         .select([col("sugars_g"), col("calories")])
@@ -17,5 +21,39 @@ fn test_streaming_csv() -> PolarsResult<()> {
     let out_one_shot = q2.collect()?;
 
     assert!(out_streaming.frame_equal(&out_one_shot));
+    Ok(())
+}
+
+#[test]
+fn test_streaming_first_sum() -> PolarsResult<()> {
+    let q = get_file();
+
+    let q = q
+        .select([col("sugars_g"), col("calories")])
+        .groupby([col("sugars_g")])
+        .agg([col("calories").sum(), col("calories").first().alias("calories_first")])
+        .sort("sugars_g", Default::default());
+
+    let q1 = q.clone().with_streaming(true);
+    let q2 = q.clone();
+    let out_streaming = q1.collect()?;
+    let out_one_shot = q2.collect()?;
+
+    assert!(out_streaming.frame_equal(&out_one_shot));
+    Ok(())
+}
+
+#[test]
+fn test_streaming2() -> PolarsResult<()> {
+
+    let out = LazyCsvReader::new("/home/ritchie46/Downloads/csv-benchmark/yellow_tripdata_2010-01.csv")
+        .finish().unwrap()
+        .groupby([col("passenger_count")])
+        .agg([
+            col("rate_code").sum(), col("rate_code").first().alias("first")
+        ]).with_streaming(true).collect()?;
+
+    dbg!(out);
+
     Ok(())
 }

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -79,7 +79,10 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
     let q = q
         .filter(col("sugars_g").gt(lit(10)))
         .groupby([col("sugars_g"), col("calories")])
-        .agg([col("fats_g").sum() * lit(10)])
+        .agg([
+            (col("fats_g") * lit(10)).sum(),
+            col("calories").mean().alias("cal_mean"),
+        ])
         .sort_by_exprs([col("sugars_g"), col("calories")], [false, false], false);
 
     let q1 = q.clone().with_streaming(true);

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+#[test]
+fn test_streaming_csv() -> PolarsResult<()> {
+    let file = "../../examples/datasets/foods1.csv";
+    let q = LazyCsvReader::new(file).finish()?;
+
+    let out = q
+        .select([col("category"), col("calories")])
+        .collect_streaming()?;
+
+    dbg!(out);
+    Ok(())
+}

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -31,7 +31,10 @@ fn test_streaming_first_sum() -> PolarsResult<()> {
     let q = q
         .select([col("sugars_g"), col("calories")])
         .groupby([col("sugars_g")])
-        .agg([col("calories").sum(), col("calories").first().alias("calories_first")])
+        .agg([
+            col("calories").sum(),
+            col("calories").first().alias("calories_first"),
+        ])
         .sort("sugars_g", Default::default());
 
     let q1 = q.clone().with_streaming(true);
@@ -45,13 +48,17 @@ fn test_streaming_first_sum() -> PolarsResult<()> {
 
 #[test]
 fn test_streaming2() -> PolarsResult<()> {
-
-    let out = LazyCsvReader::new("/home/ritchie46/Downloads/csv-benchmark/yellow_tripdata_2010-01.csv")
-        .finish().unwrap()
-        .groupby([col("passenger_count")])
-        .agg([
-            col("rate_code").sum(), col("rate_code").first().alias("first")
-        ]).with_streaming(true).collect()?;
+    let out =
+        LazyCsvReader::new("/home/ritchie46/Downloads/csv-benchmark/yellow_tripdata_2010-01.csv")
+            .finish()
+            .unwrap()
+            .groupby([col("passenger_count")])
+            .agg([
+                col("rate_code").first().alias("first"),
+                col("rate_code").sum(),
+            ])
+            .with_streaming(true)
+            .collect()?;
 
     dbg!(out);
 

--- a/polars/polars-ops/src/series/ops/various.rs
+++ b/polars/polars-ops/src/series/ops/various.rs
@@ -30,7 +30,11 @@ pub trait SeriesMethods: SeriesSealed {
                 let mut ca = s.list().unwrap().clone();
                 crate::chunked_array::hash::hash(&mut ca, build_hasher)
             }
-            _ => UInt64Chunked::from_vec(s.name(), s.0.vec_hash(build_hasher).unwrap()),
+            _ => {
+                let mut h = vec![];
+                s.0.vec_hash(build_hasher, &mut h).unwrap();
+                UInt64Chunked::from_vec(s.name(), h)
+            }
         }
     }
 }

--- a/polars/polars-utils/src/functions.rs
+++ b/polars/polars-utils/src/functions.rs
@@ -12,6 +12,9 @@ pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T
 }
 
 #[inline]
+/// # Safety
+///
+/// does an uncecked unwrap. Ensure this will never fail
 pub unsafe fn debug_unwrap<T>(item: Option<T>) -> T {
     {
         #[cfg(debug_assertions)]

--- a/polars/polars-utils/src/functions.rs
+++ b/polars/polars-utils/src/functions.rs
@@ -8,3 +8,19 @@ pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T
     }
     out
 }
+
+
+#[inline]
+pub unsafe fn debug_unwrap<T>(item: Option<T>) -> T {
+    {
+        #[cfg(debug_assertions)]
+        {
+            // check if the type is correct
+            item.unwrap()
+        }
+        #[cfg(not(debug_assertions))]
+        unsafe {
+            item.unwrap_unchecked()
+        }
+    }
+}

--- a/polars/polars-utils/src/functions.rs
+++ b/polars/polars-utils/src/functions.rs
@@ -12,24 +12,6 @@ pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T
 }
 
 #[inline]
-/// # Safety
-///
-/// does an uncecked unwrap. Ensure this will never fail
-pub unsafe fn debug_unwrap<T>(item: Option<T>) -> T {
-    {
-        #[cfg(debug_assertions)]
-        {
-            // check if the type is correct
-            item.unwrap()
-        }
-        #[cfg(not(debug_assertions))]
-        unsafe {
-            item.unwrap_unchecked()
-        }
-    }
-}
-
-#[inline]
 pub fn hash_to_partition(h: u64, n_partitions: usize) -> usize {
     debug_assert!(n_partitions.is_power_of_two());
     // n % 2^i = n & (2^i - 1)

--- a/polars/polars-utils/src/functions.rs
+++ b/polars/polars-utils/src/functions.rs
@@ -1,3 +1,5 @@
+use std::hash::{BuildHasher, Hash, Hasher};
+
 // Faster than collecting from a flattened iterator.
 pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T> {
     let len = len.unwrap_or_else(|| bufs.iter().map(|b| b.as_ref().len()).sum());
@@ -8,7 +10,6 @@ pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T
     }
     out
 }
-
 
 #[inline]
 pub unsafe fn debug_unwrap<T>(item: Option<T>) -> T {
@@ -23,4 +24,18 @@ pub unsafe fn debug_unwrap<T>(item: Option<T>) -> T {
             item.unwrap_unchecked()
         }
     }
+}
+
+#[inline]
+pub fn hash_to_partition(h: u64, n_partitions: usize) -> usize {
+    debug_assert!(n_partitions.is_power_of_two());
+    // n % 2^i = n & (2^i - 1)
+    h as usize & n_partitions.wrapping_sub(1)
+}
+
+#[inline]
+pub fn get_hash<T: Hash, B: BuildHasher>(value: T, hb: &B) -> u64 {
+    let mut hasher = hb.build_hasher();
+    value.hash(&mut hasher);
+    hasher.finish()
 }

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod contention_pool;
 mod error;
 mod functions;
 pub mod mem;
+pub mod option;
 pub mod slice;
 pub mod sort;
 

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod contention_pool;
 mod error;
 mod functions;
 pub mod mem;
+pub mod slice;
 pub mod sort;
 
 pub use functions::*;

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -4,9 +4,9 @@ pub mod contention_pool;
 mod error;
 mod functions;
 pub mod mem;
-pub mod option;
 pub mod slice;
 pub mod sort;
+pub mod unwrap;
 
 pub use functions::*;
 

--- a/polars/polars-utils/src/option.rs
+++ b/polars/polars-utils/src/option.rs
@@ -1,0 +1,26 @@
+use std::error::Error;
+use std::fmt::Debug;
+
+pub trait UnwrapUncheckedRelease<T> {
+    unsafe fn unwrap_unchecked_release(self) -> T;
+}
+
+impl<T> UnwrapUncheckedRelease<T> for Option<T> {
+    unsafe fn unwrap_unchecked_release(self) -> T {
+        if cfg!(debug_assertions) {
+            self.unwrap()
+        } else {
+            self.unwrap_unchecked()
+        }
+    }
+}
+
+impl<T, E: Debug> UnwrapUncheckedRelease<T> for Result<T, E> {
+    unsafe fn unwrap_unchecked_release(self) -> T {
+        if cfg!(debug_assertions) {
+            self.unwrap()
+        } else {
+            self.unwrap_unchecked()
+        }
+    }
+}

--- a/polars/polars-utils/src/slice.rs
+++ b/polars/polars-utils/src/slice.rs
@@ -1,0 +1,43 @@
+use core::slice::SliceIndex;
+
+pub trait GetSaferUnchecked<T> {
+    unsafe fn get_unchecked_release<I>(&self, index: I) -> &<I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>;
+
+    unsafe fn get_unchecked_release_mut<I>(
+        &mut self,
+        index: I,
+    ) -> &mut <I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>;
+}
+
+impl<T> GetSaferUnchecked<T> for [T] {
+    #[inline(always)]
+    unsafe fn get_unchecked_release<I>(&self, index: I) -> &<I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>,
+    {
+        if cfg!(debug_assertions) {
+            &self[index]
+        } else {
+            self.get_unchecked(index)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked_release_mut<I>(
+        &mut self,
+        index: I,
+    ) -> &mut <I as SliceIndex<[T]>>::Output
+    where
+        I: SliceIndex<[T]>,
+    {
+        if cfg!(debug_assertions) {
+            &mut self[index]
+        } else {
+            self.get_unchecked_mut(index)
+        }
+    }
+}

--- a/polars/polars-utils/src/slice.rs
+++ b/polars/polars-utils/src/slice.rs
@@ -1,10 +1,18 @@
 use core::slice::SliceIndex;
 
 pub trait GetSaferUnchecked<T> {
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is *[undefined behavior]*
+    /// even if the resulting reference is not used.
     unsafe fn get_unchecked_release<I>(&self, index: I) -> &<I as SliceIndex<[T]>>::Output
     where
         I: SliceIndex<[T]>;
 
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is *[undefined behavior]*
+    /// even if the resulting reference is not used.
     unsafe fn get_unchecked_release_mut<I>(
         &mut self,
         index: I,

--- a/polars/polars-utils/src/unwrap.rs
+++ b/polars/polars-utils/src/unwrap.rs
@@ -1,7 +1,9 @@
-use std::error::Error;
 use std::fmt::Debug;
 
 pub trait UnwrapUncheckedRelease<T> {
+    /// # Safety
+    ///
+    /// unwrap without checking the invariant
     unsafe fn unwrap_unchecked_release(self) -> T;
 }
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "polars-core",
  "polars-io",
  "polars-ops",
+ "polars-pipe",
  "polars-plan",
  "polars-time",
  "polars-utils",
@@ -1368,6 +1369,18 @@ version = "0.24.3"
 dependencies = [
  "polars-arrow",
  "polars-core",
+]
+
+[[package]]
+name = "polars-pipe"
+version = "0.24.3"
+dependencies = [
+ "hashbrown",
+ "polars-core",
+ "polars-io",
+ "polars-plan",
+ "polars-utils",
+ "rayon",
 ]
 
 [[package]]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1376,6 +1376,7 @@ name = "polars-pipe"
 version = "0.24.3"
 dependencies = [
  "hashbrown",
+ "num",
  "polars-core",
  "polars-io",
  "polars-plan",

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1685,6 +1685,7 @@ def collect_all(
     no_optimization: bool = False,
     slice_pushdown: bool = True,
     common_subplan_elimination: bool = True,
+    allow_streaming: bool = False,
 ) -> list[pli.DataFrame]:
     """
     Collect multiple LazyFrames at the same time.
@@ -1711,6 +1712,8 @@ def collect_all(
         Slice pushdown optimization.
     common_subplan_elimination
         Will try to cache branching subplans that occur on self-joins or unions.
+    allow_streaming
+        Run parts of the query in a streaming fashion (this is in an alpha state)
 
     Returns
     -------
@@ -1733,6 +1736,7 @@ def collect_all(
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
         prepared.append(ldf)
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -567,6 +567,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         simplify_expression: bool = True,
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
+        allow_streaming: bool = False,
     ) -> str:
         """Create a string representation of the optimized query plan."""
         ldf = self._ldf.optimization_toggle(
@@ -576,6 +577,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
 
         return ldf.describe_optimized_plan()
@@ -593,6 +595,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         simplify_expression: bool = True,
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
+        allow_streaming: bool = False,
     ) -> str | None:
         """
         Show a plot of the query plan. Note that you should have graphviz installed.
@@ -621,6 +624,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Slice pushdown optimization.
         common_subplan_elimination
             Will try to cache branching subplans that occur on self-joins or unions.
+        common_subplan_elimination
+            Will try to cache branching subplans that occur on self-joins or unions.
+        allow_streaming
+            Run parts of the query in a streaming fashion (this is in an alpha state)
 
         """
         _ldf = self._ldf.optimization_toggle(
@@ -630,6 +637,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
 
         dot = _ldf.to_dot(optimized)
@@ -750,6 +758,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         show_plot: bool = False,
         truncate_nodes: int = 0,
         figsize: tuple[int, int] = (18, 8),
+        allow_streaming: bool = False,
     ) -> tuple[pli.DataFrame, pli.DataFrame]:
         """
         Profile a LazyFrame.
@@ -783,6 +792,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             characters.
         figsize
             matplotlib figsize of the profiling plot
+        allow_streaming
+            Run parts of the query in a streaming fashion (this is in an alpha state)
 
         Returns
         -------
@@ -800,6 +811,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
         df, timings = ldf.profile()
         (df, timings) = pli.wrap_df(df), pli.wrap_df(timings)
@@ -857,6 +869,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         no_optimization: bool = False,
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
+        allow_streaming: bool = False,
     ) -> pli.DataFrame:
         """
         Collect into a DataFrame.
@@ -883,6 +896,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Slice pushdown optimization.
         common_subplan_elimination
             Will try to cache branching subplans that occur on self-joins or unions.
+        allow_streaming
+            Run parts of the query in a streaming fashion (this is in an alpha state)
 
         Returns
         -------
@@ -902,6 +917,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
         return pli.wrap_df(ldf.collect())
 
@@ -916,6 +932,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         no_optimization: bool = False,
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
+        allow_streaming: bool = False,
     ) -> pli.DataFrame:
         """
         Collect a small number of rows for debugging purposes.
@@ -949,6 +966,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Slice pushdown optimization
         common_subplan_elimination
             Will try to cache branching subplans that occur on self-joins or unions.
+        allow_streaming
+            Run parts of the query in a streaming fashion (this is in an alpha state)
 
         Returns
         -------
@@ -968,6 +987,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
+            allow_streaming,
         )
         return pli.wrap_df(ldf.fetch(n_rows))
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -341,6 +341,7 @@ impl PyLazyFrame {
         Ok(result)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn optimization_toggle(
         &self,
         type_coercion: bool,
@@ -349,6 +350,7 @@ impl PyLazyFrame {
         simplify_expr: bool,
         slice_pushdown: bool,
         cse: bool,
+        allow_streaming: bool,
     ) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         let ldf = ldf
@@ -357,6 +359,7 @@ impl PyLazyFrame {
             .with_simplify_expr(simplify_expr)
             .with_slice_pushdown(slice_pushdown)
             .with_common_subplan_elimination(cse)
+            .with_streaming(allow_streaming)
             .with_projection_pushdown(projection_pushdown);
         ldf.into()
     }


### PR DESCRIPTION
First steps into a hybrid streaming engine. The goal is to be able to run on datasets much larger than RAM where the final output should fit memory.

Think of groupbys that reduce cardinality, cross joins that explode output sizes, but are filtered/limited, etc.

Currently it can run streaming:

* scan_csv /scan_parquet
* filter
* select (any expression that operates elementwise)
* groupby aggregate on any keys. Aggregates can do arithmetic and such, but must finish with a single aggregation.
  - Aggregation functions: sum, first, last, count, mean