### PR TITLE
fix(python): collect now uses the storage_options given to scan_parquet

### DIFF
--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -118,7 +118,7 @@ def _scan_ipc_fsspec(
 
 
 def _scan_parquet_impl(  # noqa: D417
-    uri: str, with_columns: list[str] | None, *args: Any
+    uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
 ) -> pli.DataFrame:
     """
     Take the projected columns and materialize an arrow table.
@@ -133,14 +133,14 @@ def _scan_parquet_impl(  # noqa: D417
     """
     import polars as pl
 
-    return pl.read_parquet(uri, with_columns)
+    return pl.read_parquet(uri, with_columns, *args, **kwargs)
 
 
 def _scan_parquet_fsspec(
     file: str,
     storage_options: dict[str, object] | None = None,
 ) -> pli.LazyFrame:
-    func = partial(_scan_parquet_impl, file)
+    func = partial(_scan_parquet_impl, file, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 
     storage_options = storage_options or {}


### PR DESCRIPTION
`collect` on a `LazyDataFrame` opened by `scan_parquet` now uses the `storage_options` given to `scan_parquet`.

(In theory) fixes #6212. This fix resolved the error for my test file.

Unsure how this should be added to tests. My test file relies on minio, but maybe some mocking could help, what do you guys think?