### PR TITLE
feat(python): extend existing fast range->Series init to lists of ranges in a Series

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -21,7 +21,14 @@ from typing import (
 )
 
 import polars.internals as pli
-from polars.datatypes import DataType, Date, Datetime, PolarsDataType, is_polars_dtype
+from polars.datatypes import (
+    DataType,
+    Date,
+    Datetime,
+    Int64,
+    PolarsDataType,
+    is_polars_dtype,
+)
 from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
 try:
@@ -168,6 +175,19 @@ def is_str_sequence(
     if allow_str is False and isinstance(val, str):
         return False
     return isinstance(val, Sequence) and _is_iterable_of(val, str)
+
+
+def range_to_series(
+    name: str, rng: range, dtype: PolarsDataType | None = Int64
+) -> pli.Series:
+    """Fast conversion of the given range to a Series."""
+    return pli.arange(
+        low=rng.start,
+        high=rng.stop,
+        step=rng.step,
+        eager=True,
+        dtype=dtype,
+    ).rename(name, in_place=True)
 
 
 def range_to_slice(rng: range) -> slice:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1317,9 +1317,25 @@ def test_sqrt() -> None:
 
 
 def test_range() -> None:
-    s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
-    assert s[2:5].series_equal(s[range(2, 5)])
-    df = pl.DataFrame([s])
+    s1 = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
+    assert s1[2:5].series_equal(s1[range(2, 5)])
+
+    ranges = [range(-2, 1), range(3), range(2, 8, 2)]
+
+    s2 = pl.Series("b", ranges, dtype=pl.List(pl.Int8))
+    assert s2.to_list() == [[-2, -1, 0], [0, 1, 2], [2, 4, 6]]
+    assert s2.dtype == pl.List(pl.Int8)
+    assert s2.name == "b"
+
+    s3 = pl.Series("c", (ranges for _ in range(3)))
+    assert s3.to_list() == [
+        [[-2, -1, 0], [0, 1, 2], [2, 4, 6]],
+        [[-2, -1, 0], [0, 1, 2], [2, 4, 6]],
+        [[-2, -1, 0], [0, 1, 2], [2, 4, 6]],
+    ]
+    assert s3.dtype == pl.List(pl.List(pl.Int64))
+
+    df = pl.DataFrame([s1])
     assert df[2:5].frame_equal(df[range(2, 5)])
 
 


### PR DESCRIPTION
We currently have a `range => Series` fast-path; this extends the concept slightly to allow for easy creation of _lists_ of ranges within a `Series` (previously would just dump the ranges in as unexpanded python objects).

**Example**:

```python
pl.Series( "a", [range(-2,1),range(3),range(2,8,2)] ) 

# shape: (3,)
# Series: 'a' [list]
# [
#     [-2, -1, 0]
#     [0, 1, 2]
#     [2, 4, 6]
# ]

pl.Series( "b", ((range(n),range(n+1),range(n+2)) for n in range(1,4)) ) 

# shape: (3,)
# Series: 'b' [list]
# [
#     [[0], [0, 1], [0, 1, 2]]
#     [[0, 1], [0, 1, 2], [0, 1, ... 3]]
#     [[0, 1, 2], [0, 1, ... 3], [0, 1, ... 4]]
# ]
```

**Note**:

The 1D case (`range => Series`) is _fast_; the 2D case (above) is currently "ok" as the number of distinct ranges gets large; each range is mediated by creation of an associated DataFrame inside `pl.arange`. Would be interesting if we could push some kind of sequence generation based on row number (like the above) into an expression...🤔 

(FYI: I originally though pandas had some _insanely_ fast method of doing this 100s of times faster than us, until I realised it was just loading the range objects "as-is" but it's `repr` was unpacking a few rows of them when you eyeball the frame, hah! Almost spit out my tea when it first appeared to benchmark 586x faster - then reality reasserted itself :)