### PR TITLE
chore(python): Add support for ruff python linter.

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -49,7 +49,7 @@ develop-release: $(VENV)  ## Build by running `maturin develop --release`
 	$(VENV_ACT_BIN)maturin develop --release
 
 .PHONY: clean cleaner cleanest
-clean:  ## Just run `carcumgo clean`
+clean:  ## Just run `cargo clean`
 	-cargo clean
 
 cleaner: clean  ## clean + remove VENV and other auto-generated dirs & files
@@ -60,6 +60,7 @@ cleaner: clean  ## clean + remove VENV and other auto-generated dirs & files
 	-rm -rf .hypothesis
 	-rm -rf .mypy_cache
 	-rm -rf .pytest_cache
+	-rm -rf .ruff_cache
 	-rm -f .coverage
 	-rm -f coverage.xml
 	-rm -f polars/polars.abi3.so

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -72,3 +72,6 @@ exclude_lines = [
   "if TYPE_CHECKING:",
   "from typing_extensions import ",
 ]
+
+[tool.ruff]
+line-length = 88


### PR DESCRIPTION
Add support for ruff python linter, so it can be used at least locally as a fast flake8 replacement during development.