### PR TITLE
feat(python): additional `schema_overrides` param for more ergonomic `DataFrame` init

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -85,12 +85,12 @@ PythonDataType: TypeAlias = Union[
     Type[Decimal],
 ]
 
-ColumnsType: TypeAlias = Union[
+SchemaDefinition: TypeAlias = Union[
     Sequence[str],
     Mapping[str, Union[PolarsDataType, PythonDataType]],
     Sequence[Union[str, Tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
 ]
-Schema: TypeAlias = Mapping[str, PolarsDataType]
+SchemaDict: TypeAlias = Mapping[str, PolarsDataType]
 
 DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
 
@@ -375,7 +375,7 @@ class Field:
 
 
 class Struct(NestedType):
-    def __init__(self, fields: Sequence[Field] | Mapping[str, PolarsDataType]):
+    def __init__(self, fields: Sequence[Field] | SchemaDict):
         """
         Struct composite type.
 
@@ -415,7 +415,7 @@ class Struct(NestedType):
         class_name = self.__class__.__name__
         return f"{class_name}({self.fields})"
 
-    def to_schema(self) -> dict[str, PolarsDataType] | None:
+    def to_schema(self) -> SchemaDict | None:
         """Return Struct dtype as a schema dict."""
         return dict(self)
 
@@ -510,7 +510,7 @@ class _DataTypeMappings:
 
     @property
     @cache
-    def PY_STR_TO_DTYPE(self) -> dict[str, PolarsDataType]:
+    def PY_STR_TO_DTYPE(self) -> SchemaDict:
         return {str(tp.__name__): dtype for tp, dtype in self.PY_TYPE_TO_DTYPE.items()}
 
     @property
@@ -539,7 +539,7 @@ class _DataTypeMappings:
 
     @property
     @cache
-    def NUMPY_CHAR_CODE_TO_DTYPE(self) -> dict[str, PolarsDataType]:
+    def NUMPY_CHAR_CODE_TO_DTYPE(self) -> SchemaDict:
         # Note: Windows behaves differently from other platforms as C long
         # is only 32-bit on Windows, while it is 64-bit on other platforms.
         # See: https://numpy.org/doc/stable/reference/arrays.scalars.html

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Sequence
 
 import polars.internals as pli
-from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, py_type_to_dtype
+from polars.datatypes import (
+    N_INFER_DEFAULT,
+    PolarsDataType,
+    SchemaDict,
+    py_type_to_dtype,
+)
 from polars.internals.type_aliases import CsvEncoding
 from polars.utils import (
     _prepare_row_count_args,
@@ -31,7 +36,7 @@ class BatchedCsvReader:
         comment_char: str | None = None,
         quote_char: str | None = r'"',
         skip_rows: int = 0,
-        dtypes: None | (Mapping[str, PolarsDataType] | Sequence[PolarsDataType]) = None,
+        dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
         null_values: str | list[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -32,13 +32,13 @@ from polars._html import NotebookFormatter
 from polars.datatypes import (
     N_INFER_DEFAULT,
     Boolean,
-    ColumnsType,
     Int8,
     Int16,
     Int32,
     Int64,
     PolarsDataType,
-    Schema,
+    SchemaDefinition,
+    SchemaDict,
     UInt8,
     UInt16,
     UInt32,
@@ -146,6 +146,9 @@ class DataFrame:
     columns : Sequence of str, (str,DataType) pairs, or {str:DataType,} dict
         Column labels (with optional type) to use for resulting DataFrame. If specified,
         overrides any labels already present in the data. Must match data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the columns param will be overridden.
     orient : {'col', 'row'}, default None
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -285,39 +288,54 @@ class DataFrame:
             | pli.Series
             | None
         ) = None,
-        columns: ColumnsType | None = None,
+        columns: SchemaDefinition | None = None,
+        schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ):
         if data is None:
-            self._df = dict_to_pydf({}, columns=columns)
+            self._df = dict_to_pydf(
+                {}, columns=columns, schema_overrides=schema_overrides
+            )
 
         elif isinstance(data, dict):
-            self._df = dict_to_pydf(data, columns=columns)
+            self._df = dict_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides
+            )
 
         elif isinstance(data, (list, tuple, Sequence)):
             self._df = sequence_to_pydf(
                 data,
                 columns=columns,
+                schema_overrides=schema_overrides,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
         elif isinstance(data, pli.Series):
-            self._df = series_to_pydf(data, columns=columns)
+            self._df = series_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides
+            )
 
         elif _check_for_numpy(data) and isinstance(data, np.ndarray):
-            self._df = numpy_to_pydf(data, columns=columns, orient=orient)
+            self._df = numpy_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides, orient=orient
+            )
 
         elif _check_for_pyarrow(data) and isinstance(data, pa.Table):
-            self._df = arrow_to_pydf(data, columns=columns)
+            self._df = arrow_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides
+            )
 
         elif _check_for_pandas(data) and isinstance(data, pd.DataFrame):
-            self._df = pandas_to_pydf(data, columns=columns)
+            self._df = pandas_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides
+            )
 
         elif not isinstance(data, Sized) and isinstance(data, (Generator, Iterable)):
             self._df = iterable_to_pydf(
                 data,
                 columns=columns,
+                schema_overrides=schema_overrides,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
@@ -338,9 +356,9 @@ class DataFrame:
         cls: type[DF],
         data: Sequence[dict[str, Any]],
         infer_schema_length: int | None = N_INFER_DEFAULT,
-        schema: Schema | None = None,
+        schema_overrides: SchemaDict | None = None,
     ) -> DF:
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length, schema)
+        pydf = PyDataFrame.read_dicts(data, infer_schema_length, schema_overrides)
         return cls._from_pydf(pydf)
 
     @classmethod
@@ -349,7 +367,8 @@ class DataFrame:
         data: Mapping[
             str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series
         ],
-        columns: Sequence[str] | None = None,
+        schema: SchemaDefinition | None = None,
+        schema_overrides: SchemaDict | None = None,
     ) -> DF:
         """
         Construct a DataFrame from a dictionary of sequences.
@@ -357,24 +376,30 @@ class DataFrame:
         Parameters
         ----------
         data : dict of sequences
-            Two-dimensional data represented as a dictionary. dict must contain
-            Sequences.
-        columns : Sequence of str, default None
-            Column labels to use for resulting DataFrame. If specified, overrides any
-            labels already present in the data. Must match data dimensions.
+          Two-dimensional data represented as a dictionary. dict must contain
+          Sequences.
+        schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
+          Column labels to use for resulting DataFrame. If specified, overrides any
+          labels already present in the data. Must match data dimensions.
+        schema_overrides : dict, default None
+          Support type specification or override of one or more columns; note that
+          any dtypes inferred from the columns param will be overridden.
 
         Returns
         -------
         DataFrame
 
         """
-        return cls._from_pydf(dict_to_pydf(data, columns=columns))
+        return cls._from_pydf(
+            dict_to_pydf(data, columns=schema, schema_overrides=schema_overrides)
+        )
 
     @classmethod
     def _from_records(
         cls: type[DF],
         data: Sequence[Sequence[Any]],
         columns: Sequence[str] | None = None,
+        schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ) -> DF:
@@ -388,6 +413,9 @@ class DataFrame:
         columns : Sequence of str, default None
             Column labels to use for resulting DataFrame. Must match data dimensions.
             If not specified, columns will be named `column_0`, `column_1`, etc.
+        schema_overrides : dict, default None
+            Support type specification or override of one or more columns; note that
+            any dtypes inferred from the columns param will be overridden.
         orient : {'col', 'row'}, default None
             Whether to interpret two-dimensional data as columns or as rows. If None,
             the orientation is inferred by matching the columns and data dimensions. If
@@ -404,6 +432,7 @@ class DataFrame:
             sequence_to_pydf(
                 data,
                 columns=columns,
+                schema_overrides=schema_overrides,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
@@ -414,6 +443,7 @@ class DataFrame:
         cls: type[DF],
         data: np.ndarray[Any, Any],
         columns: Sequence[str] | None = None,
+        schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
     ) -> DF:
         """
@@ -426,6 +456,9 @@ class DataFrame:
         columns : Sequence of str, default None
             Column labels to use for resulting DataFrame. Must match data dimensions.
             If not specified, columns will be named `column_0`, `column_1`, etc.
+        schema_overrides : dict, default None
+            Support type specification or override of one or more columns; note that
+            any dtypes inferred from the columns param will be overridden.
         orient : {'col', 'row'}, default None
             Whether to interpret two-dimensional data as columns or as rows. If None,
             the orientation is inferred by matching the columns and data dimensions. If
@@ -436,13 +469,18 @@ class DataFrame:
         DataFrame
 
         """
-        return cls._from_pydf(numpy_to_pydf(data, columns=columns, orient=orient))
+        return cls._from_pydf(
+            numpy_to_pydf(
+                data, columns=columns, schema_overrides=schema_overrides, orient=orient
+            )
+        )
 
     @classmethod
     def _from_arrow(
         cls: type[DF],
         data: pa.Table,
         columns: Sequence[str] | None = None,
+        schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
     ) -> DF:
         """
@@ -453,12 +491,15 @@ class DataFrame:
 
         Parameters
         ----------
-        data : numpy ndarray or Sequence of sequences
-            Two-dimensional data represented as Arrow table.
+        data : arrow table, array, or sequence of sequences
+            Data representing an Arrow Table or Array.
         columns : Sequence of str, default None
             Column labels to use for resulting DataFrame. Must match data dimensions.
             If not specified, existing Array table columns are used, with missing names
             named as `column_0`, `column_1`, etc.
+        schema_overrides : dict, default None
+            Support type specification or override of one or more columns; note that
+            any dtypes inferred from the columns param will be overridden.
         rechunk : bool, default True
             Make sure that all data is in contiguous memory.
 
@@ -467,13 +508,21 @@ class DataFrame:
         DataFrame
 
         """
-        return cls._from_pydf(arrow_to_pydf(data, columns=columns, rechunk=rechunk))
+        return cls._from_pydf(
+            arrow_to_pydf(
+                data,
+                columns=columns,
+                schema_overrides=schema_overrides,
+                rechunk=rechunk,
+            )
+        )
 
     @classmethod
     def _from_pandas(
         cls: type[DF],
         data: pd.DataFrame,
         columns: Sequence[str] | None = None,
+        schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
         nan_to_none: bool = True,
     ) -> DF:
@@ -487,6 +536,9 @@ class DataFrame:
         columns : Sequence of str, default None
             Column labels to use for resulting DataFrame. If specified, overrides any
             labels already present in the data. Must match data dimensions.
+        schema_overrides : dict, default None
+            Support type specification or override of one or more columns; note that
+            any dtypes inferred from the columns param will be overridden.
         rechunk : bool, default True
             Make sure that all data is in contiguous memory.
         nan_to_none : bool, default True
@@ -505,13 +557,18 @@ class DataFrame:
                 if pd_series.dtype == np.dtype("O"):
                     series.append(pli.Series(name, [], dtype=Utf8))
                 else:
-                    col = pli.Series(name, pd_series)
+                    dtype = (schema_overrides or {}).get(name)
+                    col = pli.Series(name, pd_series, dtype=dtype)
                     series.append(pli.Series(name, col))
             return cls(series)
 
         return cls._from_pydf(
             pandas_to_pydf(
-                data, columns=columns, rechunk=rechunk, nan_to_none=nan_to_none
+                data,
+                columns=columns,
+                schema_overrides=schema_overrides,
+                rechunk=rechunk,
+                nan_to_none=nan_to_none,
             )
         )
 
@@ -525,7 +582,7 @@ class DataFrame:
         comment_char: str | None = None,
         quote_char: str | None = r'"',
         skip_rows: int = 0,
-        dtypes: None | (Mapping[str, PolarsDataType] | Sequence[PolarsDataType]) = None,
+        dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
         null_values: str | list[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
@@ -993,7 +1050,7 @@ class DataFrame:
         return self._df.dtypes()
 
     @property
-    def schema(self) -> dict[str, PolarsDataType]:
+    def schema(self) -> SchemaDict:
         """
         Get a dict[column name, DataType].
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -146,9 +146,6 @@ class DataFrame:
     columns : Sequence of str, (str,DataType) pairs, or {str:DataType,} dict
         Column labels (with optional type) to use for resulting DataFrame. If specified,
         overrides any labels already present in the data. Must match data dimensions.
-    schema_overrides : dict, default None
-        Support type specification or override of one or more columns; note that
-        any dtypes inferred from the columns param will be overridden.
     orient : {'col', 'row'}, default None
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -156,6 +153,9 @@ class DataFrame:
     infer_schema_length : int, default None
         Maximum number of rows to read for schema inference; only applies if the input
         data is a sequence or generator of rows; other input is read as-is.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the columns param will be overridden.
 
     Examples
     --------
@@ -289,9 +289,10 @@ class DataFrame:
             | None
         ) = None,
         columns: SchemaDefinition | None = None,
-        schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
+        *,
         infer_schema_length: int | None = N_INFER_DEFAULT,
+        schema_overrides: SchemaDict | None = None,
     ):
         if data is None:
             self._df = dict_to_pydf(

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -14,6 +14,7 @@ from polars.datatypes import (
     Duration,
     Int64,
     PolarsDataType,
+    SchemaDict,
     Struct,
     Time,
     UInt32,
@@ -2278,7 +2279,7 @@ def select(
 def struct(
     exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: Literal[True],
-    schema: Mapping[str, PolarsDataType] | None = None,
+    schema: SchemaDict | None = None,
 ) -> pli.Series:
     ...
 
@@ -2287,7 +2288,7 @@ def struct(
 def struct(
     exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: Literal[False],
-    schema: Mapping[str, PolarsDataType] | None = None,
+    schema: SchemaDict | None = None,
 ) -> pli.Expr:
     ...
 
@@ -2296,7 +2297,7 @@ def struct(
 def struct(
     exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: bool = False,
-    schema: Mapping[str, PolarsDataType] | None = None,
+    schema: SchemaDict | None = None,
 ) -> pli.Expr | pli.Series:
     ...
 
@@ -2304,7 +2305,7 @@ def struct(
 def struct(
     exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: bool = False,
-    schema: Mapping[str, PolarsDataType] | None = None,
+    schema: SchemaDict | None = None,
 ) -> pli.Expr | pli.Series:
     """
     Collect several columns into a Series of dtype Struct.

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -35,7 +35,7 @@ from polars.datatypes import (
     Int32,
     Int64,
     PolarsDataType,
-    Schema,
+    SchemaDict,
     Time,
     UInt8,
     UInt16,
@@ -122,7 +122,7 @@ class LazyFrame:
         comment_char: str | None = None,
         quote_char: str | None = r'"',
         skip_rows: int = 0,
-        dtypes: dict[str, PolarsDataType] | None = None,
+        dtypes: SchemaDict | None = None,
         null_values: str | list[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
@@ -417,7 +417,7 @@ class LazyFrame:
         return self._ldf.dtypes()
 
     @property
-    def schema(self) -> Schema:
+    def schema(self) -> SchemaDict:
         """
         Get a dict[column name, DataType].
 
@@ -3723,7 +3723,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         projection_pushdown: bool = True,
         slice_pushdown: bool = True,
         no_optimizations: bool = False,
-        schema: None | Schema = None,
+        schema: None | SchemaDict = None,
         validate_output_schema: bool = True,
     ) -> LDF:
         """

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, Generic, Sequence, TypeVar
 
 import polars.internals as pli
-from polars.datatypes import Schema
+from polars.datatypes import SchemaDict
 from polars.internals import selection_to_pyexpr_list
 from polars.utils import is_expr_sequence
 
@@ -154,7 +154,7 @@ class LazyGroupBy(Generic[LDF]):
         return self._lazyframe_class._from_pyldf(self.lgb.tail(n))
 
     def apply(
-        self, f: Callable[[pli.DataFrame], pli.DataFrame], schema: Schema | None
+        self, f: Callable[[pli.DataFrame], pli.DataFrame], schema: SchemaDict | None
     ) -> LDF:
         """
         Apply a custom/user-defined function (UDF) over the groups as a new DataFrame.

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -25,7 +25,7 @@ else:
 
 import polars.internals as pli
 from polars.convert import from_arrow
-from polars.datatypes import N_INFER_DEFAULT, DataType, PolarsDataType, Utf8
+from polars.datatypes import N_INFER_DEFAULT, DataType, SchemaDict, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
@@ -282,7 +282,7 @@ def read_csv(
                 [f"column_{int(column[1:]) + 1}" for column in tbl.column_names]
             )
 
-        df = cast(DataFrame, from_arrow(tbl, rechunk))
+        df = cast(DataFrame, from_arrow(tbl, rechunk=rechunk))
         if new_columns:
             return pli._update_columns(df, new_columns)
         return df
@@ -421,7 +421,7 @@ def scan_csv(
     comment_char: str | None = None,
     quote_char: str | None = r'"',
     skip_rows: int = 0,
-    dtypes: dict[str, PolarsDataType] | None = None,
+    dtypes: SchemaDict | None = None,
     null_values: str | list[str] | dict[str, str] | None = None,
     missing_utf8_is_empty_string: bool = False,
     ignore_errors: bool = False,

--- a/py-polars/polars/testing/__init__.py
+++ b/py-polars/polars/testing/__init__.py
@@ -1,11 +1,15 @@
 from polars.testing.asserts import (
     assert_frame_equal,
     assert_frame_equal_local_categoricals,
+    assert_frame_not_equal,
     assert_series_equal,
+    assert_series_not_equal,
 )
 
 __all__ = [
     "assert_series_equal",
+    "assert_series_not_equal",
     "assert_frame_equal",
+    "assert_frame_not_equal",
     "assert_frame_equal_local_categoricals",
 ]

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -29,7 +29,7 @@ def assert_frame_equal(
     check_row_order: bool = True,
 ) -> None:
     """
-    Raise detailed AssertionError if `left` does not equal `right`.
+    Raise detailed AssertionError if `left` does NOT equal `right`.
 
     Parameters
     ----------
@@ -49,10 +49,10 @@ def assert_frame_equal(
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
     check_column_order
-        if False, allows the assert/test to succeed if the required columns are present,
+        if False, frames will compare equal if the required columns are present,
         irrespective of the order in which they appear.
     check_row_order
-        if False, allows the assert/test to succeed if the required rows are present,
+        if False, frames will compare equal if the required rows are present,
         irrespective of the order in which they appear; as this requires
         sorting, you cannot set on frames that contain unsortable columns.
 
@@ -114,6 +114,71 @@ def assert_frame_equal(
         )
 
 
+def assert_frame_not_equal(
+    left: pli.DataFrame | pli.LazyFrame,
+    right: pli.DataFrame | pli.LazyFrame,
+    check_dtype: bool = True,
+    check_exact: bool = False,
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
+    nans_compare_equal: bool = True,
+    check_column_order: bool = True,
+    check_row_order: bool = True,
+) -> None:
+    """
+    Raise AssertionError if `left` DOES equal `right`.
+
+    Parameters
+    ----------
+    left
+        the dataframe to compare.
+    right
+        the dataframe to compare with.
+    check_dtype
+        if True, data types need to match exactly.
+    check_exact
+        if False, test if values are within tolerance of each other
+        (see `rtol` & `atol`).
+    rtol
+        relative tolerance for inexact checking. Fraction of values in `right`.
+    atol
+        absolute tolerance for inexact checking.
+    nans_compare_equal
+        if your assert/test requires float NaN != NaN, set this to False.
+    check_column_order
+        if False, frames will compare equal if the required columns are present,
+        irrespective of the order in which they appear.
+    check_row_order
+        if False, frames will compare equal if the required rows are present,
+        irrespective of the order in which they appear; as this requires
+        sorting, you cannot set on frames that contain unsortable columns.
+
+    Examples
+    --------
+    >>> from polars.testing import assert_frame_not_equal
+    >>> df1 = pl.DataFrame({"a": [1, 2, 3]})
+    >>> df2 = pl.DataFrame({"a": [2, 3, 4]})
+    >>> assert_frame_not_equal(df1, df2)
+
+    """
+    try:
+        assert_frame_equal(
+            left=left,
+            right=right,
+            check_dtype=check_dtype,
+            check_exact=check_exact,
+            rtol=rtol,
+            atol=atol,
+            nans_compare_equal=nans_compare_equal,
+            check_column_order=check_column_order,
+            check_row_order=check_row_order,
+        )
+    except AssertionError:
+        return
+
+    raise AssertionError("Expected the two frames to compare unequal")
+
+
 def assert_series_equal(
     left: pli.Series,
     right: pli.Series,
@@ -125,7 +190,7 @@ def assert_series_equal(
     nans_compare_equal: bool = True,
 ) -> None:
     """
-    Raise detailed AssertionError if `left` does not equal `right`.
+    Raise detailed AssertionError if `left` does NOT equal `right`.
 
     Parameters
     ----------
@@ -173,6 +238,64 @@ def assert_series_equal(
     _assert_series_inner(
         left, right, check_dtype, check_exact, nans_compare_equal, atol, rtol, obj
     )
+
+
+def assert_series_not_equal(
+    left: pli.Series,
+    right: pli.Series,
+    check_dtype: bool = True,
+    check_names: bool = True,
+    check_exact: bool = False,
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
+    nans_compare_equal: bool = True,
+) -> None:
+    """
+    Raise AssertionError if `left` DOES equal `right`.
+
+    Parameters
+    ----------
+    left
+        the series to compare.
+    right
+        the series to compare with.
+    check_dtype
+        if True, data types need to match exactly.
+    check_names
+        if True, names need to match.
+    check_exact
+        if False, test if values are within tolerance of each other
+        (see `rtol` & `atol`).
+    rtol
+        relative tolerance for inexact checking. Fraction of values in `right`.
+    atol
+        absolute tolerance for inexact checking.
+    nans_compare_equal
+        if your assert/test requires float NaN != NaN, set this to False.
+
+    Examples
+    --------
+    >>> from polars.testing import assert_series_not_equal
+    >>> s1 = pl.Series([1, 2, 3])
+    >>> s2 = pl.Series([2, 3, 4])
+    >>> assert_series_not_equal(s1, s2)
+
+    """
+    try:
+        assert_series_equal(
+            left=left,
+            right=right,
+            check_dtype=check_dtype,
+            check_names=check_names,
+            check_exact=check_exact,
+            rtol=rtol,
+            atol=atol,
+            nans_compare_equal=nans_compare_equal,
+        )
+    except AssertionError:
+        return
+
+    raise AssertionError("Expected the two series to compare unequal")
 
 
 def _assert_series_inner(

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -547,7 +547,9 @@ def test_from_dicts_schema() -> None:
 
     # let polars infer the dtypes
     # but inform about a 3rd column
-    df = pl.from_dicts(data, schema={"a": pl.Unknown, "b": pl.Unknown, "c": pl.Int32})
+    df = pl.from_dicts(
+        data, schema_overrides={"a": pl.Unknown, "b": pl.Unknown, "c": pl.Int32}
+    )
     assert df.dtypes == [pl.Int64, pl.Int64, pl.Int32]
     assert df.to_dict(False) == {
         "a": [1, 2, 3],

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -16,7 +16,11 @@ import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.dependencies import zoneinfo
 from polars.internals.construction import iterable_to_pydf
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import (
+    assert_frame_equal,
+    assert_frame_not_equal,
+    assert_series_equal,
+)
 from polars.testing.parametric import columns
 
 if TYPE_CHECKING:
@@ -187,6 +191,7 @@ def test_from_arrow() -> None:
             "b": pa.array([1, 2], pa.timestamp("ms")),
             "c": pa.array([1, 2], pa.timestamp("us")),
             "d": pa.array([1, 2], pa.timestamp("ns")),
+            "e": pa.array([1, 2], pa.int32()),
             "decimal1": pa.array([1, 2], pa.decimal128(2, 1)),
         }
     )
@@ -195,6 +200,7 @@ def test_from_arrow() -> None:
         "b": pl.Datetime("ms"),
         "c": pl.Datetime("us"),
         "d": pl.Datetime("ns"),
+        "e": pl.Int32,
         "decimal1": pl.Float64,
     }
     expected_data = [
@@ -203,6 +209,7 @@ def test_from_arrow() -> None:
             datetime(1970, 1, 1, 0, 0, 0, 1000),
             datetime(1970, 1, 1, 0, 0, 0, 1),
             datetime(1970, 1, 1, 0, 0),
+            1,
             1.0,
         ),
         (
@@ -210,6 +217,7 @@ def test_from_arrow() -> None:
             datetime(1970, 1, 1, 0, 0, 0, 2000),
             datetime(1970, 1, 1, 0, 0, 0, 2),
             datetime(1970, 1, 1, 0, 0),
+            2,
             2.0,
         ),
     ]
@@ -223,26 +231,39 @@ def test_from_arrow() -> None:
     assert df.schema == expected_schema
     assert df.rows() == []
 
+    # try a single column dtype override
+    for t in (tbl, empty_tbl):
+        df = pl.DataFrame(t, schema_overrides={"e": pl.Int8})
+        override_schema = expected_schema.copy()
+        override_schema["e"] = pl.Int8
+        assert df.schema == override_schema
+        assert df.rows() == expected_data[: (len(df))]
 
-def test_from_dict_with_dict_columns() -> None:
-    # expect schema order to take precedence
+
+def test_from_dict_with_column_order() -> None:
+    # expect schema/columns order to take precedence
     schema = {"a": pl.UInt8, "b": pl.UInt32}
-    df = pl.DataFrame({"b": [3, 4], "a": [1, 2]}, columns=schema)
-    # ┌─────┬─────┐
-    # │ a   ┆ b   │
-    # │ --- ┆ --- │
-    # │ u8  ┆ u32 │
-    # ╞═════╪═════╡
-    # │ 1   ┆ 3   │
-    # │ 2   ┆ 4   │
-    # └─────┴─────┘
-    assert df.columns == ["a", "b"]
-    assert df.rows() == [(1, 3), (2, 4)]
+    data = {"b": [3, 4], "a": [1, 2]}
+    for df in (
+        pl.DataFrame(data, columns=schema),
+        pl.DataFrame(data, columns=["a", "b"], schema_overrides=schema),
+    ):
+        # ┌─────┬─────┐
+        # │ a   ┆ b   │
+        # │ --- ┆ --- │
+        # │ u8  ┆ u32 │
+        # ╞═════╪═════╡
+        # │ 1   ┆ 3   │
+        # │ 2   ┆ 4   │
+        # └─────┴─────┘
+        assert df.columns == ["a", "b"]
+        assert df.schema == {"a": pl.UInt8, "b": pl.UInt32}
+        assert df.rows() == [(1, 3), (2, 4)]
 
-    # expected error
-    mismatched_schema = {"x": pl.UInt8, "b": pl.UInt32}
-    with pytest.raises(ValueError):
-        pl.DataFrame({"b": [3, 4], "a": [1, 2]}, columns=mismatched_schema)
+        # expect an error
+        mismatched_schema = {"x": pl.UInt8, "b": pl.UInt32}
+        with pytest.raises(ValueError):
+            pl.DataFrame({"b": [3, 4], "a": [1, 2]}, columns=mismatched_schema)
 
 
 def test_from_dict_with_scalars() -> None:
@@ -288,6 +309,7 @@ def test_from_dict_with_scalars() -> None:
             "key": pl.Int8,
         },
     )
+    assert df4.columns == ["value", "other", "misc", "key"]
     assert df4.to_dict(False) == {
         "value": ["x", "y", "z"],
         "other": [7.0, 8.0, 9.0],
@@ -302,16 +324,22 @@ def test_from_dict_with_scalars() -> None:
     }
 
     # mixed with struct cols
-    df5 = pl.from_dict(
-        {"x": {"b": [1, 3], "c": [2, 4]}, "y": [5, 6], "z": "x"},
-        columns=["x", ("y", pl.Int8), "z"],  # type: ignore[list-item]
-    )
-    assert df5.rows() == [({"b": 1, "c": 2}, 5, "x"), ({"b": 3, "c": 4}, 6, "x")]
-    assert df5.schema == {
-        "x": pl.Struct([pl.Field("b", pl.Int64), pl.Field("c", pl.Int64)]),
-        "y": pl.Int8,
-        "z": pl.Utf8,
-    }
+    for df5 in (
+        pl.from_dict(
+            {"x": {"b": [1, 3], "c": [2, 4]}, "y": [5, 6], "z": "x"},
+            schema_overrides={"y": pl.Int8},
+        ),
+        pl.from_dict(
+            {"x": {"b": [1, 3], "c": [2, 4]}, "y": [5, 6], "z": "x"},
+            columns=["x", ("y", pl.Int8), "z"],
+        ),
+    ):
+        assert df5.rows() == [({"b": 1, "c": 2}, 5, "x"), ({"b": 3, "c": 4}, 6, "x")]
+        assert df5.schema == {
+            "x": pl.Struct([pl.Field("b", pl.Int64), pl.Field("c", pl.Int64)]),
+            "y": pl.Int8,
+            "z": pl.Utf8,
+        }
 
 
 def test_dataclasses_and_namedtuple() -> None:
@@ -350,7 +378,19 @@ def test_dataclasses_and_namedtuple() -> None:
             }
             assert df.rows() == raw_data
 
-        # in conjunction with 'columns' override (rename/downcast)
+            # partial dtypes override
+            df = DF(  # type: ignore[operator]
+                data=trades,
+                schema_overrides={"timestamp": pl.Datetime("ms"), "size": pl.Int32},
+            )
+            assert df.schema == {
+                "timestamp": pl.Datetime("ms"),
+                "ticker": pl.Utf8,
+                "price": pl.Float64,
+                "size": pl.Int32,
+            }
+
+        # in conjunction with full 'columns' override (rename/downcast)
         df = pl.DataFrame(
             data=trades,
             columns=[
@@ -1197,11 +1237,18 @@ def test_string_cache_eager_lazy() -> None:
 
         # also check row-wise categorical insert.
         # (column-wise is preferred, but this shouldn't fail)
-        df3 = pl.DataFrame(
-            data=[["reg1"], ["reg2"], ["reg3"], ["reg4"], ["reg5"]],
-            columns=[("region_ids", pl.Categorical)],
-        )
-        assert_frame_equal(df1, df3)
+        for params in (
+            {"columns": [("region_ids", pl.Categorical)]},
+            {
+                "columns": ["region_ids"],
+                "schema_overrides": {"region_ids": pl.Categorical},
+            },
+        ):
+            df3 = pl.DataFrame(  # type: ignore[arg-type]
+                data=[["reg1"], ["reg2"], ["reg3"], ["reg4"], ["reg5"]],
+                **params,
+            )
+            assert_frame_equal(df1, df3)
 
 
 def test_assign() -> None:
@@ -1248,7 +1295,8 @@ def test_literal_series() -> None:
                 [datetime(2022, 8, 16), datetime(2022, 8, 17), datetime(2022, 8, 18)],
                 dtype="<M8[ns]",
             ),
-        }
+        },
+        schema_overrides={"a": pl.Float64},
     )
     out = (
         df.lazy()
@@ -1257,7 +1305,7 @@ def test_literal_series() -> None:
         .collect()
     )
     expected_schema = {
-        "a": pl.Float32,
+        "a": pl.Float64,
         "b": pl.Int8,
         "c": pl.Utf8,
         "d": pl.Datetime("ns"),
@@ -1415,16 +1463,17 @@ def test_from_rows() -> None:
     )
     df = pl.from_records(
         [[1, datetime.fromtimestamp(100)], [2, datetime.fromtimestamp(2398754908)]],
+        schema_overrides={"column_0": pl.UInt32},
         orient="row",
     )
-    assert df.dtypes == [pl.Int64, pl.Datetime]
+    assert df.dtypes == [pl.UInt32, pl.Datetime]
 
 
 def test_repeat_by() -> None:
     df = pl.DataFrame({"name": ["foo", "bar"], "n": [2, 3]})
-
     out = df.select(pl.col("n").repeat_by("n"))
     s = out["n"]
+
     assert s[0].to_list() == [2, 2]
     assert s[1].to_list() == [3, 3, 3]
 
@@ -2168,7 +2217,6 @@ def test_to_dict(as_series: bool, inner_dtype: Any) -> None:
             "optional": [28, 300, None, 2, -30],
         }
     )
-
     s = df.to_dict(as_series=as_series)
     assert isinstance(s, dict)
     for v in s.values():
@@ -2177,9 +2225,11 @@ def test_to_dict(as_series: bool, inner_dtype: Any) -> None:
 
 
 def test_df_broadcast() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    out = df.with_column(pl.Series([[1, 2]]))
+    df = pl.DataFrame({"a": [1, 2, 3]}, schema_overrides={"a": pl.UInt8})
+    out = df.with_column(pl.Series("s", [[1, 2]]))
     assert out.shape == (3, 2)
+    assert out.schema == {"a": pl.UInt8, "s": pl.List(pl.Int64)}
+    assert out.rows() == [(1, [1, 2]), (2, [1, 2]), (3, [1, 2])]
 
 
 def test_product() -> None:
@@ -2189,11 +2239,16 @@ def test_product() -> None:
             "flt": [-1.0, 12.0, 9.0],
             "bool_0": [True, False, True],
             "bool_1": [True, True, True],
-        }
+        },
+        schema_overrides={
+            "int": pl.UInt16,
+            "flt": pl.Float32,
+        },
     )
     out = df.product()
     expected = pl.DataFrame({"int": [6], "flt": [-108.0], "bool_0": [0], "bool_1": [1]})
-    assert out.frame_equal(expected)
+    assert_frame_not_equal(out, expected, check_dtype=True)
+    assert_frame_equal(out, expected, check_dtype=False)
 
 
 def test_first_last_expression(fruits_cars: pl.DataFrame) -> None:
@@ -2644,20 +2699,31 @@ def test_init_datetimes_with_timezone() -> None:
 
     dtm = datetime(2022, 10, 12, 12, 30, tzinfo=zoneinfo.ZoneInfo("UTC"))
     for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
-        df = pl.DataFrame(
-            data={"d1": [dtm], "d2": [dtm]},
-            columns=[
-                ("d1", pl.Datetime(tu, tz_us)),
-                ("d2", pl.Datetime(tu, tz_europe)),
-            ],
-        )
-        assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
-        assert df.rows() == [
-            (
-                datetime(2022, 10, 12, 8, 30, tzinfo=zoneinfo.ZoneInfo(tz_us)),
-                datetime(2022, 10, 12, 14, 30, tzinfo=zoneinfo.ZoneInfo(tz_europe)),
+        for type_overrides in (
+            {
+                "columns": [
+                    ("d1", pl.Datetime(tu, tz_us)),
+                    ("d2", pl.Datetime(tu, tz_europe)),
+                ]
+            },
+            {
+                "schema_overrides": {
+                    "d1": pl.Datetime(tu, tz_us),
+                    "d2": pl.Datetime(tu, tz_europe),
+                }
+            },
+        ):
+            df = pl.DataFrame(  # type: ignore[arg-type]
+                data={"d1": [dtm], "d2": [dtm]},
+                **type_overrides,
             )
-        ]
+            assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
+            assert df.rows() == [
+                (
+                    datetime(2022, 10, 12, 8, 30, tzinfo=zoneinfo.ZoneInfo(tz_us)),
+                    datetime(2022, 10, 12, 14, 30, tzinfo=zoneinfo.ZoneInfo(tz_europe)),
+                )
+            ]
 
 
 def test_init_physical_with_timezone() -> None:

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -4,12 +4,18 @@ import pytest
 
 import polars as pl
 from polars.exceptions import InvalidAssert
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import (
+    assert_frame_equal,
+    assert_series_equal,
+    assert_series_not_equal,
+)
 
 
 def test_compare_series_value_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.Series([2, 3, 4])
+
+    assert_series_not_equal(srs1, srs2)
     with pytest.raises(AssertionError, match="Series are different\n\nValue mismatch"):
         assert_series_equal(srs1, srs2)
 
@@ -17,7 +23,10 @@ def test_compare_series_value_mismatch() -> None:
 def test_compare_series_empty_equal() -> None:
     srs1 = pl.Series([])
     srs2 = pl.Series(())
+
     assert_series_equal(srs1, srs2)
+    with pytest.raises(AssertionError):
+        assert_series_not_equal(srs1, srs2)
 
 
 def test_compare_series_nans_assert_equal() -> None:
@@ -34,8 +43,11 @@ def test_compare_series_nans_assert_equal() -> None:
 
     with pytest.raises(AssertionError):
         assert_series_equal(srs1, srs1, nans_compare_equal=False)
+    assert_series_not_equal(srs1, srs1, nans_compare_equal=False)
+
     with pytest.raises(AssertionError):
         assert_series_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
+    assert_series_not_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
 
     for check_exact, nans_equal in (
         (False, False),
@@ -64,6 +76,7 @@ def test_compare_series_nans_assert_equal() -> None:
     assert_series_equal(srs4, srs6, check_dtype=False)
     with pytest.raises(AssertionError):
         assert_series_equal(srs5, srs6, check_dtype=False)
+    assert_series_not_equal(srs5, srs6, check_dtype=True)
 
 
 def test_compare_series_nulls() -> None:
@@ -73,6 +86,7 @@ def test_compare_series_nulls() -> None:
 
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.Series([1, None, None])
+
     with pytest.raises(AssertionError, match="Value mismatch"):
         assert_series_equal(srs1, srs2)
     with pytest.raises(AssertionError, match="Exact value mismatch"):


### PR DESCRIPTION
ref #6209.

This turned into more effort than anticipated... heads-up if you ever want to head into our constructor labyrinth; you may not come back - bring coffee :)

# What it does

As @stinodego accurately pointed out in the linked issue, we do not currently have an ergonomic way to specify specific dtypes for just one or two columns out of a larger set at frame-init time; it tends to be either all or nothing, require the full list of columns, etc - this use-case can be said to _Not Have A Good Story™_. 

The primary suggestion was to add a new `dtypes` param that can apply full _or_ partial schema information, supplementing or overriding anything gleaned from `columns`, and allowing better delineation of column names/order/types. That is what this PR implements (though we have since settled on `schema_overrides`).

While I was at it I found that quite a few of the `pl.from_<xyz>` methods didn't actually support `columns`, though in the main they pass-through to underlying functions that do; these functions have been upgraded to offer both `columns` and `schema_overrides`).

# Example

**Before**: 
_(have to refer to every column to override one)_
```python
df = pl.DataFrame(
    data = {
        "a": [1, 2 ,3],
        "b": [1, 2 ,3],
        "c": [1, 2 ,3],
        "d": [1, 2 ,3],
        "e": [1, 2 ,3],
    },
    columns = ["a", "b", "c", ("d",pl.Int8), "e"],
)
# or: columns = {"a":None, "b":None, "c":None, "d":pl.Int8, "e":None}`
```
^^ Now imagine how bad this gets for frames with 100s of columns ;)
 
**After**: 
_(previous code would still work, but now we have a much cleaner option)_
```python
df = pl.DataFrame(
    data = {
        "a": [1, 2 ,3],
        "b": [1, 2 ,3],
        "c": [1, 2 ,3],
        "d": [1, 2 ,3],
        "e": [1, 2 ,3],
    },
    schema_overrides = {"d": pl.Int8},
)
```

# Bug fixes

Several; carefully walking through the constructors again and adding more unit tests uncovered a number of previously unreported issues. Existing type overrides could potentially be ignored (eg: dataclass/namedtuple input), cause errors, or (in one especially odd case involving pyarrow) reshape the frame `repr` output in an unexpected way. I wouldn't describe any of them as major, but all have now been fixed.

# Next steps

This PR is completely backwards-compatible and additive to what we already have; aside from the bug fixes there are no changes to the current default behaviour, and no need for any changes in existing code. The new param can simply be used to write cleaner code going forward, and it lives happily alongside all of the overloads currently possible via `columns`.

Now that this gives us a more ergonomic way to apply partial schemas we have a better base to build on if there is interest in reworking it further (different param names like "schema", etc); this commit definitely doesn't address everything from the #6209 discussion, but it does take care of the biggest pain point.

I'd suggest closing out the existing issue, and starting a new one that refocuses on the remaining areas of interest?

(Should probably run through the docstrings and add more examples using `schema_overrides` too).

# Also 

_Miscellaneous:_

I know I've seen a request for this somewhere (possibly the Discord - couldn't find it in the open issue list), so I added the negative counterparts of our existing assert functions as they made sense for a couple of the updated tests:

* `assert_frame_not_equal`
* `assert_series_not_equal`