### PR TITLE
chore(python): Changing the Python Makefile again

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -1,87 +1,39 @@
-.DEFAULT_GOAL := telp
+.DEFAULT_GOAL := help
 
 SHELL=/bin/bash
-VENV ?= venv
-
-WHEELS_DEBUG   = wheels/debug
-WHEELS_RELEASE = wheels/release
+VENV = venv
 
 ifeq ($(OS),Windows_NT)
-    VENV_BIN=$(VENV)/Scripts
+	VENV_BIN=$(VENV)/Scripts
 else
-    VENV_BIN=$(VENV)/bin
+	VENV_BIN=$(VENV)/bin
 endif
 
-ifneq ($(CONDA_EXE),)
-	CONDA_DEACT = . $(shell $(CONDA_EXE) info --base -q)/etc/profile.d/conda.sh; \
-		while [ -n "$$CONDA_PREFIX" ]; do conda deactivate; done;
-else
-	CONDA_DEACT =
-endif
+venv:  ## Set up virtual environment
+	python3 -m venv $(VENV)
+	$(VENV_BIN)/python -m pip install --upgrade pip
+	$(VENV_BIN)/pip install -r requirements-dev.txt
+	$(VENV_BIN)/pip install -r requirements-lint.txt
+	$(VENV_BIN)/pip install -r docs/requirements-docs.txt
 
-ifeq ($(VENV),) # no virtual environment
-	VENV_BIN     =
-	VENV_ACT_BIN =
-	CLEAN_VENV   = @:
-venv:
-	:
-else # use VENV
-	VENV_BIN    := $(abspath $(VENV_BIN))/# no space after trailing '/'
-	VENV_ACT_BIN = $(VENV_BIN)# no space after closing ')'
-	CLEAN_VENV   = -rm -rf $(VENV)
-ifeq ($(VENV),venv)
-venv:  ## Create virtual environment for building polars (optionally with VENV=<name>)
-else
-.PHONY: venv
-venv: $(VENV)
-$(VENV):
-endif
-	python -m venv  $(VENV)
-	$(VENV_ACT_BIN)pip install -U pip
-	$(VENV_ACT_BIN)pip install -r requirements-dev.txt
-	$(VENV_ACT_BIN)pip install -r requirements-lint.txt
-	$(VENV_ACT_BIN)pip install -r docs/requirements-docs.txt
-endif
+.PHONY: build
+build: venv  ## Compile and install Polars for development
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
 
-develop: $(VENV)  ## Build by running `maturin develop`
-	$(VENV_ACT_BIN)maturin develop
-
-develop-release: $(VENV)  ## Build by running `maturin develop --release`
-	$(VENV_ACT_BIN)maturin develop --release
-
-.PHONY: clean cleaner cleanest
-clean:  ## Just run `cargo clean`
-	-cargo clean
-
-cleaner: clean  ## clean + remove VENV and other auto-generated dirs & files
-	$(CLEAN_VENV)
-	-rm -rf target
-	-rm -rf docs/build
-	-rm -rf docs/source/reference/api
-	-rm -rf .hypothesis
-	-rm -rf .mypy_cache
-	-rm -rf .pytest_cache
-	-rm -rf .ruff_cache
-	-rm -f .coverage
-	-rm -f coverage.xml
-	-rm -f polars/polars.abi3.so
-	-find . \( -type f -name '*.py[co]' \) -or \( -type d -name __pycache__ \) -delete
-
-cleanest: cleaner  ## cleaner + remove the wheels
-	-rm -rf $(WHEELS_DEBUG)
-	-rm -rf $(WHEELS_RELEASE)
-	-rm -rf wheels
+.PHONY: build-release
+build-release: venv  ## Compile and install a faster Polars binary
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release
 
 .PHONY: fmt
-fmt: $(VENV)  ## Run autoformatting and linting
-	$(VENV_ACT_BIN)isort .
-	$(VENV_ACT_BIN)black .
-	$(VENV_ACT_BIN)blackdoc .
-	$(VENV_ACT_BIN)pyupgrade --py37-plus `find polars docs tests -name "*.py" -type f`
+fmt: venv  ## Run autoformatting and linting
+	$(VENV_BIN)/isort .
+	$(VENV_BIN)/black .
+	$(VENV_BIN)/blackdoc .
+	$(VENV_BIN)/pyupgrade --py37-plus `find polars tests docs -name "*.py" -type f`
 	cargo fmt --all
 	-dprint fmt
-	-$(VENV_ACT_BIN)mypy
-	-$(VENV_ACT_BIN)flake8 polars tests docs
+	-$(VENV_BIN)/mypy
+	-$(VENV_BIN)/flake8
 
 .PHONY: clippy
 clippy:  ## Run clippy
@@ -91,53 +43,39 @@ clippy:  ## Run clippy
 pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
-test: develop # develop  ## Run fast unittests
-	$(VENV_ACT_BIN)pytest tests/unit/
+test: venv build  ## Run fast unittests
+	$(VENV_BIN)/pytest tests/unit/
 
 .PHONY: doctest
-doctest: $(VENV) develop  ## Run doctests
-	$(VENV_ACT_BIN)python tests/docs/run_doc_examples.py
+doctest: venv build  ## Run doctests
+	$(VENV_BIN)/python tests/docs/run_doc_examples.py
 
 .PHONY: test-all
-test-all: # develop  ## Run all tests
-	$(VENV_ACT_BIN)pytest
-	$(VENV_ACT_BIN)python tests/docs/run_doc_examples.py
+test-all: venv build  ## Run all tests
+	$(VENV_BIN)/pytest
+	$(VENV_BIN)/python tests/docs/run_doc_examples.py
 
 .PHONY: coverage
-coverage:  ## Run tests and report coverage
-	$(VENV_ACT_BIN)pytest --cov
+coverage: venv build  ## Run tests and report coverage
+	$(VENV_BIN)/pytest --cov
 
-build-debug: $(VENV)  ## Build debug wheel
-	$(VENV_ACT_BIN)maturin build -o $(WHEELS_DEBUG)
-
-build: $(VENV)  ## Build release wheel
-	$(VENV_ACT_BIN)maturin build -o $(WHEELS_RELEASE) --release -- -C codegen-units=16 -C lto=thin -C target-cpu=native
-
-install-debug: $(VENV)  ## pip install debug wheel
-	$(VENV_ACT_BIN)pip install --no-deps --force-reinstall -U $(WHEELS_DEBUG)/polars-*.whl
-
-install: $(VENV)  ## pip install release wheel
-	$(VENV_ACT_BIN)pip install --no-deps --force-reinstall -U $(WHEELS_RELEASE)/polars-*.whl
-
-# Shortcut targets
-build-install-debug: build-debug install-debug  ## Build and install debug wheel
-build-install: build install  ## Build and install release wheel
+.PHONY: clean
+clean:  ## Clean up caches and build artifacts
+	@rm -rf venv/
+	@rm -rf target/
+	@rm -rf docs/build/
+	@rm -rf docs/source/reference/api/
+	@rm -rf .hypothesis/
+	@rm -rf .mypy_cache/
+	@rm -rf .pytest_cache/
+	@rm -rf .ruff_cache/
+	@rm -f .coverage
+	@rm -f coverage.xml
+	@rm -f polars/polars.abi3.so
+	@find . -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -delete
+	@cargo clean
 
 .PHONY: help
 help:  ## Display this help screen
-	@echo "Usage:"
-	@echo "* To run a make <comand> with venv, issue"
-	@echo "  > make <command>"
-	@echo "* To run a make <command> with alternative environement <name>, issue"
-	@echo "  > make VENV=<name> <command>"
-	@echo "* To run a make <command> without virtual environment (ex: conda), issue"
-	@echo "  > make VENV='' <command>"
-	@echo
-	@echo "Currently:"
-	@echo "  VENV = '$(VENV)'"
-	@echo
-
 	@echo -e '\033[1mAvailable commands:\033[0m'
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort
-
-#EOF


### PR DESCRIPTION
Following up on the discussion in #5137

Changes:
* Revert a lot of the work done in #5089. The changes were not well aligned with the intended function of the Makefile as a development tool.
* No longer support custom venv folders as it turns out to be a little complex while not really adding much value. I believe #5089 actually solves this but it introduces too much complexity and clutter. Let's just use `venv` - it works!
* Removed the wheel building/installing targets again. I don't think these should be in the Makefile - but I also don't really mind re-adding them if this breaks someones development flow. As discussed in #5137 however, these are more 'production flow' targets.

Please let me know if there are any issues with the Makefile - any targets you would like or settings or output that should be different. Happy to change things around to make sure everyone can contribute most effectively.

There are still some edge cases to handle for the Makefile to work nicely on all operating systems (Windows...), I'll revisit this later.