### PR TITLE
docs(python): add integrated support for copying API examples, and auto-parallelise docs build

### DIFF
--- a/py-polars/docs/.gitignore
+++ b/py-polars/docs/.gitignore
@@ -1,3 +1,5 @@
 build/
 pandas/
 source/reference/api/
+source/reference/expressions/api/
+source/reference/series/api/

--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -7,6 +7,7 @@ hypothesis==6.56.3
 ghp-import==2.1.0
 sphinx==5.3.0
 sphinx-autosummary-accessors==2022.4.0
+sphinx-copybutton==0.5.0
 pydata-sphinx-theme==0.11.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -47,6 +47,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "sphinx_autosummary_accessors",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -70,10 +71,14 @@ html_theme = "pydata_sphinx_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]  # relative to html_static_path
-
 html_show_sourcelink = False
-
 html_logo = "../img/polars_logo.png"
+
+# adds useful copy functionality to all the examples; also
+# strips the '>>>' and '...' prompt/continuation prefixes.
+copybutton_prompt_text = r">>> |\.\.\. "
+copybutton_prompt_is_regexp = True
+
 autosummary_generate = True
 
 html_theme_options = {


### PR DESCRIPTION
API docs niceties
---
Added convenient copy support to all examples, via `sphinx-copybutton`. The copied code is automagically stripped of prompt `>>>` and continuation `...` line prefixes, as well as any inline return results; as a result you can very easily copy/paste/run any and all examples given in the docs, eg:

<img width="450" src="https://user-images.githubusercontent.com/2613171/199322700-1e5e9ec0-9969-46f1-9bcc-91ddc728d464.gif">

In the example above only the first two _functional_ lines are copied -- the Series repr output is omitted, and the `>>>` prompts are stripped. What reaches the clipboard is ready to run...

Docs build
---
Big speedup; I'm building everything a lot at the moment, and this made it quite a bit more pleasant. Added "-j auto" flag to the docs Makefile to automatically parallelise `sphinx-build`; I saw a ~4x speedup from this -- you may see more/less depending on CPU/architecture/etc.