### PR TITLE
chore(python): Fix docstring with_context

### DIFF
--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2518,7 +2518,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ null │
         └──────┘
 
-        Fill nulls with the median from another dataframe
+        Fill nulls with the median from another dataframe:
+
         >>> train_df = pl.DataFrame(
         ...     {"feature_0": [-1.0, 0, 1], "feature_1": [-1.0, 0, 1]}
         ... ).lazy()


### PR DESCRIPTION
Currently shows as this (https://pola-rs.github.io/polars/py-polars/html/reference/lazyframe/api/polars.LazyFrame.with_context.html#polars.LazyFrame.with_context)

![image](https://user-images.githubusercontent.com/11277667/211194424-24c89a28-afdd-4c82-ad2e-792deec52aca.png)


After:
![image](https://user-images.githubusercontent.com/11277667/211194441-99901704-37d9-4f71-974f-55316b9ab3c7.png)
