### PR TITLE
python polars 0.15.4

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.14.2"
-source = "git+https://github.com/ritchie46/arrow2?branch=polars_2022-12-11#8216c755ce7ad13d355fbb02adae4a89767d945e"
+source = "git+https://github.com/ritchie46/arrow2?branch=polars_2022-12-11#dfc7fc262d1ef47e4bd887c063ddee6288ef3440"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -1380,8 +1380,7 @@ dependencies = [
 [[package]]
 name = "parquet2"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bbada33c3674484db647d889a581ab1105cafb871ba77be785af2cc44a8747"
+source = "git+https://github.com/ritchie46/parquet2/?branch=fix_rle_decoding#0f8e1a24c546f07b01167bd415a040a2eb7c5c4c"
 dependencies = [
  "async-stream",
  "brotli",
@@ -1693,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.15.3"
+version = "0.15.4"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"


### PR DESCRIPTION
This patches and replaces 0.15.3 release to include a fix for a serious parquet reading bug.