### PR TITLE
docs(python): add DataFrame.pearson_corr to reference

### DIFF
--- a/py-polars/docs/source/reference/dataframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/dataframe/miscellaneous.rst
@@ -9,3 +9,4 @@ Miscellaneous
     DataFrame.apply
     DataFrame.frame_equal
     DataFrame.lazy
+    DataFrame.pearson_corr


### PR DESCRIPTION
`DataFrame.pearson_corr` doesn't show up in the docs and so it hard to find