### PR TITLE
docs(python): Don't break lines in nav but let it scroll

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -16,8 +16,3 @@ dt em.sig-param:last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
-
-/* Display long method names over multiple lines in navbar. */
-.bd-toc-item {
-    overflow-wrap: break-word;
-}


### PR DESCRIPTION
Change

<img width="1512" alt="Screenshot 2022-10-26 at 19 09 22" src="https://user-images.githubusercontent.com/88401/198080267-a773260d-9aa7-40e5-b702-e14a41d1caf0.png">

into

<img width="1512" alt="Screenshot 2022-10-26 at 19 12 24" src="https://user-images.githubusercontent.com/88401/198080287-4d97fffa-8753-4207-a855-be0d962ba938.png">
