### PR TITLE
feat(rust): When moving error out of `LogicalPlan`, leave behind String with error message instead of `None`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -1,7 +1,6 @@
 use std::io::{Read, Seek};
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 #[cfg(feature = "parquet")]
 use polars_core::cloud::CloudOptions;
@@ -56,7 +55,7 @@ macro_rules! try_delayed {
             Err(err) => {
                 return LogicalPlan::Error {
                     input: Box::new($input.clone()),
-                    err: Arc::new(Mutex::new(Some(err))),
+                    err: err.into(),
                 }
                 .$convert()
             }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -401,8 +401,7 @@ pub fn to_alp(
         LogicalPlan::Error { err, .. } => {
             // We just take the error. The LogicalPlan should not be used anymore once this
             // is taken.
-            let mut err = err.lock().unwrap();
-            return Err(err.take().unwrap());
+            return Err(err.take());
         }
         LogicalPlan::ExtContext {
             input,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -97,7 +97,7 @@ impl ErrorStateSync {
                 err
             }
             ErrorState::AlreadyEncountered { prev_err_msg } => PolarsError::ComputeError(
-                format!("LogicalPlan already failed with error: {prev_err_msg:?}").into(),
+                format!("LogicalPlan already failed with error: `{prev_err_msg}`").into(),
             ),
         }
     }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -64,6 +64,51 @@ pub enum Context {
     Default,
 }
 
+#[derive(Debug)]
+pub enum ErrorState {
+    NotYetEncountered { err: PolarsError },
+    AlreadyEncountered { prev_err_msg: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct ErrorStateSync(Arc<Mutex<ErrorState>>);
+
+impl std::ops::Deref for ErrorStateSync {
+    type Target = Arc<Mutex<ErrorState>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ErrorStateSync {
+    fn take(&self) -> PolarsError {
+        let mut err = self.0.lock().unwrap();
+        match &*err {
+            ErrorState::NotYetEncountered { err: polars_err } => {
+                let msg = format!("{polars_err:?}");
+                let err = std::mem::replace(
+                    &mut *err,
+                    ErrorState::AlreadyEncountered { prev_err_msg: msg },
+                );
+                let ErrorState::NotYetEncountered { err } = err else {
+                    unreachable!("polars bug in LogicalPlan error handling")
+                };
+                err
+            }
+            ErrorState::AlreadyEncountered { prev_err_msg } => PolarsError::ComputeError(
+                format!("LogicalPlan already failed with error: {prev_err_msg:?}").into(),
+            ),
+        }
+    }
+}
+
+impl From<PolarsError> for ErrorStateSync {
+    fn from(err: PolarsError) -> Self {
+        Self(Arc::new(Mutex::new(ErrorState::NotYetEncountered { err })))
+    }
+}
+
 // https://stackoverflow.com/questions/1031076/what-are-projection-and-selection
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -206,7 +251,7 @@ pub enum LogicalPlan {
     #[cfg_attr(feature = "serde", serde(skip))]
     Error {
         input: Box<LogicalPlan>,
-        err: Arc<Mutex<Option<PolarsError>>>,
+        err: ErrorStateSync,
     },
     /// This allows expressions to access other tables
     ExtContext {
@@ -280,16 +325,7 @@ impl LogicalPlan {
                     Cow::Borrowed(schema) => function.schema(schema),
                 }
             }
-            Error { err, .. } => {
-                // We just take the error. The LogicalPlan should not be used anymore once this
-                let mut err = err.lock().unwrap();
-                match err.take() {
-                    Some(err) => Err(err),
-                    None => Err(PolarsError::ComputeError(
-                        "LogicalPlan already failed".into(),
-                    )),
-                }
-            }
+            Error { err, .. } => Err(err.take()),
             ExtContext { schema, .. } => Ok(Cow::Borrowed(schema)),
         }
     }


### PR DESCRIPTION
A fix for #6166 . When moving an error out of a `LogicalPlan::Error` — in order to return it in a function that returns `PolarsResult` — instead of leaving a `None` in its place, we leave behind a stringified version of the error that we're moving out so that future users of the logical plan, or any clones of it, can see what failed.

This PR produces output that looks like this:

```rust
let df = df!("a" => [1,2,3]).unwrap().lazy().select(&[col("b")]);
println!("1. {:?}", df.schema());
println!("2. {:?}", df.schema());

// output
1. Err(NotFound(Owned("b")))
2. Err(ComputeError(Owned("LogicalPlan already failed with error: `NotFound(Owned(\"b\"))`")))
```

Another option would be to replace `type PolarsResult<T> = Result<T, PolarsError>` with `type PolarsResult<T> = Result<T, NoCloneCow<PolarsError>>`, where `NoCloneCow` is an `enum` with `Borrowed` and `Owned` variants, but without a `Cow`’s ability to call `into_owned()` to get an owned version (i.e., it would not have the `B: ToOwned` generic bound). This way, instead of needing to move the error at all, you could just return a `NoCloneCow::Borrowed(err)`, and you wouldn't need to modify (`Option::take()`) a `LogicalPlan` in order to get its error variant. But I don't know if it's worth making such a big change, and introducing a new type, just to make the error case a tad easier to work with.