### PR TITLE
chore(python): Enable the `isort`-style import autofix via `ruff`

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -121,6 +121,9 @@ select = [
 ]
 ignore = []
 
+fix = true
+fixable = ["I001"]
+
 extend-select = ["D"]
 extend-ignore = [
   # pydocstyle: http://www.pydocstyle.org/en/stable/error_codes.html


### PR DESCRIPTION
We were detecting it, but not acting on it.
With `fix` enabled, the `fixable` list constrains _what_ it will attempt to autofix.

**Before** (example)
```
venv/bin/ruff .
polars/internals/expr/expr.py:1:1: I001 Import block is un-sorted or un-formatted
```
**After**
```
venv/bin/ruff .
Found 1 error(s) (1 fixed, 0 remaining).
```