### PR TITLE
chore(rust): Continue removing compilation warnings

### DIFF
--- a/polars/benches/take.rs
+++ b/polars/benches/take.rs
@@ -34,6 +34,7 @@ fn create_random_idx(size: usize) -> Vec<usize> {
     (0..size).map(|_| rng.gen_range(0..size)).collect()
 }
 
+#[allow(unused_must_use)]
 fn bench_take(ca: &UInt32Chunked, idx: &[usize]) {
     let f = || ca.take(idx.iter().copied().into());
     criterion::black_box(f());

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1008,6 +1008,8 @@ mod test {
             &Series::new("temp_count", [2 as IdxSize, 2, 1])
         );
 
+        // Use of deprecated mean() for testing purposes
+        #[allow(deprecated)]
         // Select multiple
         let out = df
             .groupby_stable(["date"])?
@@ -1018,6 +1020,8 @@ mod test {
             &Series::new("temp_mean", [15.0f64, 4.0, 9.0])
         );
 
+        // Use of deprecated `mean()` for testing purposes
+        #[allow(deprecated)]
         // Group by multiple
         let out = df
             .groupby_stable(&["date", "temp"])?
@@ -1025,12 +1029,16 @@ mod test {
             .mean()?;
         assert!(out.column("rain_mean").is_ok());
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         let out = df.groupby_stable(["date"])?.select(["temp"]).sum()?;
         assert_eq!(
             out.column("temp_sum")?,
             &Series::new("temp_sum", [30, 8, 9])
         );
 
+        // Use of deprecated `n_unique()` for testing purposes
+        #[allow(deprecated)]
         // implicit select all and only aggregate on methods that support that aggregation
         let gb = df.groupby(["date"]).unwrap().n_unique().unwrap();
         // check the group by column is filtered out.
@@ -1059,6 +1067,8 @@ mod test {
         let df =
             DataFrame::new(vec![s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12]).unwrap();
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         let adf = df
             .groupby(&[
                 "G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10", "G11", "G12",
@@ -1101,6 +1111,8 @@ mod test {
         // Create the dataframe with the computed series.
         let df = DataFrame::new(series).unwrap();
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         // Compute the aggregated DataFrame by the 13 columns defined in `series_names`.
         let adf = df
             .groupby(&series_names)
@@ -1132,6 +1144,8 @@ mod test {
                     "val" => [1, 1, 1, 1, 1]
         }
         .unwrap();
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         let res = df.groupby(["flt"]).unwrap().sum().unwrap();
         let res = res.sort(["flt"], false).unwrap();
         assert_eq!(
@@ -1153,6 +1167,8 @@ mod test {
         df.apply("foo", |s| s.cast(&DataType::Categorical(None)).unwrap())
             .unwrap();
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         // check multiple keys and categorical
         let res = df
             .groupby_stable(["foo", "ham"])
@@ -1194,6 +1210,8 @@ mod test {
             "a" => ["a", "a", "a", "b", "b"],
             "b" => [Some(1), Some(2), None, None, Some(1)]
         )?;
+        // Use of deprecated `mean()` for testing purposes
+        #[allow(deprecated)]
         let out = df.groupby_stable(["a"])?.mean()?;
 
         assert_eq!(
@@ -1213,9 +1231,13 @@ mod test {
             "int" => [1, 2, 3]
         ]?;
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         let out = df.groupby_stable(["g"])?.select(["int"]).var(1)?;
 
         assert_eq!(out.column("int_agg_var")?.f64()?.get(0), Some(0.5));
+        // Use of deprecated `std()` for testing purposes
+        #[allow(deprecated)]
         let out = df.groupby_stable(["g"])?.select(["int"]).std(1)?;
         let val = out.column("int_agg_std")?.f64()?.get(0).unwrap();
         let expected = f64::FRAC_1_SQRT_2();
@@ -1236,6 +1258,8 @@ mod test {
 
         df.try_apply("g", |s| s.cast(&DataType::Categorical(None)))?;
 
+        // Use of deprecated `sum()` for testing purposes
+        #[allow(deprecated)]
         let _ = df.groupby(["g"])?.sum()?;
         Ok(())
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -274,6 +274,8 @@ fn get_pat(pat: &Utf8Chunked) -> PolarsResult<&str> {
     })
 }
 
+// used only if feature="regex"
+#[allow(dead_code)]
 fn iter_and_replace<'a, F>(ca: &'a Utf8Chunked, val: &'a Utf8Chunked, f: F) -> Utf8Chunked
 where
     F: Fn(&'a str, &'a str) -> Cow<'a, str>,

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -128,6 +128,8 @@ where
 
 #[cfg(test)]
 mod test {
+    // used only if feature="diagonal_concat"
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1,7 +1,5 @@
-use polars_arrow::prelude::QuantileInterpolOptions;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::series::ops::NullBehavior;
-use polars_time::prelude::DateMethods;
 
 use super::*;
 

--- a/polars/tests/it/io/parquet.rs
+++ b/polars/tests/it/io/parquet.rs
@@ -26,6 +26,8 @@ fn test_scan_parquet_files() -> PolarsResult<()> {
         "../examples/datasets/foods2.parquet".to_string(),
     ];
 
+    // Use of deprecated scan_parquet_files() for testing purposes
+    #[allow(deprecated)]
     let df = LazyFrame::scan_parquet_files(files_to_load_set, Default::default())?.collect()?;
     assert_eq!(df.shape(), (54, 4));
     Ok(())

--- a/polars/tests/it/lazy/explodes.rs
+++ b/polars/tests/it/lazy/explodes.rs
@@ -1,3 +1,5 @@
+// used only if feature="strings"
+#[allow(unused_imports)]
 use super::*;
 
 #[cfg(feature = "strings")]

--- a/polars/tests/it/lazy/functions.rs
+++ b/polars/tests/it/lazy/functions.rs
@@ -1,3 +1,5 @@
+// used only if feature="format_str"
+#[allow(unused_imports)]
 use super::*;
 
 #[test]

--- a/polars/tests/it/lazy/groupby.rs
+++ b/polars/tests/it/lazy/groupby.rs
@@ -1,4 +1,6 @@
 use polars_core::series::ops::NullBehavior;
+// used only if feature="dtype-duration", "dtype-struct"
+#[allow(unused_imports)]
 use polars_core::SINGLE_LOCK;
 
 use super::*;

--- a/polars/tests/it/lazy/groupby_dynamic.rs
+++ b/polars/tests/it/lazy/groupby_dynamic.rs
@@ -1,5 +1,9 @@
+// used only if feature="temporal", "dtype-date", "dynamic_groupby"
+#[allow(unused_imports)]
 use polars::export::chrono::prelude::*;
 
+// used only if feature="temporal", "dtype-date", "dynamic_groupby"
+#[allow(unused_imports)]
 use super::*;
 
 #[test]

--- a/polars/tests/it/lazy/predicate_queries.rs
+++ b/polars/tests/it/lazy/predicate_queries.rs
@@ -1,3 +1,5 @@
+// used only if feature="is_in", feature="dtype-categorical"
+#[allow(unused_imports)]
 use polars_core::{with_string_cache, SINGLE_LOCK};
 
 use super::*;


### PR DESCRIPTION
Addresses: #5659 

* Attaches `#[allow(...)]` blocks with accompanying labels justifying block
* Removes two unused imports from test `polars/polars-lazy/src/tests/queries.rs`