### PR TITLE
ci(python): try to turn off build_info

### DIFF
--- a/.github/workflows/create-python-release.yaml
+++ b/.github/workflows/create-python-release.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma --cfg build_info
         with:
           rust-toolchain: nightly-2022-11-03
           maturin-version: '0.13.5'
@@ -52,6 +52,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+          RUSTFLAGS: --cfg build_info
         with:
           rust-toolchain: nightly-2022-11-03
           target: aarch64-unknown-linux-gnu
@@ -82,7 +83,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma --cfg build_info
         with:
           rust-toolchain: nightly-2022-11-03
           maturin-version: '0.13.5'
@@ -109,7 +110,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc --cfg build_info
         with:
           rust-toolchain: nightly-2022-11-03
           maturin-version: '0.13.5'
@@ -138,7 +139,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
+          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2 --cfg build_info
         with:
           rust-toolchain: nightly-2022-11-03
           maturin-version: '0.13.5'
@@ -170,6 +171,7 @@ jobs:
         uses: messense/maturin-action@v1
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
+          RUSTFLAGS: --cfg build_info
         with:
           maturin-version: '0.13.5'
           command: publish

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -20,6 +20,12 @@ mimalloc = { version = "*", default-features = false }
 [target.'cfg(all(target_os = "linux", not(use_mimalloc)))'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
 
+[target.'cfg(build_info)'.dependencies]
+pyo3-built = { version = "0.4" }
+
+[target.'cfg(build_info)'.build-dependencies]
+built = { version = "0.5", features = ["chrono", "git2"]}
+
 [dependencies]
 ahash = "0.8"
 bincode = "1.3"
@@ -31,7 +37,6 @@ once_cell = "1"
 polars-core = { path = "../polars/polars-core", default-features = false }
 polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-features = false }
 pyo3 = { version = "0.16", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
-pyo3-built = { version = "0.4", optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "^1.0"
 
@@ -62,7 +67,6 @@ pivot = ["polars/pivot"]
 top_k = ["polars/top_k"]
 propagate_nans = ["polars/propagate_nans"]
 sql = ["polars/sql"]
-build_info = ["dep:pyo3-built", "dep:built"]
 
 all = [
   "json",
@@ -86,7 +90,6 @@ all = [
   "object",
   "pivot",
   "top_k",
-  "build_info",
   # we need to add this, as maturin fails if we don't
   # remove this once polars-algo is released
   "polars/algo",
@@ -177,4 +180,3 @@ lto = "fat"
 # target-cpu = "native"
 
 [build-dependencies]
-built = { version = "0.5", features = ["chrono", "git2"], optional = true }


### PR DESCRIPTION
I try to make `build_info` only compiled in CI, but it doesn't work for some reason. Modifying any unrelated file leads to a recompile.

#5612 

@slonik-az, @stinodego  do you think I am missing something obvious here?