### PR TITLE
test(rust, python): don't set aggregated flag on null propagated aggregation.

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -50,7 +50,7 @@ impl PhysicalExpr for AggregationExpr {
         let keep_name = ac.series().name().to_string();
 
         let check_flat = || {
-            if matches!(ac.agg_state(), AggState::AggregatedFlat(_)) {
+            if !ac.null_propagated && matches!(ac.agg_state(), AggState::AggregatedFlat(_)) {
                 Err(PolarsError::ComputeError(
                     format!(
                         "Cannot aggregate as {}. The column is already aggregated.",

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -286,7 +286,18 @@ impl PhysicalExpr for BinaryExpr {
                 match null_propagate_empty(ac_l.series(), ac_r.series()) {
                     Some(null_prop) => {
                         ac_l.with_update_groups(UpdateGroups::No);
-                        ac_l.with_series(null_prop, true);
+                        // don't set to aggregated.
+                        // this null prop can exist due to:
+                        // assuming 2 rows
+                        //
+                        // expr = col().filter(false)
+                        //
+                        // this would null propagate
+                        // (expr - expr.mean()) -> [None, None]
+                        //
+                        // but adding another aggregation is valid:
+                        // (expr - expr.mean()).mean()
+                        ac_l.with_series(null_prop, false);
                     }
                     None => {
                         let out = null_propagate_empty(ac_l.series(), ac_r.series())

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -286,7 +286,6 @@ impl PhysicalExpr for BinaryExpr {
                 match null_propagate_empty(ac_l.series(), ac_r.series()) {
                     Some(null_prop) => {
                         ac_l.with_update_groups(UpdateGroups::No);
-                        // don't set to aggregated.
                         // this null prop can exist due to:
                         // assuming 2 rows
                         //
@@ -297,7 +296,8 @@ impl PhysicalExpr for BinaryExpr {
                         //
                         // but adding another aggregation is valid:
                         // (expr - expr.mean()).mean()
-                        ac_l.with_series(null_prop, false);
+                        ac_l.with_series(null_prop, true);
+                        ac_l.null_propagated = true;
                     }
                     None => {
                         let out = null_propagate_empty(ac_l.series(), ac_r.series())

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -111,6 +111,11 @@ pub struct AggregationContext<'a> {
     /// This is true when the Series and GroupsProxy still have all
     /// their original values. Not the case when filtered
     original_len: bool,
+    // special state that just should propagate nulls on aggregations.
+    // this is needed as (expr - expr.mean()) could leave nulls but is
+    // not really a final aggregation as left is still a list, but right only
+    // contains null and thus propagates that.
+    null_propagated: bool,
 }
 
 impl<'a> AggregationContext<'a> {
@@ -218,6 +223,7 @@ impl<'a> AggregationContext<'a> {
             sorted: false,
             update_groups: UpdateGroups::No,
             original_len: true,
+            null_propagated: false,
         }
     }
 
@@ -228,6 +234,7 @@ impl<'a> AggregationContext<'a> {
             sorted: false,
             update_groups: UpdateGroups::No,
             original_len: true,
+            null_propagated: false,
         }
     }
 

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -251,3 +251,21 @@ def test_groupby_min_max_string_type() -> None:
             .to_dict(False)
             == expected
         )
+
+
+def test_groupby_6185() -> None:
+    df_1 = pl.DataFrame({"A": [0, 0], "B": [1, 2]})
+
+    df_2 = pl.DataFrame({"A": [0, 0] * 2, "B": [1, 2] * 2})
+
+    expr = pl.col("A").filter(pl.col("A") > 0)
+
+    expected = {"B": [1, 2], "A": [None, None]}
+    assert (
+        df_1.groupby("B").agg((expr - expr.mean()).mean()).sort("B").to_dict(False)
+        == expected
+    )
+    assert (
+        df_2.groupby("B").agg((expr - expr.mean()).mean()).sort("B").to_dict(False)
+        == expected
+    )

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -253,19 +253,13 @@ def test_groupby_min_max_string_type() -> None:
         )
 
 
-def test_groupby_6185() -> None:
+def test_groupby_null_propagation_6185() -> None:
     df_1 = pl.DataFrame({"A": [0, 0], "B": [1, 2]})
-
-    df_2 = pl.DataFrame({"A": [0, 0] * 2, "B": [1, 2] * 2})
 
     expr = pl.col("A").filter(pl.col("A") > 0)
 
     expected = {"B": [1, 2], "A": [None, None]}
     assert (
         df_1.groupby("B").agg((expr - expr.mean()).mean()).sort("B").to_dict(False)
-        == expected
-    )
-    assert (
-        df_2.groupby("B").agg((expr - expr.mean()).mean()).sort("B").to_dict(False)
         == expected
     )


### PR DESCRIPTION
partially fix for #6185