### PR TITLE
tests(rust): Add test for arithmetic & aggregate methods on sorted ChunkedArray

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -669,17 +669,20 @@ pub(crate) mod test {
         let a = a.sort(false);
         let b = a.into_iter().collect::<Vec<_>>();
         assert_eq!(b, [Some("a"), Some("b"), Some("c")]);
+        assert_eq!(a.is_sorted(), true);
     }
 
     #[test]
     fn arithmetic() {
-        let s1 = get_chunked_array();
-        println!("{:?}", s1.chunks);
-        let s2 = &s1;
-        let s1 = &s1;
-        println!("{:?}", s1 + s2);
-        println!("{:?}", s1 - s2);
-        println!("{:?}", s1 * s2);
+        let a = &Int32Chunked::new("a", &[1, 100, 6, 40]);
+        let b = &Int32Chunked::new("b", &[-1, 2, 3, 4]);
+
+        // Not really asserting anything here but shill making sure the code is exercised
+        // This (and more) is properly tested from the integration test suite and Python bindings.
+        println!("{:?}", a + b);
+        println!("{:?}", a - b);
+        println!("{:?}", a * b);
+        println!("{:?}", a / b);
     }
 
     #[test]
@@ -708,11 +711,11 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn aggregates_numeric() {
-        let a = get_chunked_array();
-        assert_eq!(a.max(), Some(3));
+    fn aggregates() {
+        let a = &Int32Chunked::new("a", &[1, 100, 10, 9]);
+        assert_eq!(a.max(), Some(100));
         assert_eq!(a.min(), Some(1));
-        assert_eq!(a.sum(), Some(6))
+        assert_eq!(a.sum(), Some(120))
     }
 
     #[test]

--- a/polars/tests/it/core/mod.rs
+++ b/polars/tests/it/core/mod.rs
@@ -5,6 +5,7 @@ mod list;
 mod pivot;
 #[cfg(feature = "rolling_window")]
 mod rolling_window;
+mod series;
 mod utils;
 
 use polars::prelude::*;

--- a/polars/tests/it/core/series.rs
+++ b/polars/tests/it/core/series.rs
@@ -1,0 +1,38 @@
+use polars::prelude::*;
+use polars::series::*;
+
+#[test]
+fn test_series_arithmetic() {
+    let a = &Series::new("a", &[1, 100, 6, 40]);
+    let b = &Series::new("b", &[-1, 2, 3, 4]);
+    assert_eq!(a + b, Series::new("a", &[0, 102, 9, 44]));
+    assert_eq!(a - b, Series::new("a", &[2, 98, 3, 36]));
+    assert_eq!(a * b, Series::new("a", &[-1, 200, 18, 160]));
+    assert_eq!(a / b, Series::new("a", &[-1, 50, 2, 10]));
+}
+
+#[test]
+fn test_aggregates() {
+    let a = &Series::new("a", &[9, 11, 10]);
+    assert_eq!(a.max(), Some(11));
+    assert_eq!(a.min(), Some(9));
+    assert_eq!(a.sum(), Some(30));
+    assert_eq!(a.mean(), Some(10.0));
+    assert_eq!(a.median(), Some(10.0));
+}
+
+#[test]
+fn test_min_max_sorted_asc() {
+    let a = &mut Series::new("a", &[1, 2, 3, 4]);
+    a.set_sorted(IsSorted::Ascending);
+    assert_eq!(a.max(), Some(4));
+    assert_eq!(a.min(), Some(1));
+}
+
+#[test]
+fn test_min_max_sorted_desc() {
+    let mut a = &mut Series::new("a", &[4, 3, 2, 1]);
+    a.set_sorted(IsSorted::Descending);
+    assert_eq!(a.max(), Some(4));
+    assert_eq!(a.min(), Some(1));
+}


### PR DESCRIPTION
Was just passing by this part of Polar's code base and noticed the `chunked_array::arithmetic` wasn't really testing anything, so spent some time on adding actual tests for some code paths that weren't being tested  and asses test coverage using `llvm-cov`.

Before:

```
Filename                                  Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
chunked_array/arithmetic.rs                    153                97    36.60%          65                40    38.46%         276               135    51.09%           0                 0         -
chunked_array/bitwise.rs                        68                43    36.76%          20                12    40.00%         174               118    32.18%           0                 0         -
chunked_array/builder/boolean.rs                 5                 1    80.00%           5                 1    80.00%          28                 3    89.29%           0                 0         -
chunked_array/builder/from.rs                    5                 2    60.00%           5                 2    60.00%          24                 6    75.00%           0                 0         -
chunked_array/builder/list.rs                  125                85    32.00%          48                29    39.58%         356               229    35.67%           0                 0         -
chunked_array/builder/mod.rs                    64                11    82.81%          28                 4    85.71%         141                21    85.11%           0                 0         -
chunked_array/builder/primitive.rs               5                 1    80.00%           5                 1    80.00%          30                 3    90.00%           0                 0         -
chunked_array/builder/utf8.rs                   11                 7    36.36%          11                 7    36.36%          49                23    53.06%           0                 0         -
chunked_array/cast.rs                           85                30    64.71%          20                 7    65.00%         149                39    73.83%           0                 0         -
chunked_array/comparison.rs                    542               148    72.69%         127                38    70.08%         895               183    79.55%           0                 0         -
chunked_array/float.rs                           7                 7     0.00%           6                 6     0.00%          20                20     0.00%           0                 0         -
chunked_array/from.rs                           16                 3    81.25%           5                 2    60.00%          92                32    65.22%           0                 0         -
chunked_array/iterator/mod.rs                  227                11    95.15%          70                 7    90.00%         525                35    93.33%           0                 0         -
chunked_array/iterator/par/list.rs              14                14     0.00%           7                 7     0.00%          35                35     0.00%           0                 0         -
chunked_array/iterator/par/utf8.rs              13                13     0.00%           6                 6     0.00%          34                34     0.00%           0                 0         -
chunked_array/kernels/take.rs                   20                20     0.00%           7                 7     0.00%          62                62     0.00%           0                 0         -
chunked_array/list/iterator.rs                  50                37    26.00%          15                 7    53.33%         158                68    56.96%           0                 0         -
chunked_array/list/mod.rs                       10                 8    20.00%           4                 2    50.00%          16                10    37.50%           0                 0         -
chunked_array/logical/mod.rs                     6                 6     0.00%           6                 6     0.00%          23                23     0.00%           0                 0         -
chunked_array/mod.rs                           200                59    70.50%          93                23    75.27%         496               150    69.76%           0                 0         -
chunked_array/ops/aggregate.rs                 395               129    67.34%         109                45    58.72%        1053               222    78.92%           0                 0         -
chunked_array/ops/any_value.rs                  39                19    51.28%           9                 5    44.44%          71                24    66.20%           0                 0         -
chunked_array/ops/append.rs                     14                 6    57.14%           5                 1    80.00%          36                10    72.22%           0                 0         -
chunked_array/ops/apply.rs                     218               195    10.55%          87                73    16.09%         615               519    15.61%           0                 0         -
chunked_array/ops/bit_repr.rs                   39                11    71.79%          11                 3    72.73%         151                49    67.55%           0                 0         -
chunked_array/ops/chunkops.rs                   48                10    79.17%          13                 2    84.62%         115                17    85.22%           0                 0         -
chunked_array/ops/compare_inner.rs              60                48    20.00%          26                21    19.23%         135               104    22.96%           0                 0         -
chunked_array/ops/downcast.rs                   49                19    61.22%          27                12    55.56%         118                43    63.56%           0                 0         -
chunked_array/ops/explode.rs                   265                92    65.28%          26                10    61.54%         524               141    73.09%           0                 0         -
chunked_array/ops/extend.rs                     58                 8    86.21%          12                 1    91.67%         161                23    85.71%           0                 0         -
chunked_array/ops/fill_null.rs                 155               111    28.39%          36                26    27.78%         285               192    32.63%           0                 0         -
chunked_array/ops/filter.rs                     35                21    40.00%           8                 4    50.00%          80                50    37.50%           0                 0         -
chunked_array/ops/full.rs                       13                 9    30.77%           9                 5    44.44%          57                35    38.60%           0                 0         -
chunked_array/ops/mod.rs                        41                37     9.76%          31                28     9.68%          96                91     5.21%           0                 0         -
chunked_array/ops/peaks.rs                       2                 2     0.00%           2                 2     0.00%           8                 8     0.00%           0                 0         -
chunked_array/ops/reverse.rs                    12                 2    83.33%           2                 0   100.00%          18                 2    88.89%           0                 0         -
chunked_array/ops/rolling_window.rs              2                 2     0.00%           2                 2     0.00%           9                 9     0.00%           0                 0         -
chunked_array/ops/set.rs                       111                62    44.14%          21                10    52.38%         239               134    43.93%           0                 0         -
chunked_array/ops/shift.rs                      34                13    61.76%          10                 4    60.00%          75                27    64.00%           0                 0         -
chunked_array/ops/sort/argsort.rs               28                 0   100.00%           5                 0   100.00%          56                 0   100.00%           0                 0         -
chunked_array/ops/sort/mod.rs                  138                37    73.19%          46                12    73.91%         471                73    84.50%           0                 0         -
chunked_array/ops/take/mod.rs                  177               138    22.03%          37                31    16.22%         257               189    26.46%           0                 0         -
chunked_array/ops/take/take_chunked.rs          41                41     0.00%          22                22     0.00%         153               153     0.00%           0                 0         -
chunked_array/ops/take/take_every.rs            24                24     0.00%           4                 4     0.00%          29                29     0.00%           0                 0         -
chunked_array/ops/take/take_random.rs          103                82    20.39%          36                28    22.22%         180               141    21.67%           0                 0         -
chunked_array/ops/take/take_single.rs           26                12    53.85%          12                 6    50.00%          48                23    52.08%           0                 0         -
chunked_array/ops/take/traits.rs                55                35    36.36%          15                 7    53.33%          93                59    36.56%           0                 0         -
chunked_array/ops/unique/mod.rs                127                75    40.94%          44                26    40.91%         254               121    52.36%           0                 0         -
chunked_array/temporal/conversion.rs             6                 6     0.00%           6                 6     0.00%          29                29     0.00%           0                 0         -
chunked_array/temporal/mod.rs                    1                 1     0.00%           1                 1     0.00%           3                 3     0.00%           0                 0         -
chunked_array/trusted_len.rs                    35                12    65.71%          18                 6    66.67%         150                45    70.00%           0                 0         -
chunked_array/upstream_traits.rs               118                63    46.61%          38                17    55.26%         312               140    55.13%           0                 0         -
error.rs                                        22                17    22.73%          10                 7    30.00%          33                20    39.39%           0                 0         -
fmt.rs                                         253               235     7.11%          36                27    25.00%         361               137    62.05%           0                 0         -
functions.rs                                    49                18    63.27%          10                 1    90.00%          85                17    80.00%           0                 0         -
lib.rs                                           7                 2    71.43%           5                 2    60.00%          19                 2    89.47%           0                 0         -
named_from.rs                                   51                36    29.41%          26                19    26.92%         103                74    28.16%           0                 0         -
schema.rs                                       83                77     7.23%          39                37     5.13%         147               134     8.84%           0                 0         -
testing.rs                                      77                 9    88.31%          22                 3    86.36%         149                24    83.89%           0                 0         -
tests.rs                                        13                 3    76.92%           2                 0   100.00%          13                 0   100.00%           0                 0         -
vector_hasher.rs                               143                38    73.43%          69                30    56.52%         392                94    76.02%           0                 0         -
rustc/c97d02cdb5ca5f5e9eff1fa9e4560d220d1fd2a0/library/std/src/thread/local.rs                      6                 3    50.00%           3                 1    66.67%          33                 1    96.97%           0                 0         -
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                           4799              2363    50.76%        1505               761    49.44%       10799              4437    58.91%           0                 0         -
```

After:
```
Filename                                    Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
chunked_array/arithmetic.rs                    153                97    36.60%          65                40    38.46%         276               135    51.09%           0                 0         -
chunked_array/bitwise.rs                        68                43    36.76%          20                12    40.00%         174               118    32.18%           0                 0         -
chunked_array/builder/boolean.rs                 5                 1    80.00%           5                 1    80.00%          28                 3    89.29%           0                 0         -
chunked_array/builder/from.rs                    5                 2    60.00%           5                 2    60.00%          24                 6    75.00%           0                 0         -
chunked_array/builder/list.rs                  125                85    32.00%          48                29    39.58%         356               229    35.67%           0                 0         -
chunked_array/builder/mod.rs                    64                11    82.81%          28                 4    85.71%         141                21    85.11%           0                 0         -
chunked_array/builder/primitive.rs               5                 1    80.00%           5                 1    80.00%          30                 3    90.00%           0                 0         -
chunked_array/builder/utf8.rs                   11                 7    36.36%          11                 7    36.36%          49                23    53.06%           0                 0         -
chunked_array/cast.rs                           85                30    64.71%          20                 7    65.00%         149                39    73.83%           0                 0         -
chunked_array/comparison.rs                    542               148    72.69%         127                38    70.08%         895               183    79.55%           0                 0         -
chunked_array/float.rs                           7                 7     0.00%           6                 6     0.00%          20                20     0.00%           0                 0         -
chunked_array/from.rs                           16                 3    81.25%           5                 2    60.00%          92                32    65.22%           0                 0         -
chunked_array/iterator/mod.rs                  227                11    95.15%          70                 7    90.00%         525                35    93.33%           0                 0         -
chunked_array/iterator/par/list.rs              14                14     0.00%           7                 7     0.00%          35                35     0.00%           0                 0         -
chunked_array/iterator/par/utf8.rs              13                13     0.00%           6                 6     0.00%          34                34     0.00%           0                 0         -
chunked_array/kernels/take.rs                   20                20     0.00%           7                 7     0.00%          62                62     0.00%           0                 0         -
chunked_array/list/iterator.rs                  50                37    26.00%          15                 7    53.33%         158                68    56.96%           0                 0         -
chunked_array/list/mod.rs                       10                 8    20.00%           4                 2    50.00%          16                10    37.50%           0                 0         -
chunked_array/logical/mod.rs                     6                 6     0.00%           6                 6     0.00%          23                23     0.00%           0                 0         -
chunked_array/mod.rs                           222                59    73.42%         100                23    77.00%         520               150    71.15%           0                 0         -
chunked_array/ops/aggregate.rs                 395               129    67.34%         109                45    58.72%        1053               222    78.92%           0                 0         -
chunked_array/ops/any_value.rs                  39                19    51.28%           9                 5    44.44%          71                24    66.20%           0                 0         -
chunked_array/ops/append.rs                     14                 6    57.14%           5                 1    80.00%          36                10    72.22%           0                 0         -
chunked_array/ops/apply.rs                     218               195    10.55%          87                73    16.09%         615               519    15.61%           0                 0         -
chunked_array/ops/bit_repr.rs                   39                11    71.79%          11                 3    72.73%         151                49    67.55%           0                 0         -
chunked_array/ops/chunkops.rs                   48                10    79.17%          13                 2    84.62%         115                17    85.22%           0                 0         -
chunked_array/ops/compare_inner.rs              60                48    20.00%          26                21    19.23%         135               104    22.96%           0                 0         -
chunked_array/ops/downcast.rs                   49                19    61.22%          27                12    55.56%         118                43    63.56%           0                 0         -
chunked_array/ops/explode.rs                   265                92    65.28%          26                10    61.54%         524               141    73.09%           0                 0         -
chunked_array/ops/extend.rs                     58                 8    86.21%          12                 1    91.67%         161                23    85.71%           0                 0         -
chunked_array/ops/fill_null.rs                 155               111    28.39%          36                26    27.78%         285               192    32.63%           0                 0         -
chunked_array/ops/filter.rs                     35                21    40.00%           8                 4    50.00%          80                50    37.50%           0                 0         -
chunked_array/ops/full.rs                       13                 9    30.77%           9                 5    44.44%          57                35    38.60%           0                 0         -
chunked_array/ops/mod.rs                        41                37     9.76%          31                28     9.68%          96                91     5.21%           0                 0         -
chunked_array/ops/peaks.rs                       2                 2     0.00%           2                 2     0.00%           8                 8     0.00%           0                 0         -
chunked_array/ops/reverse.rs                    12                 2    83.33%           2                 0   100.00%          18                 2    88.89%           0                 0         -
chunked_array/ops/rolling_window.rs              2                 2     0.00%           2                 2     0.00%           9                 9     0.00%           0                 0         -
chunked_array/ops/set.rs                       111                62    44.14%          21                10    52.38%         239               134    43.93%           0                 0         -
chunked_array/ops/shift.rs                      34                13    61.76%          10                 4    60.00%          75                27    64.00%           0                 0         -
chunked_array/ops/sort/argsort.rs               28                 0   100.00%           5                 0   100.00%          56                 0   100.00%           0                 0         -
chunked_array/ops/sort/mod.rs                  138                37    73.19%          46                12    73.91%         471                73    84.50%           0                 0         -
chunked_array/ops/take/mod.rs                  177               138    22.03%          37                31    16.22%         257               189    26.46%           0                 0         -
chunked_array/ops/take/take_chunked.rs          41                41     0.00%          22                22     0.00%         153               153     0.00%           0                 0         -
chunked_array/ops/take/take_every.rs            24                24     0.00%           4                 4     0.00%          29                29     0.00%           0                 0         -
chunked_array/ops/take/take_random.rs          103                82    20.39%          36                28    22.22%         180               141    21.67%           0                 0         -
chunked_array/ops/take/take_single.rs           26                12    53.85%          12                 6    50.00%          48                23    52.08%           0                 0         -
chunked_array/ops/take/traits.rs                55                35    36.36%          15                 7    53.33%          93                59    36.56%           0                 0         -
chunked_array/ops/unique/mod.rs                127                75    40.94%          44                26    40.91%         254               121    52.36%           0                 0         -
chunked_array/temporal/conversion.rs             6                 6     0.00%           6                 6     0.00%          29                29     0.00%           0                 0         -
chunked_array/temporal/mod.rs                    1                 1     0.00%           1                 1     0.00%           3                 3     0.00%           0                 0         -
chunked_array/trusted_len.rs                    35                12    65.71%          18                 6    66.67%         150                45    70.00%           0                 0         -
chunked_array/upstream_traits.rs               123                62    49.59%          40                16    60.00%         322               136    57.76%           0                 0         -
error.rs                                        22                17    22.73%          10                 7    30.00%          33                20    39.39%           0                 0         -
fmt.rs                                         253               235     7.11%          36                27    25.00%         361               137    62.05%           0                 0         -
functions.rs                                    49                18    63.27%          10                 1    90.00%          85                17    80.00%           0                 0         -
lib.rs                                           7                 2    71.43%           5                 2    60.00%          19                 2    89.47%           0                 0         -
named_from.rs                                   51                36    29.41%          26                19    26.92%         103                74    28.16%           0                 0         -
schema.rs                                       83                77     7.23%          39                37     5.13%         147               134     8.84%           0                 0         -
testing.rs                                      77                 9    88.31%          22                 3    86.36%         149                24    83.89%           0                 0         -
tests.rs                                        13                 3    76.92%           2                 0   100.00%          13                 0   100.00%           0                 0         -
vector_hasher.rs                               143                38    73.43%          69                30    56.52%         392                94    76.02%           0                 0         -
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                         4826              2362    51.06%        1514               760    49.80%       10833              4433    59.08%           0                 0         -
```