### PR TITLE
fix(rust, python): properly handle json with unclosed strings

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -57,7 +57,7 @@ rayon.workspace = true
 regex = "1.6"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
-simd-json = { version = "0.6.0", optional = true, features = ["allow-non-simd", "known-key"] }
+simd-json = { version = "0.7.0", optional = true, features = ["allow-non-simd", "known-key"] }
 simdutf8 = "0.1"
 
 [dev-dependencies]

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -11,7 +11,7 @@ description = "IO related logic for the Polars DataFrame library"
 
 [features]
 # support for arrows json parsing
-json = ["arrow/io_json", "simd-json", "memmap", "lexical", "lexical-core", "csv-core"]
+json = ["arrow/io_json", "simd-json", "memmap", "lexical", "lexical-core", "csv-core", "serde_json"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression", "memmap"]
 # support for arrows streaming ipc file parsing
@@ -56,7 +56,7 @@ polars-utils = { version = "0.25.1", path = "../polars-utils" }
 rayon.workspace = true
 regex = "1.6"
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
 simd-json = { version = "0.6.0", optional = true, features = ["allow-non-simd", "known-key"] }
 simdutf8 = "0.1"
 

--- a/polars/tests/it/io/json.rs
+++ b/polars/tests/it/io/json.rs
@@ -59,24 +59,27 @@ fn read_json_with_whitespace() {
 }
 #[test]
 fn read_json_with_escapes() {
-    let escaped_json = r#"{"id": 0, "text":"\"","date":"2013-08-03 15:17:23"}
-{"id": 1, "text":"\"123\"","date":"2009-05-19 21:07:53"}
-{"id": 2, "text":"\/....","date":"2009-05-19 21:07:53"}
-{"id": 3, "text":"\n\n..","date":"2"}
-{"id": 4, "text":"\"'\/\n...","date":"2009-05-19 21:07:53"}
-{"id": 5, "text":".h\"h1hh\\21hi1e2emm...","date":"2009-05-19 21:07:53"}
-{"id": 6, "text":"xxxx....","date":"2009-05-19 21:07:53"}
-{"id": 7, "text":".\"quoted text\".","date":"2009-05-19 21:07:53"}
+    let escaped_json = r#"{"id": 1, "text": "\""}
+    {"text": "\n{\n\t\t\"inner\": \"json\n}\n", "id": 10}
+    {"id": 0, "text":"\"","date":"2013-08-03 15:17:23"}
+    {"id": 1, "text":"\"123\"","date":"2009-05-19 21:07:53"}
+    {"id": 2, "text":"/....","date":"2009-05-19 21:07:53"}
+    {"id": 3, "text":"\n\n..","date":"2"}
+    {"id": 4, "text":"\"'/\n...","date":"2009-05-19 21:07:53"}
+    {"id": 5, "text":".h\"h1hh\\21hi1e2emm...","date":"2009-05-19 21:07:53"}
+    {"id": 6, "text":"xxxx....","date":"2009-05-19 21:07:53"}
+    {"id": 7, "text":".\"quoted text\".","date":"2009-05-19 21:07:53"}
+    
 "#;
     let file = Cursor::new(escaped_json);
     let df = JsonLineReader::new(file)
-        .infer_schema_len(Some(3))
+        .infer_schema_len(Some(6))
         .finish()
         .unwrap();
     assert_eq!("id", df.get_columns()[0].name());
     assert_eq!(AnyValue::Utf8("\""), df.column("text").unwrap().get(0));
     assert_eq!("text", df.get_columns()[1].name());
-    assert_eq!((8, 3), df.shape());
+    assert_eq!((10, 3), df.shape());
 }
 
 #[test]

--- a/polars/tests/it/io/json.rs
+++ b/polars/tests/it/io/json.rs
@@ -58,6 +58,28 @@ fn read_json_with_whitespace() {
     assert_eq!((12, 4), df.shape());
 }
 #[test]
+fn read_json_with_escapes() {
+    let escaped_json = r#"{"id": 0, "text":"\"","date":"2013-08-03 15:17:23"}
+{"id": 1, "text":"\"123\"","date":"2009-05-19 21:07:53"}
+{"id": 2, "text":"\/....","date":"2009-05-19 21:07:53"}
+{"id": 3, "text":"\n\n..","date":"2"}
+{"id": 4, "text":"\"'\/\n...","date":"2009-05-19 21:07:53"}
+{"id": 5, "text":".h\"h1hh\\21hi1e2emm...","date":"2009-05-19 21:07:53"}
+{"id": 6, "text":"xxxx....","date":"2009-05-19 21:07:53"}
+{"id": 7, "text":".\"quoted text\".","date":"2009-05-19 21:07:53"}
+"#;
+    let file = Cursor::new(escaped_json);
+    let df = JsonLineReader::new(file)
+        .infer_schema_len(Some(3))
+        .finish()
+        .unwrap();
+    assert_eq!("id", df.get_columns()[0].name());
+    assert_eq!(AnyValue::Utf8("\""), df.column("text").unwrap().get(0));
+    assert_eq!("text", df.get_columns()[1].name());
+    assert_eq!((8, 3), df.shape());
+}
+
+#[test]
 fn read_unordered_json() {
     let unordered_json = r#"{"a":1, "b":2.0, "c":false, "d":"4"}
 {"a":-10, "b":-3.5, "c":true, "d":"4"}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "array-init-cursor"
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bincode"
@@ -229,9 +229,9 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -255,9 +255,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d16bb3da60be2f7c7acfc438f2ae6f3496897ce68c291d0509bb67b4e248e"
+checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
 dependencies = [
  "crossterm",
  "strum",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -473,15 +473,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,13 +675,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -703,9 +705,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "halfbrown"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce69ed202df415a3d4a01e6f3341320ca88b9bd4f0bf37be6fa239cdea06d9bf"
+checksum = "ff8ba437813c5a31783dd9a21ce4f555583dc9b048af6bd2b12217394ed9c199"
 dependencies = [
  "fxhash",
  "hashbrown",
@@ -751,9 +753,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -939,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libflate"
@@ -1079,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1201,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1224,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "parking_lot"
@@ -1248,7 +1250,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1384,7 +1386,7 @@ dependencies = [
 name = "polars-core"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
  "arrow2",
  "base64",
@@ -1414,7 +1416,7 @@ dependencies = [
 name = "polars-io"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
  "arrow2",
  "csv-core",
@@ -1442,7 +1444,7 @@ dependencies = [
 name = "polars-lazy"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "bitflags",
  "glob",
  "polars-arrow",
@@ -1487,7 +1489,7 @@ dependencies = [
 name = "polars-plan"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -1552,7 +1554,7 @@ dependencies = [
 name = "py-polars"
 version = "0.14.25"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "bincode",
  "jemallocator",
  "libc",
@@ -1782,18 +1784,18 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,11 +1846,12 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd78b840b9de64fa3f7d72909b76343849f68e8c3d32608db8d38e4e5481f84"
+checksum = "8e3375b6c3d8c048ba09c8b4b6c3f1d3f35e06b71db07d231c323943a949e1b8"
 dependencies = [
  "halfbrown",
+ "lexical-core",
  "serde",
  "serde_json",
  "simdutf8",
@@ -1956,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2040,9 +2043,9 @@ checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "value-trait"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a635407649b66e125e4d2ffd208153210179f8c7c8b71c030aa2ad3eeb4c8f"
+checksum = "7c39f0b6c3d217fc9864f14a7bbae74cf562eddf4e0e276b91846b70425c8a87"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -2155,30 +2158,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2189,21 +2179,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2213,21 +2191,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2240,12 +2206,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_json",
  "simd-json",
  "simdutf8",
 ]

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -73,3 +73,11 @@ def test_write_json2(df: pl.DataFrame) -> None:
     file.seek(0)
     out = pl.read_json(file)
     assert df.frame_equal(out, null_equal=True)
+
+
+def test_read_escaped_json() -> None:
+    file_path = os.path.join(os.path.dirname(__file__), "escape_chars.json")
+    file_str = str(file_path)
+    expected = pl.DataFrame({"text": ['"hello', '"world"'], "id": [1, 2]})
+    actual = pl.scan_ndjson(file_str).collect()
+    assert expected.frame_equal(actual)

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -73,11 +73,3 @@ def test_write_json2(df: pl.DataFrame) -> None:
     file.seek(0)
     out = pl.read_json(file)
     assert df.frame_equal(out, null_equal=True)
-
-
-def test_read_escaped_json() -> None:
-    file_path = os.path.join(os.path.dirname(__file__), "escape_chars.json")
-    file_str = str(file_path)
-    expected = pl.DataFrame({"text": ['"hello', '"world"'], "id": [1, 2]})
-    actual = pl.scan_ndjson(file_str).collect()
-    assert expected.frame_equal(actual)

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from os import path
+
 import polars as pl
 
 
@@ -23,3 +25,43 @@ def test_scan_ndjson(foods_ndjson: str) -> None:
     )
 
     assert df["foo"].to_list() == [10, 16, 21, 23, 24, 30, 35]
+
+
+def test_scan_with_projection() -> None:
+    json = r"""
+{"text": "\"hello", "id": 1}
+{"text": "\n{\n\t\t\"inner\": \"json\n}\n", "id": 10}
+{"id": 0, "text":"\"","date":"2013-08-03 15:17:23"}
+{"id": 1, "text":"\"123\"","date":"2009-05-19 21:07:53"}
+{"id": 2, "text":"/....","date":"2009-05-19 21:07:53"}
+{"id": 3, "text":"\n\n..","date":"2"}
+{"id": 4, "text":"\"'/\n...","date":"2009-05-19 21:07:53"}
+{"id": 5, "text":".h\"h1hh\\21hi1e2emm...","date":"2009-05-19 21:07:53"}
+{"id": 6, "text":"xxxx....","date":"2009-05-19 21:07:53"}
+{"id": 7, "text":".\"quoted text\".","date":"2009-05-19 21:07:53"}
+"""
+    json_bytes = bytes(json, "utf-8")
+    file = path.join(path.dirname(__file__), "escape_chars.json")
+    with open(file, "wb") as f:
+        f.write(
+            json_bytes,
+        )
+    actual = pl.scan_ndjson(file).select(["id", "text"]).collect()
+    expected = pl.DataFrame(
+        {
+            "id": [1, 10, 0, 1, 2, 3, 4, 5, 6, 7],
+            "text": [
+                '"hello',
+                '\n{\n\t\t"inner": "json\n}\n',
+                '"',
+                '"123"',
+                "/....",
+                "\n\n..",
+                "\"'/\n...",
+                '.h"h1hh\\21hi1e2emm...',
+                "xxxx....",
+                '."quoted text".',
+            ],
+        }
+    )
+    assert actual.frame_equal(expected, null_equal=True)


### PR DESCRIPTION
fixes #5371 

A little note about the implementation. The `SplitLines` iterator is not really designed to handle all the nuances of json parsing. So I decided to go back to leveraging the `serde_json:: StreamDeserializer`, but now we are using it exclusively as a mechanism to iterate over the rows. We can do this via the `RawValue` type in `serde_json`. Which just returns the raw `str` of each row without doing any parsing of the values, acting as a drop in replacement to `SplitLines`. 

The actual parsing of the rows is still done by `simd_json`. So the performance impact should be minimal. I'll post some benchmarks once my release build is finished. 

