### PR TITLE
fix(rust): export anonymousscan in lazy prelude

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use polars_core::prelude::*;
 
-use crate::prelude::AnonymousScanOptions;
+pub use super::options::AnonymousScanOptions;
 
 pub trait AnonymousScan: Send + Sync {
     /// Creates a dataframe from the supplied function & scan options.

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod options;
 mod projection;
 mod schema;
 
+pub use options::AnonymousScanOptions;
 pub use aexpr::*;
 pub use alp::*;
 pub use anonymous_scan::*;

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -26,7 +26,6 @@ pub(crate) mod options;
 mod projection;
 mod schema;
 
-pub use options::AnonymousScanOptions;
 pub use aexpr::*;
 pub use alp::*;
 pub use anonymous_scan::*;

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -1,7 +1,6 @@
 pub(crate) use polars_ops::prelude::*;
-pub use polars_plan::logical_plan::options::AnonymousScanOptions;
 pub use polars_plan::logical_plan::{
-    AnonymousScan, Literal, LiteralValue, LogicalPlan, Null, NULL,
+    AnonymousScan, AnonymousScanOptions, Literal, LiteralValue, LogicalPlan, Null, NULL,
 };
 pub(crate) use polars_plan::prelude::*;
 #[cfg(feature = "rolling_window")]

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -1,5 +1,8 @@
 pub(crate) use polars_ops::prelude::*;
-pub use polars_plan::logical_plan::{Literal, LiteralValue, LogicalPlan, Null, NULL};
+pub use polars_plan::logical_plan::options::AnonymousScanOptions;
+pub use polars_plan::logical_plan::{
+    AnonymousScan, Literal, LiteralValue, LogicalPlan, Null, NULL,
+};
 pub(crate) use polars_plan::prelude::*;
 #[cfg(feature = "rolling_window")]
 pub use polars_time::{prelude::RollingOptions, Duration};


### PR DESCRIPTION
previously `AnonymousScan` and `AnonymousScanOptions` were exported in the prelude. It looks like this was removed by mistake. This PR re exports those. 