### PR TITLE
chore(python): Update py-polars/Cargo.lock

### DIFF
--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -4,3 +4,4 @@ target/
 venv/
 .hypothesis
 .DS_Store
+.ruff_cache/

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.9"
+version = "0.15.11"
 dependencies = [
  "ahash",
  "bincode",


### PR DESCRIPTION
Somehow, the lock file in the master branch still has py-polars `0.15.9`. This fixes it.

Do we even need the lock file checked in?