### PR TITLE
Refer to DataFrame::unique instead of `distinct`

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2934,7 +2934,7 @@ impl DataFrame {
     /// | 3   | 3   | "c" |
     /// +-----+-----+-----+
     /// ```
-    #[deprecated(note = "use distinct")]
+    #[deprecated(note = "use DataFrame::unique")]
     pub fn drop_duplicates(
         &self,
         maintain_order: bool,
@@ -2987,7 +2987,7 @@ impl DataFrame {
         self.unique_impl(true, subset, keep)
     }
 
-    /// Unstable distinct. See [`DataFrame::distinct_stable`].
+    /// Unstable distinct. See [`DataFrame::unique_stable`].
     pub fn unique(
         &self,
         subset: Option<&[String]>,


### PR DESCRIPTION
I was using the `DataFrame` API and noticed that `drop_duplicates` is deprecated and refers to `distinct`.
That method does not exist, and I assume it should be `DataFrame::unique` instead.
