### PR TITLE
fix(python): strptime now respects pl.Datetime's time_unit

### DIFF
--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -106,17 +106,6 @@ class ExprStringNameSpace:
             return pli.wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
         elif datatype == Datetime:
             tu = datatype.tu  # type: ignore[union-attr]
-            if tu is None:
-                if fmt is None:
-                    tu = "us"
-                elif any(
-                    directive in fmt for directive in ("%.9f", "%9f", "%f", "%.f")
-                ):
-                    tu = "ns"
-                elif any(directive in fmt for directive in ("%.3f", "%3f")):
-                    tu = "ms"
-                else:
-                    tu = "us"
             dtcol = pli.wrap_expr(
                 self._pyexpr.str_parse_datetime(fmt, strict, exact, cache, tz_aware, tu)
             )

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -106,8 +106,19 @@ class ExprStringNameSpace:
             return pli.wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
         elif datatype == Datetime:
             tu = datatype.tu  # type: ignore[union-attr]
+            if tu is None:
+                if fmt is None:
+                    tu = "us"
+                elif any(
+                    directive in fmt for directive in ("%.9f", "%9f", "%f", "%.f")
+                ):
+                    tu = "ns"
+                elif any(directive in fmt for directive in ("%.3f", "%3f")):
+                    tu = "ms"
+                else:
+                    tu = "us"
             dtcol = pli.wrap_expr(
-                self._pyexpr.str_parse_datetime(fmt, strict, exact, cache, tz_aware)
+                self._pyexpr.str_parse_datetime(fmt, strict, exact, cache, tz_aware, tu)
             )
             return dtcol if (tu is None) else dtcol.dt.cast_time_unit(tu)
         elif datatype == Time:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -564,25 +564,22 @@ impl PyExpr {
         tz_aware: bool,
         tu: Option<Wrap<TimeUnit>>,
     ) -> PyExpr {
-        let result_tu = if let Some(value) = tu {
-            value.0
-        } else {
-            match fmt {
-                Some(ref fmt) => {
-                    if fmt.contains("%.9f")
-                        || fmt.contains("%9f")
-                        || fmt.contains("%f")
-                        || fmt.contains("%.f")
-                    {
-                        TimeUnit::Nanoseconds
-                    } else if fmt.contains("%.3f") || fmt.contains("%3f") {
-                        TimeUnit::Milliseconds
-                    } else {
-                        TimeUnit::Microseconds
-                    }
+        let result_tu = match (&fmt, tu) {
+            (_, Some(tu)) => tu.0,
+            (Some(fmt), None) => {
+                if fmt.contains("%.9f")
+                    || fmt.contains("%9f")
+                    || fmt.contains("%f")
+                    || fmt.contains("%.f")
+                {
+                    TimeUnit::Nanoseconds
+                } else if fmt.contains("%.3f") || fmt.contains("%3f") {
+                    TimeUnit::Milliseconds
+                } else {
+                    TimeUnit::Microseconds
                 }
-                None => TimeUnit::Microseconds,
             }
+            (None, None) => TimeUnit::Microseconds,
         };
         self.inner
             .clone()

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -562,28 +562,13 @@ impl PyExpr {
         exact: bool,
         cache: bool,
         tz_aware: bool,
+        tu: Wrap<TimeUnit>,
     ) -> PyExpr {
-        let tu = match fmt {
-            Some(ref fmt) => {
-                if fmt.contains("%.9f")
-                    || fmt.contains("%9f")
-                    || fmt.contains("%f")
-                    || fmt.contains("%.f")
-                {
-                    TimeUnit::Nanoseconds
-                } else if fmt.contains("%.3f") || fmt.contains("%3f") {
-                    TimeUnit::Milliseconds
-                } else {
-                    TimeUnit::Microseconds
-                }
-            }
-            None => TimeUnit::Microseconds,
-        };
         self.inner
             .clone()
             .str()
             .strptime(StrpTimeOptions {
-                date_dtype: DataType::Datetime(tu, None),
+                date_dtype: DataType::Datetime(tu.0, None),
                 fmt,
                 strict,
                 exact,

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -564,7 +564,9 @@ impl PyExpr {
         tz_aware: bool,
         tu: Option<Wrap<TimeUnit>>,
     ) -> PyExpr {
-        let result_tu = if tu.is_none() {
+        let result_tu = if let Some(value) = tu {
+            value.0
+        } else {
             match fmt {
                 Some(ref fmt) => {
                     if fmt.contains("%.9f")
@@ -581,8 +583,6 @@ impl PyExpr {
                 }
                 None => TimeUnit::Microseconds,
             }
-        } else {
-            tu.unwrap().0
         };
         self.inner
             .clone()

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -981,9 +981,10 @@ def test_strptime_precision() -> None:
     ("unit", "expected"),
     [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
 )
-def test_strptime_precision_with_time_unit(unit: TimeUnit, expected: str) -> None:
+@pytest.mark.parametrize('fmt', ['%Y-%m-%d %H:%M:%S.%f', None])
+def test_strptime_precision_with_time_unit(unit: TimeUnit, expected: str, fmt: str) -> None:
     ser = pl.Series(["2020-01-01 00:00:00.123456789"])
-    result = ser.str.strptime(pl.Datetime(unit)).dt.strftime("%f")[0]
+    result = ser.str.strptime(pl.Datetime(unit), fmt=fmt).dt.strftime("%f")[0]
     assert result == expected
 
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -977,6 +977,16 @@ def test_strptime_precision() -> None:
         assert ds.dt.nanosecond().to_list() == expected_values
 
 
+@pytest.mark.parametrize(
+    ("unit", "expected"),
+    [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
+)
+def test_strptime_precision_with_time_unit(unit: TimeUnit, expected: str) -> None:
+    ser = pl.Series(["2020-01-01 00:00:00.123456789"])
+    result = ser.str.strptime(pl.Datetime(unit)).dt.strftime("%f")[0]
+    assert result == expected
+
+
 def test_asof_join_tolerance_grouper() -> None:
     from datetime import date
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -981,8 +981,10 @@ def test_strptime_precision() -> None:
     ("unit", "expected"),
     [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
 )
-@pytest.mark.parametrize('fmt', ['%Y-%m-%d %H:%M:%S.%f', None])
-def test_strptime_precision_with_time_unit(unit: TimeUnit, expected: str, fmt: str) -> None:
+@pytest.mark.parametrize("fmt", ["%Y-%m-%d %H:%M:%S.%f", None])
+def test_strptime_precision_with_time_unit(
+    unit: TimeUnit, expected: str, fmt: str
+) -> None:
     ser = pl.Series(["2020-01-01 00:00:00.123456789"])
     result = ser.str.strptime(pl.Datetime(unit), fmt=fmt).dt.strftime("%f")[0]
     assert result == expected


### PR DESCRIPTION
closes #6228 

Here's my attempt at fixing the linked issue - I'm new to rust so apologies if I've done anything illegal here, I'll study it properly now