### PR TITLE
fix(rust): fix `date + duration` offsets outside of nanosecond datetime bounds

### DIFF
--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -124,10 +124,11 @@ macro_rules! impl_dyn_series {
                         let rhs = rhs.cast(&dt)?;
                         lhs.subtract(&rhs)
                     }
-                    (DataType::Date, DataType::Duration(tu)) => {
-                        ((&self.cast(&DataType::Datetime(*tu, None)).unwrap()) - rhs)
-                            .cast(&DataType::Date)
-                    }
+                    (DataType::Date, DataType::Duration(_)) => ((&self
+                        .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
+                        .unwrap())
+                        - rhs)
+                        .cast(&DataType::Date),
                     (dtl, dtr) => Err(PolarsError::ComputeError(
                         format!(
                             "cannot do subtraction on these date types: {:?}, {:?}",
@@ -139,10 +140,11 @@ macro_rules! impl_dyn_series {
             }
             fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
                 match (self.dtype(), rhs.dtype()) {
-                    (DataType::Date, DataType::Duration(tu)) => {
-                        ((&self.cast(&DataType::Datetime(*tu, None)).unwrap()) + rhs)
-                            .cast(&DataType::Date)
-                    }
+                    (DataType::Date, DataType::Duration(_)) => ((&self
+                        .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
+                        .unwrap())
+                        + rhs)
+                        .cast(&DataType::Date),
                     (dtl, dtr) => Err(PolarsError::ComputeError(
                         format!(
                             "cannot do addition on these date types: {:?}, {:?}",

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1002,15 +1002,91 @@ def test_asof_join_tolerance_grouper() -> None:
     assert out.frame_equal(expected)
 
 
-def test_duration_function() -> None:
+def test_datetime_duration_offset() -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": [
+                datetime(1999, 1, 1, 7),
+                datetime(2022, 1, 2, 14),
+                datetime(3000, 12, 31, 21),
+            ],
+            "add": [1, 2, -1],
+        }
+    )
+    out = df.select(
+        [
+            (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
+            (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
+            (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
+            (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
+            (pl.col("datetime") + pl.duration(microseconds=pl.col("add") * 1000)).alias(
+                "add_usecs"
+            ),
+        ]
+    )
+    expected = pl.DataFrame(
+        {
+            "add_weeks": [
+                datetime(1999, 1, 8, 7),
+                datetime(2022, 1, 16, 14),
+                datetime(3000, 12, 24, 21),
+            ],
+            "add_days": [
+                datetime(1999, 1, 2, 7),
+                datetime(2022, 1, 4, 14),
+                datetime(3000, 12, 30, 21),
+            ],
+            "add_hours": [
+                datetime(1999, 1, 1, hour=8),
+                datetime(2022, 1, 2, hour=16),
+                datetime(3000, 12, 31, hour=20),
+            ],
+            "add_seconds": [
+                datetime(1999, 1, 1, 7, second=1),
+                datetime(2022, 1, 2, 14, second=2),
+                datetime(3000, 12, 31, 20, 59, 59),
+            ],
+            "add_usecs": [
+                datetime(1999, 1, 1, 7, microsecond=1000),
+                datetime(2022, 1, 2, 14, microsecond=2000),
+                datetime(3000, 12, 31, 20, 59, 59, 999000),
+            ],
+        }
+    )
+    assert out.frame_equal(expected)
+
+
+def test_date_duration_offset() -> None:
+    df = pl.DataFrame(
+        {
+            "date": [date(10, 1, 1), date(2000, 7, 5), date(9990, 12, 31)],
+            "offset": [365, 7, -31],
+        }
+    )
+    out = df.select(
+        [
+            (pl.col("date") + pl.duration(days="offset")).alias("add_days"),
+            (pl.col("date") - pl.duration(days="offset")).alias("sub_days"),
+            (pl.col("date") + pl.duration(weeks="offset")).alias("add_weeks"),
+            (pl.col("date") - pl.duration(weeks="offset")).alias("sub_weeks"),
+        ]
+    )
+    assert out.to_dict(False) == {
+        "add_days": [date(11, 1, 1), date(2000, 7, 12), date(9990, 11, 30)],
+        "sub_days": [date(9, 1, 1), date(2000, 6, 28), date(9991, 1, 31)],
+        "add_weeks": [date(16, 12, 30), date(2000, 8, 23), date(9990, 5, 28)],
+        "sub_weeks": [date(3, 1, 3), date(2000, 5, 17), date(9991, 8, 5)],
+    }
+
+
+def test_add_duration_3786() -> None:
     df = pl.DataFrame(
         {
             "datetime": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
             "add": [1, 2],
         }
     )
-
-    out = df.select(
+    assert df.slice(0, 1).with_columns(
         [
             (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
             (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
@@ -1020,25 +1096,15 @@ def test_duration_function() -> None:
             ),
             (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
         ]
-    )
-
-    expected = pl.DataFrame(
-        {
-            "add_weeks": [datetime(2022, 1, 8), datetime(2022, 1, 16)],
-            "add_days": [datetime(2022, 1, 2), datetime(2022, 1, 4)],
-            "add_seconds": [
-                datetime(2022, 1, 1, second=1),
-                datetime(2022, 1, 2, second=2),
-            ],
-            "add_milliseconds": [
-                datetime(2022, 1, 1, microsecond=1000),
-                datetime(2022, 1, 2, microsecond=2000),
-            ],
-            "add_hours": [datetime(2022, 1, 1, hour=1), datetime(2022, 1, 2, hour=2)],
-        }
-    )
-
-    assert out.frame_equal(expected)
+    ).to_dict(False) == {
+        "datetime": [datetime(2022, 1, 1, 0, 0)],
+        "add": [1],
+        "add_weeks": [datetime(2022, 1, 8, 0, 0)],
+        "add_days": [datetime(2022, 1, 2, 0, 0)],
+        "add_seconds": [datetime(2022, 1, 1, 0, 0, 1)],
+        "add_milliseconds": [datetime(2022, 1, 1, 0, 0, 0, 1000)],
+        "add_hours": [datetime(2022, 1, 1, 1, 0)],
+    }
 
 
 def test_rolling_groupby_by_argument() -> None:
@@ -1516,34 +1582,6 @@ def test_groupby_rolling_by_ordering() -> None:
             datetime(2022, 1, 1, 0, 6),
         ],
         "sum val": [2, 2, 1, 1, 2, 2, 1],
-    }
-
-
-def test_add_duration_3786() -> None:
-    df = pl.DataFrame(
-        {
-            "datetime": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
-            "add": [1, 2],
-        }
-    )
-    assert df.slice(0, 1).with_columns(
-        [
-            (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
-            (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
-            (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
-            (pl.col("datetime") + pl.duration(milliseconds="add")).alias(
-                "add_milliseconds"
-            ),
-            (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
-        ]
-    ).to_dict(False) == {
-        "datetime": [datetime(2022, 1, 1, 0, 0)],
-        "add": [1],
-        "add_weeks": [datetime(2022, 1, 8, 0, 0)],
-        "add_days": [datetime(2022, 1, 2, 0, 0)],
-        "add_seconds": [datetime(2022, 1, 1, 0, 0, 1)],
-        "add_milliseconds": [datetime(2022, 1, 1, 0, 0, 0, 1000)],
-        "add_hours": [datetime(2022, 1, 1, 1, 0)],
     }
 
 


### PR DESCRIPTION
Adding `duration` values to `DateChunked` was only working inside a narrow range (by default), specifically that of nanosecond-bounded `Datetime` arrays. Outside of this range the default behaviour would cause an overflow/wrap-around into odd values.

This could be worked-around by explicitly casting the duration (which defaults to `ns` precision) to millisecond/microsecond precision, but this PR addresses it internally so that the calculations always work "out of the box".

Example
---
**Setup**
```python
df = pl.DataFrame({
    "date": [date.min, date(2000, 7, 5), date.max],
    "add": [365, 7, -31],
}).with_columns([
    (pl.col("date") + pl.duration(days="add")).alias("add_days"),
    (pl.col("date") + pl.duration(weeks="add")).alias("add_weeks"),
])
```
**Before**
```python
# ┌────────────┬─────┬────────────┬────────────┐
# │ date       ┆ add ┆ add_days   ┆ add_weeks  │
# │ ---        ┆ --- ┆ ---        ┆ ---        │
# │ date       ┆ i64 ┆ date       ┆ date       │
# ╞════════════╪═════╪════════════╪════════════╡
# │ 0001-01-01 ┆ 365 ┆ 1755-08-31 ┆ 1761-08-29 │ ❎
# │ 2000-07-05 ┆ 7   ┆ 2000-07-12 ┆ 2000-08-23 │ ✅
# │ 9999-12-31 ┆ -31 ┆ 1816-02-28 ┆ 1815-08-26 │ ❎
# └────────────┴─────┴────────────┴────────────┘
```

**After**
```python
# ┌────────────┬─────┬────────────┬────────────┐
# │ date       ┆ add ┆ add_days   ┆ add_weeks  │
# │ ---        ┆ --- ┆ ---        ┆ ---        │
# │ date       ┆ i64 ┆ date       ┆ date       │
# ╞════════════╪═════╪════════════╪════════════╡
# │ 0001-01-01 ┆ 365 ┆ 0002-01-01 ┆ 0007-12-31 │
# │ 2000-07-05 ┆ 7   ┆ 2000-07-12 ┆ 2000-08-23 │
# │ 9999-12-31 ┆ -31 ┆ 9999-11-30 ┆ 9999-05-28 │
# └────────────┴─────┴────────────┴────────────┘
```
Added new test coverage for date/datetime offsets across a broader span of dates, and explicit coverage for _subtracting_ offsets too.