### PR TITLE
chore(python): Remove pyarrow nightlies requirement.

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,6 +1,3 @@
-# for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
---extra-index-url https://pypi.fury.io/arrow-nightlies/
---pre
 --prefer-binary
 
 numpy

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -2,9 +2,6 @@
 # We're not pinning package dependencies, because our tests need to pass with the
 # latest version of the packages.
 
-# for PyArrow, as PyArrow 10.0.0 does not have wheels for Python 3.11
---extra-index-url https://pypi.fury.io/arrow-nightlies/
---pre
 --prefer-binary
 
 # Dependencies


### PR DESCRIPTION
PyArrow 10.0.1 supports Python 3.11.