### PR TITLE
refactor(rust)!: remove Series::append_array

### DIFF
--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -123,10 +123,6 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0.slice(offset, length).into_series()
     }

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -137,10 +137,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0.slice(offset, length).into_series()
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -174,10 +174,6 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.logical_mut().shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.logical_mut().append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.with_state(false, |cats| cats.slice(offset, length))
             .into_series()

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -206,10 +206,6 @@ macro_rules! impl_dyn_series {
                 self.0.shrink_to_fit()
             }
 
-            fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-                self.0.append_array(other)
-            }
-
             fn slice(&self, offset: i64, length: usize) -> Series {
                 self.0.slice(offset, length).$into_logical().into_series()
             }

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -216,10 +216,6 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0
             .slice(offset, length)

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -244,10 +244,6 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0
             .slice(offset, length)

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -182,10 +182,6 @@ macro_rules! impl_dyn_series {
                 self.0.shrink_to_fit()
             }
 
-            fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-                self.0.append_array(other)
-            }
-
             fn slice(&self, offset: i64, length: usize) -> Series {
                 return self.0.slice(offset, length).into_series();
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -66,10 +66,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0.slice(offset, length).into_series()
     }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -273,10 +273,6 @@ macro_rules! impl_dyn_series {
                 self.0.shrink_to_fit()
             }
 
-            fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-                self.0.append_array(other)
-            }
-
             fn slice(&self, offset: i64, length: usize) -> Series {
                 return self.0.slice(offset, length).into_series();
             }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -88,10 +88,6 @@ where
         ObjectChunked::chunks(&self.0)
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        ObjectChunked::append_array(&mut self.0, other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         ObjectChunked::slice(&self.0, offset, length).into_series()
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -123,10 +123,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.shrink_to_fit()
     }
 
-    fn append_array(&mut self, other: ArrayRef) -> PolarsResult<()> {
-        self.0.append_array(other)
-    }
-
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0.slice(offset, length).into_series()
     }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -198,12 +198,6 @@ impl Series {
         self._get_inner_mut().shrink_to_fit()
     }
 
-    /// Append arrow array of same datatype.
-    pub fn append_array(&mut self, other: ArrayRef) -> PolarsResult<&mut Self> {
-        self._get_inner_mut().append_array(other)?;
-        Ok(self)
-    }
-
     /// Append in place. This is done by adding the chunks of `other` to this [`Series`].
     ///
     /// See [`ChunkedArray::append`] and [`ChunkedArray::extend`].

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -263,11 +263,6 @@ pub trait SeriesTrait:
         panic!("shrink to fit not supported for dtype {:?}", self.dtype())
     }
 
-    /// Append Arrow array of same dtype to this Series.
-    fn append_array(&mut self, _other: ArrayRef) -> PolarsResult<()> {
-        invalid_operation_panic!(self)
-    }
-
     /// Take `num_elements` from the top as a zero copy view.
     fn limit(&self, num_elements: usize) -> Series {
         self.slice(0, num_elements)


### PR DESCRIPTION
This is removed as it is hard to ensure invariants hold.