### PR TITLE
fix(rust, python) Summation on empty series evaluates to `Some(0)`

### DIFF
--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -317,6 +317,16 @@ def test_arithmetic(s: pl.Series) -> None:
         2**a
 
 
+def test_arithmetic_empty() -> None:
+    series = pl.Series("a", [])
+    assert series.sum() == 0
+
+
+def test_arithmetic_null() -> None:
+    series = pl.Series("a", [None])
+    assert series.sum() is None
+
+
 def test_power() -> None:
     a = pl.Series([1, 2], dtype=Int64)
     b = pl.Series([None, 2.0], dtype=Float64)


### PR DESCRIPTION
Closes: #5604 

Changes:
* Calling `Series::sum()` on an empty series now evaluates to `Some(0)`.
* Calling `Series::sum_as_series()` on an empty series now returns a Series with a single zero'd value. This is done to enable the above change in both Rust and Python libraries.
* Adjusted documentation to reflect this change.
* Added two unit tests to Python tests: `test_arithmetic_empty `, `test_arithmetic_null `.

----
I chose to add logic directly to `sum_as_series()` as to reduce the blast radius of this new logic. Please let me know if any changes are needed, including location of tests!