### PR TITLE
chore(rust): Use `NaiveTime::from_hms_opt` instead of `NaiveTime::from_hms`

### DIFF
--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -468,8 +468,8 @@ mod test {
             "datetime" => [NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0)],
             "optional_date" => [Some(NaiveDate::from_ymd(2021, 1, 1))],
             "optional_datetime" => [Some(NaiveDate::from_ymd(2021, 1, 1).and_hms(0, 0, 0))],
-            "time" => [NaiveTime::from_hms(23, 23, 23)],
-            "optional_time" => [Some(NaiveTime::from_hms(23, 23, 23))],
+            "time" => [NaiveTime::from_hms_opt(23, 23, 23).unwrap()],
+            "optional_time" => [Some(NaiveTime::from_hms_opt(23, 23, 23).unwrap())],
             "duration" => [ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap()],
             "optional_duration" => [Some(ChronoDuration::from_std(std::time::Duration::from_secs(10)).unwrap())],
         ].unwrap();

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -430,9 +430,9 @@ fn test_lazy_query_10() {
     let x: Series = DatetimeChunked::from_naive_datetime(
         "x",
         [
-            NaiveDateTime::new(date, NaiveTime::from_hms(12, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(13, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(14, 0, 0)),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(13, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(14, 0, 0).unwrap()),
         ],
         TimeUnit::Nanoseconds,
     )
@@ -440,9 +440,9 @@ fn test_lazy_query_10() {
     let y: Series = DatetimeChunked::from_naive_datetime(
         "y",
         [
-            NaiveDateTime::new(date, NaiveTime::from_hms(11, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(11, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(11, 0, 0)),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(11, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(11, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(11, 0, 0).unwrap()),
         ],
         TimeUnit::Nanoseconds,
     )
@@ -467,9 +467,9 @@ fn test_lazy_query_10() {
     let x: Series = DatetimeChunked::from_naive_datetime(
         "x",
         [
-            NaiveDateTime::new(date, NaiveTime::from_hms(2, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(3, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(4, 0, 0)),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(2, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(3, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(4, 0, 0).unwrap()),
         ],
         TimeUnit::Milliseconds,
     )
@@ -477,9 +477,9 @@ fn test_lazy_query_10() {
     let y: Series = DatetimeChunked::from_naive_datetime(
         "y",
         [
-            NaiveDateTime::new(date, NaiveTime::from_hms(1, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(1, 0, 0)),
-            NaiveDateTime::new(date, NaiveTime::from_hms(1, 0, 0)),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(1, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(1, 0, 0).unwrap()),
+            NaiveDateTime::new(date, NaiveTime::from_hms_opt(1, 0, 0).unwrap()),
         ],
         TimeUnit::Nanoseconds,
     )
@@ -505,12 +505,12 @@ fn test_lazy_query_10() {
 fn test_lazy_query_7() {
     let date = NaiveDate::from_ymd(2021, 3, 5);
     let dates = [
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 0, 0)),
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 1, 0)),
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 2, 0)),
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 3, 0)),
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 4, 0)),
-        NaiveDateTime::new(date, NaiveTime::from_hms(12, 5, 0)),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 1, 0).unwrap()),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 2, 0).unwrap()),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 3, 0).unwrap()),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 4, 0).unwrap()),
+        NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 5, 0).unwrap()),
     ];
     let data = vec![Some(1.), Some(2.), Some(3.), Some(4.), None, None];
     let df = DataFrame::new(vec![
@@ -523,7 +523,10 @@ fn test_lazy_query_7() {
         .lazy()
         .with_column(col("data").shift(-1).alias("output"))
         .with_column(col("output").shift(2).alias("shifted"))
-        .filter(col("date").gt(lit(NaiveDateTime::new(date, NaiveTime::from_hms(12, 2, 0)))))
+        .filter(col("date").gt(lit(NaiveDateTime::new(
+            date,
+            NaiveTime::from_hms_opt(12, 2, 0).unwrap(),
+        ))))
         .collect()
         .unwrap();
     let a = out.column("shifted").unwrap().sum::<f64>().unwrap() - 7.0;


### PR DESCRIPTION
Partially addresses #5659.

This removes the following deprecating warning which used to be raised several times:

```
warning: use of deprecated associated function `chrono::NaiveTime::from_hms_opt`: use `from_hms_opt()` instead
```