### PR TITLE
fix(python): address a frame init/construction error, and expose `infer_schema_length` to frame init

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
 
-from polars.datatypes import Schema
+from polars.datatypes import N_INFER_DEFAULT, Schema
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
@@ -55,7 +55,7 @@ def from_dict(
 
 def from_dicts(
     dicts: Sequence[dict[str, Any]],
-    infer_schema_length: int | None = 50,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     *,
     schema: Schema | None = None,
 ) -> DataFrame:
@@ -127,7 +127,7 @@ def from_records(
     data: Sequence[Sequence[Any]],
     columns: Sequence[str] | None = None,
     orient: Orientation | None = None,
-    infer_schema_length: int | None = 50,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> DataFrame:
     """
     Construct a DataFrame from a sequence of sequences. This operation clones data.

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -61,6 +61,10 @@ if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit
 
 
+# number of rows to scan by default when inferring datatypes
+N_INFER_DEFAULT = 100
+
+
 # note: defined this way as some types can have instances that
 # act as specialisations (eg: "List" and "List[Int32]")
 PolarsDataType: TypeAlias = Union["DataTypeClass", "DataType"]

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Mapping, Sequence
 
 import polars.internals as pli
-from polars.datatypes import PolarsDataType, py_type_to_dtype
+from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, py_type_to_dtype
 from polars.internals.type_aliases import CsvEncoding
 from polars.utils import (
     _prepare_row_count_args,
@@ -37,7 +37,7 @@ class BatchedCsvReader:
         ignore_errors: bool = False,
         parse_dates: bool = False,
         n_threads: int | None = None,
-        infer_schema_length: int | None = 100,
+        infer_schema_length: int | None = N_INFER_DEFAULT,
         batch_size: int = 50_000,
         n_rows: int | None = None,
         encoding: CsvEncoding = "utf8",

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -21,6 +21,7 @@ from polars import internals as pli
 from polars.cfg import Config
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
+    N_INFER_DEFAULT,
     Boolean,
     Categorical,
     DataType,
@@ -127,7 +128,7 @@ class LazyFrame:
         ignore_errors: bool = False,
         cache: bool = True,
         with_column_names: Callable[[list[str]], list[str]] | None = None,
-        infer_schema_length: int | None = 100,
+        infer_schema_length: int | None = N_INFER_DEFAULT,
         n_rows: int | None = None,
         encoding: CsvEncoding = "utf8",
         low_memory: bool = False,

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -25,7 +25,7 @@ else:
 
 import polars.internals as pli
 from polars.convert import from_arrow
-from polars.datatypes import DataType, PolarsDataType, Utf8
+from polars.datatypes import N_INFER_DEFAULT, DataType, PolarsDataType, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
@@ -75,7 +75,7 @@ def read_csv(
     ignore_errors: bool = False,
     parse_dates: bool = False,
     n_threads: int | None = None,
-    infer_schema_length: int | None = 100,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int = 8192,
     n_rows: int | None = None,
     encoding: CsvEncoding | str = "utf8",
@@ -427,7 +427,7 @@ def scan_csv(
     ignore_errors: bool = False,
     cache: bool = True,
     with_column_names: Callable[[list[str]], list[str]] | None = None,
-    infer_schema_length: int | None = 100,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     n_rows: int | None = None,
     encoding: CsvEncoding = "utf8",
     low_memory: bool = False,
@@ -709,7 +709,7 @@ def scan_parquet(
 
 def scan_ndjson(
     file: str | Path,
-    infer_schema_length: int | None = 100,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,
     n_rows: int | None = None,
     low_memory: bool = False,
@@ -1684,7 +1684,7 @@ def read_csv_batched(
     ignore_errors: bool = False,
     parse_dates: bool = False,
     n_threads: int | None = None,
-    infer_schema_length: int | None = 100,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int = 50_000,
     n_rows: int | None = None,
     encoding: CsvEncoding | str = "utf8",

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -22,6 +22,7 @@ def test_groupby_sorted_empty_dataframe_3680() -> None:
         .tail(1)
         .collect()
     )
+    assert df.rows() == []
     assert df.shape == (0, 2)
     assert df.schema == {"key": pl.Categorical, "val": pl.Float64}
 


### PR DESCRIPTION
Closes #6207.

**Also**:

* Exposes `infer_schema_length` to the top-level frame constructor.
* Standardises default #rows used by `infer_schema_length` - was 50 in some places, 100 in others, and the value wasn't sourced from one place. (If we find there are any other magic numbers lurking in the codebase we can move them to one sensible place later).
* Improves/extends various unit tests (especially those relying on `shape` instead of checking the actual values; this one may be an ongoing project ;)