### PR TITLE
fix(python): implement missing DataFrame `__floordiv__` op

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -432,6 +432,22 @@ class Unknown(DataType):
     """Type representing Datatype values that could not be determined statically."""
 
 
+TEMPORAL_DTYPES = frozenset([Datetime, Date, Time, Duration])
+FLOAT_DTYPES = frozenset([Float32, Float64])
+INTEGER_DTYPES = frozenset(
+    [
+        Int8,
+        Int16,
+        Int32,
+        Int64,
+        UInt8,
+        UInt16,
+        UInt32,
+        UInt64,
+    ]
+)
+
+
 T = TypeVar("T")
 
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -346,9 +346,9 @@ def date_range(
     Parameters
     ----------
     low
-        Lower bound of the date range.
+        Lower bound of the date range, given as a date, datetime, Expr, or column name.
     high
-        Upper bound of the date range.
+        Upper bound of the date range, given as a date, datetime, Expr, or column name.
     interval
         Interval periods. It can be a python timedelta object, like
         ``timedelta(days=10)``, or a polars duration string, such as ``3d12h4m25s``


### PR DESCRIPTION
Closes #6274 (1 of 2 - have asked for the other part to be broken out as a separate Issue).

Both `Series` and `Expr` already have `__floordiv__` implementations (aka: `//` integer division). This PR adds it for `DataFrame`, along with new test coverage (for both floordiv _and_ truediv) that validates scalar literal broadcast, Series, and DataFrame division.

**Example**:
```python
import polars as pl

df = pl.DataFrame(
    data = {
        "x": [ 0, -1, -2 , -3 ],
        "y": [-0.,-3., 5., -7.],
        "z": [10,  3 ,-5,   7 ],
    }
)
```

**Before**:
```python
df // 3 

# TypeError: unsupported operand type(s) for //: 'DataFrame' and 'int'
```

**After**:
```python
df // 3 

# shape: (4, 3)
# ┌─────┬──────┬─────┐
# │ x   ┆ y    ┆ z   │
# │ --- ┆ ---  ┆ --- │
# │ i64 ┆ f64  ┆ i64 │
# ╞═════╪══════╪═════╡
# │ 0   ┆ -0.0 ┆ 3   │
# │ -1  ┆ -1.0 ┆ 1   │
# │ -1  ┆ 1.0  ┆ -2  │
# │ -1  ┆ -3.0 ┆ 2   │
# └─────┴──────┴─────┘
```

