### PR TITLE
In polars_io::csv::parser::parse_lines, change unsafe block into iter_mut

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -603,15 +603,8 @@ pub(super) fn parse_lines<'a>(
         // there can be lines that miss fields (also the comma values)
         // this means the splitter won't process them.
         // We traverse them to read them as null values.
-        while processed_fields < projection.len() {
-            debug_assert!(processed_fields < buffers.len());
-            let buf = unsafe {
-                // SAFETY: processed fields index can never exceed the projection indices.
-                buffers.get_unchecked_mut(processed_fields)
-            };
-
+        for buf in buffers[processed_fields..].iter_mut() {
             buf.add_null();
-            processed_fields += 1;
         }
 
         line_count += 1;


### PR DESCRIPTION
After some digging because I found it an interesting example of Rust's out of bounds checking and its possible performance cost, I was unable to find a performance benefit for this piece of code in the CSV parser. ~~I think the slice approach using `iter_mut` already skips bounds checking.~~ 

### Benchmarks 

Benchmarks were run using Criterion and the included `csv` bench group. CSV file had 1M rows and about 50% missing values/null values per row.

Before (using while loop with get_unchecked_mut):
```
parse csv               time:   [390.94 ms 393.08 ms 395.10 ms]
                        change: [-0.7779% +0.1041% +0.8652%] (p = 0.80 > 0.05)
                        No change in performance detected.
```

After (using slice with iter_mut):
```
parse csv               time:   [384.35 ms 386.85 ms 389.27 ms]
                        change: [-2.3725% -1.5860% -0.7449%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

Isolated example ([Godbolt](https://godbolt.org/z/PreqKn6E8)):

```
indexing into tail elements of vector/while loop with index                                                                             
                        time:   [16.798 ns 16.817 ns 16.842 ns]

indexing into tail elements of vector/slice with iter_mut                                                                             
                        time:   [16.455 ns 16.468 ns 16.483 ns]

indexing into tail elements of vector/while loop with get_unchecked_mut                                                                             
                        time:   [16.905 ns 16.911 ns 16.919 ns]
```