### PR TITLE
fix(rust, python): fix ternary with list output on empty frame

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -110,6 +110,9 @@ impl PhysicalExpr for TernaryExpr {
         if falsy.is_empty() {
             return Ok(falsy);
         }
+        if mask.is_empty() {
+            return Ok(Series::new_empty(truthy.name(), truthy.dtype()));
+        }
 
         expand_lengths(&mut truthy, &mut falsy, &mut mask);
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -94,3 +94,9 @@ def test_streaming_empty_df() -> None:
     assert df.lazy().join(df.lazy(), on="a", how="inner").filter(
         2 == 1  # noqa: SIM300
     ).collect(allow_streaming=True).to_dict(False) == {"a": [], "b": [], "b_right": []}
+
+
+def test_when_then_empty_list_5547() -> None:
+    out = pl.DataFrame({"a": []}).select([pl.when(pl.col("a") > 1).then([1])])
+    assert out.shape == (0, 1)
+    assert out.dtypes == [pl.List(pl.Int64)]


### PR DESCRIPTION
fixes #5547