### PR TITLE
fix(python): don't allow duplicate columns in read_csv arg

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libflate"

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -162,8 +162,12 @@ def handle_projection_columns(
             columns = None
         elif not is_str_sequence(columns):
             raise ValueError(
-                "columns arg should contain a list of all integers or all strings"
+                "'columns' arg should contain a list of all integers or all strings"
                 " values."
+            )
+        if len(set(columns)) != len(columns):  # type: ignore[arg-type]
+            raise ValueError(
+                f"'columns' arg should only have unique values. Got '{columns}'."
             )
     return projection, columns  # type: ignore[return-value]
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -165,9 +165,13 @@ def handle_projection_columns(
                 "'columns' arg should contain a list of all integers or all strings"
                 " values."
             )
-        if len(set(columns)) != len(columns):  # type: ignore[arg-type]
+        if columns and len(set(columns)) != len(columns):
             raise ValueError(
                 f"'columns' arg should only have unique values. Got '{columns}'."
+            )
+        if projection and len(set(projection)) != len(projection):
+            raise ValueError(
+                f"'columns' arg should only have unique values. Got '{projection}'."
             )
     return projection, columns  # type: ignore[return-value]
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -301,3 +301,13 @@ def test_epoch_time_type() -> None:
         pl.ComputeError, match="Cannot compute timestamp of a series with dtype 'Time'"
     ):
         pl.Series([time(0, 0, 1)]).dt.epoch("s")
+
+
+def test_duplicate_columns_arg_csv() -> None:
+    f = io.BytesIO()
+    pl.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"]}).write_csv(f)
+    f.seek(0)
+    with pytest.raises(
+        ValueError, match=r"'columns' arg should only have unique values"
+    ):
+        pl.read_csv(f, columns=["x", "x", "y"])


### PR DESCRIPTION
fixes #5895