### PR TITLE
perf(rust, polars):  use iterator instead of loop `polars_io::csv::parser::skip_condition`

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -98,15 +98,8 @@ where
     if input.is_empty() {
         return input;
     }
-    let mut read = 0;
-    let len = input.len();
-    while read < len {
-        let b = input[read];
-        if !f(b) {
-            break;
-        }
-        read += 1;
-    }
+
+    let read = input.iter().position(|b| !f(*b)).unwrap_or(input.len());
     &input[read..]
 }
 


### PR DESCRIPTION
This guarantees the removal of bounds checking inside the loop, which allows for a very minor performance gain.

Benchmark was run using Criterion using 1M rows.

Before (using while with indexing):
```
parse csv               time:   [391.85 ms 394.01 ms 396.03 ms]
 ```
 
 After (using `iter().position(...)`
 
 ```
 parse csv               time:   [387.96 ms 389.62 ms 391.05 ms]
                        change: [-1.7745% -1.1159% -0.4741%] (p = 0.00 < 0.05)
```

Sidenote: I re-used behavior from the old implementation but there is actually a potential OOB if the predicate does not satisfy any of the remaining bytes in the input buffer. Since `input.len()` is returned in those cases, the consecutive line will trigger an OOB. (This was also the case in the old implementation.) I am unsure how to fix, since a pointer has to be returned... 
