### PR TITLE
chore(python): Assert deprecation warning on check_column_names

### DIFF
--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -194,7 +194,8 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     assert_frame_equal(df1, df2, check_column_order=False)
 
     # deprecated param name
-    assert_frame_equal(df1, df2, check_column_names=False)  # type: ignore[call-arg]
+    with pytest.deprecated_call():
+        assert_frame_equal(df1, df2, check_column_names=False)  # type: ignore[call-arg]
 
 
 def test_assert_frame_equal_ignore_row_order() -> None:


### PR DESCRIPTION
Tests that the warning is raised + silences it in the pytest output. See #6096 for the deprecation change.