### PR TITLE
fix(python): improved interaction of namespace-accessor with attributes (for sphinx/docs)

### DIFF
--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -5,6 +5,13 @@ Categories
 The following methods are available under the `Series.cat` attribute.
 
 .. currentmodule:: polars
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/accessor_attributes.rst
+
+    Series.cat.ordered
+
 .. autosummary::
    :toctree: api/
    :template: autosummary/accessor_method.rst

--- a/py-polars/polars/internals/series/categorical.py
+++ b/py-polars/polars/internals/series/categorical.py
@@ -19,6 +19,12 @@ class CatNameSpace:
     def __init__(self, series: pli.Series):
         self._s: PySeries = series._s
 
+    @property
+    def ordered(self) -> bool:
+        """Return if sorting uses the categories or the lexical order of the string values."""  # noqa: E501
+        # == TESTING NAMESPACED @property WITH SPHINX ==
+        return True
+
     def set_ordering(self, ordering: CategoricalOrdering) -> pli.Series:
         """
         Determine how this categorical series should be sorted.

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -421,6 +421,7 @@ _series_dtype = {
 }
 NS = TypeVar("NS")
 
+
 class sphinx_accessor(property):  # type: ignore[no-redef]
     def __get__(  # type: ignore[override]
         self,
@@ -430,14 +431,14 @@ class sphinx_accessor(property):  # type: ignore[no-redef]
         try:
             obj = self.fget
             if isinstance(instance, cls):
-                return obj(instance)  # type:ignore [misc]
+                return obj(instance)  # type:ignore[misc]
             else:
                 lookup = getattr(obj, "__qualname__")  # noqa: B009
                 dtype = _series_dtype.get(lookup)
                 return (
-                    obj(cls)  # type:ignore [misc]
+                    obj(cls)  # type:ignore[misc]
                     if dtype is None
-                    else obj(cls(dtype=dtype))  # type:ignore [misc,call-arg]
+                    else obj(cls(dtype=dtype))  # type:ignore[misc,call-arg]
                 )
         except AttributeError:
             return None  # type: ignore[return-value]


### PR DESCRIPTION
Relates to #5705 - when building the Sphinx docs (and only then) where we don't have a `Series` instance, this patch improves the `@accessor` decorator behaviour to provide a dummy Series of the correct type. This means we don't need special handling for `_s = None`, and avoids a `sphinx-build` error when adding property attributes to namespaces.

When _not_ building docs the `@accessor` decorator remains a simple `@property`, as before.
