### PR TITLE
feat(python): add missing `width` property to `LazyFrame`

### DIFF
--- a/py-polars/docs/source/reference/lazyframe.rst
+++ b/py-polars/docs/source/reference/lazyframe.rst
@@ -18,6 +18,7 @@ Attributes
     LazyFrame.columns
     LazyFrame.dtypes
     LazyFrame.schema
+    LazyFrame.width
 
 Aggregation
 -----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -399,6 +399,20 @@ class LazyFrame:
         """  # noqa: E501
         return self._ldf.schema()
 
+    @property
+    def width(self) -> int:
+        """
+        Get the width of the LazyFrame.
+
+        Examples
+        --------
+        >>> lf = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]}).lazy()
+        >>> lf.width
+        2
+
+        """
+        return self._ldf.width()
+
     def __bool__(self) -> NoReturn:
         raise ValueError(
             "The truth value of a LazyFrame is ambiguous; consequently it "

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -837,4 +837,8 @@ impl PyLazyFrame {
     pub fn unnest(&self, cols: Vec<String>) -> PyLazyFrame {
         self.ldf.clone().unnest(cols).into()
     }
+
+    pub fn width(&self) -> PyResult<usize> {
+        Ok(self.get_schema()?.len())
+    }
 }


### PR DESCRIPTION
Brings in-line with `DataFrame` (spotted while starting another pass through the docs).
```python
import polars as pl
df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})

df.width
2

df.lazy().width
2
```