### PR TITLE
chore(python): Add ModuleType for import functions in import_check.py

### DIFF
--- a/py-polars/polars/import_check.py
+++ b/py-polars/polars/import_check.py
@@ -1,23 +1,33 @@
 import importlib.util
+import sys
+from types import ModuleType
 from typing import Any, Callable
 
 
-def pandas_mod() -> Any:
-    import pandas as pd
+def numpy_mod() -> ModuleType:
+    import numpy
 
-    return pd
-
-
-def pyarrow_mod() -> Any:
-    import pyarrow as pa
-
-    return pa
+    return numpy
 
 
-def numpy_mod() -> Any:
-    import numpy as np
+def pandas_mod() -> ModuleType:
+    import pandas
 
-    return np
+    return pandas
+
+
+def pyarrow_mod() -> ModuleType:
+    import pyarrow
+
+    return pyarrow
+
+
+def zoneinfo_mod() -> ModuleType:
+    if sys.version_info >= (3, 9):
+        import zoneinfo
+    else:
+        from backports import zoneinfo
+    return zoneinfo
 
 
 def pkg_is_available(name: str) -> bool:
@@ -31,7 +41,12 @@ def lazy_isinstance(value: Any, module_bound: str, types: Callable[[], Any]) -> 
     return False
 
 
+_FSSPEC_AVAILABLE = pkg_is_available("fsspec")
+_NUMPY_AVAILABLE = pkg_is_available("numpy")
 _PANDAS_AVAILABLE = pkg_is_available("pandas")
 _PYARROW_AVAILABLE = pkg_is_available("pyarrow")
-_NUMPY_AVAILABLE = pkg_is_available("numpy")
-_WITH_FSSPEC = pkg_is_available("fsspec")
+_ZONEINFO_AVAILABLE = (
+    pkg_is_available("zoneinfo")
+    if sys.version_info >= (3, 9)
+    else pkg_is_available("backports.zoneinfo")
+)

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -8,7 +8,7 @@ from typing import Any, BinaryIO, ContextManager, Iterator, TextIO, overload
 
 import polars.internals as pli
 from polars.datatypes import DataType
-from polars.import_check import _WITH_FSSPEC
+from polars.import_check import _FSSPEC_AVAILABLE
 from polars.utils import format_path
 
 try:
@@ -111,7 +111,7 @@ def _prepare_file_arg(
         # to read from http
         if file.startswith("http"):
             return _process_http_file(file, encoding_str)
-        if _WITH_FSSPEC:
+        if _FSSPEC_AVAILABLE:
             import fsspec
             from fsspec.utils import infer_storage_options
 
@@ -121,7 +121,7 @@ def _prepare_file_arg(
             kwargs["encoding"] = encoding
             return fsspec.open(file, **kwargs)
     if isinstance(file, list) and bool(file) and all(isinstance(f, str) for f in file):
-        if _WITH_FSSPEC:
+        if _FSSPEC_AVAILABLE:
             import fsspec
             from fsspec.utils import infer_storage_options
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Callable, Iterable, Sequence, TypeVar
 
 import polars.internals as pli
 from polars.datatypes import DataType, Date, Datetime, PolarsDataType, is_polars_dtype
+from polars.import_check import _ZONEINFO_AVAILABLE, zoneinfo_mod
 
 try:
     from polars.polars import PyExpr
@@ -25,18 +26,6 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec, TypeGuard
 
-
-if sys.version_info >= (3, 9):
-    import zoneinfo
-
-    _ZONEINFO_AVAILABLE = True
-else:
-    try:
-        from backports import zoneinfo
-
-        _ZONEINFO_AVAILABLE = True
-    except ImportError:
-        _ZONEINFO_AVAILABLE = False
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import SizeUnit, TimeUnit
@@ -230,6 +219,7 @@ def _to_python_datetime(
                     "Install polars[timezone] to handle datetimes with timezones."
                 )
 
+            zoneinfo = zoneinfo_mod()
             utc = zoneinfo.ZoneInfo("UTC")
             if tu == "ns":
                 # nanoseconds to seconds
@@ -256,7 +246,7 @@ def _localize(dt: datetime, tz: str) -> datetime:
             "backports.zoneinfo is not installed. Please run "
             "`pip install backports.zoneinfo`."
         )
-
+    zoneinfo = zoneinfo_mod()
     return dt.astimezone(zoneinfo.ZoneInfo(tz))
 
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -14,17 +14,14 @@ import pytest
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.exceptions import NoRowsReturned, TooManyRowsReturned
+from polars.import_check import zoneinfo_mod
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing._parametric import columns
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    from backports.zoneinfo import ZoneInfo
-
-
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy
+
+zoneinfo = zoneinfo_mod()
 
 
 def test_version() -> None:
@@ -2400,7 +2397,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_us = "America/New_York"
     tz_europe = "Europe/Amsterdam"
 
-    dtm = datetime(2022, 10, 12, 12, 30, tzinfo=ZoneInfo("UTC"))
+    dtm = datetime(2022, 10, 12, 12, 30, tzinfo=zoneinfo.ZoneInfo("UTC"))
     for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},
@@ -2412,8 +2409,8 @@ def test_init_datetimes_with_timezone() -> None:
         assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
         assert df.rows() == [
             (
-                datetime(2022, 10, 12, 8, 30, tzinfo=ZoneInfo(tz_us)),
-                datetime(2022, 10, 12, 14, 30, tzinfo=ZoneInfo(tz_europe)),
+                datetime(2022, 10, 12, 8, 30, tzinfo=zoneinfo.ZoneInfo(tz_us)),
+                datetime(2022, 10, 12, 14, 30, tzinfo=zoneinfo.ZoneInfo(tz_europe)),
             )
         ]
 
@@ -2435,7 +2432,7 @@ def test_init_physical_with_timezone() -> None:
         assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
         assert df.rows() == [
             (
-                datetime(2022, 10, 12, 16, 30, tzinfo=ZoneInfo(tz_uae)),
-                datetime(2022, 10, 12, 21, 30, tzinfo=ZoneInfo(tz_asia)),
+                datetime(2022, 10, 12, 16, 30, tzinfo=zoneinfo.ZoneInfo(tz_uae)),
+                datetime(2022, 10, 12, 21, 30, tzinfo=zoneinfo.ZoneInfo(tz_asia)),
             )
         ]


### PR DESCRIPTION
Add ModuleType for import functions in import_check.py and rename `_WITH_FSSPEC` to `_FSSPEC_AVAILABLE`
and add `_ZONEINFO_AVAILABLE`.