### PR TITLE
fix(rust, python): don't run cse cache_states if no projections found

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cache_states.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cache_states.rs
@@ -146,7 +146,7 @@ pub(super) fn set_cache_states(
         // and finally remove that last projection and stitch the subplan
         // back to the cache node again
         if !cache_schema_and_children.is_empty() {
-            let pd = projection_pushdown::ProjectionPushDown {};
+            let mut pd = ProjectionPushDown::new();
             for (_cache_id, (children, columns)) in cache_schema_and_children {
                 if !columns.is_empty() {
                     let projection = columns

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -96,11 +96,14 @@ pub fn optimize(
 
     // should be run before predicate pushdown
     if projection_pushdown {
-        let projection_pushdown_opt = ProjectionPushDown {};
+        let mut projection_pushdown_opt = ProjectionPushDown::new();
         let alp = lp_arena.take(lp_top);
         let alp = projection_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
         lp_arena.replace(lp_top, alp);
-        cache_states::set_cache_states(lp_top, lp_arena, expr_arena, scratch, cse_changed);
+
+        if projection_pushdown_opt.changed {
+            cache_states::set_cache_states(lp_top, lp_arena, expr_arena, scratch, cse_changed);
+        }
     }
 
     if predicate_pushdown {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/generic.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/generic.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_generic(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     lp: ALogicalPlan,
     acc_projections: Vec<Node>,
     projected_names: PlHashSet<Arc<str>>,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/groupby.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/groupby.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_groupby(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     input: Node,
     keys: Vec<Node>,
     aggs: Vec<Node>,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/hstack.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/hstack.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_hstack(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     input: Node,
     mut exprs: Vec<Node>,
     mut acc_projections: Vec<Node>,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
@@ -41,7 +41,7 @@ fn add_nodes_to_accumulated_state(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_join(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     input_left: Node,
     input_right: Node,
     left_on: Vec<Node>,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/melt.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/melt.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_melt(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     input: Node,
     args: Arc<MeltArgs>,
     schema: SchemaRef,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_projection(
-    proj_pd: &ProjectionPushDown,
+    proj_pd: &mut ProjectionPushDown,
     input: Node,
     exprs: Vec<Node>,
     mut acc_projections: Vec<Node>,

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -1,4 +1,5 @@
 import re
+from datetime import date
 
 import polars as pl
 
@@ -31,3 +32,29 @@ def test_union_duplicates() -> None:
         )
         == 10
     )
+
+
+def test_cse_schema_6081() -> None:
+    df = pl.DataFrame(
+        data=[
+            [date(2022, 12, 12), 1, 1],
+            [date(2022, 12, 12), 1, 2],
+            [date(2022, 12, 13), 5, 2],
+        ],
+        columns=["date", "id", "value"],
+        orient="row",
+    ).lazy()
+
+    min_value_by_group = df.groupby(["date", "id"]).agg(
+        pl.col("value").min().alias("min_value")
+    )
+
+    result = df.join(min_value_by_group, on=["date", "id"], how="left")
+    assert result.collect(
+        common_subplan_elimination=True, projection_pushdown=True
+    ).to_dict(False) == {
+        "date": [date(2022, 12, 12), date(2022, 12, 12), date(2022, 12, 13)],
+        "id": [1, 1, 5],
+        "value": [1, 2, 2],
+        "min_value": [1, 1, 2],
+    }


### PR DESCRIPTION
fixes #6081