### PR TITLE
feat(python): Deprecate `with_column`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3347,7 +3347,7 @@ class DataFrame:
         Examples
         --------
         >>> def cast_str_to_int(data, col_name):
-        ...     return data.with_column(pl.col(col_name).cast(pl.Int64))
+        ...     return data.with_columns(pl.col(col_name).cast(pl.Int64))
         ...
         >>> df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["10", "20", "30", "40"]})
         >>> df.pipe(cast_str_to_int, col_name="b")
@@ -3570,7 +3570,7 @@ class DataFrame:
         ...     "2020-01-03 19:45:32",
         ...     "2020-01-08 23:16:43",
         ... ]
-        >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_column(
+        >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
         ...     pl.col("dt").str.strptime(pl.Datetime)
         ... )
         >>> out = df.groupby_rolling(index_column="dt", period="2d").agg(
@@ -4353,44 +4353,23 @@ class DataFrame:
         Creating a new DataFrame using this method does not create a new copy of
         existing data.
 
+        .. deprecated:: 0.15.14
+            `with_column` will be removed in favor of the more generic `with_columns`
+            in version 0.17.0.
+
         Parameters
         ----------
         column
             Series, where the name of the Series refers to the column in the DataFrame.
 
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [1, 3, 5],
-        ...         "b": [2, 4, 6],
-        ...     }
-        ... )
-        >>> df.with_column((pl.col("b") ** 2).alias("b_squared"))  # added
-        shape: (3, 3)
-        ┌─────┬─────┬───────────┐
-        │ a   ┆ b   ┆ b_squared │
-        │ --- ┆ --- ┆ ---       │
-        │ i64 ┆ i64 ┆ f64       │
-        ╞═════╪═════╪═══════════╡
-        │ 1   ┆ 2   ┆ 4.0       │
-        │ 3   ┆ 4   ┆ 16.0      │
-        │ 5   ┆ 6   ┆ 36.0      │
-        └─────┴─────┴───────────┘
-        >>> df.with_column(pl.col("a") ** 2)  # replaced
-        shape: (3, 2)
-        ┌──────┬─────┐
-        │ a    ┆ b   │
-        │ ---  ┆ --- │
-        │ f64  ┆ i64 │
-        ╞══════╪═════╡
-        │ 1.0  ┆ 2   │
-        │ 9.0  ┆ 4   │
-        │ 25.0 ┆ 6   │
-        └──────┴─────┘
-
         """
-        return self.lazy().with_column(column).collect(no_optimization=True)
+        warnings.warn(
+            "`with_column` has been deprecated in favor of `with_columns`."
+            " This method will be removed in version 0.17.0",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.lazy().with_columns(column).collect(no_optimization=True)
 
     def hstack(
         self: DF,
@@ -5211,7 +5190,7 @@ class DataFrame:
 
         if how == "horizontal":
             df = (
-                df.with_column(  # type: ignore[assignment]
+                df.with_columns(  # type: ignore[assignment]
                     (pli.arange(0, n_cols * n_rows, eager=True) % n_cols).alias(
                         "__sort_order"
                     ),
@@ -5666,6 +5645,40 @@ class DataFrame:
         ...         "c": [True, True, False, True],
         ...     }
         ... )
+
+        Passing in a single expression, adding the column as we give it a new name:
+
+        >>> df.with_columns((pl.col("a") ** 2).alias("a^2"))
+        shape: (4, 4)
+        ┌─────┬──────┬───────┬──────┐
+        │ a   ┆ b    ┆ c     ┆ a^2  │
+        │ --- ┆ ---  ┆ ---   ┆ ---  │
+        │ i64 ┆ f64  ┆ bool  ┆ f64  │
+        ╞═════╪══════╪═══════╪══════╡
+        │ 1   ┆ 0.5  ┆ true  ┆ 1.0  │
+        │ 2   ┆ 4.0  ┆ true  ┆ 4.0  │
+        │ 3   ┆ 10.0 ┆ false ┆ 9.0  │
+        │ 4   ┆ 13.0 ┆ true  ┆ 16.0 │
+        └─────┴──────┴───────┴──────┘
+
+        We can also override a column, by giving the expression a name that already
+        exists:
+
+        >>> df.with_columns((pl.col("a") ** 2).alias("c"))
+        shape: (4, 3)
+        ┌─────┬──────┬──────┐
+        │ a   ┆ b    ┆ c    │
+        │ --- ┆ ---  ┆ ---  │
+        │ i64 ┆ f64  ┆ f64  │
+        ╞═════╪══════╪══════╡
+        │ 1   ┆ 0.5  ┆ 1.0  │
+        │ 2   ┆ 4.0  ┆ 4.0  │
+        │ 3   ┆ 10.0 ┆ 9.0  │
+        │ 4   ┆ 13.0 ┆ 16.0 │
+        └─────┴──────┴──────┘
+
+        Passing in multiple expressions as a list:
+
         >>> df.with_columns(
         ...     [
         ...         (pl.col("a") ** 2).alias("a^2"),
@@ -5706,8 +5719,6 @@ class DataFrame:
         └─────┴──────┴───────┴──────┴───────┘
 
         """
-        if exprs is not None and not isinstance(exprs, Sequence):
-            exprs = [exprs]
         return (
             self.lazy().with_columns(exprs, **named_exprs).collect(no_optimization=True)
         )

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -828,7 +828,7 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.all().is_null().suffix("_isnull"))  # nan != null
+        >>> df.with_columns(pl.all().is_null().suffix("_isnull"))  # nan != null
         shape: (5, 4)
         ┌──────┬─────┬──────────┬──────────┐
         │ a    ┆ b   ┆ a_isnull ┆ b_isnull │
@@ -857,7 +857,7 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.all().is_not_null().suffix("_not_null"))  # nan != null
+        >>> df.with_columns(pl.all().is_not_null().suffix("_not_null"))  # nan != null
         shape: (5, 4)
         ┌──────┬─────┬────────────┬────────────┐
         │ a    ┆ b   ┆ a_not_null ┆ b_not_null │
@@ -953,7 +953,7 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.col(pl.Float64).is_nan().suffix("_isnan"))
+        >>> df.with_columns(pl.col(pl.Float64).is_nan().suffix("_isnan"))
         shape: (5, 3)
         ┌──────┬─────┬─────────┐
         │ a    ┆ b   ┆ b_isnan │
@@ -987,7 +987,7 @@ class Expr:
         ...         "b": [1.0, 2.0, float("nan"), 1.0, 5.0],
         ...     }
         ... )
-        >>> df.with_column(pl.col(pl.Float64).is_not_nan().suffix("_is_not_nan"))
+        >>> df.with_columns(pl.col(pl.Float64).is_not_nan().suffix("_is_not_nan"))
         shape: (5, 3)
         ┌──────┬─────┬──────────────┐
         │ a    ┆ b   ┆ b_is_not_nan │
@@ -2693,7 +2693,7 @@ class Expr:
         ...     }
         ... )
         >>> (
-        ...     df.with_column(
+        ...     df.with_columns(
         ...         pl.col("values").max().over("groups").alias("max_by_group")
         ...     )
         ... )
@@ -2781,7 +2781,7 @@ class Expr:
         ...         "num": [1, 2, 3, 1, 5],
         ...     }
         ... )
-        >>> (df.with_column(pl.col("num").is_first().alias("is_first")))
+        >>> (df.with_columns(pl.col("num").is_first().alias("is_first")))
         shape: (5, 2)
         ┌─────┬──────────┐
         │ num ┆ is_first │
@@ -3076,7 +3076,7 @@ class Expr:
         In a selection context, the function is applied by row.
 
         >>> (
-        ...     df.with_column(
+        ...     df.with_columns(
         ...         pl.col("a").apply(lambda x: x * 2).alias("a_times_2"),
         ...     )
         ... )
@@ -3095,7 +3095,7 @@ class Expr:
         It is better to implement this with an expression:
 
         >>> (
-        ...     df.with_column(
+        ...     df.with_columns(
         ...         (pl.col("a") * 2).alias("a_times_2"),
         ...     )
         ... )  # doctest: +IGNORE_RESULT
@@ -3438,7 +3438,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"num": [1, 2, 3, 4, 5]})
-        >>> df.with_column(pl.col("num").is_between(2, 4))
+        >>> df.with_columns(pl.col("num").is_between(2, 4))
         shape: (5, 2)
         ┌─────┬────────────┐
         │ num ┆ is_between │
@@ -3454,7 +3454,7 @@ class Expr:
 
         Use the ``closed`` argument to include or exclude the values at the bounds.
 
-        >>> df.with_column(pl.col("num").is_between(2, 4, closed="left"))
+        >>> df.with_columns(pl.col("num").is_between(2, 4, closed="left"))
         shape: (5, 2)
         ┌─────┬────────────┐
         │ num ┆ is_between │
@@ -3545,7 +3545,7 @@ class Expr:
         ...         "b": ["x", None, "z"],
         ...     }
         ... )
-        >>> df.with_column(pl.all().hash(10, 20, 30, 40))  # doctest: +IGNORE_RESULT
+        >>> df.with_columns(pl.all().hash(10, 20, 30, 40))  # doctest: +IGNORE_RESULT
         shape: (3, 2)
         ┌──────────────────────┬──────────────────────┐
         │ a                    ┆ b                    │
@@ -3675,7 +3675,7 @@ class Expr:
         >>> (
         ...     df_new_grid.join(
         ...         df_original_grid, on="grid_points", how="left"
-        ...     ).with_column(pl.col("values").interpolate())
+        ...     ).with_columns(pl.col("values").interpolate())
         ... )
         shape: (10, 2)
         ┌─────────────┬────────┐
@@ -4740,7 +4740,7 @@ class Expr:
         ...         "a": [10, 11, 12, None, 12],
         ...     }
         ... )
-        >>> df.with_column(pl.col("a").pct_change().alias("pct_change"))
+        >>> df.with_columns(pl.col("a").pct_change().alias("pct_change"))
         shape: (5, 2)
         ┌──────┬────────────┐
         │ a    ┆ pct_change │
@@ -4866,7 +4866,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [-50, 5, None, 50]})
-        >>> df.with_column(pl.col("foo").clip(1, 10).alias("foo_clipped"))
+        >>> df.with_columns(pl.col("foo").clip(1, 10).alias("foo_clipped"))
         shape: (4, 2)
         ┌──────┬─────────────┐
         │ foo  ┆ foo_clipped │
@@ -4899,7 +4899,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [-50, 5, None, 50]})
-        >>> df.with_column(pl.col("foo").clip_min(0).alias("foo_clipped"))
+        >>> df.with_columns(pl.col("foo").clip_min(0).alias("foo_clipped"))
         shape: (4, 2)
         ┌──────┬─────────────┐
         │ foo  ┆ foo_clipped │
@@ -4932,7 +4932,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [-50, 5, None, 50]})
-        >>> df.with_column(pl.col("foo").clip_max(0).alias("foo_clipped"))
+        >>> df.with_columns(pl.col("foo").clip_max(0).alias("foo_clipped"))
         shape: (4, 2)
         ┌──────┬─────────────┐
         │ foo  ┆ foo_clipped │

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -699,7 +699,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
         ... )
         shape: (3, 3)

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -79,7 +79,7 @@ class ExprStringNameSpace:
         ...     ],
         ... )
         >>> (
-        ...     s.to_frame().with_column(
+        ...     s.to_frame().with_columns(
         ...         pl.col("date")
         ...         .str.strptime(pl.Date, "%F", strict=False)
         ...         .fill_null(
@@ -404,7 +404,7 @@ class ExprStringNameSpace:
         ...         "num": [-10, -1, 0, 1, 10, 100, 1000, 10000, 100000, 1000000, None],
         ...     }
         ... )
-        >>> df.with_column(pl.col("num").cast(str).str.zfill(5))
+        >>> df.with_columns(pl.col("num").cast(str).str.zfill(5))
         shape: (11, 1)
         ┌─────────┐
         │ num     │
@@ -546,7 +546,7 @@ class ExprStringNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"fruits": ["apple", "mango", None]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.col("fruits").str.ends_with("go").alias("has_suffix"),
         ... )
         shape: (3, 2)
@@ -593,7 +593,7 @@ class ExprStringNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"fruits": ["apple", "mango", None]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.col("fruits").str.starts_with("app").alias("has_prefix"),
         ... )
         shape: (3, 2)
@@ -1038,7 +1038,7 @@ class ExprStringNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"id": [1, 2], "text": ["123abc", "abc456"]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.col("text").str.replace(r"abc\b", "ABC")
         ... )  # doctest: +IGNORE_RESULT
         shape: (2, 2)
@@ -1080,7 +1080,7 @@ class ExprStringNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"id": [1, 2], "text": ["abcabc", "123a123"]})
-        >>> df.with_column(pl.col("text").str.replace_all("a", "-"))
+        >>> df.with_columns(pl.col("text").str.replace_all("a", "-"))
         shape: (2, 2)
         ┌─────┬─────────┐
         │ id  ┆ text    │
@@ -1119,7 +1119,7 @@ class ExprStringNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"s": ["pear", None, "papaya", "dragonfruit"]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.col("s").str.slice(-3).alias("s_sliced"),
         ... )
         shape: (4, 2)
@@ -1136,7 +1136,7 @@ class ExprStringNameSpace:
 
         Using the optional `length` parameter
 
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.col("s").str.slice(4, length=3).alias("s_sliced"),
         ... )
         shape: (4, 2)

--- a/py-polars/polars/internals/expr/struct.py
+++ b/py-polars/polars/internals/expr/struct.py
@@ -79,7 +79,7 @@ class ExprStructNameSpace:
         ...     .to_struct("my_struct")
         ...     .to_frame()
         ... )
-        >>> df = df.with_column(
+        >>> df = df.with_columns(
         ...     pl.col("my_struct").struct.rename_fields(["INT", "STR", "BOOL", "LIST"])
         ... )
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -551,9 +551,9 @@ def cut(
     if labels:
         if len(labels) != len(bins) + 1:
             raise ValueError("expected more labels")
-        cuts_df = cuts_df.with_column(pli.Series(name=category_label, values=labels))
+        cuts_df = cuts_df.with_columns(pli.Series(name=category_label, values=labels))
     else:
-        cuts_df = cuts_df.with_column(
+        cuts_df = cuts_df.with_columns(
             pli.format(
                 "({}, {}]",
                 pli.col(break_point_label).shift_and_fill(1, float("-inf")),
@@ -561,7 +561,7 @@ def cut(
             ).alias(category_label)
         )
 
-    cuts_df = cuts_df.with_column(pli.col(category_label).cast(Categorical))
+    cuts_df = cuts_df.with_columns(pli.col(category_label).cast(Categorical))
 
     result = (
         s.cast(Float64)

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -231,7 +231,7 @@ def element() -> pli.Expr:
     A horizontal rank computation by taking the elements of a list
 
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
-    >>> df.with_column(
+    >>> df.with_columns(
     ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
     ... )
     shape: (3, 3)
@@ -248,7 +248,7 @@ def element() -> pli.Expr:
     A mathematical operation on array elements
 
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
-    >>> df.with_column(
+    >>> df.with_columns(
     ...     pl.concat_list(["a", "b"]).arr.eval(pl.element() * 2).alias("a_b_doubled")
     ... )
     shape: (3, 3)
@@ -645,7 +645,7 @@ def sum(
 
     Sum a list of columns/expressions horizontally:
 
-    >>> df.with_column(pl.sum(["a", "c"]))
+    >>> df.with_columns(pl.sum(["a", "c"]))
     shape: (2, 4)
     ┌─────┬─────┬─────┬─────┐
     │ a   ┆ b   ┆ c   ┆ sum │
@@ -1247,7 +1247,7 @@ def cumsum(
 
     Cumulatively sum a list of columns/expressions horizontally:
 
-    >>> df.with_column(pl.cumsum(["a", "c"]))
+    >>> df.with_columns(pl.cumsum(["a", "c"]))
     shape: (2, 4)
     ┌─────┬─────┬─────┬───────────┐
     │ a   ┆ b   ┆ c   ┆ cumsum    │
@@ -2360,7 +2360,7 @@ def struct(
     >>> df = pl.DataFrame(
     ...     {"a": [1, 2, 3, 4], "b": ["one", "two", "three", "four"], "c": [9, 8, 7, 6]}
     ... )
-    >>> df.with_column(pl.struct(pl.col(["a", "b"])).alias("a_and_b"))
+    >>> df.with_columns(pl.struct(pl.col(["a", "b"])).alias("a_and_b"))
     shape: (4, 4)
     ┌─────┬───────┬─────┬─────────────┐
     │ a   ┆ b     ┆ c   ┆ a_and_b     │
@@ -2545,7 +2545,7 @@ def coalesce(
     ...     ],
     ...     schema=[("a", pl.Float64), ("b", pl.Float64), ("c", pl.Float64)],
     ... )
-    >>> df.with_column(pl.coalesce(["a", "b", "c", 99.9]).alias("d"))
+    >>> df.with_columns(pl.coalesce(["a", "b", "c", 99.9]).alias("d"))
     shape: (4, 4)
     ┌──────┬──────┬──────┬──────┐
     │ a    ┆ b    ┆ c    ┆ d    │

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -392,7 +392,7 @@ class ListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
-        >>> df.with_column(
+        >>> df.with_columns(
         ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
         ... )
         shape: (3, 3)

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -74,7 +74,7 @@ class StringNameSpace:
         ...     ],
         ... )
         >>> (
-        ...     s.to_frame().with_column(
+        ...     s.to_frame().with_columns(
         ...         pl.col("date")
         ...         .str.strptime(pl.Date, "%F", strict=False)
         ...         .fill_null(

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -144,7 +144,9 @@ def when(expr: pli.Expr | bool) -> When:
     where it isn't.
 
     >>> df = pl.DataFrame({"foo": [1, 3, 4], "bar": [3, 4, 0]})
-    >>> df.with_column(pl.when(pl.col("foo") > 2).then(pl.lit(1)).otherwise(pl.lit(-1)))
+    >>> df.with_columns(
+    ...     pl.when(pl.col("foo") > 2).then(pl.lit(1)).otherwise(pl.lit(-1))
+    ... )
     shape: (3, 3)
     ┌─────┬─────┬─────────┐
     │ foo ┆ bar ┆ literal │
@@ -158,7 +160,7 @@ def when(expr: pli.Expr | bool) -> When:
 
     Or with multiple `when, thens` chained:
 
-    >>> df.with_column(
+    >>> df.with_columns(
     ...     pl.when(pl.col("foo") > 2)
     ...     .then(1)
     ...     .when(pl.col("bar") > 2)

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -416,6 +416,6 @@ def assert_frame_equal_local_categoricals(
             raise AssertionError
 
     cat_to_str = pli.col(Categorical).cast(str)
-    assert df_a.with_column(cat_to_str).frame_equal(df_b.with_column(cat_to_str))
+    assert df_a.with_columns(cat_to_str).frame_equal(df_b.with_columns(cat_to_str))
     cat_to_phys = pli.col(Categorical).to_physical()
-    assert df_a.with_column(cat_to_phys).frame_equal(df_b.with_column(cat_to_phys))
+    assert df_a.with_columns(cat_to_phys).frame_equal(df_b.with_columns(cat_to_phys))

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -16,13 +16,15 @@ assert (time.time() - t0) < 1
 np.random.seed(1)
 mean = 769.5607652
 df = pl.DataFrame(np.random.randint(500, 1040, 5000000), schema=["value"])
-assert np.isclose(df.with_column(pl.mean("value"))[0, 0], mean)
+assert np.isclose(df.with_columns(pl.mean("value"))[0, 0], mean)
 assert np.isclose(
-    df.with_column(pl.col("value").cast(pl.Int32)).with_column(pl.mean("value"))[0, 0],
+    df.with_columns(pl.col("value").cast(pl.Int32)).with_columns(pl.mean("value"))[
+        0, 0
+    ],
     mean,
 )
 assert np.isclose(
-    df.with_column(pl.col("value").cast(pl.Int32)).get_column("value").mean(), mean
+    df.with_columns(pl.col("value").cast(pl.Int32)).get_column("value").mean(), mean
 )
 
 # https://github.com/pola-rs/polars/issues/2850

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -60,7 +60,7 @@ def test_categorical_parquet_statistics(io_test_dir: str) -> None:
                 "user": ["bob", "bob", "bob", "tim", "lucy", "lucy", "lucy", "lucy"],
             }
         )
-        .with_column(pl.col("book").cast(pl.Categorical))
+        .with_columns(pl.col("book").cast(pl.Categorical))
         .write_parquet(file, statistics=True)
     )
 
@@ -129,7 +129,7 @@ def test_row_count_schema(io_test_dir: str) -> None:
 def test_parquet_statistics(io_test_dir: str, capfd: CaptureFixture[str]) -> None:
     os.environ["POLARS_VERBOSE"] = "1"
     fname = os.path.join(io_test_dir, "stats.parquet")
-    df = pl.DataFrame({"idx": pl.arange(0, 100, eager=True)}).with_column(
+    df = pl.DataFrame({"idx": pl.arange(0, 100, eager=True)}).with_columns(
         (pl.col("idx") // 25).alias("part")
     )
     df = pl.concat(df.partition_by("part", as_dict=False), rechunk=False)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -18,7 +18,7 @@ def test_copy() -> None:
 
 def test_categorical_round_trip() -> None:
     df = pl.DataFrame({"ints": [1, 2, 3], "cat": ["a", "b", "c"]})
-    df = df.with_column(pl.col("cat").cast(pl.Categorical))
+    df = df.with_columns(pl.col("cat").cast(pl.Categorical))
 
     tbl = df.to_arrow()
     assert "dictionary" in str(tbl["cat"].type)
@@ -35,7 +35,7 @@ def test_date_list_fmt() -> None:
         }
     )
 
-    df = df.with_column(pl.col("mydate").str.strptime(pl.Date, "%Y-%m-%d"))
+    df = df.with_columns(pl.col("mydate").str.strptime(pl.Date, "%Y-%m-%d"))
     assert (
         str(df.groupby("index", maintain_order=True).agg(pl.col("mydate"))["mydate"])
         == """shape: (3,)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -166,7 +166,7 @@ def test_parquet_datetime(use_pyarrow: bool, compression: ParquetCompression) ->
         "laf_eq": [59.5999984741, 61.0, 62.2999992371, 56.9000015259, 60.0],
     }
     df = pl.DataFrame(data)
-    df = df.with_column(df["datetime"].cast(pl.Datetime))
+    df = df.with_columns(df["datetime"].cast(pl.Datetime))
 
     df.write_parquet(f, use_pyarrow=use_pyarrow, compression=compression)
     f.seek(0)
@@ -235,7 +235,7 @@ def test_lazy_self_join_file_cache_prop_3979(io_test_dir: str) -> None:
 
 def test_recursive_logical_type() -> None:
     df = pl.DataFrame({"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]})
-    df = df.with_column(pl.col("str").cast(pl.Categorical))
+    df = df.with_columns(pl.col("str").cast(pl.Categorical))
 
     df_groups = df.groupby("group").agg([pl.col("str").list().alias("cat_list")])
     f = io.BytesIO()
@@ -250,7 +250,7 @@ def test_nested_dictionary() -> None:
     with pl.StringCache():
         df = (
             pl.DataFrame({"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]})
-            .with_column(pl.col("str").cast(pl.Categorical))
+            .with_columns(pl.col("str").cast(pl.Categorical))
             .groupby("group")
             .agg([pl.col("str").list().alias("cat_list")])
         )

--- a/py-polars/tests/unit/test_aggregations.py
+++ b/py-polars/tests/unit/test_aggregations.py
@@ -45,7 +45,7 @@ def test_duration_aggs() -> None:
         }
     )
 
-    df = df.with_column((pl.col("time2") - pl.col("time1")).alias("time_difference"))
+    df = df.with_columns((pl.col("time2") - pl.col("time1")).alias("time_difference"))
 
     assert df.select("time_difference").mean().to_dict(False) == {
         "time_difference": [timedelta(days=31)]

--- a/py-polars/tests/unit/test_apply.py
+++ b/py-polars/tests/unit/test_apply.py
@@ -102,7 +102,7 @@ def test_apply_struct() -> None:
     df = pl.DataFrame(
         {"A": ["a", "a"], "B": [2, 3], "C": [True, False], "D": [12.0, None]}
     )
-    out = df.with_column(pl.struct(df.columns).alias("struct")).select(
+    out = df.with_columns(pl.struct(df.columns).alias("struct")).select(
         [
             pl.col("struct").apply(lambda x: x["A"]).alias("A_field"),
             pl.col("struct").apply(lambda x: x["B"]).alias("B_field"),
@@ -144,7 +144,7 @@ def test_apply_numpy_out_3057() -> None:
 
 def test_apply_numpy_int_out() -> None:
     df = pl.DataFrame({"col1": [2, 4, 8, 16]})
-    assert df.with_column(
+    assert df.with_columns(
         pl.col("col1").apply(lambda x: np.left_shift(x, 8)).alias("result")
     ).frame_equal(
         pl.DataFrame({"col1": [2, 4, 8, 16], "result": [512, 1024, 2048, 4096]})

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -8,7 +8,7 @@ def test_sqrt_neg_inf() -> None:
         {
             "val": [float("-Inf"), -9, 0, 9, float("Inf")],
         }
-    ).with_column(pl.col("val").sqrt().alias("sqrt"))
+    ).with_columns(pl.col("val").sqrt().alias("sqrt"))
     # comparing nans and infinities by string value as they are not cmp
     assert str(out["sqrt"].to_list()) == str(
         [float("NaN"), float("NaN"), 0.0, 3.0, float("Inf")]

--- a/py-polars/tests/unit/test_binary.py
+++ b/py-polars/tests/unit/test_binary.py
@@ -2,7 +2,7 @@ import polars as pl
 
 
 def test_binary_conversions() -> None:
-    df = pl.DataFrame({"blob": [b"abc", None, b"cde"]}).with_column(
+    df = pl.DataFrame({"blob": [b"abc", None, b"cde"]}).with_columns(
         pl.col("blob").cast(pl.Utf8).alias("decoded_blob")
     )
 

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -70,18 +70,18 @@ def test_categorical_lexical_sort() -> None:
     expected = pl.DataFrame(
         {"cats": ["a", "b", "k", "z", "z"], "vals": [2, 3, 2, 3, 1]}
     )
-    assert out.with_column(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
     out = df.sort(["cats", "vals"])
     expected = pl.DataFrame(
         {"cats": ["a", "b", "k", "z", "z"], "vals": [2, 3, 2, 1, 3]}
     )
-    assert out.with_column(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
     out = df.sort(["vals", "cats"])
 
     expected = pl.DataFrame(
         {"cats": ["z", "a", "k", "b", "z"], "vals": [1, 2, 2, 3, 3]}
     )
-    assert out.with_column(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
 
 
 def test_categorical_lexical_ordering_after_concat() -> None:
@@ -89,7 +89,7 @@ def test_categorical_lexical_ordering_after_concat() -> None:
         ldf1 = (
             pl.DataFrame([pl.Series("key1", [8, 5]), pl.Series("key2", ["fox", "baz"])])
             .lazy()
-            .with_column(
+            .with_columns(
                 pl.col("key2").cast(pl.Categorical).cat.set_ordering("lexical")
             )
         )
@@ -98,13 +98,13 @@ def test_categorical_lexical_ordering_after_concat() -> None:
                 [pl.Series("key1", [6, 8, 6]), pl.Series("key2", ["fox", "foo", "bar"])]
             )
             .lazy()
-            .with_column(
+            .with_columns(
                 pl.col("key2").cast(pl.Categorical).cat.set_ordering("lexical")
             )
         )
         df = (
             pl.concat([ldf1, ldf2])
-            .with_column(pl.col("key2").cat.set_ordering("lexical"))
+            .with_columns(pl.col("key2").cat.set_ordering("lexical"))
             .collect()
         )
 
@@ -113,7 +113,7 @@ def test_categorical_lexical_ordering_after_concat() -> None:
 
 def test_cat_to_dummies() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3, 4], "bar": ["a", "b", "a", "c"]})
-    df = df.with_column(pl.col("bar").cast(pl.Categorical))
+    df = df.with_columns(pl.col("bar").cast(pl.Categorical))
     assert pl.get_dummies(df).to_dict(False) == {
         "foo_1": [1, 0, 0, 0],
         "foo_2": [0, 1, 0, 0],
@@ -131,7 +131,7 @@ def test_comp_categorical_lit_dtype() -> None:
         schema=[("column", pl.Categorical), ("more", pl.Int32)],
     )
 
-    assert df.with_column(
+    assert df.with_columns(
         pl.when(pl.col("column") == "e")
         .then("d")
         .otherwise(pl.col("column"))
@@ -142,7 +142,7 @@ def test_comp_categorical_lit_dtype() -> None:
 def test_categorical_describe_3487() -> None:
     # test if we don't err
     df = pl.DataFrame({"cats": ["a", "b"]})
-    df = df.with_column(pl.col("cats").cast(pl.Categorical))
+    df = df.with_columns(pl.col("cats").cast(pl.Categorical))
     df.describe()
 
 
@@ -153,7 +153,7 @@ def test_categorical_is_in_list() -> None:
     with pl.StringCache():
         df = pl.DataFrame(
             {"a": [1, 2, 3, 1, 2], "b": ["a", "b", "c", "d", "e"]}
-        ).with_column(pl.col("b").cast(pl.Categorical))
+        ).with_columns(pl.col("b").cast(pl.Categorical))
 
         cat_list = ("a", "b", "c")
         assert df.filter(pl.col("b").is_in(cat_list)).to_dict(False) == {
@@ -208,7 +208,7 @@ def test_shift_and_fill() -> None:
         [pl.col("a").cast(pl.Categorical)]
     )
 
-    s = df.with_column(pl.col("a").shift_and_fill(1, "c"))["a"]
+    s = df.with_columns(pl.col("a").shift_and_fill(1, "c"))["a"]
     assert s.dtype == pl.Categorical
     assert s.to_list() == ["c", "a"]
 
@@ -221,7 +221,7 @@ def test_merge_lit_under_global_cache_4491() -> None:
                 pl.Series("value", [3, 9]),
             ]
         )
-        assert df.with_column(
+        assert df.with_columns(
             pl.when(pl.col("value") > 5)
             .then(pl.col("label"))
             .otherwise(pl.lit(None, pl.Categorical))
@@ -242,7 +242,7 @@ def test_nested_cache_composition() -> None:
     def create_lazy(data: dict) -> pl.LazyFrame:  # type: ignore[type-arg]
         with pl.StringCache():
             df = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
-            lf = df.with_column(pl.col("a").cast(pl.Categorical)).lazy()
+            lf = df.with_columns(pl.col("a").cast(pl.Categorical)).lazy()
 
         # confirm that scope-exit does NOT invalidate the
         # cache yet, as an outer context is still active
@@ -273,7 +273,7 @@ def test_categorical_list_concat_4762() -> None:
 def test_categorical_max_null_5437() -> None:
     assert (
         pl.DataFrame({"strings": ["c", "b", "a", "c"], "values": [0, 1, 2, 3]})
-        .with_column(pl.col("strings").cast(pl.Categorical).alias("cats"))
+        .with_columns(pl.col("strings").cast(pl.Categorical).alias("cats"))
         .select(pl.all().max())
     ).to_dict(False) == {"strings": ["c"], "values": [3], "cats": [None]}
 
@@ -293,11 +293,11 @@ def test_categorical_in_struct_nulls() -> None:
 def test_sort_categoricals_6014() -> None:
     with pl.StringCache():
         # create basic categorical
-        df1 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_column(
+        df1 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_columns(
             pl.col("key").cast(pl.Categorical)
         )
         # create lexically-ordered categorical
-        df2 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_column(
+        df2 = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_columns(
             pl.col("key").cast(pl.Categorical).cat.set_ordering("lexical")
         )
 

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -395,8 +395,8 @@ def test_string_cache() -> None:
     pl.toggle_string_cache(False)
     assert pl.using_string_cache() is False
 
-    df1a = df1.with_column(pl.col("a").cast(pl.Categorical))
-    df2a = df2.with_column(pl.col("a").cast(pl.Categorical))
+    df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
+    df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
     with pytest.raises(pl.ComputeError):
         _ = df1a.join(df2a, on="a", how="inner")
 
@@ -404,8 +404,8 @@ def test_string_cache() -> None:
     pl.toggle_string_cache(True)
     assert pl.using_string_cache() is True
 
-    df1b = df1.with_column(pl.col("a").cast(pl.Categorical))
-    df2b = df2.with_column(pl.col("a").cast(pl.Categorical))
+    df1b = df1.with_columns(pl.col("a").cast(pl.Categorical))
+    df2b = df2.with_columns(pl.col("a").cast(pl.Categorical))
     out = df1b.join(df2b, on="a", how="inner")
     assert out.frame_equal(pl.DataFrame({"a": ["foo"], "b": [1], "c": [3]}))
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -104,7 +104,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert df.frame_equal(truth)
 
     df = pl.DataFrame(np.array([1, 2, 3]), schema=[("a", pl.Int32)])
-    truth = pl.DataFrame({"a": [1, 2, 3]}).with_column(pl.col("a").cast(pl.Int32))
+    truth = pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").cast(pl.Int32))
     assert df.frame_equal(truth)
 
     # 2D array - default to column orientation
@@ -488,7 +488,7 @@ def test_upcast_primitive_and_strings() -> None:
 
 
 def test_u64_lit_5031() -> None:
-    df = pl.DataFrame({"foo": [1, 2, 3]}).with_column(pl.col("foo").cast(pl.UInt64))
+    df = pl.DataFrame({"foo": [1, 2, 3]}).with_columns(pl.col("foo").cast(pl.UInt64))
     assert df.filter(pl.col("foo") < (1 << 64) - 20).shape == (3, 1)
     assert df["foo"].to_list() == [1, 2, 3]
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -114,7 +114,7 @@ def test_filter_date() -> None:
     dtcol = pl.col("date")
     df = pl.DataFrame(
         {"date": ["2020-01-02", "2020-01-03", "2020-01-04"], "index": [1, 2, 3]}
-    ).with_column(dtcol.str.strptime(pl.Date, "%Y-%m-%d"))
+    ).with_columns(dtcol.str.strptime(pl.Date, "%Y-%m-%d"))
     assert df.rows() == [
         (date(2020, 1, 2), 1),
         (date(2020, 1, 3), 2),
@@ -325,7 +325,7 @@ def test_datetime_consistency() -> None:
         datetime(3099, 12, 31, 23, 59, 59, 123456),
         datetime(9999, 12, 31, 23, 59, 59, 999999),
     ]
-    ddf = pl.DataFrame({"dtm": test_data}).with_column(
+    ddf = pl.DataFrame({"dtm": test_data}).with_columns(
         pl.col("dtm").dt.nanosecond().alias("ns")
     )
     assert ddf.rows() == [
@@ -790,7 +790,7 @@ def test_rolling() -> None:
         "2020-01-08 23:16:43",
     ]
 
-    df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_column(
+    df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
         pl.col("dt").str.strptime(pl.Datetime)
     )
 
@@ -820,7 +820,7 @@ def test_upsample() -> None:
             "admin": ["Åland", "Netherlands", "Åland", "Netherlands"],
             "test2": [0, 1, 2, 3],
         }
-    ).with_column(pl.col("time").dt.with_time_zone("UTC"))
+    ).with_columns(pl.col("time").dt.with_time_zone("UTC"))
 
     up = df.upsample(
         time_column="time", every="1mo", by="admin", maintain_order=True
@@ -851,7 +851,7 @@ def test_upsample() -> None:
             ],
             "test2": [0, 0, 0, 2, 1, 1, 3],
         }
-    ).with_column(pl.col("time").dt.with_time_zone("UTC"))
+    ).with_columns(pl.col("time").dt.with_time_zone("UTC"))
 
     assert up.frame_equal(expected)
 
@@ -1198,7 +1198,7 @@ def test_groupby_rolling_mean_3020() -> None:
             ],
             "val": range(7),
         }
-    ).with_column(pl.col("Date").str.strptime(pl.Date))
+    ).with_columns(pl.col("Date").str.strptime(pl.Date))
 
     period: str | timedelta
     for period in ("1w", timedelta(days=7)):  # type: ignore[assignment]
@@ -1396,7 +1396,7 @@ def test_duration_filter() -> None:
             "start_date": [date(2022, 1, 1), date(2022, 1, 1), date(2022, 1, 1)],
             "end_date": [date(2022, 1, 7), date(2022, 2, 20), date(2023, 1, 1)],
         }
-    ).with_column((pl.col("end_date") - pl.col("start_date")).alias("time_passed"))
+    ).with_columns((pl.col("end_date") - pl.col("start_date")).alias("time_passed"))
 
     assert df.filter(pl.col("time_passed") < timedelta(days=30)).rows() == [
         (date(2022, 1, 1), date(2022, 1, 7), timedelta(days=6))
@@ -1538,7 +1538,7 @@ def test_duration_aggregations() -> None:
             ],
         }
     )
-    df = df.with_column((pl.col("end") - pl.col("start")).alias("duration"))
+    df = df.with_columns((pl.col("end") - pl.col("start")).alias("duration"))
     assert df.groupby("group", maintain_order=True).agg(
         [
             pl.col("duration").mean().alias("mean"),
@@ -1799,7 +1799,7 @@ def test_date_to_time_cast_5111() -> None:
                 date(2022, 12, 31),
             ]
         }
-    ).with_column(pl.col("xyz").cast(pl.Time))
+    ).with_columns(pl.col("xyz").cast(pl.Time))
     assert df["xyz"].to_list() == [time(0), time(0), time(0), time(0), time(0)]
 
 
@@ -1838,7 +1838,7 @@ def test_supertype_timezones_4174() -> None:
 
     # test if this runs without error
     date_to_fill = df["dt_London"][0]
-    df.with_column(df["dt_London"].shift_and_fill(1, date_to_fill))
+    df.with_columns(df["dt_London"].shift_and_fill(1, date_to_fill))
 
 
 def test_weekday() -> None:
@@ -2018,7 +2018,7 @@ def test_invalid_date_parsing_4898() -> None:
 
 def test_cast_timezone() -> None:
     ny = zoneinfo.ZoneInfo("America/New_York")
-    assert pl.DataFrame({"a": [datetime(2022, 9, 25, 14)]}).with_column(
+    assert pl.DataFrame({"a": [datetime(2022, 9, 25, 14)]}).with_columns(
         pl.col("a")
         .dt.with_time_zone("UTC")
         .dt.cast_time_zone("America/New_York")
@@ -2163,7 +2163,7 @@ def test_tz_aware_truncate() -> None:
             ).dt.tz_localize("America/New_York")
         }
     )
-    assert test.with_column(pl.col("dt").dt.truncate("1d").alias("trunced")).to_dict(
+    assert test.with_columns(pl.col("dt").dt.truncate("1d").alias("trunced")).to_dict(
         False
     ) == {
         "dt": [
@@ -2224,9 +2224,9 @@ def test_tz_aware_truncate() -> None:
             )
         }
     ).lazy()
-    lf = lf.with_column(pl.col("naive").dt.tz_localize("UTC").alias("UTC"))
-    lf = lf.with_column(pl.col("UTC").dt.with_time_zone("US/Central").alias("CST"))
-    lf = lf.with_column(pl.col("CST").dt.truncate("1d").alias("CST truncated"))
+    lf = lf.with_columns(pl.col("naive").dt.tz_localize("UTC").alias("UTC"))
+    lf = lf.with_columns(pl.col("UTC").dt.with_time_zone("US/Central").alias("CST"))
+    lf = lf.with_columns(pl.col("CST").dt.truncate("1d").alias("CST truncated"))
     assert lf.collect().to_dict(False) == {
         "naive": [
             datetime(2021, 12, 31, 23, 0),
@@ -2279,7 +2279,7 @@ def test_tz_aware_strftime() -> None:
             ).dt.tz_localize("America/New_York")
         }
     )
-    assert df.with_column(pl.col("dt").dt.strftime("%c").alias("fmt")).to_dict(
+    assert df.with_columns(pl.col("dt").dt.strftime("%c").alias("fmt")).to_dict(
         False
     ) == {
         "dt": [
@@ -2312,7 +2312,7 @@ def test_tz_aware_filter_lit() -> None:
 
     assert (
         pl.DataFrame({"date": pl.date_range(start, stop, "1h")})
-        .with_column(pl.col("date").dt.tz_localize("America/New_York").alias("nyc"))
+        .with_columns(pl.col("date").dt.tz_localize("America/New_York").alias("nyc"))
         .filter(pl.col("nyc") < dt)
     ).to_dict(False) == {
         "date": [

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -441,10 +441,10 @@ def test_replace() -> None:
 
 def test_assignment() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [2, 3, 4]})
-    df = df.with_column(pl.col("foo").alias("foo"))
+    df = df.with_columns(pl.col("foo").alias("foo"))
     # make sure that assignment does not change column order
     assert df.columns == ["foo", "bar"]
-    df = df.with_column(
+    df = df.with_columns(
         pl.when(pl.col("foo") > 1).then(9).otherwise(pl.col("foo")).alias("foo")
     )
     assert df["foo"].to_list() == [1, 9, 9]
@@ -680,7 +680,7 @@ def test_extend() -> None:
                     datetime(2021, 2, 1),
                 ],
             }
-        ).with_column(
+        ).with_columns(
             pl.col("cat").cast(pl.Categorical),
         )
         assert df1.frame_equal(expected)
@@ -1008,7 +1008,7 @@ def test_describe() -> None:
             "f": [date(2020, 1, 1), date(2021, 1, 1), date(2022, 1, 1)],
         }
     )
-    df = df.with_column(pl.col("e").cast(pl.Categorical))
+    df = df.with_columns(pl.col("e").cast(pl.Categorical))
     expected = pl.DataFrame(
         {
             "describe": ["count", "null_count", "mean", "std", "min", "max", "median"],
@@ -1074,7 +1074,7 @@ def test_string_cache_eager_lazy() -> None:
                 "region_ids": ["reg1", "reg2", "reg3", "reg4", "reg5"],
                 "score": [2.0, 1.0, None, 3.0, None],
             }
-        ).with_column(pl.col("region_ids").cast(pl.Categorical))
+        ).with_columns(pl.col("region_ids").cast(pl.Categorical))
 
         assert df1.join(
             df2, left_on="region_ids", right_on="seq_name", how="left"
@@ -1100,7 +1100,7 @@ def test_assign() -> None:
     # check if can assign in case of a single column
     df = pl.DataFrame({"a": [1, 2, 3]})
     # test if we can assign in case of single column
-    df = df.with_column(pl.col("a") * 2)
+    df = df.with_columns(pl.col("a") * 2)
     assert list(df["a"]) == [2, 4, 6]
 
 
@@ -1145,8 +1145,8 @@ def test_literal_series() -> None:
     )
     out = (
         df.lazy()
-        .with_column(pl.Series("e", [2, 1, 3], pl.Int32))
-        .with_column(pl.col("e").cast(pl.Float32))
+        .with_columns(pl.Series("e", [2, 1, 3], pl.Int32))
+        .with_columns(pl.col("e").cast(pl.Float32))
         .collect()
     )
     expected_schema = {
@@ -1379,7 +1379,7 @@ def test_str_concat() -> None:
             "name": ["ham", "spam", "foo", None],
         }
     )
-    out = df.with_column((pl.lit("Dr. ") + pl.col("name")).alias("graduated_name"))
+    out = df.with_columns((pl.lit("Dr. ") + pl.col("name")).alias("graduated_name"))
     assert out["graduated_name"][0] == "Dr. ham"
     assert out["graduated_name"][1] == "Dr. spam"
 
@@ -1465,7 +1465,7 @@ def test_hashing_on_python_objects() -> None:
         def __eq__(self, other: Any) -> bool:
             return True
 
-    df = df.with_column(pl.col("a").apply(lambda x: Foo()).alias("foo"))
+    df = df.with_columns(pl.col("a").apply(lambda x: Foo()).alias("foo"))
     assert df.groupby(["foo"]).first().shape == (1, 3)
     assert df.unique().shape == (3, 3)
 
@@ -1550,7 +1550,7 @@ def test_groupby_cat_list() -> None:
                 pl.Series("int_column", [1, 1, 2, 2, 3]),
             ]
         )
-        .with_column(pl.col("str_column").cast(pl.Categorical).alias("cat_column"))
+        .with_columns(pl.col("str_column").cast(pl.Categorical).alias("cat_column"))
         .groupby("int_column", maintain_order=True)
         .agg([pl.col("cat_column")])["cat_column"]
     )
@@ -1937,31 +1937,31 @@ def test_arithmetic() -> None:
     df2 = pl.DataFrame({"c": [10]})
 
     out = df + df2
-    expected = pl.DataFrame({"a": [11.0, None], "b": [None, None]}).with_column(
+    expected = pl.DataFrame({"a": [11.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
     assert out.frame_equal(expected, null_equal=True)
 
     out = df - df2
-    expected = pl.DataFrame({"a": [-9.0, None], "b": [None, None]}).with_column(
+    expected = pl.DataFrame({"a": [-9.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
     assert out.frame_equal(expected, null_equal=True)
 
     out = df / df2
-    expected = pl.DataFrame({"a": [0.1, None], "b": [None, None]}).with_column(
+    expected = pl.DataFrame({"a": [0.1, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
     assert out.frame_equal(expected, null_equal=True)
 
     out = df * df2
-    expected = pl.DataFrame({"a": [10.0, None], "b": [None, None]}).with_column(
+    expected = pl.DataFrame({"a": [10.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
     assert out.frame_equal(expected, null_equal=True)
 
     out = df % df2
-    expected = pl.DataFrame({"a": [1.0, None], "b": [None, None]}).with_column(
+    expected = pl.DataFrame({"a": [1.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
     assert out.frame_equal(expected, null_equal=True)
@@ -2111,7 +2111,7 @@ def test_to_dict(as_series: bool, inner_dtype: Any) -> None:
 
 def test_df_broadcast() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]}, schema_overrides={"a": pl.UInt8})
-    out = df.with_column(pl.Series("s", [[1, 2]]))
+    out = df.with_columns(pl.Series("s", [[1, 2]]))
     assert out.shape == (3, 2)
     assert out.schema == {"a": pl.UInt8, "s": pl.List(pl.Int64)}
     assert out.rows() == [(1, [1, 2]), (2, [1, 2]), (3, [1, 2])]
@@ -2466,7 +2466,7 @@ def test_with_columns() -> None:
 
 
 def test_len_compute(df: pl.DataFrame) -> None:
-    df = df.with_column(pl.struct(["list_bool", "cat"]).alias("struct"))
+    df = df.with_columns(pl.struct(["list_bool", "cat"]).alias("struct"))
     filtered = df.filter(pl.col("bools"))
     for col in filtered.columns:
         assert len(filtered[col]) == 1

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -3,7 +3,7 @@ import polars as pl
 
 def test_empty_str_concat_lit() -> None:
     df = pl.DataFrame({"a": [], "b": []}, schema=[("a", pl.Utf8), ("b", pl.Utf8)])
-    assert df.with_column(pl.lit("asd") + pl.col("a")).schema == {
+    assert df.with_columns(pl.lit("asd") + pl.col("a")).schema == {
         "a": pl.Utf8,
         "b": pl.Utf8,
         "literal": pl.Utf8,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -41,7 +41,7 @@ def test_error_on_invalid_by_in_asof_join() -> None:
         }
     )
 
-    df2 = df1.with_column(pl.col("a").cast(pl.Categorical))
+    df2 = df1.with_columns(pl.col("a").cast(pl.Categorical))
     with pytest.raises(pl.ComputeError):
         df1.join_asof(df2, on="b", by=["a", "c"])
 

--- a/py-polars/tests/unit/test_expr_multi_cols.py
+++ b/py-polars/tests/unit/test_expr_multi_cols.py
@@ -4,7 +4,7 @@ import polars as pl
 def test_exclude_name_from_dtypes() -> None:
     df = pl.DataFrame({"a": ["a"], "b": ["b"]})
 
-    assert df.with_column(pl.col(pl.Utf8).exclude("a").suffix("_foo")).frame_equal(
+    assert df.with_columns(pl.col(pl.Utf8).exclude("a").suffix("_foo")).frame_equal(
         pl.DataFrame({"a": ["a"], "b": ["b"], "b_foo": ["b"]})
     )
 
@@ -17,7 +17,7 @@ def test_fold_regex_expand() -> None:
             "y_2": [1.0, 2.5, 3.5],
         }
     )
-    assert df.with_column(
+    assert df.with_columns(
         pl.fold(acc=pl.lit(0), f=lambda acc, x: acc + x, exprs=pl.col("^y_.*$")).alias(
             "y_sum"
         ),
@@ -37,7 +37,7 @@ def test_expanding_sum() -> None:
             "y_2": [1.0, 2.5, 3.5],
         }
     )
-    assert df.with_column(pl.sum(pl.col(r"^y_.*$")).alias("y_sum"))[
+    assert df.with_columns(pl.sum(pl.col(r"^y_.*$")).alias("y_sum"))[
         "y_sum"
     ].to_list() == [2.1, 4.7, 6.8]
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -344,7 +344,7 @@ def test_list_eval_expression() -> None:
     df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
 
     for parallel in [True, False]:
-        assert df.with_column(
+        assert df.with_columns(
             pl.concat_list(["a", "b"])
             .arr.eval(pl.first().rank(), parallel=parallel)
             .alias("rank")

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -297,7 +297,7 @@ def test_argsort_sort_by_groups_update__4360() -> None:
         }
     )
 
-    out = df.with_column(
+    out = df.with_columns(
         pl.col("col2").arg_sort().over("group").alias("col2_argsort")
     ).with_columns(
         [

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -565,7 +565,7 @@ def test_from_pyarrow_chunked_array() -> None:
 
 
 def test_numpy_preserve_uint64_4112() -> None:
-    assert pl.DataFrame({"a": [1, 2, 3]}).with_column(
+    assert pl.DataFrame({"a": [1, 2, 3]}).with_columns(
         pl.col("a").hash()
     ).to_numpy().dtype == np.dtype("uint64")
 

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -92,17 +92,17 @@ def test_sorted_merge_joins() -> None:
         join_strategies: list[JoinStrategy] = ["left", "inner"]
         for cast_to in [int, str, float]:
             for how in join_strategies:
-                df_a_ = df_a.with_column(pl.col("a").cast(cast_to))
-                df_b_ = df_b.with_column(pl.col("a").cast(cast_to))
+                df_a_ = df_a.with_columns(pl.col("a").cast(cast_to))
+                df_b_ = df_b.with_columns(pl.col("a").cast(cast_to))
 
                 # hash join
                 out_hash_join = df_a_.join(df_b_, on="a", how=how)
 
                 # sorted merge join
-                out_sorted_merge_join = df_a_.with_column(
+                out_sorted_merge_join = df_a_.with_columns(
                     pl.col("a").set_sorted(reverse)
                 ).join(
-                    df_b_.with_column(pl.col("a").set_sorted(reverse)), on="a", how=how
+                    df_b_.with_columns(pl.col("a").set_sorted(reverse)), on="a", how=how
                 )
 
                 assert out_hash_join.frame_equal(out_sorted_merge_join)
@@ -126,8 +126,8 @@ def test_join_negative_integers() -> None:
 
     for dt in [pl.Int8, pl.Int16, pl.Int32, pl.Int64]:
         assert (
-            df1.with_column(pl.all().cast(dt))
-            .join(df2.with_column(pl.all().cast(dt)), on="a", how="inner")
+            df1.with_columns(pl.all().cast(dt))
+            .join(df2.with_columns(pl.all().cast(dt)), on="a", how="inner")
             .to_dict(False)
             == expected
         )
@@ -152,7 +152,7 @@ def test_join_asof_floats() -> None:
             "val": [0, 2.5, 2.6, 2.7, 3.4, 4, 5],
             "c": ["x", "x", "x", "y", "y", "y", "y"],
         }
-    ).with_column(pl.col("val").alias("b"))
+    ).with_columns(pl.col("val").alias("b"))
     assert df1.join_asof(df2, on="b", by="c").to_dict(False) == {
         "b": [
             0.0,
@@ -406,7 +406,7 @@ def test_join_on_cast() -> None:
     df_a = (
         pl.DataFrame({"a": [-5, -2, 3, 3, 9, 10]})
         .with_row_count()
-        .with_column(pl.col("a").cast(pl.Int32))
+        .with_columns(pl.col("a").cast(pl.Int32))
     )
 
     df_b = pl.DataFrame({"a": [-2, -3, 3, 10]})
@@ -563,7 +563,7 @@ def test_jit_sort_joins() -> None:
         # left key sorted right is not
         pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"])
 
-        a = pl.from_pandas(pd_result).with_column(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
         assert a.frame_equal(pl_result, null_equal=True)
         assert pl_result["a"].flags["SORTED_ASC"]
 
@@ -572,7 +572,7 @@ def test_jit_sort_joins() -> None:
         pd_result.columns = ["a", "b", "b_right"]
         pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"])
 
-        a = pl.from_pandas(pd_result).with_column(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
         assert a.frame_equal(pl_result, null_equal=True)
         assert pl_result["a"].flags["SORTED_ASC"]
 
@@ -656,7 +656,7 @@ def test_streaming_joins() -> None:
             .collect(streaming=True)
         )
 
-        a = pl.from_pandas(pd_result).with_column(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
         pl.testing.assert_frame_equal(a, pl_result, check_dtype=False)
 
         pd_result = dfa.merge(dfb, on=["a", "b"], how=how)
@@ -669,7 +669,7 @@ def test_streaming_joins() -> None:
         )
 
         # we cast to integer because pandas joins creates floats
-        a = pl.from_pandas(pd_result).with_column(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
         pl.testing.assert_frame_equal(a, pl_result, check_dtype=False)
 
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -20,12 +20,12 @@ from polars.testing.asserts import assert_series_equal
 
 def test_lazy() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    _ = df.lazy().with_column(pl.lit(1).alias("foo")).select([col("a"), col("foo")])
+    _ = df.lazy().with_columns(pl.lit(1).alias("foo")).select([col("a"), col("foo")])
 
     # test if it executes
     _ = (
         df.lazy()
-        .with_column(
+        .with_columns(
             when(pl.col("a") > pl.lit(2))
             .then(pl.lit(10))
             .otherwise(pl.lit(1))
@@ -65,9 +65,9 @@ def test_lazyframe_membership_operator() -> None:
 
 def test_apply() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    new = df.lazy().with_column(col("a").map(lambda s: s * 2).alias("foo")).collect()
+    new = df.lazy().with_columns(col("a").map(lambda s: s * 2).alias("foo")).collect()
 
-    expected = df.clone().with_column((pl.col("a") * 2).alias("foo"))
+    expected = df.clone().with_columns((pl.col("a") * 2).alias("foo"))
     assert new.frame_equal(expected)
 
 
@@ -75,7 +75,7 @@ def test_add_eager_column() -> None:
     ldf = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}).lazy()
     assert ldf.width == 2
 
-    out = ldf.with_column(pl.lit(pl.Series("c", [1, 2, 3]))).collect()
+    out = ldf.with_columns(pl.lit(pl.Series("c", [1, 2, 3]))).collect()
     assert out["c"].sum() == 6
     assert out.width == 3
 
@@ -84,7 +84,7 @@ def test_set_null() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     out = (
         df.lazy()
-        .with_column(when(col("a") > 1).then(lit(None)).otherwise(100).alias("foo"))
+        .with_columns(when(col("a") > 1).then(lit(None)).otherwise(100).alias("foo"))
         .collect()
     )
     s = out["foo"]
@@ -205,7 +205,7 @@ def test_apply_custom_function() -> None:
             "cars_count": [3, 2],
         }
     )
-    expected = expected.with_column(pl.col("cars_count").cast(pl.UInt32))
+    expected = expected.with_columns(pl.col("cars_count").cast(pl.UInt32))
     assert a.frame_equal(expected)
 
 
@@ -250,7 +250,7 @@ def test_shift_and_fill() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
 
     # use exprs
-    out = df.lazy().with_column(col("a").shift_and_fill(-2, col("b").mean())).collect()
+    out = df.lazy().with_columns(col("a").shift_and_fill(-2, col("b").mean())).collect()
     assert out["a"].null_count() == 0
 
     # use df method
@@ -559,7 +559,7 @@ def test_all_expr() -> None:
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.with_column(pl.col("A").cast(bool)).select(pl.any("A"))[0, 0]
+    assert fruits_cars.with_columns(pl.col("A").cast(bool)).select(pl.any("A"))[0, 0]
     assert fruits_cars.select(pl.any([pl.col("A"), pl.col("B")]))[0, 0]
 
 
@@ -1000,6 +1000,14 @@ def test_with_column_renamed(fruits_cars: pl.DataFrame) -> None:
     assert res.columns[0] == "C"
 
 
+def test_with_columns_single_series() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    result = df.lazy().with_columns(pl.Series("b", [3, 4])).collect()
+
+    expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    assert_frame_equal(result, expected)
+
+
 def test_reverse() -> None:
     out = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).lazy().reverse()
     expected = pl.DataFrame({"a": [2, 1], "b": [4, 3]})
@@ -1318,7 +1326,7 @@ def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:
 
 def test_nested_min_max() -> None:
     df = pl.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
-    out = df.with_column(pl.max([pl.min(["a", "b"]), pl.min(["c", "d"])]).alias("t"))
+    out = df.with_columns(pl.max([pl.min(["a", "b"]), pl.min(["c", "d"])]).alias("t"))
     assert out.shape == (1, 5)
     assert out.row(0) == (1, 2, 3, 4, 3)
     assert out.columns == ["a", "b", "c", "d", "t"]
@@ -1362,7 +1370,7 @@ def test_preservation_of_subclasses() -> None:
     # superclass and subclass
     ldf = pl.DataFrame({"column_1": [1, 2, 3]}).lazy()
     ldf.__class__ = SubClassedLazyFrame
-    extended_ldf = ldf.with_column(pl.lit(1).alias("column_2"))
+    extended_ldf = ldf.with_columns(pl.lit(1).alias("column_2"))
     assert isinstance(extended_ldf, pl.LazyFrame)
     assert isinstance(extended_ldf, SubClassedLazyFrame)
 
@@ -1472,6 +1480,18 @@ def test_predicate_count_vstack() -> None:
     assert pl.concat([l1, l2]).filter(pl.count().over("k") == 2).collect()[
         "v"
     ].to_list() == [3, 2, 5, 7]
+
+
+def test_explode_inner_lists_3985() -> None:
+    df = pl.DataFrame(
+        data={"id": [1, 1, 1], "categories": [["a"], ["b"], ["a", "c"]]}
+    ).lazy()
+
+    assert (
+        df.groupby("id")
+        .agg(pl.col("categories"))
+        .with_columns(pl.col("categories").arr.eval(pl.element().explode()))
+    ).collect().to_dict(False) == {"id": [1], "categories": [["a", "b", "a", "c"]]}
 
 
 def test_lazy_method() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -165,7 +165,7 @@ def test_list_concat_rolling_window() -> None:
 
     # this test proper null behavior of concat list
     out = (
-        df.with_column(pl.col("A").reshape((-1, 1)))  # first turn into a list
+        df.with_columns(pl.col("A").reshape((-1, 1)))  # first turn into a list
         .with_columns(
             [
                 pl.col("A").shift(i).alias(f"A_lag_{i}")
@@ -283,7 +283,7 @@ def test_list_eval_dtype_inference() -> None:
     rank_pct = pl.col("").rank(reverse=True) / pl.col("").count().cast(pl.UInt16)
 
     # the .arr.first() would fail if .arr.eval did not correctly infer the output type
-    assert grades.with_column(
+    assert grades.with_columns(
         pl.concat_list(pl.all().exclude("student")).alias("all_grades")
     ).select(
         [
@@ -368,7 +368,7 @@ def test_list_ternary_concat() -> None:
         }
     )
 
-    assert df.with_column(
+    assert df.with_columns(
         pl.when(pl.col("list1").is_null())
         .then(pl.col("list1").arr.concat(pl.col("list2")))
         .otherwise(pl.col("list2"))
@@ -379,7 +379,7 @@ def test_list_ternary_concat() -> None:
         "result": [["789"], None],
     }
 
-    assert df.with_column(
+    assert df.with_columns(
         pl.when(pl.col("list1").is_null())
         .then(pl.col("list2"))
         .otherwise(pl.col("list1").arr.concat(pl.col("list2")))
@@ -397,7 +397,7 @@ def test_list_concat_nulls() -> None:
             "a": [["a", "b"], None, ["c", "d", "e"], None],
             "t": [["x"], ["y"], None, None],
         }
-    ).with_column(pl.concat_list(["a", "t"]).alias("concat"))["concat"].to_list() == [
+    ).with_columns(pl.concat_list(["a", "t"]).alias("concat"))["concat"].to_list() == [
         ["a", "b", "x"],
         None,
         None,
@@ -409,13 +409,13 @@ def test_list_concat_supertype() -> None:
     df = pl.DataFrame(
         [pl.Series("a", [1, 2], pl.UInt8), pl.Series("b", [10000, 20000], pl.UInt16)]
     )
-    assert df.with_column(pl.concat_list(pl.col(["a", "b"])).alias("concat_list"))[
+    assert df.with_columns(pl.concat_list(pl.col(["a", "b"])).alias("concat_list"))[
         "concat_list"
     ].to_list() == [[1, 10000], [2, 20000]]
 
 
 def test_list_hash() -> None:
-    out = pl.DataFrame({"a": [[1, 2, 3], [3, 4], [1, 2, 3]]}).with_column(
+    out = pl.DataFrame({"a": [[1, 2, 3], [3, 4], [1, 2, 3]]}).with_columns(
         pl.col("a").hash().alias("b")
     )
     assert out.dtypes == [pl.List(pl.Int64), pl.UInt64]
@@ -426,7 +426,7 @@ def test_arr_contains_categorical() -> None:
     df = pl.DataFrame(
         {"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]}
     ).lazy()
-    df = df.with_column(pl.col("str").cast(pl.Categorical))
+    df = df.with_columns(pl.col("str").cast(pl.Categorical))
     df_groups = df.groupby("group").agg([pl.col("str").list().alias("str_list")])
     assert df_groups.filter(pl.col("str_list").arr.contains("C")).collect().to_dict(
         False
@@ -489,7 +489,7 @@ def test_inner_type_categorical_on_rechunk() -> None:
 def test_groupby_list_column() -> None:
     df = (
         pl.DataFrame({"a": ["a", "b", "a"]})
-        .with_column(pl.col("a").cast(pl.Categorical))
+        .with_columns(pl.col("a").cast(pl.Categorical))
         .groupby("a", maintain_order=True)
         .agg(pl.col("a").list().alias("a_list"))
     )
@@ -553,7 +553,7 @@ def test_empty_eval_dtype_5546() -> None:
     dtype = df.dtypes[0]
 
     assert (
-        df.limit(0).with_column(
+        df.limit(0).with_columns(
             pl.col("a")
             .arr.eval(pl.element().filter(pl.first().struct.field("name") == 1))
             .alias("a_filtered")

--- a/py-polars/tests/unit/test_object.py
+++ b/py-polars/tests/unit/test_object.py
@@ -7,7 +7,7 @@ def test_object_when_then_4702() -> None:
     # please don't ever do this
     x = pl.DataFrame({"Row": [1, 2], "Type": [pl.Date, pl.UInt8]})
 
-    assert x.with_column(
+    assert x.with_columns(
         pl.when(pl.col("Row") == 1)
         .then(pl.lit(pl.UInt16, allow_object=True))
         .otherwise(pl.lit(pl.UInt8, allow_object=True))

--- a/py-polars/tests/unit/test_pivot.py
+++ b/py-polars/tests/unit/test_pivot.py
@@ -110,7 +110,7 @@ def test_pivot_categorical_3968() -> None:
         }
     )
 
-    assert df.with_column(pl.col("baz").cast(str).cast(pl.Categorical)).to_dict(
+    assert df.with_columns(pl.col("baz").cast(str).cast(pl.Categorical)).to_dict(
         False
     ) == {
         "foo": ["one", "one", "one", "two", "two", "two"],

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -68,7 +68,7 @@ def test_unnest_projection_pushdown() -> None:
 
     mlf = (
         lf.melt()
-        .with_column(pl.col("variable").str.split_exact("|", 2))
+        .with_columns(pl.col("variable").str.split_exact("|", 2))
         .unnest("variable")
     )
     mlf = mlf.select(
@@ -99,7 +99,7 @@ def test_unnest_columns_available() -> None:
         }
     ).lazy()
 
-    q = df.with_column(
+    q = df.with_columns(
         pl.col("genres")
         .str.split("|")
         .arr.to_struct(
@@ -179,7 +179,7 @@ def test_asof_join_projection_() -> None:
                 "c": ["x", "x", "x", "y", "y", "y", "y"],
             }
         )
-        .with_column(pl.col("val").alias("b"))
+        .with_columns(pl.col("val").alias("b"))
         .lazy()
     )
 

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -17,7 +17,7 @@ def test_sort_by_bools() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-    out = df.with_column((pl.col("foo") % 2 == 1).alias("foo_odd")).sort(
+    out = df.with_columns((pl.col("foo") % 2 == 1).alias("foo_odd")).sort(
         by=["foo_odd", "foo"]
     )
     assert out.rows() == [
@@ -143,7 +143,7 @@ def test_sorted_groupby_optimization() -> None:
     # groups, so this is tests that we hit the sorted optimization
     for reverse in [True, False]:
         sorted_implicit = (
-            df.with_column(pl.col("a").sort(reverse=reverse))
+            df.with_columns(pl.col("a").sort(reverse=reverse))
             .groupby("a")
             .agg(pl.count())
         )
@@ -245,7 +245,7 @@ def test_opaque_filter_on_lists_3784() -> None:
     df = pl.DataFrame(
         {"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]}
     ).lazy()
-    df = df.with_column(pl.col("str").cast(pl.Categorical))
+    df = df.with_columns(pl.col("str").cast(pl.Categorical))
 
     df_groups = df.groupby("group").agg([pl.col("str").list().alias("str_list")])
 
@@ -303,7 +303,7 @@ def test_when_then_edge_cases_3994() -> None:
         df.lazy()
         .groupby(["id"])
         .agg(pl.col("type"))
-        .with_column(
+        .with_columns(
             pl.when(pl.col("type").arr.lengths() == 0)
             .then(pl.lit(None))
             .otherwise(pl.col("type"))
@@ -317,7 +317,7 @@ def test_when_then_edge_cases_3994() -> None:
         df.filter(pl.col("id") == 42)
         .groupby(["id"])
         .agg(pl.col("type"))
-        .with_column(
+        .with_columns(
             pl.when(pl.col("type").arr.lengths() == 0)
             .then(pl.lit(None))
             .otherwise(pl.col("type"))
@@ -348,9 +348,9 @@ def test_query_4438() -> None:
 
     q = (
         df.lazy()
-        .with_column(pl.col("x").rolling_max(window_size=3).alias("rolling_max"))
+        .with_columns(pl.col("x").rolling_max(window_size=3).alias("rolling_max"))
         .fill_null(strategy="backward")
-        .with_column(
+        .with_columns(
             pl.col("rolling_max").rolling_max(window_size=3).alias("rolling_max_2")
         )
     )

--- a/py-polars/tests/unit/test_rolling.py
+++ b/py-polars/tests/unit/test_rolling.py
@@ -146,7 +146,7 @@ def test_rolling_groupby_extrema() -> None:
     # two dfs, but ensure that one does not have a sorted flag
 
     # descending order
-    not_sorted_flag = pl.DataFrame({"col1": [6, 5, 4, 3, 2, 1, 0]}).with_column(
+    not_sorted_flag = pl.DataFrame({"col1": [6, 5, 4, 3, 2, 1, 0]}).with_columns(
         pl.col("col1").reverse().alias("row_nr")
     )
     assert not not_sorted_flag["col1"].flags["SORTED_DESC"]
@@ -155,7 +155,7 @@ def test_rolling_groupby_extrema() -> None:
         {
             "col1": pl.arange(0, 7, eager=True).reverse(),
         }
-    ).with_column(pl.col("col1").reverse().alias("row_nr"))
+    ).with_columns(pl.col("col1").reverse().alias("row_nr"))
 
     for df in [sorted_flag, not_sorted_flag]:
         assert (
@@ -195,9 +195,9 @@ def test_rolling_groupby_extrema() -> None:
         {
             "col1": pl.arange(0, 7, eager=True),
         }
-    ).with_column(pl.col("col1").alias("row_nr"))
+    ).with_columns(pl.col("col1").alias("row_nr"))
 
-    not_sorted_df = pl.DataFrame({"col1": [0, 1, 2, 3, 4, 5, 6]}).with_column(
+    not_sorted_df = pl.DataFrame({"col1": [0, 1, 2, 3, 4, 5, 6]}).with_columns(
         pl.col("col1").alias("row_nr")
     )
 
@@ -239,7 +239,7 @@ def test_rolling_groupby_extrema() -> None:
         {
             "col1": pl.arange(0, 7, eager=True).shuffle(1),
         }
-    ).with_column(pl.col("col1").sort().alias("row_nr"))
+    ).with_columns(pl.col("col1").sort().alias("row_nr"))
 
     assert (
         df.groupby_rolling(
@@ -463,7 +463,7 @@ def test_groupby_dynamic_startby_5599() -> None:
     start = datetime(2022, 1, 1)
     stop = datetime(2022, 1, 12, 7)
 
-    df = pl.DataFrame({"date": pl.date_range(start, stop, "12h")}).with_column(
+    df = pl.DataFrame({"date": pl.date_range(start, stop, "12h")}).with_columns(
         pl.col("date").dt.weekday().alias("day")
     )
 
@@ -498,7 +498,7 @@ def test_groupby_dynamic_by_monday_and_offset_5444() -> None:
             "label": ["a", "b", "a", "a", "b", "a", "b"],
             "value": [1, 2, 3, 4, 5, 6, 7],
         }
-    ).with_column(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+    ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
 
     result = df.groupby_dynamic(
         "date", every="1w", offset="1d", by="label", start_by="monday"

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -31,8 +31,8 @@ def test_schema_on_agg() -> None:
 def test_fill_null_minimal_upcast_4056() -> None:
     df = pl.DataFrame({"a": [-1, 2, None]})
     df = df.with_columns(pl.col("a").cast(pl.Int8))
-    assert df.with_column(pl.col(pl.Int8).fill_null(-1)).dtypes[0] == pl.Int8
-    assert df.with_column(pl.col(pl.Int8).fill_null(-1000)).dtypes[0] == pl.Int32
+    assert df.with_columns(pl.col(pl.Int8).fill_null(-1)).dtypes[0] == pl.Int8
+    assert df.with_columns(pl.col(pl.Int8).fill_null(-1000)).dtypes[0] == pl.Int32
 
 
 def test_with_column_duplicates() -> None:
@@ -275,7 +275,7 @@ def test_schema_owned_arithmetic_5669() -> None:
         pl.DataFrame({"A": [1, 2, 3]})
         .lazy()
         .filter(pl.col("A") >= 3)
-        .with_column(-pl.col("A").alias("B"))
+        .with_columns(-pl.col("A").alias("B"))
         .collect()
     )
     assert df.columns == ["A", "literal"], df.columns
@@ -297,7 +297,7 @@ def test_lazy_rename() -> None:
 
 def test_all_null_cast_5826() -> None:
     df = pl.DataFrame(data=[pl.Series("a", [None], dtype=pl.Utf8)])
-    out = df.with_column(pl.col("a").cast(pl.Boolean))
+    out = df.with_columns(pl.col("a").cast(pl.Boolean))
     assert out.dtypes == [pl.Boolean]
     assert out.item() is None
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -906,19 +906,19 @@ def test_rolling() -> None:
         pl.col("val").rolling_min(window_size=3),
         pl.col("val").rolling_max(window_size=3),
     ]:
-        out = df.with_column(e).to_series()
+        out = df.with_columns(e).to_series()
         assert out.null_count() == 2
         assert np.isnan(out.to_numpy()).sum() == 5
 
     expected = [None, None, 2.0, 3.0, 5.0, 6.0, 6.0]
     assert (
-        df.with_column(pl.col("val").rolling_median(window_size=3))
+        df.with_columns(pl.col("val").rolling_median(window_size=3))
         .to_series()
         .to_list()
         == expected
     )
     assert (
-        df.with_column(pl.col("val").rolling_quantile(0.5, window_size=3))
+        df.with_columns(pl.col("val").rolling_quantile(0.5, window_size=3))
         .to_series()
         .to_list()
         == expected
@@ -2074,7 +2074,7 @@ def test_is_between_datetime() -> None:
     expected = pl.Series("a", [False, True])
 
     # only on the expression api
-    result = s.to_frame().with_column(pl.col("*").is_between(start, end))["is_between"]
+    result = s.to_frame().with_columns(pl.col("*").is_between(start, end))["is_between"]
     assert_series_equal(result.rename("a"), expected)
 
 

--- a/py-polars/tests/unit/test_sort.py
+++ b/py-polars/tests/unit/test_sort.py
@@ -29,7 +29,7 @@ def test_sort_dates_multiples() -> None:
     assert out["values"].to_list() == expected
 
     # Date
-    out = df.with_column(pl.col("date").cast(pl.Date)).sort(["date", "values"])
+    out = df.with_columns(pl.col("date").cast(pl.Date)).sort(["date", "values"])
     assert out["values"].to_list() == expected
 
 
@@ -176,10 +176,10 @@ def test_sorted_join_and_dtypes() -> None:
         df_a = (
             pl.DataFrame({"a": [-5, -2, 3, 3, 9, 10]})
             .with_row_count()
-            .with_column(pl.col("a").cast(dt).set_sorted())
+            .with_columns(pl.col("a").cast(dt).set_sorted())
         )
 
-    df_b = pl.DataFrame({"a": [-2, -3, 3, 10]}).with_column(
+    df_b = pl.DataFrame({"a": [-2, -3, 3, 10]}).with_columns(
         pl.col("a").cast(dt).set_sorted()
     )
 
@@ -318,7 +318,7 @@ def test_sorted_join_query_5406() -> None:
                 "Value": [1, 2, 1, 1, 2, 1],
             }
         )
-        .with_column(pl.col("Datetime").str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S"))
+        .with_columns(pl.col("Datetime").str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S"))
         .with_row_count("RowId")
     )
 
@@ -367,7 +367,7 @@ def test_merge_sorted() -> None:
         pl.date_range(datetime(2022, 1, 1), datetime(2022, 12, 1), "2mo")
         .to_frame("range")
         .with_row_count()
-        .with_column(pl.col("row_nr") * 10)
+        .with_columns(pl.col("row_nr") * 10)
     )
     out = df_a.merge_sorted(df_b, key="range")
     assert out["range"].is_sorted()

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -121,10 +121,10 @@ def test_streaming_non_streaming_gb() -> None:
     q = df.lazy().groupby("a").agg(pl.count()).sort("a")
     assert q.collect(streaming=True).frame_equal(q.collect())
 
-    q = df.lazy().with_column(pl.col("a").cast(pl.Utf8))
+    q = df.lazy().with_columns(pl.col("a").cast(pl.Utf8))
     q = q.groupby("a").agg(pl.count()).sort("a")
     assert q.collect(streaming=True).frame_equal(q.collect())
-    q = df.lazy().with_column(pl.col("a").alias("b"))
+    q = df.lazy().with_columns(pl.col("a").alias("b"))
     q = q.groupby(["a", "b"]).agg(pl.count()).sort("a")
     assert q.collect(streaming=True).frame_equal(q.collect())
 
@@ -138,7 +138,7 @@ def test_streaming_groupby_sorted_fast_path() -> None:
         }
     ).with_row_count()
 
-    df_sorted = df.with_column(pl.col("a").set_sorted())
+    df_sorted = df.with_columns(pl.col("a").set_sorted())
 
     for streaming in [True, False]:
         results = []
@@ -170,7 +170,7 @@ def test_streaming_categoricals_5921() -> None:
         out_lazy = (
             pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
             .lazy()
-            .with_column(pl.col("X").cast(pl.Categorical))
+            .with_columns(pl.col("X").cast(pl.Categorical))
             .groupby("X")
             .agg(pl.col("Y").min())
             .sort("X")
@@ -179,7 +179,7 @@ def test_streaming_categoricals_5921() -> None:
 
         out_eager = (
             pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
-            .with_column(pl.col("X").cast(pl.Categorical))
+            .with_columns(pl.col("X").cast(pl.Categorical))
             .groupby("X")
             .agg(pl.col("Y").min())
             .sort("X")
@@ -194,6 +194,6 @@ def test_streaming_block_on_literals_6054() -> None:
     df = pl.DataFrame({"col_1": [0] * 5 + [1] * 5})
     s = pl.Series("col_2", list(range(10)))
 
-    assert df.lazy().with_column(s).groupby("col_1").agg(pl.all().first()).collect(
+    assert df.lazy().with_columns(s).groupby("col_1").agg(pl.all().first()).collect(
         streaming=True
     ).sort("col_1").to_dict(False) == {"col_1": [0, 1], "col_2": [0, 5]}

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -185,7 +185,7 @@ def test_zfill() -> None:
         None,
     ]
     assert (
-        df.with_column(pl.col("num").cast(str).str.zfill(5)).to_series().to_list()
+        df.with_columns(pl.col("num").cast(str).str.zfill(5)).to_series().to_list()
         == out
     )
     assert df["num"].cast(str).str.zfill(5).to_list() == out

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -109,7 +109,7 @@ def test_struct_function_expansion() -> None:
         {"a": [1, 2, 3, 4], "b": ["one", "two", "three", "four"], "c": [9, 8, 7, 6]}
     )
     struct_schema = {"a": pl.UInt32, "b": pl.Utf8}
-    s = df.with_column(pl.struct(pl.col(["a", "b"]), schema=struct_schema))["a"]
+    s = df.with_columns(pl.struct(pl.col(["a", "b"]), schema=struct_schema))["a"]
 
     assert isinstance(s, pl.Series)
     assert s.struct.fields == ["a", "b"]
@@ -150,7 +150,7 @@ def test_value_counts_expr() -> None:
 
 def test_value_counts_logical_type() -> None:
     # test logical type
-    df = pl.DataFrame({"a": ["b", "c"]}).with_column(
+    df = pl.DataFrame({"a": ["b", "c"]}).with_columns(
         pl.col("a").cast(pl.Categorical).alias("ac")
     )
     out = df.select([pl.all().value_counts()])
@@ -163,7 +163,7 @@ def test_nested_struct() -> None:
     # Nest the dataframe
     nest_l1 = df.to_struct("c").to_frame()
     # Add another column on the same level
-    nest_l1 = nest_l1.with_column(pl.col("c").is_null().alias("b"))
+    nest_l1 = nest_l1.with_columns(pl.col("c").is_null().alias("b"))
     # Nest the dataframe again
     nest_l2 = nest_l1.to_struct("a").to_frame()
 
@@ -534,7 +534,7 @@ def test_struct_arr_eval() -> None:
     df = pl.DataFrame(
         {"col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]]}
     )
-    assert df.with_column(
+    assert df.with_columns(
         pl.col("col_struct").arr.eval(pl.element().first()).alias("first")
     ).to_dict(False) == {
         "col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]],
@@ -548,7 +548,7 @@ def test_arr_unique() -> None:
         {"col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]]}
     )
     # the order is unpredictable
-    unique = df.with_column(pl.col("col_struct").arr.unique().alias("unique"))[
+    unique = df.with_columns(pl.col("col_struct").arr.unique().alias("unique"))[
         "unique"
     ].to_list()
     assert len(unique) == 1
@@ -720,7 +720,7 @@ def test_struct_any_value_get_after_append() -> None:
 
 
 def test_struct_categorical_5843() -> None:
-    df = pl.DataFrame({"foo": ["a", "b", "c", "a"]}).with_column(
+    df = pl.DataFrame({"foo": ["a", "b", "c", "a"]}).with_columns(
         pl.col("foo").cast(pl.Categorical)
     )
     result = df.select(pl.col("foo").value_counts(sort=True))

--- a/py-polars/tests/unit/test_timezone.py
+++ b/py-polars/tests/unit/test_timezone.py
@@ -19,7 +19,7 @@ def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
             ]
         }
     )
-    assert times.with_column(
+    assert times.with_columns(
         pl.col("delivery_datetime").str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S%z")
     ).to_dict(False) == {
         "delivery_datetime": [

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -98,13 +98,14 @@ def test_window_function_cache() -> None:
 
 def test_arange_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
-    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore[union-attr]
+    expr = pl.arange(0, pl.count()).over("x")  # type: ignore[union-attr]
+    out = df.with_columns(expr)
     assert out.frame_equal(
         pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "literal": [0, 1, 0, 1, 0, 1]})
     )
 
     df = pl.DataFrame({"x": []})
-    out = df.with_column(pl.arange(0, pl.count()).over("x"))  # type: ignore[union-attr]
+    out = df.with_columns(expr)
     assert out.frame_equal(pl.DataFrame({"x": [], "literal": []}))
 
 
@@ -146,7 +147,7 @@ def test_cumulative_eval_window_functions() -> None:
     )
 
     assert (
-        df.with_column(
+        df.with_columns(
             pl.col("val")
             .cumulative_eval(pl.element().max())
             .over("group")
@@ -166,7 +167,7 @@ def test_count_window() -> None:
                 "a": [1, 1, 2],
             }
         )
-        .with_column(pl.count().over("a"))["count"]
+        .with_columns(pl.count().over("a"))["count"]
         .to_list()
     ) == [2, 2, 1]
 
@@ -227,11 +228,11 @@ def test_sorted_window_expression() -> None:
     )
     expr = (pl.col("a") + pl.col("b")).over("b").alias("computed")
 
-    out1 = df.with_column(expr).sort("b")
+    out1 = df.with_columns(expr).sort("b")
 
     # explicit sort
     df = df.sort("b")
-    out2 = df.with_column(expr)
+    out2 = df.with_columns(expr)
 
     assert out1.frame_equal(out2)
 
@@ -262,7 +263,7 @@ def test_nested_aggregation_window_expression() -> None:
 def test_window_5868() -> None:
     df = pl.DataFrame({"value": [None, 2], "id": [None, 1]})
 
-    assert df.with_column(pl.col("value").max().over("id")).to_dict(False) == {
+    assert df.with_columns(pl.col("value").max().over("id")).to_dict(False) == {
         "value": [None, 2],
         "id": [None, 1],
     }
@@ -279,9 +280,9 @@ def test_window_5868() -> None:
         8,
         8,
     ]
-    assert df.with_column(pl.col("a").set_sorted()).select(pl.col("a").sum().over("a"))[
-        "a"
-    ].to_list() == [None, 1, 2, 9, 9, 9, 8, 8]
+    assert df.with_columns(pl.col("a").set_sorted()).select(
+        pl.col("a").sum().over("a")
+    )["a"].to_list() == [None, 1, 2, 9, 9, 9, 8, 8]
 
     assert df.drop_nulls().select(pl.col("a").sum().over("a"))["a"].to_list() == [
         1,
@@ -292,6 +293,6 @@ def test_window_5868() -> None:
         8,
         8,
     ]
-    assert df.drop_nulls().with_column(pl.col("a").set_sorted()).select(
+    assert df.drop_nulls().with_columns(pl.col("a").set_sorted()).select(
         pl.col("a").sum().over("a")
     )["a"].to_list() == [1, 2, 9, 9, 9, 8, 8]


### PR DESCRIPTION
See #6117. As you can see, this is a big change.

TODO's:
- [x] There are two Python tests failing, as it seems that the behaviour between `with_column` and `with_columns` is different for `Series`. I need to look into this.
- [x] tests for the deprecation warning being raised have to be added
- [x] I haven't touched the Rust api yet, would we want to do the same there?

Probably later this week done.