### PR TITLE
fix(python): throw error on invalid lazy concat strategy

### DIFF
--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -111,7 +111,7 @@ def concat(
     rechunk
         Make sure that all data is in contiguous memory.
     how : {'vertical', 'diagonal', 'horizontal'}
-        Only used if the items are DataFrames.
+        Lazy only supports the 'vertical' strategy.
 
         - Vertical: applies multiple `vstack` operations.
         - Diagonal: finds a union between the column schemas and fills missing column
@@ -156,7 +156,10 @@ def concat(
                 f"how must be one of {{'vertical', 'diagonal'}}, got {how}"
             )
     elif isinstance(first, pli.LazyFrame):
-        return pli.wrap_ldf(_concat_lf(items, rechunk, parallel))
+        if how == "vertical":
+            return pli.wrap_ldf(_concat_lf(items, rechunk, parallel))
+        else:
+            raise ValueError("Lazy only allows 'vertical' concat strategy.")
     elif isinstance(first, pli.Series):
         out = pli.wrap_s(_concat_series(items))
     elif isinstance(first, pli.Expr):

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -252,3 +252,27 @@ def test_window_expression_different_group_length() -> None:
         assert "Group:" in msg
         assert "Group length:" in msg
         assert "Output: 'shape:" in msg
+
+
+@typing.no_type_check
+def test_lazy_concat_err() -> None:
+    df1 = pl.DataFrame(
+        {
+            "foo": [1, 2],
+            "bar": [6, 7],
+            "ham": ["a", "b"],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "foo": [3, 4],
+            "ham": ["c", "d"],
+            "bar": [8, 9],
+        }
+    )
+
+    for how in ["horizontal", "diagonal"]:
+        with pytest.raises(
+            ValueError, match="Lazy only allows 'vertical' concat strategy."
+        ):
+            pl.concat([df1.lazy(), df2.lazy()], how=how).collect()


### PR DESCRIPTION
fixes #5082
fixes #2856