### PR TITLE
 fix(python): fix delta issues

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1403,6 +1403,30 @@ def scan_delta(
     ...     table_path, storage_options=storage_options
     ... ).collect()  # doctest: +SKIP
 
+    Creates a scan for a Delta table from Google Cloud storage (GCS).
+
+    Note: This implementation relies on `pyarrow.fs` and thus has to rely on fsspec
+    compatible filesystems as mentioned `here
+    <https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems-with-arrow>`__.
+    So please ensure that `pyarrow` ,`fsspec` and `gcsfs` are installed.
+
+    See a list of supported storage options for GCS `here
+    <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L570-L577>`__.
+
+    >>> import gcsfs  # doctest: +SKIP
+    >>> from pyarrow.fs import PyFileSystem, FSSpecHandler  # doctest: +SKIP
+    >>> storage_options = {"SERVICE_ACCOUNT": "SERVICE_ACCOUNT_JSON_ABSOLUTE_PATH"}
+    >>> fs = gcsfs.GCSFileSystem(
+    ...     project="my-project-id",
+    ...     token=storage_options["SERVICE_ACCOUNT"],
+    ... )  # doctest: +SKIP
+    >>> # this pyarrow fs must be created and passed to scan_delta for GCS
+    >>> pa_fs = PyFileSystem(FSSpecHandler(fs))  # doctest: +SKIP
+    >>> table_path = "gs://bucket/path/to/delta-table/"
+    >>> pl.scan_delta(
+    ...     table_path, storage_options=storage_options, raw_filesystem=pa_fs
+    ... ).collect()  # doctest: +SKIP
+
     Creates a scan for a Delta table from Azure.
 
     Note: This implementation relies on `pyarrow.fs` and thus has to rely on fsspec
@@ -1411,9 +1435,10 @@ def scan_delta(
     So please ensure that `pyarrow` ,`fsspec` and `adlfs` are installed.
 
     Following type of table paths are supported,
-        * az://<container>/<path>
-        * adl://<container>/<path>
-        * abfs://<container>/<path>
+
+    * az://<container>/<path>
+    * adl://<container>/<path>
+    * abfs://<container>/<path>
 
     See a list of supported storage options for Azure `here
     <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L524-L539>`__.
@@ -1551,9 +1576,10 @@ def read_delta(
     Reads a Delta table from Azure.
 
     Following type of table paths are supported,
-        * az://<container>/<path>
-        * adl://<container>/<path>
-        * abfs://<container>/<path>
+
+    * az://<container>/<path>
+    * adl://<container>/<path>
+    * abfs://<container>/<path>
 
     See a list of supported storage options for Azure `here
     <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L524-L539>`__.

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1321,7 +1321,7 @@ def _get_delta_lake_table(
 def scan_delta(
     table_uri: str,
     version: int | None = None,
-    raw_filesystem: pa.fs.FileSystem | None = None,
+    raw_filesystem: pyarrow.fs.FileSystem | None = None,
     storage_options: dict[str, object] | None = None,
     delta_table_options: dict[str, object] | None = None,
     pyarrow_options: dict[str, object] | None = None,
@@ -1405,13 +1405,14 @@ def scan_delta(
 
     if pyarrow_options is None:
         pyarrow_options = {}
+    from pyarrow import fs as pa_fs
 
     if raw_filesystem is None:
-        raw_filesystem, normalized_path = pa.fs.FileSystem.from_uri(table_uri)
+        raw_filesystem, normalized_path = pa_fs.FileSystem.from_uri(table_uri)
     else:
         raw_filesystem, normalized_path = raw_filesystem.from_uri(table_uri)
 
-    filesystem = pa.fs.SubTreeFileSystem(normalized_path, raw_filesystem)
+    filesystem = pa_fs.SubTreeFileSystem(normalized_path, raw_filesystem)
 
     dl_tbl = _get_delta_lake_table(
         table_path=table_uri,

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1529,7 +1529,7 @@ def read_delta(
     >>> table_path = "/path/to/delta-table/"
     >>> pl.read_delta(table_path, version=1)  # doctest: +SKIP
 
-    Reads a Delta table from S3 filesystem.
+    Reads a Delta table from AWS S3.
     See a list of supported storage options for S3 `here
     <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L423-L491>`__.
 
@@ -1538,6 +1538,14 @@ def read_delta(
     ...     "AWS_ACCESS_KEY_ID": "THE_AWS_ACCESS_KEY_ID",
     ...     "AWS_SECRET_ACCESS_KEY": "THE_AWS_SECRET_ACCESS_KEY",
     ... }
+    >>> pl.read_delta(table_path, storage_options=storage_options)  # doctest: +SKIP
+
+    Reads a Delta table from Google Cloud storage (GCS).
+    See a list of supported storage options for GCS `here
+    <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L570-L577>`__.
+
+    >>> table_path = "gs://bucket/path/to/delta-table/"
+    >>> storage_options = {"SERVICE_ACCOUNT": "SERVICE_ACCOUNT_JSON_ABSOLUTE_PATH"}
     >>> pl.read_delta(table_path, storage_options=storage_options)  # doctest: +SKIP
 
     Reads a Delta table from Azure.

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1418,8 +1418,8 @@ def scan_delta(
     See a list of supported storage options for Azure `here
     <https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L524-L539>`__.
 
-    >>> import adlfs
-    >>> from pyarrow.fs import PyFileSystem, FSSpecHandler
+    >>> import adlfs  # doctest: +SKIP
+    >>> from pyarrow.fs import PyFileSystem, FSSpecHandler  # doctest: +SKIP
     >>> storage_options = {
     ...     "AZURE_STORAGE_ACCOUNT_NAME": "AZURE_STORAGE_ACCOUNT_NAME",
     ...     "AZURE_STORAGE_ACCOUNT_KEY": "AZURE_STORAGE_ACCOUNT_KEY",
@@ -1427,9 +1427,9 @@ def scan_delta(
     >>> fs = adlfs.AzureBlobFileSystem(
     ...     account_name=storage_options["AZURE_STORAGE_ACCOUNT_NAME"],
     ...     account_key=storage_options["AZURE_STORAGE_ACCOUNT_KEY"],
-    ... )
+    ... )  # doctest: +SKIP
     >>> # this pyarrow fs must be created and passed to scan_delta for Azure
-    >>> pa_fs = PyFileSystem(FSSpecHandler(fs))
+    >>> pa_fs = PyFileSystem(FSSpecHandler(fs))  # doctest: +SKIP
     >>> table_path = "az://container/path/to/delta-table/"
     >>> pl.scan_delta(
     ...     table_path, storage_options=storage_options, raw_filesystem=pa_fs

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1346,7 +1346,11 @@ def scan_delta(
     Parameters
     ----------
     table_uri
-        Path to the root directory of the Delta lake table.
+        Path or URI to the root of the Delta lake table.
+
+        Note: For Local filesystem, absolute and relative paths are supported. But
+        for the supported object storages - GCS, Azure and S3, there is no relative
+        path support, and thus full URI must be provided.
     version
         Version of the Delta lake table.
 
@@ -1517,7 +1521,11 @@ def read_delta(
     Parameters
     ----------
     table_uri
-        Path to the root directory of the Delta lake table.
+        Path or URI to the root of the Delta lake table.
+
+        Note: For Local filesystem, absolute and relative paths are supported. But
+        for the supported object storages - GCS, Azure and S3, there is no relative
+        path support, and thus full URI must be provided.
     version
         Version of the Delta lake table.
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1414,7 +1414,7 @@ def scan_delta(
 
     if pyarrow_options is None:
         pyarrow_options = {}
-    from pyarrow import fs as pa_fs
+    import pyarrow.fs as pa_fs
 
     resolved_uri = resolve_uri(table_uri)
 

--- a/py-polars/tests/io/test_delta.py
+++ b/py-polars/tests/io/test_delta.py
@@ -39,6 +39,19 @@ def test_scan_delta_filesystem() -> None:
     assert_frame_equal(expected, ldf.collect(), check_dtype=False)
 
 
+def test_scan_delta_relative() -> None:
+    table_path = Path(__file__).parent.parent / "files" / "delta-table"
+    rel_table_path = str(table_path / ".." / "delta-table")
+
+    ldf = pl.scan_delta(rel_table_path, version=0)
+
+    expected = pl.DataFrame({"name": ["Joey", "Ivan"], "age": [14, 32]})
+    assert_frame_equal(expected, ldf.collect(), check_dtype=False)
+
+    ldf = pl.scan_delta(rel_table_path, version=1)
+    assert not expected.frame_equal(ldf.collect())
+
+
 def test_read_delta() -> None:
     table_path = str(Path(__file__).parent.parent / "files" / "delta-table")
     df = pl.read_delta(table_path, version=0)
@@ -77,7 +90,7 @@ def test_read_delta_filesystem() -> None:
 
 def test_read_delta_relative() -> None:
     table_path = Path(__file__).parent.parent / "files" / "delta-table"
-    rel_table_path = str(table_path.relative_to(str(Path(__file__).parent.parent)))
+    rel_table_path = str(table_path / ".." / "delta-table")
 
     df = pl.read_delta(rel_table_path, version=0)
 

--- a/py-polars/tests/io/test_delta.py
+++ b/py-polars/tests/io/test_delta.py
@@ -65,8 +65,21 @@ def test_read_delta_columns() -> None:
 
 def test_read_delta_filesystem() -> None:
     table_path = str(Path(__file__).parent.parent / "files" / "delta-table")
-    fs = pyarrow.fs.LocalFileSystem()
-    df = pl.read_delta(table_path, version=0, raw_filesystem=fs)
+
+    raw_filesystem = pyarrow.fs.LocalFileSystem()
+    fs = pyarrow.fs.SubTreeFileSystem(table_path, raw_filesystem)
+
+    df = pl.read_delta(table_path, version=0, pyarrow_options={"filesystem": fs})
+
+    expected = pl.DataFrame({"name": ["Joey", "Ivan"], "age": [14, 32]})
+    assert_frame_equal(expected, df, check_dtype=False)
+
+
+def test_read_delta_relative() -> None:
+    table_path = Path(__file__).parent.parent / "files" / "delta-table"
+    rel_table_path = str(table_path.relative_to(str(Path(__file__).parent.parent)))
+
+    df = pl.read_delta(rel_table_path, version=0)
 
     expected = pl.DataFrame({"name": ["Joey", "Ivan"], "age": [14, 32]})
     assert_frame_equal(expected, df, check_dtype=False)


### PR DESCRIPTION
Aims to fixes the following issues,
- https://github.com/pola-rs/polars/issues/5790
- https://github.com/pola-rs/polars/issues/5785

**Checklist**
- [x] Fix imports issue
- [x] Resolve paths before passing to delta for relative path support
- [x] `read_delta` should rely on delta side implementation 
- [x] `scan_delta` should work as expected without relying on delta implementation.
- [x] create internal test matrix of [local, s3, azure, gcs] X [read, scan] X [absolute, relative paths, absolute with external fs, relative with external fs]
- [x] additional cases for relative paths
- [x] perform tests in a separate env
- [x] added example to read and scan from azure 
- [x] added example to read and scan from gcs 

**Notes**
1. Till the time https://github.com/delta-io/delta-rs/issues/1015 is not resolved, I have added a simple delta specific path resolution in `scan_delta`. Later we can remove this in favor of the implementation provided in delta-rs itself.
2. `read_delta` now relies on the implementation provided in delta-rs itself.
3. For GCS, Azure and S3 there is no relative path support, full URI must be provided.

**Testing** 
1. For LocalFS, GCS, Azure and S3, I've created an internal test matrix as described in the check list which contains over 35 additional tests other than the unit tests. I'll check how to mock different `pyarrow.fs` somehow and then add these to the unit tests later.
2. This will matrix was also executed in a separate venv, after locally installing polars with fixes from a local full build (`maturin build`) as the import errors were not caught in the unit tests before.

Signed-off-by: chitralverma <chitralverma@gmail.com>