### PR TITLE
feat(python): Access rows as namedtuples

### DIFF
--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -4,17 +4,6 @@ import polars as pl
 from polars.exceptions import NoRowsReturned, TooManyRowsReturned
 
 
-def test_iterrows() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [None, False, None]})
-
-    it = df.iterrows()
-    assert next(it) == (1, None)
-    assert next(it) == (2, False)
-    assert next(it) == (3, None)
-    with pytest.raises(StopIteration):
-        next(it)
-
-
 def test_row_tuple() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
 
@@ -23,9 +12,21 @@ def test_row_tuple() -> None:
     assert df.row(1) == ("bar", 2, 2.0)
     assert df.row(-1) == ("2", 3, 3.0)
 
+    # return row by index as namedtuple
+    row = df.row(0, named=True)
+    assert row.a == "foo"
+    assert row.b == 1
+    assert row.c == 1.0
+
     # return row by predicate
     assert df.row(by_predicate=pl.col("a") == "bar") == ("bar", 2, 2.0)
     assert df.row(by_predicate=pl.col("b").is_in([2, 4, 6])) == ("bar", 2, 2.0)
+
+    # return row by predicate as namedtuple
+    row = df.row(by_predicate=pl.col("a") == "bar", named=True)
+    assert row.a == "bar"
+    assert row.b == 2
+    assert row.c == 2.0
 
     # expected error conditions
     with pytest.raises(TooManyRowsReturned):
@@ -40,11 +41,11 @@ def test_row_tuple() -> None:
 
     # must call 'by_predicate' by keyword
     with pytest.raises(TypeError):
-        df.row(None, pl.col("a") == "bar")  # type: ignore[misc]
+        df.row(None, pl.col("a") == "bar")  # type: ignore[call-overload]
 
     # cannot pass predicate into 'index'
     with pytest.raises(TypeError):
-        df.row(pl.col("a") == "bar")  # type: ignore[arg-type]
+        df.row(pl.col("a") == "bar")  # type: ignore[call-overload]
 
     # at least one of 'index' and 'by_predicate' must be set
     with pytest.raises(ValueError):
@@ -53,5 +54,40 @@ def test_row_tuple() -> None:
 
 def test_rows() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [1, 2]})
+
+    # Regular rows
     assert df.rows() == [(1, 1), (2, 2)]
     assert df.reverse().rows() == [(2, 2), (1, 1)]
+
+    # Named rows
+    rows = df.rows(named=True)
+    assert [row.a for row in rows] == [1, 2]
+    assert [row.b for row in rows] == [1, 2]
+
+
+def test_iterrows() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [None, False, None]})
+
+    # Regular iterrows
+    it = df.iterrows()
+    assert next(it) == (1, None)
+    assert next(it) == (2, False)
+    assert next(it) == (3, None)
+    with pytest.raises(StopIteration):
+        next(it)
+
+    # Named iterrows
+    it_named = df.iterrows(named=True)
+
+    row = next(it_named)
+    assert row.a == 1
+    assert row.b is None
+    row = next(it_named)
+    assert row.a == 2
+    assert row.b is False
+    row = next(it_named)
+    assert row.a == 3
+    assert row.b is None
+
+    with pytest.raises(StopIteration):
+        next(it_named)


### PR DESCRIPTION
Resolves #5935

Changes:
* Add `named` argument (defaults to `False`) to the methods `DataFrame.row/rows/iterrows`. This dynamically constructs a `Row` namedtuple based on the columns of the DataFrame, and converts the row tuple(s) to this namedtuple.

Note that because the `Row` namedtuple is created dynamically, it cannot be used in type hinting. Therefore, `Any` is used here.