### PR TITLE
feat(python, rust): allow polars Config options to be serialised/shared, and more easily unset

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -521,6 +521,8 @@ impl Display for DataFrame {
 
             if std::env::var("POLARS_FMT_TABLE_HIDE_DATAFRAME_SHAPE_INFORMATION").is_ok() {
                 write!(f, "{}", table)?;
+            } else if std::env::var("POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW").is_ok() {
+                write!(f, "{}\nshape: {:?}", table, self.shape())?;
             } else {
                 write!(f, "shape: {:?}\n{}", self.shape(), table)?;
             }

--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -4,8 +4,8 @@ Config
 ============
 .. currentmodule:: polars
 
-Config options
---------------
+Config options (set/unset)
+--------------------------
 
 .. autosummary::
    :toctree: api/
@@ -26,11 +26,12 @@ Config options
     Config.set_utf8_tables
     Config.set_verbose
 
-Config load/save
-----------------
+Config load/save and state
+--------------------------
 .. autosummary::
    :toctree: api/
 
     Config.load
     Config.save
+    Config.state
     Config.restore_defaults

--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -4,23 +4,33 @@ Config
 ============
 .. currentmodule:: polars
 
+Config options
+--------------
+
 .. autosummary::
    :toctree: api/
 
-    Config.set_tbl_formatting
-    Config.set_tbl_cell_alignment
     Config.set_ascii_tables
     Config.set_fmt_str_lengths
-    Config.set_global_string_cache
+    Config.set_tbl_cell_alignment
+    Config.set_tbl_change_column_data_type_position_format
     Config.set_tbl_cols
+    Config.set_tbl_dataframe_shape_below
+    Config.set_tbl_formatting
+    Config.set_tbl_hide_column_data_types
+    Config.set_tbl_hide_column_names
+    Config.set_tbl_hide_column_separator
+    Config.set_tbl_hide_dataframe_shape
     Config.set_tbl_rows
     Config.set_tbl_width_chars
     Config.set_utf8_tables
-    Config.set_tbl_hide_column_separator
-    Config.set_tbl_hide_dataframe_shape
-    Config.set_tbl_change_column_data_type_position_format
-    Config.set_tbl_hide_column_data_types
-    Config.set_tbl_hide_column_names
-    Config.unset_global_string_cache
-    toggle_string_cache
-    StringCache
+    Config.set_verbose
+
+Config load/save
+----------------
+.. autosummary::
+   :toctree: api/
+
+    Config.load
+    Config.save
+    Config.restore_defaults

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -271,7 +271,7 @@ def format_path(path: str | Path) -> str:
 
 
 def threadpool_size() -> int:
-    """Get the size of polars; thread pool."""
+    """Get the size of polars' thread pool."""
     return _pool_size()
 
 


### PR DESCRIPTION
**Config enhancements:** 
_(backwards-compatible, no changes to existing behaviour)_

* Added new `save` and `load` classmethods to allow for easy serialisation of `Config` options to a simple JSON dict/string that can then be shared, stored, or reloaded later.
* Added `restore_defaults` method that can unset all registered `Config` vars from the environment.
* Added `state` method to easily see the state of environment vars set from `Config` (as dict).
* Previously only `set_tbl_change_column_data_type_position_format` had an `active` param that supported setting/unsetting its boolean value; now _all_ boolean config options support the same.

  ```python
  # save current config settings to json string
  cfg = pl.Config.save()

  # clear current environment and load a previously-saved config
  pl.Config.restore_defaults().load( cfg )
  ```


**Also:**
_(new config options)_

* Added `set_verbose` option to allow for easy set/unset of `POLARS_VERBOSE`.
* Added `POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW` env var to allow for `shape` output to be printed _below_ the table data (closes #5202).  Defaults to False; no change to the standard layout/formatting.

  ```python
  pl.Config.set_verbose( True )  
  pl.Config.set_tbl_dataframe_shape_below( True )  
  ```

