### PR TITLE
feat(Python): Support Python 3.11

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
 

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'py-polars/docs/requirements-docs.txt'
 

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'py-polars/requirements-lint.txt'
       - name: Install Python dependencies

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,5 +1,5 @@
 # for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
---index-url https://pypi.fury.io/arrow-nightlies/
+--extra-index-url https://pypi.fury.io/arrow-nightlies/
 --pre
 --prefer-binary
 

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,3 +1,8 @@
+# for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
+--index-url https://pypi.fury.io/arrow-nightlies/
+--pre
+--prefer-binary
+
 numpy
 pandas
 pyarrow

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -2,6 +2,11 @@
 # We're not pinning package dependencies, because our tests need to pass with the
 # latest version of the packages.
 
+# for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
+--index-url https://pypi.fury.io/arrow-nightlies/
+--pre
+--prefer-binary
+
 # Dependencies
 numpy
 pandas

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -3,7 +3,7 @@
 # latest version of the packages.
 
 # for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
---index-url https://pypi.fury.io/arrow-nightlies/
+--extra-index-url https://pypi.fury.io/arrow-nightlies/
 --pre
 --prefer-binary
 


### PR DESCRIPTION
# Intro

Python 3.11 has been released on Oct 24, 2022. It seems most of our dependencies (pandas, numpy) have wheels available by now. We are not building wheels for a specific Python version, nor do we have a constraint that says <= Python 3.10, so 3.11 users can already do a `pip install polars`, and install using the wheels. This works fine, with the exception of PyArrow integration (see below). However, we currently do not test against 3.11 in our CI, so we are not really able to support 3.11 users yet. Therefore, in this PR, I want to upgrade the version from 3.10 to 3.11. As before, we make the assumption that if it works on Python 3.7 and Python 3.11, the versions in between are fine as well. The upgrade is for tests, linting and docs building, so that Polars contributors only need one Python version installed.

# Implementation

Note that PyArrow 10.0.0, the latest published version, does not have 3.11 wheels yet. So upgrading would only work for users not requiring PyArrow support (which works for most of the code due to our lazy loading), or compiling PyArrow locally. I could not get the latter to work yet. Other (dev) dependencies are fine.

I guess two potential cons:
1. we are testing against a dev version of PyArrow, breakage on their side may block our CI. Risk seems small, as we have a very small surface area with PyArrow)
2. the `--pre` flag in the requirements files can only be set globally, so potentially we pull pre-release versions of other packages on pip (numpy, pandas; not even sure they do pre-releases). This is not happening right now, but if that happens, we have an elevated risk of breaking our CI. Again, risk seems minimal.