### PR TITLE
chore(rust): Remove unused symbols and uneeded `mut` qualifier

### DIFF
--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1287,7 +1287,6 @@ mod test {
             .unwrap();
         // create a new cache
         reset_string_cache();
-        let sc = IUseStringCache::new();
 
         df_b.try_apply("bar", |s| s.cast(&DataType::Categorical(None)))
             .unwrap();

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1288,6 +1288,9 @@ mod test {
         // create a new cache
         reset_string_cache();
 
+        // _sc is needed to ensure we hold the string cache.
+        let _sc = IUseStringCache::new();
+
         df_b.try_apply("bar", |s| s.cast(&DataType::Categorical(None)))
             .unwrap();
         let out = df_a.join(&df_b, ["b"], ["bar"], JoinType::Left, None);

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1,7 +1,6 @@
 use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::series::ops::NullBehavior;
-use polars_core::utils::concat_df;
 use polars_time::prelude::DateMethods;
 
 use super::*;

--- a/polars/polars-lazy/src/tests/streaming.rs
+++ b/polars/polars-lazy/src/tests/streaming.rs
@@ -1,5 +1,3 @@
-use polars_core::prelude::JoinType::AsOf;
-
 use super::*;
 
 fn get_csv_file() -> LazyFrame {

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -758,7 +758,7 @@ mod test {
         let groups = Series::new("groups", ["a", "a", "a", "b", "b", "a", "a"]);
         let df = DataFrame::new(vec![range, groups.clone()]).unwrap();
 
-        let (mut time_key, mut keys, groups) = df
+        let (mut time_key, keys, _groups) = df
             .groupby_dynamic(
                 vec![groups],
                 &DynamicGroupOptions {


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/5659.

This removes the warnings due to unused imports and variables and a unneeded `mut` qualifier.