### PR TITLE
fix(python): allow integer-compatible row indexes that are not strictly typed as `int`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6503,13 +6503,19 @@ class DataFrame:
         if named:
             Row = namedtuple("Row", self.columns)  # type: ignore[misc]
 
-        if isinstance(index, int):
+        if index is not None:
             row = self._df.row_tuple(index)
             if named:
                 return Row(*row)
             else:
                 return row
-        elif isinstance(by_predicate, pli.Expr):
+
+        elif by_predicate is not None:
+            if not isinstance(by_predicate, pli.Expr):
+                raise TypeError(
+                    f"Expected 'by_predicate to be an expression; "
+                    f"found {type(by_predicate)}"
+                )
             rows = self.filter(by_predicate).rows()
             n_rows = len(rows)
             if n_rows > 1:
@@ -6518,6 +6524,7 @@ class DataFrame:
                 )
             elif n_rows == 0:
                 raise NoRowsReturned(f"Predicate <{by_predicate!s}> returned no rows")
+
             row = rows[0]
             if named:
                 return Row(*row)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -31,6 +31,7 @@ def test_null_count() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", None]})
     assert df.null_count().shape == (1, 2)
     assert df.null_count().row(0) == (0, 1)
+    assert df.null_count().row(np.int64(0)) == (0, 1)  # type: ignore[call-overload]
 
 
 def test_init_empty() -> None:


### PR DESCRIPTION
Closes #6265.

This doesn't add any extra numpy support, but it does technically allow formats that are _intrinsically_ integer compliant (_such as_ numpy ints) to work with the `.row(n)` method, allowing the linked issue to be closed. 

Unsuitable types to either parameter will also now raise a proper `TypeError`, which is an improvement over the slightly misleading `ValueError` that we currently raise in this case.