### PR TITLE
feat(python)!: Remove deprecated `read/write_json` arguments

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1954,12 +1954,9 @@ class DataFrame:
     @overload
     def write_json(
         self,
-        file: None = None,
+        file: None = ...,
         pretty: bool = ...,
         row_oriented: bool = ...,
-        json_lines: bool | None = ...,
-        *,
-        to_string: bool | None = ...,
     ) -> str:
         ...
 
@@ -1969,9 +1966,6 @@ class DataFrame:
         file: IOBase | str | Path,
         pretty: bool = ...,
         row_oriented: bool = ...,
-        json_lines: bool | None = ...,
-        *,
-        to_string: bool | None = ...,
     ) -> None:
         ...
 
@@ -1980,9 +1974,6 @@ class DataFrame:
         file: IOBase | str | Path | None = None,
         pretty: bool = False,
         row_oriented: bool = False,
-        json_lines: bool | None = None,
-        *,
-        to_string: bool | None = None,
     ) -> str | None:
         """
         Serialize to JSON representation.
@@ -1996,10 +1987,6 @@ class DataFrame:
             Pretty serialize json.
         row_oriented
             Write to row oriented json. This is slower, but more common.
-        json_lines
-            Deprecated argument. Toggle between `JSON` and `NDJSON` format.
-        to_string
-            Deprecated argument. Ignore file argument and return a string.
 
         See Also
         --------
@@ -2019,32 +2006,12 @@ class DataFrame:
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
 
         """
-        if json_lines is not None:
-            warnings.warn(
-                "`json_lines` argument for `DataFrame.write_json` will be removed in a"
-                " future version. Remove the argument or use `DataFrame.write_ndjson`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            json_lines = False
-
-        if to_string is not None:
-            warnings.warn(
-                "`to_string` argument for `DataFrame.write_json` will be removed in a"
-                " future version. Remove the argument and set `file=None`.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            to_string = False
-
         if isinstance(file, (str, Path)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
-        if to_string or file is None or to_string_io:
+        if file is None or to_string_io:
             with BytesIO() as buf:
-                self._df.write_json(buf, pretty, row_oriented, json_lines)
+                self._df.write_json(buf, pretty, row_oriented)
                 json_bytes = buf.getvalue()
 
             json_str = json_bytes.decode("utf8")
@@ -2053,7 +2020,7 @@ class DataFrame:
             else:
                 return json_str
         else:
-            self._df.write_json(file, pretty, row_oriented, json_lines)
+            self._df.write_json(file, pretty, row_oriented)
         return None
 
     @overload

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, Generic, Iterator, Sequence, TypeVar
 
@@ -107,7 +106,7 @@ class GroupBy(Generic[DF]):
         if isinstance(self.by, (str, pli.Expr)):
             self._group_names = iter(group_names.to_series())
         else:
-            self._group_names = group_names.iterrows()
+            self._group_names = group_names.iter_rows()
 
         self._group_indices = groups_df.select(temp_col).to_series()
         self._current_index = 0

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -17,7 +17,6 @@ from typing import (
     TypeVar,
     overload,
 )
-from warnings import warn
 
 from polars import internals as pli
 from polars.cfg import Config
@@ -512,29 +511,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 """  # noqa: E501
 
     @overload
-    def write_json(
-        self,
-        file: None = None,
-        *,
-        to_string: bool | None = ...,
-    ) -> str:
+    def write_json(self, file: None = ...) -> str:
         ...
 
     @overload
-    def write_json(
-        self,
-        file: IOBase | str | Path,
-        *,
-        to_string: bool | None = ...,
-    ) -> None:
+    def write_json(self, file: IOBase | str | Path) -> None:
         ...
 
-    def write_json(
-        self,
-        file: IOBase | str | Path | None = None,
-        *,
-        to_string: bool | None = None,
-    ) -> str | None:
+    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
         """
         Write the logical plan of this LazyFrame to a file or string in JSON format.
 
@@ -543,8 +527,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         file
             File path to which the result should be written. If set to ``None``
             (default), the output is returned as a string instead.
-        to_string
-            Deprecated argument. Ignore file argument and return a string.
 
         See Also
         --------
@@ -562,20 +544,10 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         '{"DataFrameScan":{"df":{"columns":[{"name":"foo","datatype":"Int64","values":[1,2,3]},{"name":"bar","datatype":"Int64","values":[6,7,8]}]},"schema":{"inner":{"foo":"Int64","bar":"Int64"}},"output_schema":null,"projection":null,"selection":null}}'
 
         """
-        if to_string is not None:
-            warn(
-                "`to_string` argument for `LazyFrame.write_json` will be removed in a"
-                " future version. Remove the argument and set `file=None` (default).",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            to_string = False
-
         if isinstance(file, (str, Path)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
-        if to_string or file is None or to_string_io:
+        if file is None or to_string_io:
             with BytesIO() as buf:
                 self._ldf.write_json(buf)
                 json_bytes = buf.getvalue()

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -332,10 +332,7 @@ class LazyFrame:
         return wrap_ldf(PyLazyFrame.read_json(file))
 
     @classmethod
-    def read_json(
-        cls,
-        file: str | Path | IOBase,
-    ) -> LazyFrame:
+    def read_json(cls, file: str | Path | IOBase) -> LazyFrame:
         """
         Read a logical plan from a JSON file to construct a LazyFrame.
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
     overload,
 )
-from warnings import warn
 
 from polars import BatchedCsvReader
 
@@ -969,7 +968,7 @@ def read_parquet(
         )
 
 
-def read_json(file: str | Path | IOBase, json_lines: bool | None = None) -> DataFrame:
+def read_json(file: str | Path | IOBase) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.
 
@@ -977,27 +976,12 @@ def read_json(file: str | Path | IOBase, json_lines: bool | None = None) -> Data
     ----------
     file
         Path to a file or a file-like object.
-    json_lines
-        Deprecated argument. Toggle between `JSON` and `NDJSON` format.
 
     See Also
     --------
     read_ndjson
 
     """
-    if json_lines is not None:
-        warn(
-            "`json_lines` argument for `read_json` will be removed in a future version."
-            " Remove the argument or use `pl.read_ndjson`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    else:
-        json_lines = False
-
-    if json_lines:
-        return read_ndjson(file)
-
     return DataFrame._read_json(file)
 
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -374,26 +374,16 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "json")]
-    pub fn write_json(
-        &mut self,
-        py_f: PyObject,
-        pretty: bool,
-        row_oriented: bool,
-        json_lines: bool,
-    ) -> PyResult<()> {
+    pub fn write_json(&mut self, py_f: PyObject, pretty: bool, row_oriented: bool) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
 
-        let r = match (pretty, row_oriented, json_lines) {
-            (_, true, true) => panic!("{}", "only one of {row_oriented, json_lines} should be set"),
-            (_, _, true) => JsonWriter::new(file)
-                .with_json_format(JsonFormat::JsonLines)
-                .finish(&mut self.df),
-            (_, true, false) => JsonWriter::new(file)
+        let r = match (pretty, row_oriented) {
+            (_, true) => JsonWriter::new(file)
                 .with_json_format(JsonFormat::Json)
                 .finish(&mut self.df),
-            (true, _, _) => serde_json::to_writer_pretty(file, &self.df)
+            (true, _) => serde_json::to_writer_pretty(file, &self.df)
                 .map_err(|e| PolarsError::ComputeError(format!("{e:?}").into())),
-            (false, _, _) => serde_json::to_writer(file, &self.df)
+            (false, _) => serde_json::to_writer(file, &self.df)
                 .map_err(|e| PolarsError::ComputeError(format!("{e:?}").into())),
         };
         r.map_err(|e| PyPolarsErr::Other(format!("{e:?}")))?;

--- a/py-polars/tests/unit/io/conftest.py
+++ b/py-polars/tests/unit/io/conftest.py
@@ -80,7 +80,7 @@ if not os.path.isfile(FOODS_IPC):
     pl.read_csv(FOODS_CSV).write_ipc(FOODS_IPC)
 
 if not os.path.isfile(FOODS_NDJSON):
-    pl.read_csv(FOODS_CSV).write_json(FOODS_NDJSON, json_lines=True)
+    pl.read_csv(FOODS_CSV).write_ndjson(FOODS_NDJSON)
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -15,7 +15,7 @@ def test_pickling_simple_expression() -> None:
 
 def test_serde_lazy_frame_lp() -> None:
     lf = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).lazy().select(pl.col("a"))
-    json = lf.write_json(to_string=True)
+    json = lf.write_json()
 
     assert (
         pl.LazyFrame.from_json(json)


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

Changes:
* Remove `json_lines` argument for `read_json`/`DataFrame.write_json`. Use `read_ndjson`/`DataFrame.write_ndjson` instead.
* Remove `to_string` argument for `DataFrame/LazyFrame.write_json`. Use `write_json(file=None)` instead (default).