### PR TITLE
ci: install stable data.table from nearest repo

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate data
         working-directory: py-polars/tests/db-benchmark
         run: |
-          Rscript -e 'install.packages("data.table"); data.table::update_dev_pkg()'
+          Rscript -e 'install.packages("data.table",repos = "https://cloud.r-project.org")'
           Rscript groupby-datagen.R 1e7 1e2 5 0
 
       - name: Set up Rust


### PR DESCRIPTION
install stable data.table from the nearest official [mirror](https://cran.r-project.org/mirrors.html)
