### PR TITLE
chore(rust): move polars-sql under polars folder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
   "polars/polars-lazy",
   "polars/polars-lazy/polars-plan",
   "polars/polars-lazy/polars-pipe",
-  "polars-sql",
+  "polars/polars-sql",
   "examples/read_csv",
   "examples/read_parquet",
   "examples/python_rust_compiled_function",

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -281,8 +281,8 @@ polars-core = { version = "0.24.3", path = "./polars-core", features = ["docs", 
 polars-io = { version = "0.24.3", path = "./polars-io", features = ["private"], default-features = false, optional = true }
 polars-lazy = { version = "0.24.3", path = "./polars-lazy", features = ["private"], default-features = false, optional = true }
 polars-ops = { version = "0.24.3", path = "./polars-ops" }
-polars-time = { version = "0.24.3", path = "./polars-time", default-features = false, optional = true }
 polars-sql = { version = "0.1.0", path = "./polars-sql", default-features = false, optional = true }
+polars-time = { version = "0.24.3", path = "./polars-time", default-features = false, optional = true }
 
 [dev-dependencies]
 ahash = "0.7"

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/pola-rs/polars"
 description = "DataFrame Library based on Apache Arrow"
 
 [features]
+sql = ["polars-sql"]
 rows = ["polars-core/rows"]
 simd = ["polars-core/simd"]
 avx512 = ["polars-core/avx512"]
@@ -281,6 +282,7 @@ polars-io = { version = "0.24.3", path = "./polars-io", features = ["private"], 
 polars-lazy = { version = "0.24.3", path = "./polars-lazy", features = ["private"], default-features = false, optional = true }
 polars-ops = { version = "0.24.3", path = "./polars-ops" }
 polars-time = { version = "0.24.3", path = "./polars-time", default-features = false, optional = true }
+polars-sql = { version = "0.1.0", path = "./polars-sql", default-features = false, optional = true }
 
 [dev-dependencies]
 ahash = "0.7"

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -9,18 +9,10 @@ binary = ["clap"]
 
 [dependencies]
 clap = { version = "3.2.22", features = ["derive"], optional = true }
-polars-arrow = { path = "../polars/polars-arrow", features = ["like"] }
-polars-lazy = { path = "../polars/polars-lazy", features = ["compile"] }
-polars-plan = { path = "../polars/polars-lazy/polars-plan", features = ["compile"] }
+polars-arrow = { path = "../polars-arrow", features = ["like"] }
+polars-core = { path = "../polars-core", features = [] }
+polars-lazy = { path = "../polars-lazy", features = ["compile", "strings", "cross_join"] }
+polars-plan = { path = "../polars-lazy/polars-plan", features = ["compile"] }
 serde = "1"
 serde_json = { version = "1" }
 sqlparser = { version = "0.19" }
-
-[dependencies.polars]
-path = "../polars"
-default-features = false
-features = [
-  "lazy",
-  "cross_join",
-  "strings",
-]

--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
-use polars::error::PolarsResult;
-use polars::prelude::*;
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
 use polars_plan::prelude::*;
 use polars_plan::utils::expressions_to_schema;
 use sqlparser::ast::{

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -5,7 +5,8 @@ pub use context::SQLContext;
 
 #[cfg(test)]
 mod test {
-    use polars::prelude::*;
+    use polars_core::prelude::*;
+    use polars_lazy::prelude::*;
 
     use super::*;
 

--- a/polars/polars-sql/src/main.rs
+++ b/polars/polars-sql/src/main.rs
@@ -1,4 +1,4 @@
-use polars::prelude::*;
+use polars_core::prelude::*;
 
 #[cfg(feature = "binary")]
 mod binary {

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -1,5 +1,5 @@
-use polars::error::PolarsError;
-use polars::prelude::*;
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
 use sqlparser::ast::{
     BinaryOperator as SQLBinaryOperator, BinaryOperator, DataType as SQLDataType, Expr as SqlExpr,
     Function as SQLFunction, JoinConstraint, TrimWhereField, Value as SqlValue, WindowSpec,

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -168,6 +168,7 @@
 //! * `lazy` - Lazy API
 //!     - `lazy_regex` - Use regexes in [column selection](crate::lazy::dsl::col)
 //!     - `dot_diagram` - Create dot diagrams from lazy logical plans.
+//! * `sql` - Pass SQL queries to polars.
 //! * `random` - Generate arrays with randomly sampled values
 //! * `ndarray`- Convert from `DataFrame` to `ndarray`
 //! * `temporal` - Conversions between [Chrono](https://docs.rs/chrono/) and Polars for temporal data types
@@ -369,6 +370,8 @@
 pub mod docs;
 pub mod export;
 pub mod prelude;
+#[cfg(feature = "sql")]
+pub mod sql;
 
 pub use polars_core::{
     apply_method_all_arrow_series, chunked_array, datatypes, df, doc, error, frame, functions,

--- a/polars/src/sql.rs
+++ b/polars/src/sql.rs
@@ -1,0 +1,1 @@
+pub use polars_sql::SQLContext;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "polars-io",
  "polars-lazy",
  "polars-ops",
+ "polars-sql",
  "polars-time",
 ]
 
@@ -1418,8 +1419,8 @@ dependencies = [
 name = "polars-sql"
 version = "0.1.0"
 dependencies = [
- "polars",
  "polars-arrow",
+ "polars-core",
  "polars-lazy",
  "polars-plan",
  "serde",
@@ -1477,7 +1478,6 @@ dependencies = [
  "polars",
  "polars-core",
  "polars-lazy",
- "polars-sql",
  "pyo3",
  "serde_json",
  "thiserror",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -31,7 +31,6 @@ numpy = "0.16"
 once_cell = "1"
 polars-core = { path = "../polars/polars-core", default-features = false }
 polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-features = false }
-polars-sql = { path = "../polars-sql", optional = true }
 pyo3 = { version = "0.16", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
 serde_json = { version = "1", optional = true }
 thiserror = "^1.0"
@@ -60,6 +59,7 @@ extract_jsonpath = ["polars/extract_jsonpath"]
 pivot = ["polars/pivot"]
 top_k = ["polars/top_k"]
 propagate_nans = ["polars/propagate_nans"]
+sql = ["polars/sql"]
 
 all = [
   "json",
@@ -89,7 +89,7 @@ all = [
   "polars/cse",
   "propagate_nans",
   "polars/groupby_list",
-  "polars-sql",
+  "sql",
   "polars/dtype-binary",
 ]
 

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude;
 pub(crate) mod py_modules;
 pub mod series;
 mod set;
-#[cfg(feature = "polars-sql")]
+#[cfg(feature = "sql")]
 mod sql;
 pub mod utils;
 
@@ -528,7 +528,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyLazyFrame>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<dsl::PyExpr>().unwrap();
-    #[cfg(feature = "polars-sql")]
+    #[cfg(feature = "sql")]
     m.add_class::<sql::PySQLContext>().unwrap();
     m.add_wrapped(wrap_pyfunction!(col)).unwrap();
     m.add_wrapped(wrap_pyfunction!(count)).unwrap();

--- a/py-polars/src/sql.rs
+++ b/py-polars/src/sql.rs
@@ -1,4 +1,4 @@
-use polars_sql::SQLContext;
+use polars::sql::SQLContext;
 use pyo3::prelude::*;
 
 use crate::{PyLazyFrame, PyPolarsErr};


### PR DESCRIPTION
Accommodate #5175


The `SQLContext` is now available under `polars::sql::SQLContext` if the `sql` feature is activated.