### PR TITLE
feat(python): check file target is not an existing directory

### DIFF
--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -9,8 +9,8 @@ from polars.internals.type_aliases import CsvEncoding
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
-    format_path,
     handle_projection_columns,
+    normalise_filepath,
 )
 
 try:
@@ -52,7 +52,7 @@ class BatchedCsvReader:
 
         path: str | None
         if isinstance(file, (str, Path)):
-            path = format_path(file)
+            path = normalise_filepath(file)
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -66,11 +66,11 @@ from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
     _timedelta_to_pl_duration,
-    format_path,
     handle_projection_columns,
     is_bool_sequence,
     is_int_sequence,
     is_str_sequence,
+    normalise_filepath,
     range_to_slice,
     scale_bytes,
 )
@@ -527,7 +527,7 @@ class DataFrame:
 
         path: str | None
         if isinstance(file, (str, Path)):
-            path = format_path(file)
+            path = normalise_filepath(file)
         else:
             path = None
             if isinstance(file, BytesIO):
@@ -644,7 +644,7 @@ class DataFrame:
 
         """
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         if isinstance(columns, str):
             columns = [columns]
 
@@ -709,7 +709,7 @@ class DataFrame:
 
         """
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         projection, columns = handle_projection_columns(columns)
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_avro(file, columns, projection, n_rows)
@@ -755,7 +755,7 @@ class DataFrame:
 
         """
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         if isinstance(columns, str):
             columns = [columns]
 
@@ -807,7 +807,7 @@ class DataFrame:
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
         elif isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_json(file, False)
@@ -828,7 +828,7 @@ class DataFrame:
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
         elif isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_ndjson(file)
@@ -1868,7 +1868,7 @@ class DataFrame:
             to_string = False
 
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if to_string or file is None or to_string_io:
             with BytesIO() as buf:
@@ -1915,7 +1915,7 @@ class DataFrame:
 
         """
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if file is None or to_string_io:
             with BytesIO() as buf:
@@ -2051,7 +2051,7 @@ class DataFrame:
             return str(buffer.getvalue(), encoding="utf-8")
 
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         self._df.write_csv(
             file,
@@ -2100,7 +2100,7 @@ class DataFrame:
         if compression is None:
             compression = "uncompressed"
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         self._df.write_avro(file, compression)
 
@@ -2137,7 +2137,7 @@ class DataFrame:
         if compression is None:
             compression = "uncompressed"
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         self._df.write_ipc(file, compression)
 
@@ -2204,7 +2204,7 @@ class DataFrame:
         if compression is None:
             compression = "uncompressed"
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         if use_pyarrow:
             tbl = self.to_arrow()

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -53,7 +53,7 @@ from polars.utils import (
     _process_null_values,
     _timedelta_to_pl_duration,
     deprecated_alias,
-    format_path,
+    normalise_filepath,
 )
 
 try:
@@ -246,7 +246,7 @@ class LazyFrame:
 
         """
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         # try fsspec scanner
         if not pli._is_local_file(file):
@@ -342,7 +342,7 @@ class LazyFrame:
         if isinstance(file, StringIO):
             file = BytesIO(file.getvalue().encode())
         elif isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
 
         return wrap_ldf(PyLazyFrame.read_json(file))
 
@@ -562,7 +562,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             to_string = False
 
         if isinstance(file, (str, Path)):
-            file = format_path(file)
+            file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if to_string or file is None or to_string_io:
             with BytesIO() as buf:

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -30,7 +30,7 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltal
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
 from polars.internals.io import _prepare_file_arg
-from polars.utils import deprecated_alias, format_path, handle_projection_columns
+from polars.utils import deprecated_alias, handle_projection_columns, normalise_filepath
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import CsvEncoding, ParallelStrategy
@@ -555,7 +555,7 @@ def scan_csv(
     _check_arg_is_1byte("quote_char", quote_char, True)
 
     if isinstance(file, (str, Path)):
-        file = format_path(file)
+        file = normalise_filepath(file)
 
     return LazyFrame._scan_csv(
         file=file,
@@ -682,7 +682,7 @@ def scan_parquet(
 
     """
     if isinstance(file, (str, Path)):
-        file = format_path(file)
+        file = normalise_filepath(file)
 
     return LazyFrame._scan_parquet(
         file=file,
@@ -735,7 +735,7 @@ def scan_ndjson(
 
     """
     if isinstance(file, (str, Path)):
-        file = format_path(file)
+        file = normalise_filepath(file)
 
     return LazyFrame._scan_ndjson(
         file=file,
@@ -774,7 +774,7 @@ def read_avro(
 
     """
     if isinstance(file, (str, Path)):
-        file = format_path(file)
+        file = normalise_filepath(file)
 
     return DataFrame._read_avro(file, n_rows=n_rows, columns=columns)
 
@@ -1226,7 +1226,7 @@ def read_excel(
         ) from None
 
     if isinstance(file, (str, Path)):
-        file = format_path(file)
+        file = normalise_filepath(file)
 
     if not xlsx2csv_options:
         xlsx2csv_options = {}

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -351,17 +351,20 @@ def _in_notebook() -> bool:
     return True
 
 
-def format_path(path: str | Path) -> str:
-    """Create a string path, expanding the home directory if present."""
-    return os.path.expanduser(path)
-
-
 def arrlen(obj: Any) -> int | None:
     """Return length of (non-string) sequence object; returns None for non-sequences."""
     try:
         return None if isinstance(obj, str) else len(obj)
     except TypeError:
         return None
+
+
+def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> str:
+    """Create a string path, expanding the home directory if present."""
+    path = os.path.expanduser(path)
+    if check_not_directory and os.path.exists(path) and os.path.isdir(path):
+        raise IsADirectoryError(f"Expected a file path; {path!r} is a directory")
+    return path
 
 
 def threadpool_size() -> int:


### PR DESCRIPTION
Closes #6181.

* Raise explicit/helpful `IsADirectoryError` if the file target already exists and is a directory.
* Renamed `format_path` to `normalise_filepath` (now it's not just about formatting).