### PR TITLE
fix(rust, python): fix arrow nested null conversion

### DIFF
--- a/polars/polars-core/src/series/into.rs
+++ b/polars/polars-core/src/series/into.rs
@@ -27,10 +27,18 @@ impl Series {
                 let arr = ca.chunks[chunk_idx].clone();
                 let arr = arr.as_any().downcast_ref::<ListArray<i64>>().unwrap();
 
-                let s = unsafe {
-                    Series::from_chunks_and_dtype_unchecked("", vec![arr.values().clone()], inner)
+                let new_values = if let DataType::Null = &**inner {
+                    arr.values().clone()
+                } else {
+                    let s = unsafe {
+                        Series::from_chunks_and_dtype_unchecked(
+                            "",
+                            vec![arr.values().clone()],
+                            inner,
+                        )
+                    };
+                    s.to_arrow(0)
                 };
-                let new_values = s.to_arrow(0);
 
                 let data_type = ListArray::<i64>::default_datatype(inner.to_arrow());
                 let arr = ListArray::<i64>::new(

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -490,3 +490,14 @@ def test_numpy_preserve_uint64_4112() -> None:
 def test_view_ub() -> None:
     # this would be UB if the series was dropped and not passed to the view
     assert np.sum(pl.Series([3, 1, 5]).sort().view()) == 9
+
+
+def test_arrow_list_null_5697() -> None:
+    # Create a pyarrow table with a list[null] column.
+    pa_table = pa.table([[[None]]], names=["mycol"])
+    df = pl.from_arrow(pa_table)
+    pa_table = df.to_arrow()
+    # again to polars to test the schema
+    assert pl.from_arrow(pa_table,).schema == {  # type: ignore[union-attr]
+        "mycol": pl.List(pl.Null)
+    }


### PR DESCRIPTION
fixes #5697