### PR TITLE
fix(python): Tiny change to to_list return type

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2462,7 +2462,7 @@ class Series:
 
         """
 
-    def to_list(self, use_pyarrow: bool = False) -> list[Any | None]:
+    def to_list(self, use_pyarrow: bool = False) -> list[Any]:
         """
         Convert this Series to a Python List. This operation clones data.
 


### PR DESCRIPTION
The pylance type checker is complaining that I'm trying to pass an `Any | None` type into a `date` argument. I think the explicit inclusion of `None` confuses the type checker.

<img width="869" alt="image" src="https://user-images.githubusercontent.com/2721423/200676839-1874f064-f155-4070-8d58-4603c2d257db.png">

If I change `Any | None` into `Any`, as per this PR, the error goes away. This is also more correct, [since `None` is encompassed by `Any` already](https://docs.python.org/3/library/typing.html#typing.Any).