### PR TITLE
feat(python): improvements to dtype-based column selection

### DIFF
--- a/py-polars/docs/source/reference/api.rst
+++ b/py-polars/docs/source/reference/api.rst
@@ -63,6 +63,17 @@ Examples
                 ]
             )
 
+            # shape: (3, 1)   shape: (3, 2)
+            # ┌──────────┐    ┌───────────────┬──────────────────┐
+            # │ column_0 │    │ hi there      ┆ bye              │
+            # │ ---      │    │ ---           ┆ ---              │
+            # │ str      │    │ str           ┆ str              │
+            # ╞══════════╡ >> ╞═══════════════╪══════════════════╡
+            # │ world    │    │ Hello world   ┆ Sayōnara world   │
+            # │ world!   │    │ Hello world!  ┆ Sayōnara world!  │
+            # │ world!!  │    │ Hello world!! ┆ Sayōnara world!! │
+            # └──────────┘    └───────────────┴──────────────────┘
+
     .. tab-item:: DataFrame
 
         .. code-block:: python
@@ -84,6 +95,16 @@ Examples
                 data=["aaa", "bbb", "ccc", "ddd", "eee", "fff"],
                 columns=[("txt", pl.Utf8)],
             ).split.by_alternate_rows()
+
+            # [┌─────┐  ┌─────┐
+            #  │ txt │  │ txt │
+            #  │ --- │  │ --- │
+            #  │ str │  │ str │
+            #  ╞═════╡  ╞═════╡
+            #  │ aaa │  │ bbb │
+            #  │ ccc │  │ ddd │
+            #  │ eee │  │ fff │
+            #  └─────┘, └─────┘]
 
     .. tab-item:: LazyFrame
 
@@ -108,6 +129,16 @@ Examples
 
             ldf.types.upcast_integer_types()
 
+            # shape: (2, 3)          shape: (2, 3)
+            # ┌─────┬─────┬─────┐    ┌─────┬─────┬─────┐
+            # │ a   ┆ b   ┆ c   │    │ a   ┆ b   ┆ c   │
+            # │ --- ┆ --- ┆ --- │    │ --- ┆ --- ┆ --- │
+            # │ i16 ┆ i32 ┆ f32 │ >> │ i64 ┆ i64 ┆ f32 │
+            # ╞═════╪═════╪═════╡    ╞═════╪═════╪═════╡
+            # │ 1   ┆ 3   ┆ 5.6 │    │ 1   ┆ 3   ┆ 5.6 │
+            # │ 2   ┆ 4   ┆ 6.7 │    │ 2   ┆ 4   ┆ 6.7 │
+            # └─────┴─────┴─────┘    └─────┴─────┴─────┘
+
     .. tab-item:: Series
 
         .. code-block:: python
@@ -128,3 +159,13 @@ Examples
 
             s2 = s.math.square().rename("n2", in_place=True)
             s3 = s.math.cube().rename("n3", in_place=True)
+
+            # shape: (5,)          shape: (5,)           shape: (5,)
+            # Series: 'n' [i64]    Series: 'n2' [i64]    Series: 'n3' [i64]
+            # [                    [                     [
+            #     1                    1                      1
+            #     2                    4                      8
+            #     3                    9                      27
+            #     4                    16                     64
+            #     5                    25                    125
+            # ]                    ]                    ]

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -432,21 +432,31 @@ class Unknown(DataType):
     """Type representing Datatype values that could not be determined statically."""
 
 
-TEMPORAL_DTYPES = frozenset([Datetime, Date, Time, Duration])
-FLOAT_DTYPES = frozenset([Float32, Float64])
-INTEGER_DTYPES = frozenset(
+TEMPORAL_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
-        Int8,
-        Int16,
-        Int32,
-        Int64,
+        Datetime("ms"),
+        Datetime("us"),
+        Datetime("ns"),
+        Date,
+        Time,
+        Duration("ms"),
+        Duration("us"),
+        Duration("ns"),
+    ]
+)
+INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
+    [
         UInt8,
         UInt16,
         UInt32,
         UInt64,
+        Int8,
+        Int16,
+        Int32,
+        Int64,
     ]
 )
-
+FLOAT_DTYPES: frozenset[PolarsDataType] = frozenset([Float32, Float64])
 
 T = TypeVar("T")
 

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -457,6 +457,8 @@ INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
     ]
 )
 FLOAT_DTYPES: frozenset[PolarsDataType] = frozenset([Float32, Float64])
+NUMERIC_DTYPES: frozenset[PolarsDataType] = FLOAT_DTYPES | INTEGER_DTYPES
+
 
 T = TypeVar("T")
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES, TEMPORAL_DTYPES
 from polars.testing import assert_series_equal
 from polars.testing._private import verify_series_and_expr_api
 
@@ -280,6 +281,57 @@ def test_dot_in_groupby() -> None:
         .agg(pl.col("x").dot("y").alias("dot"))
         .frame_equal(pl.DataFrame({"group": ["a", "b"], "dot": [6, 15]}))
     )
+
+
+def test_dtype_col_selection() -> None:
+    df = pl.DataFrame(
+        data=[],
+        columns={
+            "a1": pl.Datetime,
+            "a2": pl.Datetime("ms"),
+            "a3": pl.Datetime("ms"),
+            "a4": pl.Datetime("ns"),
+            "b": pl.Date,
+            "c": pl.Time,
+            "d1": pl.Duration,
+            "d2": pl.Duration("ms"),
+            "d3": pl.Duration("us"),
+            "d4": pl.Duration("ns"),
+            "e": pl.Int8,
+            "f": pl.Int16,
+            "g": pl.Int32,
+            "h": pl.Int64,
+            "i": pl.Float32,
+            "j": pl.Float64,
+            "k": pl.UInt8,
+            "l": pl.UInt16,
+            "m": pl.UInt32,
+            "n": pl.UInt64,
+        },
+    )
+    assert set(df.select(pl.col(INTEGER_DTYPES)).columns) == {
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+    }
+    assert set(df.select(pl.col(FLOAT_DTYPES)).columns) == {"i", "j"}
+    assert set(df.select(pl.col(TEMPORAL_DTYPES)).columns) == {
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+        "b",
+        "c",
+        "d1",
+        "d2",
+        "d3",
+        "d4",
+    }
 
 
 def test_list_eval_expression() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -8,7 +8,12 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES, TEMPORAL_DTYPES
+from polars.datatypes import (
+    FLOAT_DTYPES,
+    INTEGER_DTYPES,
+    NUMERIC_DTYPES,
+    TEMPORAL_DTYPES,
+)
 from polars.testing import assert_series_equal
 from polars.testing._private import verify_series_and_expr_api
 
@@ -320,6 +325,18 @@ def test_dtype_col_selection() -> None:
         "n",
     }
     assert set(df.select(pl.col(FLOAT_DTYPES)).columns) == {"i", "j"}
+    assert set(df.select(pl.col(NUMERIC_DTYPES)).columns) == {
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+    }
     assert set(df.select(pl.col(TEMPORAL_DTYPES)).columns) == {
         "a1",
         "a2",


### PR DESCRIPTION
I think there are a few more improvements still to be made here (and I'll look at making them later ;), but it's a reasonable start. There are now `datatypes` entries for INTEGER_DTYPES, FLOAT_DTYPES, NUMERIC_DTYPES, and TEMPORAL_DTYPES.

**Updates**:

* Allows sets/frozensets of dtypes to be passed to `col`, in addition to lists/tuples/scalars of such.
* Adds new NUMERIC_DTYPES group as the union of INTEGER/FLOAT_DTYPES.
* Improves the TEMPORAL_DTYPES grouping to account for timeunits.
* Adds new test coverage for all of the above.

**Example**:

```python
from polars.datatypes import FLOAT_DTYPES
import polars as pl

df = pl.DataFrame({
    "w": ["aa", "bb", "cc"],
    "x": [1.50, 2.25, 3.75],
    "y": [1234, 5678, 9101],
    "z": [4.55, -2.5, 0.05],
})

df.select( pl.col(FLOAT_DTYPES) )
# shape: (3, 2)
# ┌──────┬──────┐
# │ x    ┆ z    │
# │ ---  ┆ ---  │
# │ f64  ┆ f64  │
# ╞══════╪══════╡
# │ 1.5  ┆ 4.55 │
# │ 2.25 ┆ -2.5 │
# │ 3.75 ┆ 0.05 │
# └──────┴──────┘
```

**Misc**:
* Also added some example _output_ to the `api` docs for each of the main examples there.

----

Closes #5643.