### PR TITLE
feat(python): support -ve indexing for DataFrame `head` and `tail` methods

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2969,9 +2969,9 @@ class DataFrame:
         """
         return self.head(n)
 
-    def head(self: DF, n: int = 5) -> DF:
+    def head(self: DF, n: int | None = 5) -> DF:
         """
-        Get the first `n` rows.
+        Get the first `n` rows (if negative, returns all rows except the last `n`).
 
         Parameters
         ----------
@@ -2980,7 +2980,7 @@ class DataFrame:
 
         See Also
         --------
-        tail, glimpse
+        tail, glimpse, slice
 
         Examples
         --------
@@ -3003,12 +3003,26 @@ class DataFrame:
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
+        Negative values of ``head`` return all rows _except_ the last abs(n).
+
+        >>> df.head(-3)
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ham │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 6   ┆ a   │
+        │ 2   ┆ 7   ┆ b   │
+        └─────┴─────┴─────┘
         """
+        if n and n < 0:
+            n = len(self) + n
         return self._from_pydf(self._df.head(n))
 
-    def tail(self: DF, n: int = 5) -> DF:
+    def tail(self: DF, n: int | None = 5) -> DF:
         """
-        Get the last `n` rows.
+        Get the last `n` rows (if negative, returns all rows except the first `n`).
 
         Parameters
         ----------
@@ -3017,7 +3031,7 @@ class DataFrame:
 
         See Also
         --------
-        head
+        head, slice
 
         Examples
         --------
@@ -3040,7 +3054,21 @@ class DataFrame:
         │ 5   ┆ 10  ┆ e   │
         └─────┴─────┴─────┘
 
+        Negative values of ``tail`` return all rows _except_ the first abs(n).
+
+        >>> df.tail(-3)
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ham │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 4   ┆ 9   ┆ d   │
+        │ 5   ┆ 10  ┆ e   │
+        └─────┴─────┴─────┘
         """
+        if n and n < 0:
+            n = len(self) + n
         return self._from_pydf(self._df.tail(n))
 
     def drop_nulls(self: DF, subset: str | Sequence[str] | None = None) -> DF:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -480,6 +480,12 @@ def test_head_tail_limit() -> None:
     # limit is an alias of head
     assert df.head(5).frame_equal(df.limit(5))
 
+    # negative values
+    assert df.head(-7).rows() == [(0, 0), (1, 1), (2, 2)]
+    assert len(df.head(-2)) == 8
+    assert df.tail(-8).rows() == [(8, 8), (9, 9)]
+    assert len(df.tail(-6)) == 4
+
 
 def test_drop_nulls() -> None:
     df = pl.DataFrame(
@@ -489,7 +495,6 @@ def test_drop_nulls() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-
     result = df.drop_nulls()
     expected = pl.DataFrame(
         {


### PR DESCRIPTION
Closes #6171.

Adds support for -ve `head` and `tail` indexing on the Python side (where -ve indexing is idiomatic) for `DataFrame`; doesn't seem like this is idiomatic for Rust, so no attempt at changes there, but it's trivial for the caller to get the same effect if they want it.
```
-ve head: "return all rows except the last abs(n)"
-ve tail: "return all rows except the first abs(n)"
```
* Brings `head` and `tail` to feature parity with pandas.
* Added new docstring examples and test coverage.