### PR TITLE
Build `comfy-table` with default_features = false

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -153,7 +153,7 @@ base64 = { version = "0.13", optional = true }
 bitflags.workspace = true
 chrono = { version = "0.4", optional = true }
 chrono-tz = { version = "0.6", optional = true }
-comfy-table = { version = "6.1.1", optional = true }
+comfy-table = { version = "6.1.1", optional = true, default_features = false }
 hashbrown.workspace = true
 hex = { version = "0.4", optional = true }
 indexmap = { version = "1", features = ["std"] }


### PR DESCRIPTION
`comfy-table` by default pulls in `console2`, which isn't needed as far as I can tell by the `polars/fmt` feature, and is a blocker when building Polars for wasm32.