### PR TITLE
feat(python): Add datatype hierarchy

### DIFF
--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -7,7 +7,7 @@ from polars.datatypes import (
     DataType,
     Date,
     Datetime,
-    TemporalDataType,
+    PolarsTemporalType,
     Time,
     is_polars_dtype,
 )
@@ -27,7 +27,7 @@ class ExprStringNameSpace:
 
     def strptime(
         self,
-        datatype: TemporalDataType,
+        datatype: PolarsTemporalType,
         fmt: str | None = None,
         strict: bool = True,
         exact: bool = True,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -3301,9 +3301,18 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             elif isinstance(value, bool):
                 dtypes = [Boolean]
             elif matches_supertype and isinstance(value, (int, float)):
-                ints = [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64]
-                floats = [Float32, Float64]
-                dtypes = ints + floats
+                dtypes = [
+                    Int8,
+                    Int16,
+                    Int32,
+                    Int64,
+                    UInt8,
+                    UInt16,
+                    UInt32,
+                    UInt64,
+                    Float32,
+                    Float64,
+                ]
             elif isinstance(value, int):
                 dtypes = [Int64]
             elif isinstance(value, float):

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import TemporalDataType
+from polars.datatypes import PolarsTemporalType
 from polars.internals.series.utils import expr_dispatch
 from polars.utils import deprecated_alias
 
@@ -23,7 +23,7 @@ class StringNameSpace:
 
     def strptime(
         self,
-        datatype: TemporalDataType,
+        datatype: PolarsTemporalType,
         fmt: str | None = None,
         strict: bool = True,
         exact: bool = True,

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -16,7 +16,7 @@ else:
     from backports import zoneinfo
 
 import polars as pl
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, TemporalDataType
+from polars.datatypes import DTYPE_TEMPORAL_UNITS, PolarsTemporalType
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing._private import verify_series_and_expr_api
 
@@ -637,7 +637,7 @@ def test_date_range_lazy() -> None:
         (date(5001, 1, 1), date(5001, 1, 2)),
     ],
 )
-def test_date_comp(one: TemporalDataType, two: TemporalDataType) -> None:
+def test_date_comp(one: PolarsTemporalType, two: PolarsTemporalType) -> None:
     a = pl.Series("a", [one, two])
     assert (a == one).to_list() == [True, False]
     assert (a == two).to_list() == [False, True]


### PR DESCRIPTION
I added a hierarchy to the data types on the Python side. It doesn't do much yet, but some bonuses are:
* It might come in handy if we want to do stuff like `if issubclass(dtype, NumericType): ...`.
* It can help out in type hints if we want to accept a specific dtype, e.g. `def strptime(dtype: TemporalType)`

Hierarchy currently is:
* DataType
  * NumericType
    * IntegralType (Ints and UInts)
    * FractionalType (Floats and maybe later Decimals)
  * TemporalType (Date, Time, Datetime, Duration)
  * NestedType (List, Struct)

Other changes:
* Cleaned up the `datatypes` module a bit.
  * Added some docstrings
  * Grouped similar objects (all type aliases at the top, etc.)
  * Improved some type hints