### PR TITLE
fix(rust, python): keep column names in is_null/is_not_null

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -343,7 +343,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// Get a mask of the null values.
     pub fn is_null(&self) -> BooleanChunked {
         if !self.has_validity() {
-            return BooleanChunked::full("is_null", false, self.len());
+            return BooleanChunked::full(self.name(), false, self.len());
         }
         let chunks = self
             .chunks
@@ -362,7 +362,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// Get a mask of the valid values.
     pub fn is_not_null(&self) -> BooleanChunked {
         if !self.has_validity() {
-            return BooleanChunked::full("is_not_null", true, self.len());
+            return BooleanChunked::full(self.name(), true, self.len());
         }
         let chunks = self
             .chunks


### PR DESCRIPTION
fixes #6023