### PR TITLE
feat(python): additional support for using `timedelta` with duration-type arguments

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5,6 +5,7 @@ import math
 import os
 import sys
 from collections.abc import Sized
+from datetime import timedelta
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
@@ -62,6 +63,7 @@ from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
+    _timedelta_to_pl_duration,
     deprecated_alias,
     format_path,
     handle_projection_columns,
@@ -3147,8 +3149,8 @@ class DataFrame:
     def groupby_rolling(
         self: DF,
         index_column: str,
-        period: str,
-        offset: str | None = None,
+        period: str | timedelta,
+        offset: str | timedelta | None = None,
         closed: ClosedWindow = "right",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> RollingGroupBy[DF]:
@@ -3161,8 +3163,8 @@ class DataFrame:
         individual values and are not of constant intervals. For constant intervals use
         *groupby_dynamic*
 
-        The `period` and `offset` arguments are created with
-        the following string language:
+        The `period` and `offset` arguments are created either from a timedelta, or
+        by using the following string language:
 
         - 1ns   (1 nanosecond)
         - 1us   (1 microsecond)
@@ -3257,9 +3259,9 @@ class DataFrame:
     def groupby_dynamic(
         self: DF,
         index_column: str,
-        every: str,
-        period: str | None = None,
-        offset: str | None = None,
+        every: str | timedelta,
+        period: str | timedelta | None = None,
+        offset: str | timedelta | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: ClosedWindow = "left",
@@ -3573,8 +3575,8 @@ class DataFrame:
     def upsample(
         self: DF,
         time_column: str,
-        every: str,
-        offset: str | None = None,
+        every: str | timedelta,
+        offset: str | timedelta | None = None,
         by: str | Sequence[str] | None = None,
         maintain_order: bool = False,
     ) -> DF:
@@ -3595,7 +3597,7 @@ class DataFrame:
         maintain_order
             Keep the ordering predictable. This is slower.
 
-        The `period` and `offset` arguments are created with
+        The `every` and `offset` arguments are created with
         the following string language:
 
         - 1ns   (1 nanosecond)
@@ -3663,6 +3665,9 @@ class DataFrame:
             by = [by]
         if offset is None:
             offset = "0ns"
+
+        every = _timedelta_to_pl_duration(every)
+        offset = _timedelta_to_pl_duration(offset)
 
         return self._from_pydf(
             self._df.upsample(by, time_column, every, offset, maintain_order)

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import warnings
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Sequence, TypeVar
 
 import polars.internals as pli
 from polars.internals.dataframe.pivot import PivotOps
+from polars.utils import _timedelta_to_pl_duration
 
 if TYPE_CHECKING:
     from polars.datatypes import DataType
@@ -834,11 +836,14 @@ class RollingGroupBy(Generic[DF]):
         self,
         df: DF,
         index_column: str,
-        period: str,
-        offset: str | None,
+        period: str | timedelta,
+        offset: str | timedelta | None,
         closed: ClosedWindow = "none",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ):
+        period = _timedelta_to_pl_duration(period)
+        offset = _timedelta_to_pl_duration(offset)
+
         self.df = df
         self.time_column = index_column
         self.period = period
@@ -861,7 +866,7 @@ class DynamicGroupBy(Generic[DF]):
     """
     A dynamic grouper.
 
-    This has an `.agg` method which will allow you to run all polars expressions in a
+    This has an `.agg` method which allows you to run all polars expressions in a
     groupby context.
     """
 
@@ -869,14 +874,19 @@ class DynamicGroupBy(Generic[DF]):
         self,
         df: DF,
         index_column: str,
-        every: str,
-        period: str | None,
-        offset: str | None,
+        every: str | timedelta,
+        period: str | timedelta | None,
+        offset: str | timedelta | None,
         truncate: bool = True,
         include_boundaries: bool = True,
         closed: ClosedWindow = "none",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ):
+
+        period = _timedelta_to_pl_duration(period)
+        offset = _timedelta_to_pl_duration(offset)
+        every = _timedelta_to_pl_duration(every)
+
         self.df = df
         self.time_column = index_column
         self.every = every

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -141,11 +141,13 @@ class ExprDateTimeNameSpace:
         """
         if offset is None:
             offset = "0ns"
-        if isinstance(every, timedelta):
-            every = _timedelta_to_pl_duration(every)
-        if isinstance(offset, timedelta):
-            offset = _timedelta_to_pl_duration(offset)
-        return pli.wrap_expr(self._pyexpr.dt_truncate(every, offset))
+
+        return pli.wrap_expr(
+            self._pyexpr.dt_truncate(
+                _timedelta_to_pl_duration(every),
+                _timedelta_to_pl_duration(offset),
+            )
+        )
 
     def round(
         self,
@@ -277,11 +279,13 @@ class ExprDateTimeNameSpace:
         """
         if offset is None:
             offset = "0ns"
-        if isinstance(every, timedelta):
-            every = _timedelta_to_pl_duration(every)
-        if isinstance(offset, timedelta):
-            offset = _timedelta_to_pl_duration(offset)
-        return pli.wrap_expr(self._pyexpr.dt_round(every, offset))
+
+        return pli.wrap_expr(
+            self._pyexpr.dt_round(
+                _timedelta_to_pl_duration(every),
+                _timedelta_to_pl_duration(offset),
+            )
+        )
 
     def strftime(self, fmt: str) -> pli.Expr:
         """

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -24,7 +24,7 @@ from polars.internals.expr.list import ExprListNameSpace
 from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
-from polars.utils import accessor, deprecated_alias
+from polars.utils import _timedelta_to_pl_duration, accessor, deprecated_alias
 
 try:
     from polars.polars import PyExpr
@@ -3799,7 +3799,7 @@ class Expr:
 
     def rolling_min(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -3817,7 +3817,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -3831,8 +3831,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -3900,7 +3900,7 @@ class Expr:
 
     def rolling_max(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -3918,7 +3918,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -3932,8 +3932,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -3943,7 +3943,7 @@ class Expr:
         center
             Set the labels at the center of the window
         by
-            If the `window_size` is temporal for instance `"5h"` or `"3s`, you must
+            If the `window_size` is temporal, for instance `"5h"` or `"3s`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
@@ -4001,7 +4001,7 @@ class Expr:
 
     def rolling_mean(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4019,7 +4019,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4033,8 +4033,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -4100,7 +4100,7 @@ class Expr:
 
     def rolling_sum(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4118,7 +4118,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4132,8 +4132,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length of the window that will be multiplied
             elementwise with the values in the window.
@@ -4201,7 +4201,7 @@ class Expr:
 
     def rolling_std(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4219,7 +4219,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4233,8 +4233,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -4302,7 +4302,7 @@ class Expr:
 
     def rolling_var(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4320,7 +4320,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4334,8 +4334,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -4403,7 +4403,7 @@ class Expr:
 
     def rolling_median(
         self,
-        window_size: int | str,
+        window_size: int | timedelta | str,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4417,7 +4417,7 @@ class Expr:
         ----------
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4431,8 +4431,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -4502,7 +4502,7 @@ class Expr:
         self,
         quantile: float,
         interpolation: InterpolationMethod = "nearest",
-        window_size: int | str = 2,
+        window_size: int | timedelta | str = 2,
         weights: list[float] | None = None,
         min_periods: int | None = None,
         center: bool = False,
@@ -4520,7 +4520,7 @@ class Expr:
             Interpolation method.
         window_size
             The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by the following string language:
+            size indicated by a timedelta or the following string language:
 
             - 1ns   (1 nanosecond)
             - 1us   (1 microsecond)
@@ -4534,8 +4534,8 @@ class Expr:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-            If the dynamic string language is used, the `by` and `closed` arguments must
-            also be set.
+            If a timedelta or the dynamic string language is used, the `by`
+            and `closed` arguments must also be set.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
@@ -4688,9 +4688,9 @@ class Expr:
         Parameters
         ----------
         window_size
-            Size of the rolling window
+            Integer size of the rolling window.
         bias
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         """
         return wrap_expr(self._pyexpr.rolling_skew(window_size, bias))
@@ -4936,7 +4936,7 @@ class Expr:
         Parameters
         ----------
         bias : bool, optional
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         Notes
         -----
@@ -4992,7 +4992,7 @@ class Expr:
             If True, Fisher's definition is used (normal ==> 0.0). If False,
             Pearson's definition is used (normal ==> 3.0).
         bias : bool, optional
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         Examples
         --------
@@ -6316,13 +6316,15 @@ def _prepare_alpha(
 
 
 def _prepare_rolling_window_args(
-    window_size: int | str,
+    window_size: int | timedelta | str,
     min_periods: int | None = None,
 ) -> tuple[str, int]:
     if isinstance(window_size, int):
         if min_periods is None:
             min_periods = window_size
         window_size = f"{window_size}i"
+    elif isinstance(window_size, timedelta):
+        window_size = _timedelta_to_pl_duration(window_size)
     if min_periods is None:
         min_periods = 1
     return window_size, min_periods

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -42,6 +42,7 @@ from polars.utils import (
     _in_notebook,
     _prepare_row_count_args,
     _process_null_values,
+    _timedelta_to_pl_duration,
     format_path,
 )
 
@@ -1289,8 +1290,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     def groupby_rolling(
         self: LDF,
         index_column: str,
-        period: str,
-        offset: str | None = None,
+        period: str | timedelta,
+        offset: str | timedelta | None = None,
         closed: ClosedWindow = "right",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
@@ -1300,11 +1301,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Also works for index values of type Int32 or Int64.
 
         Different from a ``dynamic_groupby`` the windows are now determined by the
-        individual values and are not of constant intervals. For constant intervals use
-        *groupby_dynamic*
+        individual values and are not of constant intervals. For constant intervals
+        use *groupby_dynamic*.
 
-        The `period` and `offset` arguments are created with
-        the following string language:
+        The `period` and `offset` arguments are created either from a timedelta, or
+        by using the following string language:
 
         - 1ns   (1 nanosecond)
         - 1us   (1 microsecond)
@@ -1396,7 +1397,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         if offset is None:
             offset = f"-{period}"
+
         pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
+        period = _timedelta_to_pl_duration(period)
+        offset = _timedelta_to_pl_duration(offset)
 
         lgb = self._ldf.groupby_rolling(
             index_column, period, offset, closed, pyexprs_by
@@ -1406,9 +1410,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     def groupby_dynamic(
         self: LDF,
         index_column: str,
-        every: str,
-        period: str | None = None,
-        offset: str | None = None,
+        every: str | timedelta,
+        period: str | timedelta | None = None,
+        offset: str | timedelta | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
         closed: ClosedWindow = "left",
@@ -1490,8 +1494,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
                 offset = f"-{every}"
             else:
                 offset = "0ns"
+
         if period is None:
             period = every
+
+        period = _timedelta_to_pl_duration(period)
+        offset = _timedelta_to_pl_duration(offset)
+        every = _timedelta_to_pl_duration(every)
+
         pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
         lgb = self._ldf.groupby_dynamic(
             index_column,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3970,9 +3970,9 @@ class Series:
         Parameters
         ----------
         window_size
-            Size of the rolling window
+            Integer size of the rolling window.
         bias
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         Examples
         --------
@@ -4326,7 +4326,7 @@ class Series:
         Parameters
         ----------
         bias : bool, optional
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         Notes
         -----
@@ -4369,7 +4369,7 @@ class Series:
             If True, Fisher's definition is used (normal ==> 0.0). If False,
             Pearson's definition is used (normal ==> 3.0).
         bias : bool, optional
-            If False, then the calculations are corrected for statistical bias.
+            If False, the calculations are corrected for statistical bias.
 
         """
         return self._s.kurtosis(fisher, bias)

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar, overload
 
 import polars.internals as pli
 from polars.datatypes import DataType, Date, Datetime, PolarsDataType, is_polars_dtype
@@ -40,8 +40,25 @@ def _process_null_values(
         return null_values
 
 
-def _timedelta_to_pl_duration(td: timedelta) -> str:
-    return f"{td.days}d{td.seconds}s{td.microseconds}us"
+@overload
+def _timedelta_to_pl_duration(td: None) -> None:
+    ...
+
+
+@overload
+def _timedelta_to_pl_duration(td: timedelta | str) -> str:
+    ...
+
+
+def _timedelta_to_pl_duration(td: timedelta | str | None) -> str | None:
+    """Convert python timedelta to a polars duration string."""
+    if td is None or isinstance(td, str):
+        return td
+    else:
+        d = td.days and f"{td.days}d" or ""
+        s = td.seconds and f"{td.seconds}s" or ""
+        us = td.microseconds and f"{td.microseconds}us" or ""
+        return f"{d}{s}{us}"
 
 
 def _datetime_to_pl_timestamp(dt: datetime, tu: TimeUnit | None) -> int:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -686,16 +686,19 @@ def test_rolling() -> None:
     df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_column(
         pl.col("dt").str.strptime(pl.Datetime)
     )
-    out = df.groupby_rolling(index_column="dt", period="2d").agg(
-        [
-            pl.sum("a").alias("sum_a"),
-            pl.min("a").alias("min_a"),
-            pl.max("a").alias("max_a"),
-        ]
-    )
-    assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
-    assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]
-    assert out["min_a"].to_list() == [3, 3, 3, 3, 2, 1]
+
+    period: str | timedelta
+    for period in ("2d", timedelta(days=2)):  # type: ignore[assignment]
+        out = df.groupby_rolling(index_column="dt", period=period).agg(
+            [
+                pl.sum("a").alias("sum_a"),
+                pl.min("a").alias("min_a"),
+                pl.max("a").alias("max_a"),
+            ]
+        )
+        assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
+        assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]
+        assert out["min_a"].to_list() == [3, 3, 3, 3, 2, 1]
 
 
 def test_upsample() -> None:
@@ -972,26 +975,29 @@ def test_groupby_rolling_mean_3020() -> None:
             "val": range(7),
         }
     ).with_column(pl.col("Date").str.strptime(pl.Date))
-    assert (
-        df.groupby_rolling(index_column="Date", period="1w")
-        .agg(pl.col("val").mean().alias("val_mean"))
-        .frame_equal(
-            pl.DataFrame(
-                {
-                    "Date": [
-                        date(1998, 4, 12),
-                        date(1998, 4, 19),
-                        date(1998, 4, 26),
-                        date(1998, 5, 3),
-                        date(1998, 5, 10),
-                        date(1998, 5, 17),
-                        date(1998, 5, 24),
-                    ],
-                    "val_mean": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-                }
+
+    period: str | timedelta
+    for period in ("1w", timedelta(days=7)):  # type: ignore[assignment]
+        assert (
+            df.groupby_rolling(index_column="Date", period=period)
+            .agg(pl.col("val").mean().alias("val_mean"))
+            .frame_equal(
+                pl.DataFrame(
+                    {
+                        "Date": [
+                            date(1998, 4, 12),
+                            date(1998, 4, 19),
+                            date(1998, 4, 26),
+                            date(1998, 5, 3),
+                            date(1998, 5, 10),
+                            date(1998, 5, 17),
+                            date(1998, 5, 24),
+                        ],
+                        "val_mean": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                    }
+                )
             )
         )
-    )
 
 
 def test_asof_join() -> None:
@@ -1444,7 +1450,7 @@ def test_groupby_rolling_by_() -> None:
     )
     out = (
         df.sort("datetime")
-        .groupby_rolling(index_column="datetime", by="group", period="3d")
+        .groupby_rolling(index_column="datetime", by="group", period=timedelta(days=3))
         .agg([pl.count().alias("count")])
     )
 


### PR DESCRIPTION
Enables use of py-native `timedelta` values for most (all?) parameters that would otherwise require duration-string notation; may not be as flexible/granular, but it's convenient if that's what you're already working with to pass them straight in.

For example:
```python
df.groupby_rolling(
    index_column = "dt", 
    period = timedelta(days=3),  # << or just "3d" (as normal)
)
```

* ref: https://github.com/pola-rs/polars/issues/5470#issuecomment-1311747965