### PR TITLE
fix(rust): Fix a bug in floating regex handling used in CSV type inference

### DIFF
--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -83,7 +83,8 @@ pub fn get_reader_bytes<R: Read + MmapBytesReader + ?Sized>(
 }
 
 static FLOAT_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^(\s*-?((\d*\.\d+)[eE]?[-\+]?\d*)|[-+]?inf|[-+]?NaN|\d+[eE][-+]\d+)$").unwrap()
+    Regex::new(r"^(\s*-?((\d*\.\d+)[eE]?[-\+]?\d*)|[-+]?inf|[-+]?NaN|[-+]?\d+[eE][-+]\d+)$")
+        .unwrap()
 });
 
 static INTEGER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\s*-?(\d+)$").unwrap());
@@ -624,6 +625,9 @@ mod test {
         assert!(FLOAT_RE.is_match("-NaN"));
         assert!(FLOAT_RE.is_match("-inf"));
         assert!(FLOAT_RE.is_match("inf"));
+        assert!(FLOAT_RE.is_match("-7e-05"));
+        assert!(FLOAT_RE.is_match("7e-05"));
+        assert!(FLOAT_RE.is_match("+7e+05"));
     }
 
     #[test]


### PR DESCRIPTION
Type regular expression did not correctly match numbers of the form -7e+5. It correctly handled the case of 7e+5 but the RE would fail matching when the number is preceded with [+-]?

The regular expressio is updated and I added additional test cases. All existing test cases still pass.