### PR TITLE
feat(python): handle Series init from python sequence of numpy arrays

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -255,7 +255,12 @@ class Series:
             )
         elif isinstance(values, Sequence):
             self._s = sequence_to_pyseries(
-                name, values, dtype=dtype, strict=strict, dtype_if_empty=dtype_if_empty
+                name,
+                values,
+                dtype=dtype,
+                strict=strict,
+                dtype_if_empty=dtype_if_empty,
+                nan_to_null=nan_to_null,
             )
         elif _PANDAS_TYPE(values) and isinstance(values, (pd.Series, pd.DatetimeIndex)):
             self._s = pandas_to_pyseries(name, values)

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1065,7 +1065,7 @@ def read_sql(
 
     Notes
     -----
-    Make sure to install connectorx>=0.2.2. Read the documentation
+    Make sure to install connectorx>=0.3.1. Read the documentation
     `here <https://sfu-db.github.io/connector-x/intro.html>`_.
 
     Examples
@@ -1100,7 +1100,7 @@ def read_sql(
         import connectorx as cx
     except ImportError:
         raise ImportError(
-            "connectorx is not installed. Please run `pip install connectorx>=0.2.2`."
+            "connectorx is not installed. Please run `pip install connectorx>=0.3.1`."
         ) from None
 
     tbl = cx.read_sql(


### PR DESCRIPTION
Closes #5905.

----

We already handle `Series` init from 2D numpy arrays; this PR extends that slightly so that we can _also_ recognise/handle init from a python sequence (list/tuple) of numpy arrays.

**Before**
```python
import numpy as np
import polars as pl

df = pl.DataFrame({ 
    "colx": [np.array([1,2,3]), np.array([4,5,6])],
})
# ┌─────────┐
# │ colx    │
# │ ---     │
# │ object  │  << 'object' dtype
# ╞═════════╡
# │ [1 2 3] │
# │ [4 5 6] │
# └─────────┘

df.select( 
  [pl.struct(["colx"])] 
)
# pyo3_runtime.PanicException: cannot convert object to arrow
```
**After**
```python
df = pl.DataFrame({ 
    "colx": [np.array([1,2,3]), np.array([4,5,6])],
})
# ┌───────────┐
# │ colx      │
# │ ---       │
# │ list[i64] │  << native dtype
# ╞═══════════╡
# │ [1, 2, 3] │
# │ [4, 5, 6] │
# └───────────┘

df.select( 
  [pl.struct(["colx"])] 
)
# ┌─────────────┐
# │ colx        │
# │ ---         │
# │ struct[1]   │
# ╞═════════════╡
# │ {[1, 2, 3]} │
# │ {[4, 5, 6]} │
# └─────────────┘
```