### PR TITLE
chore(python): Consistent naming for Python release workflow

### DIFF
--- a/.github/workflows/create-py-release-mac-universal2.yaml
+++ b/.github/workflows/create-py-release-mac-universal2.yaml
@@ -1,4 +1,4 @@
-name: Create macOs universal2/aarch64-apple-darwin python release
+name: Create Python release macOs universal2/aarch64-apple-darwin
 
 on:
   push:


### PR DESCRIPTION
Just a small rename to make this workflow consistent with the others.

PS: Can I delete the old "Create Python release" workflow run? It only has one run for 0.0.1 and doesn't have a workflow attached to it so it's useless. I'm asking because it might have sentimental value or something? 😄 