### PR TITLE
chore: Remove top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-fmt_toml:
-	dprint fmt

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -4,7 +4,7 @@ BASE ?= master
 
 fmt:
 	cargo fmt --all
-	$(MAKE) -C .. fmt_toml
+	dprint fmt
 
 check:
 	cargo check --all-features \


### PR DESCRIPTION
I feel like this Makefile doesn't really add much. All it does is run `dprint fmt`, which you don't need a Makefile for. Let's get rid of it!