### PR TITLE
chore(rust): Remove dbg statement from union

### DIFF
--- a/polars/polars-lazy/src/physical_plan/executors/union.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/union.rs
@@ -89,7 +89,6 @@ impl Executor for UnionExec {
                     })
                     .collect::<PolarsResult<Vec<_>>>()
             });
-            dbg!(&out);
 
             concat_df(out?.iter().flat_map(|dfs| dfs.iter()))
         }


### PR DESCRIPTION
After using newest version, I realized this has been clogging up our stderr a lot ;)

Should we yank 0.15.3 and replace?