### PR TITLE
fix(rust, python): keep dtype when eval on empty list

### DIFF
--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -36,6 +36,9 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
         let expr2 = expr.clone();
         let func = move |s: Series| {
             let lst = s.list()?;
+            if lst.is_empty() {
+                return Ok(s);
+            }
 
             let phys_expr =
                 prepare_expression_for_context("", &expr, &lst.inner_dtype(), Context::Default)?;

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -545,3 +545,17 @@ def test_list_sliced_get_5186() -> None:
             ]
         )
     )
+
+
+def test_empty_eval_dtype_5546() -> None:
+    df = pl.DataFrame([{"a": [{"name": 1}, {"name": 2}]}])
+
+    dtype = df.dtypes[0]
+
+    assert (
+        df.limit(0).with_column(
+            pl.col("a")
+            .arr.eval(pl.element().filter(pl.first().struct.field("name") == 1))
+            .alias("a_filtered")
+        )
+    ).dtypes == [dtype, dtype]


### PR DESCRIPTION
fixes #5546