### PR TITLE
feat(python): add `dt.combine` for combining date and time components 

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -222,4 +222,12 @@ impl DateLikeNameSpace {
                 tz,
             )))
     }
+
+    pub fn combine(self, time: Expr, tu: TimeUnit) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::TemporalExpr(TemporalFunction::Combine(tu)),
+            &[time],
+            false,
+        )
+    }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
@@ -34,6 +34,7 @@ pub enum TemporalFunction {
         closed: ClosedWindow,
         tz: Option<TimeZone>,
     },
+    Combine(TimeUnit),
 }
 
 impl Display for TemporalFunction {
@@ -62,6 +63,7 @@ impl Display for TemporalFunction {
             #[cfg(feature = "timezones")]
             TzLocalize(_) => "tz_localize",
             DateRange { .. } => return write!(f, "date_range"),
+            Combine(_) => "combine",
         };
         write!(f, "dt.{s}")
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -459,6 +459,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             CastTimezone(tz) => map!(datetime::cast_timezone, &tz),
             #[cfg(feature = "timezones")]
             TzLocalize(tz) => map!(datetime::tz_localize, &tz),
+            Combine(tu) => map_as_slice!(temporal::combine, tu),
             DateRange {
                 name,
                 every,

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -159,6 +159,7 @@ impl FunctionExpr {
                     #[cfg(feature = "timezones")]
                     CastTimezone(tz) | TzLocalize(tz) => return cast_tz(tz),
                     DateRange { .. } => return super_type(),
+                    Combine(tu) => DataType::Datetime(*tu, None),
                 };
                 with_dtype(dtype)
             }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "date_offset")]
 use polars_time::prelude::*;
 
-#[cfg(feature = "date_offset")]
 use super::*;
 
 #[cfg(feature = "date_offset")]
@@ -32,4 +31,15 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
             format!("cannot use 'date_offset' on Series of dtype: {dt:?}").into(),
         )),
     }
+}
+
+pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
+    let date = &s[0];
+    let time = &s[1];
+
+    let date = date.cast(&DataType::Date)?;
+    let datetime = date.cast(&DataType::Datetime(tu, None)).unwrap();
+
+    let duration = time.cast(&DataType::Duration(tu))?;
+    Ok(datetime + duration)
 }

--- a/py-polars/docs/source/reference/expressions/timeseries.rst
+++ b/py-polars/docs/source/reference/expressions/timeseries.rst
@@ -11,6 +11,7 @@ The following methods are available under the `expr.dt` attribute.
 
     Expr.dt.cast_time_unit
     Expr.dt.cast_time_zone
+    Expr.dt.combine
     Expr.dt.day
     Expr.dt.days
     Expr.dt.epoch

--- a/py-polars/docs/source/reference/series/timeseries.rst
+++ b/py-polars/docs/source/reference/series/timeseries.rst
@@ -11,6 +11,7 @@ The following methods are available under the `Series.dt` attribute.
 
     Series.dt.cast_time_unit
     Series.dt.cast_time_zone
+    Series.dt.combine
     Series.dt.day
     Series.dt.days
     Series.dt.epoch

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -143,7 +143,7 @@ class ExprDateTimeNameSpace:
 
         Each date/datetime in the first half of the interval
         is mapped to the start of its bucket.
-        Each date/datetime in the seconod half of the interval
+        Each date/datetime in the second half of the interval
         is mapped to the end of its bucket.
 
         Parameters
@@ -267,6 +267,7 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
+        >>> from datetime import datetime, date, time
         >>> df = pl.DataFrame(
         ...     {
         ...         "dtm": [
@@ -274,7 +275,7 @@ class ExprDateTimeNameSpace:
         ...             datetime(2023, 7, 5, 23, 59, 59),
         ...         ],
         ...         "dt": [date(2022, 10, 10), date(2022, 7, 5)],
-        ...         "tm": [time(1, 2, 3, 456), time(7, 8, 9, 101)],
+        ...         "tm": [time(1, 2, 3, 456000), time(7, 8, 9, 101000)],
         ...     }
         ... )
         >>> df

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -4,7 +4,7 @@ from datetime import time, timedelta
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Duration, Int32
+from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils import _timedelta_to_pl_duration
 
 if TYPE_CHECKING:
@@ -253,7 +253,7 @@ class ExprDateTimeNameSpace:
             )
         )
 
-    def combine(self, tm: time | pli.Expr) -> pli.Expr:
+    def combine(self, tm: time | pli.Expr, tu: TimeUnit = "us") -> pli.Expr:
         """
         Create a naive Datetime from an existing Date/Datetime expression and a Time.
 
@@ -264,6 +264,8 @@ class ExprDateTimeNameSpace:
         ----------
         tm
             A python time literal or polars expression/column that resolves to a time.
+        tu : {'ns', 'us', 'ms'}
+            Time unit.
 
         Examples
         --------
@@ -309,10 +311,8 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"Expected 'tm' to be a python time or polars expression, found {tm!r}"
             )
-        duration = pli.expr_to_lit_or_expr(tm).cast(Duration)
-        return pli.wrap_expr(
-            self._pyexpr.cast(Date, True).cast(Datetime, True) + duration._pyexpr
-        )
+        tm = pli.expr_to_lit_or_expr(tm)
+        return pli.wrap_expr(self._pyexpr.dt_combine(tm._pyexpr, tu))
 
     def strftime(self, fmt: str) -> pli.Expr:
         """
@@ -905,7 +905,7 @@ class ExprDateTimeNameSpace:
 
         Parameters
         ----------
-        tu : {'us', 'ns', 'ms', 's', 'd'}
+        tu : {'ns', 'us', 'ms', 's', 'd'}
             Time unit.
 
         Examples
@@ -950,7 +950,7 @@ class ExprDateTimeNameSpace:
 
         Parameters
         ----------
-        tu : {'us', 'ns', 'ms'}
+        tu : {'ns', 'us', 'ms'}
             Time unit.
 
         Examples

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
@@ -1534,6 +1534,37 @@ class DateTimeNameSpace:
                 2001-01-01 00:30:00
                 2001-01-01 01:00:00
                 2001-01-01 01:00:00
+        ]
+
+        """
+
+    def combine(self, tm: time | pli.Series, tu: TimeUnit = "us") -> pli.Expr:
+        """
+        Create a naive Datetime from an existing Date/Datetime expression and a Time.
+
+        If the underlying expression is a Datetime then its time component is replaced,
+        and if it is a Date then a new Datetime is created by combining the two values.
+
+        Parameters
+        ----------
+        tm
+            A python time literal or Series of the same length as this Series.
+        tu : {'ns', 'us', 'ms'}
+            Time unit.
+
+        Examples
+        --------
+        >>> from datetime import datetime, time
+        >>> s = pl.Series(
+        ...     "dtm",
+        ...     [datetime(2022, 12, 31, 10, 30, 45), datetime(2023, 7, 5, 23, 59, 59)],
+        ... )
+        >>> s.dt.combine(time(1, 2, 3, 456000))
+        shape: (2,)
+        Series: 'dtm' [datetime[μs]]
+        [
+            2022-12-31 01:02:03.456
+            2023-07-05 01:02:03.456
         ]
 
         """

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1448,7 +1448,7 @@ class DateTimeNameSpace:
 
         Each date/datetime in the first half of the interval
         is mapped to the start of its bucket.
-        Each date/datetime in the seconod half of the interval
+        Each date/datetime in the second half of the interval
         is mapped to the end of its bucket.
 
         The `every` and `offset` argument are created with the

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1029,6 +1029,10 @@ impl PyExpr {
         self.inner.clone().dt().round(every, offset).into()
     }
 
+    pub fn dt_combine(&self, time: PyExpr, tu: Wrap<TimeUnit>) -> PyExpr {
+        self.inner.clone().dt().combine(time.inner, tu.0).into()
+    }
+
     pub fn rolling_apply(
         &self,
         py: Python,


### PR DESCRIPTION
**Background**:

Saw two references to this not being straightforward recently, once in the shiny new [Modern Polars](https://kevinheavey.github.io/modern-polars/method_chaining.html#extract-city-names) guide...

> _"It turns out that combining pl.Date and pl.Time isn’t that straightforward: we have to convert them both to microseconds, add them and then cast as pl.Datetime."_

...and again in the [Discord](https://discord.com/channels/908022250106667068/911186243465904178/1058919494619246622):

> _"and how can I combine both date and time column so that I can group by datetime? I found the pl.datetime function but it takes y/m/d/h/m/s as individual args"_

**Naming**:

Follows the equivalent method associated with python datetimes:
```python
>>> from datetime import datetime, date, time
>>> datetime.combine( date(2020,12,31), time(10,30,45) )
datetime( 2020,12,31,10,30,45 )
```

**Example**:

If the underlying expression is a `Datetime` then its `Time` component is _replaced_, and if it is a `Date` then a new `Datetime` is created by _combining_ the two components as-is. 

```python
from datetime import datetime, date, time
import polars as pl

df = pl.DataFrame({
    "dtm": [
        datetime(2022,12,31,10,30,45),
        datetime(2023,7,5,23,59,59),
    ],
    "dt": [
        date(2022,10,10),
        date(2022,7,5),
    ],
    "tm": [
         time(1,2,3,456000),
         time(7,8,9,101000),
     ],
})
# shape: (2, 3)
# ┌─────────────────────┬────────────┬──────────────┐
# │ dtm                 ┆ dt         ┆ tm           │
# │ ---                 ┆ ---        ┆ ---          │
# │ datetime[μs]        ┆ date       ┆ time         │
# ╞═════════════════════╪════════════╪══════════════╡
# │ 2022-12-31 10:30:45 ┆ 2022-10-10 ┆ 01:02:03.456 │
# │ 2023-07-05 23:59:59 ┆ 2022-07-05 ┆ 07:08:09.101 │
# └─────────────────────┴────────────┴──────────────┘
df.select(
    [
        pl.col("dtm").dt.combine( pl.col("tm") ).alias("d1"),
        pl.col("dt").dt.combine( pl.col("tm") ).alias("d2"),
        pl.col("dt").dt.combine( time(4,5,6) ).alias("d3"),
    ]
)
# shape: (2, 3)
# ┌─────────────────────────┬─────────────────────────┬─────────────────────┐
# │ d1                      ┆ d2                      ┆ d3                  │
# │ ---                     ┆ ---                     ┆ ---                 │
# │ datetime[μs]            ┆ datetime[μs]            ┆ datetime[μs]        │
# ╞═════════════════════════╪═════════════════════════╪═════════════════════╡
# │ 2022-12-31 01:02:03.456 ┆ 2022-10-10 01:02:03.456 ┆ 2022-10-10 04:05:06 │
# │ 2023-07-05 07:08:09.101 ┆ 2022-07-05 07:08:09.101 ┆ 2022-07-05 04:05:06 │
# └─────────────────────────┴─────────────────────────┴─────────────────────┘

```

**Next**:

This is only exposed via Python at the moment, but I'd definitely like to move it down into Rust; I had a quick look at doing so, but there was rather more indirection than I recall, so I thought I'd get it working here first and _then_ move it down. 

@ritchie46 - if you can suggest looking at an existing function that's at least vaguely similar in approach to this one, I'm sure I can work it out...🤣