### PR TITLE
fix(python): Update docstring `with_columns` to reflect a new dataframe is being returned

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5456,7 +5456,7 @@ class DataFrame:
         **named_exprs: pli.Expr | pli.Series,
     ) -> DataFrame:
         """
-        Add or overwrite multiple columns in a DataFrame.
+        Return a new DataFrame with the columns added, if new, or replaced.
 
         Parameters
         ----------
@@ -5493,9 +5493,9 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
 
-        >>> # Support for kwarg expressions is considered EXPERIMENTAL.
-        >>> # Currently requires opt-in via `pl.Config` boolean flag:
-        >>>
+        Support for kwarg expressions is considered EXPERIMENTAL. Currently
+        requires opt-in via `pl.Config` boolean flag:
+
         >>> pl.Config.with_columns_kwargs = True
         >>> df.with_columns(
         ...     d=pl.col("a") * pl.col("b"),

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4164,7 +4164,12 @@ class DataFrame:
 
     def with_column(self, column: pli.Series | pli.Expr) -> DataFrame:
         """
-        Return a new DataFrame with the column added or replaced.
+        Return a new DataFrame with the column added, if new, or replaced.
+
+        Notes
+        -----
+        Creating a new DataFrame using this method does not create a new copy of
+        existing underlying data.
 
         Parameters
         ----------
@@ -5457,6 +5462,11 @@ class DataFrame:
     ) -> DataFrame:
         """
         Return a new DataFrame with the columns added, if new, or replaced.
+
+        Notes
+        -----
+        Creating a new DataFrame using this method does not create a new copy of
+        existing underlying data.
 
         Parameters
         ----------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2398,7 +2398,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         **named_exprs: pli.Expr | pli.Series | str,
     ) -> LDF:
         """
-        Add or overwrite multiple columns in a DataFrame.
+        Return a new LazyFrame with the columns added, if new, or replaced.
 
         Parameters
         ----------
@@ -2435,9 +2435,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
 
-        >>> # Support for kwarg expressions is considered EXPERIMENTAL.
-        >>> # Currently requires opt-in via `pl.Config` boolean flag:
-        >>>
+        Support for kwarg expressions is considered EXPERIMENTAL. Currently
+        requires opt-in via `pl.Config` boolean flag:
+
         >>> pl.Config.with_columns_kwargs = True
         >>> ldf.with_columns(
         ...     d=pl.col("a") * pl.col("b"),

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2400,6 +2400,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         Return a new LazyFrame with the columns added, if new, or replaced.
 
+        Notes
+        -----
+        Creating a new LazyFrame using this method does not create a new copy of
+        existing underlying data.
+
         Parameters
         ----------
         exprs
@@ -2550,7 +2555,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def with_column(self: LDF, column: pli.Series | pli.Expr) -> LDF:
         """
-        Add or overwrite column in a DataFrame.
+        Return a new LazyFrame with the column added, if new, or replaced.
+
+        Notes
+        -----
+        Creating a new LazyFrame using this method does not create a new copy of
+        existing underlying data.
 
         Parameters
         ----------


### PR DESCRIPTION
In line with the docstring of `with_column` (singular).

I have also converted the comments about the experimental flag into normal text, that is much nicer in the docs.