### PR TITLE
fix(python): improved namespace/accessor behaviour (resolves VSCode autocomplete issue)

### DIFF
--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -1,6 +1,8 @@
 # Minimal makefile for Sphinx documentation
 #
 
+export BUILDING_SPHINX_DOCS = 1
+
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?= -j auto

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -141,4 +141,4 @@ def test_series_timeunits(
         if isinstance(us, int)
     ):
         for ns, us in zip(s2.dt.nanoseconds(), micros):
-            assert ns == (us * 1000)
+            assert ns == (us * 1000)  # type: ignore[operator]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1699,7 +1699,7 @@ def test_str_encode() -> None:
     verify_series_and_expr_api(s, hex_encoded, "str.encode", "hex")
     verify_series_and_expr_api(s, base64_encoded, "str.encode", "base64")
     with pytest.raises(ValueError):
-        s.str.encode("utf8")
+        s.str.encode("utf8")  # type: ignore[arg-type]
 
 
 def test_str_decode() -> None:
@@ -1718,7 +1718,7 @@ def test_str_decode_exception() -> None:
     with pytest.raises(Exception):
         s.str.decode(encoding="base64", strict=True)
     with pytest.raises(ValueError):
-        s.str.decode("utf8")
+        s.str.decode("utf8")  # type: ignore[arg-type]
 
 
 def test_str_replace_str_replace_all() -> None:


### PR DESCRIPTION
Closes #5460.

----

Building the docs properly requires access to the `Expr` & `Series` namespaces from the class-level, so the `@accessor` decorator (which is capable of _also_ behaving as a classproperty) was introduced. PyCharm autocomplete is fine with this, but apparently VSCode is not.

Given that this access pattern is only required for sphinx docs to build, I've reworked it so that the docs build exports a temporary environment variable, allowing the `@accessor` to function as such _only_ when building docs, and to map to a vanilla `@property` in all other cases (eg: developing/editing, runtime, etc). 

With this new approach I have confirmed that the docs still correctly generate namespaced methods (without exposing the internal/private paths) _and_ that proper autocomplete is preserved for both VSCode & PyCharm (screenshots below). Best of both worlds... 

<img title="VSCode autocomplete" width="312" alt="Screenshot 2022-11-11 at 00 21 07" src="https://user-images.githubusercontent.com/2613171/201205251-ea4ee77b-682d-468e-8077-2c83140cd35a.png"> <img title="PyCharm autocomplete" width="371" alt="Screenshot 2022-11-11 at 00 21 39" src="https://user-images.githubusercontent.com/2613171/201204983-40718692-bffd-475b-b780-cbecbbb6c7ce.png">
