### PR TITLE
docs(python): Fix misspelling in LazyFrame docstring

### DIFF
--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -81,7 +81,7 @@ def wrap_ldf(ldf: PyLazyFrame) -> LazyFrame:
 
 class LazyFrame:
     """
-    Representation of a Lazy computation graph/query againat a DataFrame.
+    Representation of a Lazy computation graph/query against a DataFrame.
 
     Notes
     -----


### PR DESCRIPTION
Just a simple misspelling on Line 84 of the word against. , nothing crazy :)