### PR TITLE
feat(python): much faster lazy type-checks

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import inspect
 import re
 import sys
+from functools import cache
 from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
@@ -28,6 +28,8 @@ class _LazyModule(ModuleType):
     module for our own use, but it lives _exclusively_ within polars.
 
     """
+
+    __lazy__ = True
 
     _mod_pfx: dict[str, str] = {
         "numpy": "np.",
@@ -163,25 +165,26 @@ else:
     )
 
 
-def _NUMPY_TYPE(obj: Any) -> bool:
-    return _NUMPY_AVAILABLE and any(
-        "numpy." in str(o)
-        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
-    )
+@cache
+def _might_be(cls: type, type_: str) -> bool:
+    # infer whether the given class "might" be associated with the given
+    # module (in which case it's reasonable to do a real isinstance check)
+    try:
+        return any(f"{type_}." in str(o) for o in cls.mro())
+    except TypeError:
+        return False
 
 
-def _PANDAS_TYPE(obj: Any) -> bool:
-    return _PANDAS_AVAILABLE and any(
-        "pandas." in str(o)
-        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
-    )
+def _check_for_numpy(obj: Any) -> bool:
+    return _NUMPY_AVAILABLE and _might_be(type(obj), "numpy")
 
 
-def _PYARROW_TYPE(obj: Any) -> bool:
-    return _PYARROW_AVAILABLE and any(
-        "pyarrow." in str(o)
-        for o in (obj if inspect.isclass(obj) else obj.__class__).mro()
-    )
+def _check_for_pandas(obj: Any) -> bool:
+    return _PANDAS_AVAILABLE and _might_be(type(obj), "pandas")
+
+
+def _check_for_pyarrow(obj: Any) -> bool:
+    return _PYARROW_AVAILABLE and _might_be(type(obj), "pyarrow")
 
 
 __all__ = [
@@ -194,11 +197,11 @@ __all__ = [
     "_LazyModule",
     "_FSSPEC_AVAILABLE",
     "_NUMPY_AVAILABLE",
-    "_NUMPY_TYPE",
+    "_check_for_numpy",
     "_PANDAS_AVAILABLE",
-    "_PANDAS_TYPE",
+    "_check_for_pandas",
     "_PYARROW_AVAILABLE",
-    "_PYARROW_TYPE",
+    "_check_for_pyarrow",
     "_ZONEINFO_AVAILABLE",
     "_HYPOTHESIS_AVAILABLE",
     "_DELTALAKE_AVAILABLE",

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import re
 import sys
-from functools import cache
+from functools import lru_cache
 from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Hashable, cast
 
 _FSSPEC_AVAILABLE = True
 _NUMPY_AVAILABLE = True
@@ -165,7 +165,7 @@ else:
     )
 
 
-@cache
+@lru_cache(maxsize=None)
 def _might_be(cls: type, type_: str) -> bool:
     # infer whether the given class "might" be associated with the given
     # module (in which case it's reasonable to do a real isinstance check)
@@ -176,15 +176,15 @@ def _might_be(cls: type, type_: str) -> bool:
 
 
 def _check_for_numpy(obj: Any) -> bool:
-    return _NUMPY_AVAILABLE and _might_be(type(obj), "numpy")
+    return _NUMPY_AVAILABLE and _might_be(cast(Hashable, type(obj)), "numpy")
 
 
 def _check_for_pandas(obj: Any) -> bool:
-    return _PANDAS_AVAILABLE and _might_be(type(obj), "pandas")
+    return _PANDAS_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pandas")
 
 
 def _check_for_pyarrow(obj: Any) -> bool:
-    return _PYARROW_AVAILABLE and _might_be(type(obj), "pyarrow")
+    return _PYARROW_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pyarrow")
 
 
 __all__ = [

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -41,9 +41,9 @@ from polars.datatypes_constructor import (
     py_type_to_constructor,
 )
 from polars.dependencies import (
+    _check_for_numpy,
+    _check_for_pandas,
     _NUMPY_AVAILABLE,
-    _NUMPY_TYPE,
-    _PANDAS_TYPE,
     _PYARROW_AVAILABLE,
 )
 from polars.dependencies import numpy as np
@@ -374,7 +374,7 @@ def sequence_to_pyseries(
             return PySeries.new_object(name, values, strict)
 
         elif (
-            _NUMPY_TYPE(value)
+            _check_for_numpy(value)
             and isinstance(value, np.ndarray)
             and len(value.shape) == 1
         ):
@@ -584,7 +584,7 @@ def dict_to_pydf(
         count_numpy = 0
         for val in data.values():
             # only start a thread pool from a reasonable size.
-            count_numpy += int(isinstance(val, np.ndarray) and len(val) > 1000)
+            count_numpy += int(_check_for_numpy(val) and isinstance(val, np.ndarray) and len(val) > 1000)
 
         # if we have more than 3 numpy arrays we multi-thread
         if count_numpy > 2:
@@ -721,7 +721,7 @@ def sequence_to_pydf(
             pydf = _post_apply_columns(pydf, columns, categoricals)
         return pydf
 
-    elif _PANDAS_TYPE(data[0]) and isinstance(data[0], (pd.Series, pd.DatetimeIndex)):
+    elif _check_for_pandas(data[0]) and isinstance(data[0], (pd.Series, pd.DatetimeIndex)):
         dtypes = {}
         if columns is not None:
             columns, dtypes = _unpack_columns(columns, n_expected=1)

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -41,10 +41,10 @@ from polars.datatypes_constructor import (
     py_type_to_constructor,
 )
 from polars.dependencies import (
-    _check_for_numpy,
-    _check_for_pandas,
     _NUMPY_AVAILABLE,
     _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
@@ -584,7 +584,11 @@ def dict_to_pydf(
         count_numpy = 0
         for val in data.values():
             # only start a thread pool from a reasonable size.
-            count_numpy += int(_check_for_numpy(val) and isinstance(val, np.ndarray) and len(val) > 1000)
+            count_numpy += int(
+                _check_for_numpy(val)
+                and isinstance(val, np.ndarray)
+                and len(val) > 1000
+            )
 
         # if we have more than 3 numpy arrays we multi-thread
         if count_numpy > 2:
@@ -721,7 +725,9 @@ def sequence_to_pydf(
             pydf = _post_apply_columns(pydf, columns, categoricals)
         return pydf
 
-    elif _check_for_pandas(data[0]) and isinstance(data[0], (pd.Series, pd.DatetimeIndex)):
+    elif _check_for_pandas(data[0]) and isinstance(
+        data[0], (pd.Series, pd.DatetimeIndex)
+    ):
         dtypes = {}
         if columns is not None:
             columns, dtypes = _unpack_columns(columns, n_expected=1)

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -658,7 +658,7 @@ def sequence_to_pydf(
             pydf = _post_apply_columns(pydf, column_names)
         return pydf
 
-    elif isinstance(data[0], Sequence) and not isinstance(data[0], str):
+    elif isinstance(data[0], (list, tuple, Sequence)) and not isinstance(data[0], str):
         if is_namedtuple(data[0]):
             if columns is None:
                 columns = data[0]._fields  # type: ignore[attr-defined]

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -274,13 +274,13 @@ class DataFrame:
         elif isinstance(data, dict):
             self._df = dict_to_pydf(data, columns=columns)
 
-        elif isinstance(data, Sequence) and not isinstance(data, str):
-            self._df = sequence_to_pydf(
-                data, columns=columns, orient=orient, infer_schema_length=50
-            )
         elif isinstance(data, pli.Series):
             self._df = series_to_pydf(data, columns=columns)
 
+        elif isinstance(data, (list, tuple, Sequence)):
+            self._df = sequence_to_pydf(
+                data, columns=columns, orient=orient, infer_schema_length=50
+            )
         elif _check_for_numpy(data) and isinstance(data, np.ndarray):
             self._df = numpy_to_pydf(data, columns=columns, orient=orient)
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -290,7 +290,7 @@ class DataFrame:
         elif _check_for_pandas(data) and isinstance(data, pd.DataFrame):
             self._df = pandas_to_pydf(data, columns=columns)
 
-        elif isinstance(data, (Generator, Iterable)) and not isinstance(data, Sized):
+        elif not isinstance(data, Sized) and isinstance(data, (Generator, Iterable)):
             self._df = iterable_to_pydf(data, columns=columns, orient=orient)
         else:
             raise ValueError(

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -46,7 +46,7 @@ from polars.datatypes import (
     get_idx_type,
     py_type_to_dtype,
 )
-from polars.dependencies import _NUMPY_TYPE, _PANDAS_TYPE, _PYARROW_TYPE
+from polars.dependencies import _check_for_numpy, _check_for_pandas, _check_for_pyarrow
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
@@ -274,12 +274,6 @@ class DataFrame:
         elif isinstance(data, dict):
             self._df = dict_to_pydf(data, columns=columns)
 
-        elif _NUMPY_TYPE(data) and isinstance(data, np.ndarray):
-            self._df = numpy_to_pydf(data, columns=columns, orient=orient)
-
-        elif _PYARROW_TYPE(data) and isinstance(data, pa.Table):
-            self._df = arrow_to_pydf(data, columns=columns)
-
         elif isinstance(data, Sequence) and not isinstance(data, str):
             self._df = sequence_to_pydf(
                 data, columns=columns, orient=orient, infer_schema_length=50
@@ -287,7 +281,13 @@ class DataFrame:
         elif isinstance(data, pli.Series):
             self._df = series_to_pydf(data, columns=columns)
 
-        elif _PANDAS_TYPE(data) and isinstance(data, pd.DataFrame):
+        elif _check_for_numpy(data) and isinstance(data, np.ndarray):
+            self._df = numpy_to_pydf(data, columns=columns, orient=orient)
+
+        elif _check_for_pyarrow(data) and isinstance(data, pa.Table):
+            self._df = arrow_to_pydf(data, columns=columns)
+
+        elif _check_for_pandas(data) and isinstance(data, pd.DataFrame):
             self._df = pandas_to_pydf(data, columns=columns)
 
         elif isinstance(data, (Generator, Iterable)) and not isinstance(data, Sized):
@@ -1176,7 +1176,7 @@ class DataFrame:
 
                 return idxs.cast(idx_type)
 
-        if _NUMPY_TYPE(idxs) and isinstance(idxs, np.ndarray):
+        if _check_for_numpy(idxs) and isinstance(idxs, np.ndarray):
             if idxs.ndim != 1:
                 raise ValueError("Only 1D numpy array is supported as index.")
             if idxs.dtype.kind in ("i", "u"):
@@ -1301,7 +1301,8 @@ class DataFrame:
             # df[2, :] (select row as df)
             if isinstance(row_selection, int):
                 if isinstance(col_selection, (slice, list)) or (
-                    _NUMPY_TYPE(col_selection) and isinstance(col_selection, np.ndarray)
+                    _check_for_numpy(col_selection)
+                    and isinstance(col_selection, np.ndarray)
                 ):
                     df = self[:, col_selection]
                     return df.slice(row_selection, 1)
@@ -1348,7 +1349,7 @@ class DataFrame:
         # select rows by numpy mask or index
         # df[np.array([1, 2, 3])]
         # df[np.array([True, False, True])]
-        if _NUMPY_TYPE(item) and isinstance(item, np.ndarray):
+        if _check_for_numpy(item) and isinstance(item, np.ndarray):
             if item.ndim != 1:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
@@ -2556,7 +2557,7 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        if _NUMPY_TYPE(predicate) and isinstance(predicate, np.ndarray):
+        if _check_for_numpy(predicate) and isinstance(predicate, np.ndarray):
             predicate = pli.Series(predicate)
 
         return (

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -15,7 +15,7 @@ from polars.datatypes import (
     is_polars_dtype,
     py_type_to_dtype,
 )
-from polars.dependencies import _NUMPY_TYPE
+from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.internals.expr.binary import ExprBinaryNameSpace
 from polars.internals.expr.categorical import ExprCatNameSpace
@@ -1945,7 +1945,7 @@ class Expr:
 
         """
         if isinstance(indices, list) or (
-            _NUMPY_TYPE(indices) and isinstance(indices, np.ndarray)
+            _check_for_numpy(indices) and isinstance(indices, np.ndarray)
         ):
             indices = cast("np.ndarray[Any, Any]", indices)
             indices_lit = pli.lit(pli.Series("", indices, dtype=UInt32))

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -194,7 +194,7 @@ def col(
     if isinstance(name, DataType):
         return pli.wrap_expr(_dtype_cols([name]))
 
-    elif not isinstance(name, str) and isinstance(name, Sequence):
+    elif not isinstance(name, str) and isinstance(name, (list, tuple, Sequence)):
         if len(name) == 0 or isinstance(name[0], str):
             return pli.wrap_expr(pycols(name))
         elif is_polars_dtype(name[0]):

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -19,7 +19,7 @@ from polars.datatypes import (
     is_polars_dtype,
     py_type_to_dtype,
 )
-from polars.dependencies import _NUMPY_TYPE
+from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.internals.type_aliases import EpochTimeUnit
 from polars.utils import (
@@ -1101,7 +1101,7 @@ def lit(
             return e
         return e.alias(name)
 
-    if _NUMPY_TYPE(value) and isinstance(value, np.ndarray):
+    if _check_for_numpy(value) and isinstance(value, np.ndarray):
         return lit(pli.Series("", value))
 
     if dtype:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -46,10 +46,10 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.dependencies import (
-    _NUMPY_TYPE,
-    _PANDAS_TYPE,
+    _check_for_numpy,
+    _check_for_pandas,
+    _check_for_pyarrow,
     _PYARROW_AVAILABLE,
-    _PYARROW_TYPE,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
@@ -232,25 +232,6 @@ class Series:
         elif isinstance(values, Series):
             self._s = series_to_pyseries(name, values)
 
-        elif _PYARROW_TYPE(values) and isinstance(values, (pa.Array, pa.ChunkedArray)):
-            self._s = arrow_to_pyseries(name, values)
-
-        elif _NUMPY_TYPE(values) and isinstance(values, np.ndarray):
-            self._s = numpy_to_pyseries(name, values, strict, nan_to_null)
-            if values.dtype.type == np.datetime64:
-                # cast to appropriate dtype, handling NaT values
-                dtype = _resolve_datetime_dtype(dtype, values.dtype)
-                if dtype is not None:
-                    self._s = (
-                        self.cast(dtype)
-                        .set_at_idx(np.argwhere(np.isnat(values)).flatten(), None)
-                        ._s
-                    )
-                    return
-
-            if dtype is not None:
-                self._s = self.cast(dtype, strict=True)._s
-
         elif isinstance(values, range):
             self._s = (
                 pli.arange(
@@ -272,7 +253,28 @@ class Series:
                 dtype_if_empty=dtype_if_empty,
                 nan_to_null=nan_to_null,
             )
-        elif _PANDAS_TYPE(values) and isinstance(values, (pd.Series, pd.DatetimeIndex)):
+        elif _check_for_numpy(values) and isinstance(values, np.ndarray):
+            self._s = numpy_to_pyseries(name, values, strict, nan_to_null)
+            if values.dtype.type == np.datetime64:
+                # cast to appropriate dtype, handling NaT values
+                dtype = _resolve_datetime_dtype(dtype, values.dtype)
+                if dtype is not None:
+                    self._s = (
+                        self.cast(dtype)
+                        .set_at_idx(np.argwhere(np.isnat(values)).flatten(), None)
+                        ._s
+                    )
+                    return
+
+            if dtype is not None:
+                self._s = self.cast(dtype, strict=True)._s
+
+        elif _check_for_pyarrow(values) and isinstance(values, (pa.Array, pa.ChunkedArray)):
+            self._s = arrow_to_pyseries(name, values)
+
+        elif _check_for_pandas(values) and isinstance(
+            values, (pd.Series, pd.DatetimeIndex)
+        ):
             self._s = pandas_to_pyseries(name, values)
 
         elif _is_generator(values):
@@ -627,7 +629,7 @@ class Series:
 
     def __matmul__(self, other: Any) -> float | Series | None:
         if isinstance(other, Sequence) or (
-            _NUMPY_TYPE(other) and isinstance(other, np.ndarray)
+            _check_for_numpy(other) and isinstance(other, np.ndarray)
         ):
             other = Series(other)
         # elif isinstance(other, pli.DataFrame):
@@ -636,7 +638,7 @@ class Series:
 
     def __rmatmul__(self, other: Any) -> float | Series | None:
         if isinstance(other, Sequence) or (
-            _NUMPY_TYPE(other) and isinstance(other, np.ndarray)
+            _check_for_numpy(other) and isinstance(other, np.ndarray)
         ):
             other = Series(other)
         return other.dot(self)
@@ -706,7 +708,7 @@ class Series:
 
                 return idxs.cast(idx_type)
 
-        elif _NUMPY_TYPE(idxs) and isinstance(idxs, np.ndarray):
+        elif _check_for_numpy(idxs) and isinstance(idxs, np.ndarray):
             if idxs.ndim != 1:
                 raise ValueError("Only 1D numpy array is supported as index.")
             if idxs.dtype.kind in ("i", "u"):
@@ -785,7 +787,7 @@ class Series:
             return wrap_s(self._s.take_with_series(self._pos_idxs(item)._s))
 
         elif (
-            _NUMPY_TYPE(item)
+            _check_for_numpy(item)
             and isinstance(item, np.ndarray)
             and item.dtype.kind in ("i", "u")
         ):
@@ -843,7 +845,7 @@ class Series:
             return wrap_s(self._s.filter(item._s))
 
         elif (
-            _NUMPY_TYPE(item)
+            _check_for_numpy(item)
             and isinstance(item, np.ndarray)
             and item.dtype.kind == "b"
         ):
@@ -897,7 +899,7 @@ class Series:
                 self._s = self.set_at_idx(key, value)._s
 
         # TODO: implement for these types without casting to series
-        elif _NUMPY_TYPE(key) and isinstance(key, np.ndarray):
+        elif _check_for_numpy(key) and isinstance(key, np.ndarray):
             if key.dtype == np.bool_:
                 # boolean numpy mask
                 self._s = self.set_at_idx(np.argwhere(key)[:, 0], value)._s

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -46,10 +46,10 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.dependencies import (
+    _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
     _check_for_pyarrow,
-    _PYARROW_AVAILABLE,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
@@ -269,7 +269,9 @@ class Series:
             if dtype is not None:
                 self._s = self.cast(dtype, strict=True)._s
 
-        elif _check_for_pyarrow(values) and isinstance(values, (pa.Array, pa.ChunkedArray)):
+        elif _check_for_pyarrow(values) and isinstance(
+            values, (pa.Array, pa.ChunkedArray)
+        ):
             self._s = arrow_to_pyseries(name, values)
 
         elif _check_for_pandas(values) and isinstance(

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -312,8 +312,7 @@ def test_init_1d_sequence() -> None:
     assert df.rows() == [(None,), (1,), (0,)]
 
     # String sequence
-    with pytest.raises(ValueError):
-        pl.DataFrame("abc")
+    assert pl.DataFrame("abc", columns=["s"]).to_dict(False) == {"s": ["a", "b", "c"]}
 
 
 def test_init_pandas(monkeypatch: Any) -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -173,7 +173,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
         _ = pl.DataFrame(np.array([[1, 2], [3, 4]]), columns=["a"])
 
     # NumPy not available
-    monkeypatch.setattr(pl.internals.dataframe.frame, "_NUMPY_TYPE", lambda x: False)
+    monkeypatch.setattr(pl.internals.dataframe.frame, "_check_for_numpy", lambda x: False)
     with pytest.raises(ValueError):
         pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
 
@@ -358,7 +358,7 @@ def test_init_pandas(monkeypatch: Any) -> None:
     assert df.rows() == [(datetime(2022, 10, 31, 10, 30, 45, 123456),)]
 
     # pandas is not available
-    monkeypatch.setattr(pl.internals.dataframe.frame, "_PANDAS_TYPE", lambda x: False)
+    monkeypatch.setattr(pl.internals.dataframe.frame, "_check_for_pandas", lambda x: False)
     with pytest.raises(ValueError):
         pl.DataFrame(pandas_df)
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -173,7 +173,9 @@ def test_init_ndarray(monkeypatch: Any) -> None:
         _ = pl.DataFrame(np.array([[1, 2], [3, 4]]), columns=["a"])
 
     # NumPy not available
-    monkeypatch.setattr(pl.internals.dataframe.frame, "_check_for_numpy", lambda x: False)
+    monkeypatch.setattr(
+        pl.internals.dataframe.frame, "_check_for_numpy", lambda x: False
+    )
     with pytest.raises(ValueError):
         pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
 
@@ -358,7 +360,9 @@ def test_init_pandas(monkeypatch: Any) -> None:
     assert df.rows() == [(datetime(2022, 10, 31, 10, 30, 45, 123456),)]
 
     # pandas is not available
-    monkeypatch.setattr(pl.internals.dataframe.frame, "_check_for_pandas", lambda x: False)
+    monkeypatch.setattr(
+        pl.internals.dataframe.frame, "_check_for_pandas", lambda x: False
+    )
     with pytest.raises(ValueError):
         pl.DataFrame(pandas_df)
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -134,7 +134,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
         pl.Series("bigint", [2**64])
 
     # numpy not available
-    monkeypatch.setattr(pl.internals.series.series, "_NUMPY_TYPE", lambda x: False)
+    monkeypatch.setattr(pl.internals.series.series, "_check_for_numpy", lambda x: False)
     with pytest.raises(ValueError):
         pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
 


### PR DESCRIPTION
First-pass fix for a performance regression (ref #6052).

* Makes all of the lazy type-checks ~7-8x faster. 
* Renamed the checks to better-describe what they are actually doing
* Moved the expensive checks last, during initial type-determination (frame/series init).
* Faster `Sequence` type-checks for the common case (~3.5x).

Will do another pass later to take care of other low-hanging fruit.