### PR TITLE
feat(rust): add predicate pushdown to anonymous_scan

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -88,6 +88,7 @@ impl LogicalPlanBuilder {
                 n_rows,
                 output_schema: None,
                 with_columns: None,
+                predicate: None,
             },
         }
         .into())

--- a/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
@@ -6,6 +6,8 @@ use polars_time::{DynamicGroupOptions, RollingGroupOptions};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::prelude::Expr;
+
 pub type FileCount = u32;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -226,5 +228,6 @@ pub struct AnonymousScanOptions {
     pub skip_rows: Option<usize>,
     pub n_rows: Option<usize>,
     pub with_columns: Option<Arc<Vec<String>>>,
+    pub predicate: Option<Expr>,
     pub fmt_str: &'static str,
 }


### PR DESCRIPTION
this pushes the predicate `Expr` down to the anonymous scan so that it can be leveraged directly at the source, given they can map an `Expr` to something it can understand. 