### PR TITLE
test(python): Parametrize `test_parquet_datetime`

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -131,7 +131,7 @@ def test_parquet_chunks() -> None:
 
 @pytest.mark.parametrize("use_pyarrow", [True, False])
 @pytest.mark.parametrize("compression", COMPRESSIONS)
-def test_parquet_datetime(use_pyarrow, compression: ParquetCompression) -> None:
+def test_parquet_datetime(use_pyarrow: bool, compression: ParquetCompression) -> None:
     if compression == "lzo":
         back_end = "C++" if use_pyarrow else "Rust"
         pytest.skip(


### PR DESCRIPTION
This removes a `todo!`-comment.

I think there are several ways of treating this: let me know if what I propose here fit your conventions.