### PR TITLE
feat(python): large speedup for `df.iterrows` (~200-400%)

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6537,18 +6537,18 @@ class DataFrame:
         """
         # note: buffering rows results in a 2-4x speedup over individual calls
         # to ".row(i)", so it should only be disabled in extremely specific cases.
+        if named:
+            Row = namedtuple("Row", self.columns)  # type: ignore[misc]
         if buffer_size:
             for offset in range(0, self.height, buffer_size):
                 rows_chunk = self.slice(offset, buffer_size).rows(named=False)
                 if named:
-                    Row = namedtuple("Row", self.columns)  # type: ignore[misc]
                     for row in rows_chunk:
                         yield Row(*row)
                 else:
                     yield from rows_chunk
 
         elif named:
-            Row = namedtuple("Row", self.columns)  # type: ignore[misc,no-redef]
             for i in range(self.height):
                 yield Row(*self.row(i))
         else:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6447,6 +6447,11 @@ class DataFrame:
             Return named tuples instead of regular tuples. This is more expensive than
             returning regular tuples, but allows for accessing values by column name.
 
+        Warnings
+        --------
+        Row-iteration is not optimal as the underlying data is stored in columnar form;
+        where possible, prefer export via one of the dedicated export/output methods.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -6468,15 +6473,19 @@ class DataFrame:
             return self._df.row_tuples()
 
     @overload
-    def iterrows(self, named: Literal[False] = ...) -> Iterator[tuple[Any, ...]]:
+    def iterrows(
+        self, named: Literal[False] = ..., buffer_size: int = ...
+    ) -> Iterator[tuple[Any, ...]]:
         ...
 
     @overload
-    def iterrows(self, named: Literal[True] = ...) -> Iterator[Any]:
+    def iterrows(
+        self, named: Literal[True] = ..., buffer_size: int = ...
+    ) -> Iterator[Any]:
         ...
 
     def iterrows(
-        self, named: bool = False
+        self, named: bool = False, buffer_size: int = 500
     ) -> Iterator[tuple[Any, ...]] | Iterator[Any]:
         """
         Returns an iterator over the rows in the DataFrame.
@@ -6487,9 +6496,17 @@ class DataFrame:
             Return named tuples instead of regular tuples. This is more expensive than
             returning regular tuples, but allows for accessing values by column name.
 
+        buffer_size
+            Determines the number of rows that are buffered internally while iterating
+            over the data; you should only modify this in very specific cases where the
+            default value is determined not to be a good fit to your access pattern, as
+            the speedup from using the buffer is significant (~2-4x). Setting this
+            value to zero disables row buffering.
+
         Warnings
         --------
-        This is very expensive and should not be used in any performance critical code!
+        Row-iteration is not optimal as the underlying data is stored in columnar form;
+        where possible, prefer export via one of the dedicated export/output methods.
 
         Examples
         --------
@@ -6505,8 +6522,20 @@ class DataFrame:
         [2, 4, 6]
 
         """
-        if named:
-            Row = namedtuple("Row", self.columns)  # type: ignore[misc]
+        # note: buffering rows results in a 2-4x speedup over individual calls
+        # to ".row(i)", so it should only be disabled in extremely specific cases.
+        if buffer_size:
+            for offset in range(0, self.height, buffer_size):
+                rows_chunk = self.slice(offset, buffer_size).rows(named=False)
+                if named:
+                    Row = namedtuple("Row", self.columns)  # type: ignore[misc]
+                    for row in rows_chunk:
+                        yield Row(*row)
+                else:
+                    yield from rows_chunk
+
+        elif named:
+            Row = namedtuple("Row", self.columns)  # type: ignore[misc,no-redef]
             for i in range(self.height):
                 yield Row(*self.row(i))
         else:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6465,6 +6465,10 @@ class DataFrame:
         >>> df.rows(named=True)
         [Row(a=1, b=2), Row(a=3, b=4), Row(a=5, b=6)]
 
+        See Also
+        --------
+        iterrows : row iterator over frame data (does not materialise all rows).
+
         """
         if named:
             Row = namedtuple("Row", self.columns)  # type: ignore[misc]
@@ -6508,6 +6512,11 @@ class DataFrame:
         Row-iteration is not optimal as the underlying data is stored in columnar form;
         where possible, prefer export via one of the dedicated export/output methods.
 
+        Notes
+        -----
+        If you are planning to materialise all frame data at once you should prefer
+        calling ``rows()``, which will be faster.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -6520,6 +6529,10 @@ class DataFrame:
         [1, 3, 5]
         >>> [row.b for row in df.iterrows(named=True)]
         [2, 4, 6]
+
+        See Also
+        --------
+        rows : materialises all frame data as a list of rows.
 
         """
         # note: buffering rows results in a 2-4x speedup over individual calls

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -68,7 +68,7 @@ def test_rows() -> None:
 def test_iterrows() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [None, False, None]})
 
-    # Regular iterrows
+    # Default iterrows behaviour
     it = df.iterrows()
     assert next(it) == (1, None)
     assert next(it) == (2, False)
@@ -76,18 +76,27 @@ def test_iterrows() -> None:
     with pytest.raises(StopIteration):
         next(it)
 
-    # Named iterrows
-    it_named = df.iterrows(named=True)
+    # Apply explicit row-buffer size
+    for sz in (0, 1, 2, 3, 4):
+        it = df.iterrows(buffer_size=sz)
+        assert next(it) == (1, None)
+        assert next(it) == (2, False)
+        assert next(it) == (3, None)
+        with pytest.raises(StopIteration):
+            next(it)
 
-    row = next(it_named)
-    assert row.a == 1
-    assert row.b is None
-    row = next(it_named)
-    assert row.a == 2
-    assert row.b is False
-    row = next(it_named)
-    assert row.a == 3
-    assert row.b is None
+        # Return rows as namedtuples
+        it_named = df.iterrows(named=True, buffer_size=sz)
 
-    with pytest.raises(StopIteration):
-        next(it_named)
+        row = next(it_named)
+        assert row.a == 1
+        assert row.b is None
+        row = next(it_named)
+        assert row.a == 2
+        assert row.b is False
+        row = next(it_named)
+        assert row.a == 3
+        assert row.b is None
+
+        with pytest.raises(StopIteration):
+            next(it_named)


### PR DESCRIPTION
Big speedup for the new `iterrows` method; internally buffering rows (via a zero-copy offset slice in the style of a database `fetchmany` call) results in a 2-4x speedup, depending on the underlying frame size/shape. 

Benchmarked a lot of different sizes for the default buffer (on a lot of different frame shapes) and the sweet spot was ~500 rows in all cases. Graph below was generated against a simple 1000000 row dataset, showing the time taken to iterate over the frame with no buffer (previous behaviour) vs iteration using buffers of various sizes (new default behaviour):

<img width="487" alt="image" src="https://user-images.githubusercontent.com/2613171/210182057-1ce1d39c-1a99-4d4c-bd0d-d956812ab2ee.png">

As a result of the magnitude of the speed-up, I made the docstring warning slightly more advisory rather than _"dear god don't do this :)"_, and added the same warning to `.rows()`, along with mutual "See Also" references.