### PR TITLE
feat(python): additional autocomplete affordances for `IPython` users

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1462,6 +1462,9 @@ class DataFrame:
     def __deepcopy__(self: DF, memo: None = None) -> DF:
         return self.clone()
 
+    def _ipython_key_completions_(self) -> list[str]:
+        return self.columns
+
     def _repr_html_(self) -> str:
         """
         Format output data in HTML for display in Jupyter Notebooks.

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -27,6 +27,9 @@ class StructNameSpace:
         else:
             raise ValueError(f"expected type 'int | str', got {type(item)}")
 
+    def _ipython_key_completions_(self) -> list[str]:
+        return self.fields
+
     def to_frame(self) -> pli.DataFrame:
         """Convert this Struct Series to a DataFrame."""
         return pli.wrap_df(self._s.struct_to_frame())

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -283,6 +283,7 @@ def test_dataframe_membership_operator() -> None:
     df = pl.DataFrame({"name": ["Jane", "John"], "age": [20, 30]})
     assert "name" in df
     assert "phone" not in df
+    assert df._ipython_key_completions_() == ["name", "age"]
 
 
 def test_sort() -> None:

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -23,6 +23,7 @@ def test_struct_various() -> None:
     assert s.struct.field("int").to_list() == [1, 2]
 
     assert df.to_struct("my_struct").struct.to_frame().frame_equal(df)
+    assert s.struct._ipython_key_completions_() == s.struct.fields
 
 
 def test_struct_to_list() -> None:


### PR DESCRIPTION
Closes #5468.

----

Implements special `_ipython_key_completions_` method, enabling autocomplete suggestions in IPython for `DataFrame`columns  and `Series.struct` fields:

<img width="462" src="https://user-images.githubusercontent.com/2613171/201316773-8efb65a5-4dfa-4f13-8253-82bd51221623.png" title="Autocomplete DataFrame columns" />

<img width="462" src="https://user-images.githubusercontent.com/2613171/201316796-fccead47-3421-483a-8e26-d005665c8cd8.png" title="Autocomplete Series struct fields" />
