### PR TITLE
feat(rust,python): `str.strip` with multiple chars

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -406,9 +406,9 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Replace { all, literal } => map_as_slice!(strings::replace, literal, all),
             Uppercase => map!(strings::uppercase),
             Lowercase => map!(strings::lowercase),
-            Strip(matches) => map!(strings::strip, matches),
-            LStrip(matches) => map!(strings::lstrip, matches),
-            RStrip(matches) => map!(strings::rstrip, matches),
+            Strip(matches) => map!(strings::strip, &matches),
+            LStrip(matches) => map!(strings::lstrip, &matches),
+            RStrip(matches) => map!(strings::rstrip, &matches),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -406,9 +406,9 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Replace { all, literal } => map_as_slice!(strings::replace, literal, all),
             Uppercase => map!(strings::uppercase),
             Lowercase => map!(strings::lowercase),
-            Strip(matches) => map!(strings::strip, &matches),
-            LStrip(matches) => map!(strings::lstrip, &matches),
-            RStrip(matches) => map!(strings::rstrip, &matches),
+            Strip(matches) => map!(strings::strip, matches.as_deref()),
+            LStrip(matches) => map!(strings::lstrip, matches.as_deref()),
+            RStrip(matches) => map!(strings::rstrip, matches.as_deref()),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -142,7 +142,7 @@ pub(super) fn rjust(s: &Series, width: usize, fillchar: char) -> PolarsResult<Se
     Ok(ca.rjust(width, fillchar).into_series())
 }
 
-pub(super) fn strip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
+pub(super) fn strip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca
@@ -153,7 +153,7 @@ pub(super) fn strip(s: &Series, matches: &Option<String>) -> PolarsResult<Series
     }
 }
 
-pub(super) fn lstrip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
+pub(super) fn lstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
 
     if let Some(matches) = matches {
@@ -165,7 +165,7 @@ pub(super) fn lstrip(s: &Series, matches: &Option<String>) -> PolarsResult<Serie
     }
 }
 
-pub(super) fn rstrip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
+pub(super) fn rstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -147,7 +147,7 @@ fn set_contains_char(matches: &BTreeSet<char>, c: &char) -> bool {
     matches.contains(c)
 }
 
-pub(super) fn strip(s: &Series, matches: Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn strip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca
@@ -158,7 +158,7 @@ pub(super) fn strip(s: &Series, matches: Option<BTreeSet<char>>) -> PolarsResult
     }
 }
 
-pub(super) fn lstrip(s: &Series, matches: Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn lstrip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
 
     if let Some(matches) = matches {
@@ -170,7 +170,7 @@ pub(super) fn lstrip(s: &Series, matches: Option<BTreeSet<char>>) -> PolarsResul
     }
 }
 
-pub(super) fn rstrip(s: &Series, matches: Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn rstrip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -145,9 +145,16 @@ pub(super) fn rjust(s: &Series, width: usize, fillchar: char) -> PolarsResult<Se
 pub(super) fn strip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
-        Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
-            .into_series())
+        if matches.chars().count() == 1 {
+            // Fast path for when a single character is passed
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_matches(matches.chars().next().unwrap())))
+                .into_series())
+        } else {
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
+                .into_series())
+        }
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim())).into_series())
     }
@@ -157,9 +164,16 @@ pub(super) fn lstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
     let ca = s.utf8()?;
 
     if let Some(matches) = matches {
-        Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
-            .into_series())
+        if matches.chars().count() == 1 {
+            // Fast path for when a single character is passed
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_start_matches(matches.chars().next().unwrap())))
+                .into_series())
+        } else {
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
+                .into_series())
+        }
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_start())).into_series())
     }
@@ -168,9 +182,16 @@ pub(super) fn lstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
 pub(super) fn rstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
-        Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
-            .into_series())
+        if matches.chars().count() == 1 {
+            // Fast path for when a single character is passed
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_end_matches(matches.chars().next().unwrap())))
+                .into_series())
+        } else {
+            Ok(ca
+                .apply(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
+                .into_series())
+        }
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_end())).into_series())
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use polars_arrow::utils::CustomIterTools;
 #[cfg(feature = "regex")]
@@ -50,9 +49,9 @@ pub enum StringFunction {
     },
     Uppercase,
     Lowercase,
-    Strip(Option<BTreeSet<char>>),
-    RStrip(Option<BTreeSet<char>>),
-    LStrip(Option<BTreeSet<char>>),
+    Strip(Option<String>),
+    RStrip(Option<String>),
+    LStrip(Option<String>),
 }
 
 impl Display for StringFunction {
@@ -143,38 +142,34 @@ pub(super) fn rjust(s: &Series, width: usize, fillchar: char) -> PolarsResult<Se
     Ok(ca.rjust(width, fillchar).into_series())
 }
 
-fn set_contains_char(matches: &BTreeSet<char>, c: &char) -> bool {
-    matches.contains(c)
-}
-
-pub(super) fn strip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn strip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_matches(|c| set_contains_char(&matches, &c))))
+            .apply(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
             .into_series())
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim())).into_series())
     }
 }
 
-pub(super) fn lstrip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn lstrip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
 
     if let Some(matches) = matches {
         Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_start_matches(|c| set_contains_char(&matches, &c))))
+            .apply(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
             .into_series())
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_start())).into_series())
     }
 }
 
-pub(super) fn rstrip(s: &Series, matches: &Option<BTreeSet<char>>) -> PolarsResult<Series> {
+pub(super) fn rstrip(s: &Series, matches: &Option<String>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     if let Some(matches) = matches {
         Ok(ca
-            .apply(|s| Cow::Borrowed(s.trim_end_matches(|c| set_contains_char(&matches, &c))))
+            .apply(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
             .into_series())
     } else {
         Ok(ca.apply(|s| Cow::Borrowed(s.trim_end())).into_series())

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use polars_arrow::array::ValueSize;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array};
@@ -342,19 +344,19 @@ impl StringNameSpace {
     }
 
     /// Remove whitespace on both sides.
-    pub fn strip(self, matches: Option<char>) -> Expr {
+    pub fn strip(self, matches: Option<BTreeSet<char>>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::Strip(matches)))
     }
 
     /// Remove leading whitespace.
-    pub fn lstrip(self, matches: Option<char>) -> Expr {
+    pub fn lstrip(self, matches: Option<BTreeSet<char>>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::LStrip(matches)))
     }
 
     /// Remove trailing whitespace.
-    pub fn rstrip(self, matches: Option<char>) -> Expr {
+    pub fn rstrip(self, matches: Option<BTreeSet<char>>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::RStrip(matches)))
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use polars_arrow::array::ValueSize;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array};
@@ -343,20 +341,20 @@ impl StringNameSpace {
         )
     }
 
-    /// Remove whitespace on both sides.
-    pub fn strip(self, matches: Option<BTreeSet<char>>) -> Expr {
+    /// Remove leading and trailing characters, or whitespace if matches is None.
+    pub fn strip(self, matches: Option<String>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::Strip(matches)))
     }
 
-    /// Remove leading whitespace.
-    pub fn lstrip(self, matches: Option<BTreeSet<char>>) -> Expr {
+    /// Remove leading characters, or whitespace if matches is None.
+    pub fn lstrip(self, matches: Option<String>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::LStrip(matches)))
     }
 
-    /// Remove trailing whitespace.
-    pub fn rstrip(self, matches: Option<BTreeSet<char>>) -> Expr {
+    /// Remove trailing characters, or whitespace if matches is None..
+    pub fn rstrip(self, matches: Option<String>) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::RStrip(matches)))
     }

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -181,25 +181,19 @@ pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> PolarsResult<Expr> {
                 Some((TrimWhereField::Both, sql_expr)) => {
                     let lit = parse_sql_expr(sql_expr)?;
                     if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        if val.len() == 1 {
-                            return Ok(expr.str().strip(Some(val.chars().next().unwrap())));
-                        }
+                        return Ok(expr.str().strip(Some(val)));
                     }
                 }
                 Some((TrimWhereField::Leading, sql_expr)) => {
                     let lit = parse_sql_expr(sql_expr)?;
                     if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        if val.len() == 1 {
-                            return Ok(expr.str().lstrip(Some(val.chars().next().unwrap())));
-                        }
+                        return Ok(expr.str().lstrip(Some(val)));
                     }
                 }
                 Some((TrimWhereField::Trailing, sql_expr)) => {
                     let lit = parse_sql_expr(sql_expr)?;
                     if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        if val.len() == 1 {
-                            return Ok(expr.str().rstrip(Some(val.chars().next().unwrap())));
-                        }
+                        return Ok(expr.str().rstrip(Some(val)));
                     }
                 }
             }

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -292,8 +292,6 @@ class ExprStringNameSpace:
         └───────┘
 
         """
-        if matches is not None:
-            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_strip(matches))
 
     def lstrip(self, matches: str | None = None) -> pli.Expr:
@@ -325,8 +323,6 @@ class ExprStringNameSpace:
         └────────┘
 
         """
-        if matches is not None:
-            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_lstrip(matches))
 
     def rstrip(self, matches: str | None = None) -> pli.Expr:
@@ -358,8 +354,6 @@ class ExprStringNameSpace:
         └───────┘
 
         """
-        if matches is not None:
-            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_rstrip(matches))
 
     def zfill(self, alignment: int) -> pli.Expr:

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -264,7 +264,7 @@ class ExprStringNameSpace:
         return pli.wrap_expr(self._pyexpr.str_to_lowercase())
 
     def strip(self, matches: str | None = None) -> pli.Expr:
-        """
+        r"""
         Remove leading and trailing characters.
 
         Parameters
@@ -272,30 +272,43 @@ class ExprStringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [" lead", "trail ", " both "]})
+        >>> df = pl.DataFrame({"foo": [" hello ", "\tworld"]})
         >>> df.select(pl.col("foo").str.strip())
-        shape: (3, 1)
+        shape: (2, 1)
         ┌───────┐
         │ foo   │
         │ ---   │
         │ str   │
         ╞═══════╡
-        │ lead  │
+        │ hello │
         ├╌╌╌╌╌╌╌┤
-        │ trail │
-        ├╌╌╌╌╌╌╌┤
-        │ both  │
+        │ world │
         └───────┘
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> df.select(pl.col("foo").str.strip("od\t"))
+        shape: (2, 1)
+        ┌─────────┐
+        │ foo     │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │  hello  │
+        ├╌╌╌╌╌╌╌╌╌┤
+        │ worl    │
+        └─────────┘
 
         """
         return pli.wrap_expr(self._pyexpr.str_strip(matches))
 
     def lstrip(self, matches: str | None = None) -> pli.Expr:
-        """
+        r"""
         Remove leading characters.
 
         Parameters
@@ -303,30 +316,43 @@ class ExprStringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [" lead", "trail ", " both "]})
+        >>> df = pl.DataFrame({"foo": [" hello ", "\tworld"]})
         >>> df.select(pl.col("foo").str.lstrip())
-        shape: (3, 1)
+        shape: (2, 1)
         ┌────────┐
         │ foo    │
         │ ---    │
         │ str    │
         ╞════════╡
-        │ lead   │
+        │ hello  │
         ├╌╌╌╌╌╌╌╌┤
-        │ trail  │
-        ├╌╌╌╌╌╌╌╌┤
-        │ both   │
+        │ world  │
         └────────┘
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> df.select(pl.col("foo").str.lstrip("wod\t"))
+        shape: (2, 1)
+        ┌─────────┐
+        │ foo     │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │  hello  │
+        ├╌╌╌╌╌╌╌╌╌┤
+        │ rld     │
+        └─────────┘
 
         """
         return pli.wrap_expr(self._pyexpr.str_lstrip(matches))
 
     def rstrip(self, matches: str | None = None) -> pli.Expr:
-        """
+        r"""
         Remove trailing characters.
 
         Parameters
@@ -334,24 +360,37 @@ class ExprStringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [" lead", "trail ", " both "]})
+        >>> df = pl.DataFrame({"foo": [" hello ", "world\t"]})
         >>> df.select(pl.col("foo").str.rstrip())
-        shape: (3, 1)
-        ┌───────┐
-        │ foo   │
-        │ ---   │
-        │ str   │
-        ╞═══════╡
-        │  lead │
-        ├╌╌╌╌╌╌╌┤
-        │ trail │
-        ├╌╌╌╌╌╌╌┤
-        │  both │
-        └───────┘
+        shape: (2, 1)
+        ┌────────┐
+        │ foo    │
+        │ ---    │
+        │ str    │
+        ╞════════╡
+        │  hello │
+        ├╌╌╌╌╌╌╌╌┤
+        │ world  │
+        └────────┘
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> df.select(pl.col("foo").str.rstrip("wod\t"))
+        shape: (2, 1)
+        ┌─────────┐
+        │ foo     │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │  hello  │
+        ├╌╌╌╌╌╌╌╌╌┤
+        │ worl    │
+        └─────────┘
 
         """
         return pli.wrap_expr(self._pyexpr.str_rstrip(matches))

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -263,14 +263,16 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_to_lowercase())
 
-    def strip(self, matches: None | str = None) -> pli.Expr:
+    def strip(self, matches: str | None = None) -> pli.Expr:
         """
-        Remove leading and trailing whitespace.
+        Remove leading and trailing characters.
 
         Parameters
         ----------
         matches
-            An optional single character that should be trimmed
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         Examples
         --------
@@ -290,13 +292,20 @@ class ExprStringNameSpace:
         └───────┘
 
         """
-        if matches is not None and len(matches) > 1:
-            raise ValueError("matches should contain a single character")
+        if matches is not None:
+            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_strip(matches))
 
-    def lstrip(self, matches: None | str = None) -> pli.Expr:
+    def lstrip(self, matches: str | None = None) -> pli.Expr:
         """
-        Remove leading whitespace.
+        Remove leading characters.
+
+        Parameters
+        ----------
+        matches
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         Examples
         --------
@@ -316,18 +325,20 @@ class ExprStringNameSpace:
         └────────┘
 
         """
-        if matches is not None and len(matches) > 1:
-            raise ValueError("matches should contain a single character")
+        if matches is not None:
+            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_lstrip(matches))
 
-    def rstrip(self, matches: None | str = None) -> pli.Expr:
+    def rstrip(self, matches: str | None = None) -> pli.Expr:
         """
-        Remove trailing whitespace.
+        Remove trailing characters.
 
         Parameters
         ----------
         matches
-            An optional single character that should be trimmed
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         Examples
         --------
@@ -347,8 +358,8 @@ class ExprStringNameSpace:
         └───────┘
 
         """
-        if matches is not None and len(matches) > 1:
-            raise ValueError("matches should contain a single character")
+        if matches is not None:
+            matches = set(matches)
         return pli.wrap_expr(self._pyexpr.str_rstrip(matches))
 
     def zfill(self, alignment: int) -> pli.Expr:

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -649,36 +649,42 @@ class StringNameSpace:
 
         """
 
-    def strip(self, matches: None | str = None) -> pli.Series:
+    def strip(self, matches: str | None = None) -> pli.Series:
         """
-        Remove leading and trailing whitespace.
+        Remove leading and trailing characters.
 
         Parameters
         ----------
         matches
-            An optional single character that should be trimmed
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         """
 
-    def lstrip(self, matches: None | str = None) -> pli.Series:
+    def lstrip(self, matches: str | None = None) -> pli.Series:
         """
-        Remove leading whitespace.
+        Remove leading characters.
 
         Parameters
         ----------
         matches
-            An optional single character that should be trimmed
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         """
 
-    def rstrip(self, matches: None | str = None) -> pli.Series:
+    def rstrip(self, matches: str | None = None) -> pli.Series:
         """
-        Remove trailing whitespace.
+        Remove trailing characters.
 
         Parameters
         ----------
         matches
-            An optional single character that should be trimmed
+            The set of characters to be removed. All combinations of this set of
+            characters will be stripped. If set to None (default), all whitespace is
+            removed.
 
         """
 

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -650,7 +650,7 @@ class StringNameSpace:
         """
 
     def strip(self, matches: str | None = None) -> pli.Series:
-        """
+        r"""
         Remove leading and trailing characters.
 
         Parameters
@@ -658,12 +658,34 @@ class StringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
+
+        Examples
+        --------
+        >>> s = pl.Series([" hello ", "\tworld"])
+        >>> s.str.strip()
+        shape: (2,)
+        Series: '' [str]
+        [
+                "hello"
+                "world"
+        ]
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> s.str.strip("od\t")
+        shape: (2,)
+        Series: '' [str]
+        [
+                " hello "
+                "worl"
+        ]
 
         """
 
     def lstrip(self, matches: str | None = None) -> pli.Series:
-        """
+        r"""
         Remove leading characters.
 
         Parameters
@@ -671,12 +693,34 @@ class StringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
+
+        Examples
+        --------
+        >>> s = pl.Series([" hello ", "\tworld"])
+        >>> s.str.lstrip()
+        shape: (2,)
+        Series: '' [str]
+        [
+                "hello "
+                "world"
+        ]
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> s.str.lstrip("wod\t")
+        shape: (2,)
+        Series: '' [str]
+        [
+                " hello "
+                "rld"
+        ]
 
         """
 
     def rstrip(self, matches: str | None = None) -> pli.Series:
-        """
+        r"""
         Remove trailing characters.
 
         Parameters
@@ -684,7 +728,29 @@ class StringNameSpace:
         matches
             The set of characters to be removed. All combinations of this set of
             characters will be stripped. If set to None (default), all whitespace is
-            removed.
+            removed instead.
+
+        Examples
+        --------
+        >>> s = pl.Series([" hello ", "world\t"])
+        >>> s.str.rstrip()
+        shape: (2,)
+        Series: '' [str]
+        [
+                " hello"
+                "world"
+        ]
+
+        Characters can be stripped by passing a string as argument. Note that whitespace
+        will not be stripped automatically when doing so.
+
+        >>> s.str.rstrip("wod\t")
+        shape: (2,)
+        Series: '' [str]
+        [
+                " hello "
+                "worl"
+        ]
 
         """
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use polars::lazy::dsl;
 use polars::lazy::dsl::Operator;
 use polars::prelude::*;
@@ -608,15 +610,15 @@ impl PyExpr {
             .into()
     }
 
-    pub fn str_strip(&self, matches: Option<char>) -> PyExpr {
+    pub fn str_strip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
         self.inner.clone().str().strip(matches).into()
     }
 
-    pub fn str_rstrip(&self, matches: Option<char>) -> PyExpr {
+    pub fn str_rstrip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
         self.inner.clone().str().rstrip(matches).into()
     }
 
-    pub fn str_lstrip(&self, matches: Option<char>) -> PyExpr {
+    pub fn str_lstrip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
         self.inner.clone().str().lstrip(matches).into()
     }
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use polars::lazy::dsl;
 use polars::lazy::dsl::Operator;
 use polars::prelude::*;
@@ -610,15 +608,15 @@ impl PyExpr {
             .into()
     }
 
-    pub fn str_strip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
+    pub fn str_strip(&self, matches: Option<String>) -> PyExpr {
         self.inner.clone().str().strip(matches).into()
     }
 
-    pub fn str_rstrip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
+    pub fn str_rstrip(&self, matches: Option<String>) -> PyExpr {
         self.inner.clone().str().rstrip(matches).into()
     }
 
-    pub fn str_lstrip(&self, matches: Option<BTreeSet<char>>) -> PyExpr {
+    pub fn str_lstrip(&self, matches: Option<String>) -> PyExpr {
         self.inner.clone().str().lstrip(matches).into()
     }
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1826,16 +1826,6 @@ def test_str_to_uppercase() -> None:
     verify_series_and_expr_api(s, expected, "str.to_uppercase")
 
 
-def test_str_rstrip() -> None:
-    s = pl.Series([" hello ", "world\t "])
-    expected = pl.Series([" hello", "world"])
-    assert_series_equal(s.str.rstrip(), expected)
-
-    s = pl.Series([" hello ", "world\t "])
-    expected = pl.Series([" hell", "world"])
-    assert_series_equal(s.str.rstrip().str.rstrip("o"), expected)
-
-
 def test_str_strip() -> None:
     s = pl.Series([" hello ", "world\t "])
     expected = pl.Series(["hello", "world"])
@@ -1844,13 +1834,45 @@ def test_str_strip() -> None:
     expected = pl.Series(["hello", "worl"])
     assert_series_equal(s.str.strip().str.strip("d"), expected)
 
+    expected = pl.Series(["ell", "rld\t"])
+    assert_series_equal(s.str.strip(" hwo"), expected)
+
 
 def test_str_lstrip() -> None:
     s = pl.Series([" hello ", "\t world"])
     expected = pl.Series(["hello ", "world"])
     assert_series_equal(s.str.lstrip(), expected)
+
     expected = pl.Series(["ello ", "world"])
     assert_series_equal(s.str.lstrip().str.lstrip("h"), expected)
+
+    expected = pl.Series(["ello ", "\t world"])
+    assert_series_equal(s.str.lstrip("hw "), expected)
+
+
+def test_str_rstrip() -> None:
+    s = pl.Series([" hello ", "world\t "])
+    expected = pl.Series([" hello", "world"])
+    assert_series_equal(s.str.rstrip(), expected)
+
+    expected = pl.Series([" hell", "world"])
+    assert_series_equal(s.str.rstrip().str.rstrip("o"), expected)
+
+    expected = pl.Series([" he", "wor"])
+    assert_series_equal(s.str.rstrip("odl \t"), expected)
+
+
+def test_str_strip_whitespace() -> None:
+    a = pl.Series("a", ["trailing  ", "  leading", "  both  "])
+
+    expected = pl.Series("a", ["trailing", "  leading", "  both"])
+    verify_series_and_expr_api(a, expected, "str.rstrip")
+
+    expected = pl.Series("a", ["trailing  ", "leading", "both  "])
+    verify_series_and_expr_api(a, expected, "str.lstrip")
+
+    expected = pl.Series("a", ["trailing", "leading", "both"])
+    verify_series_and_expr_api(a, expected, "str.strip")
 
 
 def test_str_strptime() -> None:
@@ -2233,16 +2255,6 @@ def test_product() -> None:
     a = pl.Series("a", [None, 2, 3])
     out = a.product()
     assert out is None
-
-
-def test_strip() -> None:
-    a = pl.Series("a", ["trailing  ", "  leading", "  both  "])
-    expected = pl.Series("a", ["trailing", "  leading", "  both"])
-    verify_series_and_expr_api(a, expected, "str.rstrip")
-    expected = pl.Series("a", ["trailing  ", "leading", "both  "])
-    verify_series_and_expr_api(a, expected, "str.lstrip")
-    expected = pl.Series("a", ["trailing", "leading", "both"])
-    verify_series_and_expr_api(a, expected, "str.strip")
 
 
 def test_ceil() -> None:


### PR DESCRIPTION
Resolves #5876

Changes:
* Allow passing a string to `str.strip`, which will strip all the characters in that string.
  * This works by passing a closure to the `trim_matches` method instead of a single character.

Note that this will be a breaking change for Rust, but not for Python.