### PR TITLE
fix(rust, python): allow appending categoricals that are all null

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -4,6 +4,12 @@ use crate::series::IsSorted;
 
 impl CategoricalChunked {
     pub fn append(&mut self, other: &Self) -> PolarsResult<()> {
+        if self.logical.null_count() == self.len() && other.logical.null_count() == other.len() {
+            let len = self.len();
+            self.logical_mut().length += other.len() as IdxSize;
+            new_chunks(&mut self.logical.chunks, &other.logical().chunks, len);
+            return Ok(());
+        }
         let is_local_different_source =
             match (self.get_rev_map().as_ref(), other.get_rev_map().as_ref()) {
                 (RevMapping::Local(arr_l), RevMapping::Local(arr_r)) => !std::ptr::eq(arr_l, arr_r),

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -268,3 +268,11 @@ def test_categorical_list_concat_4762() -> None:
     q = df.lazy().select([pl.concat_list([pl.col("x").cast(pl.Categorical)] * 2)])
     with pl.StringCache():
         assert q.collect().to_dict(False) == expected
+
+
+def test_categorical_max_null_5437() -> None:
+    assert (
+        pl.DataFrame({"strings": ["c", "b", "a", "c"], "values": [0, 1, 2, 3]})
+        .with_column(pl.col("strings").cast(pl.Categorical).alias("cats"))
+        .select(pl.all().max())
+    ).to_dict(False) == {"strings": ["c"], "values": [3], "cats": [None]}


### PR DESCRIPTION
fixes #5437