### PR TITLE
fix(python): Fix `from_epoch` function signature

### DIFF
--- a/py-polars/docs/source/reference/expressions/functions.rst
+++ b/py-polars/docs/source/reference/expressions/functions.rst
@@ -34,6 +34,7 @@ These functions are available from the polars module root and can be used as exp
    first
    fold
    format
+   from_epoch
    groups
    head
    list


### PR DESCRIPTION
Resolves #6022

Changes:
* Add `from_epoch` to the API reference under Expressions/Functions
* Fixed the function signature
  * Removed the `eager` parameter, as it wasn't doing anything. The below behaviour was in place regardless of the eager parameter:
    * If you pass a str/Expr, it returns an Expr
    * If you pass a sequence/Series, it returns a Series
  * Adjusted overload specification accordingly

Not sure this should be considered breaking, since it wasn't in the API reference.

If this is breaking, I can turn this into a non-breaking change by accepting 'eager' as a parameter that does nothing and raising a Deprecation warning.