### PR TITLE
fix(rust, python): fix dynamic struct inference

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -67,8 +67,10 @@ where
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => {
                 // cast to first field dtype
-                let dtype = &fields[0].dtype;
-                let s = cast_impl_inner(self.name(), &self.chunks, dtype, true)?;
+                let fld = &fields[0];
+                let dtype = &fld.dtype;
+                let name = &fld.name;
+                let s = cast_impl_inner(name, &self.chunks, dtype, true)?;
                 Ok(StructChunked::new_unchecked(self.name(), &[s]).into_series())
             }
             _ => cast_impl_inner(self.name(), &self.chunks, data_type, checked).map(|mut s| {
@@ -206,7 +208,7 @@ impl ChunkCast for ListChunked {
                         new_values,
                         arr.validity().cloned(),
                     );
-                    Series::try_from((s.name(), Box::new(new_arr) as ArrayRef))
+                    Series::try_from((self.name(), Box::new(new_arr) as ArrayRef))
                 }
             }
             _ => Err(PolarsError::ComputeError("Cannot cast list type".into())),

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -259,7 +259,7 @@ fn is_nested_null(av: &AnyValue) -> bool {
     }
 }
 
-// nested dtypes that are all null, will be set as null leaf dtype
+// nested dtypes that are all null, will be set as null leave dtype
 fn infer_dtype_dynamic(av: &AnyValue) -> DataType {
     match av {
         AnyValue::List(s) if s.null_count() == s.len() => DataType::List(Box::new(DataType::Null)),

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -458,6 +458,15 @@ def test_from_dicts_list_struct_without_inner_dtype() -> None:
         "days_of_week": [1, 2],
     }
 
+    # 5611
+    df = pl.from_dicts(
+        [
+            {"a": []},
+            {"a": [{"b": 1}]},
+        ]
+    )
+    assert df.to_dict(False) == {"a": [[], [{"b": 1}]]}
+
 
 def test_upcast_primitive_and_strings() -> None:
     assert pl.Series([1, 1.0, 1]).dtype == pl.Float64


### PR DESCRIPTION
fixes #5611