### PR TITLE
perf(rust): Aggregate projection pushdown

### DIFF
--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -360,3 +360,20 @@ where
     }
     single_pred.expect("an empty iterator was passed")
 }
+
+pub fn expr_is_projected_upstream(
+    e: &Node,
+    input: Node,
+    lp_arena: &mut Arena<ALogicalPlan>,
+    expr_arena: &Arena<AExpr>,
+    projected_names: &PlHashSet<Arc<str>>,
+) -> bool {
+    let input_schema = lp_arena.get(input).schema(lp_arena);
+    // don't do projection that is not used in upstream selection
+    let output_field = expr_arena
+        .get(*e)
+        .to_field(input_schema.as_ref(), Context::Default, expr_arena)
+        .unwrap();
+    let output_name = output_field.name();
+    projected_names.contains(output_name.as_str())
+}

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -41,6 +41,19 @@ def test_double_projection_pushdown() -> None:
     )
 
 
+def test_groupby_projection_pushdown() -> None:
+    assert (
+        "PROJECT 2/3 COLUMNS"
+        in (
+            pl.DataFrame({"c0": [], "c1": [], "c2": []})
+            .lazy()
+            .groupby("c0")
+            .agg(pl.col("*"))
+            .select(["c1"])
+        ).describe_optimized_plan()
+    )
+
+
 def test_unnest_projection_pushdown() -> None:
     lf = pl.DataFrame({"x|y|z": [1, 2], "a|b|c": [2, 3]}).lazy()
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -48,8 +48,13 @@ def test_groupby_projection_pushdown() -> None:
             pl.DataFrame({"c0": [], "c1": [], "c2": []})
             .lazy()
             .groupby("c0")
-            .agg(pl.col("*"))
-            .select(["c1"])
+            .agg(
+                [
+                    pl.col("c1").sum().alias("sum(c1)"),
+                    pl.col("c2").mean().alias("mean(c2)"),
+                ]
+            )
+            .select(["sum(c1)"])
         ).describe_optimized_plan()
     )
 


### PR DESCRIPTION
Allow for projection pushdown past groupby(...) operation in optimization of logical plan.
closes #5553 