### PR TITLE
Use auto_doc_cfg

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build Rust documentation
         env:
-          RUSTFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs
         run: cargo doc --features=docs-selection --package polars
 
       - name: Prepare deployment

--- a/polars/polars-algo/src/lib.rs
+++ b/polars/polars-algo/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 mod algo;
 pub use algo::*;
 pub mod prelude;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -30,10 +30,8 @@ mod from;
 pub(crate) mod list;
 pub(crate) mod logical;
 #[cfg(feature = "object")]
-#[cfg_attr(docsrs, doc(cfg(feature = "object")))]
 pub mod object;
 #[cfg(feature = "random")]
-#[cfg_attr(docsrs, doc(cfg(feature = "random")))]
 mod random;
 pub mod strings;
 #[cfg(any(
@@ -41,7 +39,6 @@ pub mod strings;
     feature = "dtype-datetime",
     feature = "dtype-date"
 ))]
-#[cfg_attr(docsrs, doc(cfg(feature = "temporal")))]
 pub mod temporal;
 mod trusted_len;
 pub mod upstream_traits;

--- a/polars/polars-core/src/chunked_array/ndarray.rs
+++ b/polars/polars-core/src/chunked_array/ndarray.rs
@@ -9,7 +9,6 @@ where
 {
     /// If data is aligned in a single chunk and has no Null values a zero copy view is returned
     /// as an `ndarray`
-    #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
     pub fn to_ndarray(&self) -> PolarsResult<ArrayView1<T::Native>> {
         let slice = self.cont_slice()?;
         Ok(aview1(slice))
@@ -18,7 +17,6 @@ where
 
 impl ListChunked {
     /// If all nested `Series` have the same length, a 2 dimensional `ndarray::Array` is returned.
-    #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
     pub fn to_ndarray<N>(&self) -> PolarsResult<Array2<N::Native>>
     where
         N: PolarsNumericType,
@@ -96,7 +94,6 @@ impl DataFrame {
     ///  [2.0, 8.0],
     ///  [3.0, 6.0]], shape=[3, 2], strides=[2, 1], layout=C (0x1), const ndim=2/
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
     pub fn to_ndarray<N>(&self) -> PolarsResult<Array2<N::Native>>
     where
         N: PolarsNumericType,

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -476,7 +476,6 @@ pub trait ChunkUnique<T: PolarsDataType> {
 
     /// The most occurring value(s). Can return multiple Values
     #[cfg(feature = "mode")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "mode")))]
     fn mode(&self) -> PolarsResult<ChunkedArray<T>> {
         Err(PolarsError::InvalidOperation(
             "mode is not implemented for this dtype".into(),
@@ -728,7 +727,6 @@ pub trait ChunkPeaks {
 
 /// Check if element is member of list array
 #[cfg(feature = "is_in")]
-#[cfg_attr(docsrs, doc(cfg(feature = "is_in")))]
 pub trait IsIn {
     /// Check if elements of this array are in the right Series, or List values of the right Series.
     fn is_in(&self, _other: &Series) -> PolarsResult<BooleanChunked> {
@@ -750,7 +748,6 @@ pub trait ArgAgg {
 
 /// Repeat the values `n` times.
 #[cfg(feature = "repeat_by")]
-#[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
 pub trait RepeatBy {
     /// Repeat the values `n` times, where `n` is determined by the values in `by`.
     fn repeat_by(&self, _by: &IdxCa) -> ListChunked {
@@ -759,7 +756,6 @@ pub trait RepeatBy {
 }
 
 #[cfg(feature = "is_first")]
-#[cfg_attr(docsrs, doc(cfg(feature = "is_first")))]
 /// Mask the first unique values as `true`
 pub trait IsFirst<T: PolarsDataType> {
     fn is_first(&self) -> PolarsResult<BooleanChunked> {
@@ -770,7 +766,6 @@ pub trait IsFirst<T: PolarsDataType> {
 }
 
 #[cfg(feature = "is_first")]
-#[cfg_attr(docsrs, doc(cfg(feature = "is_first")))]
 /// Mask the last unique values as `true`
 pub trait IsLast<T: PolarsDataType> {
     fn is_last(&self) -> PolarsResult<BooleanChunked> {
@@ -781,7 +776,6 @@ pub trait IsLast<T: PolarsDataType> {
 }
 
 #[cfg(feature = "concat_str")]
-#[cfg_attr(docsrs, doc(cfg(feature = "concat_str")))]
 /// Concat the values into a string array.
 pub trait StrConcat {
     /// Concat the values into a string array.

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -119,13 +119,11 @@ impl PolarsDataType for ListType {
 }
 
 #[cfg(feature = "object")]
-#[cfg_attr(docsrs, doc(cfg(feature = "object")))]
 pub struct ObjectType<T>(T);
 #[cfg(feature = "object")]
 pub type ObjectChunked<T> = ChunkedArray<ObjectType<T>>;
 
 #[cfg(feature = "object")]
-#[cfg_attr(docsrs, doc(cfg(feature = "object")))]
 impl<T: PolarsObject> PolarsDataType for ObjectType<T> {
     fn get_dtype() -> DataType {
         DataType::Object(T::type_name())

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -619,7 +619,6 @@ fn dispatch_join<T: PolarsNumericType>(
 }
 
 impl DataFrame {
-    #[cfg_attr(docsrs, doc(cfg(feature = "asof_join")))]
     #[allow(clippy::too_many_arguments)]
     #[doc(hidden)]
     pub fn _join_asof_by(
@@ -704,7 +703,6 @@ impl DataFrame {
     /// This is similar to a left-join except that we match on nearest key rather than equal keys.
     /// The keys must be sorted to perform an asof join. This is a special implementation of an asof join
     /// that searches for the nearest keys within a subgroup set by `by`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "asof_join")))]
     #[allow(clippy::too_many_arguments)]
     pub fn join_asof_by<I, S>(
         &self,

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -196,7 +196,6 @@ impl DataFrame {
 
     /// This is similar to a left-join except that we match on nearest key rather than equal keys.
     /// The keys must be sorted to perform an asof join
-    #[cfg_attr(docsrs, doc(cfg(feature = "asof_join")))]
     pub fn join_asof(
         &self,
         other: &DataFrame,

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -2778,7 +2778,6 @@ impl DataFrame {
 
     /// Aggregate the column horizontally to their min values.
     #[cfg(feature = "zip_with")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zip_with")))]
     pub fn hmin(&self) -> PolarsResult<Option<Series>> {
         let min_fn = |acc: &Series, s: &Series| {
             let mask = acc.lt(s)? & acc.is_not_null() | s.is_null();
@@ -2808,7 +2807,6 @@ impl DataFrame {
 
     /// Aggregate the column horizontally to their max values.
     #[cfg(feature = "zip_with")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zip_with")))]
     pub fn hmax(&self) -> PolarsResult<Option<Series>> {
         let max_fn = |acc: &Series, s: &Series| {
             let mask = acc.gt(s)? & acc.is_not_null() | s.is_null();
@@ -3305,7 +3303,6 @@ impl DataFrame {
 
     /// Split into multiple DataFrames partitioned by groups
     #[cfg(feature = "partition_by")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "partition_by")))]
     pub fn partition_by(&self, cols: impl IntoVec<String>) -> PolarsResult<Vec<DataFrame>> {
         let cols = cols.into_vec();
         self._partition_by_impl(&cols, false)
@@ -3314,7 +3311,6 @@ impl DataFrame {
     /// Split into multiple DataFrames partitioned by groups
     /// Order of the groups are maintained.
     #[cfg(feature = "partition_by")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "partition_by")))]
     pub fn partition_by_stable(&self, cols: impl IntoVec<String>) -> PolarsResult<Vec<DataFrame>> {
         let cols = cols.into_vec();
         self._partition_by_impl(&cols, true)
@@ -3323,7 +3319,6 @@ impl DataFrame {
     /// Unnest the given `Struct` columns. This means that the fields of the `Struct` type will be
     /// inserted as columns.
     #[cfg(feature = "dtype-struct")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dtype-struct")))]
     pub fn unnest<I: IntoVec<String>>(&self, cols: I) -> PolarsResult<DataFrame> {
         let cols = cols.into_vec();
         self.unnest_impl(cols.into_iter().collect())

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -18,7 +18,6 @@ impl<'a> Row<'a> {
 
 impl DataFrame {
     /// Get a row from a DataFrame. Use of this is discouraged as it will likely be slow.
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub fn get_row(&self, idx: usize) -> PolarsResult<Row> {
         let values = self
             .columns
@@ -31,7 +30,6 @@ impl DataFrame {
     /// Amortize allocations by reusing a row.
     /// The caller is responsible to make sure that the row has at least the capacity for the number
     /// of columns in the DataFrame
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub fn get_row_amortized<'a>(&'a self, idx: usize, row: &mut Row<'a>) -> PolarsResult<()> {
         for (s, any_val) in self.columns.iter().zip(&mut row.0) {
             *any_val = s.get(idx)?;
@@ -46,7 +44,6 @@ impl DataFrame {
     /// # Safety
     /// Does not do any bounds checking.
     #[inline]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub unsafe fn get_row_amortized_unchecked<'a>(&'a self, idx: usize, row: &mut Row<'a>) {
         self.columns
             .iter()
@@ -58,14 +55,12 @@ impl DataFrame {
 
     /// Create a new DataFrame from rows. This should only be used when you have row wise data,
     /// as this is a lot slower than creating the `Series` in a columnar fashion
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub fn from_rows_and_schema(rows: &[Row], schema: &Schema) -> PolarsResult<Self> {
         Self::from_rows_iter_and_schema(rows.iter(), schema)
     }
 
     /// Create a new DataFrame from an iterator over rows. This should only be used when you have row wise data,
     /// as this is a lot slower than creating the `Series` in a columnar fashion
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub fn from_rows_iter_and_schema<'a, I>(mut rows: I, schema: &Schema) -> PolarsResult<Self>
     where
         I: Iterator<Item = &'a Row<'a>>,
@@ -108,7 +103,6 @@ impl DataFrame {
 
     /// Create a new DataFrame from rows. This should only be used when you have row wise data,
     /// as this is a lot slower than creating the `Series` in a columnar fashion
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     pub fn from_rows(rows: &[Row]) -> PolarsResult<Self> {
         let schema = rows_to_schema_first_non_null(rows, Some(50));
         let has_nulls = schema
@@ -177,7 +171,6 @@ impl DataFrame {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "rows")))]
     /// Transpose a DataFrame. This is a very expensive operation.
     pub fn transpose(&self) -> PolarsResult<DataFrame> {
         let height = self.height();

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -136,7 +136,6 @@ impl<'a> IterBroadCast<'a> {
 /// The concatenated strings are separated by a `delimiter`.
 /// If no `delimiter` is needed, an empty &str should be passed as argument.
 #[cfg(feature = "concat_str")]
-#[cfg_attr(docsrs, doc(cfg(feature = "concat_str")))]
 pub fn concat_str(s: &[Series], delimiter: &str) -> PolarsResult<Utf8Chunked> {
     if s.is_empty() {
         return Err(PolarsError::NoData(
@@ -212,7 +211,6 @@ pub fn concat_str(s: &[Series], delimiter: &str) -> PolarsResult<Utf8Chunked> {
 
 /// Concat `[DataFrame]`s horizontally.
 #[cfg(feature = "horizontal_concat")]
-#[cfg_attr(docsrs, doc(cfg(feature = "horizontal_concat")))]
 /// Concat horizontally and extend with null values if lengths don't match
 pub fn hor_concat_df(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
     let max_len = dfs
@@ -253,7 +251,6 @@ pub fn hor_concat_df(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
 
 /// Concat `[DataFrame]`s diagonally.
 #[cfg(feature = "diagonal_concat")]
-#[cfg_attr(docsrs, doc(cfg(feature = "diagonal_concat")))]
 /// Concat diagonally thereby combining different schemas.
 pub fn diag_concat_df(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
     // TODO! replace with lazy only?

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate core;
 
 #[macro_use]
@@ -17,7 +17,6 @@ mod named_from;
 pub mod prelude;
 pub mod schema;
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde;
 pub mod series;
 pub mod testing;

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -63,7 +63,6 @@ where
             .map(|ca| ca.into_series())
     }
 }
-#[cfg_attr(docsrs, doc(cfg(feature = "object")))]
 impl<T> SeriesTrait for SeriesWrap<ObjectChunked<T>>
 where
     T: PolarsObject,

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -370,7 +370,6 @@ impl Series {
     /// Create a new ChunkedArray with values from self where the mask evaluates `true` and values
     /// from `other` where the mask evaluates `false`
     #[cfg(feature = "zip_with")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zip_with")))]
     pub fn zip_with(&self, mask: &BooleanChunked, other: &Series) -> PolarsResult<Series> {
         let (lhs, rhs) = coerce_lhs_rhs(self, other)?;
         lhs.zip_with_same_type(mask, rhs.as_ref())
@@ -511,7 +510,6 @@ impl Series {
     }
 
     #[cfg(feature = "dot_product")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_product")))]
     pub fn dot(&self, other: &Series) -> Option<f64> {
         (self * other).sum::<f64>()
     }
@@ -536,7 +534,6 @@ impl Series {
     }
 
     /// Get an array with the cumulative max computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cummax(&self, _reverse: bool) -> Series {
         #[cfg(feature = "cum_agg")]
         {
@@ -549,7 +546,6 @@ impl Series {
     }
 
     /// Get an array with the cumulative min computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cummin(&self, _reverse: bool) -> Series {
         #[cfg(feature = "cum_agg")]
         {
@@ -565,7 +561,6 @@ impl Series {
     ///
     /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16}` the `Series` is
     /// first cast to `Int64` to prevent overflow issues.
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     #[allow(unused_variables)]
     pub fn cumsum(&self, reverse: bool) -> Series {
         #[cfg(feature = "cum_agg")]
@@ -614,7 +609,6 @@ impl Series {
     ///
     /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16, Int32, UInt32}` the `Series` is
     /// first cast to `Int64` to prevent overflow issues.
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     #[allow(unused_variables)]
     pub fn cumprod(&self, reverse: bool) -> Series {
         #[cfg(feature = "cum_agg")]
@@ -655,7 +649,6 @@ impl Series {
     ///
     /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16}` the `Series` is
     /// first cast to `Int64` to prevent overflow issues.
-    #[cfg_attr(docsrs, doc(cfg(feature = "product")))]
     pub fn product(&self) -> Series {
         #[cfg(feature = "product")]
         {
@@ -688,7 +681,6 @@ impl Series {
     }
 
     #[cfg(feature = "rank")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
     pub fn rank(&self, options: RankOptions) -> Series {
         rank(self, options.method, options.descending)
     }
@@ -807,7 +799,6 @@ impl Series {
     }
 
     #[cfg(feature = "abs")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "abs")))]
     /// convert numerical values to their absolute value
     pub fn abs(&self) -> PolarsResult<Series> {
         let a = self.to_physical_repr();

--- a/polars/polars-core/src/series/ops/diff.rs
+++ b/polars/polars-core/src/series/ops/diff.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use crate::series::ops::NullBehavior;
 
 impl Series {
-    #[cfg_attr(docsrs, doc(cfg(feature = "diff")))]
     pub fn diff(&self, n: usize, null_behavior: NullBehavior) -> Series {
         use DataType::*;
         let s = match self.dtype() {

--- a/polars/polars-core/src/series/ops/mod.rs
+++ b/polars/polars-core/src/series/ops/mod.rs
@@ -1,20 +1,15 @@
 #[cfg(feature = "diff")]
-#[cfg_attr(docsrs, doc(cfg(feature = "diff")))]
 pub mod diff;
 mod downcast;
 #[cfg(feature = "ewma")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ewma")))]
 mod ewm;
 mod extend;
 #[cfg(feature = "moment")]
-#[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
 pub mod moment;
 mod null;
 #[cfg(feature = "pct_change")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pct_change")))]
 pub mod pct_change;
 #[cfg(feature = "round_series")]
-#[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
 mod round;
 mod to_list;
 mod unique;

--- a/polars/polars-core/src/series/ops/moment.rs
+++ b/polars/polars-core/src/series/ops/moment.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
 fn moment_precomputed_mean(s: &Series, moment: usize, mean: f64) -> PolarsResult<Option<f64>> {
     // see: https://github.com/scipy/scipy/blob/47bb6febaa10658c72962b9615d5d5aa2513fa3a/scipy/stats/stats.py#L922
     let out = match moment {
@@ -48,7 +47,6 @@ impl Series {
     /// is close enough to zero, statistically speaking.
     ///
     /// see: https://github.com/scipy/scipy/blob/47bb6febaa10658c72962b9615d5d5aa2513fa3a/scipy/stats/stats.py#L1024
-    #[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
     pub fn skew(&self, bias: bool) -> PolarsResult<Option<f64>> {
         let mean = match self.mean() {
             Some(mean) => mean,
@@ -77,7 +75,6 @@ impl Series {
     /// eliminate bias coming from biased moment estimators
     ///
     /// see: https://github.com/scipy/scipy/blob/47bb6febaa10658c72962b9615d5d5aa2513fa3a/scipy/stats/stats.py#L1027
-    #[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
     pub fn kurtosis(&self, fisher: bool, bias: bool) -> PolarsResult<Option<f64>> {
         let mean = match self.mean() {
             Some(mean) => mean,

--- a/polars/polars-core/src/series/ops/pct_change.rs
+++ b/polars/polars-core/src/series/ops/pct_change.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use crate::series::ops::NullBehavior;
 
 impl Series {
-    #[cfg_attr(docsrs, doc(cfg(feature = "pct_change")))]
     pub fn pct_change(&self, n: usize) -> PolarsResult<Series> {
         match self.dtype() {
             DataType::Float64 | DataType::Float32 => {}

--- a/polars/polars-core/src/series/ops/round.rs
+++ b/polars/polars-core/src/series/ops/round.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 impl Series {
     /// Round underlying floating point array to given decimal.
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn round(&self, decimals: u32) -> PolarsResult<Self> {
         use num::traits::Pow;
         if let Ok(ca) = self.f32() {
@@ -26,7 +25,6 @@ impl Series {
         ))
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.
     pub fn floor(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
@@ -42,7 +40,6 @@ impl Series {
         ))
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     pub fn ceil(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
@@ -58,7 +55,6 @@ impl Series {
         ))
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     /// Clamp underlying values to the `min` and `max` values.
     pub fn clip(mut self, min: AnyValue<'_>, max: AnyValue<'_>) -> PolarsResult<Self> {
         if self.dtype().is_numeric() {
@@ -84,7 +80,6 @@ impl Series {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     /// Clamp underlying values to the `max` value.
     pub fn clip_max(mut self, max: AnyValue<'_>) -> PolarsResult<Self> {
         use num::traits::clamp_max;
@@ -108,7 +103,6 @@ impl Series {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     /// Clamp underlying values to the `min` value.
     pub fn clip_min(mut self, min: AnyValue<'_>) -> PolarsResult<Self> {
         use num::traits::clamp_min;

--- a/polars/polars-core/src/series/ops/unique.rs
+++ b/polars/polars-core/src/series/ops/unique.rs
@@ -8,7 +8,6 @@ use crate::prelude::*;
 use crate::utils::NoNull;
 
 #[cfg(feature = "unique_counts")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unique_counts")))]
 fn unique_counts<I, J>(items: I) -> IdxCa
 where
     I: Iterator<Item = J>,
@@ -29,7 +28,6 @@ where
 impl Series {
     /// Returns a count of the unique values in the order of appearance.
     #[cfg(feature = "unique_counts")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unique_counts")))]
     pub fn unique_counts(&self) -> IdxCa {
         if self.dtype().to_physical().is_numeric() {
             if self.bit_repr_is_large() {

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -327,7 +327,6 @@ pub trait SeriesTrait:
     /// Take by index from an iterator. This operation clones the data.
     /// todo! remove?
     #[cfg(feature = "take_opt_iter")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "take_opt_iter")))]
     fn take_opt_iter(&self, _iter: &mut dyn TakeIteratorNulls) -> PolarsResult<Series> {
         invalid_operation_panic!(self)
     }
@@ -601,7 +600,6 @@ pub trait SeriesTrait:
     }
 
     #[cfg(feature = "object")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "object")))]
     /// Get the value at this index as a downcastable Any trait ref.
     fn get_object(&self, _index: usize) -> Option<&dyn PolarsObjectSafe> {
         invalid_operation_panic!(self)
@@ -631,37 +629,31 @@ pub trait SeriesTrait:
 
     /// Check if elements of this Series are in the right Series, or List values of the right Series.
     #[cfg(feature = "is_in")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "is_in")))]
     fn is_in(&self, _other: &Series) -> PolarsResult<BooleanChunked> {
         invalid_operation_panic!(self)
     }
     #[cfg(feature = "repeat_by")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
     fn repeat_by(&self, _by: &IdxCa) -> ListChunked {
         invalid_operation_panic!(self)
     }
     #[cfg(feature = "checked_arithmetic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "checked_arithmetic")))]
     fn checked_div(&self, _rhs: &Series) -> PolarsResult<Series> {
         invalid_operation_panic!(self)
     }
 
     #[cfg(feature = "is_first")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "is_first")))]
     /// Get a mask of the first unique values.
     fn is_first(&self) -> PolarsResult<BooleanChunked> {
         invalid_operation_panic!(self)
     }
 
     #[cfg(feature = "mode")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "mode")))]
     /// Compute the most occurring element in the array.
     fn mode(&self) -> PolarsResult<Series> {
         invalid_operation_panic!(self)
     }
 
     #[cfg(feature = "rolling_window")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     /// Apply a custom function over a rolling/ moving window of the array.
     /// This has quite some dynamic dispatch, so prefer rolling_min, max, mean, sum over this.
     fn rolling_apply(
@@ -672,7 +664,6 @@ pub trait SeriesTrait:
         panic!("rolling apply not implemented for this dtype. Only implemented for numeric data.")
     }
     #[cfg(feature = "concat_str")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "concat_str")))]
     /// Concat the values into a string array.
     /// # Arguments
     ///

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -1,22 +1,16 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "avro")]
-#[cfg_attr(docsrs, doc(cfg(feature = "avro")))]
 pub mod avro;
 #[cfg(any(feature = "csv-file", feature = "json"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "csv-file")))]
 pub mod csv;
 #[cfg(feature = "parquet")]
-#[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
 pub mod export;
 #[cfg(any(feature = "ipc", feature = "ipc_streaming"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "ipc", feature = "ipc_streaming"))))]
 pub mod ipc;
 #[cfg(feature = "json")]
-#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
 #[cfg(feature = "json")]
-#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod ndjson_core;
 #[cfg(feature = "object_store")]
 mod object_store;
@@ -32,7 +26,6 @@ pub use crate::object_store::glob as async_glob;
 pub mod mmap;
 mod options;
 #[cfg(feature = "parquet")]
-#[cfg_attr(docsrs, doc(cfg(feature = "feature")))]
 pub mod parquet;
 #[cfg(feature = "private")]
 pub mod predicates;

--- a/polars/polars-lazy/polars-plan/src/dot.rs
+++ b/polars/polars-lazy/polars-plan/src/dot.rs
@@ -8,7 +8,6 @@ use crate::utils::expr_to_leaf_column_names;
 
 impl Expr {
     /// Get a dot language representation of the Expression.
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_diagram")))]
     pub fn to_dot(&self) -> PolarsResult<String> {
         let mut s = String::with_capacity(512);
         self.dot_viz(&mut s, (0, 0), "").expect("io error");
@@ -35,7 +34,6 @@ impl Expr {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_diagram")))]
     fn dot_viz(
         &self,
         acc_str: &mut String,
@@ -122,7 +120,6 @@ impl LogicalPlan {
     ///     Used to make sure that the dot boxes are distinct.
     ///     branch is an id per join/union branch
     ///     id is incremented by the depth traversal of the tree.
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_diagram")))]
     pub fn dot(
         &self,
         acc_str: &mut String,

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -87,7 +87,6 @@ impl DateLikeNameSpace {
     // This method takes a naive Datetime Series and makes this time zone aware.
     // It does not move the time to another time zone.
     #[cfg(feature = "timezones")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "timezones")))]
     pub fn tz_localize(self, tz: TimeZone) -> Expr {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::TzLocalize(tz)))
@@ -212,13 +211,11 @@ impl DateLikeNameSpace {
     /// Offset this `Date/Datetime` by a given offset [`Duration`].
     /// This will take leap years/ months into account.
     #[cfg(feature = "date_offset")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "date_offset")))]
     pub fn offset_by(self, by: Duration) -> Expr {
         self.0.map_private(FunctionExpr::DateOffset(by))
     }
 
     #[cfg(feature = "timezones")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "timezones")))]
     pub fn cast_time_zone(self, tz: TimeZone) -> Expr {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::CastTimezone(

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -178,7 +178,6 @@ pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
 ///     If to `false` then `NaN` are regarded as larger than any finite number
 ///     and thus lead to the highest rank.
 #[cfg(all(feature = "rank", feature = "propagate_nans"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "rank", feature = "propagate_nans"))))]
 pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> Expr {
     use polars_ops::prelude::nan_propagating_aggregate::nan_max_s;
 
@@ -254,7 +253,6 @@ pub fn argsort_by<E: AsRef<[Expr]>>(by: E, reverse: &[bool]) -> Expr {
 }
 
 #[cfg(all(feature = "concat_str", feature = "strings"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "concat_str")))]
 /// Horizontally concat string columns in linear time
 pub fn concat_str<E: AsRef<[Expr]>>(s: E, sep: &str) -> Expr {
     let input = s.as_ref().to_vec();
@@ -273,7 +271,6 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, sep: &str) -> Expr {
 }
 
 #[cfg(all(feature = "concat_str", feature = "strings"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "format_str")))]
 /// Format the results of an array of expressions using a format string
 pub fn format_str<E: AsRef<[Expr]>>(format: &str, args: E) -> PolarsResult<Expr> {
     let mut args: std::collections::VecDeque<Expr> = args.as_ref().to_vec().into();
@@ -324,7 +321,6 @@ pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> Expr {
 /// - if `low` and `high` are a column, every element will expand into an array in a list column.
 /// - if `low` and `high` are literals the output will be of `Int64`.
 #[cfg(feature = "arange")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arange")))]
 pub fn arange(low: Expr, high: Expr, step: usize) -> Expr {
     let has_col_without_agg = |e: &Expr| {
         has_expr(e, |ae| matches!(ae, Expr::Column(_)))
@@ -850,7 +846,6 @@ where
 
 /// Accumulate over multiple columns horizontally / row wise.
 #[cfg(feature = "dtype-struct")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
 pub fn cumreduce_exprs<F: 'static, E: AsRef<[Expr]>>(f: F, exprs: E) -> Expr
 where
     F: Fn(Series, Series) -> PolarsResult<Series> + Send + Sync + Clone,
@@ -896,7 +891,6 @@ where
 
 /// Accumulate over multiple columns horizontally / row wise.
 #[cfg(feature = "dtype-struct")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
 pub fn cumfold_exprs<F: 'static, E: AsRef<[Expr]>>(
     acc: Expr,
     f: F,
@@ -1071,7 +1065,6 @@ pub fn repeat<L: Literal>(value: L, n_times: Expr) -> Expr {
 }
 
 #[cfg(feature = "arg_where")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arg_where")))]
 /// Get the indices where `condition` evaluates `true`.
 pub fn arg_where<E: Into<Expr>>(condition: E) -> Expr {
     let condition = condition.into();

--- a/polars/polars-lazy/polars-plan/src/dsl/list.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/list.rs
@@ -128,7 +128,6 @@ impl ListNameSpace {
     /// - `null_on_oob`: Return a null when an index is out of bounds.
     /// This behavior is more expensive than defaulting to returing an `Error`.
     #[cfg(feature = "list_take")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "list_take")))]
     pub fn take(self, index: Expr, null_on_oob: bool) -> Expr {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Take(null_on_oob)),
@@ -182,7 +181,6 @@ impl ListNameSpace {
 
     /// Diff every sublist.
     #[cfg(feature = "diff")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "diff")))]
     pub fn diff(self, n: usize, null_behavior: NullBehavior) -> Expr {
         self.0
             .map(
@@ -222,7 +220,6 @@ impl ListNameSpace {
     }
 
     #[cfg(feature = "list_to_struct")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "list_to_struct")))]
     #[allow(clippy::wrong_self_convention)]
     /// Convert this `List` to a `Series` of type `Struct`. The width will be determined according to
     /// `ListToStructWidthStrategy` and the names of the fields determined by the given `name_generator`.
@@ -279,7 +276,6 @@ impl ListNameSpace {
     }
 
     #[cfg(feature = "is_in")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "is_in")))]
     /// Check if the list array contain an element
     pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
         let other = other.into();

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -875,7 +875,6 @@ impl Expr {
     }
 
     /// Get an array with the cumulative sum computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cumsum(self, reverse: bool) -> Self {
         self.apply(
             move |s: Series| Ok(s.cumsum(reverse)),
@@ -900,7 +899,6 @@ impl Expr {
     }
 
     /// Get an array with the cumulative product computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cumprod(self, reverse: bool) -> Self {
         self.apply(
             move |s: Series| Ok(s.cumprod(reverse)),
@@ -919,7 +917,6 @@ impl Expr {
     }
 
     /// Get an array with the cumulative min computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cummin(self, reverse: bool) -> Self {
         self.apply(
             move |s: Series| Ok(s.cummin(reverse)),
@@ -929,7 +926,6 @@ impl Expr {
     }
 
     /// Get an array with the cumulative max computed at every element
-    #[cfg_attr(docsrs, doc(cfg(feature = "cum_agg")))]
     pub fn cummax(self, reverse: bool) -> Self {
         self.apply(
             move |s: Series| Ok(s.cummax(reverse)),
@@ -939,7 +935,6 @@ impl Expr {
     }
 
     /// Get the product aggregation of an expression
-    #[cfg_attr(docsrs, doc(cfg(feature = "product")))]
     pub fn product(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
@@ -982,7 +977,6 @@ impl Expr {
 
     /// Round underlying floating point array to given decimal numbers.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn round(self, decimals: u32) -> Self {
         self.map(move |s: Series| s.round(decimals), GetOutput::same_type())
             .with_fmt("round")
@@ -990,7 +984,6 @@ impl Expr {
 
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn floor(self) -> Self {
         self.map(move |s: Series| s.floor(), GetOutput::same_type())
             .with_fmt("floor")
@@ -998,7 +991,6 @@ impl Expr {
 
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn ceil(self) -> Self {
         self.map(move |s: Series| s.ceil(), GetOutput::same_type())
             .with_fmt("ceil")
@@ -1006,7 +998,6 @@ impl Expr {
 
     /// Clip underlying values to a set boundary.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn clip(self, min: AnyValue<'_>, max: AnyValue<'_>) -> Self {
         self.map_private(FunctionExpr::Clip {
             min: Some(min.into_static().unwrap()),
@@ -1016,7 +1007,6 @@ impl Expr {
 
     /// Clip underlying values to a set boundary.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn clip_max(self, max: AnyValue<'_>) -> Self {
         self.map_private(FunctionExpr::Clip {
             min: None,
@@ -1026,7 +1016,6 @@ impl Expr {
 
     /// Clip underlying values to a set boundary.
     #[cfg(feature = "round_series")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "round_series")))]
     pub fn clip_min(self, min: AnyValue<'_>) -> Self {
         self.map_private(FunctionExpr::Clip {
             min: Some(min.into_static().unwrap()),
@@ -1036,7 +1025,6 @@ impl Expr {
 
     /// Convert all values to their absolute/positive value.
     #[cfg(feature = "abs")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "abs")))]
     pub fn abs(self) -> Self {
         self.map(move |s: Series| s.abs(), GetOutput::same_type())
             .with_fmt("abs")
@@ -1380,7 +1368,6 @@ impl Expr {
     /// Check if the values of the left expression are in the lists of the right expr.
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_in")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "is_in")))]
     pub fn is_in<E: Into<Expr>>(self, other: E) -> Self {
         let other = other.into();
         let has_literal = has_root_literal_expr(&other);
@@ -1437,7 +1424,6 @@ impl Expr {
     }
 
     #[cfg(feature = "repeat_by")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "repeat_by")))]
     /// Repeat the column `n` times, where `n` is determined by the values in `by`.
     /// This yields an `Expr` of dtype `List`
     pub fn repeat_by<E: Into<Expr>>(self, by: E) -> Expr {
@@ -1445,7 +1431,6 @@ impl Expr {
     }
 
     #[cfg(feature = "is_first")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "is_first")))]
     #[allow(clippy::wrong_self_convention)]
     /// Get a mask of the first unique value.
     pub fn is_first(self) -> Expr {
@@ -1465,13 +1450,11 @@ impl Expr {
     }
 
     #[cfg(feature = "dot_product")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_product")))]
     pub fn dot<E: Into<Expr>>(self, other: E) -> Expr {
         self.dot_impl(other.into())
     }
 
     #[cfg(feature = "mode")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "mode")))]
     /// Compute the mode(s) of this column. This is the most occurring value.
     pub fn mode(self) -> Expr {
         self.apply(
@@ -1561,7 +1544,6 @@ impl Expr {
 
     // Interpolate None values
     #[cfg(feature = "interpolate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "interpolate")))]
     pub fn interpolate(self, method: InterpolationMethod) -> Expr {
         self.apply_private(FunctionExpr::Interpolate(method))
     }
@@ -1632,7 +1614,6 @@ impl Expr {
 
     /// Apply a rolling min See:
     /// [ChunkedArray::rolling_min]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_min(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1645,7 +1626,6 @@ impl Expr {
 
     /// Apply a rolling max See:
     /// [ChunkedArray::rolling_max]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_max(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1658,7 +1638,6 @@ impl Expr {
 
     /// Apply a rolling mean See:
     /// [ChunkedArray::rolling_mean]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_mean(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1671,7 +1650,6 @@ impl Expr {
 
     /// Apply a rolling sum See:
     /// [ChunkedArray::rolling_sum]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_sum(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1684,7 +1662,6 @@ impl Expr {
 
     /// Apply a rolling median See:
     /// [`ChunkedArray::rolling_median`]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_median(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1697,7 +1674,6 @@ impl Expr {
 
     /// Apply a rolling quantile See:
     /// [`ChunkedArray::rolling_quantile`]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_quantile(
         self,
@@ -1714,7 +1690,6 @@ impl Expr {
     }
 
     /// Apply a rolling variance
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_var(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1726,7 +1701,6 @@ impl Expr {
     }
 
     /// Apply a rolling std-dev
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     pub fn rolling_std(self, options: RollingOptions) -> Expr {
         self.finish_rolling(
@@ -1738,14 +1712,12 @@ impl Expr {
     }
 
     /// Apply a rolling skew
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "rolling_window", feature = "moment"))))]
     #[cfg(feature = "rolling_window")]
     #[cfg(feature = "moment")]
     pub fn rolling_skew(self, window_size: usize, bias: bool) -> Expr {
         self.apply_private(FunctionExpr::RollingSkew { window_size, bias })
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     /// Apply a custom function over a rolling/ moving window of the array.
     /// This has quite some dynamic dispatch, so prefer rolling_min, max, mean, sum over this.
@@ -1762,7 +1734,6 @@ impl Expr {
         .with_fmt("rolling_apply")
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "rolling_window")))]
     #[cfg(feature = "rolling_window")]
     /// Apply a custom function over a rolling/ moving window of the array.
     /// Prefer this over rolling_apply in case of floating point numbers as this is faster.
@@ -1802,7 +1773,6 @@ impl Expr {
     }
 
     #[cfg(feature = "rank")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rank")))]
     pub fn rank(self, options: RankOptions) -> Expr {
         self.apply(
             move |s| Ok(s.rank(options)),
@@ -1815,13 +1785,11 @@ impl Expr {
     }
 
     #[cfg(feature = "diff")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "diff")))]
     pub fn diff(self, n: usize, null_behavior: NullBehavior) -> Expr {
         self.apply_private(FunctionExpr::Diff(n, null_behavior))
     }
 
     #[cfg(feature = "pct_change")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "pct_change")))]
     pub fn pct_change(self, n: usize) -> Expr {
         use DataType::*;
         self.apply(
@@ -1835,7 +1803,6 @@ impl Expr {
     }
 
     #[cfg(feature = "moment")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
     /// Compute the sample skewness of a data set.
     ///
     /// For normally distributed data, the skewness should be about zero. For
@@ -1858,7 +1825,6 @@ impl Expr {
     }
 
     #[cfg(feature = "moment")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "moment")))]
     pub fn kurtosis(self, fisher: bool, bias: bool) -> Expr {
         self.apply(
             move |s| {
@@ -2113,7 +2079,6 @@ impl Expr {
     }
 
     #[cfg(feature = "dtype-struct")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dtype-struct")))]
     /// Count all unique values and create a struct mapping value to count
     /// Note that it is better to turn multithreaded off in the aggregation context
     pub fn value_counts(self, multithreaded: bool, sorted: bool) -> Self {
@@ -2133,7 +2098,6 @@ impl Expr {
     }
 
     #[cfg(feature = "unique_counts")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unique_counts")))]
     /// Returns a count of the unique values in the order of appearance.
     /// This method differs from [`Expr::value_counts]` in that it does not return the
     /// values, only the counts and might be faster
@@ -2146,7 +2110,6 @@ impl Expr {
     }
 
     #[cfg(feature = "log")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     /// Compute the logarithm to a given base
     pub fn log(self, base: f64) -> Self {
         self.map(
@@ -2163,7 +2126,6 @@ impl Expr {
     }
 
     #[cfg(feature = "log")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     /// Calculate the exponential of all elements in the input array
     pub fn exp(self) -> Self {
         self.map(
@@ -2180,7 +2142,6 @@ impl Expr {
     }
 
     #[cfg(feature = "log")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     /// Compute the entropy as `-sum(pk * log(pk)`.
     /// where `pk` are discrete probabilities.
     pub fn entropy(self, base: f64, normalize: bool) -> Self {

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -51,7 +51,6 @@ impl StringNameSpace {
     /// rather than before.
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     pub fn zfill(self, alignment: usize) -> Expr {
         self.0.map_private(StringFunction::Zfill(alignment).into())
     }
@@ -60,7 +59,6 @@ impl StringNameSpace {
     /// Padding is done using the specified `fillchar`,
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     pub fn ljust(self, width: usize, fillchar: char) -> Expr {
         self.0
             .map_private(StringFunction::LJust { width, fillchar }.into())
@@ -70,7 +68,6 @@ impl StringNameSpace {
     /// Padding is done using the specified `fillchar`,
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     pub fn rjust(self, width: usize, fillchar: char) -> Expr {
         self.0
             .map_private(StringFunction::RJust { width, fillchar }.into())

--- a/polars/polars-lazy/polars-plan/src/lib.rs
+++ b/polars/polars-lazy/polars-plan/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod dot;
 pub mod dsl;

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -98,7 +98,6 @@ impl LogicalPlanBuilder {
     }
 
     #[cfg(any(feature = "parquet", feature = "parquet_async"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     pub fn scan_parquet<P: Into<PathBuf>>(
         path: P,
         n_rows: Option<usize>,
@@ -155,7 +154,6 @@ impl LogicalPlanBuilder {
     }
 
     #[cfg(feature = "ipc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
     pub fn scan_ipc<P: Into<PathBuf>>(path: P, options: IpcScanOptions) -> PolarsResult<Self> {
         use polars_io::SerReader as _;
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -96,7 +96,6 @@ pub enum LogicalPlan {
         predicate: Option<Expr>,
     },
     #[cfg(feature = "parquet")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     /// Scan a Parquet file
     ParquetScan {
         path: PathBuf,
@@ -105,7 +104,6 @@ pub enum LogicalPlan {
         options: ParquetOptions,
     },
     #[cfg(feature = "ipc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
     IpcScan {
         path: PathBuf,
         file_info: FileInfo,

--- a/polars/polars-lazy/src/dot.rs
+++ b/polars/polars-lazy/src/dot.rs
@@ -8,7 +8,6 @@ use crate::prelude::*;
 
 impl LazyFrame {
     /// Get a dot language representation of the LogicalPlan.
-    #[cfg_attr(docsrs, doc(cfg(feature = "dot_diagram")))]
     pub fn to_dot(&self, optimized: bool) -> PolarsResult<String> {
         let mut s = String::with_capacity(512);
 

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -51,7 +51,6 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
 }
 
 #[cfg(feature = "diagonal_concat")]
-#[cfg_attr(docsrs, doc(cfg(feature = "diagonal_concat")))]
 /// Concat [LazyFrame]s diagonally.
 /// Calls [concat] internally.
 pub fn diag_concat_lf<L: AsRef<[LazyFrame]>>(

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -25,7 +25,6 @@ impl IntoListNameSpace for ListNameSpace {
 pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
     /// Run any [`Expr`] on these lists elements
     #[cfg(feature = "list_eval")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "list_eval")))]
     fn eval(self, expr: Expr, parallel: bool) -> Expr {
         let this = self.into_list_name_space();
 

--- a/polars/polars-lazy/src/frame/ipc.rs
+++ b/polars/polars-lazy/src/frame/ipc.rs
@@ -51,7 +51,6 @@ impl LazyFrame {
     }
 
     /// Create a LazyFrame directly from a ipc scan.
-    #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
     pub fn scan_ipc(path: impl AsRef<Path>, args: ScanArgsIpc) -> PolarsResult<Self> {
         let path = path.as_ref();
         let path_str = path.to_string_lossy();

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -154,7 +154,6 @@ impl LazyFrame {
 
     /// Toggle common subplan elimination optimization on or off
     #[cfg(feature = "cse")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "cse")))]
     pub fn with_common_subplan_elimination(mut self, toggle: bool) -> Self {
         self.opt_state.common_subplan_elimination = toggle;
         self
@@ -724,7 +723,6 @@ impl LazyFrame {
     /// individual values and are not of constant intervals. For constant intervals use
     /// *groupby_dynamic*
     #[cfg(feature = "dynamic_groupby")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dynamic_groupby")))]
     pub fn groupby_rolling<E: AsRef<[Expr]>>(
         self,
         by: E,
@@ -757,7 +755,6 @@ impl LazyFrame {
     /// The `by` argument should be empty `[]` if you don't want to combine this
     /// with a ordinary groupby on these keys.
     #[cfg(feature = "dynamic_groupby")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dynamic_groupby")))]
     pub fn groupby_dynamic<E: AsRef<[Expr]>>(
         self,
         by: E,
@@ -1194,7 +1191,6 @@ impl LazyFrame {
     /// Unnest the given `Struct` columns. This means that the fields of the `Struct` type will be
     /// inserted as columns.
     #[cfg(feature = "dtype-struct")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dtype-struct")))]
     pub fn unnest<I: IntoIterator<Item = S>, S: AsRef<str>>(self, cols: I) -> Self {
         self.map_private(FunctionNode::Unnest {
             columns: Arc::new(cols.into_iter().map(|s| Arc::from(s.as_ref())).collect()),

--- a/polars/polars-lazy/src/frame/parquet.rs
+++ b/polars/polars-lazy/src/frame/parquet.rs
@@ -75,7 +75,6 @@ impl LazyFrame {
     }
 
     /// Create a LazyFrame directly from a parquet scan.
-    #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     #[deprecated(note = "please use `concat_lf` instead")]
     pub fn scan_parquet_files<P: AsRef<Path>>(
         paths: Vec<P>,
@@ -100,7 +99,6 @@ impl LazyFrame {
     }
 
     /// Create a LazyFrame directly from a parquet scan.
-    #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
     pub fn scan_parquet(path: impl AsRef<Path>, args: ScanArgsParquet) -> PolarsResult<Self> {
         let path = path.as_ref();
         let path_str = path.to_string_lossy();

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -182,7 +182,7 @@
 //!      )
 //! }
 //! ```
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate core;
 
 #[cfg(feature = "dot_diagram")]

--- a/polars/polars-ops/src/chunked_array/binary/mod.rs
+++ b/polars/polars-ops/src/chunked_array/binary/mod.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(docsrs, doc(cfg(feature = "dtype-binary")))]
 mod namespace;
 
 pub use namespace::*;

--- a/polars/polars-ops/src/chunked_array/list/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/list/namespace.rs
@@ -174,7 +174,6 @@ pub trait ListNameSpaceImpl: AsList {
     }
 
     #[cfg(feature = "diff")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "diff")))]
     fn lst_diff(&self, n: usize, null_behavior: NullBehavior) -> ListChunked {
         let ca = self.as_list();
         ca.apply_amortized(|s| s.as_ref().diff(n, null_behavior))

--- a/polars/polars-ops/src/chunked_array/strings/mod.rs
+++ b/polars/polars-ops/src/chunked_array/strings/mod.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "extract_jsonpath")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extract_jsonpath")))]
 mod json_path;
 #[cfg(feature = "strings")]
-#[cfg_attr(docsrs, doc(cfg(feature = "strings")))]
 mod namespace;
 
 #[cfg(feature = "extract_jsonpath")]

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -30,7 +30,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// rather than before.
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     fn zfill<'a>(&'a self, alignment: usize) -> Utf8Chunked {
         let ca = self.as_utf8();
 
@@ -62,7 +61,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// Padding is done using the specified `fillchar`,
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     fn ljust<'a>(&'a self, width: usize, fillchar: char) -> Utf8Chunked {
         let ca = self.as_utf8();
 
@@ -86,7 +84,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// Padding is done using the specified `fillchar`,
     /// The original string is returned if width is less than or equal to `s.len()`.
     #[cfg(feature = "string_justify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "string_justify")))]
     fn rjust<'a>(&'a self, width: usize, fillchar: char) -> Utf8Chunked {
         let ca = self.as_utf8();
 

--- a/polars/polars-ops/src/lib.rs
+++ b/polars/polars-ops/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 mod chunked_array;
 #[cfg(feature = "pivot")]
 pub use frame::pivot;

--- a/polars/polars-ops/src/series/ops/log.rs
+++ b/polars/polars-ops/src/series/ops/log.rs
@@ -12,7 +12,6 @@ fn exp<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Float64Chunked {
 
 pub trait LogSeries: SeriesSealed {
     /// Compute the logarithm to a given base
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     fn log(&self, base: f64) -> Series {
         let s = self.as_series().to_physical_repr();
         let s = s.as_ref();
@@ -29,7 +28,6 @@ pub trait LogSeries: SeriesSealed {
         }
     }
 
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     /// Calculate the exponential of all elements in the input array.
     fn exp(&self) -> Series {
         let s = self.as_series().to_physical_repr();
@@ -49,7 +47,6 @@ pub trait LogSeries: SeriesSealed {
 
     /// Compute the entropy as `-sum(pk * log(pk)`.
     /// where `pk` are discrete probabilities.
-    #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
     fn entropy(&self, base: f64, normalize: bool) -> Option<f64> {
         let s = self.as_series().to_physical_repr();
         match s.dtype() {

--- a/polars/polars-time/src/lib.rs
+++ b/polars/polars-time/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod chunkedarray;
 mod date_range;
 mod groupby;

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "nightly", feature(build_hasher_simple_hash_one))]
 
 pub mod arena;

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -373,7 +373,7 @@
 //!
 //! ## User Guide
 //! If you want to read more, [check the User Guide](https://pola-rs.github.io/polars-book/).
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod docs;
 pub mod export;
 pub mod prelude;


### PR DESCRIPTION
This makes it so one doesn't need to manually configure the
documentation cfg for feature flags.

This PR also changes from `RUSTFLAGS` to `RUSTDOCFLAGS` for the GitHub Actions
build step.

https://github.com/rust-lang/rust/pull/90502

Fixes https://github.com/pola-rs/polars/issues/6123
