### PR TITLE
feat(python): huge speedup of scalar-to-array expansion on frame init from dict

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def from_dict(
-    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]]],
+    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
     columns: Sequence[str] | None = None,
 ) -> DataFrame:
     """

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -83,7 +83,7 @@ PythonDataType: TypeAlias = Union[
 ColumnsType: TypeAlias = Union[
     Sequence[str],
     Mapping[str, Union[PolarsDataType, PythonDataType]],
-    Sequence[Tuple[str, Union[PolarsDataType, PythonDataType, None]]],
+    Sequence[Union[str, Tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
 ]
 Schema: TypeAlias = Mapping[str, PolarsDataType]
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -257,7 +257,7 @@ class DataFrame:
     def __init__(
         self,
         data: (
-            dict[str, Sequence[Any]]
+            Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series]
             | Sequence[Any]
             | np.ndarray[Any, Any]
             | pa.Table
@@ -274,13 +274,13 @@ class DataFrame:
         elif isinstance(data, dict):
             self._df = dict_to_pydf(data, columns=columns)
 
-        elif isinstance(data, pli.Series):
-            self._df = series_to_pydf(data, columns=columns)
-
         elif isinstance(data, (list, tuple, Sequence)):
             self._df = sequence_to_pydf(
                 data, columns=columns, orient=orient, infer_schema_length=50
             )
+        elif isinstance(data, pli.Series):
+            self._df = series_to_pydf(data, columns=columns)
+
         elif _check_for_numpy(data) and isinstance(data, np.ndarray):
             self._df = numpy_to_pydf(data, columns=columns, orient=orient)
 
@@ -317,7 +317,9 @@ class DataFrame:
     @classmethod
     def _from_dict(
         cls: type[DF],
-        data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]]],
+        data: Mapping[
+            str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series
+        ],
         columns: Sequence[str] | None = None,
     ) -> DF:
         """

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -79,7 +79,7 @@ def test_init_dict() -> None:
 
     df = pl.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6]},
-        columns=["c", ("d", pl.Int8)],  # type: ignore[arg-type]
+        columns=["c", ("d", pl.Int8)],
     )  # partial type info (allowed, but mypy doesn't like it ;p)
     assert df.schema == {"c": pl.Int64, "d": pl.Int8}
 
@@ -120,7 +120,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
 
     df = pl.DataFrame(
         data=[[1, 2.0, "a"], [None, None, None]],
-        columns=[("x", pl.Boolean), ("y", pl.Int32), "z"],  # type: ignore[arg-type]
+        columns=[("x", pl.Boolean), ("y", pl.Int32), "z"],
         orient="row",
     )
     assert df.rows() == [(True, 2, "a"), (None, None, None)]
@@ -416,10 +416,10 @@ def test_init_only_columns() -> None:
     for no_data in (None, {}, []):
         df = pl.DataFrame(
             data=no_data,
-            columns=[  # type: ignore[arg-type]
+            columns=[
                 ("a", pl.Date),
                 ("b", pl.UInt64),
-                ("c", pl.datatypes.Int8),
+                ("c", pl.Int8),
                 ("d", pl.List(pl.UInt8)),
             ],
         )

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -64,7 +64,7 @@ def test_fill_null_temporal() -> None:
             [dtm, dtm_ms, dtm, dtm, dt, tm, td, td, td, td],
             [None] * 10,
         ],
-        columns=[  # type: ignore[arg-type]
+        columns=[
             ("a", pl.Datetime),
             ("b", pl.Datetime("ms")),
             ("c", pl.Datetime("us")),


### PR DESCRIPTION
Spotted the existence of `Series.extend_constant` and reworked PR #6034 to use it; dramatically faster.

**Example**:
```python
df = pl.DataFrame({
    "a": range(50_000_000),
    "b": 1234567890,
    "c": "tuvwxyz",
    "d": None,
})

# shape: (50000000, 4)
# ┌──────────┬────────────┬─────────┬──────┐
# │ a        ┆ b          ┆ c       ┆ d    │
# │ ---      ┆ ---        ┆ ---     ┆ ---  │
# │ i64      ┆ i64        ┆ str     ┆ f64  │
# ╞══════════╪════════════╪═════════╪══════╡
# │ 0        ┆ 1234567890 ┆ tuvwxyz ┆ null │
# │ 1        ┆ 1234567890 ┆ tuvwxyz ┆ null │
# │ 2        ┆ 1234567890 ┆ tuvwxyz ┆ null │
# │ 3        ┆ 1234567890 ┆ tuvwxyz ┆ null │
#  ...
```
**Timings**:
```python
# Before: 7.1974 secs
# After:  0.8025 secs
```
**Also**:

* Fixed scalar expansion in conjunction with `columns` override.
* Fixed error when trying to expand scalars in the presence of `struct` columns.
* Some minor typing improvements, allowing removal of some `# type: ignore` directives.
* Additional test coverage for all of the above.