### PR TITLE
perf(rust, python): specialized utf8 groupby in streaming

### DIFF
--- a/polars/polars-core/src/datatypes/any_value.rs
+++ b/polars/polars-core/src/datatypes/any_value.rs
@@ -609,7 +609,7 @@ impl<'a> From<AnyValue<'a>> for Option<i64> {
 }
 
 impl PartialEq for AnyValue<'_> {
-    // Everything of Any is slow. Don't use.
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         use AnyValue::*;
         match (self.as_borrowed(), other.as_borrowed()) {

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -18,6 +18,7 @@ polars-io = { version = "0.25.1", path = "../../polars-io", default-features = f
 polars-plan = { version = "0.25.1", path = "../polars-plan", default-features = false, features = ["compile"] }
 polars-utils = { version = "0.25.1", path = "../../polars-utils" }
 rayon.workspace = true
+smartstring = { version = "1" }
 
 [features]
 compile = []

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) mod aggregates;
 mod generic;
 mod primitive;
+mod string;
 mod utils;
 
 pub(crate) use generic::*;
 pub(crate) use primitive::*;
+pub(crate) use string::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -109,7 +109,6 @@ where
     }
 
     fn pre_finalize(&mut self) -> PolarsResult<Vec<DataFrame>> {
-        // TODO! parallel
         let mut aggregators = std::mem::take(&mut self.aggregators);
         let slices = compute_slices(&self.pre_agg_partitions, self.slice);
 

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -177,6 +177,13 @@ where
                         )) as Box<dyn Sink>
                     })
                 }
+                (DataType::Utf8, 1) => Box::new(groupby::Utf8GroupbySink::new(
+                    key_columns[0].clone(),
+                    aggregation_columns,
+                    agg_fns,
+                    output_schema.clone(),
+                    options.slice,
+                )) as Box<dyn Sink>,
                 _ => Box::new(groupby::GenericGroupbySink::new(
                     key_columns,
                     aggregation_columns,

--- a/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
@@ -1,6 +1,11 @@
 use std::any::Any;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::SeqCst;
 
-use polars_core::error::PolarsResult;
+use polars_core::error::{
+    PolarsResult, PolarsError
+};
 use polars_core::frame::DataFrame;
 use polars_core::utils::concat_df_unchecked;
 use polars_core::POOL;
@@ -23,6 +28,8 @@ pub struct PipeLine {
     sink_nodes: Vec<Node>,
     rh_sides: Vec<PipeLine>,
     operator_offset: usize,
+    sink_error: Arc<Mutex<Option<PolarsError>>>,
+    sink_finished: Arc<AtomicBool>
 }
 
 impl PipeLine {
@@ -58,6 +65,8 @@ impl PipeLine {
             sink_nodes,
             rh_sides: vec![],
             operator_offset,
+            sink_error: Default::default(),
+            sink_finished: Default::default()
         }
     }
 
@@ -84,40 +93,55 @@ impl PipeLine {
         ec: &PExecutionContext,
         operator_start: usize,
         operator_end: usize,
-    ) -> PolarsResult<Vec<SinkResult>> {
+    )  {
         debug_assert!(chunks.len() <= sink.len());
         let mut operators = std::mem::take(&mut self.operators);
-        let out = POOL.install(|| {
+        POOL.install(|| {
             chunks
                 .into_par_iter()
                 .zip(sink.par_iter_mut())
                 .zip(operators.par_iter_mut())
-                .map(|((chunk, sink), operator_pipe)| {
+                .for_each(|((chunk, sink), operator_pipe)| {
                     // truncate the operators that should run into the current sink.
                     let operator_pipe = &mut operator_pipe[operator_start..operator_end];
 
-                    if operator_pipe.is_empty() {
+                    let sink_out = if operator_pipe.is_empty() {
                         sink.sink(ec, chunk)
                     } else {
-                        match self.push_operators(chunk, ec, operator_pipe)? {
-                            OperatorResult::Finished(chunk) => sink.sink(ec, chunk),
-                            // probably empty chunk?
-                            OperatorResult::NeedsNewData => Ok(SinkResult::CanHaveMoreInput),
-                            _ => todo!(),
+                        match self.push_operators(chunk, ec, operator_pipe) {
+                            Ok(result) => {
+                                match result {
+                                    OperatorResult::Finished(chunk) => sink.sink(ec, chunk),
+                                    // probably empty chunk?
+                                    OperatorResult::NeedsNewData => Ok(SinkResult::CanHaveMoreInput),
+                                    _ => todo!(),
+                                }
+                            },
+                            Err(err) => {
+                                self.sink_finished.store(true, SeqCst);
+                                let mut sink_error = self.sink_error.lock().unwrap();
+                                *sink_error = Some(err);
+                                return
+                            }
+                        }
+                    };
+                    match sink_out {
+                        Ok(SinkResult::Finished) => {
+                            self.sink_finished.store(true, SeqCst);
+                        }
+                        Ok(SinkResult::CanHaveMoreInput) => {
+                            // pass
+                        }
+                        Err(err) => {
+                            self.sink_finished.store(true, SeqCst);
+                            let mut sink_error = self.sink_error.lock().unwrap();
+                            *sink_error = Some(err);
+
                         }
                     }
-                })
-                // only collect failed and finished messages as there should be acted upon those
-                // the other ones (e.g. success and can have more input) can be ignored
-                // this saves a lot of allocations.
-                .filter(|result| match result {
-                    Ok(sink_result) => matches!(sink_result, SinkResult::Finished),
-                    Err(_) => true,
-                })
-                .collect()
+                });
         });
         self.operators = operators;
-        out
     }
 
     fn push_operators(
@@ -185,18 +209,20 @@ impl PipeLine {
         {
             for src in &mut std::mem::take(&mut self.sources) {
                 while let SourceResult::GotMoreData(chunks) = src.get_batches(ec)? {
-                    let results = self.par_process_chunks(
+                    self.par_process_chunks(
                         chunks,
                         &mut sink,
                         ec,
                         operator_start,
                         operator_end,
-                    )?;
-
-                    if results
-                        .iter()
-                        .any(|sink_result| matches!(sink_result, SinkResult::Finished))
-                    {
+                    );
+                    let finished = self.sink_finished.load(SeqCst);
+                    if finished {
+                        // check for errors
+                        let mut err = self.sink_error.lock().unwrap();
+                        if let Some(err) = err.take() {
+                            return Err(err)
+                        }
                         break;
                     }
                 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "polars-plan",
  "polars-utils",
  "rayon",
+ "smartstring",
 ]
 
 [[package]]


### PR DESCRIPTION
On my local benchmark the groupby can be faster than the default engine.