### PR TITLE
refactor(rust): simplify fast projection by schema

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use polars_core::datatypes::Field;
 use polars_core::error::PolarsResult;
-use polars_core::prelude::{DataType, Series, IDX_DTYPE, SchemaRef};
+use polars_core::prelude::{DataType, SchemaRef, Series, IDX_DTYPE};
 use polars_core::schema::Schema;
 use polars_plan::logical_plan::{ArenaExprIter, Context};
 use polars_plan::prelude::{AAggExpr, AExpr};

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
@@ -202,10 +202,6 @@ impl GenericGroupbySink {
 
 impl Sink for GenericGroupbySink {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
-        let state = context.execution_state.as_ref();
-        if !state.input_schema_is_set() {
-            state.set_input_schema(self.input_schema.clone())
-        }
         let num_aggs = self.number_of_aggs();
 
         // todo! amortize allocation
@@ -416,8 +412,7 @@ impl Sink for GenericGroupbySink {
         Box::new(new)
     }
 
-    fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
-        context.execution_state.clear_input_schema();
+    fn finalize(&mut self, _context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         let dfs = self.pre_finalize()?;
         if dfs.is_empty() {
             return Ok(FinalizedSink::Finished(DataFrame::from(

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -182,10 +182,6 @@ where
     ChunkedArray<K>: IntoSeries,
 {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
-        let state = context.execution_state.as_ref();
-        if !state.input_schema_is_set() {
-            state.set_input_schema(self.input_schema.clone())
-        }
         let num_aggs = self.number_of_aggs();
 
         let s = self
@@ -307,8 +303,7 @@ where
             });
     }
 
-    fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
-        context.execution_state.clear_input_schema();
+    fn finalize(&mut self, _context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         let dfs = self.pre_finalize()?;
         if dfs.is_empty() {
             return Ok(FinalizedSink::Finished(DataFrame::from(

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/string.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/string.rs
@@ -169,10 +169,6 @@ impl Utf8GroupbySink {
 
 impl Sink for Utf8GroupbySink {
     fn sink(&mut self, context: &PExecutionContext, chunk: DataChunk) -> PolarsResult<SinkResult> {
-        let state = context.execution_state.as_ref();
-        if !state.input_schema_is_set() {
-            state.set_input_schema(self.input_schema.clone())
-        }
         let num_aggs = self.number_of_aggs();
 
         // todo! amortize allocation
@@ -348,8 +344,7 @@ impl Sink for Utf8GroupbySink {
         Box::new(new)
     }
 
-    fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
-        context.execution_state.clear_input_schema();
+    fn finalize(&mut self, _context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         let dfs = self.pre_finalize()?;
         if dfs.is_empty() {
             return Ok(FinalizedSink::Finished(DataFrame::from(

--- a/polars/polars-lazy/polars-pipe/src/operators/context.rs
+++ b/polars/polars-lazy/polars-pipe/src/operators/context.rs
@@ -1,14 +1,6 @@
 use std::any::Any;
 
-use polars_core::schema::SchemaRef;
-
 pub trait SExecutionContext: Send + Sync {
-    fn input_schema_is_set(&self) -> bool;
-
-    fn set_input_schema(&self, schema: SchemaRef);
-
-    fn clear_input_schema(&self);
-
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -15,7 +15,7 @@ fn exprs_to_physical<F>(
     exprs: &[Node],
     expr_arena: &mut Arena<AExpr>,
     to_physical: &F,
-    schema: Option<&SchemaRef>
+    schema: Option<&SchemaRef>,
 ) -> PolarsResult<Vec<Arc<dyn PhysicalPipedExpr>>>
 where
     F: Fn(Node, &Arena<AExpr>, Option<&SchemaRef>) -> PolarsResult<Arc<dyn PhysicalPipedExpr>>,
@@ -123,10 +123,18 @@ where
             #[cfg(feature = "cross_join")]
             JoinType::Cross => Box::new(CrossJoin::new(options.suffix.clone())) as Box<dyn Sink>,
             join_type @ JoinType::Inner | join_type @ JoinType::Left => {
-                let join_columns_left =
-                    Arc::new(exprs_to_physical(left_on, expr_arena, to_physical, Some(schema))?);
-                let join_columns_right =
-                    Arc::new(exprs_to_physical(right_on, expr_arena, to_physical, Some(schema))?);
+                let join_columns_left = Arc::new(exprs_to_physical(
+                    left_on,
+                    expr_arena,
+                    to_physical,
+                    Some(schema),
+                )?);
+                let join_columns_right = Arc::new(exprs_to_physical(
+                    right_on,
+                    expr_arena,
+                    to_physical,
+                    Some(schema),
+                )?);
 
                 let swapped = swap_join_order(options);
 
@@ -158,7 +166,12 @@ where
             options,
             ..
         } => {
-            let key_columns = Arc::new(exprs_to_physical(keys, expr_arena, to_physical, Some(output_schema))?);
+            let key_columns = Arc::new(exprs_to_physical(
+                keys,
+                expr_arena,
+                to_physical,
+                Some(output_schema),
+            )?);
 
             let mut aggregation_columns = Vec::with_capacity(aggs.len());
             let mut agg_fns = Vec::with_capacity(aggs.len());

--- a/polars/polars-lazy/src/dsl/eval.rs
+++ b/polars/polars-lazy/src/dsl/eval.rs
@@ -21,7 +21,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
             let expr = expr.clone();
             let mut arena = Arena::with_capacity(10);
             let aexpr = to_aexpr(expr, &mut arena);
-            let phys_expr = create_physical_expr(aexpr, Context::Default, &arena)?;
+            let phys_expr = create_physical_expr(aexpr, Context::Default, &arena, None)?;
 
             let state = ExecutionState::new();
 

--- a/polars/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -48,7 +48,6 @@ pub(super) fn groupby_helper(
     let gb = df.groupby_with_series(keys, true, maintain_order)?;
 
     if let Some(f) = apply {
-        state.clear_schema_cache();
         return gb.apply(move |df| f.call_udf(df));
     }
 
@@ -86,7 +85,6 @@ pub(super) fn groupby_helper(
     let agg_columns = agg_columns?;
 
     columns.extend_from_slice(&agg_columns);
-    state.clear_schema_cache();
     DataFrame::new(columns)
 }
 
@@ -96,7 +94,6 @@ impl GroupByExec {
         state: &mut ExecutionState,
         df: DataFrame,
     ) -> PolarsResult<DataFrame> {
-        state.set_schema(self.input_schema.clone());
         let keys = self
             .keys
             .iter()

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_dynamic.rs
@@ -24,7 +24,6 @@ impl GroupByDynamicExec {
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
         df.as_single_chunk_par();
-        state.set_schema(self.input_schema.clone());
 
         // if the periods are larger than the intervals,
         // the groups overlap
@@ -75,7 +74,6 @@ impl GroupByDynamicExec {
                 .collect::<PolarsResult<Vec<_>>>()
         })?;
 
-        state.clear_schema_cache();
         let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
         columns.extend_from_slice(&keys);
         columns.push(time_key);

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -12,10 +12,12 @@ pub struct PartitionGroupByExec {
     maintain_order: bool,
     slice: Option<(i64, usize)>,
     input_schema: SchemaRef,
+    output_schema: SchemaRef,
     from_partitioned_ds: bool,
 }
 
 impl PartitionGroupByExec {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         input: Box<dyn Executor>,
         keys: Vec<Arc<dyn PhysicalExpr>>,
@@ -23,6 +25,7 @@ impl PartitionGroupByExec {
         maintain_order: bool,
         slice: Option<(i64, usize)>,
         input_schema: SchemaRef,
+        output_schema: SchemaRef,
         from_partitioned_ds: bool,
     ) -> Self {
         Self {
@@ -32,6 +35,7 @@ impl PartitionGroupByExec {
             maintain_order,
             slice,
             input_schema,
+            output_schema,
             from_partitioned_ds,
         }
     }
@@ -258,6 +262,7 @@ impl PartitionGroupByExec {
             )?
         };
 
+        state.set_schema(self.output_schema.clone());
         // MERGE phase
         // merge and hash aggregate again
         let df = accumulate_dataframes_vertical(dfs)?;
@@ -296,6 +301,7 @@ impl PartitionGroupByExec {
             POOL.install(|| rayon::join(get_columns, get_agg));
 
         columns.extend(agg_columns?);
+        state.clear_schema_cache();
 
         Ok(DataFrame::new(columns).unwrap())
     }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -231,8 +231,6 @@ impl PartitionGroupByExec {
             // of groups.
             let keys = self.keys(&original_df, state)?;
 
-            // set it here, because `self.input.execute` will clear the schema cache.
-            state.set_schema(self.input_schema.clone());
             if !can_run_partitioned(&keys, &original_df, state, self.from_partitioned_ds)? {
                 return groupby_helper(
                     original_df,
@@ -259,7 +257,6 @@ impl PartitionGroupByExec {
                 self.maintain_order,
             )?
         };
-        state.clear_schema_cache();
 
         // MERGE phase
         // merge and hash aggregate again
@@ -299,7 +296,6 @@ impl PartitionGroupByExec {
             POOL.install(|| rayon::join(get_columns, get_agg));
 
         columns.extend(agg_columns?);
-        state.clear_schema_cache();
 
         Ok(DataFrame::new(columns).unwrap())
     }

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -22,7 +22,6 @@ impl GroupByRollingExec {
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
         df.as_single_chunk_par();
-        state.set_schema(self.input_schema.clone());
 
         let keys = self
             .keys
@@ -73,7 +72,6 @@ impl GroupByRollingExec {
                 .collect::<PolarsResult<Vec<_>>>()
         })?;
 
-        state.clear_schema_cache();
         let mut columns = Vec::with_capacity(agg_columns.len() + 1 + keys.len());
         columns.extend_from_slice(&keys);
         columns.push(time_key);

--- a/polars/polars-lazy/src/physical_plan/executors/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/mod.rs
@@ -114,7 +114,6 @@ fn execute_projection_cached_window_fns(
     for mut partition in windows {
         // clear the cache for every partitioned group
         let mut state = state.split();
-        state.clear_expr_cache();
 
         // don't bother caching if we only have a single window function in this partition
         if partition.1.len() == 1 {
@@ -172,7 +171,6 @@ pub(crate) fn evaluate_physical_expressions(
                 .collect::<PolarsResult<_>>()
         })?
     };
-    state.clear_schema_cache();
 
     check_expand_literals(selected_columns, zero_length)
 }

--- a/polars/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/projection.rs
@@ -17,8 +17,7 @@ impl ProjectionExec {
         state: &mut ExecutionState,
         df: DataFrame,
     ) -> PolarsResult<DataFrame> {
-        state.set_schema(self.input_schema.clone());
-
+        #[allow(clippy::let_and_return)]
         let df = evaluate_physical_expressions(&df, &self.expr, state, self.has_windows);
 
         // this only runs during testing and check if the runtime type matches the predicted schema
@@ -33,7 +32,6 @@ impl ProjectionExec {
             });
         }
 
-        state.clear_expr_cache();
         df
     }
 }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -79,7 +79,6 @@ impl Executor for DataFrameExec {
         // projection should be before selection as those are free
         // TODO: this is only the case if we don't create new columns
         if let Some(projection) = &self.projection {
-            state.may_set_schema(&df, projection.len());
             df = df.select(projection.as_ref())?;
         }
 
@@ -90,7 +89,6 @@ impl Executor for DataFrameExec {
             })?;
             df = df.filter(mask)?;
         }
-        state.clear_schema_cache();
 
         if let Some(limit) = _set_n_rows_for_scan(None) {
             Ok(df.head(Some(limit)))

--- a/polars/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/stack.rs
@@ -13,7 +13,6 @@ impl StackExec {
         state: &mut ExecutionState,
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
-        state.set_schema(self.input_schema.clone());
         let res = if self.has_windows {
             // we have a different run here
             // to ensure the window functions run sequential and share caches
@@ -26,7 +25,6 @@ impl StackExec {
                     .collect::<PolarsResult<Vec<_>>>()
             })?
         };
-        state.clear_schema_cache();
         state.clear_expr_cache();
 
         let schema = &*self.input_schema;

--- a/polars/polars-lazy/src/physical_plan/exotic.rs
+++ b/polars/polars-lazy/src/physical_plan/exotic.rs
@@ -39,5 +39,5 @@ pub(crate) fn prepare_expression_for_context(
     let lp = lp_arena.get(optimized);
     let aexpr = lp.get_exprs().pop().unwrap();
 
-    create_physical_expr(aexpr, ctxt, &expr_arena)
+    create_physical_expr(aexpr, ctxt, &expr_arena, None)
 }

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -10,7 +10,7 @@ pub(crate) fn create_physical_expressions(
     exprs: &[Node],
     context: Context,
     expr_arena: &Arena<AExpr>,
-    schema: Option<&SchemaRef>
+    schema: Option<&SchemaRef>,
 ) -> PolarsResult<Vec<Arc<dyn PhysicalExpr>>> {
     exprs
         .iter()
@@ -22,7 +22,7 @@ pub(crate) fn create_physical_expr(
     expression: Node,
     ctxt: Context,
     expr_arena: &Arena<AExpr>,
-    schema: Option<&SchemaRef>
+    schema: Option<&SchemaRef>,
 ) -> PolarsResult<Arc<dyn PhysicalExpr>> {
     use AExpr::*;
 
@@ -37,7 +37,8 @@ pub(crate) fn create_physical_expr(
             // TODO! Order by
             let group_by =
                 create_physical_expressions(&partition_by, Context::Default, expr_arena, schema)?;
-            let phys_function = create_physical_expr(function, Context::Aggregation, expr_arena, schema)?;
+            let phys_function =
+                create_physical_expr(function, Context::Aggregation, expr_arena, schema)?;
             let mut out_name = None;
             let mut apply_columns = aexpr_to_leaf_names(function, expr_arena);
             // sort and then dedup removes consecutive duplicates == all duplicates
@@ -95,6 +96,7 @@ pub(crate) fn create_physical_expr(
         Column(column) => Ok(Arc::new(ColumnExpr::new(
             column,
             node_to_expr(expression, expr_arena),
+            schema.cloned(),
         ))),
         Sort { expr, options } => {
             let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -10,10 +10,11 @@ pub(crate) fn create_physical_expressions(
     exprs: &[Node],
     context: Context,
     expr_arena: &Arena<AExpr>,
+    schema: Option<&SchemaRef>
 ) -> PolarsResult<Vec<Arc<dyn PhysicalExpr>>> {
     exprs
         .iter()
-        .map(|e| create_physical_expr(*e, context, expr_arena))
+        .map(|e| create_physical_expr(*e, context, expr_arena, schema))
         .collect()
 }
 
@@ -21,6 +22,7 @@ pub(crate) fn create_physical_expr(
     expression: Node,
     ctxt: Context,
     expr_arena: &Arena<AExpr>,
+    schema: Option<&SchemaRef>
 ) -> PolarsResult<Arc<dyn PhysicalExpr>> {
     use AExpr::*;
 
@@ -34,8 +36,8 @@ pub(crate) fn create_physical_expr(
         } => {
             // TODO! Order by
             let group_by =
-                create_physical_expressions(&partition_by, Context::Default, expr_arena)?;
-            let phys_function = create_physical_expr(function, Context::Aggregation, expr_arena)?;
+                create_physical_expressions(&partition_by, Context::Default, expr_arena, schema)?;
+            let phys_function = create_physical_expr(function, Context::Aggregation, expr_arena, schema)?;
             let mut out_name = None;
             let mut apply_columns = aexpr_to_leaf_names(function, expr_arena);
             // sort and then dedup removes consecutive duplicates == all duplicates
@@ -81,8 +83,8 @@ pub(crate) fn create_physical_expr(
             node_to_expr(expression, expr_arena),
         ))),
         BinaryExpr { left, op, right } => {
-            let lhs = create_physical_expr(left, ctxt, expr_arena)?;
-            let rhs = create_physical_expr(right, ctxt, expr_arena)?;
+            let lhs = create_physical_expr(left, ctxt, expr_arena, schema)?;
+            let rhs = create_physical_expr(right, ctxt, expr_arena, schema)?;
             Ok(Arc::new(phys_expr::BinaryExpr::new(
                 lhs,
                 op,
@@ -95,7 +97,7 @@ pub(crate) fn create_physical_expr(
             node_to_expr(expression, expr_arena),
         ))),
         Sort { expr, options } => {
-            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
             Ok(Arc::new(SortExpr::new(
                 phys_expr,
                 options,
@@ -103,8 +105,8 @@ pub(crate) fn create_physical_expr(
             )))
         }
         Take { expr, idx } => {
-            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
-            let phys_idx = create_physical_expr(idx, ctxt, expr_arena)?;
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
+            let phys_idx = create_physical_expr(idx, ctxt, expr_arena, schema)?;
             Ok(Arc::new(TakeExpr {
                 phys_expr,
                 idx: phys_idx,
@@ -112,8 +114,8 @@ pub(crate) fn create_physical_expr(
             }))
         }
         SortBy { expr, by, reverse } => {
-            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
-            let phys_by = create_physical_expressions(&by, ctxt, expr_arena)?;
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
+            let phys_by = create_physical_expressions(&by, ctxt, expr_arena, schema)?;
             Ok(Arc::new(SortByExpr::new(
                 phys_expr,
                 phys_by,
@@ -122,8 +124,8 @@ pub(crate) fn create_physical_expr(
             )))
         }
         Filter { input, by } => {
-            let phys_input = create_physical_expr(input, ctxt, expr_arena)?;
-            let phys_by = create_physical_expr(by, ctxt, expr_arena)?;
+            let phys_input = create_physical_expr(input, ctxt, expr_arena, schema)?;
+            let phys_by = create_physical_expr(by, ctxt, expr_arena, schema)?;
             Ok(Arc::new(FilterExpr::new(
                 phys_input,
                 phys_by,
@@ -131,7 +133,7 @@ pub(crate) fn create_physical_expr(
             )))
         }
         Alias(expr, name) => {
-            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
             Ok(Arc::new(AliasExpr::new(
                 phys_expr,
                 name,
@@ -144,7 +146,7 @@ pub(crate) fn create_physical_expr(
                     input: expr,
                     propagate_nans,
                 } => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             if propagate_nans {
@@ -197,7 +199,7 @@ pub(crate) fn create_physical_expr(
                     input: expr,
                     propagate_nans,
                 } => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             if propagate_nans {
@@ -247,7 +249,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Sum(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Sum)))
@@ -268,7 +270,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Std(expr, ddof) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
                             input,
@@ -290,7 +292,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Var(expr, ddof) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
                             input,
@@ -312,7 +314,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Mean(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Mean)))
@@ -333,7 +335,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Median(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Median)))
@@ -354,7 +356,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::First(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::First)))
@@ -375,7 +377,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::Last(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Last)))
@@ -396,7 +398,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::List(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::List)))
@@ -417,7 +419,7 @@ pub(crate) fn create_physical_expr(
                     }
                 }
                 AAggExpr::NUnique(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => Ok(Arc::new(AggregationExpr::new(
                             input,
@@ -447,7 +449,7 @@ pub(crate) fn create_physical_expr(
                     interpol,
                 } => {
                     // todo! add schema to get correct output type
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggQuantileExpr::new(input, quantile, interpol)))
@@ -471,14 +473,14 @@ pub(crate) fn create_physical_expr(
                     if let Context::Default = ctxt {
                         panic!("agg groups expression only supported in aggregation context")
                     }
-                    let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     Ok(Arc::new(AggregationExpr::new(
                         phys_expr,
                         GroupByMethod::Groups,
                     )))
                 }
                 AAggExpr::Count(expr) => {
-                    let input = create_physical_expr(expr, ctxt, expr_arena)?;
+                    let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
                     match ctxt {
                         Context::Aggregation => {
                             Ok(Arc::new(AggregationExpr::new(input, GroupByMethod::Count)))
@@ -507,7 +509,7 @@ pub(crate) fn create_physical_expr(
             data_type,
             strict,
         } => {
-            let phys_expr = create_physical_expr(expr, ctxt, expr_arena)?;
+            let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
             Ok(Arc::new(CastExpr {
                 input: phys_expr,
                 data_type,
@@ -520,9 +522,9 @@ pub(crate) fn create_physical_expr(
             truthy,
             falsy,
         } => {
-            let predicate = create_physical_expr(predicate, ctxt, expr_arena)?;
-            let truthy = create_physical_expr(truthy, ctxt, expr_arena)?;
-            let falsy = create_physical_expr(falsy, ctxt, expr_arena)?;
+            let predicate = create_physical_expr(predicate, ctxt, expr_arena, schema)?;
+            let truthy = create_physical_expr(truthy, ctxt, expr_arena, schema)?;
+            let falsy = create_physical_expr(falsy, ctxt, expr_arena, schema)?;
             Ok(Arc::new(TernaryExpr::new(
                 predicate,
                 truthy,
@@ -536,7 +538,7 @@ pub(crate) fn create_physical_expr(
             output_type: _,
             options,
         } => {
-            let input = create_physical_expressions(&input, ctxt, expr_arena)?;
+            let input = create_physical_expressions(&input, ctxt, expr_arena, schema)?;
 
             Ok(Arc::new(ApplyExpr {
                 inputs: input,
@@ -553,7 +555,7 @@ pub(crate) fn create_physical_expr(
             options,
             ..
         } => {
-            let input = create_physical_expressions(&input, ctxt, expr_arena)?;
+            let input = create_physical_expressions(&input, ctxt, expr_arena, schema)?;
 
             Ok(Arc::new(ApplyExpr {
                 inputs: input,
@@ -569,9 +571,9 @@ pub(crate) fn create_physical_expr(
             offset,
             length,
         } => {
-            let input = create_physical_expr(input, ctxt, expr_arena)?;
-            let offset = create_physical_expr(offset, ctxt, expr_arena)?;
-            let length = create_physical_expr(length, ctxt, expr_arena)?;
+            let input = create_physical_expr(input, ctxt, expr_arena, schema)?;
+            let offset = create_physical_expr(offset, ctxt, expr_arena, schema)?;
+            let length = create_physical_expr(length, ctxt, expr_arena, schema)?;
             Ok(Arc::new(SliceExpr {
                 input,
                 offset,
@@ -580,7 +582,7 @@ pub(crate) fn create_physical_expr(
             }))
         }
         Explode(expr) => {
-            let input = create_physical_expr(expr, ctxt, expr_arena)?;
+            let input = create_physical_expr(expr, ctxt, expr_arena, schema)?;
             let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
                 let s = std::mem::take(&mut s[0]);
                 s.explode()

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -167,19 +167,19 @@ pub fn create_physical_plan(
         }
         Selection { input, predicate } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let predicate = create_physical_expr(predicate, Context::Default, expr_arena)?;
+            let predicate = create_physical_expr(predicate, Context::Default, expr_arena, None)?;
             Ok(Box::new(executors::FilterExec::new(predicate, input)))
         }
         #[cfg(feature = "csv-file")]
         CsvScan {
             path,
             file_info,
-            output_schema: _,
+            output_schema,
             options,
             predicate,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
                 .map_or(Ok(None), |v| v.map(Some))?;
             Ok(Box::new(executors::CsvExec {
                 path,
@@ -192,12 +192,12 @@ pub fn create_physical_plan(
         IpcScan {
             path,
             file_info,
-            output_schema: _,
+            output_schema,
             predicate,
             options,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
                 .map_or(Ok(None), |v| v.map(Some))?;
 
             Ok(Box::new(executors::IpcExec {
@@ -211,12 +211,12 @@ pub fn create_physical_plan(
         ParquetScan {
             path,
             file_info,
-            output_schema: _,
+            output_schema,
             predicate,
             options,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
                 .map_or(Ok(None), |v| v.map(Some))?;
 
             Ok(Box::new(executors::ParquetExec::new(
@@ -229,51 +229,51 @@ pub fn create_physical_plan(
         Projection {
             expr,
             input,
-            schema: _schema,
+            schema,
             ..
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
             let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
+            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::ProjectionExec {
                 input,
                 expr: phys_expr,
                 has_windows,
                 input_schema,
                 #[cfg(test)]
-                schema: _schema,
+                schema
             }))
         }
         LocalProjection {
             expr,
             input,
-            #[cfg(test)]
-                schema: _schema,
+            schema,
             ..
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
 
             let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena)?;
+            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::ProjectionExec {
                 input,
                 expr: phys_expr,
                 has_windows,
                 input_schema,
                 #[cfg(test)]
-                schema: _schema,
+                schema
             }))
         }
         DataFrameScan {
             df,
             projection,
             selection,
+            schema,
             ..
         } => {
             let selection = selection
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, Some(&schema)))
                 .map_or(Ok(None), |v| v.map(Some))?;
             Ok(Box::new(executors::DataFrameExec {
                 df,
@@ -285,10 +285,11 @@ pub fn create_physical_plan(
             function,
             predicate,
             options,
+            output_schema,
             ..
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena))
+                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
                 .map_or(Ok(None), |v| v.map(Some))?;
             Ok(Box::new(executors::AnonymousScanExec {
                 function,
@@ -302,7 +303,7 @@ pub fn create_physical_plan(
             args,
         } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let by_column = create_physical_expressions(&by_column, Context::Default, expr_arena)?;
+            let by_column = create_physical_expressions(&by_column, Context::Default, expr_arena, None)?;
             Ok(Box::new(executors::SortExec {
                 input,
                 by_column,
@@ -326,13 +327,13 @@ pub fn create_physical_plan(
             keys,
             aggs,
             apply,
-            schema: _output_schema,
+            schema,
             maintain_order,
             options,
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
-            let phys_keys = create_physical_expressions(&keys, Context::Default, expr_arena)?;
-            let phys_aggs = create_physical_expressions(&aggs, Context::Aggregation, expr_arena)?;
+            let phys_keys = create_physical_expressions(&keys, Context::Default, expr_arena, Some(&schema))?;
+            let phys_aggs = create_physical_expressions(&aggs, Context::Aggregation, expr_arena, Some(&schema))?;
 
             let _slice = options.slice;
             #[cfg(feature = "dynamic_groupby")]
@@ -372,11 +373,11 @@ pub fn create_physical_plan(
                     && aggs.len() < 10
                     && std::env::var("POLARS_NO_STREAMING_GROUPBY").is_err()
                 {
-                    let key_dtype = _output_schema.get_index(0).unwrap().1.to_physical();
+                    let key_dtype = schema.get_index(0).unwrap().1.to_physical();
                     // only on numeric and string keys for now
                     let allowed_key = keys.len() == 1 && key_dtype.is_numeric()
                         || matches!(key_dtype, DataType::Utf8);
-                    let allowed_aggs = _output_schema.iter_dtypes().skip(1).all(|dtype| {
+                    let allowed_aggs = schema.iter_dtypes().skip(1).all(|dtype| {
                         let dt = dtype.to_physical();
                         dt.is_numeric() || matches!(dt, DataType::Utf8 | DataType::Boolean)
                     });
@@ -386,7 +387,7 @@ pub fn create_physical_plan(
                         keys,
                         aggs,
                         apply,
-                        schema: _output_schema,
+                        schema,
                         maintain_order,
                         options: options.clone(),
                     };
@@ -442,6 +443,7 @@ pub fn create_physical_plan(
             left_on,
             right_on,
             options,
+            schema,
             ..
         } => {
             let parallel = if options.force_parallel {
@@ -461,8 +463,8 @@ pub fn create_physical_plan(
 
             let input_left = create_physical_plan(input_left, lp_arena, expr_arena)?;
             let input_right = create_physical_plan(input_right, lp_arena, expr_arena)?;
-            let left_on = create_physical_expressions(&left_on, Context::Default, expr_arena)?;
-            let right_on = create_physical_expressions(&right_on, Context::Default, expr_arena)?;
+            let left_on = create_physical_expressions(&left_on, Context::Default, expr_arena, Some(&schema))?;
+            let right_on = create_physical_expressions(&right_on, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::JoinExec::new(
                 input_left,
                 input_right,
@@ -474,11 +476,11 @@ pub fn create_physical_plan(
                 options.slice,
             )))
         }
-        HStack { input, exprs, .. } => {
+        HStack { input, exprs, schema } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
             let has_windows = exprs.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&exprs, Context::Default, expr_arena)?;
+            let phys_expr = create_physical_expressions(&exprs, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::StackExec {
                 input,
                 has_windows,

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -179,7 +179,9 @@ pub fn create_physical_plan(
             predicate,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
+                .map(|pred| {
+                    create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref())
+                })
                 .map_or(Ok(None), |v| v.map(Some))?;
             Ok(Box::new(executors::CsvExec {
                 path,
@@ -197,7 +199,9 @@ pub fn create_physical_plan(
             options,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
+                .map(|pred| {
+                    create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref())
+                })
                 .map_or(Ok(None), |v| v.map(Some))?;
 
             Ok(Box::new(executors::IpcExec {
@@ -216,7 +220,9 @@ pub fn create_physical_plan(
             options,
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
+                .map(|pred| {
+                    create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref())
+                })
                 .map_or(Ok(None), |v| v.map(Some))?;
 
             Ok(Box::new(executors::ParquetExec::new(
@@ -235,14 +241,15 @@ pub fn create_physical_plan(
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
             let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
+            let phys_expr =
+                create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::ProjectionExec {
                 input,
                 expr: phys_expr,
                 has_windows,
                 input_schema,
                 #[cfg(test)]
-                schema
+                schema,
             }))
         }
         LocalProjection {
@@ -255,14 +262,15 @@ pub fn create_physical_plan(
 
             let has_windows = expr.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
+            let phys_expr =
+                create_physical_expressions(&expr, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::ProjectionExec {
                 input,
                 expr: phys_expr,
                 has_windows,
                 input_schema,
                 #[cfg(test)]
-                schema
+                schema,
             }))
         }
         DataFrameScan {
@@ -289,7 +297,9 @@ pub fn create_physical_plan(
             ..
         } => {
             let predicate = predicate
-                .map(|pred| create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref()))
+                .map(|pred| {
+                    create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref())
+                })
                 .map_or(Ok(None), |v| v.map(Some))?;
             Ok(Box::new(executors::AnonymousScanExec {
                 function,
@@ -303,7 +313,8 @@ pub fn create_physical_plan(
             args,
         } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let by_column = create_physical_expressions(&by_column, Context::Default, expr_arena, None)?;
+            let by_column =
+                create_physical_expressions(&by_column, Context::Default, expr_arena, None)?;
             Ok(Box::new(executors::SortExec {
                 input,
                 by_column,
@@ -332,8 +343,14 @@ pub fn create_physical_plan(
             options,
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
-            let phys_keys = create_physical_expressions(&keys, Context::Default, expr_arena, Some(&schema))?;
-            let phys_aggs = create_physical_expressions(&aggs, Context::Aggregation, expr_arena, Some(&schema))?;
+            let phys_keys =
+                create_physical_expressions(&keys, Context::Default, expr_arena, Some(&schema))?;
+            let phys_aggs = create_physical_expressions(
+                &aggs,
+                Context::Aggregation,
+                expr_arena,
+                Some(&schema),
+            )?;
 
             let _slice = options.slice;
             #[cfg(feature = "dynamic_groupby")]
@@ -463,8 +480,14 @@ pub fn create_physical_plan(
 
             let input_left = create_physical_plan(input_left, lp_arena, expr_arena)?;
             let input_right = create_physical_plan(input_right, lp_arena, expr_arena)?;
-            let left_on = create_physical_expressions(&left_on, Context::Default, expr_arena, Some(&schema))?;
-            let right_on = create_physical_expressions(&right_on, Context::Default, expr_arena, Some(&schema))?;
+            let left_on =
+                create_physical_expressions(&left_on, Context::Default, expr_arena, Some(&schema))?;
+            let right_on = create_physical_expressions(
+                &right_on,
+                Context::Default,
+                expr_arena,
+                Some(&schema),
+            )?;
             Ok(Box::new(executors::JoinExec::new(
                 input_left,
                 input_right,
@@ -476,11 +499,16 @@ pub fn create_physical_plan(
                 options.slice,
             )))
         }
-        HStack { input, exprs, schema } => {
+        HStack {
+            input,
+            exprs,
+            schema,
+        } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
             let has_windows = exprs.iter().any(|node| has_aexpr_window(*node, expr_arena));
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let phys_expr = create_physical_expressions(&exprs, Context::Default, expr_arena, Some(&schema))?;
+            let phys_expr =
+                create_physical_expressions(&exprs, Context::Default, expr_arena, Some(&schema))?;
             Ok(Box::new(executors::StackExec {
                 input,
                 has_windows,

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 use bitflags::bitflags;
 use polars_core::frame::groupby::GroupsProxy;
@@ -52,6 +52,7 @@ pub struct ExecutionState {
     // cache file reads until all branches got there file, then we delete it
     #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
     pub(crate) file_cache: FileCache,
+    pub(super) schema_cache: RwLock<Option<SchemaRef>>,
     /// Used by Window Expression to prevent redundant grouping
     pub(super) group_tuples: GroupsProxyCache,
     /// Used by Window Expression to prevent redundant joins
@@ -96,6 +97,7 @@ impl ExecutionState {
             df_cache: self.df_cache.clone(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: self.file_cache.clone(),
+            schema_cache: Default::default(),
             group_tuples: Default::default(),
             join_tuples: Default::default(),
             branch_idx: self.branch_idx,
@@ -111,6 +113,7 @@ impl ExecutionState {
             df_cache: self.df_cache.clone(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: self.file_cache.clone(),
+            schema_cache: self.schema_cache.read().unwrap().clone().into(),
             group_tuples: self.group_tuples.clone(),
             join_tuples: self.join_tuples.clone(),
             branch_idx: self.branch_idx,
@@ -128,6 +131,7 @@ impl ExecutionState {
     pub(crate) fn with_finger_prints(finger_prints: Option<Vec<FileFingerPrint>>) -> Self {
         Self {
             df_cache: Arc::new(Mutex::new(PlHashMap::default())),
+            schema_cache: Default::default(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: FileCache::new(finger_prints),
             group_tuples: Arc::new(Mutex::new(PlHashMap::default())),
@@ -147,6 +151,7 @@ impl ExecutionState {
         }
         Self {
             df_cache: Default::default(),
+            schema_cache: Default::default(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: FileCache::new(None),
             group_tuples: Default::default(),
@@ -156,6 +161,22 @@ impl ExecutionState {
             ext_contexts: Default::default(),
             node_timer: None,
         }
+    }
+    pub(crate) fn set_schema(&self, schema: SchemaRef) {
+        let mut lock = self.schema_cache.write().unwrap();
+        *lock = Some(schema);
+    }
+
+    /// Clear the schema. Typically at the end of a projection.
+    pub(crate) fn clear_schema_cache(&self) {
+        let mut lock = self.schema_cache.write().unwrap();
+        *lock = None;
+    }
+
+    /// Get the schema.
+    pub(crate) fn get_schema(&self) -> Option<SchemaRef> {
+        let lock = self.schema_cache.read().unwrap();
+        lock.clone()
     }
 
     /// Check if we have DataFrame in cache

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::sync::{Mutex, RwLock};
+use std::sync::Mutex;
 
 use bitflags::bitflags;
 use polars_core::frame::groupby::GroupsProxy;
@@ -52,7 +52,6 @@ pub struct ExecutionState {
     // cache file reads until all branches got there file, then we delete it
     #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
     pub(crate) file_cache: FileCache,
-    pub(super) schema_cache: RwLock<Option<SchemaRef>>,
     /// Used by Window Expression to prevent redundant grouping
     pub(super) group_tuples: GroupsProxyCache,
     /// Used by Window Expression to prevent redundant joins
@@ -97,7 +96,6 @@ impl ExecutionState {
             df_cache: self.df_cache.clone(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: self.file_cache.clone(),
-            schema_cache: Default::default(),
             group_tuples: Default::default(),
             join_tuples: Default::default(),
             branch_idx: self.branch_idx,
@@ -113,7 +111,6 @@ impl ExecutionState {
             df_cache: self.df_cache.clone(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: self.file_cache.clone(),
-            schema_cache: self.schema_cache.read().unwrap().clone().into(),
             group_tuples: self.group_tuples.clone(),
             join_tuples: self.join_tuples.clone(),
             branch_idx: self.branch_idx,
@@ -131,7 +128,6 @@ impl ExecutionState {
     pub(crate) fn with_finger_prints(finger_prints: Option<Vec<FileFingerPrint>>) -> Self {
         Self {
             df_cache: Arc::new(Mutex::new(PlHashMap::default())),
-            schema_cache: Default::default(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: FileCache::new(finger_prints),
             group_tuples: Arc::new(Mutex::new(PlHashMap::default())),
@@ -151,7 +147,6 @@ impl ExecutionState {
         }
         Self {
             df_cache: Default::default(),
-            schema_cache: Default::default(),
             #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
             file_cache: FileCache::new(None),
             group_tuples: Default::default(),
@@ -161,30 +156,6 @@ impl ExecutionState {
             ext_contexts: Default::default(),
             node_timer: None,
         }
-    }
-    pub(crate) fn set_schema(&self, schema: SchemaRef) {
-        let mut lock = self.schema_cache.write().unwrap();
-        *lock = Some(schema);
-    }
-
-    /// Set the schema. Typically at the start of a projection.
-    pub(crate) fn may_set_schema(&mut self, df: &DataFrame, exprs_len: usize) {
-        if exprs_len > 1 && df.get_columns().len() > 10 {
-            let schema = Arc::new(df.schema());
-            self.set_schema(schema);
-        }
-    }
-
-    /// Clear the schema. Typically at the end of a projection.
-    pub(crate) fn clear_schema_cache(&self) {
-        let mut lock = self.schema_cache.write().unwrap();
-        *lock = None;
-    }
-
-    /// Get the schema.
-    pub(crate) fn get_schema(&self) -> Option<SchemaRef> {
-        let lock = self.schema_cache.read().unwrap();
-        lock.clone()
     }
 
     /// Check if we have DataFrame in cache

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -33,7 +33,7 @@ impl PhysicalPipedExpr for Wrap {
 fn to_physical_piped_expr(
     node: Node,
     expr_arena: &Arena<AExpr>,
-    schema: Option<&SchemaRef>
+    schema: Option<&SchemaRef>,
 ) -> PolarsResult<Arc<dyn PhysicalPipedExpr>> {
     // this is a double Arc<dyn> explore if we can create a single of it.
     create_physical_expr(node, Context::Default, expr_arena, schema)
@@ -403,18 +403,6 @@ struct Branch {
 }
 
 impl SExecutionContext for ExecutionState {
-    fn input_schema_is_set(&self) -> bool {
-        self.schema_cache.read().unwrap().is_some()
-    }
-
-    fn set_input_schema(&self, schema: SchemaRef) {
-        self.set_schema(schema);
-    }
-
-    fn clear_input_schema(&self) {
-        self.clear_schema_cache();
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -33,9 +33,10 @@ impl PhysicalPipedExpr for Wrap {
 fn to_physical_piped_expr(
     node: Node,
     expr_arena: &Arena<AExpr>,
+    schema: Option<&SchemaRef>
 ) -> PolarsResult<Arc<dyn PhysicalPipedExpr>> {
     // this is a double Arc<dyn> explore if we can create a single of it.
-    create_physical_expr(node, Context::Default, expr_arena)
+    create_physical_expr(node, Context::Default, expr_arena, schema)
         .map(|e| Arc::new(Wrap(e)) as Arc<dyn PhysicalPipedExpr>)
 }
 


### PR DESCRIPTION
This greatly simplifies the fast projection code as we let the physical `Column` expression keep ownership of the schema. This removes the need of the context to set the schema and clear it on every node. Especially in streaming code this was hacky and a source of contention.