### PR TITLE
feat(python): Improve `Expr.is_between` API

### DIFF
--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1168,44 +1168,35 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
     assert fruits_cars.select(pl.col("A").quantile(0.24, "linear"))["A"][0] == 1.96
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between(fruits_cars: pl.DataFrame) -> None:
     result = fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"]
     assert result.series_equal(
         pl.Series("is_between", [False, False, True, False, False])
     )
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, False))["is_between"]
-    assert result.series_equal(
-        pl.Series("is_between", [False, False, True, False, False])
-    )
-
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, (False, False)))[
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none"))[
         "is_between"
     ]
     assert result.series_equal(
         pl.Series("is_between", [False, False, True, False, False])
     )
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, True))["is_between"]
-    assert result.series_equal(
-        pl.Series("is_between", [False, True, True, True, False])
-    )
-
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, (True, True)))[
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both"))[
         "is_between"
     ]
     assert result.series_equal(
         pl.Series("is_between", [False, True, True, True, False])
     )
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, (False, True)))[
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="right"))[
         "is_between"
     ]
     assert result.series_equal(
         pl.Series("is_between", [False, False, True, True, False])
     )
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, (True, False)))[
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left"))[
         "is_between"
     ]
     assert result.series_equal(
@@ -1213,6 +1204,7 @@ def test_is_between(fruits_cars: pl.DataFrame) -> None:
     )
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between_data_types() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2050,6 +2050,7 @@ def test_to_physical() -> None:
     verify_series_and_expr_api(a, expected, "to_physical")
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between_datetime() -> None:
     s = pl.Series("a", [datetime(2020, 1, 1, 10, 0, 0), datetime(2020, 1, 1, 20, 0, 0)])
     start = datetime(2020, 1, 1, 12, 0, 0)


### PR DESCRIPTION
Changes:
* Deprecate the `include_bounds` argument for the `Expr.is_between` method. It is replaced by `closed`, which is what Polars uses everywhere else to specify the bounds of an interval.
* Add a FutureWarning that the default behaviour will change to be **inclusive** rather than **exclusive**. This follows the default for `BETWEEN` in SQL and `between` in pandas.

This will be followed up with a breaking PR that actually changes the default behaviour and removes the `include_bounds` argument.

Possibly I'd like to rename this to `between` rather than `is_between`, but let's do one thing at a time :)