### PR TITLE
fix(rust, python): implement min/max aggregation for utf8 in groupby

### DIFF
--- a/polars/polars-arrow/src/index.rs
+++ b/polars/polars-arrow/src/index.rs
@@ -33,3 +33,7 @@ pub type IdxSize = u64;
 pub type IdxArr = UInt32Array;
 #[cfg(feature = "bigidx")]
 pub type IdxArr = UInt64Array;
+
+pub fn indexes_to_usizes(idx: &[IdxSize]) -> impl Iterator<Item = usize> + '_ {
+    idx.iter().map(|idx| *idx as usize)
+}

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -62,6 +62,14 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.agg_list(groups)
     }
 
+    unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
+        self.0.agg_min(groups)
+    }
+
+    unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
+        self.0.agg_max(groups)
+    }
+
     fn zip_outer_join_column(
         &self,
         right_column: &Series,

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -234,3 +234,20 @@ def test_groupby_all_masked_out() -> None:
     parts = df.partition_by("val")
     assert len(parts) == 1
     assert parts[0].frame_equal(df)
+
+
+def test_groupby_min_max_string_type() -> None:
+    table = pl.from_dict({"a": [1, 1, 2, 2, 2], "b": ["a", "b", "c", "d", None]})
+
+    expected = {"a": [1, 2], "min": ["a", "c"], "max": ["b", "d"]}
+
+    for streaming in [True, False]:
+        assert (
+            table.lazy()
+            .groupby("a")
+            .agg([pl.min("b").alias("min"), pl.max("b").alias("max")])
+            .collect(streaming=streaming)
+            .sort("a")
+            .to_dict(False)
+            == expected
+        )


### PR DESCRIPTION
fixes #5735