### PR TITLE
feat(rust, python): improve error msg if window expressions length do…

### DIFF
--- a/polars/polars-core/src/series/unstable.rs
+++ b/polars/polars-core/src/series/unstable.rs
@@ -4,7 +4,7 @@ use std::ptr::NonNull;
 use crate::prelude::*;
 
 /// A wrapper type that should make it a bit more clear that we should not clone Series
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[cfg(feature = "private")]
 pub struct UnstableSeries<'a> {
     lifetime: PhantomData<&'a Series>,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import re
 import typing
 from datetime import date, datetime, timedelta
 
@@ -240,13 +239,16 @@ def test_is_nan_on_non_boolean() -> None:
 
 
 def test_window_expression_different_group_length() -> None:
-    msg = re.escape(
-        r"""The length of the window expression did not match that of the group.
-> Group: ("b")
-> Group length: 1
-> Output: 'shape: (2,)"""
-    )
-    with pytest.raises(pl.ComputeError, match=msg):
+    try:
         pl.DataFrame({"groups": ["a", "a", "b", "a", "b"]}).select(
             [pl.col("groups").apply(lambda _: pl.Series([1, 2])).over("groups")]
         )
+    except pl.ComputeError as e:
+        msg = str(e)
+        assert (
+            "The length of the window expression did not match that of the group."
+            in msg
+        )
+        assert "Group:" in msg
+        assert "Group length:" in msg
+        assert "Output: 'shape:" in msg


### PR DESCRIPTION
…es not match that of the group

```python
pl.DataFrame({
    "groups": ["a", "a", "b", "a", "b"]
}).select([
    pl.col("groups").apply(lambda _: pl.Series([1, 2])).over("groups")
])

ComputeError: The length of the window expression did not match that of the group.
> Group: ("b")
> Group length: 1
> Output: 'shape: (2,)
Series: '' [i64]
[
	1
	2
]'

```