### PR TITLE
fix(rust, python): keep name when sorting categorical in lexial order

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -65,11 +65,14 @@ impl CategoricalChunked {
                     );
                     let cats: NoNull<UInt32Chunked> =
                         vals.into_iter().map(|(idx, _v)| idx).collect_trusted();
+                    let mut cats = cats.into_inner();
+                    cats.rename(self.name());
+
                     // safety:
                     // we only reordered the indexes so we are still in bounds
                     unsafe {
                         CategoricalChunked::from_cats_and_rev_map_unchecked(
-                            cats.into_inner(),
+                            cats,
                             self.get_rev_map().clone(),
                         )
                     }

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -288,3 +288,20 @@ def test_categorical_in_struct_nulls() -> None:
     assert s[0] == {"job": None, "counts": 3}
     assert s[1] == {"job": "doctor", "counts": 2}
     assert s[2] == {"job": "waiter", "counts": 1}
+
+
+def test_sort_categoricals_6014() -> None:
+    with pl.StringCache():
+        # create basic categorical
+        df1 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_column(
+            pl.col("key").cast(pl.Categorical)
+        )
+        # create lexically-ordered categorical
+        df2 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_column(
+            pl.col("key").cast(pl.Categorical).cat.set_ordering("lexical")
+        )
+
+    out = df1.sort("key")
+    assert out.to_dict(False) == {"key": ["bbb", "aaa", "ccc"]}
+    out = df2.sort("key")
+    assert out.to_dict(False) == {"key": ["aaa", "bbb", "ccc"]}


### PR DESCRIPTION
closes #6014