### PR TITLE
feat(python): support `DataFrame` init with Datetime dtypes that specify a timezone

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -11,7 +11,7 @@ tzdata; platform_system == 'Windows'
 xlsx2csv
 
 # Tooling
-hypothesis==6.55.0
+hypothesis==6.56.2
 maturin==0.13.5
 mypy==0.981
 pytest==7.1.3

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -12,8 +12,15 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.exceptions import NoRowsReturned, TooManyRowsReturned
 from polars.testing import assert_frame_equal, assert_series_equal, columns
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+else:
+    from backports.zoneinfo import ZoneInfo
+
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy
@@ -2386,3 +2393,27 @@ def test_union_with_aliases_4770() -> None:
     ).filter(pl.col("x").is_not_null())
 
     assert lf.collect()["x"].to_list() == [1, 3, 4]
+
+
+def test_init_with_timezone() -> None:
+    for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+        df = pl.DataFrame(
+            data={
+                "d1": [datetime(2022, 10, 12, 12, 30)],
+                "d2": [datetime(2022, 10, 12, 12, 30)],
+            },
+            columns=[
+                ("d1", pl.Datetime(tu, "America/New_York")),  # type: ignore[arg-type]
+                ("d2", pl.Datetime(tu, "Asia/Tokyo")),  # type: ignore[arg-type]
+            ],
+        )
+        # note: setting timezone doesn't change the underlying/physical value...
+        assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
+
+        # ...but (as expected) it _does_ change the interpretation of that value
+        assert df.rows() == [
+            (
+                datetime(2022, 10, 12, 8, 30, tzinfo=ZoneInfo("America/New_York")),
+                datetime(2022, 10, 12, 21, 30, tzinfo=ZoneInfo("Asia/Tokyo")),
+            )
+        ]


### PR DESCRIPTION
Can now initialize `DataFrame` with timezone-aware `DataType`; previously had to post-convert per-column.

Example
----
```python
from datetime import datetime
import polars as pl

df = pl.DataFrame(
    data={
        "d1": [datetime(2022,10,12,12,30)],
        "d2": [datetime(2022,10,12,12,30)],
    },
    columns=[
        ("d1", pl.Datetime(time_zone="America/New_York")),
        ("d2", pl.Datetime(time_zone="Asia/Tokyo")),
    ],
)
```

**Before:**
```python
# NotImplementedError: Conversion of polars data type 
#  datetime[μs, America/New_York] to Python type not implemented.
```

**After:**

```python
# ┌────────────────────────────────┬──────────────────────────┐
# │ d1                             ┆ d2                       │
# │ ---                            ┆ ---                      │
# │ datetime[μs, America/New_York] ┆ datetime[μs, Asia/Tokyo] │
# ╞════════════════════════════════╪══════════════════════════╡
# │ 2022-10-12 12:30:00 EDT        ┆ 2022-10-12 12:30:00 JST  │
# └────────────────────────────────┴──────────────────────────┘

df.row(0)

# (datetime(2022,10,12, 8,30,tzinfo=ZoneInfo(key='America/New_York')),
#  datetime(2022,10,12,21,30,tzinfo=ZoneInfo(key='Asia/Tokyo')))
```
**Misc:**
* Also improves/simplifies some type datatype lookups/conversions.