### PR TITLE
feat(python): enable frame init from sequence of pandas series, and improve lazy typechecks (handle subclasses)

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import re
 import sys
 from importlib.machinery import ModuleSpec
@@ -41,7 +42,7 @@ def _proxy_module(module_name: str, register: bool = True) -> ModuleType:
         if re.match(r"^__\w+__$", attr):
             return None
 
-        # other attribute access raises exception
+        # all other attribute access raises exception
         pfx = _mod_pfx.get(module_name, "")
         raise ModuleNotFoundError(
             f"{pfx}{attr} requires '{module_name}' module to be installed"
@@ -145,15 +146,24 @@ else:
 
 
 def _NUMPY_TYPE(obj: Any) -> bool:
-    return _NUMPY_AVAILABLE and "numpy." in str(type(obj))
+    return _NUMPY_AVAILABLE and any(
+        "numpy." in str(o)
+        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
+    )
 
 
 def _PANDAS_TYPE(obj: Any) -> bool:
-    return _PANDAS_AVAILABLE and "pandas." in str(type(obj))
+    return _PANDAS_AVAILABLE and any(
+        "pandas." in str(o)
+        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
+    )
 
 
 def _PYARROW_TYPE(obj: Any) -> bool:
-    return _PYARROW_AVAILABLE and "pyarrow." in str(type(obj))
+    return _PYARROW_AVAILABLE and any(
+        "pyarrow." in str(o)
+        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
+    )
 
 
 __all__ = [


### PR DESCRIPTION
DataFrame init
----
Can already init `pl.DataFrame` from `pd.DataFrame`, and `pl.Series` from `pd.Series`. Made a minor tweak so that we can _also_ now cleanly init `pl.DataFrame` from one or more individual `pd.Series` without having them turn into opaque objects (or error).

```python
import numpy as np
import pandas as pd
import polars as pl

df = pl.DataFrame(
    data=[
        pd.Series(name="x", data=[10.0, 25.0], dtype=np.dtype("f4")),
    ],
)
```

**Before:** _(loaded as object)_

```python
# shape: (1, 1)
# ┌─────────────────┐
# │ column_0        │
# │ ---             │
# │ object          │
# ╞═════════════════╡
# │ 0    10.0       │
# │ 1    25.0       │
# │ Name: x, dty... │
# └─────────────────┘
```

**After:** _(loaded data, with name/type)_

```python
# shape: (2, 1)
# ┌──────┐
# │ x    │
# │ ---  │
# │ f32  │
# ╞══════╡
# │ 10.0 │
# │ 25.0 │
# └──────┘
```

Lazy typechecks
----
Discovered that the lazy typechecks could return `False` on subclasses; fixed it so that we don't accidentally fail to recognise them (while maintaining full laziness).

```python
class CustomSeries(pd.Series):
    @property
    def _constructor(self) -> type:
        return CustomSeries

s = pl.Series( 
    CustomSeries([1,2,3], name="s", dtype=np.dtype("f4")) 
)
```

**Before:**

```python
# ValueError: Series constructor not called properly.
```

**After:**

```python
# shape: (3,)
# Series: 's' [f32]
# [
#     1.0
#     2.0
#     3.0
# ]
```

---

Suitable unit test coverage added for all of the above.