### PR TITLE
Accept quote_char in SplitLines constructor to properly parse newlines 

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -636,4 +636,13 @@ mod test {
         assert_eq!(fields2.next(), Some(("12345".as_bytes(), false)));
         assert_eq!(fields2.next(), None);
     }
+
+    #[test]
+    fn test_splitlines() {
+        let input = "1,\"foo\n\"\n2,\"foo\n\"\n";
+        let mut lines = SplitLines::new(input.as_bytes(), b'\n');
+        assert_eq!(lines.next(), Some("1,\"foo\n\"".as_bytes()));
+        assert_eq!(lines.next(), Some("2,\"foo\n\"".as_bytes()));
+        assert_eq!(lines.next(), None);
+    }
 }

--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -243,6 +243,7 @@ impl<'a> Iterator for SplitLines<'a> {
             match iter.next() {
                 Some(&c) => {
                     pos += 1;
+
                     if c == b'"' {
                         // toggle between string field enclosure
                         //      if we encounter a starting '"' -> in_field = true;
@@ -250,7 +251,7 @@ impl<'a> Iterator for SplitLines<'a> {
                         in_field = !in_field;
                     }
                     // if we are not in a string and we encounter '\n' we can stop at this position.
-                    if c == self.end_line_char && !in_field {
+                    else if c == self.end_line_char && !in_field {
                         break;
                     }
                 }

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -191,7 +191,7 @@ pub fn infer_file_schema(
     if bytes.is_empty() {
         return Err(PolarsError::NoData("empty csv".into()));
     }
-    let mut lines = SplitLines::new(bytes, eol_char).skip(*skip_rows);
+    let mut lines = SplitLines::new(bytes, quote_char.unwrap_or(b'"'), eol_char).skip(*skip_rows);
     // it can be that we have a single line without eol char
     let has_eol = bytes.contains(&eol_char);
 
@@ -295,7 +295,7 @@ pub fn infer_file_schema(
     };
     if !has_header {
         // re-init lines so that the header is included in type inference.
-        lines = SplitLines::new(bytes, eol_char).skip(*skip_rows);
+        lines = SplitLines::new(bytes, quote_char.unwrap_or(b'"'), eol_char).skip(*skip_rows);
     }
 
     let header_length = headers.len();

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -324,7 +324,7 @@ fn parse_lines<'a>(
 
     let total_bytes = bytes.len();
     let mut offset = 0;
-    for line in SplitLines::new(bytes, NEWLINE) {
+    for line in SplitLines::new(bytes, QUOTE_CHAR, NEWLINE) {
         offset += 1; // the newline
         offset += parse_impl(line, buffers, &mut buf)?;
     }

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -228,6 +228,21 @@ fn test_escape_double_quotes() {
     )));
 }
 
+
+#[test]
+fn test_newline_in_custom_quote_char() {
+    // missing data should not lead to parser error.
+    let csv = r#"column_1,column_2
+        1,'foo
+        bar'
+        2,'bar'
+"#;
+
+    let file = Cursor::new(csv);
+    let df = CsvReader::new(file).finish().unwrap();
+    assert_eq!(df.shape(), (2,2));
+}
+
 #[test]
 fn test_escape_2() {
     // this is is harder than it looks.

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -228,10 +228,9 @@ fn test_escape_double_quotes() {
     )));
 }
 
-
 #[test]
 fn test_newline_in_custom_quote_char() {
-    // missing data should not lead to parser error.
+    // newline inside custom quote char (default is ") should parse correctly
     let csv = r#"column_1,column_2
         1,'foo
         bar'
@@ -239,8 +238,11 @@ fn test_newline_in_custom_quote_char() {
 "#;
 
     let file = Cursor::new(csv);
-    let df = CsvReader::new(file).finish().unwrap();
-    assert_eq!(df.shape(), (2,2));
+    let df = CsvReader::new(file)
+        .with_quote_char(Some(b'\''))
+        .finish()
+        .unwrap();
+    assert_eq!(df.shape(), (2, 2));
 }
 
 #[test]


### PR DESCRIPTION
This fixes a small bug when using newlines inside string fields while using a custom quote character. Also includes an unit test and an integration test to make sure the parameter propagates down properly.

Function API could perhaps be cleaned-up a little by making `next_line_position()` accept a `u8` value directly and unwrapping in `get_line_stats()` but as these functions are marked `public` I am nowhere near comfortable enough to make that decision. 