### PR TITLE
docs(python): Add with_time_zone to reference guide

### DIFF
--- a/py-polars/docs/source/reference/expression.rst
+++ b/py-polars/docs/source/reference/expression.rst
@@ -284,6 +284,7 @@ The following methods are available under the `expr.dt` attribute.
 
     ExprDateTimeNameSpace.cast_time_unit
     ExprDateTimeNameSpace.cast_time_zone
+    ExprDateTimeNameSpace.with_time_zone
     ExprDateTimeNameSpace.day
     ExprDateTimeNameSpace.days
     ExprDateTimeNameSpace.epoch

--- a/py-polars/docs/source/reference/series.rst
+++ b/py-polars/docs/source/reference/series.rst
@@ -230,6 +230,7 @@ The following methods are available under the `Series.dt` attribute.
 
     DateTimeNameSpace.cast_time_unit
     DateTimeNameSpace.cast_time_zone
+    DateTimeNameSpace.with_time_zone
     DateTimeNameSpace.day
     DateTimeNameSpace.days
     DateTimeNameSpace.epoch


### PR DESCRIPTION
We refer to `with_time_zone` in the docstring of `cast_time_zone`, so seems odd to me we do not have this method in our reference guide.

See also #4679.