### PR TITLE
docs(python): add build_info() to the API doc 

### DIFF
--- a/py-polars/docs/source/reference/utils.rst
+++ b/py-polars/docs/source/reference/utils.rst
@@ -7,4 +7,5 @@ Utils
 .. autosummary::
    :toctree: api/
 
+    build_info
     show_versions


### PR DESCRIPTION
(followup to PR #5423)

Forgot to add new `build_info()` function to the API doc. Hence, this little PR.