### PR TITLE
feat(python): Replace `is_upper/lowercase` by `upper/lower`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5946,7 +5946,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"letters": ["a", "b"]})
-        >>> df.select(pl.col("letters").str.to_uppercase())
+        >>> df.select(pl.col("letters").str.upper())
         shape: (2, 1)
         ┌─────────┐
         │ letters │

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from warnings import warn
 
 import polars.internals as pli
 from polars.datatypes import (
@@ -210,14 +211,55 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_concat(delimiter))
 
-    def to_uppercase(self) -> pli.Expr:
+    def lower(self) -> pli.Expr:
         """
-        Transform to uppercase variant.
+        Transforms strings to lowercase.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": ["cat", "dog"]})
-        >>> df.select(pl.col("foo").str.to_uppercase())
+        >>> df = pl.DataFrame({"foo": ["CAT", "Dog"]})
+        >>> df.select(pl.col("foo").str.lower())
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ cat │
+        │ dog │
+        └─────┘
+
+        """
+        return pli.wrap_expr(self._pyexpr.str_to_lowercase())
+
+    def to_lowercase(self) -> pli.Expr:
+        """
+        Transforms strings to lowercase.
+
+        .. deprecated:: 0.15.10
+            `to_lowercase` will be removed in favor of the equivalent `lower`.
+
+        See Also
+        --------
+        lower
+
+        """
+        warn(
+            "`to_lowercase` will be replaced by the equivalent `lower` in a future"
+            "version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.lower()
+
+    def upper(self) -> pli.Expr:
+        """
+        Transforms strings to uppercase.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": ["cat", "Dog"]})
+        >>> df.select(pl.col("foo").str.upper())
         shape: (2, 1)
         ┌─────┐
         │ foo │
@@ -231,26 +273,25 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_to_uppercase())
 
-    def to_lowercase(self) -> pli.Expr:
+    def to_uppercase(self) -> pli.Expr:
         """
-        Transform to lowercase variant.
+        Transforms strings to uppercase.
 
-        Examples
+        .. deprecated:: 0.15.10
+            `to_uppercase` will be removed in favor of the equivalent `upper`.
+
+        See Also
         --------
-        >>> df = pl.DataFrame({"foo": ["CAT", "DOG"]})
-        >>> df.select(pl.col("foo").str.to_lowercase())
-        shape: (2, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ str │
-        ╞═════╡
-        │ cat │
-        │ dog │
-        └─────┘
+        upper
 
         """
-        return pli.wrap_expr(self._pyexpr.str_to_lowercase())
+        warn(
+            "`to_uppercase` will be replaced by the equivalent `upper` in a future"
+            "version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.upper()
 
     def strip(self, matches: str | None = None) -> pli.Expr:
         r"""

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -819,11 +819,65 @@ class StringNameSpace:
 
         """
 
+    def lower(self) -> pli.Series:
+        """
+        Transforms strings to lowercase.
+
+        Examples
+        --------
+        >>> s = pl.Series(["CAT", "Dog"])
+        >>> s.str.lower()
+        shape: (2,)
+        Series: '' [str]
+        [
+                "cat"
+                "dog"
+        ]
+
+        """
+
     def to_lowercase(self) -> pli.Series:
-        """Modify the strings to their lowercase equivalent."""
+        """
+        Transforms strings to lowercase.
+
+        .. deprecated:: 0.15.10
+            `to_lowercase` will be removed in favor of the equivalent `lower`.
+
+        See Also
+        --------
+        lower
+
+        """
+
+    def upper(self) -> pli.Series:
+        """
+        Transforms strings to uppercase.
+
+        Examples
+        --------
+        >>> s = pl.Series(["cat", "Dog"])
+        >>> s.str.upper()
+        shape: (2,)
+        Series: '' [str]
+        [
+                "CAT"
+                "DOG"
+        ]
+
+        """
 
     def to_uppercase(self) -> pli.Series:
-        """Modify the strings to their uppercase equivalent."""
+        """
+        Transforms strings to uppercase.
+
+        .. deprecated:: 0.15.10
+            `to_uppercase` will be removed in favor of the equivalent `upper`.
+
+        See Also
+        --------
+        upper
+
+        """
 
     @deprecated_alias(start="offset")
     def slice(self, offset: int, length: int | None = None) -> pli.Series:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -151,9 +151,11 @@ def test_wildcard_expansion() -> None:
     # see: #2867
 
     df = pl.DataFrame({"a": ["x", "Y", "z"], "b": ["S", "o", "S"]})
-    assert df.select(
-        pl.concat_str(pl.all()).str.to_lowercase()
-    ).to_series().to_list() == ["xs", "yo", "zs"]
+    assert df.select(pl.concat_str(pl.all()).str.lower()).to_series().to_list() == [
+        "xs",
+        "yo",
+        "zs",
+    ]
 
 
 def test_split() -> None:

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -379,7 +379,7 @@ def test_query_4538() -> None:
             pl.Series("value", ["aaa", "bbb"]),
         ]
     )
-    assert df.select([pl.col("value").str.to_uppercase().is_in(["AAA"])])[
+    assert df.select([pl.col("value").str.upper().is_in(["AAA"])])[
         "value"
     ].to_list() == [True, False]
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1814,16 +1814,16 @@ def test_str_replace_str_replace_all() -> None:
     verify_series_and_expr_api(s, expected, "str.replace_all", "o", "0")
 
 
-def test_str_to_lowercase() -> None:
+def test_str_lower() -> None:
     s = pl.Series(["Hello", "WORLD"])
     expected = pl.Series(["hello", "world"])
-    verify_series_and_expr_api(s, expected, "str.to_lowercase")
+    verify_series_and_expr_api(s, expected, "str.lower")
 
 
-def test_str_to_uppercase() -> None:
+def test_str_upper() -> None:
     s = pl.Series(["Hello", "WORLD"])
     expected = pl.Series(["HELLO", "WORLD"])
-    verify_series_and_expr_api(s, expected, "str.to_uppercase")
+    verify_series_and_expr_api(s, expected, "str.upper")
 
 
 def test_str_strip() -> None:


### PR DESCRIPTION
Python users are used to calling `"abc".upper()` and `"ABC".lower()`. Let's mimic this in our Python API. It's more familiar and it's shorter!

Changes:
* Add `str.lower` and `str.upper`
* Deprecate `str.to_lowercase` and `str.to_uppercase`

For what it's worth, pandas and pyspark equivalents are also called `lower`/`upper`.