### PR TITLE
chore(python): Improve drop_nulls docstrings

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3045,12 +3045,12 @@ class DataFrame:
 
     def drop_nulls(self: DF, subset: str | Sequence[str] | None = None) -> DF:
         """
-        Return a new DataFrame where the null values are dropped.
+        Return a new DataFrame where rows with null values are dropped.
 
         Parameters
         ----------
         subset
-            Subset of column(s) on which ``drop_nulls`` will be applied.
+            Subset of column(s) for which null values are considered.
 
         Examples
         --------
@@ -3072,7 +3072,7 @@ class DataFrame:
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        This method only drops nulls row-wise if any single value of the row is null.
+        This method drops rows where any single value of the row is null.
 
         Below are some example snippets that show how you could drop null values based
         on other conditions
@@ -3099,13 +3099,7 @@ class DataFrame:
 
         Drop a row only if all values are null:
 
-        >>> df.filter(
-        ...     ~pl.fold(
-        ...         acc=True,
-        ...         f=lambda acc, s: acc & s.is_null(),
-        ...         exprs=pl.all(),
-        ...     )
-        ... )
+        >>> df.filter(~pl.all(pl.all().is_null()))
         shape: (3, 3)
         ┌──────┬─────┬──────┐
         │ a    ┆ b   ┆ c    │

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -3559,12 +3559,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def drop_nulls(self: LDF, subset: list[str] | str | None = None) -> LDF:
         """
-        Drop rows with null values from this LazyFrame.
+        Return a new LazyFrame where rows with null values are dropped.
 
         Parameters
         ----------
         subset
-            Subset of column(s) on which ``drop_nulls`` will be applied.
+            Subset of column(s) for which null values are considered.
 
         Examples
         --------
@@ -3586,7 +3586,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        This method only drops nulls row-wise if any single value of the row is null.
+        This method drops a row if any single value of the row is null.
 
         Below are some example snippets that show how you could drop null values based
         on other conditions:
@@ -3613,13 +3613,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Drop a row only if all values are null:
 
-        >>> df.filter(
-        ...     ~pl.fold(
-        ...         acc=True,
-        ...         f=lambda acc, s: acc & s.is_null(),
-        ...         exprs=pl.all(),
-        ...     )
-        ... )
+        >>> df.filter(~pl.all(pl.all().is_null()))
         shape: (3, 3)
         ┌──────┬─────┬──────┐
         │ a    ┆ b   ┆ c    │


### PR DESCRIPTION
* The summary line did not mention rows are dropped
* The ``subset`` parameter was described in a way that could be interpreted that other columns would be dropped. Instead, it is the set of columns to consider in the null masking
* One code example for dropping rows only with *all* columns null was very clever using ``pl.fold``, but I think my change here is a much easier solution