### PR TITLE
feat(python): support `DataFrame` init from generators

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -577,11 +577,15 @@ def dtype_to_py_type(dtype: PolarsDataType) -> type:
         ) from None
 
 
-def is_polars_dtype(data_type: Any) -> bool:
+def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
-    return isinstance(data_type, DataType) or (
-        type(data_type) is type and issubclass(data_type, DataType)
-    )
+    if data_type == Unknown:
+        # does not represent a realisable dtype, so ignore by default
+        return include_unknown
+    else:
+        return isinstance(data_type, DataType) or (
+            type(data_type) is type and issubclass(data_type, DataType)
+        )
 
 
 def py_type_to_dtype(data_type: Any, raise_unmatched: bool = True) -> PolarsDataType:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import math
 import os
 import sys
+from collections.abc import Sized
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
@@ -11,6 +12,8 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Generator,
+    Iterable,
     Iterator,
     Mapping,
     NoReturn,
@@ -48,6 +51,7 @@ from polars.exceptions import NoRowsReturned, TooManyRowsReturned
 from polars.internals.construction import (
     arrow_to_pydf,
     dict_to_pydf,
+    iterable_to_pydf,
     numpy_to_pydf,
     pandas_to_pydf,
     sequence_to_pydf,
@@ -279,13 +283,14 @@ class DataFrame:
             self._df = sequence_to_pydf(
                 data, columns=columns, orient=orient, infer_schema_length=50
             )
-
         elif isinstance(data, pli.Series):
             self._df = series_to_pydf(data, columns=columns)
 
         elif _PANDAS_TYPE(data) and isinstance(data, pd.DataFrame):
             self._df = pandas_to_pydf(data, columns=columns)
 
+        elif isinstance(data, (Generator, Iterable)) and not isinstance(data, Sized):
+            self._df = iterable_to_pydf(data, columns=columns, orient=orient)
         else:
             raise ValueError("DataFrame constructor not called properly.")
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections.abc import Sized
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -9,7 +10,6 @@ from typing import (
     Callable,
     Generator,
     Iterable,
-    Mapping,
     NoReturn,
     Sequence,
     Union,
@@ -258,7 +258,7 @@ class Series:
             self._s = pandas_to_pyseries(name, values)
 
         elif isinstance(values, (Generator, Iterable)) and not isinstance(
-            values, Mapping
+            values, Sized
         ):
             self._s = iterable_to_pyseries(
                 name,


### PR DESCRIPTION
Expands on https://github.com/pola-rs/polars/pull/5411, adding support for initialising `DataFrames` from generators (in either orientation). Can even init from a generator of generators now, if that floats your boat ;)

```python
from random import randint
import polars as pl

def gendata(n_rows, n_cols):
    for i in range(n_rows):
        yield (randint(-100,100) for j in range(n_cols))

pl.DataFrame( gendata(5,3), columns=["x","y","z"] )

# shape: (5, 3)
# ┌─────┬─────┬─────┐
# │ x   ┆ y   ┆ z   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 60  ┆ 26  ┆ -69 │
# │ 3   ┆ -58 ┆ 19  │
# │ -49 ┆ 76  ┆ 63  │
# │ 44  ┆ -93 ┆ -71 │
# │ 42  ┆ -2  ┆ 58  │
# └─────┴─────┴─────┘
```
It's a bit more complex than the previous `Series` update, as you don't necessarily know in advance how many columns you have; if that can't be inferred (eg: no 'columns' param) then the initial chunk is limited to 1000 rows - all subsequent updates can then target taking chunks of 1,000,000 elements, which initial testing shows seems to be reasonable, but we can probably micro-optimise further based on the underlying/inferred schema. 

**Also:** 

* Calls to `PyDataFrame.read_rows` make better use of the relatively new schema override param, to avoid post-init casts.
* Fixed `Series` init from generators that return no data.
* Better generator type-detection.