### PR TITLE
test(python): Ignore hash doctests

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6840,7 +6840,7 @@ class DataFrame:
         ...         "ham": ["a", "b", None, "d"],
         ...     }
         ... )
-        >>> df.hash_rows(seed=42)
+        >>> df.hash_rows(seed=42)  # doctest: +IGNORE_RESULT
         shape: (4,)
         Series: '' [u64]
         [

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3549,7 +3549,7 @@ class Expr:
         ...         "b": ["x", None, "z"],
         ...     }
         ... )
-        >>> df.with_column(pl.all().hash(10, 20, 30, 40))
+        >>> df.with_column(pl.all().hash(10, 20, 30, 40))  # doctest: +IGNORE_RESULT
         shape: (3, 2)
         ┌──────────────────────┬──────────────────────┐
         │ a                    ┆ b                    │

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4265,7 +4265,7 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.hash(seed=42)
+        >>> s.hash(seed=42)  # doctest: +IGNORE_RESULT
         shape: (3,)
         Series: 'a' [u64]
         [


### PR DESCRIPTION
These tests failed on my M1 MacBook. Let's ignore them to facilitate contributors that work on a Mac.

(Should we run tests on MacOS in the CI?)