### PR TITLE
fix(python): Fix type for Datetime/Duration time unit

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -226,10 +226,10 @@ class Date(DataType):
 class Datetime(DataType):
     """Calendar date and time type."""
 
-    tu: TimeUnit | None = None
+    tu: TimeUnit
     tz: str | None = None
 
-    def __init__(self, time_unit: TimeUnit | None = "us", time_zone: str | None = None):
+    def __init__(self, time_unit: TimeUnit = "us", time_zone: str | None = None):
         """
         Calendar date and time type.
 
@@ -261,7 +261,7 @@ class Datetime(DataType):
 class Duration(DataType):
     """Time duration/delta type."""
 
-    tu: TimeUnit | None = None
+    tu: TimeUnit
 
     def __init__(self, time_unit: TimeUnit = "us"):
         """

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -242,6 +242,7 @@ class Datetime(DataType):
             ``import zoneinfo; zoneinfo.available_timezones()`` for a full list).
 
         """
+        # TODO: Remove the `or "us"` part, since time_unit cannot be None.
         self.tu = time_unit or "us"
         self.tz = time_zone
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2482,7 +2482,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_europe = "Europe/Amsterdam"
 
     dtm = datetime(2022, 10, 12, 12, 30, tzinfo=zoneinfo.ZoneInfo("UTC"))
-    for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for tu in DTYPE_TEMPORAL_UNITS:
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},
             columns=[
@@ -2504,7 +2504,7 @@ def test_init_physical_with_timezone() -> None:
     tz_asia = "Asia/Tokyo"
 
     dtm_us = 1665577800000000
-    for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for tu in DTYPE_TEMPORAL_UNITS:
         dtm = {"ms": dtm_us // 1_000, "ns": dtm_us * 1_000}.get(str(tu), dtm_us)
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},


### PR DESCRIPTION
The time unit attribute `tu` for Datetime and Duration cannot be actually `None` - it will always be set to a default.

I will also add a 'breaking' PR that removes handling of the `None` input (see the TODO comment).