### PR TITLE
fix(rust, python): allow empty sort on any dtype

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1837,6 +1837,9 @@ impl DataFrame {
         nulls_last: bool,
         slice: Option<(i64, usize)>,
     ) -> PolarsResult<Self> {
+        if self.height() == 0 {
+            return Ok(self.clone());
+        }
         // note that the by_column argument also contains evaluated expression from polars-lazy
         // that may not even be present in this dataframe.
 

--- a/py-polars/tests/unit/test_object.py
+++ b/py-polars/tests/unit/test_object.py
@@ -49,3 +49,18 @@ def test_object_in_struct() -> None:
     assert (arr == np_a).sum() == 3
     arr = out["foo"][1]["B"]
     assert (arr == np_b).sum() == 3
+
+
+def test_empty_sort() -> None:
+    df = pl.DataFrame(
+        data=[
+            ({"name": "bar", "sort_key": 2},),
+            ({"name": "foo", "sort_key": 1},),
+        ],
+        columns=[
+            ("blob", pl.Object),
+        ],
+        orient="row",
+    )
+    df_filtered = df.filter(pl.col("blob").apply(lambda blob: blob["name"] == "baz"))
+    df_filtered.sort(pl.col("blob").apply(lambda blob: blob["sort_key"]))


### PR DESCRIPTION
fixes #5964