### PR TITLE
fix(python): Fix `DataFrame.n_chunks` return type

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5606,15 +5606,11 @@ class DataFrame:
         )
 
     @overload
-    def n_chunks(self, strategy: Literal["first"]) -> int:
+    def n_chunks(self, strategy: Literal["first"] = ...) -> int:
         ...
 
     @overload
     def n_chunks(self, strategy: Literal["all"]) -> list[int]:
-        ...
-
-    @overload
-    def n_chunks(self, strategy: str = "first") -> int | list[int]:
         ...
 
     def n_chunks(self, strategy: str = "first") -> int | list[int]:


### PR DESCRIPTION
Changes:
* Fix the overloaded type for `DataFrame.n_chunks` so that it correctly infers the `int` type when called without any arguments.
