### PR TITLE
fix(python): preserve `Series` name when exporting to `pandas`

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2724,10 +2724,12 @@ class Series:
         0    1
         1    2
         2    3
-        dtype: int64
+        Name: a, dtype: int64
 
         """
-        return self.to_arrow().to_pandas()
+        pd_series = self.to_arrow().to_pandas()
+        pd_series.name = self.name
+        return pd_series
 
     def set(self, filter: Series, value: int | float | str) -> Series:
         """

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -417,6 +417,27 @@ def test_cast() -> None:
         pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
 
 
+def test_to_pandas() -> None:
+    for test_data in (
+        [1, None, 2],
+        ["abc", None, "xyz"],
+        [None, datetime.now()],
+        [[1, 2], [3, 4], None],
+    ):
+        a = pl.Series("s", test_data)
+        b = a.to_pandas()
+
+        assert a.name == b.name
+        assert b.isnull().sum() == 1
+
+        if a.dtype == pl.List:
+            cvals = [(None if x is None else x.tolist()) for x in b]
+            assert cvals == test_data
+        else:
+            c = b.replace({np.nan: None})
+            assert c.values.tolist() == test_data  # type: ignore[union-attr]
+
+
 def test_to_python() -> None:
     a = pl.Series("a", range(20))
     b = a.to_list()


### PR DESCRIPTION
Exporting `Series` to `pandas` stripped the column name, as the call is mediated by `pyarrow` and `pyarrow` arrays aren't named; this just ensures the name is preserved on export (and adds some extra test coverage).