### PR TITLE
chore(rust,python) Change allow_streaming to streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Polars is also very lightweight. It comes with zero required dependencies, and t
 ### Handles larger than RAM data
 
 If you have data that does not fit into memory, polars lazy is able to process your query (or parts of your query) in a
-streaming fashion, this drastically reduces memory requirements you might be able to process your 250GB dataset on your
-laptop. Collect with `collect(allow_streaming=True)` to run the query streaming. (This might be a little slower, but
+streaming fashion, this drastically reduces memory requirements so you might be able to process your 250GB dataset on your
+laptop. Collect with `collect(streaming=True)` to run the query streaming. (This might be a little slower, but
 it is still very fast!)
 
 ## Setup

--- a/polars/polars-core/src/frame/cross_join.rs
+++ b/polars/polars-core/src/frame/cross_join.rs
@@ -50,7 +50,7 @@ impl DataFrame {
         let n_rows_right = other.height() as IdxSize;
         let Some(total_rows) = n_rows_left.checked_mul(n_rows_right) else {
             return Err(PolarsError::ComputeError("Cross joins would produce more rows than fits into 2^32.\n\
-            Consider comping with polars-big-idx feature, or set 'allow_streaming'.".into()))
+            Consider comping with polars-big-idx feature, or set 'streaming'.".into()))
         };
 
         // the left side has the Nth row combined with every row from right.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -26,6 +26,7 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
+    deprecated_alias,
 )
 
 try:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2184,6 +2184,7 @@ def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.
     return pli.wrap_expr(_concat_lst(exprs))
 
 
+@deprecated_alias(allow_streaming="streaming")
 def collect_all(
     lazy_frames: Sequence[pli.LazyFrame],
     type_coercion: bool = True,
@@ -2194,7 +2195,7 @@ def collect_all(
     no_optimization: bool = False,
     slice_pushdown: bool = True,
     common_subplan_elimination: bool = True,
-    allow_streaming: bool = False,
+    streaming: bool = False,
 ) -> list[pli.DataFrame]:
     """
     Collect multiple LazyFrames at the same time.
@@ -2221,7 +2222,7 @@ def collect_all(
         Slice pushdown optimization.
     common_subplan_elimination
         Will try to cache branching subplans that occur on self-joins or unions.
-    allow_streaming
+    streaming
         Run parts of the query in a streaming fashion (this is in an alpha state)
 
     Returns
@@ -2245,7 +2246,7 @@ def collect_all(
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
-            allow_streaming,
+            streaming,
         )
         prepared.append(ldf)
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -927,6 +927,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by = pli.selection_to_pyexpr_list(by)
         return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse, nulls_last))
 
+    @deprecated_alias(allow_streaming="streaming")
     def profile(
         self,
         type_coercion: bool = True,
@@ -939,7 +940,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         show_plot: bool = False,
         truncate_nodes: int = 0,
         figsize: tuple[int, int] = (18, 8),
-        allow_streaming: bool = False,
+        streaming: bool = False,
     ) -> tuple[pli.DataFrame, pli.DataFrame]:
         """
         Profile a LazyFrame.
@@ -973,7 +974,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             characters.
         figsize
             matplotlib figsize of the profiling plot
-        allow_streaming
+        streaming
             Run parts of the query in a streaming fashion (this is in an alpha state)
 
         Returns
@@ -1029,7 +1030,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
-            allow_streaming,
+            streaming,
         )
         df, timings = ldf.profile()
         (df, timings) = pli.wrap_df(df), pli.wrap_df(timings)

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1164,6 +1164,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         )
         return pli.wrap_df(ldf.collect())
 
+    @deprecated_alias(allow_streaming="streaming")
     def fetch(
         self,
         n_rows: int = 500,
@@ -1175,7 +1176,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         no_optimization: bool = False,
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
-        allow_streaming: bool = False,
+        streaming: bool = False,
     ) -> pli.DataFrame:
         """
         Collect a small number of rows for debugging purposes.
@@ -1206,7 +1207,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Slice pushdown optimization
         common_subplan_elimination
             Will try to cache branching subplans that occur on self-joins or unions.
-        allow_streaming
+        streaming
             Run parts of the query in a streaming fashion (this is in an alpha state)
 
         Returns
@@ -1248,7 +1249,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             simplify_expression,
             slice_pushdown,
             common_subplan_elimination,
-            allow_streaming,
+            streaming,
         )
         return pli.wrap_df(ldf.fetch(n_rows))
 

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -686,7 +686,7 @@ def test_streaming_joins() -> None:
             dfa_pl.lazy()
             .join(dfb_pl.lazy(), on="a", how=how)
             .sort(["a", "b"])
-            .collect(allow_streaming=True)
+            .collect(streaming=True)
         )
 
         a = pl.from_pandas(pd_result).with_column(pl.all().cast(int)).sort(["a", "b"])
@@ -698,7 +698,7 @@ def test_streaming_joins() -> None:
             dfa_pl.lazy()
             .join(dfb_pl.lazy(), on=["a", "b"], how=how)
             .sort(["a", "b"])
-            .collect(allow_streaming=True)
+            .collect(streaming=True)
         )
 
         # we cast to integer because pandas joins creates floats

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -93,7 +93,7 @@ def test_streaming_empty_df() -> None:
 
     assert df.lazy().join(df.lazy(), on="a", how="inner").filter(
         2 == 1  # noqa: SIM300
-    ).collect(allow_streaming=True).to_dict(False) == {"a": [], "b": [], "b_right": []}
+    ).collect(streaming=True).to_dict(False) == {"a": [], "b": [], "b_right": []}
 
 
 def test_when_then_empty_list_5547() -> None:


### PR DESCRIPTION
See #5745 

- Change `allow_streaming` to `streaming` in optimization_toggle
- Make `allow_streaming` a deprecated alias in remaining python references