### PR TITLE
chore(docs): fix some README.md regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ pip install polars
 
 We also have a conda package (`conda install polars`), however pip is the preferred way to install Polars.
 
-# Install Polars with all optional dependencies.
+### Install Polars with all optional dependencies.
 ```sh
-pip install polars[all]
-pip install polars[numpy,pandas,pyarrow]  # install a subset of all optional dependencies
+pip install 'polars[all]'
+pip install 'polars[numpy,pandas,pyarrow]'  # install a subset of all optional dependencies
 ```
 You can also install the dependencies directly.
 


### PR DESCRIPTION
Two small fixes
* fix wrong heading level for the python optional dependencies section
* add the quotes back to pip install. Initially introduced in #3820, because `zsh` throws an error without the quotes

![image](https://user-images.githubusercontent.com/30731072/197559322-0a0180de-3dc4-411b-af71-71ae617965a6.png)

 