### PR TITLE
feat(python): Add string representation for data types

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -206,7 +206,7 @@ class Unknown(DataType):
 class List(DataType):
     inner: PolarsDataType | None = None
 
-    def __init__(self, inner: PolarsDataType | type):
+    def __init__(self, inner: PolarsDataType | PythonDataType):
         """
         Nested list/array type.
 
@@ -243,8 +243,8 @@ class List(DataType):
         return hash((List, self.inner))
 
     def __repr__(self) -> str:
-        name = self.__class__.__name__
-        return f"{name}({self.inner!r})"
+        class_name = self.__class__.__name__
+        return f"{class_name}({self.inner!r})"
 
 
 class Date(DataType):
@@ -286,8 +286,8 @@ class Datetime(DataType):
         return hash((Datetime, self.tu))
 
     def __repr__(self) -> str:
-        name = self.__class__.__name__
-        return f"{name}(tu={self.tu!r}, tz={self.tz!r})"
+        class_name = self.__class__.__name__
+        return f"{class_name}(tu={self.tu!r}, tz={self.tz!r})"
 
 
 class Duration(DataType):
@@ -320,8 +320,8 @@ class Duration(DataType):
         return hash((Duration, self.tu))
 
     def __repr__(self) -> str:
-        name = self.__class__.__name__
-        return f"{name}(tu={self.tu!r})"
+        class_name = self.__class__.__name__
+        return f"{class_name}(tu={self.tu!r})"
 
 
 class Time(DataType):
@@ -617,7 +617,7 @@ def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
         # does not represent a realisable dtype, so ignore by default
         return include_unknown
     else:
-        return isinstance(data_type, DataType) or isinstance(data_type, DataTypeClass)
+        return isinstance(data_type, (DataType, DataTypeClass))
 
 
 @overload

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -365,9 +365,13 @@ def sequence_to_pyseries(
             else:
                 try:
                     if is_polars_dtype(nested_dtype):
-                        nested_arrow_dtype = dtype_to_arrow_type(nested_dtype)  # type: ignore[arg-type]
+                        nested_arrow_dtype = dtype_to_arrow_type(
+                            nested_dtype  # type: ignore[arg-type]
+                        )
                     else:
-                        nested_arrow_dtype = py_type_to_arrow_type(nested_dtype)  # type: ignore[arg-type]
+                        nested_arrow_dtype = py_type_to_arrow_type(
+                            nested_dtype  # type: ignore[arg-type]
+                        )
                 except ValueError:  # pragma: no cover
                     return sequence_from_anyvalue_or_object(name, values)
                 try:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -81,7 +81,7 @@ def include_unknowns(
     schema: dict[str, PolarsDataType], cols: Sequence[str]
 ) -> dict[str, PolarsDataType]:
     """Complete partial schema dict by including Unknown type."""
-    return {col: (schema.get(col, Unknown) or Unknown) for col in cols}
+    return {col: schema.get(col, Unknown) for col in cols}
 
 
 ################################
@@ -364,14 +364,10 @@ def sequence_to_pyseries(
                 # pass; we create an object if we get here
             else:
                 try:
-                    to_arrow_type = (
-                        dtype_to_arrow_type
-                        if is_polars_dtype(nested_dtype)
-                        else py_type_to_arrow_type
-                    )
-                    nested_arrow_dtype = to_arrow_type(
-                        nested_dtype  # type: ignore[arg-type]
-                    )
+                    if is_polars_dtype(nested_dtype):
+                        nested_arrow_dtype = dtype_to_arrow_type(nested_dtype)  # type: ignore[arg-type]
+                    else:
+                        nested_arrow_dtype = py_type_to_arrow_type(nested_dtype)  # type: ignore[arg-type]
                 except ValueError:  # pragma: no cover
                     return sequence_from_anyvalue_or_object(name, values)
                 try:
@@ -550,7 +546,7 @@ def _unpack_columns(
     return (
         column_names or None,  # type: ignore[return-value]
         {
-            lookup.get(col[0], col[0]): col[1]
+            lookup.get(col[0], col[0]): col[1]  # type: ignore[misc]
             for col in (columns or [])
             if not isinstance(col, str) and col[1]
         },

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2585,7 +2585,7 @@ class DataFrame:
         Rows: 3
         Columns: 6
         $ a <Float64> 1.0, 2.8, 3.0
-        $ b   <Int64 4, 5, None
+        $ b   <Int64> 4, 5, None
         $ c <Boolean> True, False, True
         $ d    <Utf8> None, b, c
         $ e    <Utf8> usd, eur, None

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -170,7 +170,7 @@ class DataFrame:
     Notice that the dtype is automatically inferred as a polars Int64:
 
     >>> df.dtypes
-    [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Int64'>]
+    [Int64, Int64]
 
     In order to specify dtypes for your columns, initialize the DataFrame with a list
     of typed Series:
@@ -944,7 +944,7 @@ class DataFrame:
         ...     }
         ... )
         >>> df.dtypes
-        [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Float64'>, <class 'polars.datatypes.Utf8'>]
+        [Int64, Float64, Utf8]
         >>> df
         shape: (3, 3)
         ┌─────┬─────┬─────┐
@@ -981,7 +981,7 @@ class DataFrame:
         ...     }
         ... )
         >>> df.schema
-        {'foo': <class 'polars.datatypes.Int64'>, 'bar': <class 'polars.datatypes.Float64'>, 'ham': <class 'polars.datatypes.Utf8'>}
+        {'foo': Int64, 'bar': Float64, 'ham': Utf8}
 
         """  # noqa: E501
         return dict(zip(self.columns, self.dtypes))
@@ -2585,7 +2585,7 @@ class DataFrame:
         Rows: 3
         Columns: 6
         $ a <Float64> 1.0, 2.8, 3.0
-        $ b   <Int64> 4, 5, None
+        $ b   <Int64 4, 5, None
         $ c <Boolean> True, False, True
         $ d    <Utf8> None, b, c
         $ e    <Utf8> usd, eur, None

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time, timedelta
-from inspect import isclass
 from typing import TYPE_CHECKING, Any, Callable, Sequence, cast, overload
 
 from polars import internals as pli
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     DataType,
+    DataTypeClass,
     Date,
     Datetime,
     Duration,
@@ -205,8 +205,8 @@ def col(
     # note: we need the typing.cast call here twice to make mypy happy under Python 3.7
     # On Python 3.10, it is not needed. We use cast as it works across versions,
     # ignoring the typing error would lead to unneeded ignores under Python 3.10.
-    if isclass(name) and issubclass(cast(type, name), DataType):
-        name = [cast(type, name)]
+    if isinstance(name, DataTypeClass):
+        name = [name]
 
     if isinstance(name, DataType):
         return pli.wrap_expr(_dtype_cols([name]))

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -202,9 +202,6 @@ def col(
     if isinstance(name, pli.Series):
         name = name.to_list()  # type: ignore[assignment]
 
-    # note: we need the typing.cast call here twice to make mypy happy under Python 3.7
-    # On Python 3.10, it is not needed. We use cast as it works across versions,
-    # ignoring the typing error would lead to unneeded ignores under Python 3.10.
     if isinstance(name, DataTypeClass):
         name = [name]
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -421,7 +421,7 @@ class LazyFrame:
         >>> lf.schema
         {'foo': Int64, 'bar': Float64, 'ham': Utf8}
 
-        """  # noqa: E501
+        """
         return self._ldf.schema()
 
     @property

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -395,7 +395,7 @@ class LazyFrame:
         ...     }
         ... ).lazy()
         >>> lf.dtypes
-        [<class 'polars.datatypes.Int64'>, <class 'polars.datatypes.Float64'>, <class 'polars.datatypes.Utf8'>]
+        [Int64, Float64, Utf8]
 
         See Also
         --------
@@ -419,7 +419,7 @@ class LazyFrame:
         ...     }
         ... ).lazy()
         >>> lf.schema
-        {'foo': <class 'polars.datatypes.Int64'>, 'bar': <class 'polars.datatypes.Float64'>, 'ham': <class 'polars.datatypes.Utf8'>}
+        {'foo': Int64, 'bar': Float64, 'ham': Utf8}
 
         """  # noqa: E501
         return self._ldf.schema()

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -160,7 +160,7 @@ class Series:
     Notice that the dtype is automatically inferred as a polars Int64:
 
     >>> s.dtype
-    <class 'polars.datatypes.Int64'>
+    Int64
 
     Constructing a Series with a specific dtype:
 
@@ -309,7 +309,7 @@ class Series:
         --------
         >>> s = pl.Series("a", [1, 2, 3])
         >>> s.dtype
-        <class 'polars.datatypes.Int64'>
+        Int64
 
         """
         return self._s.dtype()

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -197,10 +197,10 @@ class Series:
         self,
         name: str | ArrayLike | None = None,
         values: ArrayLike | None = None,
-        dtype: type[DataType] | DataType | None = None,
+        dtype: PolarsDataType | None = None,
         strict: bool = True,
         nan_to_null: bool = False,
-        dtype_if_empty: type[DataType] | DataType | None = None,
+        dtype_if_empty: PolarsDataType | None = None,
     ):
 
         # Handle case where values are passed as the first argument
@@ -2457,9 +2457,7 @@ class Series:
 
     def cast(
         self,
-        dtype: (
-            type[DataType] | type[int] | type[float] | type[str] | type[bool] | DataType
-        ),
+        dtype: (PolarsDataType | type[int] | type[float] | type[str] | type[bool]),
         strict: bool = True,
     ) -> Series:
         """

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -155,9 +155,9 @@ class column:
     >>> from hypothesis.strategies import sampled_from
     >>> from polars.testing.parametric import column
     >>> column(name="unique_small_ints", dtype=pl.UInt8, unique=True)
-    column(name='unique_small_ints', dtype=<class 'polars.datatypes.UInt8'>, strategy=None, null_probability=None, unique=True)
+    column(name='unique_small_ints', dtype=UInt8, strategy=None, null_probability=None, unique=True)
     >>> column(name="ccy", strategy=sampled_from(["GBP", "EUR", "JPY"]))
-    column(name='ccy', dtype=<class 'polars.datatypes.Utf8'>, strategy=sampled_from(['GBP', 'EUR', 'JPY']), null_probability=None, unique=False)
+    column(name='ccy', dtype=Utf8, strategy=sampled_from(['GBP', 'EUR', 'JPY']), null_probability=None, unique=False)
 
     """  # noqa: E501
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -4,7 +4,14 @@ from functools import reduce
 from typing import Any
 
 import polars.internals as pli
-from polars.datatypes import Boolean, Categorical, Float32, Float64, dtype_to_py_type
+from polars.datatypes import (
+    Boolean,
+    Categorical,
+    DataTypeClass,
+    Float32,
+    Float64,
+    dtype_to_py_type,
+)
 
 
 def assert_frame_equal(
@@ -243,7 +250,7 @@ def _getattr_multi(obj: object, op: str) -> Any:
 def is_categorical_dtype(data_type: Any) -> bool:
     """Check if the input is a polars Categorical dtype."""
     return (
-        type(data_type) is type
+        type(data_type) is DataTypeClass
         and issubclass(data_type, Categorical)
         or isinstance(data_type, Categorical)
     )

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -325,7 +325,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
         let type_name = ob.get_type().name()?;
 
         let dtype = match type_name {
-            "type" => {
+            "DataTypeClass" => {
                 // just the class, not an object
                 let name = ob.getattr("__name__")?.str()?.to_str()?;
                 match name {

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import pickle
 from datetime import datetime, timedelta
 
@@ -78,6 +77,7 @@ def test_dtypes_hashable() -> None:
         ),
         (pl.List(pl.Int8), "List(Int8)"),
         (pl.List(pl.Duration(time_unit="ns")), "List(Duration(tu='ns'))"),
+        (pl.Struct, "Struct"),
         (
             pl.Struct({"name": pl.Utf8, "ids": pl.List(pl.UInt32)}),
             "Struct([Field('name': Utf8), Field('ids': List(UInt32))])",

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -15,10 +15,10 @@ def test_dtype_init_equivalence() -> None:
     all_datatypes = {
         dtype
         for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
-        if inspect.isclass(dtype) and issubclass(dtype, datatypes.DataType)
+        if isinstance(dtype, datatypes.DataTypeClass)
     }
     for dtype in all_datatypes:
-        assert dtype == dtype()  # type: ignore[comparison-overlap]
+        assert dtype == dtype()
 
 
 def test_dtype_temporal_units() -> None:
@@ -84,5 +84,5 @@ def test_dtypes_hashable() -> None:
         ),
     ],
 )
-def test_repr(dtype, representation) -> None:
+def test_repr(dtype: pl.PolarsDataType, representation: str) -> None:
     assert repr(dtype) == representation

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -4,6 +4,8 @@ import inspect
 import pickle
 from datetime import datetime, timedelta
 
+import pytest
+
 import polars as pl
 from polars import datatypes
 
@@ -63,3 +65,24 @@ def test_dtypes_hashable() -> None:
     assert len(set(all_dtypes + all_dtypes)) == len(all_dtypes)
     assert len({pl.Datetime("ms"), pl.Datetime("us"), pl.Datetime("ns")}) == 3
     assert len({pl.List, pl.List(pl.Int16), pl.List(pl.Int32), pl.List(pl.Int64)}) == 4
+
+
+@pytest.mark.parametrize(
+    ["dtype", "representation"],
+    [
+        (pl.Boolean, "Boolean"),
+        (pl.Datetime, "Datetime"),
+        (
+            pl.Datetime(time_zone="Europe/Amsterdam"),
+            "Datetime(tu='us', tz='Europe/Amsterdam')",
+        ),
+        (pl.List(pl.Int8), "List(Int8)"),
+        (pl.List(pl.Duration(time_unit="ns")), "List(Duration(tu='ns'))"),
+        (
+            pl.Struct({"name": pl.Utf8, "ids": pl.List(pl.UInt32)}),
+            "Struct([Field('name': Utf8), Field('ids': List(UInt32))])",
+        ),
+    ],
+)
+def test_repr(dtype, representation) -> None:
+    assert repr(dtype) == representation

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -135,7 +135,7 @@ def test_getitem_errs() -> None:
     with pytest.raises(
         ValueError,
         match=r"Cannot __getitem__ on Series of dtype: "
-        r"'<class 'polars.datatypes.Int64'>' with argument: "
+        r"'Int64' with argument: "
         r"'{'strange'}' of type: '<class 'set'>'.",
     ):
         df["a"][{"strange"}]

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -265,8 +265,7 @@ def test_cast_inner() -> None:
     # this creates an inner null type
     df = pl.from_pandas(pd.DataFrame(data=[[[]], [[]]], columns=["A"]))
     assert (
-        df["A"].cast(pl.List(int)).dtype.inner  # type: ignore[arg-type, attr-defined]
-        == pl.Int64
+        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore[attr-defined]
     )
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1534,7 +1534,7 @@ def test_comparisons_bool_series_to_int() -> None:
     # todo: do we want this to work?
     assert_series_equal(srs_bool / 1, pl.Series([True, False], dtype=Float64))
     match = (
-        r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'>"
+        r"cannot do arithmetic with series of dtype: Boolean"
         r" and argument of type: <class 'bool'>"
     )
     with pytest.raises(ValueError, match=match):
@@ -1542,7 +1542,7 @@ def test_comparisons_bool_series_to_int() -> None:
     with pytest.raises(ValueError, match=match):
         srs_bool + 1
     match = (
-        r"cannot do arithmetic with series of dtype: <class 'polars.datatypes.Boolean'>"
+        r"cannot do arithmetic with series of dtype: Boolean"
         r" and argument of type: <class 'bool'>"
     )
     with pytest.raises(ValueError, match=match):


### PR DESCRIPTION
Resolves #5674 

Changes:
* Add a `type` metaclass to the `DataType` class with a `__repr__`. This class is now named `DataTypeClass` (suggestions for a better name are welcome). This makes sure the uninstantiated classes get a nice string representation.
* Update the `__repr__` for the special classes (Datetime, Duration, List, Struct, Field).
* Fixed a bunch of type hints along the way

See the test case for this implementation in action.
