### PR TITLE
feat(python): support array-expansion of scalars on frame init from dict

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -50,7 +50,7 @@ from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import ShapeError
-from polars.utils import arrlen, threadpool_size
+from polars.utils import _is_generator, arrlen, threadpool_size
 
 if version_info >= (3, 10):
 
@@ -611,11 +611,12 @@ def dict_to_pydf(
         array_len = max((arrlen(val) or 0) for val in data.values())
         if array_len > 0:
             for key, val in data.items():
-                if arrlen(val) is None:
+                if arrlen(val) is None and not _is_generator(val):
                     data[key] = [val] * array_len  # type: ignore[index]
         elif all((arrlen(val) is None) for val in data.values()):
             for key, val in data.items():
-                data[key] = [val]  # type: ignore[index]
+                if not _is_generator(val):
+                    data[key] = [val]  # type: ignore[index]
 
     # fast path
     return PyDataFrame.read_dict(data)

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4949,7 +4949,7 @@ class DataFrame:
         >>> from string import ascii_uppercase
         >>> df = pl.DataFrame(
         ...     {
-        ...         "col1": ascii_uppercase[0:9],
+        ...         "col1": list(ascii_uppercase[0:9]),
         ...         "col2": pl.arange(0, 9, eager=True),
         ...     }
         ... )

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 import math
 import os
 import warnings
-from collections.abc import Sized
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
-    Iterable,
     NoReturn,
     Sequence,
     Union,
@@ -77,6 +74,7 @@ from polars.internals.slice import PolarsSlice
 from polars.utils import (
     _date_to_pl_date,
     _datetime_to_pl_timestamp,
+    _is_generator,
     _time_to_pl_time,
     is_bool_sequence,
     is_int_sequence,
@@ -277,9 +275,7 @@ class Series:
         elif _PANDAS_TYPE(values) and isinstance(values, (pd.Series, pd.DatetimeIndex)):
             self._s = pandas_to_pyseries(name, values)
 
-        elif isinstance(values, (Generator, Iterable)) and not isinstance(
-            values, Sized
-        ):
+        elif _is_generator(values):
             self._s = iterable_to_pyseries(
                 name,
                 values,

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -5,9 +5,19 @@ import functools
 import os
 import sys
 import warnings
+from collections.abc import Sized
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+    Sequence,
+    TypeVar,
+    overload,
+)
 
 import polars.internals as pli
 from polars.datatypes import DataType, Date, Datetime, PolarsDataType, is_polars_dtype
@@ -29,6 +39,18 @@ else:
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import SizeUnit, TimeUnit
+
+_dict_itertypes = tuple(
+    type(obj)
+    for obj in [
+        {}.keys(),
+        {}.values(),
+        {}.items(),
+        reversed({}.keys()),
+        reversed({}.values()),
+        reversed({}.items()),
+    ]
+)
 
 
 def _process_null_values(
@@ -93,6 +115,12 @@ def _timedelta_to_pl_timedelta(td: timedelta, tu: TimeUnit | None = None) -> int
         return int(td.total_seconds() * 1e6)
     else:
         raise ValueError(f"tu must be one of {{'ns', 'us', 'ms'}}, got {tu}")
+
+
+def _is_generator(val: object) -> bool:
+    return (
+        isinstance(val, (Generator, Iterable)) and not isinstance(val, Sized)
+    ) or isinstance(val, _dict_itertypes)
 
 
 def _date_to_pl_date(d: date) -> int:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -310,6 +310,14 @@ def format_path(path: str | Path) -> str:
     return os.path.expanduser(path)
 
 
+def arrlen(obj: Any) -> int | None:
+    """Return length of (non-string) sequence object; returns None for non-sequences."""
+    try:
+        return None if isinstance(obj, str) else len(obj)
+    except TypeError:
+        return None
+
+
 def threadpool_size() -> int:
     """Get the size of polars' thread pool."""
     return _pool_size()

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -222,6 +222,30 @@ def test_from_arrow() -> None:
     assert df.rows() == []
 
 
+def test_from_dict_with_scalars() -> None:
+    import polars as pl
+
+    # one or more valid arrays, with some scalars
+    df1 = pl.DataFrame(
+        {"key": ["aa", "bb", "cc"], "misc": "xyz", "other": None, "value": 0}
+    )
+    assert df1.to_dict(False) == {
+        "key": ["aa", "bb", "cc"],
+        "misc": ["xyz", "xyz", "xyz"],
+        "other": [None, None, None],
+        "value": [0, 0, 0],
+    }
+
+    # edge-case: all scalars
+    df2 = pl.DataFrame({"key": "aa", "misc": "xyz", "other": None, "value": 0})
+    assert df2.to_dict(False) == {
+        "key": ["aa"],
+        "misc": ["xyz"],
+        "other": [None],
+        "value": [0],
+    }
+
+
 def test_dataclasses_and_namedtuple() -> None:
     from dataclasses import dataclass
     from typing import NamedTuple

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1288,28 +1288,26 @@ def test_from_generator_or_iterable() -> None:
             "keys": d.keys(),
             "vals": d.values(),
             "itms": d.items(),
-            "rev_keys": reversed(d.keys()),
-            "rev_vals": reversed(d.values()),
-            "rev_itms": reversed(d.items()),
         }
     )
-    # ┌──────┬──────┬──────────┬──────────┬──────────┬──────────┐
-    # │ keys ┆ vals ┆ itms     ┆ rev_keys ┆ rev_vals ┆ rev_itms │
-    # │ ---  ┆ ---  ┆ ---      ┆ ---      ┆ ---      ┆ ---      │
-    # │ i64  ┆ str  ┆ object   ┆ i64      ┆ str      ┆ object   │
-    # ╞══════╪══════╪══════════╪══════════╪══════════╪══════════╡
-    # │ 0    ┆ x    ┆ (0, 'x') ┆ 2        ┆ z        ┆ (2, 'z') │
-    # │ 1    ┆ y    ┆ (1, 'y') ┆ 1        ┆ y        ┆ (1, 'y') │
-    # │ 2    ┆ z    ┆ (2, 'z') ┆ 0        ┆ x        ┆ (0, 'x') │
-    # └──────┴──────┴──────────┴──────────┴──────────┴──────────┘
     assert df.to_dict(False) == {
         "keys": [0, 1, 2],
         "vals": ["x", "y", "z"],
         "itms": [(0, "x"), (1, "y"), (2, "z")],
-        "rev_keys": [2, 1, 0],
-        "rev_vals": ["z", "y", "x"],
-        "rev_itms": [(2, "z"), (1, "y"), (0, "x")],
     }
+    if sys.version_info >= (3, 8):
+        df = pl.DataFrame(
+            {
+                "rev_keys": reversed(d.keys()),
+                "rev_vals": reversed(d.values()),
+                "rev_itms": reversed(d.items()),
+            }
+        )
+        assert df.to_dict(False) == {
+            "rev_keys": [2, 1, 0],
+            "rev_vals": ["z", "y", "x"],
+            "rev_itms": [(2, "z"), (1, "y"), (0, "x")],
+        }
 
 
 def test_from_rows() -> None:


### PR DESCRIPTION
**Example** (as per linked issue):
```python
df = pl.DataFrame({
    "a": [1, 2, 3],
    "b": [4, 5, 6],
    "c": None,
    "d": "hi",
})

# shape: (3, 4)
# ┌─────┬─────┬──────┬─────┐
# │ a   ┆ b   ┆ c    ┆ d   │
# │ --- ┆ --- ┆ ---  ┆ --- │
# │ i64 ┆ i64 ┆ f64  ┆ str │
# ╞═════╪═════╪══════╪═════╡
# │ 1   ┆ 4   ┆ null ┆ hi  │
# │ 2   ┆ 5   ┆ null ┆ hi  │
# │ 3   ┆ 6   ┆ null ┆ hi  │
# └─────┴─────┴──────┴─────┘
```
**Also**:

Improves recognition of (and init from) a broader range of specialised generator types (eg: dictionary key/val/item views, etc).

```python
d = {0:"x", 1:"y", 2:"z"}

df = pl.DataFrame(
    {
        "keys": d.keys(),
        "vals": d.values(),
        "itms": d.items(),
        "rev_keys": reversed(d.keys()),
        "rev_vals": reversed(d.values()),
        "rev_itms": reversed(d.items()),
    }
)
# ┌──────┬──────┬──────────┬──────────┬──────────┬──────────┐
# │ keys ┆ vals ┆ itms     ┆ rev_keys ┆ rev_vals ┆ rev_itms │
# │ ---  ┆ ---  ┆ ---      ┆ ---      ┆ ---      ┆ ---      │
# │ i64  ┆ str  ┆ object   ┆ i64      ┆ str      ┆ object   │
# ╞══════╪══════╪══════════╪══════════╪══════════╪══════════╡
# │ 0    ┆ x    ┆ (0, 'x') ┆ 2        ┆ z        ┆ (2, 'z') │
# │ 1    ┆ y    ┆ (1, 'y') ┆ 1        ┆ y        ┆ (1, 'y') │
# │ 2    ┆ z    ┆ (2, 'z') ┆ 0        ┆ x        ┆ (0, 'x') │
# └──────┴──────┴──────────┴──────────┴──────────┴──────────┘
```
----

Closes https://github.com/pola-rs/polars/issues/6027.