### PR TITLE
chore(python): remove unused `cmake-rs` patch

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "ahash",
  "bincode",
@@ -2476,8 +2476,3 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[patch.unused]]
-name = "cmake"
-version = "0.1.48"
-source = "git+https://github.com/messense/cmake-rs.git?branch=cross-compile#15ab68baca7c44bcf23c5d91a4201f10d40552a1"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -164,9 +164,6 @@ features = [
   "date_offset",
 ]
 
-[patch.crates-io]
-cmake = { git = "https://github.com/messense/cmake-rs.git", branch = "cross-compile" }
-
 [lib]
 name = "polars"
 crate-type = ["cdylib"]


### PR DESCRIPTION
It's unused, and the patch is [merged](https://github.com/rust-lang/cmake-rs/pull/158) in upstream and already publish to crates.io.