### PR TITLE
fix(rust, python): block is_null predicate in asof join

### DIFF
--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -125,7 +125,6 @@ pub enum JoinType {
     Inner,
     Outer,
     #[cfg(feature = "asof_join")]
-    #[cfg_attr(feature = "serde", serde(skip))]
     AsOf(AsOfOptions),
     Cross,
     #[cfg(feature = "semi_anti_join")]


### PR DESCRIPTION
fixes #5355