### PR TITLE
docs(python): update `read_sql` and `row` docstrings

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6350,7 +6350,7 @@ class DataFrame:
         named: bool = False,
     ) -> tuple[Any, ...] | Any:
         """
-        Get a row as tuple, either by index or by predicate.
+        Get a single row as a tuple, either by index or by predicate.
 
         Parameters
         ----------
@@ -6370,6 +6370,11 @@ class DataFrame:
         When using ``by_predicate`` it is an error condition if anything other than
         one row is returned; more than one row raises ``TooManyRowsReturned``, and
         zero rows will raise ``NoRowsReturned`` (both inherit from ``RowsException``).
+
+        Warning
+        -------
+        You should NEVER use this method to iterate over a DataFrame; if you absolutely
+        require row-iteration you should strongly prefer ``iterrows()`` instead.
 
         Examples
         --------
@@ -6394,6 +6399,11 @@ class DataFrame:
 
         >>> df.row(by_predicate=(pl.col("ham") == "b"))
         (2, 7, 'b')
+
+        See Also
+        --------
+        iterrows : Row iterator over frame data (does not materialise all rows).
+        rows : Materialises all frame data as a list of rows.
 
         """
         if index is not None and by_predicate is not None:
@@ -6467,7 +6477,7 @@ class DataFrame:
 
         See Also
         --------
-        iterrows : row iterator over frame data (does not materialise all rows).
+        iterrows : Row iterator over frame data (does not materialise all rows).
 
         """
         if named:
@@ -6532,7 +6542,7 @@ class DataFrame:
 
         See Also
         --------
-        rows : materialises all frame data as a list of rows.
+        rows : Materialises all frame data as a list of rows.
 
         """
         # note: buffering rows results in a 2-4x speedup over individual calls

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1028,19 +1028,11 @@ def read_sql(
     """
     Read a SQL query into a DataFrame.
 
-    Reading a SQL query from the following data sources are supported:
+    A range of databases are supported, such as PostgreSQL, Redshift, MySQL, MariaDB,
+    Clickhouse, Oracle, BigQuery, SQL Server, and so on. For an up-to-date list
+    please see the connectorx docs:
 
-        * Postgres
-        * Mysql
-        * Sqlite
-        * Redshift (through postgres protocol)
-        * Clickhouse (through mysql protocol)
-
-    If a database source is not supported, an alternative solution is to first use
-    pandas to load the SQL query, then converting the result into a polars DataFrame:
-
-    >>> import pandas as pd
-    >>> df = pl.from_pandas(pd.read_sql(sql, engine))  # doctest: +SKIP
+    * https://github.com/sfu-db/connector-x#supported-sources--destinations
 
     Parameters
     ----------


### PR DESCRIPTION
Some minor updates.

Following a StackOverflow [question](https://stackoverflow.com/questions/74967574/connect-python-polars-to-sql-server-no-support-currently/74973909?noredirect=1#comment132311752_74973909) about SQL Server support, I realised we shouldn't really be trying to actively maintain a list of connectorx-supported databases inside the `read_sql` docstring; have updated so we link to connectorx' own list for people to check if they need to. I believe we can now do without the fallback suggestion to use pandas, as connectorx support for various database has continued to grow, so I removed that too.

Also, now we have `iterrows`, I added a warning not to _ever_ use `row` for iteration and also added a `See Also` section.