### PR TITLE
docs(python): Clarify docstrings for `closed` argument

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         AvroCompression,
-        ClosedWindow,
+        ClosedInterval,
         ComparisonOperator,
         CsvEncoding,
         FillNullStrategy,
@@ -3347,7 +3347,7 @@ class DataFrame:
         *,
         period: str | timedelta,
         offset: str | timedelta | None = None,
-        closed: ClosedWindow = "right",
+        closed: ClosedInterval = "right",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> RollingGroupBy[DF]:
         """
@@ -3456,7 +3456,7 @@ class DataFrame:
         offset: str | timedelta | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
         start_by: StartBy = "window",
     ) -> DynamicGroupBy[DF]:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3398,7 +3398,7 @@ class DataFrame:
         offset
             offset of the window. Default is -period
         closed : {'right', 'left', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
 
@@ -3521,8 +3521,8 @@ class DataFrame:
             Add the lower and upper bound of the window to the "_lower_bound" and
             "_upper_bound" columns. This will impact performance because it's harder to
             parallelize
-        closed : {'right', 'left', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+        closed : {'left', 'right', 'both', 'none'}
+            Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday'}

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -10,7 +10,7 @@ from polars.utils import _timedelta_to_pl_duration
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
-        ClosedWindow,
+        ClosedInterval,
         RollingInterpolationMethod,
         StartBy,
     )
@@ -736,7 +736,7 @@ class RollingGroupBy(Generic[DF]):
         index_column: str,
         period: str | timedelta,
         offset: str | timedelta | None,
-        closed: ClosedWindow = "none",
+        closed: ClosedInterval = "none",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ):
         period = _timedelta_to_pl_duration(period)
@@ -781,7 +781,7 @@ class DynamicGroupBy(Generic[DF]):
         offset: str | timedelta | None,
         truncate: bool = True,
         include_boundaries: bool = True,
-        closed: ClosedWindow = "none",
+        closed: ClosedInterval = "none",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
         start_by: StartBy = "window",
     ):

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -35,7 +35,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
-        ClosedWindow,
+        ClosedInterval,
         FillNullStrategy,
         InterpolationMethod,
         NullBehavior,
@@ -3412,7 +3412,7 @@ class Expr:
         start: Expr | datetime | date | int | float,
         end: Expr | datetime | date | int | float,
         include_bounds: bool | tuple[bool, bool] | None = None,
-        closed: ClosedWindow | None = None,
+        closed: ClosedInterval | None = None,
     ) -> Expr:
         """
         Check if this expression is between start and end.
@@ -3708,7 +3708,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Apply a rolling min (moving min) over the values in this array.
@@ -3804,7 +3804,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Apply a rolling max (moving max) over the values in this array.
@@ -3900,7 +3900,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Apply a rolling mean (moving mean) over the values in this array.
@@ -3994,7 +3994,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Apply a rolling sum (moving sum) over the values in this array.
@@ -4090,7 +4090,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Compute a rolling standard deviation.
@@ -4186,7 +4186,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Compute a rolling variance.
@@ -4282,7 +4282,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Compute a rolling median.
@@ -4376,7 +4376,7 @@ class Expr:
         min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
     ) -> Expr:
         """
         Compute a rolling quantile.

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3433,7 +3433,7 @@ class Expr:
             - (False, True):   Exclude start and include end.
             - (True, False):   Include start and exclude end.
         closed : {'none', 'left', 'right', 'both'}
-            Define whether the interval is closed or not. Defaults to 'none'.
+            Define which sides of the interval are closed (inclusive).
 
         Returns
         -------
@@ -3750,7 +3750,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -3846,7 +3846,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -3942,7 +3942,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -4036,7 +4036,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -4132,7 +4132,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -4228,7 +4228,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -4320,7 +4320,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------
@@ -4418,7 +4418,7 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype `{Date, Datetime}`
         closed : {'left', 'right', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
 
         Warnings
         --------

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -30,7 +30,7 @@ except ImportError:
     _DOCUMENTING = True
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import ClosedWindow, ConcatMethod, TimeUnit
+    from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit
 
 
 def get_dummies(
@@ -277,7 +277,7 @@ def date_range(
     interval: str | timedelta,
     *,
     lazy: Literal[False] = ...,
-    closed: ClosedWindow = "both",
+    closed: ClosedInterval = "both",
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,
@@ -292,7 +292,7 @@ def date_range(
     interval: str | timedelta,
     *,
     lazy: Literal[False] = ...,
-    closed: ClosedWindow = "both",
+    closed: ClosedInterval = "both",
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,
@@ -307,7 +307,7 @@ def date_range(
     interval: str | timedelta,
     *,
     lazy: Literal[False] = ...,
-    closed: ClosedWindow = "both",
+    closed: ClosedInterval = "both",
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,
@@ -322,7 +322,7 @@ def date_range(
     interval: str | timedelta,
     *,
     lazy: Literal[True],
-    closed: ClosedWindow = "both",
+    closed: ClosedInterval = "both",
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,
@@ -337,7 +337,7 @@ def date_range(
     interval: str | timedelta,
     *,
     lazy: bool = False,
-    closed: ClosedWindow = "both",
+    closed: ClosedInterval = "both",
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -67,7 +67,7 @@ except ImportError:
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
-        ClosedWindow,
+        ClosedInterval,
         CsvEncoding,
         FillNullStrategy,
         JoinStrategy,
@@ -1646,7 +1646,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         *,
         period: str | timedelta,
         offset: str | timedelta | None = None,
-        closed: ClosedWindow = "right",
+        closed: ClosedInterval = "right",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
     ) -> LazyGroupBy[LDF]:
         """
@@ -1765,7 +1765,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         offset: str | timedelta | None = None,
         truncate: bool = True,
         include_boundaries: bool = False,
-        closed: ClosedWindow = "left",
+        closed: ClosedInterval = "left",
         by: str | Sequence[str] | pli.Expr | Sequence[pli.Expr] | None = None,
         start_by: StartBy = "window",
     ) -> LazyGroupBy[LDF]:

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1697,7 +1697,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         offset
             offset of the window. Default is -period
         closed : {'right', 'left', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
 
@@ -1831,7 +1831,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             "_upper_bound" columns. This will impact performance because it's harder to
             parallelize
         closed : {'right', 'left', 'both', 'none'}
-            Define whether the temporal window interval is closed or not.
+            Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday'}

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -21,7 +21,6 @@ ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq
 # The following all have an equivalent Rust enum with the same name
 AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
 CategoricalOrdering: TypeAlias = Literal["physical", "lexical"]
-ClosedWindow: TypeAlias = Literal["left", "right", "both", "none"]
 StartBy: TypeAlias = Literal["window", "datapoint", "monday"]
 CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 FillNullStrategy: TypeAlias = Literal[
@@ -56,6 +55,7 @@ SizeUnit: TypeAlias = Literal[
 
 # The following have a Rust enum equivalent with a different name
 AsofJoinStrategy: TypeAlias = Literal["backward", "forward"]  # AsofStrategy
+ClosedInterval: TypeAlias = Literal["left", "right", "both", "none"]  # ClosedWindow
 RollingInterpolationMethod: TypeAlias = Literal[
     "nearest", "higher", "lower", "midpoint", "linear"
 ]  # QuantileInterpolOptions

--- a/py-polars/tests/unit/test_rolling.py
+++ b/py-polars/tests/unit/test_rolling.py
@@ -10,7 +10,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import ClosedWindow
+    from polars.internals.type_aliases import ClosedInterval
 
 
 def test_rolling_kernels_and_groupby_rolling() -> None:
@@ -35,7 +35,7 @@ def test_rolling_kernels_and_groupby_rolling() -> None:
         timedelta(days=2),
         timedelta(days=3),
     ]:
-        closed_windows: list[ClosedWindow] = ["left", "right", "none", "both"]
+        closed_windows: list[ClosedInterval] = ["left", "right", "none", "both"]
         for closed in closed_windows:
 
             out1 = df.select(

--- a/py-polars/tests/unit/test_rolling.py
+++ b/py-polars/tests/unit/test_rolling.py
@@ -37,7 +37,6 @@ def test_rolling_kernels_and_groupby_rolling() -> None:
     ]:
         closed_windows: list[ClosedInterval] = ["left", "right", "none", "both"]
         for closed in closed_windows:
-
             out1 = df.select(
                 [
                     pl.col("dt"),


### PR DESCRIPTION
Resolves #6180 

Changes:
* Rename the type alias from `ClosedWindow` to `ClosedInterval`. I think it's a bit more clear. I left the Rust enum alone.
* Slightly reword the docstring for the `closed` argument to hopefully make it clear that closed = inclusive.