### PR TITLE
chore(python): enable `unused import` autofix via ruff

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -124,7 +124,7 @@ select = [
 ignore = []
 
 fix = true
-fixable = ["I001"]
+fixable = ["F401", "I001"]
 
 extend-select = ["D"]
 extend-ignore = [


### PR DESCRIPTION
Adds a new allowed autofix - removal of unused imports. Had this come up a few times locally while experimenting and it worked like a charm.