### PR TITLE
fix(python): Fix type hint for IO `storage_options` argument

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -81,7 +81,7 @@ def read_csv(
     low_memory: bool = False,
     rechunk: bool = True,
     use_pyarrow: bool = False,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     skip_rows_after_header: int = 0,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
@@ -593,7 +593,7 @@ def scan_ipc(
     rechunk: bool = True,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     memory_map: bool = True,
 ) -> LazyFrame:
     """
@@ -648,7 +648,7 @@ def scan_parquet(
     rechunk: bool = True,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     low_memory: bool = False,
 ) -> LazyFrame:
     """
@@ -789,7 +789,7 @@ def read_ipc(
     n_rows: int | None = None,
     use_pyarrow: bool = False,
     memory_map: bool = True,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
     rechunk: bool = True,
@@ -875,7 +875,7 @@ def read_parquet(
     n_rows: int | None = None,
     use_pyarrow: bool = False,
     memory_map: bool = True,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     parallel: ParallelStrategy = "auto",
     row_count_name: str | None = None,
     row_count_offset: int = 0,
@@ -1280,7 +1280,7 @@ def _read_excel_sheet(
 def _get_delta_lake_table(
     table_path: str,
     version: int | None = None,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     delta_table_options: dict[str, object] | None = None,
 ) -> deltalake.DeltaTable:
     """
@@ -1332,7 +1332,7 @@ def scan_delta(
     table_uri: str,
     version: int | None = None,
     raw_filesystem: pa.fs.FileSystem | None = None,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     delta_table_options: dict[str, object] | None = None,
     pyarrow_options: dict[str, object] | None = None,
 ) -> LazyFrame:
@@ -1507,7 +1507,7 @@ def read_delta(
     table_uri: str,
     version: int | None = None,
     columns: list[str] | None = None,
-    storage_options: dict[str, object] | None = None,
+    storage_options: dict[str, Any] | None = None,
     delta_table_options: dict[str, object] | None = None,
     pyarrow_options: dict[str, object] | None = None,
 ) -> DataFrame:


### PR DESCRIPTION
For the following file:

```python
import polars as pl
storage_options = {"account_name": "ABC", "account_key": "123abc"}
df = pl.read_csv("path", storage_options=storage_options)
```

`mypy` complains that the type is incorrect:

```bash
check_type.py:5: error: Argument "storage_options" to "read_csv" has incompatible type "Dict[str, str]"; expected "Optional[Dict[str, object]]"  [arg-type]
check_type.py:5: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
check_type.py:5: note: Consider using "Mapping" instead, which is covariant in the value type
```

We actually want to use a dict here, but `object` is too restrictive. Setting this to `Any` solves the issue here.