### PR TITLE
refactor(rust): add single threaded sort internally

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -484,11 +484,22 @@ pub trait ChunkUnique<T: PolarsDataType> {
     }
 }
 
-#[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortOptions {
     pub descending: bool,
     pub nulls_last: bool,
+    pub multithreaded: bool,
+}
+
+impl Default for SortOptions {
+    fn default() -> Self {
+        Self {
+            descending: false,
+            nulls_last: false,
+            multithreaded: true,
+        }
+    }
 }
 
 /// Sort operations on `ChunkedArray`.

--- a/polars/polars-core/src/chunked_array/ops/sort/argsort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/argsort.rs
@@ -56,7 +56,13 @@ where
         vals.extend(iter);
     }
 
-    argsort_branch(vals.as_mut_slice(), reverse, default_order, reverse_order);
+    argsort_branch(
+        vals.as_mut_slice(),
+        reverse,
+        default_order,
+        reverse_order,
+        options.multithreaded,
+    );
 
     let iter = vals.into_iter().map(|(idx, _v)| idx);
     let idx = if reverse || nulls_last {

--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -62,6 +62,7 @@ impl CategoricalChunked {
                         options.descending,
                         |(_, a), (_, b)| order_default_null(a, b),
                         |(_, a), (_, b)| order_reverse_null(a, b),
+                        options.multithreaded,
                     );
                     let cats: NoNull<UInt32Chunked> =
                         vals.into_iter().map(|(idx, _v)| idx).collect_trusted();
@@ -97,6 +98,7 @@ impl CategoricalChunked {
         self.sort_with(SortOptions {
             nulls_last: false,
             descending: reverse,
+            multithreaded: true,
         })
     }
 

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -822,6 +822,7 @@ mod test {
         let out = a.sort_with(SortOptions {
             descending: false,
             nulls_last: false,
+            multithreaded: true,
         });
         assert_eq!(
             Vec::from(&out),
@@ -839,6 +840,7 @@ mod test {
         let out = a.sort_with(SortOptions {
             descending: false,
             nulls_last: true,
+            multithreaded: true,
         });
         assert_eq!(
             Vec::from(&out),
@@ -919,6 +921,7 @@ mod test {
         let out = ca.sort_with(SortOptions {
             descending: false,
             nulls_last: false,
+            multithreaded: true,
         });
         let expected = &[None, None, Some("a"), Some("b"), Some("c")];
         assert_eq!(Vec::from(&out), expected);
@@ -926,6 +929,7 @@ mod test {
         let out = ca.sort_with(SortOptions {
             descending: true,
             nulls_last: false,
+            multithreaded: true,
         });
 
         let expected = &[None, None, Some("c"), Some("b"), Some("a")];
@@ -934,6 +938,7 @@ mod test {
         let out = ca.sort_with(SortOptions {
             descending: false,
             nulls_last: true,
+            multithreaded: true,
         });
         let expected = &[Some("a"), Some("b"), Some("c"), None, None];
         assert_eq!(Vec::from(&out), expected);
@@ -941,6 +946,7 @@ mod test {
         let out = ca.sort_with(SortOptions {
             descending: true,
             nulls_last: true,
+            multithreaded: true,
         });
         let expected = &[Some("c"), Some("b"), Some("a"), None, None];
         assert_eq!(Vec::from(&out), expected);

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -209,6 +209,7 @@ pub fn _sort_or_hash_inner(
             let sort_idx = s_right.argsort(SortOptions {
                 descending: false,
                 nulls_last: false,
+                multithreaded: true,
             });
             let s_right = unsafe { s_right.take_unchecked(&sort_idx).unwrap() };
             let ids = par_sorted_merge_inner(s_left, &s_right);
@@ -232,6 +233,7 @@ pub fn _sort_or_hash_inner(
             let sort_idx = s_left.argsort(SortOptions {
                 descending: false,
                 nulls_last: false,
+                multithreaded: true,
             });
             let s_left = unsafe { s_left.take_unchecked(&sort_idx).unwrap() };
             let ids = par_sorted_merge_inner(&s_left, s_right);
@@ -280,6 +282,7 @@ pub(super) fn sort_or_hash_left(s_left: &Series, s_right: &Series, verbose: bool
             let sort_idx = s_right.argsort(SortOptions {
                 descending: false,
                 nulls_last: false,
+                multithreaded: true,
             });
             let s_right = unsafe { s_right.take_unchecked(&sort_idx).unwrap() };
 

--- a/polars/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/sort.rs
@@ -36,6 +36,7 @@ impl SortExec {
             std::mem::take(&mut self.args.reverse),
             self.args.nulls_last,
             self.args.slice,
+            true,
         )
     }
 }

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -442,6 +442,7 @@ fn take_aggregations() -> PolarsResult<()> {
                         .arg_sort(SortOptions {
                             descending: true,
                             nulls_last: false,
+                            multithreaded: true,
                         })
                         .head(Some(2)),
                 )
@@ -479,6 +480,7 @@ fn test_take_consistency() -> PolarsResult<()> {
             .arg_sort(SortOptions {
                 descending: true,
                 nulls_last: false,
+                multithreaded: true,
             })
             .take(lit(0))])
         .collect()?;
@@ -495,6 +497,7 @@ fn test_take_consistency() -> PolarsResult<()> {
             .arg_sort(SortOptions {
                 descending: true,
                 nulls_last: false,
+                multithreaded: true,
             })
             .take(lit(0))])
         .collect()?;
@@ -513,6 +516,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                 .arg_sort(SortOptions {
                     descending: true,
                     nulls_last: false,
+                    multithreaded: true,
                 })
                 .take(lit(0))
                 .alias("1"),
@@ -522,6 +526,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                         .arg_sort(SortOptions {
                             descending: true,
                             nulls_last: false,
+                            multithreaded: true,
                         })
                         .take(lit(0)),
                 )

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -890,6 +890,7 @@ fn test_lazy_groupby_filter() -> PolarsResult<()> {
             SortOptions {
                 descending: false,
                 nulls_last: false,
+                multithreaded: true,
             },
         )
         .collect()?;
@@ -1755,6 +1756,7 @@ fn test_single_group_result() -> PolarsResult<()> {
             .arg_sort(SortOptions {
                 descending: false,
                 nulls_last: false,
+                multithreaded: true,
             })
             .list()
             .over([col("a")])

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -986,6 +986,7 @@ impl PyDataFrame {
                 SortOptions {
                     descending: reverse,
                     nulls_last,
+                    multithreaded: true,
                 },
             )
             .map_err(PyPolarsErr::from)?;

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -379,6 +379,7 @@ impl PyLazyFrame {
             SortOptions {
                 descending: reverse,
                 nulls_last,
+                multithreaded: true,
             },
         )
         .into()

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -231,6 +231,7 @@ impl PyExpr {
             .sort_with(SortOptions {
                 descending,
                 nulls_last,
+                multithreaded: true,
             })
             .into()
     }
@@ -241,6 +242,7 @@ impl PyExpr {
             .arg_sort(SortOptions {
                 descending: reverse,
                 nulls_last,
+                multithreaded: true,
             })
             .into()
     }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1136,6 +1136,7 @@ impl PySeries {
         let options = SortOptions {
             descending: reverse,
             nulls_last: reverse,
+            multithreaded: true,
         };
         self.series.is_sorted(options)
     }


### PR DESCRIPTION
This adds an internal API (external in rust) to ensure the sort runs single threaded. This is needed for ooc sort later one, where every thread will do sorting work and we don't want contention.