### PR TITLE
feat(rust): Add newline to Aggregate..FROM describe_optimization_plan

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -175,11 +175,8 @@ impl LogicalPlan {
             Aggregate {
                 input, keys, aggs, ..
             } => {
-                writeln!(
-                    f,
-                    "{:indent$}Aggregate\n\t{:?} BY {:?} FROM",
-                    "", aggs, keys
-                )?;
+                writeln!(f, "{:indent$}Aggregate", "")?;
+                writeln!(f, "{:indent$}{:?} BY {:?} FROM", "", aggs, keys)?;
                 writeln!(f, "{:indent$}\t{:?}", "", input)
             }
             Join {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -174,7 +174,11 @@ impl LogicalPlan {
             }
             Aggregate {
                 input, keys, aggs, ..
-            } => write!(f, "Aggregate\n\t{:?} BY {:?} FROM {:?}", aggs, keys, input),
+            } => write!(
+                f,
+                "Aggregate\n\t{:?} BY {:?} FROM\n {:?}",
+                aggs, keys, input
+            ),
             Join {
                 input_left,
                 input_right,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -180,7 +180,7 @@ impl LogicalPlan {
                     "{:indent$}Aggregate\n\t{:?} BY {:?} FROM",
                     "", aggs, keys
                 )?;
-                writeln!(f, "{:indent$}{:?}", "", input)
+                writeln!(f, "{:indent$}\t{:?}", "", input)
             }
             Join {
                 input_left,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -174,11 +174,14 @@ impl LogicalPlan {
             }
             Aggregate {
                 input, keys, aggs, ..
-            } => write!(
-                f,
-                "Aggregate\n\t{:?} BY {:?} FROM\n\t{:?}",
-                aggs, keys, input
-            ),
+            } => {
+                writeln!(
+                    f,
+                    "{:indent$}Aggregate\n\t{:?} BY {:?} FROM",
+                    "", aggs, keys
+                )?;
+                writeln!(f, "{:indent$}{:?}", "", input)
+            }
             Join {
                 input_left,
                 input_right,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -176,7 +176,7 @@ impl LogicalPlan {
                 input, keys, aggs, ..
             } => write!(
                 f,
-                "Aggregate\n\t{:?} BY {:?} FROM\n {:?}",
+                "Aggregate\n\t{:?} BY {:?} FROM\n\t{:?}",
                 aggs, keys, input
             ),
             Join {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -176,7 +176,7 @@ impl LogicalPlan {
                 input, keys, aggs, ..
             } => {
                 writeln!(f, "{:indent$}Aggregate", "")?;
-                writeln!(f, "{:indent$}{:?} BY {:?} FROM", "", aggs, keys)?;
+                writeln!(f, "{:indent$}\t{:?} BY {:?} FROM", "", aggs, keys)?;
                 writeln!(f, "{:indent$}\t{:?}", "", input)
             }
             Join {


### PR DESCRIPTION
```python
import polars as pl

df = pl.DataFrame({'a':[0,1],'b':[1,2]})

print(
df.lazy().groupby("a").agg(pl.col("b").mean()).describe_optimized_plan()
)
```

Now returns:
```
Aggregate
        [col("b").mean()] BY [col("a")] FROM
   DF ["a", "b"]; PROJECT 2/2 COLUMNS; SELECTION: "None"
```

Closes #5208