### PR TITLE
fix(python): Fix typing for `DataFrame.select`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5363,7 +5363,7 @@ class DataFrame:
         exprs: str
         | pli.Expr
         | pli.Series
-        | Sequence[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
+        | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
     ) -> DF:
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5,7 +5,7 @@ import os
 import random
 import warnings
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, NoReturn, Sequence, cast
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -50,7 +50,7 @@ def selection_to_pyexpr_list(
     exprs: str
     | Expr
     | pli.Series
-    | Sequence[
+    | Iterable[
         str
         | Expr
         | pli.Series

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -5,7 +5,16 @@ import typing
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    NoReturn,
+    Sequence,
+    TypeVar,
+    overload,
+)
 from warnings import warn
 
 from polars import internals as pli
@@ -1498,7 +1507,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         exprs: str
         | pli.Expr
         | pli.Series
-        | Sequence[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
+        | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
     ) -> LDF:
         """
         Select columns from this DataFrame.


### PR DESCRIPTION
Fixes #6026

Turns out `Iterable` is an acceptable type, rather than `Sequence`. There are probably a lot of other functions that can be fixed this way (anything that utilizes `selection_to_pyexpr_list`), but I'll leave it at this for now.