### PR TITLE
feat(python): 30x speedup initialising `Series` from python `range` object

### DIFF
--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1387,11 +1387,13 @@ def arange(
     """
     low = pli.expr_to_lit_or_expr(low, str_to_lit=False)
     high = pli.expr_to_lit_or_expr(high, str_to_lit=False)
-
     if eager:
-        df = pli.DataFrame({"a": [1]})
-        return df.select(arange(low, high, step).alias("arange"))["arange"]
-
+        return (
+            pli.DataFrame()
+            .select(arange(low, high, step))
+            .to_series()
+            .rename("arange", in_place=True)
+        )
     return pli.wrap_expr(pyarange(low._pyexpr, high._pyexpr, step))
 
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -206,8 +206,10 @@ class Series:
             )
         elif isinstance(values, Series):
             self._s = series_to_pyseries(name, values)
+
         elif _PYARROW_TYPE(values) and isinstance(values, (pa.Array, pa.ChunkedArray)):
             self._s = arrow_to_pyseries(name, values)
+
         elif _NUMPY_TYPE(values) and isinstance(values, np.ndarray):
             self._s = numpy_to_pyseries(name, values, strict, nan_to_null)
             if values.dtype.type == np.datetime64:
@@ -223,13 +225,13 @@ class Series:
 
             if dtype is not None:
                 self._s = self.cast(dtype, strict=True)._s
+
         elif isinstance(values, range):
             self._s = (
-                pli.DataFrame()
-                .select(pli.arange(values.start, values.stop, values.step))
-                .to_series()
+                pli.arange(values.start, values.stop, values.step, eager=True)
                 .rename(name, in_place=True)
-            )._s
+                ._s
+            )
         elif isinstance(values, Sequence):
             self._s = sequence_to_pyseries(
                 name, values, dtype=dtype, strict=strict, dtype_if_empty=dtype_if_empty

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -223,6 +223,13 @@ class Series:
 
             if dtype is not None:
                 self._s = self.cast(dtype, strict=True)._s
+        elif isinstance(values, range):
+            self._s = (
+                pli.DataFrame()
+                .select(pli.arange(values.start, values.stop, values.step))
+                .to_series()
+                .rename(name, in_place=True)
+            )._s
         elif isinstance(values, Sequence):
             self._s = sequence_to_pyseries(
                 name, values, dtype=dtype, strict=strict, dtype_if_empty=dtype_if_empty


### PR DESCRIPTION
Took a quick look at #5395 (on my lunch break, hah :) and spotted an optimisation opportunity; can automatically substitute python `range` for polars' `arange` expression.

```python
import polars as pl
s = pl.Series( range(1_000_000_000) )
```
**Before:** `31.87s`
**After:** `1.045s`

FYI: looks like pandas was already doing a similar optimisation; we were much slower, and now we're ~40% faster (pandas timing for Series init with the same range object: `1.47s`).

Can look at the actual issue itself later this evening.