### PR TITLE
feat(python): allow Config to be used as a context manager, and update some docs

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -26,8 +26,8 @@ Config options (set/unset)
     Config.set_utf8_tables
     Config.set_verbose
 
-Config load/save and state
---------------------------
+Config load, save, and current state
+------------------------------------
 .. autosummary::
    :toctree: api/
 

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -96,7 +96,6 @@ class Config:
 
         Examples
         --------
-        >>> pl.Config.restore_defaults().set_ascii_tables().set_verbose(True)
         >>> cfg = pl.Config.save()
 
         """


### PR DESCRIPTION
Building on the previous PR, can now use the new `save`, `load`, and `restore_defaults` methods to enable use as a context manager; potentially helpful for targeted debugging and/or other temporary state.

**Example:**

```python
# scope some code with verbose logging, extra columns, and ascii representation
with pl.Config() as cfg:
    cfg.set_verbose(True).set_tbl_cols(50).set_ascii_tables()
    do_some_debugging_stuff()
    
# original config state restored on scope exit
```
Also improved some of the `Config` docstrings.