### PR TITLE
feat(python): push down predicates to pyarrow datasets

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
@@ -430,6 +430,31 @@ pub enum Operator {
     And,
     Or,
     Xor,
+}
+
+impl Display for Operator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use Operator::*;
+        let tkn = match self {
+            Eq => "==",
+            NotEq => "!=",
+            Lt => "<",
+            LtEq => "<=",
+            Gt => ">",
+            GtEq => ">=",
+            Plus => "+",
+            Minus => "-",
+            Multiply => "*",
+            Divide => "//",
+            TrueDivide => "/",
+            FloorDivide => "floor_div",
+            Modulus => "%",
+            And => "&",
+            Or => "|",
+            Xor => "^",
+        };
+        write!(f, "{}", tkn)
+    }
 }
 
 impl Operator {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -30,6 +30,7 @@ pub enum ALogicalPlan {
     #[cfg(feature = "python")]
     PythonScan {
         options: PythonOptions,
+        predicate: Option<Node>,
     },
     Melt {
         input: Node,
@@ -164,7 +165,7 @@ impl ALogicalPlan {
         use ALogicalPlan::*;
         match self {
             #[cfg(feature = "python")]
-            PythonScan { options } => &options.schema,
+            PythonScan { options, .. } => &options.schema,
             #[cfg(feature = "csv-file")]
             CsvScan { file_info, .. } => &file_info.schema,
             #[cfg(feature = "parquet")]
@@ -181,7 +182,7 @@ impl ALogicalPlan {
         use ALogicalPlan::*;
         let schema = match self {
             #[cfg(feature = "python")]
-            PythonScan { options } => &options.schema,
+            PythonScan { options, .. } => &options.schema,
             Union { inputs, .. } => return arena.get(inputs[0]).schema(arena),
             Cache { input, .. } => return arena.get(*input).schema(arena),
             Sort { input, .. } => return arena.get(*input).schema(arena),
@@ -249,8 +250,9 @@ impl ALogicalPlan {
 
         match self {
             #[cfg(feature = "python")]
-            PythonScan { options } => PythonScan {
+            PythonScan { options, predicate } => PythonScan {
                 options: options.clone(),
+                predicate: *predicate,
             },
             Union { options, .. } => Union {
                 inputs,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -175,7 +175,10 @@ pub fn to_alp(
             options,
         },
         #[cfg(feature = "python")]
-        LogicalPlan::PythonScan { options } => ALogicalPlan::PythonScan { options },
+        LogicalPlan::PythonScan { options } => ALogicalPlan::PythonScan {
+            options,
+            predicate: None,
+        },
         LogicalPlan::Union { inputs, options } => {
             let inputs = inputs
                 .into_iter()
@@ -668,7 +671,7 @@ impl ALogicalPlan {
                 options,
             },
             #[cfg(feature = "python")]
-            ALogicalPlan::PythonScan { options } => LogicalPlan::PythonScan { options },
+            ALogicalPlan::PythonScan { options, .. } => LogicalPlan::PythonScan { options },
             ALogicalPlan::Union { inputs, options } => {
                 let inputs = inputs
                     .into_iter()

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -24,6 +24,8 @@ mod lit;
 pub(crate) mod optimizer;
 pub(crate) mod options;
 mod projection;
+#[cfg(feature = "python")]
+mod pyarrow;
 mod schema;
 
 pub use aexpr::*;

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
@@ -230,7 +230,7 @@ fn lp_node_equal(a: &ALogicalPlan, b: &ALogicalPlan, expr_arena: &Arena<AExpr>) 
                 && expr_nodes_equal(agg_l, agg_r, expr_arena)
         }
         #[cfg(feature = "python")]
-        (PythonScan { options: l }, PythonScan { options: r, .. }) => l == r,
+        (PythonScan { options: l, .. }, PythonScan { options: r, .. }) => l == r,
         _ => {
             // joins and unions are also false
             // they do not originate from a single trail

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -455,7 +455,10 @@ impl ProjectionPushDown {
                 Ok(lp)
             }
             #[cfg(feature = "python")]
-            PythonScan { mut options } => {
+            PythonScan {
+                mut options,
+                predicate,
+            } => {
                 options.with_columns = get_scan_columns(&mut acc_projections, expr_arena);
 
                 options.output_schema = if options.with_columns.is_none() {
@@ -468,7 +471,7 @@ impl ProjectionPushDown {
                         true,
                     )?))
                 };
-                Ok(PythonScan { options })
+                Ok(PythonScan { options, predicate })
             }
             #[cfg(feature = "csv-file")]
             CsvScan {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
@@ -219,6 +219,10 @@ pub struct PythonOptions {
     pub schema: SchemaRef,
     pub output_schema: Option<SchemaRef>,
     pub with_columns: Option<Arc<Vec<String>>>,
+    pub pyarrow: bool,
+    // a pyarrow predicate python expression
+    // can be evaluated with python.eval
+    pub predicate: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]

--- a/polars/polars-lazy/polars-plan/src/logical_plan/pyarrow.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/pyarrow.rs
@@ -1,0 +1,59 @@
+use crate::prelude::*;
+
+// convert to a pyarrow expression that can be evaluated with pythons eval
+pub(super) fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Option<String> {
+    match expr_arena.get(predicate) {
+        AExpr::BinaryExpr { left, right, op } => {
+            if op.is_comparison() {
+                let left = predicate_to_pa(*left, expr_arena)?;
+                let right = predicate_to_pa(*right, expr_arena)?;
+                Some(format!("({} {} {})", left, op, right))
+            } else {
+                None
+            }
+        }
+        AExpr::Column(name) => Some(format!("pa.dataset.field('{}')", name.as_ref())),
+        AExpr::Alias(input, _) => predicate_to_pa(*input, expr_arena),
+        AExpr::Literal(lv) => {
+            let av = lv.to_anyvalue()?;
+            let dtype = av.dtype();
+            if dtype.is_float() {
+                let val = av.extract::<f64>()?;
+                Some(format!("{}", val))
+            } else if dtype.is_integer() {
+                let val = av.extract::<i64>()?;
+                Some(format!("{}", val))
+            } else {
+                None
+            }
+        }
+        AExpr::Function {
+            function: FunctionExpr::Not,
+            input,
+            ..
+        } => {
+            let input = input.first().unwrap();
+            let input = predicate_to_pa(*input, expr_arena)?;
+            Some(format!("~({})", input))
+        }
+        AExpr::Function {
+            function: FunctionExpr::IsNull,
+            input,
+            ..
+        } => {
+            let input = input.first().unwrap();
+            let input = predicate_to_pa(*input, expr_arena)?;
+            Some(format!("({}).is_null()", input))
+        }
+        AExpr::Function {
+            function: FunctionExpr::IsNotNull,
+            input,
+            ..
+        } => {
+            let input = input.first().unwrap();
+            let input = predicate_to_pa(*input, expr_arena)?;
+            Some(format!("~({}).is_null()", input))
+        }
+        _ => None,
+    }
+}

--- a/polars/polars-lazy/src/frame/python.rs
+++ b/polars/polars-lazy/src/frame/python.rs
@@ -3,11 +3,12 @@ use polars_core::prelude::*;
 use crate::prelude::*;
 
 impl LazyFrame {
-    pub fn scan_from_python_function(schema: Schema, scan_fn: Vec<u8>) -> Self {
+    pub fn scan_from_python_function(schema: Schema, scan_fn: Vec<u8>, pyarrow: bool) -> Self {
         LogicalPlan::PythonScan {
             options: PythonOptions {
                 scan_fn,
                 schema: Arc::new(schema),
+                pyarrow,
                 ..Default::default()
             },
         }

--- a/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/python_scan.rs
@@ -16,6 +16,7 @@ impl Executor for PythonScanExec {
             }
         }
         let with_columns = self.options.with_columns.take();
+        let pyarrow_predicate = self.options.predicate.take();
         Python::with_gil(|py| {
             let pl = PyModule::import(py, "polars").unwrap();
             let pli = pl.getattr("internals").unwrap();
@@ -27,7 +28,7 @@ impl Executor for PythonScanExec {
                 with_columns.map(|mut cols| std::mem::take(Arc::make_mut(&mut cols)));
 
             let out = deser_and_exec
-                .call1((bytes, with_columns))
+                .call1((bytes, with_columns, pyarrow_predicate))
                 .map_err(|err| PolarsError::ComputeError(format!("{:?}", err).into()))?;
             let pydf = out.getattr("_df").unwrap();
             let raw_parts = pydf.call_method0("into_raw_parts").unwrap();

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -149,7 +149,7 @@ pub fn create_physical_plan(
     let logical_plan = lp_arena.take(root);
     match logical_plan {
         #[cfg(feature = "python")]
-        PythonScan { options } => Ok(Box::new(executors::PythonScanExec { options })),
+        PythonScan { options, .. } => Ok(Box::new(executors::PythonScanExec { options })),
         Union { inputs, options } => {
             let inputs = inputs
                 .into_iter()

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -16,20 +16,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -40,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -85,9 +74,9 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
 name = "arrow-format"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb83ada98f9d252a3c3642d96c53a357684a87d2e9a753ddf2a30bae20b91790"
+checksum = "07884ea216994cdc32a2d5f8274a8bee979cfe90274b83f86f440866ee3132c7"
 dependencies = [
  "planus",
  "serde",
@@ -96,9 +85,9 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.14.2"
-source = "git+https://github.com/ritchie46/arrow2?branch=polars_2022-12-11#80359ce87a1d15d3ce999f4290a101c5723af113"
+source = "git+https://github.com/ritchie46/arrow2?branch=polars_2022-12-11#8216c755ce7ad13d355fbb02adae4a89767d945e"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "arrow-format",
  "avro-schema",
  "base64",
@@ -152,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -225,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f346b6890a0dfa7266974910e7df2d5088120dd54721b9b0e5aae1ae5e05715"
+checksum = "5b9c056b9ed43aee5e064b683aa1ec783e19c6acec7559e3ae931b7490472fbe"
 dependencies = [
  "cargo-lock",
  "chrono",
@@ -268,9 +257,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-lock"
-version = "7.1.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
+checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
  "semver",
  "serde",
@@ -280,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -295,9 +284,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -342,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.2"
+version = "6.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
+checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
 dependencies = [
  "crossterm",
  "strum",
@@ -427,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -440,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -499,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -511,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -526,15 +515,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac3c0b9fa6eb75255ebb42c0ba3e2210d102a66d2795afef6fed668f373311"
+checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -599,9 +588,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -761,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
@@ -780,12 +769,12 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "halfbrown"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8ba437813c5a31783dd9a21ce4f555583dc9b048af6bd2b12217394ed9c199"
+checksum = "9e2a3c70a9c00cc1ee87b54e89f9505f73bb17d63f1b25c9a462ba8ef885444f"
 dependencies = [
  "fxhash",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.1",
  "serde",
 ]
 
@@ -800,9 +789,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
@@ -810,7 +796,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "rayon",
 ]
 
@@ -871,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -1035,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libflate"
@@ -1061,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
@@ -1073,17 +1059,18 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc093ab289b0bfda3aa1bdfab9c9542be29c7ef385cfcbe77f8c9813588eb48"
+checksum = "04d1c67deb83e6b75fa4fe3309e09cfeade12e7721d95322af500d3814ea60c9"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1163,36 +1150,36 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mimalloc"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ce6a4b40d3bff9eb3ce9881ca0737a85072f9f975886082640cd46a75cdb35"
+checksum = "9b2374e2999959a7b583e1811a1ddbf1d3a4b9496eceb9746f1192a59d871eca"
 dependencies = [
  "libmimalloc-sys",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1369,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1528,7 +1515,7 @@ dependencies = [
 name = "polars-core"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "anyhow",
  "arrow2",
  "base64",
@@ -1559,7 +1546,7 @@ dependencies = [
 name = "polars-io"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "anyhow",
  "arrow2",
  "csv-core",
@@ -1587,7 +1574,7 @@ dependencies = [
 name = "polars-lazy"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "bitflags",
  "glob",
  "polars-arrow",
@@ -1635,7 +1622,7 @@ dependencies = [
 name = "polars-plan"
 version = "0.25.1"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -1708,7 +1695,7 @@ dependencies = [
 name = "py-polars"
 version = "0.15.2"
 dependencies = [
- "ahash 0.8.1",
+ "ahash",
  "bincode",
  "built",
  "jemallocator",
@@ -1849,21 +1836,19 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1964,18 +1949,18 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2078,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "sqlparser"
@@ -2114,9 +2099,9 @@ checksum = "d55dd09aaa2f85ef8767cc9177294d63c30d62c8533329e75aa51d8b94976e22"
 
 [[package]]
 name = "strength_reduce"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strum"
@@ -2139,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2185,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -2282,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "value-trait"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c39f0b6c3d217fc9864f14a7bbae74cf562eddf4e0e276b91846b70425c8a87"
+checksum = "995de1aa349a0dc50f4aa40870dce12961a30229027230bad09acd2843edbe9e"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -2485,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import pickle
 from functools import partial
-from typing import cast
+from typing import Any, cast
 
 import polars as pl
 from polars import internals as pli
 from polars.dependencies import pyarrow as pa
 
 
-def _deser_and_exec(buf: bytes, with_columns: list[str] | None) -> pli.DataFrame:
+def _deser_and_exec(
+    buf: bytes, with_columns: list[str] | None, *args: Any
+) -> pli.DataFrame:
     """
     Deserialize and execute the given function for the projected columns.
 
@@ -25,11 +27,11 @@ def _deser_and_exec(buf: bytes, with_columns: list[str] | None) -> pli.DataFrame
 
     """
     func = pickle.loads(buf)
-    return func(with_columns)
+    return func(with_columns, *args)
 
 
 def _scan_ds_impl(
-    ds: pa.dataset.dataset, with_columns: list[str] | None
+    ds: pa.dataset.dataset, with_columns: list[str] | None, predicate: str | None
 ) -> pli.DataFrame:
     """
     Take the projected columns and materialize an arrow table.
@@ -40,16 +42,25 @@ def _scan_ds_impl(
         pyarrow dataset
     with_columns
         Columns that are projected
+    predicate
+        pyarrow expression that can be evaluated with eval
 
     Returns
     -------
     DataFrame
 
     """
-    return cast(pli.DataFrame, pl.from_arrow(ds.to_table(columns=with_columns)))
+    _filter = None
+    if predicate:
+        _filter = eval(predicate)
+    return cast(
+        pli.DataFrame, pl.from_arrow(ds.to_table(columns=with_columns, filter=_filter))
+    )
 
 
-def _scan_ds(ds: pa.dataset.dataset) -> pli.LazyFrame:
+def _scan_ds(
+    ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True
+) -> pli.LazyFrame:
     """
     Pickle the partially applied function `_scan_ds_impl`.
 
@@ -60,14 +71,22 @@ def _scan_ds(ds: pa.dataset.dataset) -> pli.LazyFrame:
     ----------
     ds
         pyarrow dataset
+    allow_pyarrow_filter
+        Allow predicates to be pushed down to pyarrow. This can lead to different
+        results if comparisons are done with null values as pyarrow handles this
+        different than polars does.
 
     """
     func = partial(_scan_ds_impl, ds)
     func_serialized = pickle.dumps(func)
-    return pli.LazyFrame._scan_python_function(ds.schema, func_serialized)
+    return pli.LazyFrame._scan_python_function(
+        ds.schema, func_serialized, allow_pyarrow_filter
+    )
 
 
-def _scan_ipc_impl(uri: str, with_columns: list[str] | None) -> pli.DataFrame:
+def _scan_ipc_impl(
+    uri: str, with_columns: list[str] | None, *args: Any
+) -> pli.DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
@@ -98,7 +117,9 @@ def _scan_ipc_fsspec(
     return pli.LazyFrame._scan_python_function(schema, func_serialized)
 
 
-def _scan_parquet_impl(uri: str, with_columns: list[str] | None) -> pli.DataFrame:
+def _scan_parquet_impl(
+    uri: str, with_columns: list[str] | None, *args: Any
+) -> pli.DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -339,16 +339,19 @@ class LazyFrame:
 
     @classmethod
     def _scan_python_function(
-        cls, schema: pa.schema | dict[str, type[DataType]], scan_fn: bytes
+        cls,
+        schema: pa.schema | dict[str, type[DataType]],
+        scan_fn: bytes,
+        pyarrow: bool = False,
     ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, dict):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
-                [(name, dt) for name, dt in schema.items()], scan_fn
+                [(name, dt) for name, dt in schema.items()], scan_fn, pyarrow
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(
-                list(schema), scan_fn
+                list(schema), scan_fn, pyarrow
             )
         return self
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1537,7 +1537,7 @@ def read_delta(
     )
 
 
-def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
+def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.
 
@@ -1547,6 +1547,10 @@ def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
     ----------
     ds
         Pyarrow dataset to scan.
+    allow_pyarrow_filter
+        Allow predicates to be pushed down to pyarrow. This can lead to different
+        results if comparisons are done with null values as pyarrow handles this
+        different than polars does.
 
     Warnings
     --------
@@ -1573,7 +1577,7 @@ def scan_ds(ds: pa.dataset.dataset) -> LazyFrame:
     └───────┴────────┴────────────┘
 
     """
-    return _scan_ds(ds)
+    return _scan_ds(ds, allow_pyarrow_filter)
 
 
 def read_csv_batched(

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -311,18 +311,20 @@ impl PyLazyFrame {
     pub fn scan_from_python_function_arrow_schema(
         schema: &PyList,
         scan_fn: Vec<u8>,
+        pyarrow: bool,
     ) -> PyResult<Self> {
         let schema = pyarrow_schema_to_rust(schema)?;
-        Ok(LazyFrame::scan_from_python_function(schema, scan_fn).into())
+        Ok(LazyFrame::scan_from_python_function(schema, scan_fn, pyarrow).into())
     }
 
     #[staticmethod]
     pub fn scan_from_python_function_pl_schema(
         schema: Vec<(&str, Wrap<DataType>)>,
         scan_fn: Vec<u8>,
+        pyarrow: bool,
     ) -> PyResult<Self> {
         let schema = Schema::from_iter(schema.into_iter().map(|(name, dt)| Field::new(name, dt.0)));
-        Ok(LazyFrame::scan_from_python_function(schema, scan_fn).into())
+        Ok(LazyFrame::scan_from_python_function(schema, scan_fn, pyarrow).into())
     }
 
     pub fn describe_plan(&self) -> String {

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -1,29 +1,73 @@
 from __future__ import annotations
 
 import os
+import typing
 
 import pyarrow.dataset as ds
 
 import polars as pl
 
 
+@typing.no_type_check
+def helper_dataset_test(io_test_dir: str, query) -> None:
+    file = os.path.join(io_test_dir, "small.ipc")
+    dset = ds.dataset(file, format="ipc")
+
+    expected = query(pl.scan_ipc(file))
+    out = query(pl.scan_ds(dset))
+    assert out.frame_equal(expected)
+
+
 def test_dataset(io_test_dir: str) -> None:
     # windows path does not seem to work
     if os.name != "nt":
-        file = os.path.join(io_test_dir, "small.ipc")
-        dset = ds.dataset(file, format="ipc")
-
-        expected = (
-            pl.scan_ipc(file)
-            .filter("bools")
-            .select(["bools", "floats", "date"])
-            .collect()
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter("bools").select(["bools", "floats", "date"]).collect(),
         )
-        out = (
-            pl.scan_ds(dset)
-            .filter("bools")
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(~pl.col("bools"))
             .select(["bools", "floats", "date"])
-            .collect()
+            .collect(),
         )
-
-        assert out.frame_equal(expected)
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("int_nulls").is_null())
+            .select(["bools", "floats", "date"])
+            .collect(),
+        )
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("int_nulls").is_not_null())
+            .select(["bools", "floats", "date"])
+            .collect(),
+        )
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("int_nulls").is_not_null() == pl.col("bools"))
+            .select(["bools", "floats", "date"])
+            .collect(),
+        )
+        # this equality on a column with nulls fails as pyarrow has different
+        # handling kleene logic. We leave it for now and document it in the function.
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("int") == 10)
+            .select(["bools", "floats", "int_nulls"])
+            .collect(),
+        )
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("int") != 10)
+            .select(["bools", "floats", "int_nulls"])
+            .collect(),
+        )
+        # this predicate is not supported by pyarrow
+        # check if we still do it on our side
+        helper_dataset_test(
+            io_test_dir,
+            lambda lf: lf.filter(pl.col("floats").sum().over("date") == 10)
+            .select(["bools", "floats", "date"])
+            .collect(),
+        )


### PR DESCRIPTION
Simple predicates can now be pushed down to pyarrow datasets. This means that pyarrow datasets now support predicate and projection pushdown having the most important optimizations for IO.
