### PR TITLE
chore: Remove old changelog generator file

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,6 +1,0 @@
-since-tag=py-polars-v0.10.1
-future-release=v0.10.1
-base=py-polars/CHANGELOG.md
-output=AUTO_CHANGELOG.md
-exclude-labels=no-changelog,question
-add-sections={"features":{"prefix":"**Enhancements:**","labels":["enhancement"]}, "documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}, "testing":{"prefix":"**Testing updates:**","labels":["testing"]}}


### PR DESCRIPTION
This file was used for some old version of generating the changelog; we can get rid of it.