### PR TITLE
docs(python): Fix docs for sink_parquet

### DIFF
--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -8,12 +8,12 @@ Miscellaneous
 
     LazyFrame.cache
     LazyFrame.collect
-    LazyFrame.sink_parquet
     LazyFrame.fetch
     LazyFrame.lazy
     LazyFrame.map
     LazyFrame.pipe
     LazyFrame.profile
+    LazyFrame.sink_parquet
 
 
 Read/write logical plan

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -8,6 +8,7 @@ Miscellaneous
 
     LazyFrame.cache
     LazyFrame.collect
+    LazyFrame.sink_parquet
     LazyFrame.fetch
     LazyFrame.lazy
     LazyFrame.map

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1185,10 +1185,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         slice_pushdown: bool = True,
     ) -> pli.DataFrame:
         """
-        Collect into a DataFrame.
+        Persists a LazyFrame at the provided path.
 
-        Note: use :func:`fetch` if you want to run your query on the first `n` rows
-        only. This can be a huge time saver in debugging queries.
+        This allows streaming results that are larger than RAM to be written to disk.
 
         Parameters
         ----------
@@ -1233,6 +1232,15 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Turn off (certain) optimizations.
         slice_pushdown
             Slice pushdown optimization.
+
+        Returns
+        -------
+        DataFrame
+
+        Examples
+        --------
+        >>> ldf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
+        >>> ldf.sink_parquet("/tmp/out.parquet")  # doctest: +SKIP
 
         """
         if no_optimization:


### PR DESCRIPTION
Seems like the docs for `collect(...)` were copied over to `sink_parquet(...)`.

This PR fixes the docs, adds example and return type to docs, and fixes links to this method in sphinx html render.

Signed-off-by: Chitral Verma <chitralverma@gmail.com>