### PR TITLE
fix(python): bound complex type from 3.8 to 3.11

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -38,7 +38,7 @@ else:
     from typing_extensions import ParamSpec, TypeGuard
 
 # note: reversed views don't match as instances of MappingView
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 11):
     _reverse_mapping_views = tuple(
         type(reversed(cast(Reversible[Any], view)))
         for view in ({}.keys(), {}.values(), {}.items())
@@ -117,7 +117,7 @@ def _is_generator(val: object) -> bool:
     return (
         (isinstance(val, (Generator, Iterable)) and not isinstance(val, Sized))
         or isinstance(val, MappingView)
-        or (sys.version_info >= (3, 8) and isinstance(val, _reverse_mapping_views))
+        or (sys.version_info >= (3, 11) and isinstance(val, _reverse_mapping_views))
     )
 
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1330,7 +1330,7 @@ def test_from_generator_or_iterable() -> None:
         "vals": ["x", "y", "z"],
         "itms": [(0, "x"), (1, "y"), (2, "z")],
     }
-    if sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 11):
         df = pl.DataFrame(
             {
                 "rev_keys": reversed(d.keys()),


### PR DESCRIPTION
fixes #6070 