### PR TITLE
feat(rust, python): pl.min & pl.max accept wildcard similar to pl.sum

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -898,39 +898,27 @@ pub fn sum_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
 
 /// Get the the maximum value per row
 pub fn max_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
-    let mut exprs = exprs.as_ref().to_vec();
+    let exprs = exprs.as_ref().to_vec();
     if exprs.is_empty() {
         return Expr::Columns(Vec::new());
     }
-
     let func = |s1, s2| {
         let df = DataFrame::new_no_checks(vec![s1, s2]);
         df.hmax().map(|s| s.unwrap())
     };
-    let init = match exprs.pop() {
-        Some(e) => e,
-        // use u32 as that is not cast to float as eagerly
-        _ => lit(Series::new_empty("", &DataType::Int32)),
-    };
-    fold_exprs(init, func, exprs).alias("max")
+    reduce_exprs(func, exprs).alias("max")
 }
 
 pub fn min_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
-    let mut exprs = exprs.as_ref().to_vec();
+    let exprs = exprs.as_ref().to_vec();
     if exprs.is_empty() {
         return Expr::Columns(Vec::new());
     }
-
     let func = |s1, s2| {
         let df = DataFrame::new_no_checks(vec![s1, s2]);
         df.hmin().map(|s| s.unwrap())
     };
-    let init = match exprs.pop() {
-        Some(e) => e,
-        // use u32 as that is not cast to float as eagerly
-        _ => lit(Series::new_empty("", &DataType::Int32)),
-    };
-    fold_exprs(init, func, exprs).alias("min")
+    reduce_exprs(func, exprs).alias("min")
 }
 
 /// Evaluate all the expressions with a bitwise or

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -898,52 +898,39 @@ pub fn sum_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
 
 /// Get the the maximum value per row
 pub fn max_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
-    let exprs = exprs.as_ref().to_vec();
-    max_exprs_impl(exprs)
-}
-
-fn max_exprs_impl(mut exprs: Vec<Expr>) -> Expr {
-    if exprs.len() == 1 {
-        return std::mem::take(&mut exprs[0]);
+    let mut exprs = exprs.as_ref().to_vec();
+    if exprs.len() == 0 {
+        return Expr::Columns(Vec::new());
     }
 
-    let first = std::mem::take(&mut exprs[0]);
-    first
-        .map_many(
-            |s| {
-                let s = s.to_vec();
-                let df = DataFrame::new_no_checks(s);
-                df.hmax().map(|s| s.unwrap())
-            },
-            &exprs[1..],
-            GetOutput::super_type(),
-        )
-        .alias("max")
+    let func = |s1, s2| {
+        let df = DataFrame::new_no_checks(vec![s1, s2]);
+        df.hmax().map(|s| s.unwrap())
+    };
+    let init = match exprs.pop() {
+        Some(e) => e,
+        // use u32 as that is not cast to float as eagerly
+        _ => lit(Series::new_empty("", &DataType::Int32)),
+    };
+    fold_exprs(init, func, exprs).alias("max")
 }
 
-/// Get the the minimum value per row
 pub fn min_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
-    let exprs = exprs.as_ref().to_vec();
-    min_exprs_impl(exprs)
-}
-
-fn min_exprs_impl(mut exprs: Vec<Expr>) -> Expr {
-    if exprs.len() == 1 {
-        return std::mem::take(&mut exprs[0]);
+    let mut exprs = exprs.as_ref().to_vec();
+    if exprs.len() == 0 {
+        return Expr::Columns(Vec::new());
     }
 
-    let first = std::mem::take(&mut exprs[0]);
-    first
-        .map_many(
-            |s| {
-                let s = s.to_vec();
-                let df = DataFrame::new_no_checks(s);
-                df.hmin().map(|s| s.unwrap())
-            },
-            &exprs[1..],
-            GetOutput::super_type(),
-        )
-        .alias("min")
+    let func = |s1, s2| {
+        let df = DataFrame::new_no_checks(vec![s1, s2]);
+        df.hmin().map(|s| s.unwrap())
+    };
+    let init = match exprs.pop() {
+        Some(e) => e,
+        // use u32 as that is not cast to float as eagerly
+        _ => lit(Series::new_empty("", &DataType::Int32)),
+    };
+    fold_exprs(init, func, exprs).alias("min")
 }
 
 /// Evaluate all the expressions with a bitwise or

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -899,7 +899,7 @@ pub fn sum_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
 /// Get the the maximum value per row
 pub fn max_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
     let mut exprs = exprs.as_ref().to_vec();
-    if exprs.len() == 0 {
+    if exprs.is_empty() {
         return Expr::Columns(Vec::new());
     }
 
@@ -917,7 +917,7 @@ pub fn max_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
 
 pub fn min_exprs<E: AsRef<[Expr]>>(exprs: E) -> Expr {
     let mut exprs = exprs.as_ref().to_vec();
-    if exprs.len() == 0 {
+    if exprs.is_empty() {
         return Expr::Columns(Vec::new());
     }
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1283,6 +1283,14 @@ def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:
     assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
 
 
+def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min(["*"]))
+    assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
+
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max(["*"]))
+    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+
+
 def test_head_tail(fruits_cars: pl.DataFrame) -> None:
     res_expr = fruits_cars.select([pl.head("A", 2)])
     res_series = pl.head(fruits_cars["A"], 2)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1286,8 +1286,17 @@ def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:
 def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min(["*"]))
     assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min([pl.all()]))
+    assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
 
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max(["*"]))
+    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max([pl.all()]))
+    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(
+        pl.max([pl.all(), "A", "*"])
+    )
     assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
 
 


### PR DESCRIPTION
pl.min and pl.max cannot handle wildcards as pl.sum.

pl.min(["*"])  becomes the same as pl.col(['*']) because code impl handles [selected columns] as tokens before wildcard expansion. 

this PR suggest to use the pl.sum impl pattern which relies on a fold that does wild card expansion with all bells and whistles.

Contra:
This PR do perform extra shallow copies which might hit performance if +1000 columns.
Maybe this can be fixed.