### PR TITLE
fix(python): error on fill_nan on non float dtype

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -312,7 +312,13 @@ impl Series {
         match self.dtype() {
             DataType::Float32 => Ok(self.f32().unwrap().is_nan()),
             DataType::Float64 => Ok(self.f64().unwrap().is_nan()),
-            _ => Ok(BooleanChunked::full(self.name(), false, self.len())),
+            _ => Err(PolarsError::InvalidOperation(
+                format!(
+                    "'is_nan' not supported for series with dtype {:?}",
+                    self.dtype()
+                )
+                .into(),
+            )),
         }
     }
 
@@ -321,7 +327,13 @@ impl Series {
         match self.dtype() {
             DataType::Float32 => Ok(self.f32().unwrap().is_not_nan()),
             DataType::Float64 => Ok(self.f64().unwrap().is_not_nan()),
-            _ => Ok(BooleanChunked::full(self.name(), true, self.len())),
+            _ => Err(PolarsError::InvalidOperation(
+                format!(
+                    "'is_not_nan' not supported for series with dtype {:?}",
+                    self.dtype()
+                )
+                .into(),
+            )),
         }
     }
 
@@ -332,7 +344,7 @@ impl Series {
             DataType::Float64 => Ok(self.f64().unwrap().is_finite()),
             _ => Err(PolarsError::InvalidOperation(
                 format!(
-                    "is_nan not supported for series with dtype {:?}",
+                    "'is_finite' not supported for series with dtype {:?}",
                     self.dtype()
                 )
                 .into(),
@@ -347,7 +359,7 @@ impl Series {
             DataType::Float64 => Ok(self.f64().unwrap().is_infinite()),
             _ => Err(PolarsError::InvalidOperation(
                 format!(
-                    "is_nan not supported for series with dtype {:?}",
+                    "'is_infinite' not supported for series with dtype {:?}",
                     self.dtype()
                 )
                 .into(),

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -962,6 +962,11 @@ class Expr:
         """
         Returns a boolean Series indicating which values are NaN.
 
+        Notes
+        -----
+        Floating point ```NaN`` (Not A Number) should not be confused
+        with missing data represented as ``Null/None``.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -970,23 +975,23 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.all().is_nan().suffix("_isnan"))  # nan != null
-        shape: (5, 4)
-        ┌──────┬─────┬─────────┬─────────┐
-        │ a    ┆ b   ┆ a_isnan ┆ b_isnan │
-        │ ---  ┆ --- ┆ ---     ┆ ---     │
-        │ i64  ┆ f64 ┆ bool    ┆ bool    │
-        ╞══════╪═════╪═════════╪═════════╡
-        │ 1    ┆ 1.0 ┆ false   ┆ false   │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-        │ 2    ┆ 2.0 ┆ false   ┆ false   │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-        │ null ┆ NaN ┆ false   ┆ true    │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-        │ 1    ┆ 1.0 ┆ false   ┆ false   │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-        │ 5    ┆ 5.0 ┆ false   ┆ false   │
-        └──────┴─────┴─────────┴─────────┘
+        >>> df.with_column(pl.col(pl.Float64).is_nan().suffix("_isnan"))
+        shape: (5, 3)
+        ┌──────┬─────┬─────────┐
+        │ a    ┆ b   ┆ b_isnan │
+        │ ---  ┆ --- ┆ ---     │
+        │ i64  ┆ f64 ┆ bool    │
+        ╞══════╪═════╪═════════╡
+        │ 1    ┆ 1.0 ┆ false   │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ 2    ┆ 2.0 ┆ false   │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ null ┆ NaN ┆ true    │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ 1    ┆ 1.0 ┆ false   │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+        │ 5    ┆ 5.0 ┆ false   │
+        └──────┴─────┴─────────┘
 
         """
         return wrap_expr(self._pyexpr.is_nan())
@@ -995,6 +1000,11 @@ class Expr:
         """
         Returns a boolean Series indicating which values are not NaN.
 
+        Notes
+        -----
+        Floating point ```NaN`` (Not A Number) should not be confused
+        with missing data represented as ``Null/None``.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -1003,23 +1013,23 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.all().is_not_nan().suffix("_is_not_nan"))  # nan != null
-        shape: (5, 4)
-        ┌──────┬─────┬──────────────┬──────────────┐
-        │ a    ┆ b   ┆ a_is_not_nan ┆ b_is_not_nan │
-        │ ---  ┆ --- ┆ ---          ┆ ---          │
-        │ i64  ┆ f64 ┆ bool         ┆ bool         │
-        ╞══════╪═════╪══════════════╪══════════════╡
-        │ 1    ┆ 1.0 ┆ true         ┆ true         │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 2    ┆ 2.0 ┆ true         ┆ true         │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ null ┆ NaN ┆ true         ┆ false        │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 1    ┆ 1.0 ┆ true         ┆ true         │
-        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ 5    ┆ 5.0 ┆ true         ┆ true         │
-        └──────┴─────┴──────────────┴──────────────┘
+        >>> df.with_column(pl.col(pl.Float64).is_not_nan().suffix("_is_not_nan"))
+        shape: (5, 3)
+        ┌──────┬─────┬──────────────┐
+        │ a    ┆ b   ┆ b_is_not_nan │
+        │ ---  ┆ --- ┆ ---          │
+        │ i64  ┆ f64 ┆ bool         │
+        ╞══════╪═════╪══════════════╡
+        │ 1    ┆ 1.0 ┆ true         │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 2    ┆ 2.0 ┆ true         │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ null ┆ NaN ┆ false        │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 1    ┆ 1.0 ┆ true         │
+        ├╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ 5    ┆ 5.0 ┆ true         │
+        └──────┴─────┴──────────────┘
 
         """
         return wrap_expr(self._pyexpr.is_not_nan())

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -2129,7 +2129,7 @@ class Expr:
         else:
             return wrap_expr(self._pyexpr.fill_null_with_strategy(strategy, limit))
 
-    def fill_nan(self, fill_value: str | int | float | bool | Expr | None) -> Expr:
+    def fill_nan(self, fill_value: int | float | Expr | None) -> Expr:
         """
         Fill floating point NaN value with a fill value.
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2184,7 +2184,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return self.select(pli.all().fill_null(value, strategy, limit))
 
-    def fill_nan(self: LDF, fill_value: int | str | float | pli.Expr | None) -> LDF:
+    def fill_nan(self: LDF, fill_value: int | float | pli.Expr | None) -> LDF:
         """
         Fill floating point NaN values.
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2848,9 +2848,7 @@ class Series:
         """
         return wrap_s(self._s.clone())
 
-    def fill_nan(
-        self, fill_value: str | int | float | bool | pli.Expr | None
-    ) -> Series:
+    def fill_nan(self, fill_value: int | float | pli.Expr | None) -> Series:
         """
         Fill floating point NaN value with a fill value.
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -229,3 +229,10 @@ def test_err_asof_join_null_values() -> None:
                 strategy="backward",
             )
         )
+
+
+def test_is_nan_on_non_boolean() -> None:
+    with pytest.raises(pl.InvalidOperationError):
+        pl.Series([1, 2, 3]).fill_nan(0)
+    with pytest.raises(pl.InvalidOperationError):
+        pl.Series(["1", "2", "3"]).fill_nan("2")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -151,7 +151,7 @@ def test_nested_struct() -> None:
     # Nest the dataframe
     nest_l1 = df.to_struct("c").to_frame()
     # Add another column on the same level
-    nest_l1 = nest_l1.with_column(pl.col("c").is_nan().alias("b"))
+    nest_l1 = nest_l1.with_column(pl.col("c").is_null().alias("b"))
     # Nest the dataframe again
     nest_l2 = nest_l1.to_struct("a").to_frame()
 


### PR DESCRIPTION
fixes #5146

Also update the types accordingly. It does not make sense to `fill_nan` with a string type for instance.