### PR TITLE
fix(rust): add missing `AnyValueBuffer` specialisation for `Duration` dtype

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -550,7 +550,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let ts = dt.call_method0("timestamp")?;
                     // s to us
                     let v = (ts.extract::<f64>()? * 1_000_000.0) as i64;
-                    // we choose us as that is pythons default unit
+                    // choose "us" as that is python's default unit
                     Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
                 }
             })

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1083,6 +1083,22 @@ def test_timelike_init() -> None:
         assert s.to_list() == ts
 
 
+def test_timedelta_timeunit_init() -> None:
+    d, s, us = 7, 45045, 123456
+    td_us = timedelta(days=d, seconds=s, microseconds=us)
+    df = pl.DataFrame(
+        [[td_us, td_us, td_us]],
+        columns=[
+            ("x", pl.Duration("ms")),
+            ("y", pl.Duration("us")),
+            ("z", pl.Duration("ns")),
+        ],
+        orient="row",
+    )
+    td_ms = timedelta(days=d, seconds=s, microseconds=(us // 1000) * 1000)
+    assert df.rows() == [(td_ms, td_us, td_us)]
+
+
 def test_duration_filter() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Fixes a scaling bug when reading rows containing non-μs `timedelta` values:

**Setup:**
```python
from datetime import timedelta
import polars as pl

td = timedelta( days=7, seconds=45045, microseconds=123456 )

df = pl.DataFrame(
    [[td, td, td]],
    columns=[
        ("x", pl.Duration('ms')),
        ("y", pl.Duration('us')),
        ("z", pl.Duration('ns')),
    ],
    orient="row",
)
```
**Before:** _(values scaled by 1e3 if not `μs` timeunit)_
```python
df.rows()

# [(timedelta(days=7521, seconds=30723, microseconds=456000),
#   timedelta(days=7, seconds=45045, microseconds=123456),
#   timedelta(seconds=649, microseconds=845123)),
# ]
```
**After:** _(successful round-trip, with appropriate `ms` truncation)_
```python
df.rows()

# [(timedelta(days=7, seconds=45045, microseconds=123000),   
#   timedelta(days=7, seconds=45045, microseconds=123456), 
#   timedelta(days=7, seconds=45045, microseconds=123456)),
# ]
```