### PR TITLE
feat(python): support `Series` init from generator

### DIFF
--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Iterator, cast
 
 import numpy as np
 import pandas as pd
@@ -22,6 +22,7 @@ from polars.datatypes import (
     UInt32,
     UInt64,
 )
+from polars.internals.construction import iterable_to_pyseries
 from polars.internals.type_aliases import EpochTimeUnit
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing._private import verify_series_and_expr_api
@@ -106,11 +107,6 @@ def test_init_inputs(monkeypatch: Any) -> None:
         pl.Series({"a": [1, 2, 3]})
     with pytest.raises(OverflowError):
         pl.Series("bigint", [2**64])
-
-    # numpy not available
-    monkeypatch.setattr(pl.internals.series.series, "_NUMPY_TYPE", lambda x: False)
-    with pytest.raises(ValueError):
-        pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
 
 
 def test_init_dataclass_namedtuple() -> None:
@@ -1377,6 +1373,43 @@ def test_to_numpy(monkeypatch: Any) -> None:
                 # As Null values can't be encoded natively in a numpy array,
                 # this array will never be a view.
                 assert np_array_with_missing_values.flags.writeable == writable
+
+
+def test_from_generator_or_iterable() -> None:
+    # iterable object
+    class Data:
+        def __init__(self, n: int):
+            self._n = n
+
+        def __iter__(self) -> Iterator[int]:
+            yield from range(self._n)
+
+    # generator function
+    def gen(n: int) -> Iterator[int]:
+        yield from range(n)
+
+    expected = pl.Series("s", range(10))
+    assert expected.dtype == pl.Int64
+
+    for generated_series in (
+        pl.Series("s", values=gen(10)),
+        pl.Series("s", values=Data(10)),
+        pl.Series("s", values=(x for x in gen(10))),
+    ):
+        assert_series_equal(expected, generated_series)
+
+    # test 'iterable_to_pyseries' directly to validate 'chunk_size' behaviour
+    ps1 = iterable_to_pyseries("s", gen(10), dtype=pl.UInt8)
+    ps2 = iterable_to_pyseries("s", gen(10), dtype=pl.UInt8, chunk_size=3)
+    ps3 = iterable_to_pyseries("s", Data(10), dtype=pl.UInt8, chunk_size=6)
+
+    expected = pl.Series("s", range(10), dtype=pl.UInt8)
+    assert expected.dtype == pl.UInt8
+
+    for ps in (ps1, ps2, ps3):
+        generated_series = pl.Series("s")
+        generated_series._s = ps
+        assert_series_equal(expected, generated_series)
 
 
 def test_from_sequences(monkeypatch: Any) -> None:


### PR DESCRIPTION
Closes #5395.

----

Currently `Series` init requires full materialisation of generators/iterables, up-front. As we don't have the same costs relating to chunked-append as pandas, we can take a more memory-friendly approach of incremental materialisation followed by a final call to `rechunk`.

**Before:** _(don't actually do this - much more efficient to init 'range' directly)_
```python
import polars as pl

def gen(n):
    yield from range(n)

pl.Series("s", gen(5), dtype=pl.Int8)

# ValueError: Series constructor not called properly. 
#  Got <generator object gen at 0x17d2fc200>.
```

**After:** 
```python
pl.Series("s", gen(5), dtype=pl.Int8)

# shape: (5,)
# Series: 's' [i8]
# [
#     0
#     1
#     2
#     3
#     4
# ]
```

**Also:**

Ensure `Series` generated from python `range` object still respect the given integer dtype, if provided (was being ignored; always i64).

**Follow-up:**

Offer generator support for `DataFrame` init; will take care of this later, in a separate PR.
