### PR TITLE
fix(python): lazy proxy module does not require registration in `sys.globals`

### DIFF
--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -317,15 +317,15 @@ def test_from_optional_not_available() -> None:
     # proxy module is created dynamically if the required module is not available
     # (see the polars.dependencies source code for additional detail/comments)
 
-    np = _proxy_module("numpy", register=False)
+    np = _proxy_module("numpy")
     with pytest.raises(ImportError, match=r"np\.array requires 'numpy'"):
         pl.from_numpy(np.array([[1, 2], [3, 4]]), columns=["a", "b"])
 
-    pa = _proxy_module("pyarrow", register=False)
+    pa = _proxy_module("pyarrow")
     with pytest.raises(ImportError, match=r"pa\.table requires 'pyarrow'"):
         pl.from_arrow(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}))
 
-    pd = _proxy_module("pandas", register=False)
+    pd = _proxy_module("pandas")
     with pytest.raises(ImportError, match=r"pd\.Series requires 'pandas'"):
         pl.from_pandas(pd.Series([1, 2, 3]))
 


### PR DESCRIPTION
Closes #5389.

----

When one of our optional dependencies does not exist, we proxy the module lazily (referencing from `polars.dependencies`) so that we can still internally pseudo-import it. Only if the user calls into code that _requires_ access to the missing module does the proxy get invoked, at which point it raises a helpful exception detailing which module is missing/required.

The mistake (mea culpa!) is that this proxy module does _not_ actually need to be registered with `sys.modules`. It is fine for us to create it, return it, and otherwise use it inside polars _without_ making it available globally.

I've further documented (in the code) how our lazy module proxying works, so that it is clearer (and so we don't accidentally reintroduce the issue on any potential future refactoring).