### PR TITLE
feat(python): additional (opt-in) options for assert_frame_equal

### DIFF
--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -42,6 +42,10 @@ except ImportError:
         """Exception raised when an unexpected state causes a panic in the underlying Rust library."""  # noqa: E501
 
 
+class InvalidAssert(Exception):
+    """Exception raised when an unsupported testing assert is made."""
+
+
 class RowsException(Exception):
     """Exception raised when the number of returned rows does not match expectation."""
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -12,17 +12,21 @@ from polars.datatypes import (
     Float64,
     dtype_to_py_type,
 )
+from polars.exceptions import InvalidAssert, PanicException
+from polars.utils import deprecated_alias
 
 
+@deprecated_alias(check_column_names="check_column_order")
 def assert_frame_equal(
     left: pli.DataFrame | pli.LazyFrame,
     right: pli.DataFrame | pli.LazyFrame,
     check_dtype: bool = True,
     check_exact: bool = False,
-    check_column_names: bool = True,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
     nans_compare_equal: bool = True,
+    check_column_order: bool = True,
+    check_row_order: bool = True,
 ) -> None:
     """
     Raise detailed AssertionError if `left` does not equal `right`.
@@ -38,14 +42,19 @@ def assert_frame_equal(
     check_exact
         if False, test if values are within tolerance of each other
         (see `rtol` & `atol`).
-    check_column_names
-        if True, dataframes must have the same column names in the same order.
     rtol
         relative tolerance for inexact checking. Fraction of values in `right`.
     atol
         absolute tolerance for inexact checking.
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
+    check_column_order
+        if False, allows the assert/test to succeed if the required columns are present,
+        irrespective of the order in which they appear.
+    check_row_order
+        if False, allows the assert/test to succeed if the required rows are present,
+        irrespective of the order in which they appear; as this requires
+        sorting, you cannot set on frames that contain unsortable columns.
 
     Examples
     --------
@@ -77,11 +86,21 @@ def assert_frame_equal(
             f"Columns {right_not_left} in right frame, but not in left"
         )
 
-    if check_column_names:
-        if left.columns != right.columns:
-            raise AssertionError("Columns are not in the same order")
+    if check_column_order and left.columns != right.columns:
+        raise AssertionError(
+            f"Columns are not in the same order:\n{left.columns!r}\n{right.columns!r}"
+        )
 
-    # this does not assume a particular order
+    if not check_row_order:
+        try:
+            left = left.sort(by=left.columns)
+            right = right.sort(by=right.columns)
+        except PanicException as err:
+            raise InvalidAssert(
+                "Cannot set 'check_row_order=False' on frame with unsortable columns"
+            ) from err
+
+    # note: does not assume a particular column order
     for c in left.columns:
         _assert_series_inner(
             left[c],  # type: ignore[arg-type, index]

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -94,7 +94,7 @@ def assert_frame_equal(
     if not check_row_order:
         try:
             left = left.sort(by=left.columns)
-            right = right.sort(by=right.columns)
+            right = right.sort(by=left.columns)
         except PanicException as err:
             raise InvalidAssert(
                 "Cannot set 'check_row_order=False' on frame with unsortable columns"

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -198,21 +198,27 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
 
 
 def test_assert_frame_equal_ignore_row_order() -> None:
-    expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-    df = pl.DataFrame({"a": [2, 1], "b": [4, 3]})
+    df1 = pl.DataFrame({"a": [1, 2], "b": [4, 3]})
+    df2 = pl.DataFrame({"a": [2, 1], "b": [3, 4]})
+    df3 = pl.DataFrame({"b": [3, 4], "a": [2, 1]})
     with pytest.raises(AssertionError, match="Value mismatch"):
-        assert_frame_equal(expected, df)
+        assert_frame_equal(df1, df2)
 
-    assert_frame_equal(expected, df, check_row_order=False)
+    assert_frame_equal(df1, df2, check_row_order=False)
     # eg:
     # ┌─────┬─────┐      ┌─────┬─────┐
     # │ a   ┆ b   │      │ a   ┆ b   │
     # │ --- ┆ --- │      │ --- ┆ --- │
     # │ i64 ┆ i64 │ (eq) │ i64 ┆ i64 │
     # ╞═════╪═════╡  ==  ╞═════╪═════╡
-    # │ 1   ┆ 3   │      │ 2   ┆ 4   │
-    # │ 2   ┆ 4   │      │ 1   ┆ 3   │
+    # │ 1   ┆ 4   │      │ 2   ┆ 3   │
+    # │ 2   ┆ 3   │      │ 1   ┆ 4   │
     # └─────┴─────┘      └─────┴─────┘
+
+    with pytest.raises(AssertionError, match="Columns are not in the same order"):
+        assert_frame_equal(df1, df3, check_row_order=False)
+
+    assert_frame_equal(df1, df3, check_row_order=False, check_column_order=False)
 
     # note: not all column types support sorting
     with pytest.raises(

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidAssert
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -188,7 +189,41 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     df2 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(AssertionError, match="Columns are not in the same order"):
         assert_frame_equal(df1, df2)
-    assert_frame_equal(df1, df2, check_column_names=False)
+
+    # preferred/new param name
+    assert_frame_equal(df1, df2, check_column_order=False)
+
+    # deprecated param name
+    assert_frame_equal(df1, df2, check_column_names=False)  # type: ignore[call-arg]
+
+
+def test_assert_frame_equal_ignore_row_order() -> None:
+    expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df = pl.DataFrame({"a": [2, 1], "b": [4, 3]})
+    with pytest.raises(AssertionError, match="Value mismatch"):
+        assert_frame_equal(expected, df)
+
+    assert_frame_equal(expected, df, check_row_order=False)
+    # eg:
+    # ┌─────┬─────┐      ┌─────┬─────┐
+    # │ a   ┆ b   │      │ a   ┆ b   │
+    # │ --- ┆ --- │      │ --- ┆ --- │
+    # │ i64 ┆ i64 │ (eq) │ i64 ┆ i64 │
+    # ╞═════╪═════╡  ==  ╞═════╪═════╡
+    # │ 1   ┆ 3   │      │ 2   ┆ 4   │
+    # │ 2   ┆ 4   │      │ 1   ┆ 3   │
+    # └─────┴─────┘      └─────┴─────┘
+
+    # note: not all column types support sorting
+    with pytest.raises(
+        InvalidAssert,
+        match="Cannot set 'check_row_order=False'.*unsortable columns",
+    ):
+        assert_frame_equal(
+            left=pl.DataFrame({"a": [[1, 2], [3, 4]], "b": [3, 4]}),
+            right=pl.DataFrame({"a": [[3, 4], [1, 2]], "b": [4, 3]}),
+            check_row_order=False,
+        )
 
 
 def test_assert_series_equal_int_overflow() -> None:


### PR DESCRIPTION
Closes #6077 and makes @stinodego more productive ;)

One new (opt-in) parameter and one name-change (mediated via `@deprecated_alias`) for an existing one that wasn't quite descriptive enough.

* **New**: `check_row_order` allows you to assert that frames are considered equal if all of the same rows exist in each, irrespective of the order they appear in. This is done by sorting each (by all cols) first and _then_ comparing. Obviously this fails if a column is unsortable (eg: list/struct), so an `InvalidAssert` is raised in this case to explain that you can't set this mode on the given frames.

* **Renamed**: `check_column_names` is now `check_column_order` - the presence of the column names (that they exist in both frames) is _always_ checked in both frames, irrespective of `check_column_names` being True/False. So, the new name makes it clearer as to _what_ is being checked (that they appear in the same order).

* **Misc**: added slightly more detail to the assert error when columns are mismatched, to actually _show_ the left/right column names.

No changes in default behaviour, test coverage added.