### PR TITLE
build(python): Move package metadata to `pyproject.toml`

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,14 +1,7 @@
 [package]
 name = "py-polars"
 version = "0.15.15"
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/index.html"
 edition = "2021"
-homepage = "https://github.com/pola-rs/polars"
-license = "MIT"
-readme = "README.md"
-repository = "https://github.com/pola-rs/polars"
-description = "Blazingly fast DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/py-polars/polars/show_versions.py
+++ b/py-polars/polars/show_versions.py
@@ -55,6 +55,7 @@ def _get_dependency_info() -> dict[str, str]:
         "fsspec",
         "connectorx",
         "xlsx2csv",
+        "deltalake",
         "matplotlib",
     ]
     return {name: _get_dep_version(name) for name in opt_deps}

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -4,10 +4,40 @@ build-backend = "maturin"
 
 [project]
 name = "polars"
+description = "Blazingly fast DataFrame library"
+readme = "README.md"
+authors = [
+  { name = "Ritchie Vink", email = "ritchie46@gmail.com" },
+]
+license = { file = "LICENSE" }
+requires-python = ">=3.7"
 dependencies = [
   "typing_extensions >= 4.0.0; python_version < '3.10'",
 ]
-requires-python = ">=3.7"
+keywords = ["dataframe", "arrow", "out-of-core"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Rust",
+  "Topic :: Scientific/Engineering",
+]
+
+[project.urls]
+homepage = "https://www.pola.rs/"
+documentation = "https://pola-rs.github.io/polars/py-polars/html/reference/"
+repository = "https://github.com/pola-rs/polars"
+changelog = "https://github.com/pola-rs/polars/releases"
 
 [project.optional-dependencies]
 # the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS


### PR DESCRIPTION
Most Python Polars project metadata now lives in the `Cargo.toml`, which `maturin` interprets when creating the Python package.

I wanted to add some extra metadata, but this wasn't possible in `Cargo.toml`. So I ended up moving the metadata to `pyproject.toml`. It makes more sense there anyway, I believe.

Changes:
* Move Python Polars metadata to `pyproject.toml` - following PEP 621 conventions as required by maturin
* Add `changelog` URL, which should show up on PyPI
* Add keywords & classifiers to improve discoverability
* Misc change: added "deltalake" to `show_versions`.