### PR TITLE
fix(python): respect schema overwrite in from rows

### DIFF
--- a/polars/polars-core/src/chunked_array/object/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/mod.rs
@@ -12,6 +12,7 @@ pub mod builder;
 pub(crate) mod extension;
 mod is_valid;
 mod iterator;
+pub mod registry;
 
 #[derive(Debug, Clone)]
 pub struct ObjectArray<T>
@@ -27,6 +28,8 @@ where
 /// Trimmed down object safe polars object
 pub trait PolarsObjectSafe: Any + Debug + Send + Sync + Display {
     fn type_name(&self) -> &'static str;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Values need to implement this so that they can be stored into a Series and DataFrame
@@ -40,6 +43,10 @@ pub trait PolarsObject:
 impl<T: PolarsObject> PolarsObjectSafe for T {
     fn type_name(&self) -> &'static str {
         T::type_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -147,6 +154,13 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         unimplemented!()
+    }
+
+    fn null_count(&self) -> usize {
+        match &self.null_bitmap {
+            None => 0,
+            Some(validity) => validity.unset_bits(),
+        }
     }
 }
 

--- a/polars/polars-core/src/chunked_array/object/registry.rs
+++ b/polars/polars-core/src/chunked_array/object/registry.rs
@@ -1,0 +1,79 @@
+use std::any::Any;
+use std::ops::Deref;
+use std::sync::{Arc, RwLock};
+
+use once_cell::sync::Lazy;
+
+use crate::chunked_array::object::builder::ObjectChunkedBuilder;
+use crate::datatypes::AnyValue;
+use crate::prelude::PolarsObject;
+use crate::series::{IntoSeries, Series};
+
+pub type BuilderConstructor =
+    Box<dyn Fn(&str, usize) -> Box<dyn AnonymousObjectBuilder> + Send + Sync>;
+pub type ObjectConverter = Arc<dyn Fn(AnyValue) -> Box<dyn Any> + Send + Sync>;
+
+struct GlobalObjectRegistry {
+    /// A function that creates an object builder
+    builder_constructor: BuilderConstructor,
+    // A function that converts AnyValue to Box<dyn Any> of the object type
+    object_converter: ObjectConverter,
+}
+
+static GLOBAL_OBJECT_REGISTRY: Lazy<RwLock<Option<GlobalObjectRegistry>>> =
+    Lazy::new(Default::default);
+
+pub trait AnonymousObjectBuilder {
+    fn append_null(&mut self);
+
+    fn append_value(&mut self, value: &dyn Any);
+
+    fn to_series(&mut self) -> Series;
+}
+
+impl<T: PolarsObject> AnonymousObjectBuilder for ObjectChunkedBuilder<T> {
+    fn append_null(&mut self) {
+        self.append_null()
+    }
+
+    fn append_value(&mut self, value: &dyn Any) {
+        let value = value.downcast_ref::<T>().unwrap();
+        self.append_value(value.clone())
+    }
+
+    fn to_series(&mut self) -> Series {
+        let builder = std::mem::take(self);
+        builder.finish().into_series()
+    }
+}
+
+pub fn register_object_builder(
+    builder_constructor: BuilderConstructor,
+    object_converter: ObjectConverter,
+) {
+    let reg = GLOBAL_OBJECT_REGISTRY.deref();
+    let mut reg = reg.write().unwrap();
+
+    *reg = Some(GlobalObjectRegistry {
+        builder_constructor,
+        object_converter,
+    })
+}
+
+pub fn is_object_builder_registered() -> bool {
+    let reg = GLOBAL_OBJECT_REGISTRY.deref();
+    let reg = reg.read().unwrap();
+    reg.is_some()
+}
+
+pub fn get_object_builder(name: &str, capacity: usize) -> Box<dyn AnonymousObjectBuilder> {
+    let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
+    let reg = reg.as_ref().unwrap();
+    (reg.builder_constructor)(name, capacity)
+}
+
+pub fn get_object_converter() -> ObjectConverter {
+    let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
+    let reg = reg.as_ref().unwrap();
+    reg.object_converter.clone()
+}

--- a/polars/polars-core/src/datatypes/time_unit.rs
+++ b/polars/polars-core/src/datatypes/time_unit.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    any(feature = "serde-lazy", feature = "serde"),
+    derive(Serialize, Deserialize)
+)]
+pub enum TimeUnit {
+    Nanoseconds,
+    Microseconds,
+    Milliseconds,
+}
+
+impl From<&ArrowTimeUnit> for TimeUnit {
+    fn from(tu: &ArrowTimeUnit) -> Self {
+        match tu {
+            ArrowTimeUnit::Nanosecond => TimeUnit::Nanoseconds,
+            ArrowTimeUnit::Microsecond => TimeUnit::Microseconds,
+            ArrowTimeUnit::Millisecond => TimeUnit::Milliseconds,
+            // will be cast
+            ArrowTimeUnit::Second => TimeUnit::Milliseconds,
+        }
+    }
+}
+
+impl Display for TimeUnit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimeUnit::Nanoseconds => {
+                write!(f, "ns")
+            }
+            TimeUnit::Microseconds => {
+                write!(f, "μs")
+            }
+            TimeUnit::Milliseconds => {
+                write!(f, "ms")
+            }
+        }
+    }
+}
+
+impl TimeUnit {
+    pub fn to_ascii(self) -> &'static str {
+        use TimeUnit::*;
+        match self {
+            Nanoseconds => "ns",
+            Microseconds => "us",
+            Milliseconds => "ms",
+        }
+    }
+
+    pub fn to_arrow(self) -> ArrowTimeUnit {
+        match self {
+            TimeUnit::Nanoseconds => ArrowTimeUnit::Nanosecond,
+            TimeUnit::Microseconds => ArrowTimeUnit::Microsecond,
+            TimeUnit::Milliseconds => ArrowTimeUnit::Millisecond,
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn convert_time_units(v: i64, tu_l: TimeUnit, tu_r: TimeUnit) -> i64 {
+    use TimeUnit::*;
+    match (tu_l, tu_r) {
+        (Nanoseconds, Microseconds) => v / 1_000,
+        (Nanoseconds, Milliseconds) => v / 1_000_000,
+        (Microseconds, Nanoseconds) => v * 1_000,
+        (Microseconds, Milliseconds) => v / 1_000,
+        (Milliseconds, Microseconds) => v * 1_000,
+        (Milliseconds, Nanoseconds) => v * 1_000_000,
+        _ => v,
+    }
+}

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -489,7 +489,7 @@ impl DataFrame {
     ///
     /// let f1: Field = Field::new("Thing", DataType::Utf8);
     /// let f2: Field = Field::new("Diameter (m)", DataType::Float64);
-    /// let sc: Schema = Schema::from(vec![f1, f2]);
+    /// let sc: Schema = Schema::from(vec![f1, f2].into_iter());
     ///
     /// assert_eq!(df.schema(), sc);
     /// # Ok::<(), PolarsError>(())

--- a/polars/polars-io/src/avro/read.rs
+++ b/polars/polars-io/src/avro/read.rs
@@ -36,7 +36,7 @@ impl<R: Read + Seek> AvroReader<R> {
     /// Get schema of the Avro File
     pub fn schema(&mut self) -> PolarsResult<Schema> {
         let schema = self.arrow_schema()?;
-        Ok((&schema.fields).into())
+        Ok((schema.fields.iter()).into())
     }
 
     /// Get arrow schema of the avro File, this is faster than a polars schema.

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -450,7 +450,7 @@ pub fn infer_file_schema(
         );
     }
 
-    Ok((Schema::from(fields), rows_count))
+    Ok((Schema::from(fields.into_iter()), rows_count))
 }
 
 // magic numbers

--- a/polars/polars-io/src/ipc/ipc_file.rs
+++ b/polars/polars-io/src/ipc/ipc_file.rs
@@ -78,7 +78,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
     /// Get schema of the Ipc File
     pub fn schema(&mut self) -> PolarsResult<Schema> {
         let metadata = read::read_file_metadata(&mut self.reader)?;
-        Ok((&metadata.schema.fields).into())
+        Ok(metadata.schema.fields.iter().into())
     }
 
     /// Get arrow schema of the Ipc File, this is faster than creating a polars schema.

--- a/polars/polars-io/src/ipc/ipc_stream.rs
+++ b/polars/polars-io/src/ipc/ipc_stream.rs
@@ -76,7 +76,7 @@ pub struct IpcStreamReader<R> {
 impl<R: Read + Seek> IpcStreamReader<R> {
     /// Get schema of the Ipc Stream File
     pub fn schema(&mut self) -> PolarsResult<Schema> {
-        Ok((&self.metadata()?.schema.fields).into())
+        Ok((self.metadata()?.schema.fields.iter()).into())
     }
 
     /// Get arrow schema of the Ipc Stream File, this is faster than creating a polars schema.

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -161,7 +161,7 @@ impl<'a> CoreJsonReader<'a> {
 
                 let data_type = arrow_ndjson::read::infer(&mut cursor, infer_schema_len).unwrap();
                 let schema: polars_core::prelude::Schema =
-                    StructArray::get_fields(&data_type).into();
+                    StructArray::get_fields(&data_type).iter().into();
 
                 Cow::Owned(schema)
             }

--- a/polars/polars-io/src/parquet/read.rs
+++ b/polars/polars-io/src/parquet/read.rs
@@ -120,7 +120,7 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         let metadata = read::read_metadata(&mut self.reader)?;
 
         let schema = read::infer_schema(&metadata)?;
-        Ok((&schema.fields).into())
+        Ok(schema.fields.iter().into())
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
@@ -20,7 +20,7 @@ impl AnonymousScan for LazyJsonLineReader {
 
         let data_type = arrow_ndjson::read::infer(&mut reader, infer_schema_length)
             .map_err(|err| PolarsError::ComputeError(format!("{:#?}", err).into()))?;
-        let schema: Schema = StructArray::get_fields(&data_type).into();
+        let schema: Schema = StructArray::get_fields(&data_type).iter().into();
 
         Ok(schema)
     }

--- a/polars/polars-lazy/src/tests/optimization_checks.rs
+++ b/polars/polars-lazy/src/tests/optimization_checks.rs
@@ -506,7 +506,7 @@ fn test_with_column_prune() -> PolarsResult<()> {
     }));
     assert_eq!(
         q.schema().unwrap().as_ref(),
-        &Schema::from([Field::new("c1", DataType::Int32)])
+        &Schema::from([Field::new("c1", DataType::Int32)].into_iter())
     );
     Ok(())
 }

--- a/polars/polars-lazy/src/tests/tpch.rs
+++ b/polars/polars-lazy/src/tests/tpch.rs
@@ -87,16 +87,19 @@ fn test_q2() -> PolarsResult<()> {
         .with_common_subplan_elimination(true);
 
     let out = q.collect()?;
-    let schema = Schema::from([
-        Field::new("s_acctbal", DataType::Float64),
-        Field::new("s_name", DataType::Utf8),
-        Field::new("n_name", DataType::Utf8),
-        Field::new("p_partkey", DataType::Int64),
-        Field::new("p_mfgr", DataType::Utf8),
-        Field::new("s_address", DataType::Utf8),
-        Field::new("s_phone", DataType::Utf8),
-        Field::new("s_comment", DataType::Utf8),
-    ]);
+    let schema = Schema::from(
+        [
+            Field::new("s_acctbal", DataType::Float64),
+            Field::new("s_name", DataType::Utf8),
+            Field::new("n_name", DataType::Utf8),
+            Field::new("p_partkey", DataType::Int64),
+            Field::new("p_mfgr", DataType::Utf8),
+            Field::new("s_address", DataType::Utf8),
+            Field::new("s_phone", DataType::Utf8),
+            Field::new("s_comment", DataType::Utf8),
+        ]
+        .into_iter(),
+    );
     assert_eq!(&out.schema(), &schema);
 
     Ok(())

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -357,7 +357,7 @@ fn test_quoted_numeric() {
 #[test]
 fn test_empty_bytes_to_dataframe() {
     let fields = vec![Field::new("test_field", DataType::Utf8)];
-    let schema = Schema::from(fields);
+    let schema = Schema::from(fields.into_iter());
     let file = Cursor::new(vec![]);
 
     let result = CsvReader::new(file)
@@ -392,11 +392,14 @@ fn test_missing_value() {
     let file = Cursor::new(csv);
     let df = CsvReader::new(file)
         .has_header(true)
-        .with_schema(&Schema::from(vec![
-            Field::new("foo", DataType::UInt32),
-            Field::new("bar", DataType::UInt32),
-            Field::new("ham", DataType::UInt32),
-        ]))
+        .with_schema(&Schema::from(
+            vec![
+                Field::new("foo", DataType::UInt32),
+                Field::new("bar", DataType::UInt32),
+                Field::new("ham", DataType::UInt32),
+            ]
+            .into_iter(),
+        ))
         .finish()
         .unwrap();
     assert_eq!(df.column("ham").unwrap().len(), 3)
@@ -414,10 +417,13 @@ AUDCAD,1616455921,0.96212,0.95666,1
     let file = Cursor::new(csv);
     let df = CsvReader::new(file)
         .has_header(true)
-        .with_dtypes(Some(&Schema::from(vec![Field::new(
-            "b",
-            DataType::Datetime(TimeUnit::Nanoseconds, None),
-        )])))
+        .with_dtypes(Some(&Schema::from(
+            vec![Field::new(
+                "b",
+                DataType::Datetime(TimeUnit::Nanoseconds, None),
+            )]
+            .into_iter(),
+        )))
         .finish()?;
 
     assert_eq!(

--- a/polars/tests/it/schema.rs
+++ b/polars/tests/it/schema.rs
@@ -3,17 +3,23 @@ use polars::prelude::*;
 #[test]
 fn test_schema_rename() {
     use DataType::*;
-    let mut schema = Schema::from([
-        Field::new("a", UInt64),
-        Field::new("b", Int32),
-        Field::new("c", Int8),
-    ]);
+    let mut schema = Schema::from(
+        [
+            Field::new("a", UInt64),
+            Field::new("b", Int32),
+            Field::new("c", Int8),
+        ]
+        .into_iter(),
+    );
     schema.rename("a", "anton".to_string()).unwrap();
-    let expected = Schema::from([
-        Field::new("anton", UInt64),
-        Field::new("b", Int32),
-        Field::new("c", Int8),
-    ]);
+    let expected = Schema::from(
+        [
+            Field::new("anton", UInt64),
+            Field::new("b", Int32),
+            Field::new("c", Int8),
+        ]
+        .into_iter(),
+    );
 
     assert_eq!(schema, expected);
 }

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -616,9 +616,17 @@ def sequence_to_pydf(
             orient = "col" if len(columns) == len(data) else "row"
 
         if orient == "row":
-            pydf = PyDataFrame.read_rows(data, infer_schema_length)
-            if columns:
-                pydf = _post_apply_columns(pydf, columns)
+
+            column_names, dtypes = _unpack_columns(columns)
+
+            if len(dtypes) > 0:
+                pydf = PyDataFrame.read_rows(data, infer_schema_length, dtypes)
+            else:
+                pydf = PyDataFrame.read_rows(data, infer_schema_length)
+
+            # change column names given by infer_schema
+            if column_names:
+                pydf = _post_apply_columns(pydf, column_names)
             return pydf
         elif orient == "col" or orient is None:
             columns, dtypes = _unpack_columns(columns, n_expected=len(data))

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -595,9 +595,10 @@ def sequence_to_pydf(
             data_series.append(s._s)
 
     elif isinstance(data[0], dict):
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length)
-        if columns:
-            pydf = _post_apply_columns(pydf, columns)
+        column_names, dtypes = _unpack_columns(columns)
+        pydf = PyDataFrame.read_dicts(data, infer_schema_length, dtypes)
+        if column_names:
+            pydf = _post_apply_columns(pydf, column_names)
         return pydf
 
     elif isinstance(data[0], Sequence) and not isinstance(data[0], str):
@@ -616,9 +617,7 @@ def sequence_to_pydf(
             orient = "col" if len(columns) == len(data) else "row"
 
         if orient == "row":
-
             column_names, dtypes = _unpack_columns(columns)
-
             if len(dtypes) > 0:
                 pydf = PyDataFrame.read_rows(data, infer_schema_length, dtypes)
             else:

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -343,7 +343,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     "Float32" => DataType::Float32,
                     "Float64" => DataType::Float64,
                     #[cfg(feature = "object")]
-                    "Object" => DataType::Object("unknown"),
+                    "Object" => DataType::Object("Object"),
                     "List" => DataType::List(Box::new(DataType::Boolean)),
                     "Null" => DataType::Null,
                     "Unknown" => DataType::Unknown,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -52,6 +52,9 @@ impl PyDataFrame {
         infer_schema_length: Option<usize>,
         schema_overwrite: Option<Schema>,
     ) -> PyResult<Self> {
+        // object builder must be registered.
+        crate::object::register_object_builder();
+
         let schema =
             rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?;
         // replace inferred nulls with boolean

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -428,9 +428,17 @@ impl PyDataFrame {
     }
 
     #[staticmethod]
-    pub fn read_dicts(dicts: &PyAny, infer_schema_length: Option<usize>) -> PyResult<Self> {
+    pub fn read_dicts(
+        dicts: &PyAny,
+        infer_schema_length: Option<usize>,
+        schema_overwrite: Option<Wrap<Schema>>,
+    ) -> PyResult<Self> {
         let (rows, names) = dicts_to_rows(dicts, infer_schema_length.unwrap_or(1))?;
-        let mut pydf = Self::finish_from_rows(rows, infer_schema_length, None)?;
+        let mut pydf = Self::finish_from_rows(
+            rows,
+            infer_schema_length,
+            schema_overwrite.map(|wrap| wrap.0),
+        )?;
         pydf.df
             .set_column_names(&names)
             .map_err(PyPolarsErr::from)?;

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -47,7 +47,11 @@ impl PyDataFrame {
         PyDataFrame { df }
     }
 
-    fn finish_from_rows(rows: Vec<Row>, infer_schema_length: Option<usize>) -> PyResult<Self> {
+    fn finish_from_rows(
+        rows: Vec<Row>,
+        infer_schema_length: Option<usize>,
+        schema_overwrite: Option<Schema>,
+    ) -> PyResult<Self> {
         let schema =
             rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?;
         // replace inferred nulls with boolean
@@ -58,7 +62,18 @@ impl PyDataFrame {
             }
             _ => fld,
         });
-        let schema = Schema::from(fields);
+        let mut schema = Schema::from(fields);
+
+        if let Some(schema_overwrite) = schema_overwrite {
+            for (i, (name, dtype)) in schema_overwrite.into_iter().enumerate() {
+                if let Some((name_, dtype_)) = schema.get_index_mut(i) {
+                    *name_ = name;
+                    *dtype_ = dtype;
+                } else {
+                    schema.with_column(name, dtype)
+                }
+            }
+        }
 
         let df = DataFrame::from_rows_and_schema(&rows, &schema).map_err(PyPolarsErr::from)?;
         Ok(df.into())
@@ -397,17 +412,25 @@ impl PyDataFrame {
 
     // somehow from_rows did not work
     #[staticmethod]
-    pub fn read_rows(rows: Vec<Wrap<Row>>, infer_schema_length: Option<usize>) -> PyResult<Self> {
+    pub fn read_rows(
+        rows: Vec<Wrap<Row>>,
+        infer_schema_length: Option<usize>,
+        schema_overwrite: Option<Wrap<Schema>>,
+    ) -> PyResult<Self> {
         // safety:
         // wrap is transparent
         let rows: Vec<Row> = unsafe { std::mem::transmute(rows) };
-        Self::finish_from_rows(rows, infer_schema_length)
+        Self::finish_from_rows(
+            rows,
+            infer_schema_length,
+            schema_overwrite.map(|wrap| wrap.0),
+        )
     }
 
     #[staticmethod]
     pub fn read_dicts(dicts: &PyAny, infer_schema_length: Option<usize>) -> PyResult<Self> {
         let (rows, names) = dicts_to_rows(dicts, infer_schema_length.unwrap_or(1))?;
-        let mut pydf = Self::finish_from_rows(rows, infer_schema_length)?;
+        let mut pydf = Self::finish_from_rows(rows, infer_schema_length, None)?;
         pydf.df
             .set_column_names(&names)
             .map_err(PyPolarsErr::from)?;

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -16,6 +16,7 @@ pub mod file;
 pub mod lazy;
 mod list_construction;
 pub mod npy;
+mod object;
 pub mod prelude;
 pub(crate) mod py_modules;
 pub mod series;

--- a/py-polars/src/object.rs
+++ b/py-polars/src/object.rs
@@ -1,0 +1,29 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use polars_core::chunked_array::object::builder::ObjectChunkedBuilder;
+use polars_core::chunked_array::object::registry;
+use polars_core::chunked_array::object::registry::AnonymousObjectBuilder;
+use polars_core::prelude::AnyValue;
+use pyo3::prelude::*;
+
+use crate::prelude::ObjectValue;
+use crate::Wrap;
+
+pub(crate) fn register_object_builder() {
+    if !registry::is_object_builder_registered() {
+        let object_builder = Box::new(|name: &str, capacity: usize| {
+            Box::new(ObjectChunkedBuilder::<ObjectValue>::new(name, capacity))
+                as Box<dyn AnonymousObjectBuilder>
+        });
+
+        let object_converter = Arc::new(|av: AnyValue| {
+            let object = Python::with_gil(|py| ObjectValue {
+                inner: Wrap(av).to_object(py),
+            });
+            Box::new(object) as Box<dyn Any>
+        });
+
+        registry::register_object_builder(object_builder, object_converter)
+    }
+}

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -461,6 +461,7 @@ def test_from_dicts_missing_columns() -> None:
 @typing.no_type_check
 def test_from_rows_dtype() -> None:
     # 50 is the default inference length
+    # 5182
     df = pl.DataFrame(
         data=[(None, None)] * 50 + [("1.23", None)],
         columns=[("foo", pl.Utf8), ("bar", pl.Utf8)],
@@ -468,3 +469,28 @@ def test_from_rows_dtype() -> None:
     )
     assert df.dtypes == [pl.Utf8, pl.Utf8]
     assert df.null_count().row(0) == (50, 51)
+
+    type1 = [{"c1": 206, "c2": "type1", "c3": {"x1": "abcd", "x2": "jkl;"}}]
+    type2 = [
+        {"c1": 208, "c2": "type2", "c3": {"a1": "abcd", "a2": "jkl;", "a3": "qwerty"}}
+    ]
+
+    df = pl.DataFrame(
+        data=type1 * 50 + type2,
+        columns=[("c1", pl.Int32), ("c2", pl.Object), ("c3", pl.Object)],
+    )
+    assert df.dtypes == [pl.Int32, pl.Object, pl.Object]
+
+    # 50 is the default inference length
+    # 5266
+    type1 = [{"c1": 206, "c2": "type1", "c3": {"x1": "abcd", "x2": "jkl;"}}]
+    type2 = [
+        {"c1": 208, "c2": "type2", "c3": {"a1": "abcd", "a2": "jkl;", "a3": "qwerty"}}
+    ]
+
+    df = pl.DataFrame(
+        data=type1 * 50 + type2,
+        columns=[("c1", pl.Int32), ("c2", pl.Object), ("c3", pl.Object)],
+    )
+    assert df.dtypes == [pl.Int32, pl.Object, pl.Object]
+    assert df.null_count().row(0) == (0, 0, 0)

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1,3 +1,4 @@
+import typing
 from datetime import date, datetime
 from typing import Any
 
@@ -455,3 +456,15 @@ def test_from_dicts_missing_columns() -> None:
     ]
 
     assert pl.from_dicts(data).to_dict(False) == {"a": [1, None], "b": [None, 2]}
+
+
+@typing.no_type_check
+def test_from_rows_dtype() -> None:
+    # 50 is the default inference length
+    df = pl.DataFrame(
+        data=[(None, None)] * 50 + [("1.23", None)],
+        columns=[("foo", pl.Utf8), ("bar", pl.Utf8)],
+        orient="row",
+    )
+    assert df.dtypes == [pl.Utf8, pl.Utf8]
+    assert df.null_count().row(0) == (50, 51)


### PR DESCRIPTION
fixes #5182
fixes #5266

This solves a long dealing problem in polars where randomly scattered objects could not be dealt with within polars-core itself as polars-core does not know anything about python objects and thus doesn't know what kind of generic `T` is.

This is now solved by letting the python process register two functions. One that creates a `builder` for python objects and another one that can convert `AnyValue` enums to the needed `Python objects`.