### PR TITLE
Fix docstring formatting

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2149,6 +2149,7 @@ class DataFrame:
             - "gzip" : min-level: 0, max-level: 10.
             - "brotli" : min-level: 0, max-level: 11.
             - "zstd" : min-level: 1, max-level: 22.
+
         statistics
             Write statistics to the parquet headers. This requires extra compute.
         row_group_size


### PR DESCRIPTION
Without an additional newline after the list, "statistics" shows up on the same line as "zstd"

<img width="642" alt="image" src="https://user-images.githubusercontent.com/1297369/205450387-0f8a3786-54e9-41ad-b5b3-b23e81bd32fd.png">
