### PR TITLE
refactor(rust): shrink anyvalue size

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -192,7 +192,10 @@ impl LogicalType for StructChunked {
     /// Gets AnyValue from LogicalType
     fn get_any_value(&self, i: usize) -> AnyValue<'_> {
         if let DataType::Struct(flds) = self.dtype() {
-            AnyValue::Struct(self.fields.iter().map(|s| s.get(i)).collect(), flds)
+            AnyValue::Struct(Box::new((
+                self.fields.iter().map(|s| s.get(i)).collect(),
+                flds,
+            )))
         } else {
             unreachable!()
         }

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -78,8 +78,8 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
                 .iter()
                 .zip(flds)
                 .map(|(arr, fld)| arr_to_any_value(&**arr, idx, fld.data_type()))
-                .collect();
-            AnyValue::Struct(vals, flds)
+                .collect::<_>();
+            AnyValue::Struct(Box::new((vals, flds)))
         }
         #[cfg(feature = "dtype-datetime")]
         DataType::Datetime(tu, tz) => {

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -359,8 +359,8 @@ impl IsIn for StructChunked {
                 let mut ca: BooleanChunked = if self.len() == 1 && other.len() != 1 {
                     let mut value = vec![];
                     let left = self.clone().into_series();
-                    if let AnyValue::Struct(val, _) = left.get(0) {
-                        value = val
+                    if let AnyValue::Struct(val) = left.get(0) {
+                        value = val.0;
                     }
                     other
                         .list()?

--- a/polars/polars-core/src/datatypes/any_value.rs
+++ b/polars/polars-core/src/datatypes/any_value.rs
@@ -52,7 +52,7 @@ pub enum AnyValue<'a> {
     /// Can be used to fmt and implements Any, so can be downcasted to the proper value type.
     Object(&'a dyn PolarsObjectSafe),
     #[cfg(feature = "dtype-struct")]
-    Struct(Vec<AnyValue<'a>>, &'a [Field]),
+    Struct(Box<(Vec<AnyValue<'a>>, &'a [Field])>),
     #[cfg(feature = "dtype-struct")]
     StructOwned(Box<(Vec<AnyValue<'a>>, Vec<Field>)>),
     /// A UTF8 encoded string type.
@@ -345,7 +345,9 @@ impl<'a> AnyValue<'a> {
             Categorical(_, _) => DataType::Categorical(None),
             List(s) => DataType::List(Box::new(s.dtype().clone())),
             #[cfg(feature = "dtype-struct")]
-            Struct(_, field) => DataType::Struct(field.to_vec()),
+            Struct(payload) => DataType::Struct(payload.1.to_vec()),
+            #[cfg(feature = "dtype-struct")]
+            StructOwned(payload) => DataType::Struct(payload.1.clone()),
             #[cfg(feature = "dtype-binary")]
             Binary(_) => DataType::Binary,
             _ => unimplemented!(),
@@ -520,29 +522,29 @@ impl<'a> AnyValue<'a> {
     pub fn into_static(self) -> PolarsResult<AnyValue<'static>> {
         use AnyValue::*;
         let av = match self {
-            Null => AnyValue::Null,
-            Int8(v) => AnyValue::Int8(v),
-            Int16(v) => AnyValue::Int16(v),
-            Int32(v) => AnyValue::Int32(v),
-            Int64(v) => AnyValue::Int64(v),
-            UInt8(v) => AnyValue::UInt8(v),
-            UInt16(v) => AnyValue::UInt16(v),
-            UInt32(v) => AnyValue::UInt32(v),
-            UInt64(v) => AnyValue::UInt64(v),
-            Boolean(v) => AnyValue::Boolean(v),
-            Float32(v) => AnyValue::Float32(v),
-            Float64(v) => AnyValue::Float64(v),
+            Null => Null,
+            Int8(v) => Int8(v),
+            Int16(v) => Int16(v),
+            Int32(v) => Int32(v),
+            Int64(v) => Int64(v),
+            UInt8(v) => UInt8(v),
+            UInt16(v) => UInt16(v),
+            UInt32(v) => UInt32(v),
+            UInt64(v) => UInt64(v),
+            Boolean(v) => Boolean(v),
+            Float32(v) => Float32(v),
+            Float64(v) => Float64(v),
             #[cfg(feature = "dtype-date")]
-            Date(v) => AnyValue::Date(v),
+            Date(v) => Date(v),
             #[cfg(feature = "dtype-time")]
-            Time(v) => AnyValue::Time(v),
-            List(v) => AnyValue::List(v),
-            Utf8(v) => AnyValue::Utf8Owned(v.into()),
-            Utf8Owned(v) => AnyValue::Utf8Owned(v),
+            Time(v) => Time(v),
+            List(v) => List(v),
+            Utf8(v) => Utf8Owned(v.into()),
+            Utf8Owned(v) => Utf8Owned(v),
             #[cfg(feature = "dtype-binary")]
-            Binary(v) => AnyValue::BinaryOwned(v.to_vec()),
+            Binary(v) => BinaryOwned(v.to_vec()),
             #[cfg(feature = "dtype-binary")]
-            BinaryOwned(v) => AnyValue::BinaryOwned(v),
+            BinaryOwned(v) => BinaryOwned(v),
             dt => {
                 return Err(PolarsError::ComputeError(
                     format!("cannot get static AnyValue from {}", dt).into(),

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -741,7 +741,7 @@ impl Display for AnyValue<'_> {
             #[cfg(feature = "object")]
             AnyValue::Object(v) => write!(f, "{}", v),
             #[cfg(feature = "dtype-struct")]
-            AnyValue::Struct(vals, _) => fmt_struct(f, vals),
+            AnyValue::Struct(payload) => fmt_struct(f, &payload.0),
             #[cfg(feature = "dtype-struct")]
             AnyValue::StructOwned(payload) => fmt_struct(f, &payload.0),
         }

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -254,7 +254,7 @@ fn is_nested_null(av: &AnyValue) -> bool {
         AnyValue::Null => true,
         AnyValue::List(s) => s.null_count() == s.len(),
         #[cfg(feature = "dtype-struct")]
-        AnyValue::Struct(avs, _) => avs.iter().all(is_nested_null),
+        AnyValue::Struct(payload) => payload.0.iter().all(is_nested_null),
         _ => false,
     }
 }
@@ -264,8 +264,10 @@ fn infer_dtype_dynamic(av: &AnyValue) -> DataType {
     match av {
         AnyValue::List(s) if s.null_count() == s.len() => DataType::List(Box::new(DataType::Null)),
         #[cfg(feature = "dtype-struct")]
-        AnyValue::Struct(avs, _) => DataType::Struct(
-            avs.iter()
+        AnyValue::Struct(payload) => DataType::Struct(
+            payload
+                .0
+                .iter()
                 .map(|av| {
                     let dtype = infer_dtype_dynamic(av);
                     Field::new("", dtype)

--- a/polars/polars-core/src/series/any_value.rs
+++ b/polars/polars-core/src/series/any_value.rs
@@ -229,7 +229,7 @@ impl<'a> From<&AnyValue<'a>> for DataType {
             #[cfg(feature = "dtype-struct")]
             StructOwned(payload) => DataType::Struct(payload.1.to_vec()),
             #[cfg(feature = "dtype-struct")]
-            Struct(_, fields) => DataType::Struct(fields.to_vec()),
+            Struct(payload) => DataType::Struct(payload.1.to_vec()),
             #[cfg(feature = "dtype-duration")]
             Duration(_, tu) => DataType::Duration(*tu),
             UInt8(_) => DataType::UInt8,


### PR DESCRIPTION
Shrink 8 bits of the size. This will make dealing with structs slower but speed up the most occurring values.