### PR TITLE
feat(python): enhanced `Series.dot` method and related interop

### DIFF
--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -23,7 +23,7 @@ pub enum DataType {
     /// in days (32 bits).
     Date,
     /// A 64-bit date representing the elapsed time since UNIX epoch (1970-01-01)
-    /// in milliseconds (64 bits).
+    /// in the given timeunit (64 bits).
     Datetime(TimeUnit, Option<TimeZone>),
     // 64-bit integer representing difference between times in milliseconds or nanoseconds
     Duration(TimeUnit),

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -292,7 +292,9 @@ class DataFrame:
         elif isinstance(data, (Generator, Iterable)) and not isinstance(data, Sized):
             self._df = iterable_to_pydf(data, columns=columns, orient=orient)
         else:
-            raise ValueError("DataFrame constructor not called properly.")
+            raise ValueError(
+                f"DataFrame constructor called with unsupported type; got {type(data)}"
+            )
 
     @classmethod
     def _from_pydf(cls: type[DF], py_df: PyDataFrame) -> DF:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -22,6 +22,7 @@ from polars.datatypes import (
     UInt32,
     UInt64,
 )
+from polars.exceptions import ShapeError
 from polars.internals.construction import iterable_to_pyseries
 from polars.internals.type_aliases import EpochTimeUnit
 from polars.testing import assert_frame_equal, assert_series_equal
@@ -1613,9 +1614,21 @@ def test_is_duplicated() -> None:
 
 
 def test_dot() -> None:
-    s = pl.Series("a", [1, 2, 3])
+    s1 = pl.Series("a", [1, 2, 3])
     s2 = pl.Series("b", [4.0, 5.0, 6.0])
-    assert s.dot(s2) == 32
+
+    assert np.array([1, 2, 3]) @ np.array([4, 5, 6]) == 32
+
+    for dot_result in (
+        s1.dot(s2),
+        s1 @ s2,
+        [1, 2, 3] @ s2,
+        s1 @ np.array([4, 5, 6]),
+    ):
+        assert dot_result == 32
+
+    with pytest.raises(ShapeError, match="length mismatch"):
+        s1 @ [4, 5, 6, 7, 8]
 
 
 def test_sample() -> None:


### PR DESCRIPTION
Added `@` matrix multiplication operator support for `Series`, along with implicit coercion for types that make sense (1D lists and/or numpy arrays).

```python
import numpy as np
import polars as pl

s1 = pl.Series("a", [1, 2, 3])
s2 = pl.Series("b", [4.0, 5.0, 6.0])

for dot_result in (
    s1.dot(s2),                # << existing
    s1 @ s2,                   # << new
    s1 @ [4, 5, 6],            # << new
    s1 @ np.array([4, 5, 6]),  # << new
):
    assert dot_result == 32
```
Reference: _(numpy behaviour)_
```python
np.array([1, 2, 3]) @ np.array([4, 5, 6]) 
# 32
np.array([1, 2, 3]) @ [4, 5, 6]
# 32
```

**Also:**

Slightly more informative error messages on failed Series/DataFrame init, for example:
* Before: `"DataFrame constructor not called properly."`
* After: `f"DataFrame constructor called with unsupported type; got {type(data)}"`

----

I admit to being tempted to try proper 2D matrix multiplication support without taking on additional dependencies, but getting that _fast_ is non-trivial! (There is a reason [BLAS](https://netlib.org/blas/) exists :). So, for now, just adding `@` support for `Series`.