### PR TITLE
refactor(python): Parse fixed timezone offsets without pytz

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -52,7 +52,6 @@ module = [
   "connectorx",
   "IPython.*",
   "zoneinfo",
-  "pytz",
 ]
 ignore_missing_imports = true
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -8,7 +8,6 @@
 numpy
 pandas
 pyarrow
-pytz
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv

--- a/py-polars/tests/unit/test_timezone.py
+++ b/py-polars/tests/unit/test_timezone.py
@@ -1,17 +1,21 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
-import pytz
+import pytest
 
 import polars as pl
 
 
-def test_timezone_aware_strptime() -> None:
+@pytest.mark.parametrize(
+    "tz_string,timedelta",
+    [("+01:00", timedelta(minutes=60)), ("-01:30", timedelta(hours=-1, minutes=-30))],
+)
+def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
     times = pl.DataFrame(
         {
             "delivery_datetime": [
-                "2021-12-05 06:00:00+01:00",
-                "2021-12-05 07:00:00+01:00",
-                "2021-12-05 08:00:00+01:00",
+                "2021-12-05 06:00:00" + tz_string,
+                "2021-12-05 07:00:00" + tz_string,
+                "2021-12-05 08:00:00" + tz_string,
             ]
         }
     )
@@ -19,8 +23,8 @@ def test_timezone_aware_strptime() -> None:
         pl.col("delivery_datetime").str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S%z")
     ).to_dict(False) == {
         "delivery_datetime": [
-            datetime(2021, 12, 5, 6, 0, tzinfo=pytz.FixedOffset(60)),
-            datetime(2021, 12, 5, 7, 0, tzinfo=pytz.FixedOffset(60)),
-            datetime(2021, 12, 5, 8, 0, tzinfo=pytz.FixedOffset(60)),
+            datetime(2021, 12, 5, 6, 0, tzinfo=timezone(timedelta)),
+            datetime(2021, 12, 5, 7, 0, tzinfo=timezone(timedelta)),
+            datetime(2021, 12, 5, 8, 0, tzinfo=timezone(timedelta)),
         ]
     }


### PR DESCRIPTION
Python's ZoneInfo only supports named offsets. For fixed offsets, one can construct this by using `timezone(timedelta( timedelta(hours=..., minutes=...))`. Instead of rolling our own regex, we use fromisoformat() instead, seems much safer.

Note that the LRU cache is now on the offset only, we were not using the cache on _localize either.

Also added a test case with a different, negative, fixed offset.

See #5736 for the initial addition of pytz.