### PR TITLE
refactor(python): improve typing; many `list` types are better defined as `Sequence`

### DIFF
--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -837,7 +837,7 @@ class RollingGroupBy(Generic[DF]):
         period: str,
         offset: str | None,
         closed: ClosedWindow = "none",
-        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+        by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ):
         self.df = df
         self.time_column = index_column
@@ -875,7 +875,7 @@ class DynamicGroupBy(Generic[DF]):
         truncate: bool = True,
         include_boundaries: bool = True,
         closed: ClosedWindow = "none",
-        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+        by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ):
         self.df = df
         self.time_column = index_column
@@ -911,8 +911,8 @@ class GBSelection(Generic[DF]):
     def __init__(
         self,
         df: PyDataFrame,
-        by: str | list[str],
-        selection: list[str] | None,
+        by: str | Sequence[str],
+        selection: Sequence[str] | None,
         dataframe_class: type[DF],
     ):
         self._df = df

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1128,7 +1128,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def groupby(
         self: LDF,
-        by: str | list[str] | pli.Expr | list[pli.Expr],
+        by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr],
         maintain_order: bool = False,
     ) -> LazyGroupBy[LDF]:
         """
@@ -1181,7 +1181,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         period: str,
         offset: str | None = None,
         closed: ClosedWindow = "right",
-        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+        by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """
         Create rolling groups based on a time column.
@@ -1301,7 +1301,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: ClosedWindow = "left",
-        by: str | list[str] | pli.Expr | list[pli.Expr] | None = None,
+        by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """
         Group based on a time value (or index value of type Int32, Int64).
@@ -1400,9 +1400,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         left_on: str | None = None,
         right_on: str | None = None,
         on: str | None = None,
-        by_left: str | list[str] | None = None,
-        by_right: str | list[str] | None = None,
-        by: str | list[str] | None = None,
+        by_left: str | Sequence[str] | None = None,
+        by_right: str | Sequence[str] | None = None,
+        by: str | Sequence[str] | None = None,
         strategy: AsofJoinStrategy = "backward",
         suffix: str = "_right",
         tolerance: str | int | float | None = None,
@@ -1487,13 +1487,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         if left_on is None or right_on is None:
             raise ValueError("You should pass the column to join on as an argument.")
 
-        by_left_: list[str] | None
+        by_left_: Sequence[str] | None
         if isinstance(by_left, str):
             by_left_ = [by_left]
         else:
             by_left_ = by_left
 
-        by_right_: list[str] | None
+        by_right_: Sequence[str] | None
         if isinstance(by_right, (str, pli.Expr)):
             by_right_ = [by_right]
         else:
@@ -2354,7 +2354,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def explode(
         self: LDF,
-        columns: str | list[str] | pli.Expr | list[pli.Expr],
+        columns: str | Sequence[str] | pli.Expr | Sequence[pli.Expr],
     ) -> LDF:
         """
         Explode lists to long format.

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -144,13 +144,15 @@ def range_to_slice(rng: range) -> slice:
 
 
 def handle_projection_columns(
-    columns: list[str] | list[int] | None,
+    columns: Sequence[str] | Sequence[int] | str | None,
 ) -> tuple[list[int] | None, list[str] | None]:
     """Disambiguates between columns specified as integers vs. strings."""
     projection: list[int] | None = None
     if columns:
-        if is_int_sequence(columns):
-            projection = columns  # type: ignore[assignment]
+        if isinstance(columns, str):
+            columns = [columns]
+        elif is_int_sequence(columns):
+            projection = list(columns)
             columns = None
         elif not is_str_sequence(columns):
             raise ValueError(

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2336,7 +2336,7 @@ def test_set() -> None:
 
     # needs to be a 2 element tuple
     with pytest.raises(ValueError):
-        df[(1, 2, 3)] = 1  # type: ignore[index]
+        df[(1, 2, 3)] = 1
 
     # we cannot index with any type, such as bool
     with pytest.raises(ValueError):


### PR DESCRIPTION
Ran through _frame.py_ and _lazyframe.py_ briefly; a lot (most) of the `list[xyz]` type decorators are better written as `Sequence[xyz]` so that they don't cause unnecessary linting errors when passing these params as tuples.

------

**Example:** _(from `join_asof` method)_
```python
# before
  by_left: str | list[str] | None = None,
  by_right: str | list[str] | None = None,
  by: str | list[str] | None = None,

# after
  by_left: str | Sequence[str] | None = None,
  by_right: str | Sequence[str] | None = None,
  by: str | Sequence[str] | None = None,
```