### PR TITLE
feat(rust): async parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "polars/polars-sql",
   "examples/read_csv",
   "examples/read_parquet",
+  "examples/read_parquet_async",
   "examples/python_rust_compiled_function",
 ]
 
@@ -50,6 +51,7 @@ features = [
   "compute_filter",
   "compute_if_then_else",
 ]
+
 
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }

--- a/examples/read_parquet_async/Cargo.toml
+++ b/examples/read_parquet_async/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "read_parquet_async"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-creds = "0.34.0"
+polars = { path = "../../polars", features = ["lazy", "parquet-async", ] }
+tokio = "1.23.0"

--- a/examples/read_parquet_async/src/main.rs
+++ b/examples/read_parquet_async/src/main.rs
@@ -1,0 +1,25 @@
+use awscreds::Credentials;
+use polars::prelude::*;
+use tokio;
+use std::env;
+
+#[tokio::main]
+async fn main() -> PolarsResult<()> {
+    let cred = Credentials::default().unwrap();
+    env::set_var("AWS_SECRET_ACCESS_KEY", cred.secret_key.unwrap());
+    env::set_var("AWS_REGION", "us-east-2");
+    env::set_var("AWS_ACCESS_KEY_ID", cred.access_key.unwrap());
+
+    let df = LazyFrame::scan_parquet_async(
+        "s3://lov2test/delta-rs/rust/tests/data/simple_table/part-00190-8ac0ae67-fb1d-461d-a3d3-8dc112766ff5-c000.snappy.parquet",
+        ScanArgsParquet::default(),
+    ).await?
+    .select([
+        // select all columns
+        all(),
+    ])
+    .collect()?;
+
+    dbg!(df);
+    Ok(())
+}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -31,6 +31,7 @@ ndarray = ["polars-core/ndarray"]
 serde = ["polars-core/serde"]
 serde-lazy = ["polars-core/serde-lazy", "polars-lazy/serde", "polars-time/serde", "polars-io/serde", "polars-ops/serde"]
 parquet = ["polars-io", "polars-core/parquet", "polars-lazy/parquet", "polars-io/parquet"]
+parquet-async = ["parquet", "polars-io", "polars-core/parquet", "polars-lazy/parquet-async", "polars-io/parquet"]
 lazy = ["polars-core/lazy", "polars-lazy", "polars-lazy/compile"]
 # commented out until UB is fixed
 # parallel = ["polars-core/parallel"]

--- a/polars/polars-core/src/error.rs
+++ b/polars/polars-core/src/error.rs
@@ -59,6 +59,8 @@ pub enum PolarsError {
     Io(#[from] std::io::Error),
     #[error("DuplicateError: {0}")]
     Duplicate(ErrString),
+    #[error("External: {0}")]
+    External(String, Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl From<ArrowError> for PolarsError {

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -31,6 +31,7 @@ dtype-binary = ["polars-core/dtype-binary"]
 fmt = ["polars-core/fmt"]
 lazy = []
 parquet = ["polars-core/parquet", "arrow/io_parquet", "arrow/io_parquet_compression", "memmap"]
+parquet-async = ["parquet", "async-trait", "futures", "object_store", "tokio", "url"]
 partition = ["polars-core/partition_by"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
 # don't use this
@@ -40,14 +41,18 @@ private = ["polars-time/private"]
 ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
+async-trait = {version ="0.1.59", optional = true}
+bytes = "1.3.0"
 csv-core = { version = "0.1.10", optional = true }
 dirs = "4.0"
 flate2 = { version = "1", optional = true, default-features = false }
+futures = {version ="0.3.25", optional=true}
 lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-floats", "parse-integers"] }
 lexical-core = { version = "0.8", optional = true }
 memchr = "2.5"
 memmap = { package = "memmap2", version = "0.5.2", optional = true }
 num.workspace = true
+object_store = {version = "0.5.2", features=["aws"], optional=true}
 once_cell = "1"
 polars-arrow = { version = "0.25.1", path = "../polars-arrow" }
 polars-core = { version = "0.25.1", path = "../polars-core", features = ["private"], default-features = false }
@@ -59,6 +64,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
 simd-json = { version = "0.7.0", optional = true, features = ["allow-non-simd", "known-key"] }
 simdutf8 = "0.1"
+tokio = {version="1.22.0", features=["full"], optional=true}
+url = {version="2.3.1", optional=true}
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/polars/polars-io/src/parquet/async_impl.rs
+++ b/polars/polars-io/src/parquet/async_impl.rs
@@ -1,0 +1,479 @@
+//! Read parquet files in parallel from the Object Store without a third party crate.
+use std::borrow::Cow;
+use std::io::{self};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+
+use arrow::io::parquet::read::{
+    self as parquet2_read, read_columns_async, to_deserializer, ColumnChunkMetaData,
+    RowGroupMetaData,
+};
+use arrow::io::parquet::write::FileMetaData;
+use futures::executor::block_on;
+use futures::future::BoxFuture;
+use futures::lock::Mutex;
+use futures::{
+    stream, AsyncRead, AsyncSeek, Future, Stream, StreamExt, TryFutureExt, TryStreamExt,
+};
+use object_store::aws::AmazonS3Builder;
+use object_store::path::{Path, Path as ObjectPath};
+use object_store::ObjectStore;
+use polars_core::error::{PolarsError, PolarsResult};
+use polars_core::prelude::*;
+use polars_core::schema::Schema;
+use polars_core::utils::accumulate_dataframes_vertical;
+use polars_core::POOL;
+use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use url::Url;
+
+use super::predicates::read_this_row_group;
+use super::read_impl::array_iter_to_series;
+use super::ParallelStrategy;
+use crate::predicates::{apply_predicate, arrow_schema_to_empty_df, PhysicalIoExpr};
+use crate::prelude::apply_projection;
+use crate::RowCount;
+
+pub struct AsyncCloudObject {
+    pos: u64,
+    length: Option<u64>, // total size
+    object_store: Arc<Mutex<dyn ObjectStore>>,
+    path: Path,
+    active: Arc<Mutex<Option<BoxFuture<'static, std::io::Result<Vec<u8>>>>>>,
+}
+
+impl AsyncCloudObject {
+    pub fn new(length: Option<u64>, object_store: Arc<Mutex<dyn ObjectStore>>, path: Path) -> Self {
+        Self {
+            pos: 0,
+            length,
+            object_store,
+            path,
+            active: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    async fn create_future_once(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        lenght: usize,
+    ) -> std::task::Poll<std::io::Result<Vec<u8>>> {
+        let start = self.pos as usize;
+
+        // If we already have a future just poll it.
+        if let Some(fut) = self.active.lock().await.as_mut() {
+            return Future::poll(fut.as_mut(), cx);
+        }
+
+        // Create the future.
+        let future = {
+            let path = self.path.clone();
+            let arc = self.object_store.clone();
+            // Use an async move block to get our owned objects.
+            async move {
+                let object_store = arc.lock().await;
+                object_store
+                    .get_range(&path, start..start + lenght)
+                    .map_ok(|r| r.to_vec())
+                    .map_err(|e| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("object store error {}", e),
+                        )
+                    })
+                    .await
+            }
+        };
+        let mut future = Box::pin(future);
+
+        // Need to poll it once to get the pump going.
+        let polled = Future::poll(future.as_mut(), cx);
+
+        // Save for next time.
+        let mut state = self.active.lock().await;
+        *state = Some(future);
+        polled
+    }
+}
+
+impl AsyncRead for AsyncCloudObject {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match block_on(self.create_future_once(cx, buf.len())) {
+            Poll::Ready(Ok(bytes)) => {
+                buf.copy_from_slice(&bytes[..]);
+                Poll::Ready(Ok(bytes.len()))
+            }
+            Poll::Ready(Err(e)) => {
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => {
+                Poll::Pending
+            }
+        }
+    }
+}
+impl AsyncSeek for AsyncCloudObject {
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        pos: io::SeekFrom,
+    ) -> std::task::Poll<std::io::Result<u64>> {
+        match pos {
+            io::SeekFrom::Start(pos) => self.pos = pos,
+            io::SeekFrom::End(pos) => {
+                let length = self.length.ok_or::<io::Error>(io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Cannot seek from end of stream when length is unknown.",
+                ))?;
+                self.pos = (length as i64 + pos) as u64
+            }
+            io::SeekFrom::Current(pos) => self.pos = (self.pos as i64 + pos) as u64,
+        };
+        std::task::Poll::Ready(Ok(self.pos))
+    }
+}
+
+pub(crate) struct ParquetImpl {
+    store: Arc<Mutex<dyn ObjectStore>>,
+    path: ObjectPath,
+    length: Option<u64>,
+    metadata: Option<FileMetaData>,
+}
+
+impl ParquetImpl {
+    pub fn from_s3_path(path: &str) -> PolarsResult<Self> {
+        let parsed =
+            Url::parse(path).map_err(|e| PolarsError::External("url parse".into(), Box::new(e)))?;
+        let s3 = AmazonS3Builder::from_env()
+            //.with_access_key_id(cred.access_key.unwrap())
+            //.with_secret_access_key(cred.secret_key.unwrap())
+            .with_region("us-west-2")
+            .with_bucket_name(
+                parsed
+                    .host()
+                    .ok_or(PolarsError::External(
+                        "wrong host".into(),
+                        format!("Cannot parse host from {}", path).into(),
+                    ))?
+                    .to_string(),
+            )
+            .build()
+            .map_err(|e| {
+                PolarsError::External("object store amazon s3 builder".into(), Box::new(e))
+            })?;
+        let store = Arc::new(Mutex::new(s3));
+        let path = ObjectPath::from(parsed.path());
+
+        Ok(ParquetImpl {
+            store,
+            path,
+            length: None,
+            metadata: None,
+        })
+    }
+
+    async fn initialize_lenght(&mut self) -> PolarsResult<()> {
+        if self.length.is_some() {
+            return Ok(());
+        }
+        let path = self.path.clone();
+        let locked_store = self.store.lock().await;
+        self.length = Some({
+            locked_store
+                .head(&path)
+                .await
+                .map_err(|e| PolarsError::External("reading object lenght".into(), Box::new(e)))?
+                .size as u64
+        });
+        Ok(())
+    }
+
+    pub async fn schema(&mut self) -> PolarsResult<Schema> {
+        let metadata = self.get_metadata().await?;
+
+        let arrow_schema = parquet2_read::infer_schema(&metadata)
+            .map_err(|e| PolarsError::External("infer schema".into(), Box::new(e)))?;
+
+        Ok(arrow_schema.fields.iter().into())
+    }
+
+    /// Number of rows in the parquet file.
+    pub async fn num_rows(&mut self) -> PolarsResult<usize> {
+        let metadata = self.get_metadata().await?;
+        Ok(metadata.num_rows)
+    }
+
+    /// Fetch the metadata of the parquet file, do not memoize it.
+    pub async fn fetch_metadata(&self) -> PolarsResult<FileMetaData> {
+        let object_store = self.store.clone();
+        let path = self.path.clone();
+        let length = self.length.clone();
+        let mut reader = AsyncCloudObject::new(length, object_store, path);
+        parquet2_read::read_metadata_async(&mut reader)
+            .await
+            .map_err(|e| PolarsError::External("read metadata async".into(), Box::new(e)))
+    }
+
+    /// Fetch and memoize the metadata of the parquet file.
+    pub async fn get_metadata(&mut self) -> PolarsResult<&FileMetaData> {
+        self.initialize_lenght().await?;
+        if self.metadata.is_none() {
+            self.metadata = Some(self.fetch_metadata().await?);
+        }
+        Ok(self.metadata.as_ref().unwrap())
+    }
+}
+
+fn column_idx_to_series(
+    column_i: usize,
+    md: &RowGroupMetaData,
+    remaining_rows: usize,
+    schema: &ArrowSchema,
+    downloaded_columns: Vec<(&ColumnChunkMetaData, Vec<u8>)>,
+    chunk_size: usize,
+) -> PolarsResult<Series> {
+    let mut field = schema.fields[column_i].clone();
+
+    match field.data_type {
+        ArrowDataType::Utf8 => {
+            field.data_type = ArrowDataType::LargeUtf8;
+        }
+        ArrowDataType::List(fld) => field.data_type = ArrowDataType::LargeList(fld),
+        _ => {}
+    }
+
+    let iter = to_deserializer(
+        downloaded_columns,
+        field.clone(),
+        remaining_rows,
+        Some(chunk_size),
+        None,
+    )?;
+
+    if remaining_rows < md.num_rows() {
+        array_iter_to_series(iter, &field, Some(remaining_rows))
+    } else {
+        array_iter_to_series(iter, &field, None)
+    }
+}
+
+/// Download rowgroups for the column whose indexes are given in `projection`.
+///
+/// Each rowgroup may be made out of 1 or more chunks. The function return a vector of vectors of tuples:
+///
+///   - the top level vector contains  one entry for each column, in the order of the columns.
+///   - each entry is in turn a vector containing the columns for the given rowgroup.
+///   - each tuple has a reference to the column metadata and then the content of the column.
+#[allow(unused_variables)]
+fn download_projection<'a: 'b, 'b>(
+    projection: &[usize],
+    md: &'a RowGroupMetaData,
+    remaining_rows: usize,
+    schema: &ArrowSchema,
+    async_reader: &'b ParquetImpl,
+    chunk_size: usize,
+) -> impl Stream<Item = PolarsResult<Vec<(&'a ColumnChunkMetaData, Vec<u8>)>>> + 'b {
+    let fields = projection
+        .iter()
+        .map(|i| schema.fields[*i].name.clone())
+        .collect::<Vec<_>>();
+    let columns = md.columns();
+
+    let reader_factory = || {
+        let object_store = async_reader.store.clone();
+        let path = async_reader.path.clone();
+        Box::pin(futures::future::ready(Ok(AsyncCloudObject::new(
+            async_reader.length,
+            object_store,
+            path,
+        ))))
+    }
+        as BoxFuture<'static, std::result::Result<AsyncCloudObject, std::io::Error>>;
+    stream::iter(fields.into_iter()).then(move |name| async move {
+        let reader_factory = reader_factory.clone();
+        let columns = columns.clone();
+        read_columns_async(reader_factory, columns, name.as_ref())
+            .map_err(|e| PolarsError::External("parquet read_columns_async".into(), e.into()))
+            .await
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+// might parallelize over columns
+async fn rg_to_dfs(
+    async_reader: &ParquetImpl,
+    previous_row_count: &mut IdxSize,
+    row_group_start: usize,
+    row_group_end: usize,
+    remaining_rows: &mut usize,
+    file_metadata: &FileMetaData,
+    schema: &ArrowSchema,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    row_count: Option<RowCount>,
+    parallel: ParallelStrategy,
+    projection: &[usize],
+) -> PolarsResult<Vec<DataFrame>> {
+    let mut dfs = Vec::with_capacity(row_group_end - row_group_start);
+
+    for rg in row_group_start..row_group_end {
+        let md = &file_metadata.row_groups[rg];
+        let current_row_count = md.num_rows() as IdxSize;
+
+        if !read_this_row_group(predicate.as_ref(), file_metadata, schema, rg)? {
+            *previous_row_count += current_row_count;
+            continue;
+        }
+        // test we don't read the parquet file if this env var is set
+        #[cfg(debug_assertions)]
+        {
+            assert!(std::env::var("POLARS_PANIC_IF_PARQUET_PARSED").is_err())
+        }
+
+        // First fetch all the columns.
+
+        let chunk_size = md.num_rows();
+        let downloaded_columns = download_projection(
+            projection,
+            md,
+            *remaining_rows,
+            schema,
+            async_reader,
+            chunk_size,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+        let columns = if let ParallelStrategy::Columns = parallel {
+            POOL.install(|| {
+                downloaded_columns
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(index, columns)| {
+                        column_idx_to_series(
+                            projection[index],
+                            md,
+                            *remaining_rows,
+                            schema,
+                            columns,
+                            chunk_size,
+                        )
+                    })
+                    .collect::<PolarsResult<Vec<_>>>()
+            })?
+        } else {
+            downloaded_columns
+                .into_iter()
+                .enumerate()
+                .map(|(index, columns)| {
+                    column_idx_to_series(
+                        projection[index],
+                        md,
+                        *remaining_rows,
+                        schema,
+                        columns,
+                        chunk_size,
+                    )
+                })
+                .collect::<PolarsResult<Vec<_>>>()?
+        };
+
+        *remaining_rows = remaining_rows.saturating_sub(file_metadata.row_groups[rg].num_rows());
+
+        let mut df = DataFrame::new_no_checks(columns);
+        if let Some(rc) = &row_count {
+            df.with_row_count_mut(&rc.name, Some(*previous_row_count + rc.offset));
+        }
+
+        apply_predicate(&mut df, predicate.as_deref(), true)?;
+
+        *previous_row_count += current_row_count;
+        dfs.push(df);
+
+        if *remaining_rows == 0 {
+            break;
+        }
+    }
+    Ok(dfs)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn read_parquet_async(
+    async_reader: &ParquetImpl,
+    mut limit: usize,
+    projection: Option<&[usize]>,
+    schema: &ArrowSchema,
+    metadata: FileMetaData,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    mut parallel: ParallelStrategy,
+    row_count: Option<RowCount>,
+) -> PolarsResult<DataFrame> {
+    let row_group_len = metadata.row_groups.len();
+
+    let projection = projection
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned((0usize..schema.fields.len()).collect::<Vec<_>>()));
+
+    if let ParallelStrategy::Auto = parallel {
+        if row_group_len > projection.len() || row_group_len > POOL.current_num_threads() {
+            parallel = ParallelStrategy::RowGroups;
+        } else {
+            parallel = ParallelStrategy::Columns;
+        }
+    }
+
+    if let (ParallelStrategy::Columns, true) = (parallel, projection.len() == 1) {
+        parallel = ParallelStrategy::None;
+    }
+
+    let dfs = match parallel {
+        ParallelStrategy::Columns | ParallelStrategy::None => {
+            rg_to_dfs(
+                &async_reader,
+                &mut 0,
+                0,
+                row_group_len,
+                &mut limit,
+                &metadata,
+                schema,
+                predicate,
+                row_count,
+                parallel,
+                &projection,
+            )
+            .await?
+        }
+        // TODO: implement row group parallelism.
+        ParallelStrategy::RowGroups => {
+            rg_to_dfs(
+                &async_reader,
+                &mut 0,
+                metadata.row_groups.len(),
+                row_group_len,
+                &mut limit,
+                &metadata,
+                schema,
+                predicate,
+                row_count,
+                parallel,
+                &projection,
+            )
+            .await?
+        }
+        // auto should already be replaced by Columns or RowGroups
+        ParallelStrategy::Auto => unimplemented!(),
+    };
+
+    if dfs.is_empty() {
+        let schema = if let Cow::Borrowed(_) = projection {
+            Cow::Owned(apply_projection(schema, &projection))
+        } else {
+            Cow::Borrowed(schema)
+        };
+        Ok(arrow_schema_to_empty_df(&schema))
+    } else {
+        accumulate_dataframes_vertical(dfs.into_iter())
+    }
+}

--- a/polars/polars-io/src/parquet/mod.rs
+++ b/polars/polars-io/src/parquet/mod.rs
@@ -14,6 +14,8 @@
 //! }
 //! ```
 //!
+#[cfg(feature = "parquet-async")]
+pub(super) mod async_impl;
 pub(super) mod mmap;
 pub mod predicates;
 mod read;

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -49,7 +49,7 @@ fn column_idx_to_series(
     }
 }
 
-fn array_iter_to_series(
+pub(super) fn array_iter_to_series(
     iter: ArrayIter,
     field: &ArrowField,
     num_rows: Option<usize>,

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 
 [dependencies]
 ahash.workspace = true
+async-trait = "0.1.59"
 bitflags.workspace = true
 glob = "0.3"
 polars-arrow = { version = "0.25.1", path = "../polars-arrow" }
@@ -33,6 +34,7 @@ compile = ["polars-plan/compile"]
 streaming = ["chunked_ids", "polars-pipe/compile", "polars-plan/streaming"]
 default = ["compile", "private"]
 parquet = ["polars-core/parquet", "polars-io/parquet", "polars-plan/parquet", "polars-pipe/parquet"]
+parquet-async = ["polars-plan/parquet-async"]
 ipc = ["polars-io/ipc", "polars-plan/ipc"]
 json = ["polars-io/json", "polars-plan/json"]
 csv-file = ["polars-io/csv-file", "polars-plan/csv-file", "polars-pipe/csv-file"]

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -20,6 +20,7 @@ pyo3 = { version = "0.16", optional = true }
 rayon.workspace = true
 regex = { version = "1.6", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+futures = {version="0.3.25", optional = true}
 
 [features]
 python = ["pyo3"]
@@ -29,6 +30,7 @@ compile = []
 default = ["compile", "private"]
 streaming = []
 parquet = ["polars-core/parquet", "polars-io/parquet"]
+parquet-async = ["polars-core/parquet", "polars-io/parquet-async", "futures"]
 ipc = ["polars-io/ipc"]
 json = ["polars-io/json"]
 csv-file = ["polars-io/csv-file"]

--- a/polars/polars-lazy/polars-plan/src/dot.rs
+++ b/polars/polars-lazy/polars-plan/src/dot.rs
@@ -435,6 +435,39 @@ impl LogicalPlan {
                     self.write_dot(acc_str, prev_node, current_node, id_map)
                 }
             }
+            #[cfg(feature = "parquet-async")]
+            ParquetScanAsync {
+                path,
+                file_info,
+                predicate,
+                options,
+                ..
+            } => {
+                let total_columns = file_info.schema.len();
+                let mut n_columns = "*".to_string();
+                if let Some(columns) = &options.with_columns {
+                    n_columns = format!("{}", columns.len());
+                }
+
+                let pred = fmt_predicate(predicate.as_ref());
+                let fmt = format!(
+                    "PARQUET SCAN {};\nπ {}/{};\nσ {}",
+                    path.to_string_lossy(),
+                    n_columns,
+                    total_columns,
+                    pred,
+                );
+                let current_node = DotNode {
+                    branch,
+                    id,
+                    fmt: &fmt,
+                };
+                if self.is_single(branch, id) {
+                    self.write_single_node(acc_str, current_node)
+                } else {
+                    self.write_dot(acc_str, prev_node, current_node, id_map)
+                }
+            }
             #[cfg(feature = "ipc")]
             IpcScan {
                 path,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -233,6 +233,19 @@ pub fn to_alp(
             predicate: predicate.map(|expr| to_aexpr(expr, expr_arena)),
             options,
         },
+        #[cfg(feature = "parquet-async")]
+        LogicalPlan::ParquetScanAsync {
+            path,
+            file_info,
+            predicate,
+            options,
+        } => ALogicalPlan::ParquetScan {
+            path,
+            file_info,
+            output_schema: None,
+            predicate: predicate.map(|expr| to_aexpr(expr, expr_arena)),
+            options,
+        },
         #[cfg(feature = "parquet")]
         LogicalPlan::ParquetScan {
             path,
@@ -713,6 +726,19 @@ impl ALogicalPlan {
                 predicate,
                 options,
             } => LogicalPlan::IpcScan {
+                path,
+                file_info,
+                predicate: predicate.map(|n| node_to_expr(n, expr_arena)),
+                options,
+            },
+            #[cfg(feature = "parquet-async")]
+            ALogicalPlan::ParquetScanAsync {
+                path,
+                file_info,
+                output_schema: _,
+                predicate,
+                options,
+            } => LogicalPlan::ParquetScanAsync {
                 path,
                 file_info,
                 predicate: predicate.map(|n| node_to_expr(n, expr_arena)),

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -90,6 +90,29 @@ impl LogicalPlan {
                     predicate,
                 )
             }
+            #[cfg(feature = "parquet-async")]
+            ParquetScanAsync {
+                path,
+                file_info,
+                predicate,
+                options,
+                ..
+            } => {
+                let n_columns = options
+                    .with_columns
+                    .as_ref()
+                    .map(|columns| columns.len() as i64)
+                    .unwrap_or(-1);
+                write_scan(
+                    f,
+                    "PARQUET-ASYNC",
+                    path,
+                    indent,
+                    n_columns,
+                    file_info.schema.len(),
+                    predicate,
+                )
+            }
             #[cfg(feature = "ipc")]
             IpcScan {
                 path,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -93,6 +93,15 @@ pub enum LogicalPlan {
         /// Filters at the scan level
         predicate: Option<Expr>,
     },
+    #[cfg(feature = "parquet-async")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parquet-async")))]
+    /// Scan a Parquet file using asynchronous code.
+    ParquetScanAsync {
+        path: PathBuf,
+        file_info: FileInfo,
+        predicate: Option<Expr>,
+        options: ParquetOptions,
+    },
     #[cfg(feature = "parquet")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     /// Scan a Parquet file
@@ -247,6 +256,8 @@ impl LogicalPlan {
             Explode { schema, .. } => Ok(Cow::Borrowed(schema)),
             #[cfg(feature = "parquet")]
             ParquetScan { file_info, .. } => Ok(Cow::Borrowed(&file_info.schema)),
+            #[cfg(feature = "parquet-async")]
+            ParquetScanAsync { file_info, .. } => Ok(Cow::Borrowed(&file_info.schema)),
             #[cfg(feature = "ipc")]
             IpcScan { file_info, .. } => Ok(Cow::Borrowed(&file_info.schema)),
             DataFrameScan { schema, .. } => Ok(Cow::Borrowed(schema)),

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -284,6 +284,27 @@ impl PredicatePushDown {
                 };
                 Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
             }
+            #[cfg(feature = "parquet-async")]
+            ParquetScanAsync {
+                path,
+                file_info,
+                output_schema,
+                predicate,
+                options,
+            } => {
+                let local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
+
+                let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
+
+                let lp = ParquetScanAsync {
+                    path,
+                    file_info,
+                    output_schema,
+                    predicate,
+                    options,
+                };
+                Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
+            }
             #[cfg(feature = "parquet")]
             ParquetScan {
                 path,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -423,7 +423,36 @@ impl ProjectionPushDown {
                 };
                 Ok(lp)
             }
+            #[cfg(feature = "parquet-async")]
+            ParquetScanAsync {
+                path,
+                file_info,
+                predicate,
+                mut options,
+                ..
+            } => {
+                let with_columns = get_scan_columns(&mut acc_projections, expr_arena);
+                let output_schema = if with_columns.is_none() {
+                    None
+                } else {
+                    Some(Arc::new(update_scan_schema(
+                        &acc_projections,
+                        expr_arena,
+                        &file_info.schema,
+                        false,
+                    )?))
+                };
+                options.with_columns = with_columns;
 
+                let lp = ParquetScanAsync {
+                    path,
+                    file_info,
+                    output_schema,
+                    predicate,
+                    options,
+                };
+                Ok(lp)
+            }
             #[cfg(feature = "parquet")]
             ParquetScan {
                 path,

--- a/polars/polars-lazy/src/physical_plan/executors/executor.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/executor.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use super::*;
 
 // Executor are the executors of the physical plan and produce DataFrames. They
@@ -9,6 +11,12 @@ use super::*;
 /// physical plan until the last executor is evaluated.
 pub trait Executor: Send {
     fn execute(&mut self, cache: &mut ExecutionState) -> PolarsResult<DataFrame>;
+}
+
+/// An Executor that can handle async processing.
+#[async_trait]
+pub trait AsyncExecutor: Send {
+    async fn execute(&mut self, cache: &mut ExecutionState) -> PolarsResult<DataFrame>;
 }
 
 pub struct Dummy {}

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -31,6 +31,12 @@ impl ParquetExec {
             self.options.n_rows,
         );
 
+        #[cfg(feature = "parquet-async")]
+        {
+            ParquetAsyncReader::from_uri("file");
+            Ok(DataFrame::default())
+        }
+        #[cfg(not(feature = "parquet-async"))]
         ParquetReader::new(file)
             .with_n_rows(n_rows)
             .read_parallel(self.options.parallel)

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet_async.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet_async.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+
+use super::*;
+
+pub struct ParquetExecAsync {
+    path: PathBuf,
+    schema: SchemaRef,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    options: ParquetOptions,
+    async_options: bool,
+}
+
+impl ParquetExecAsync {
+    pub(crate) fn new(
+        path: PathBuf,
+        schema: SchemaRef,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        options: ParquetOptions,
+        async_options: bool,
+    ) -> Self {
+        ParquetExecAsync {
+            path,
+            schema,
+            predicate,
+            options,
+            async_options,
+        }
+    }
+
+    async fn read(&mut self) -> PolarsResult<DataFrame> {
+        let (projection, n_rows, predicate) = prepare_generic_scan_args(
+            &self.predicate,
+            &mut self.options.with_columns,
+            &mut self.schema,
+            self.options.n_rows,
+        );
+
+        {
+            ParquetAsyncReader::from_uri("file")?
+                .with_n_rows(n_rows)
+                .with_row_count(std::mem::take(&mut self.options.row_count))
+                .set_rechunk(self.options.rechunk)
+                .set_low_memory(self.options.low_memory)
+                ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
+                .await
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncExecutor for ParquetExecAsync {
+    async fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        // --- caching not ported yet for async execution.
+        // let finger_print = FileFingerPrint {
+        //     path: self.path.clone(),
+        //     predicate: self
+        //         .predicate
+        //         .as_ref()
+        //         .map(|ae| ae.as_expression().unwrap().clone()),
+        //     slice: (0, self.options.n_rows),
+        // };
+
+        // let profile_name = if state.has_node_timer() {
+        //     let mut ids = vec![self.path.to_string_lossy().to_string()];
+        //     if self.predicate.is_some() {
+        //         ids.push("predicate".to_string())
+        //     }
+        //     let name = column_delimited("parquet".to_string(), &ids);
+        //     Cow::Owned(name)
+        // } else {
+        //     Cow::Borrowed("")
+        // };
+
+        // state.record(
+        //     || {
+        //         state
+        //             .file_cache
+        //             .read(finger_print, self.options.file_counter, &mut || self.read())
+        //     },
+        //     profile_name,
+        // )
+        self.read().await
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -211,6 +211,28 @@ pub fn create_physical_plan(
                 options,
             }))
         }
+        #[cfg(feature = "parquet-async")]
+        ParquetScanAsync {
+            path,
+            file_info,
+            output_schema,
+            predicate,
+            options,
+        } => {
+            let predicate = predicate
+                .map(|pred| {
+                    create_physical_expr(pred, Context::Default, expr_arena, output_schema.as_ref())
+                })
+                .map_or(Ok(None), |v| v.map(Some))?;
+
+            Ok(Box::new(executors::ParquetExecAsync::new(
+                path,
+                file_info.schema,
+                predicate,
+                options,
+
+            )))
+        }
         #[cfg(feature = "parquet")]
         ParquetScan {
             path,
@@ -230,6 +252,7 @@ pub fn create_physical_plan(
                 file_info.schema,
                 predicate,
                 options,
+
             )))
         }
         Projection {


### PR DESCRIPTION
Use object_store and async facilities to integrate S3 parquet download in polars.

I am not sure how to keep on propagating `async` on the executor path. Maybe using the streaming approach would be a good fit here? Ideally really big parquet files would not be kept in memory when predicates do not match a record.