### PR TITLE
feat(python): r-associative support for commutative `DataFrame` operators

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1071,6 +1071,9 @@ class DataFrame:
         other = _prepare_other_arg(other)
         return self._from_pydf(self._df.mul(other._s))
 
+    def __rmul__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
+        return self * other
+
     def __truediv__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.div_df(other._df))
@@ -1079,13 +1082,19 @@ class DataFrame:
         return self._from_pydf(self._df.div(other._s))
 
     def __add__(
-        self: DF,
-        other: DataFrame | pli.Series | int | float | bool | str,
+        self: DF, other: DataFrame | pli.Series | int | float | bool | str
     ) -> DF:
         if isinstance(other, DataFrame):
             return self._from_pydf(self._df.add_df(other._df))
         other = _prepare_other_arg(other)
         return self._from_pydf(self._df.add(other._s))
+
+    def __radd__(
+        self: DF, other: DataFrame | pli.Series | int | float | bool | str
+    ) -> DF:
+        if isinstance(other, str):
+            return self.select((pli.lit(other) + pli.col("*")).keep_name())
+        return self + other
 
     def __sub__(self: DF, other: DataFrame | pli.Series | int | float | bool) -> DF:
         if isinstance(other, DataFrame):

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1786,17 +1786,17 @@ def test_shrink_to_fit() -> None:
 def test_arithmetic() -> None:
     df = pl.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
 
-    df_mul = df * 2
-    expected = pl.DataFrame({"a": [2, 4], "b": [6, 8]})
-    assert df_mul.frame_equal(expected)
+    for df_mul in (df * 2, 2 * df):
+        expected = pl.DataFrame({"a": [2, 4], "b": [6, 8]})
+        assert df_mul.frame_equal(expected)
+
+    for df_plus in (df + 2, 2 + df):
+        expected = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
+        assert df_plus.frame_equal(expected)
 
     df_div = df / 2
     expected = pl.DataFrame({"a": [0.5, 1.0], "b": [1.5, 2.0]})
     assert df_div.frame_equal(expected)
-
-    df_plus = df + 2
-    expected = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
-    assert df_plus.frame_equal(expected)
 
     df_minus = df - 2
     expected = pl.DataFrame({"a": [-1, 0], "b": [1, 2]})
@@ -1845,11 +1845,15 @@ def test_arithmetic() -> None:
 
 def test_add_string() -> None:
     df = pl.DataFrame({"a": ["hi", "there"], "b": ["hello", "world"]})
-    result = df + " hello"
     expected = pl.DataFrame(
         {"a": ["hi hello", "there hello"], "b": ["hello hello", "world hello"]}
     )
-    assert result.frame_equal(expected)
+    assert (df + " hello").frame_equal(expected)
+
+    expected = pl.DataFrame(
+        {"a": ["hello hi", "hello there"], "b": ["hello hello", "hello world"]}
+    )
+    assert ("hello " + df).frame_equal(expected)
 
 
 def test_get_item() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -269,9 +269,10 @@ def test_arithmetic(s: pl.Series) -> None:
     assert ((a / 1) == [1.0, 2.0]).sum() == 2
     assert ((a // 2) == [0, 1]).sum() == 2
     assert ((a * 2) == [2, 4]).sum() == 2
-    assert ((1 + a) == [2, 3]).sum() == 2
+    assert ((2 + a) == [3, 4]).sum() == 2
     assert ((1 - a) == [0, -1]).sum() == 2
-    assert ((1 * a) == [1, 2]).sum() == 2
+    assert ((2 * a) == [2, 4]).sum() == 2
+
     # integer division
     assert_series_equal(1 / a, pl.Series([1.0, 0.5]))
     if s.dtype == Int64:
@@ -343,6 +344,9 @@ def test_add_string() -> None:
     s = pl.Series(["hello", "weird"])
     result = s + " world"
     assert_series_equal(result, pl.Series(["hello world", "weird world"]))
+
+    result = "pfx:" + s
+    assert_series_equal(result, pl.Series(["pfx:hello", "pfx:weird"]))
 
 
 def test_append_extend() -> None:


### PR DESCRIPTION
Closes #5327.

----

* `Series` already has r-associative `+` and `*` support; this adds it for `DataFrame`.
* Also fixes `Series.__radd__` for strings, as `"a"+"x"` is not equivalent to `"x"+"a"`.

Test coverage added for all of the above.