### PR TITLE
Diag concat for LazyFrames

### DIFF
--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -84,7 +84,7 @@ pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
             });
     }
 
-    let dfs = lfs
+    let lfs_with_all_columns = lfs
         .into_iter()
         // Zip Frames with their Schemas
         .zip(schemas.into_iter())
@@ -109,7 +109,7 @@ pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
         })
         .collect::<PolarsResult<Vec<_>>>()?;
 
-    concat(dfs, rechunk, parallel)
+    concat(lfs_with_all_columns, rechunk, parallel)
 }
 
 

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -50,6 +50,69 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
     }
 }
 
+#[cfg(feature = "diagonal_concat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "diagonal_concat")))]
+/// Concat [LazyFrame]s diagonally.
+/// Calls [concat] internally.
+pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
+    lfs: L,
+    rechunk: bool,
+    parallel: bool,
+) -> PolarsResult<LazyFrame> {
+    let lfs = lfs.as_ref().to_vec();
+    let schemas = lfs
+        .iter()
+        .map(|lf| Ok(lf.schema()?))
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let upper_bound_width = schemas
+        .iter()
+        .map(|sch| sch.len())
+        .sum();
+
+    // Use Vec to preserve order
+    let mut column_names = Vec::with_capacity(upper_bound_width);
+    let mut total_schema = Vec::with_capacity(upper_bound_width);
+
+    for sch in schemas.iter() {
+        sch.iter()
+            .for_each(|(name, dtype)|{
+                if !column_names.contains(name) {
+                    column_names.push(name.clone());
+                    total_schema.push((name.clone(), dtype.clone()));
+                }
+            });
+    }
+
+    let dfs = lfs
+        .into_iter()
+        // Zip Frames with their Schemas
+        .zip(schemas.into_iter())
+        .map(|(mut lf, lf_schema)| {
+
+            for (name, dtype) in total_schema.iter() {
+                // If a name from Total Schema is not present - append
+                if lf_schema.get_field(name).is_none() {
+                    lf = lf.with_column(NULL.lit().cast(dtype.clone()).alias(name))
+                }
+            }
+
+            // Now, reorder to match schema
+            let reordered_lf = lf.select(
+                column_names
+                    .iter()
+                    .map(|col_name| col(col_name))
+                    .collect::<Vec<Expr>>(),
+            );
+
+            Ok(reordered_lf)
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    concat(dfs, rechunk, parallel)
+}
+
+
 /// Concat multiple
 pub fn concat<L: AsRef<[LazyFrame]>>(
     inputs: L,
@@ -67,4 +130,43 @@ where
     let iter = lfs.into_par_iter();
 
     polars_core::POOL.install(|| iter.map(|lf| lf.collect()).collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "diagonal_concat")]
+    fn test_diag_concat_lf() -> PolarsResult<()> {
+        let a = df![
+            "a" => [1, 2],
+            "b" => ["a", "b"]
+        ]?;
+
+        let b = df![
+            "b" => ["a", "b"],
+            "c" => [1, 2]
+        ]?;
+
+        let c = df![
+            "a" => [5, 7],
+            "c" => [1, 2],
+            "d" => [1, 2]
+        ]?;
+
+        let out = diag_concat_lf(&[a.lazy(), b.lazy(), c.lazy()], false, false)?
+            .collect()?;
+
+        let expected = df![
+            "a" => [Some(1), Some(2), None, None, Some(5), Some(7)],
+            "b" => [Some("a"), Some("b"), Some("a"), Some("b"), None, None],
+            "c" => [None, None, Some(1), Some(2), Some(1), Some(2)],
+            "d" => [None, None, None, None, Some(1), Some(2)]
+        ]?;
+
+        assert!(out.frame_equal_missing(&expected));
+
+        Ok(())
+    }
 }

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -65,23 +65,19 @@ pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
         .map(|lf| Ok(lf.schema()?))
         .collect::<PolarsResult<Vec<_>>>()?;
 
-    let upper_bound_width = schemas
-        .iter()
-        .map(|sch| sch.len())
-        .sum();
+    let upper_bound_width = schemas.iter().map(|sch| sch.len()).sum();
 
     // Use Vec to preserve order
     let mut column_names = Vec::with_capacity(upper_bound_width);
     let mut total_schema = Vec::with_capacity(upper_bound_width);
 
     for sch in schemas.iter() {
-        sch.iter()
-            .for_each(|(name, dtype)|{
-                if !column_names.contains(name) {
-                    column_names.push(name.clone());
-                    total_schema.push((name.clone(), dtype.clone()));
-                }
-            });
+        sch.iter().for_each(|(name, dtype)| {
+            if !column_names.contains(name) {
+                column_names.push(name.clone());
+                total_schema.push((name.clone(), dtype.clone()));
+            }
+        });
     }
 
     let lfs_with_all_columns = lfs
@@ -89,7 +85,6 @@ pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
         // Zip Frames with their Schemas
         .zip(schemas.into_iter())
         .map(|(mut lf, lf_schema)| {
-
             for (name, dtype) in total_schema.iter() {
                 // If a name from Total Schema is not present - append
                 if lf_schema.get_field(name).is_none() {
@@ -111,7 +106,6 @@ pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(
 
     concat(lfs_with_all_columns, rechunk, parallel)
 }
-
 
 /// Concat multiple
 pub fn concat<L: AsRef<[LazyFrame]>>(
@@ -155,8 +149,7 @@ mod test {
             "d" => [1, 2]
         ]?;
 
-        let out = diag_concat_lf(&[a.lazy(), b.lazy(), c.lazy()], false, false)?
-            .collect()?;
+        let out = diag_concat_lf(&[a.lazy(), b.lazy(), c.lazy()], false, false)?.collect()?;
 
         let expected = df![
             "a" => [Some(1), Some(2), None, None, Some(5), Some(7)],


### PR DESCRIPTION
diag_concat exists for Eager frames, but not for Lazy frames. This function is a diag_concat for lazy frames.

PS: I've been trying to test this with `cargo test test_diag_concat_lf --features=diagonal_concat,lazy` but couldn't compile due to errors. Ran this exact test locally and it passed.