### PR TITLE
tests(python): harden unit tests

### DIFF
--- a/py-polars/tests/unit/test_apply.py
+++ b/py-polars/tests/unit/test_apply.py
@@ -51,10 +51,8 @@ def test_apply_none() -> None:
 
 def test_apply_return_py_object() -> None:
     df = pl.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-
     out = df.select([pl.all().map(lambda s: reduce(lambda a, b: a + b, s))])
-
-    assert out.shape == (1, 2)
+    assert out.rows() == [(6, 15)]
 
 
 @no_type_check

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -182,6 +182,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     df = pl.DataFrame({"a": np.arange(10, dtype=np.int64).reshape(2, -1)})
     assert df.dtypes == [pl.List(pl.Int64)]
     assert df.shape == (2, 1)
+    assert df.rows() == [([0, 1, 2, 3, 4],), ([5, 6, 7, 8, 9],)]
 
 
 def test_init_arrow() -> None:
@@ -400,6 +401,7 @@ def test_init_only_columns() -> None:
         assert df.schema["d"].inner == pl.UInt8  # type: ignore[union-attr]
 
         dfe = df.cleared()
+        assert len(dfe) == 0
         assert (df.schema == dfe.schema) and (dfe.shape == df.shape)
 
 
@@ -443,3 +445,4 @@ def test_upcast_primitive_and_strings() -> None:
 def test_u64_lit_5031() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3]}).with_column(pl.col("foo").cast(pl.UInt64))
     assert df.filter(pl.col("foo") < (1 << 64) - 20).shape == (3, 1)
+    assert df["foo"].to_list() == [1, 2, 3]

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -111,9 +111,11 @@ def test_sample() -> None:
     out = pl.select(
         pl.lit(a).sample(frac=0.5, with_replacement=False, seed=1)
     ).to_series()
+
     assert out.shape == (10,)
     assert out.to_list() != out.sort().to_list()
     assert out.unique().shape == (10,)
+    assert set(out).issubset(set(a))
 
     out = pl.select(pl.lit(a).sample(n=10, with_replacement=False, seed=1)).to_series()
     assert out.shape == (10,)
@@ -125,7 +127,6 @@ def test_map_alias() -> None:
     out = pl.DataFrame({"foo": [1, 2, 3]}).select(
         (pl.col("foo") * 2).map_alias(lambda name: f"{name}{name}")
     )
-
     expected = pl.DataFrame({"foofoo": [2, 4, 6]})
     assert out.frame_equal(expected)
 

--- a/py-polars/tests/unit/test_filter.py
+++ b/py-polars/tests/unit/test_filter.py
@@ -5,10 +5,10 @@ def test_simplify_expression_lit_true_4376() -> None:
     df = pl.DataFrame([[1, 4, 7], [2, 5, 8], [3, 6, 9]])
     assert df.lazy().filter(pl.lit(True) | (pl.col("column_0") == 1)).collect(
         simplify_expression=True
-    ).shape == (3, 3)
+    ).rows() == [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
     assert df.lazy().filter((pl.col("column_0") == 1) | pl.lit(True)).collect(
         simplify_expression=True
-    ).shape == (3, 3)
+    ).rows() == [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
 
 
 def test_melt_values_predicate_pushdown() -> None:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -108,9 +108,16 @@ def test_cut() -> None:
     }
 
     # test cut on integers #4939
+    inf = float("inf")
     df = pl.DataFrame({"a": list(range(5))})
     ser = df.select("a").to_series()
-    assert pl.cut(ser, bins=[-1, 1]).shape == (5, 3)
+    assert pl.cut(ser, bins=[-1, 1]).rows() == [
+        (0.0, 1.0, "(-1.0, 1.0]"),
+        (1.0, 1.0, "(-1.0, 1.0]"),
+        (2.0, inf, "(1.0, inf]"),
+        (3.0, inf, "(1.0, inf]"),
+        (4.0, inf, "(1.0, inf]"),
+    ]
 
 
 def test_null_handling_correlation() -> None:

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -8,7 +8,7 @@ import polars as pl
 
 
 def test_groupby_sorted_empty_dataframe_3680() -> None:
-    assert (
+    df = (
         pl.DataFrame(
             [
                 pl.Series("key", [], dtype=pl.Categorical),
@@ -20,7 +20,9 @@ def test_groupby_sorted_empty_dataframe_3680() -> None:
         .groupby("key")
         .tail(1)
         .collect()
-    ).shape == (0, 2)
+    )
+    assert df.shape == (0, 2)
+    assert df.schema == {"key": pl.Categorical, "val": pl.Float64}
 
 
 def test_groupby_custom_agg_empty_list() -> None:

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -232,9 +232,11 @@ def test_join() -> None:
 
     joined = df_left.join(df_right, left_on="a", right_on="a").sort("a")
     assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2]))
+
     joined = df_left.join(df_right, left_on="a", right_on="a", how="left").sort("a")
     assert joined["c_right"].is_null().sum() == 1
     assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2, 4]))
+
     joined = df_left.join(df_right, left_on="a", right_on="a", how="outer").sort("a")
     assert joined["c_right"].null_count() == 1
     assert joined["c"].null_count() == 1
@@ -258,11 +260,12 @@ def test_join() -> None:
 
     # just check if join on multiple columns runs
     df_a.join(df_b, left_on=["a", "b"], right_on=["foo", "bar"])
-
     eager_join = df_a.join(df_b, left_on="a", right_on="foo")
-
     lazy_join = df_a.lazy().join(df_b.lazy(), left_on="a", right_on="foo").collect()
+
+    cols = ["a", "b", "bar", "ham"]
     assert lazy_join.shape == eager_join.shape
+    assert lazy_join.sort(by=cols).frame_equal(eager_join.sort(by=cols))
 
 
 def test_joins_dispatch() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -956,11 +956,38 @@ def test_describe() -> None:
     date_s = pl.Series([date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)])
     empty_s = pl.Series(np.empty(0))
 
-    assert num_s.describe().shape == (6, 2)
-    assert float_s.describe().shape == (6, 2)
-    assert str_s.describe().shape == (3, 2)
-    assert bool_s.describe().shape == (3, 2)
-    assert date_s.describe().shape == (4, 2)
+    assert {k: v for k, v in num_s.describe().rows()} == {
+        "count": 3.0,
+        "max": 3.0,
+        "mean": 2.0,
+        "min": 1.0,
+        "null_count": 0.0,
+        "std": 1.0,
+    }
+    assert {k: v for k, v in float_s.describe().rows()} == {
+        "count": 3.0,
+        "max": 8.9,
+        "mean": 4.933333333333334,
+        "min": 1.3,
+        "null_count": 0.0,
+        "std": 3.8109491381194442,
+    }
+    assert {k: v for k, v in str_s.describe().rows()} == {
+        "count": 3,
+        "null_count": 0,
+        "unique": 3,
+    }
+    assert {k: v for k, v in bool_s.describe().rows()} == {
+        "count": 5,
+        "null_count": 1,
+        "sum": 3,
+    }
+    assert {k: v for k, v in date_s.describe().rows()} == {
+        "count": "3",
+        "max": "2021-01-03",
+        "min": "2021-01-01",
+        "null_count": "0",
+    }
 
     with pytest.raises(ValueError):
         assert empty_s.describe()

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -410,7 +410,10 @@ def test_struct_comparison() -> None:
             "col2": [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
         }
     )
-    assert df.filter(pl.col("col1") == pl.col("col2")).shape == (2, 2)
+    assert df.filter(pl.col("col1") == pl.col("col2")).rows() == [
+        ({"a": 1, "b": 2}, {"a": 1, "b": 2}),
+        ({"a": 3, "b": 4}, {"a": 3, "b": 4}),
+    ]
     # floats w/ ints
     df = pl.DataFrame(
         {
@@ -418,7 +421,10 @@ def test_struct_comparison() -> None:
             "col2": [{"a": 1.0, "b": 2}, {"a": 3.0, "b": 4}],
         }
     )
-    assert df.filter(pl.col("col1") == pl.col("col2")).shape == (2, 2)
+    assert df.filter(pl.col("col1") == pl.col("col2")).rows() == [
+        ({"a": 1, "b": 2}, {"a": 1.0, "b": 2}),
+        ({"a": 3, "b": 4}, {"a": 3.0, "b": 4}),
+    ]
 
     df = pl.DataFrame(
         {


### PR DESCRIPTION
As a follow-up to _"Notes on updated unit tests"_ (mentioned in https://github.com/pola-rs/polars/pull/5152), I've now run through _**all**_ the unit tests to find those which only checked `shape`, and hardened them appropriately (mostly by also checking the values returned from `rows`). Should leave fewer holes in specific coverage 👍 