### PR TITLE
feat(python)!: Change `Series.shuffle` default behaviour

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5271,7 +5271,7 @@ class Expr:
 
     def shuffle(self, seed: int | None = None) -> Expr:
         """
-        Shuffle the contents of this expr.
+        Shuffle the contents of this expression.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -15,7 +15,6 @@ from typing import (
     Union,
     overload,
 )
-from warnings import warn
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -4566,7 +4565,8 @@ class Series:
         Parameters
         ----------
         seed
-            Seed for the random number generator.
+            Seed for the random number generator. If set to None (default), a random
+            seed is generated using the ``random`` module.
 
         Examples
         --------
@@ -4581,15 +4581,6 @@ class Series:
         ]
 
         """
-        if seed is None:
-            warn(
-                "Series.shuffle will default to a random seed in a future version."
-                " Provide a value for the seed argument to silence this warning.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            seed = 0
-        return self.to_frame().select(pli.col(self.name).shuffle(seed)).to_series()
 
     def ewm_mean(
         self,


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

Changes:
* Change `Series.shuffle` default behaviour to use a random seed if `seed` argument is not provided.
* Dispatch `Series.shuffle` to `Expr.shuffle`

Another one for the next breaking release 😸 