### PR TITLE
fix(python): Fix Series -> Expr dispatch for @property methods

### DIFF
--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -72,7 +72,10 @@ def _expr_lookup(namespace: str | None) -> set[tuple[str | None, str, tuple[str,
     lookup = set()
     for name in dir(expr):
         if not name.startswith("_"):
-            m = getattr(expr, name)
+            try:
+                m = getattr(expr, name)
+            except AttributeError:  # May be raised for @property methods
+                continue
             if callable(m):
                 # add function signature (argument names only) to the lookup
                 # as a _possible_ candidate for expression-dispatch


### PR DESCRIPTION
This is a bit of an ugly patch, but it was impossible to define a `@property` method on the `Expr` side. This is a workaround.

For context, I was trying to define an `ordered` property on the categorical namespace when I ran into this.

Overall I am not really happy with how the 'dispatching' worked out. The piece of code that takes care of it is too complicated for what it actually does. Anyway, that's a worry for another time, I guess.