### PR TITLE
feat(python): Add .item() on DataFrame and Series

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -26,6 +26,7 @@ Manipulation/selection
     DataFrame.hstack
     DataFrame.insert_at_idx
     DataFrame.interpolate
+    DataFrame.item
     DataFrame.join
     DataFrame.join_asof
     DataFrame.limit

--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -27,6 +27,7 @@ Manipulation/selection
     Series.floor
     Series.head
     Series.interpolate
+    Series.item
     Series.limit
     Series.new_from_index
     Series.rechunk

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1498,6 +1498,26 @@ class DataFrame:
             ).render()
         )
 
+    def item(self) -> Any:
+        """
+        Return the dataframe as a scalar.
+
+        Equivalent to ``df[0,0]``, with a check that the shape is (1,1).
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": [1]})
+        >>> df.item()
+        1
+
+        """
+        if self.shape != (1, 1):
+            raise ValueError(
+                f"Can only call .item() if the dataframe is of shape (1,1), "
+                f"dataframe is of shape {self.shape}"
+            )
+        return self[0, 0]
+
     def to_arrow(self) -> pa.Table:
         """
         Collect the underlying arrow arrays in an Arrow Table.

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1506,9 +1506,19 @@ class DataFrame:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [1]})
-        >>> df.item()
-        1
+        >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> result = df.select((pl.col("a") * pl.col("b")).sum())
+        >>> result
+        shape: (1, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 32  │
+        └─────┘
+        >>> result.item()
+        32
 
         """
         if self.shape != (1, 1):

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -957,6 +957,26 @@ class Series:
         """Format output data in HTML for display in Jupyter Notebooks."""
         return self.to_frame()._repr_html_(from_series=True)
 
+    def item(self) -> Any:
+        """
+        Return the series as a scalar.
+
+        Equivalent to ``df[0]``, with a check that the shape is (1,).
+
+        Examples
+        --------
+        >>> df = pl.Series("a", [1])
+        >>> df.item()
+        1
+
+        """
+        if len(self) != 1:
+            raise ValueError(
+                f"Can only call .item() if the series is of length 1, "
+                f"series is of length {len(self)}"
+            )
+        return self[0]
+
     def estimated_size(self, unit: SizeUnit = "b") -> int | float:
         """
         Return an estimation of the total (heap) allocated size of the Series.

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -961,12 +961,12 @@ class Series:
         """
         Return the series as a scalar.
 
-        Equivalent to ``df[0]``, with a check that the shape is (1,).
+        Equivalent to ``s[0]``, with a check that the shape is (1,).
 
         Examples
         --------
-        >>> df = pl.Series("a", [1])
-        >>> df.item()
+        >>> s = pl.Series("a", [1])
+        >>> s.item()
         1
 
         """

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2545,3 +2545,20 @@ $ d    <Utf8> None, b, c
 $ e    <Utf8> usd, eur, None                                                                            
 $ f    <Date> 2020-01-01, 2021-01-02, 2022-01-01"""
     assert result.strip() == expected
+
+
+def test_item() -> None:
+    df = pl.DataFrame({"a": [1]})
+    assert df.item() == 1
+
+    with pytest.raises(ValueError):
+        df = pl.DataFrame({"a": [1, 2]})
+        df.item()
+
+    with pytest.raises(ValueError):
+        df = pl.DataFrame({"a": [1], "b": [2]})
+        df.item()
+
+    with pytest.raises(ValueError):
+        df = pl.DataFrame({})
+        df.item()

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2476,13 +2476,13 @@ def test_get_chunks() -> None:
 
 
 def test_item() -> None:
-    df = pl.Series("a", [1])
-    assert df.item() == 1
+    s = pl.Series("a", [1])
+    assert s.item() == 1
 
     with pytest.raises(ValueError):
-        df = pl.Series("a", [1, 2])
-        df.item()
+        s = pl.Series("a", [1, 2])
+        s.item()
 
     with pytest.raises(ValueError):
-        df = pl.Series("a", [])
-        df.item()
+        s = pl.Series("a", [])
+        s.item()

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2473,3 +2473,16 @@ def test_get_chunks() -> None:
     chunks = pl.concat([a, b], rechunk=False).get_chunks()
     assert chunks[0].series_equal(a)
     assert chunks[1].series_equal(b)
+
+
+def test_item() -> None:
+    df = pl.Series("a", [1])
+    assert df.item() == 1
+
+    with pytest.raises(ValueError):
+        df = pl.Series("a", [1, 2])
+        df.item()
+
+    with pytest.raises(ValueError):
+        df = pl.Series("a", [])
+        df.item()


### PR DESCRIPTION
# Problem
When running expressions on dataframes, the outcome can be (there is more, such as `to_list`, `to_pandas`, etc, but talking about the common operations):
1. another **Dataframe** (multiple rows/columns)
2. a **Series**. For example `df.sum(axis=1)` returns a Series
3. a **Scalar**

Scalar example: suppose we want the sumproduct of two columns:
```python
>>> df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
>>> df.select((pl.col("a")*pl.col("b")).sum())
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 32  │
└─────┘
```
This is being returned as a dataframe. It keeps things simpler than returning a scalar directly, as an expression does not have to lead to a scalar. Also it would be troublesome once you add more expressions. However, in the case where a single scalar value results, the most convenient way to access currently would be (assuming the resulting dataframe is called `result`) to use `result[0,0]`. This is a bit awkward, because we know there should be just one value.

# Solution
Add a method, named `item`, that asserts the DataFrame/Series is a scalar value, and return that value. So one can write `result.item()`, and be comfortable it is a scalar, and avoid the ugly indexing.

We implement this both on the `DataFrame` and `Series` level. The latter is handy in the context mainly of DataFrames, interestingly enough:
```python
>>> df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
>>> result = df.sum()
>>> result
shape: (1, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ 6   ┆ 15  │
└─────┴─────┘
>>> result["a"].item()
6
```

I dont see much added value for Series directly, as operations resulting in a scalar already return a scalar. Continuing the example above:

```python
>>> a = df["a"]
>>> a.sum()
6
```

# Bikeshedding / input requested
The name `item` is taken from [Numpy](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.item.html ), per the Discord convo. I have on purpose not allowed an input argument. We have our indexing machinery and syntax, and this method is purely for converting to a scalar. Otherwise people start to write `s.item(3)` rather than `s[3]`. Having said that, maybe we should therefore call this method `to_scalar`, that is probably more clear, including that it will error if it cannot be converted to a scalar. Although if the single entry would be a string, is "scalar" the right terminology? Open to suggestions.

# Background

Requested on Discord 

Requested on StackOverflow: https://stackoverflow.com/questions/74843947/whats-the-equivalent-of-the-item-function-in-polars

