### PR TITLE
feat(rust, python): tz-aware strptime

### DIFF
--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -45,7 +45,7 @@ pub(crate) fn cast_columns(
         (Utf8, Datetime(tu, _)) => s
             .utf8()
             .unwrap()
-            .as_datetime(None, *tu, false)
+            .as_datetime(None, *tu, false, false)
             .map(|ca| ca.into_series()),
         (_, dt) => s.cast(dt),
     };

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -205,7 +205,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
         }
         DataType::Datetime(tu, _) => {
             if options.exact {
-                ca.as_datetime(options.fmt.as_deref(), *tu, options.cache)?
+                ca.as_datetime(options.fmt.as_deref(), *tu, options.cache, options.tz_aware)?
                     .into_series()
             } else {
                 ca.as_datetime_not_exact(options.fmt.as_deref(), *tu)?

--- a/polars/polars-lazy/polars-plan/src/dsl/options.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/options.rs
@@ -19,6 +19,8 @@ pub struct StrpTimeOptions {
     pub exact: bool,
     /// use a cache of unique, converted dates to apply the datetime conversion.
     pub cache: bool,
+    /// Parse a timezone aware timestamp
+    pub tz_aware: bool,
 }
 
 impl Default for StrpTimeOptions {
@@ -29,6 +31,7 @@ impl Default for StrpTimeOptions {
             strict: false,
             exact: false,
             cache: true,
+            tz_aware: false,
         }
     }
 }

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -506,7 +506,7 @@ mod test {
                     "2020-01-08 23:16:43",
                 ],
             )
-            .as_datetime(None, tu, false)?
+            .as_datetime(None, tu, false, false)?
             .into_series();
             let a = Series::new("a", [3, 7, 5, 9, 2, 1]);
             let df = DataFrame::new(vec![date, a.clone()])?;
@@ -544,7 +544,7 @@ mod test {
                 "2020-01-08 23:16:43",
             ],
         )
-        .as_datetime(None, TimeUnit::Milliseconds, false)?
+        .as_datetime(None, TimeUnit::Milliseconds, false, false)?
         .into_series();
         let a = Series::new("a", [3, 7, 5, 9, 2, 1]);
         let df = DataFrame::new(vec![date, a.clone()])?;

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -32,6 +32,7 @@ class ExprStringNameSpace:
         strict: bool = True,
         exact: bool = True,
         cache: bool = True,
+        tz_aware: bool = False,
     ) -> pli.Expr:
         """
         Parse a Utf8 expression to a Date/Datetime/Time type.
@@ -51,6 +52,9 @@ class ExprStringNameSpace:
             - If False, allow the format to match anywhere in the target string.
         cache
             Use a cache of unique, converted dates to apply the datetime conversion.
+        tz_aware
+            Parse timezone aware datetimes. This may be automatically toggled by the
+            'fmt' given.
 
         Notes
         -----
@@ -106,7 +110,7 @@ class ExprStringNameSpace:
         elif datatype == Datetime:
             tu = datatype.tu  # type: ignore[union-attr]
             dtcol = pli.wrap_expr(
-                self._pyexpr.str_parse_datetime(fmt, strict, exact, cache)
+                self._pyexpr.str_parse_datetime(fmt, strict, exact, cache, tz_aware)
             )
             return dtcol if (tu is None) else dtcol.dt.cast_time_unit(tu)
         elif datatype == Time:

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -28,6 +28,7 @@ class StringNameSpace:
         strict: bool = True,
         exact: bool = True,
         cache: bool = True,
+        tz_aware: bool = False,
     ) -> pli.Series:
         """
         Parse a Series of dtype Utf8 to a Date/Datetime Series.
@@ -48,6 +49,9 @@ class StringNameSpace:
             - If False, allow the format to match anywhere in the target string.
         cache
             Use a cache of unique, converted dates to apply the datetime conversion.
+        tz_aware
+            Parse timezone aware datetimes. This may be automatically toggled by the
+            'fmt' given.
 
         Returns
         -------

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -43,7 +43,17 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["backports", "pyarrow.*", "polars.polars", "matplotlib.*", "fsspec.*", "connectorx", "IPython.*", "zoneinfo"]
+module = [
+  "backports",
+  "pyarrow.*",
+  "polars.polars",
+  "matplotlib.*",
+  "fsspec.*",
+  "connectorx",
+  "IPython.*",
+  "zoneinfo",
+  "pytz",
+]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -8,6 +8,7 @@
 numpy
 pandas
 pyarrow
+pytz
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -527,6 +527,7 @@ impl PyExpr {
                 strict,
                 exact,
                 cache,
+                tz_aware: false,
             })
             .into()
     }
@@ -537,6 +538,7 @@ impl PyExpr {
         strict: bool,
         exact: bool,
         cache: bool,
+        tz_aware: bool,
     ) -> PyExpr {
         let tu = match fmt {
             Some(ref fmt) => {
@@ -563,6 +565,7 @@ impl PyExpr {
                 strict,
                 exact,
                 cache,
+                tz_aware,
             })
             .into()
     }
@@ -583,6 +586,7 @@ impl PyExpr {
                 strict,
                 exact,
                 cache,
+                tz_aware: false,
             })
             .into()
     }

--- a/py-polars/tests/unit/test_timezone.py
+++ b/py-polars/tests/unit/test_timezone.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+import pytz
+
+import polars as pl
+
+
+def test_timezone_aware_strptime() -> None:
+    times = pl.DataFrame(
+        {
+            "delivery_datetime": [
+                "2021-12-05 06:00:00+01:00",
+                "2021-12-05 07:00:00+01:00",
+                "2021-12-05 08:00:00+01:00",
+            ]
+        }
+    )
+    assert times.with_column(
+        pl.col("delivery_datetime").str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S%z")
+    ).to_dict(False) == {
+        "delivery_datetime": [
+            datetime(2021, 12, 5, 6, 0, tzinfo=pytz.FixedOffset(60)),
+            datetime(2021, 12, 5, 7, 0, tzinfo=pytz.FixedOffset(60)),
+            datetime(2021, 12, 5, 8, 0, tzinfo=pytz.FixedOffset(60)),
+        ]
+    }


### PR DESCRIPTION
closes #5656

I had to use `pytz` for this as `zoneinfo` does not support fixed offsets and thus has only half of timezone support. Any thoughts on this @zundertj @stinodego ?

Maybe we should switch back again.