### PR TITLE
fix(python): ensure multi-line type hints are parenthesised

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1211,11 +1211,13 @@ class DataFrame:
     @overload
     def __getitem__(
         self: DF,
-        item: int
-        | np.ndarray[Any, Any]
-        | MultiColSelector
-        | tuple[int, MultiColSelector]
-        | tuple[MultiRowSelector, MultiColSelector],
+        item: (
+            int
+            | np.ndarray[Any, Any]
+            | MultiColSelector
+            | tuple[int, MultiColSelector]
+            | tuple[MultiRowSelector, MultiColSelector]
+        ),
     ) -> DF:
         ...
 
@@ -2493,12 +2495,9 @@ class DataFrame:
 
     def filter(
         self,
-        predicate: pli.Expr
-        | str
-        | pli.Series
-        | list[bool]
-        | np.ndarray[Any, Any]
-        | bool,
+        predicate: (
+            pli.Expr | str | pli.Series | list[bool] | np.ndarray[Any, Any] | bool
+        ),
     ) -> DataFrame:
         """
         Filter the rows in the DataFrame based on a predicate expression.
@@ -5361,10 +5360,12 @@ class DataFrame:
 
     def select(
         self: DF,
-        exprs: str
-        | pli.Expr
-        | pli.Series
-        | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
+        exprs: (
+            str
+            | pli.Expr
+            | pli.Series
+            | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen]
+        ),
     ) -> DF:
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -48,21 +48,23 @@ elif os.getenv("BUILDING_SPHINX_DOCS"):
 
 
 def selection_to_pyexpr_list(
-    exprs: str
-    | Expr
-    | pli.Series
-    | Iterable[
+    exprs: (
         str
         | Expr
         | pli.Series
-        | timedelta
-        | date
-        | datetime
-        | int
-        | float
-        | pli.WhenThen
-        | pli.WhenThenThen
-    ],
+        | Iterable[
+            str
+            | Expr
+            | pli.Series
+            | timedelta
+            | date
+            | datetime
+            | int
+            | float
+            | pli.WhenThen
+            | pli.WhenThenThen
+        ]
+    ),
 ) -> list[PyExpr]:
     if isinstance(exprs, (str, Expr, pli.Series)):
         exprs = [exprs]

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -831,11 +831,13 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def sort(
         self: LDF,
-        by: str
-        | pli.Expr
-        | Sequence[str]
-        | Sequence[pli.Expr]
-        | Sequence[str | pli.Expr],
+        by: (
+            str
+            | pli.Expr
+            | Sequence[str]
+            | Sequence[pli.Expr]
+            | Sequence[str | pli.Expr]
+        ),
         reverse: bool | Sequence[bool] = False,
         nulls_last: bool = False,
     ) -> LDF:
@@ -1504,10 +1506,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def select(
         self: LDF,
-        exprs: str
-        | pli.Expr
-        | pli.Series
-        | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen],
+        exprs: (
+            str
+            | pli.Expr
+            | pli.Series
+            | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen]
+        ),
     ) -> LDF:
         """
         Select columns from this DataFrame.

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -761,13 +761,9 @@ class Series:
 
     def __getitem__(
         self,
-        item: int
-        | Series
-        | range
-        | slice
-        | np.ndarray[Any, Any]
-        | list[int]
-        | list[bool],
+        item: (
+            int | Series | range | slice | np.ndarray[Any, Any] | list[int] | list[bool]
+        ),
     ) -> Any:
 
         if isinstance(item, Series) and item.dtype in {
@@ -2928,20 +2924,22 @@ class Series:
     def set_at_idx(
         self,
         idx: Series | np.ndarray[Any, Any] | Sequence[int] | int,
-        value: int
-        | float
-        | str
-        | bool
-        | Sequence[int]
-        | Sequence[float]
-        | Sequence[bool]
-        | Sequence[str]
-        | Sequence[date]
-        | Sequence[datetime]
-        | date
-        | datetime
-        | Series
-        | None,
+        value: (
+            int
+            | float
+            | str
+            | bool
+            | Sequence[int]
+            | Sequence[float]
+            | Sequence[bool]
+            | Sequence[str]
+            | Sequence[date]
+            | Sequence[datetime]
+            | date
+            | datetime
+            | Series
+            | None
+        ),
     ) -> Series:
         """
         Set values at the index locations.


### PR DESCRIPTION
Closes #6090.

Will have a look to see if there's a lint for this; my _regex-fu_ found the following cases, but I'm not completely convinced there might not be one or two more (and a lint would stop us from adding new ones in the future).