### PR TITLE
refactor(python): lazily import connectorx

### DIFF
--- a/polars/Makefile
+++ b/polars/Makefile
@@ -113,5 +113,5 @@ publish:
 
 .PHONY: help
 help:  ## Display this help screen
-	@echo -e '\033[1mAvailable commands:\033[0m'
+	@echo -e "\033[1mAvailable commands:\033[0m\n"
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -77,5 +77,5 @@ clean:  ## Clean up caches and build artifacts
 
 .PHONY: help
 help:  ## Display this help screen
-	@echo -e '\033[1mAvailable commands:\033[0m'
+	@echo -e "\033[1mAvailable commands:\033[0m\n"
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1097,7 +1097,7 @@ def read_sql(
 
     """
     try:
-        import connectorx as cx  # type: ignore[import]
+        import connectorx as cx
     except ImportError:
         raise ImportError(
             "connectorx is not installed. Please run `pip install connectorx>=0.2.2`."


### PR DESCRIPTION
As discussed [here](https://github.com/pola-rs/polars/pull/5761#discussion_r1045279345), `connectorx` was still being imported eagerly. This PR move it inside the function for lazy importing.

Signed-off-by: chitralverma <chitralverma@gmail.com>