### PR TITLE
docs(python): minor navbar improvements; adds discord and twitter links, fixes github icon

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -87,7 +87,17 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/pola-rs/polars",
-            "icon": "fab fa-github-square",
+            "icon": "fa-brands fa-github",
+        },
+        {
+            "name": "Discord",
+            "url": "https://discord.gg/4UfP5cfBE7",
+            "icon": "fa-brands fa-discord",
+        },
+        {
+            "name": "Twitter",
+            "url": "https://twitter.com/DataPolars",
+            "icon": "fa-brands fa-twitter",
         },
     ],
     "favicons": [


### PR DESCRIPTION
Adds the Polars' social icons/links to the navbar at the top of the [API docs](https://pola-rs.github.io/polars/py-polars/html/reference/index.html), and fixes the small/square GitHub icon.

**Before:**

<img width="329" alt="navbar_before" src="https://user-images.githubusercontent.com/2613171/198898425-7214e574-45fa-4516-bae8-f4135d8b7312.png">

**After:** _(adds twitter and discord, fixes github)_

<img width="335" alt="navbar_after" src="https://user-images.githubusercontent.com/2613171/198898429-e5cd69c8-1242-455a-863d-a361d136d238.png">

