### PR TITLE
fix(rust): microsecond noise on `date` >> `time` cast (add `00:00:00` fast-path)

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/date.rs
+++ b/polars/polars-core/src/chunked_array/logical/date.rs
@@ -1,5 +1,3 @@
-use std::iter::repeat;
-
 use super::*;
 use crate::prelude::*;
 pub type DateChunked = Logical<DateType, Int32Type>;
@@ -41,12 +39,9 @@ impl LogicalType for DateChunked {
                     .into_datetime(*tu, tz.clone())
                     .into_series())
             }
-            (Date, Time) => Ok(Int64Chunked::from_iter_values(
-                self.name(),
-                repeat(0i64).take(self.len()),
-            )
-            .into_time()
-            .into_series()),
+            (Date, Time) => Ok(Int64Chunked::full(self.name(), 0i64, self.len())
+                .into_time()
+                .into_series()),
             _ => self.0.cast(dtype),
         }
     }

--- a/polars/polars-core/src/chunked_array/logical/date.rs
+++ b/polars/polars-core/src/chunked_array/logical/date.rs
@@ -1,6 +1,7 @@
+use std::iter::repeat;
+
 use super::*;
 use crate::prelude::*;
-
 pub type DateChunked = Logical<DateType, Int32Type>;
 
 impl From<Int32Chunked> for DateChunked {
@@ -40,6 +41,12 @@ impl LogicalType for DateChunked {
                     .into_datetime(*tu, tz.clone())
                     .into_series())
             }
+            (Date, Time) => Ok(Int64Chunked::from_iter_values(
+                self.name(),
+                repeat(0i64).take(self.len()),
+            )
+            .into_time()
+            .into_series()),
             _ => self.0.cast(dtype),
         }
     }

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1371,6 +1371,22 @@ def test_time_microseconds_3843() -> None:
     assert s.to_list() == in_val
 
 
+def test_date_to_time_cast_5111() -> None:
+    # check date -> time casts (fast-path: always 00:00:00)
+    df = pl.DataFrame(
+        {
+            "xyz": [
+                date(1969, 1, 1),
+                date(1990, 3, 8),
+                date(2000, 6, 16),
+                date(2010, 9, 24),
+                date(2022, 12, 31),
+            ]
+        }
+    ).with_column(pl.col("xyz").cast(pl.Time))
+    assert df["xyz"].to_list() == [time(0), time(0), time(0), time(0), time(0)]
+
+
 def test_year_empty_df() -> None:
     df = pl.DataFrame(pl.Series(name="date", dtype=pl.Date))
     assert df.select(pl.col("date").dt.year()).dtypes == [pl.Int32]


### PR DESCRIPTION
Closes #5111.

-----

Cast from `Date` to `Time` now jumps straight to returning a `TimeChunked`-backed `Series` of `00:00:00` literals (fast-path; `Date` has no time component). I _think_ the patch looks efficient, but if there's a better option that I missed, please point me in the right direction and I'll update/improve it ;)

**Example**
```python
from datetime import date
import polars as pl

df = pl.DataFrame({
    "dt": [
        date(1988, 1, 1),
        date(2000, 3, 8),
        date(2010, 6, 15),
        date(2022, 12, 31),
    ]
}).with_column(
    pl.col("dt").cast(pl.Time).alias("tm")
)
```

**Before** _(incrementing microsecs/noise)_
```python
# ┌────────────┬────────────────────┐
# │ dt         ┆ tm                 │
# │ ---        ┆ ---                │
# │ date       ┆ time               │
# ╞════════════╪════════════════════╡
# │ 1988-01-01 ┆ 00:00:00.000006574 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 2000-03-08 ┆ 00:00:00.000011024 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 2010-06-15 ┆ 00:00:00.000014775 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
# │ 2022-12-31 ┆ 00:00:00.000019357 │
# └────────────┴────────────────────┘
```
**After** _(always 00:00:00, as expected)_
```python
# ┌────────────┬──────────┐
# │ dt         ┆ tm       │
# │ ---        ┆ ---      │
# │ date       ┆ time     │
# ╞════════════╪══════════╡
# │ 1988-01-01 ┆ 00:00:00 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
# │ 2000-03-08 ┆ 00:00:00 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
# │ 2010-06-15 ┆ 00:00:00 │
# ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
# │ 2022-12-31 ┆ 00:00:00 │
# └────────────┴──────────┘
```
(Think I'll subject temporal casting to some parametric testing, as it's still not clear to me how the gradually-incrementing microsecond noise came about in the first place; the extra tests should provide some additional insight and/or reassurance that there isn't something else waiting to be found).