### PR TITLE
feat(python): frame-level `n_unique()` that can count unique rows or col/expr subsets

### DIFF
--- a/py-polars/docs/source/reference/dataframe.rst
+++ b/py-polars/docs/source/reference/dataframe.rst
@@ -61,6 +61,7 @@ Descriptive stats
     DataFrame.is_empty
     DataFrame.is_unique
     DataFrame.n_chunks
+    DataFrame.n_unique
     DataFrame.null_count
 
 Computations

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -37,6 +37,7 @@ from polars.internals.lazy_functions import (
     format,
     lit,
     select,
+    struct,
 )
 from polars.internals.lazyframe import LazyFrame, wrap_ldf
 from polars.internals.series import Series, wrap_s
@@ -64,6 +65,7 @@ __all__ = [
     "read_parquet_schema",
     "select",
     "selection_to_pyexpr_list",
+    "struct",
     "when",
     "wrap_df",
     "wrap_expr",


### PR DESCRIPTION
Closes #5147.

----

As discussed, this PR provides a new _frame_-level `n_unique()` method that can count unique rows and/or col/expr subsets; offers a `subset` param in the same vein as the dataframe `unique()` method (note: no modification/extensions made to the existing _expression_-level `n_unique` syntax).

**Example:**

```python
import polars as pl

df = pl.DataFrame(
    {
        "a": [1, 1, 2, 3, 4, 5],
        "b": [0.5, 0.5, 1.0, 2.0, 3.0, 3.0],
        "c": [True, True, True, False, True, True],
    }
)

# unique rows (=> 5)
df.n_unique()

# simple columns subset (=> 4)
df.n_unique(subset=["b", "c"])

# more involved expression subset (=> 3)
df.n_unique(
    subset=[
        (pl.col("a") // 2),
        (pl.col("c") | (pl.col("b") >= 2)),
    ],
)
```
This new method's docstring has a `Notes` section the points the reader at struct-packing if expression-level subset behaviour is needed (and also mentions generic/non-subset expression and aggregate `n_unique` usage). Should cover all the bases!

As always, some decent test coverage added for the new code.