### PR TITLE
feat(python)!: Remove deprecated argument aliases

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -24,7 +24,7 @@ from polars.internals.expr.list import ExprListNameSpace
 from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
-from polars.utils import _timedelta_to_pl_duration, deprecated_alias, sphinx_accessor
+from polars.utils import _timedelta_to_pl_duration, sphinx_accessor
 
 try:
     from polars.polars import PyExpr
@@ -1966,7 +1966,6 @@ class Expr:
 
         return wrap_expr(self._pyexpr.sort_by(by, reverse))
 
-    @deprecated_alias(index="indices")
     def take(
         self, indices: int | list[int] | Expr | pli.Series | np.ndarray[Any, Any]
     ) -> Expr:

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -11,7 +11,6 @@ from polars.datatypes import (
     Time,
     is_polars_dtype,
 )
-from polars.utils import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TransferEncoding
@@ -1104,7 +1103,6 @@ class ExprStringNameSpace:
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )
 
-    @deprecated_alias(start="offset")
     def slice(self, offset: int, length: int | None = None) -> pli.Expr:
         """
         Create subslices of the string values of a Utf8 Series.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -28,7 +28,6 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
-    deprecated_alias,
 )
 
 try:
@@ -2176,14 +2175,12 @@ def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.
     return pli.wrap_expr(_concat_lst(exprs))
 
 
-@deprecated_alias(allow_streaming="streaming")
 def collect_all(
     lazy_frames: Sequence[pli.LazyFrame],
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
-    string_cache: bool = False,
     no_optimization: bool = False,
     slice_pushdown: bool = True,
     common_subplan_elimination: bool = True,
@@ -2206,8 +2203,6 @@ def collect_all(
         Do projection pushdown optimization.
     simplify_expression
         Run simplify expressions optimization.
-    string_cache
-        This argument is deprecated and will be ignored
     no_optimization
         Turn off optimizations.
     slice_pushdown

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -53,7 +53,6 @@ from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
     _timedelta_to_pl_duration,
-    deprecated_alias,
     normalise_filepath,
 )
 
@@ -668,7 +667,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             return self._ldf.describe_optimized_plan()
         return self._ldf.describe_plan()
 
-    @deprecated_alias(allow_streaming="streaming")
     def describe_optimized_plan(
         self,
         type_coercion: bool = True,
@@ -692,7 +690,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return ldf.describe_optimized_plan()
 
-    @deprecated_alias(allow_streaming="streaming")
     def show_graph(
         self,
         optimized: bool = True,
@@ -936,7 +933,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         by = pli.selection_to_pyexpr_list(by)
         return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse, nulls_last))
 
-    @deprecated_alias(allow_streaming="streaming")
     def profile(
         self,
         type_coercion: bool = True,
@@ -1083,7 +1079,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return df, timings
 
-    @deprecated_alias(allow_streaming="streaming")
     def collect(
         self,
         *,
@@ -1338,7 +1333,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             maintain_order=maintain_order,
         )
 
-    @deprecated_alias(allow_streaming="streaming")
     def fetch(
         self,
         n_rows: int = 500,

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import polars.internals as pli
 from polars.datatypes import PolarsTemporalType
 from polars.internals.series.utils import expr_dispatch
-from polars.utils import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TransferEncoding
@@ -836,7 +835,6 @@ class StringNameSpace:
     def to_uppercase(self) -> pli.Series:
         """Modify the strings to their uppercase equivalent."""
 
-    @deprecated_alias(start="offset")
     def slice(self, offset: int, length: int | None = None) -> pli.Series:
         """
         Create subslices of the string values of a Utf8 Series.
@@ -880,10 +878,6 @@ class StringNameSpace:
         ]
 
         """
-        s = pli.wrap_s(self._s)
-        return (
-            s.to_frame().select(pli.col(s.name).str.slice(offset, length)).to_series()
-        )
 
     def explode(self) -> pli.Series:
         """

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -30,7 +30,7 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltal
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
 from polars.internals.io import _prepare_file_arg
-from polars.utils import deprecated_alias, handle_projection_columns, normalise_filepath
+from polars.utils import handle_projection_columns, normalise_filepath
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import CsvEncoding, ParallelStrategy
@@ -54,12 +54,6 @@ def _check_arg_is_1byte(
             )
 
 
-@deprecated_alias(
-    has_headers="has_header",
-    dtype="dtypes",
-    stop_after_n_rows="n_rows",
-    projection="columns",
-)
 def read_csv(
     file: str | TextIO | BytesIO | Path | BinaryIO | bytes,
     has_header: bool = True,
@@ -413,7 +407,6 @@ def read_csv(
     return df
 
 
-@deprecated_alias(has_headers="has_header", dtype="dtypes", stop_after_n_rows="n_rows")
 def scan_csv(
     file: str | Path,
     has_header: bool = True,
@@ -592,7 +585,6 @@ def scan_csv(
     )
 
 
-@deprecated_alias(stop_after_n_rows="n_rows")
 def scan_ipc(
     file: str | Path,
     n_rows: int | None = None,
@@ -646,7 +638,6 @@ def scan_ipc(
     )
 
 
-@deprecated_alias(stop_after_n_rows="n_rows")
 def scan_parquet(
     file: str | Path,
     n_rows: int | None = None,
@@ -759,7 +750,6 @@ def scan_ndjson(
     )
 
 
-@deprecated_alias(projection="columns")
 def read_avro(
     file: str | Path | BytesIO | BinaryIO,
     columns: list[int] | list[str] | None = None,
@@ -789,7 +779,6 @@ def read_avro(
     return DataFrame._read_avro(file, n_rows=n_rows, columns=columns)
 
 
-@deprecated_alias(stop_after_n_rows="n_rows", projection="columns")
 def read_ipc(
     file: str | BinaryIO | BytesIO | Path | bytes,
     columns: list[int] | list[str] | None = None,
@@ -875,7 +864,6 @@ def read_ipc(
         )
 
 
-@deprecated_alias(stop_after_n_rows="n_rows", projection="columns")
 def read_parquet(
     source: str | Path | BinaryIO | BytesIO | bytes,
     columns: list[int] | list[str] | None = None,
@@ -981,7 +969,6 @@ def read_parquet(
         )
 
 
-@deprecated_alias(source="file")
 def read_json(file: str | Path | IOBase, json_lines: bool | None = None) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

Changes:
* Remove the deprecated argument aliases for several functions.

That's the lowest-hanging fruit with regards to breaking API changes done.