### PR TITLE
fix(rust):Count chars rather than bytes

### DIFF
--- a/polars/polars-arrow/src/kernels/string.rs
+++ b/polars/polars-arrow/src/kernels/string.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 use crate::trusted_len::PushUnchecked;
 
 pub fn string_lengths(array: &Utf8Array<i64>) -> ArrayRef {
-    let values = array.offsets().windows(2).map(|x| (x[1] - x[0]) as u32);
+    let values = array.values_iter().map(|x| x.chars().count() as u32);
 
     let values: Buffer<_> = Vec::from_trusted_len_iter(values).into();
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1617,8 +1617,8 @@ def test_str_concat() -> None:
 
 
 def test_str_lengths() -> None:
-    s = pl.Series(["messi", "ronaldo", None])
-    expected = pl.Series([5, 7, None], dtype=UInt32)
+    s = pl.Series(["messi", "ronaldo", "中", "café", None])
+    expected = pl.Series([5, 7, 1, 4, None], dtype=UInt32)
     verify_series_and_expr_api(s, expected, "str.lengths")
 
 


### PR DESCRIPTION
Count characters in string length function rather than bytes.

```python
import polars as pl
df = pl.DataFrame(
    {
        "data": ["a", "b", "中"],
    }
)
df.select(
    [
        pl.col('data').str.lengths()
    ]
)
```
returns:

```
shape: (3, 1)
┌─────┐
│ data│
│ --- │
│ u32 │
╞═════╡
│  1  │
├╌╌╌╌╌┤
│  1  │
├╌╌╌╌╌┤
│  1  │
└─────┘
```

Closes #5249