### PR TITLE
feat(python)!: Change `Expr.is_between` default behaviour

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3409,8 +3409,7 @@ class Expr:
         self,
         start: Expr | datetime | date | time | int | float,
         end: Expr | datetime | date | time | int | float,
-        include_bounds: bool | tuple[bool, bool] | None = None,
-        closed: ClosedInterval | None = None,
+        closed: ClosedInterval = "both",
     ) -> Expr:
         """
         Check if this expression is between start and end.
@@ -3421,16 +3420,7 @@ class Expr:
             Lower bound as primitive type or datetime.
         end
             Upper bound as primitive type or datetime.
-        include_bounds
-            This argument is deprecated. Use ``closed`` instead!
-
-            - False:           Exclude both start and end (default).
-            - True:            Include both start and end.
-            - (False, False):  Exclude start and exclude end.
-            - (True, True):    Include start and include end.
-            - (False, True):   Exclude start and include end.
-            - (True, False):   Include start and exclude end.
-        closed : {'none', 'left', 'right', 'both'}
+        closed : {'both', 'left', 'right', 'none'}
             Define which sides of the interval are closed (inclusive).
 
         Returns
@@ -3448,9 +3438,9 @@ class Expr:
         │ i64 ┆ bool       │
         ╞═════╪════════════╡
         │ 1   ┆ false      │
-        │ 2   ┆ false      │
+        │ 2   ┆ true       │
         │ 3   ┆ true       │
-        │ 4   ┆ false      │
+        │ 4   ┆ true       │
         │ 5   ┆ false      │
         └─────┴────────────┘
 
@@ -3471,37 +3461,6 @@ class Expr:
         └─────┴────────────┘
 
         """
-        if include_bounds is not None:
-            warnings.warn(
-                "The `include_bounds` argument will be replaced in a future version."
-                " Use the `closed` argument to silence this warning.",
-                category=DeprecationWarning,
-            )
-            if isinstance(include_bounds, list):
-                include_bounds = tuple(include_bounds)
-
-            if include_bounds is False or include_bounds == (False, False):
-                closed = "none"
-            elif include_bounds is True or include_bounds == (True, True):
-                closed = "both"
-            elif include_bounds == (False, True):
-                closed = "right"
-            elif include_bounds == (True, False):
-                closed = "left"
-            else:
-                raise ValueError(
-                    "include_bounds should be a bool or tuple[bool, bool]."
-                )
-
-        if closed is None:
-            warnings.warn(
-                "Default behaviour will change from excluding both bounds to including"
-                " both bounds. Provide a value for the `closed` argument to silence"
-                " this warning.",
-                category=FutureWarning,
-            )
-            closed = "none"
-
         if closed == "none":
             return ((self > start) & (self < end)).alias("is_between")
         elif closed == "both":
@@ -3513,7 +3472,7 @@ class Expr:
         else:
             raise ValueError(
                 "closed must be one of {'left', 'right', 'both', 'none'},"
-                f" got {closed}"
+                f" got {closed!r}"
             )
 
     def hash(

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1177,11 +1177,10 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
     assert fruits_cars.select(pl.col("A").quantile(0.24, "linear"))["A"][0] == 1.96
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between(fruits_cars: pl.DataFrame) -> None:
     result = fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"]
     assert result.series_equal(
-        pl.Series("is_between", [False, False, True, False, False])
+        pl.Series("is_between", [False, True, True, True, False])
     )
 
     result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none"))[
@@ -1213,7 +1212,6 @@ def test_is_between(fruits_cars: pl.DataFrame) -> None:
     )
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between_data_types() -> None:
     df = pl.DataFrame(
         {
@@ -1234,7 +1232,7 @@ def test_is_between_data_types() -> None:
         pl.Series("is_between", [True, True, False]),
     )
     assert_series_equal(
-        df.select(pl.col("int").is_between(1.5, 4))[:, 0],
+        df.select(pl.col("int").is_between(1.5, 3))[:, 0],
         pl.Series("is_between", [True, True, False]),
     )
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2066,7 +2066,6 @@ def test_to_physical() -> None:
     verify_series_and_expr_api(a, expected, "to_physical")
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_is_between_datetime() -> None:
     s = pl.Series("a", [datetime(2020, 1, 1, 10, 0, 0), datetime(2020, 1, 1, 20, 0, 0)])
     start = datetime(2020, 1, 1, 12, 0, 0)


### PR DESCRIPTION
**!!  THIS IS A BREAKING CHANGE !!**

See #5981

Changes:
* Change default behaviour of `Expr.is_between` from exclusive (`"none"`) to inclusive (`"both"`).
* Remove deprecated `include_bounds` argument.