### PR TITLE
chore: Remove .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.ipynb linguist-documentation


### PR DESCRIPTION
This file was added to the repo in [this commit](https://github.com/pola-rs/polars/commit/0f380f1a65fa296015f6501c77ce4e616440e5b8); not sure what it does but it seems to support the [Linguist](https://github.com/github/linguist) tool in order to enable the "10 minutes to Polars" notebook.

This notebook is no longer part of the repo, and there are no other notebooks in the repo, so I believe this file can be removed.