### PR TITLE
fix(rust, python): fix generic streaming groupby on logical types

### DIFF
--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -500,7 +500,7 @@ impl<'a> AnyValueBuffer<'a> {
         }
     }
 
-    pub fn new(dtype: &DataType, capacity: usize) -> AnyValueBuffer<'_> {
+    pub fn new(dtype: &DataType, capacity: usize) -> AnyValueBuffer<'a> {
         (dtype, capacity).into()
     }
 }


### PR DESCRIPTION
Also improves the performance of streaming groupbys with multiple columns by first checking hash equality.