### PR TITLE
fix(rust, python): fix streaming empty join panic

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -288,6 +288,9 @@ ahash = "0.7"
 criterion = "0.3"
 rand = "0.8"
 
+[build-dependencies]
+version_check = "0.9.4"
+
 # see: https://bheisler.github.io/criterion.rs/book/faq.html
 [lib]
 bench = false

--- a/polars/build.rs
+++ b/polars/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let channel = version_check::Channel::read().unwrap();
+    if channel.is_nightly() {
+        println!("cargo:rustc-cfg=feature=\"nightly\"");
+    }
+}

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -176,6 +176,9 @@ impl GenericBuild {
 impl Sink for GenericBuild {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
         if chunk.is_empty() {
+            if self.chunks.is_empty() {
+                self.chunks.push(chunk)
+            }
             return Ok(SinkResult::CanHaveMoreInput);
         }
         let mut hashes = std::mem::take(&mut self.hashes);
@@ -300,7 +303,9 @@ impl Sink for GenericBuild {
                         .map(|chunk| chunk.data),
                 );
                 if let Ok(n_chunks) = left_df.n_chunks() {
-                    assert_eq!(n_chunks, chunks_len);
+                    if left_df.height() > 0 {
+                        assert_eq!(n_chunks, chunks_len);
+                    }
                 }
                 let materialized_join_cols =
                     Arc::new(std::mem::take(&mut self.materialized_join_cols));

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "polars-ops",
  "polars-sql",
  "polars-time",
+ "version_check",
 ]
 
 [[package]]

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -93,4 +93,4 @@ def test_streaming_empty_df() -> None:
 
     assert df.lazy().join(df.lazy(), on="a", how="inner").filter(
         2 == 1  # noqa: SIM300
-    ).collect().to_dict(False) == {"a": [], "b": [], "b_right": []}
+    ).collect(allow_streaming=True).to_dict(False) == {"a": [], "b": [], "b_right": []}


### PR DESCRIPTION
fixes #5523

As a drive by also automatically activates "nightly" feature if compiled with nightly rustc.