### PR TITLE
(chore)python: Fix test_read_missing_file

### DIFF
--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -6,7 +6,7 @@ import typing
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Iterator, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, cast
 
 import numpy as np
 import pyarrow as pa
@@ -828,7 +828,7 @@ def test_file_buffer() -> None:
 @pytest.mark.parametrize(
     "read_function", [pl.read_parquet, pl.read_csv, pl.read_ipc, pl.read_avro]
 )
-def test_read_missing_file(read_function) -> None:  # type: ignore[no-untyped-def]
+def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None:
     with pytest.raises(FileNotFoundError, match="fake_file"):
         read_function("fake_file")
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -825,18 +825,12 @@ def test_file_buffer() -> None:
         pl.read_parquet(f)
 
 
-def test_read_missing_file() -> None:
-    with pytest.raises(FileNotFoundError, match="fake_parquet_file"):
-        pl.read_parquet("fake_parquet_file")
-
-    with pytest.raises(FileNotFoundError, match="fake_csv_file"):
-        pl.read_csv("fake_csv_file")
-
-    with pytest.raises(FileNotFoundError, match="fake_ipc_file"):
-        pl.read_ipc("fake_ipc_file")
-
-    with pytest.raises(FileNotFoundError, match="fake_avro_file"):
-        pl.read_ipc("fake_avro_file")
+@pytest.mark.parametrize(
+    "read_function", [pl.read_parquet, pl.read_csv, pl.read_ipc, pl.read_avro]
+)
+def test_read_missing_file(read_function) -> None:  # type: ignore[no-untyped-def]
+    with pytest.raises(FileNotFoundError, match="fake_file"):
+        read_function("fake_file")
 
 
 def test_melt() -> None:


### PR DESCRIPTION
* was not covering pl.read_avro, instead pl.read_ipc was there twice
* took the opportunity to refactor. The match being the same across different functions is not a problem, you just want to check that the path comes back in the error message, the contents of the path we test for are not relevant.