### PR TITLE
refactor(python): simplify `_from_pandas` constructor

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -476,7 +476,7 @@ def _pandas_series_to_arrow(
 
     """
     dtype = getattr(values, "dtype", None)
-    if dtype == "object" and len(values) > 0:
+    if dtype == "object":
         first_non_none = _get_first_non_none(values.values)  # type: ignore[arg-type]
 
         if isinstance(first_non_none, str):

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -554,19 +554,6 @@ class DataFrame:
         DataFrame
 
         """
-        # path for table without rows that keeps datatype
-        if data.shape[0] == 0:
-            series = []
-            for name in data.columns:
-                pd_series = data[name]
-                if pd_series.dtype == np.dtype("O"):
-                    series.append(pli.Series(name, [], dtype=Utf8))
-                else:
-                    dtype = (schema_overrides or {}).get(name)
-                    col = pli.Series(name, pd_series, dtype=dtype)
-                    series.append(pli.Series(name, col))
-            return cls(series)
-
         return cls._from_pydf(
             pandas_to_pydf(
                 data,

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -459,12 +459,29 @@ def test_from_empty_pandas() -> None:
     assert polars_df.dtypes == [pl.Float64, pl.Float64]
 
 
-def test_from_empty_pandas_strings() -> None:
+def test_from_empty_pandas_with_dtypes() -> None:
     df = pd.DataFrame(columns=["a", "b"])
     df["a"] = df["a"].astype(str)
     df["b"] = df["b"].astype(float)
-    df_pl = pl.from_pandas(df)
-    assert df_pl.dtypes == [pl.Utf8, pl.Float64]
+    assert pl.from_pandas(df).dtypes == [pl.Utf8, pl.Float64]
+
+    df = pl.DataFrame(
+        data=[],
+        columns={
+            "a": pl.Int32,
+            "b": pl.Datetime,
+            "c": pl.Float32,
+            "d": pl.Duration,
+            "e": pl.Utf8,
+        },
+    ).to_pandas()
+    assert pl.from_pandas(df).dtypes == [
+        pl.Int32,
+        pl.Datetime,
+        pl.Float32,
+        pl.Duration,
+        pl.Utf8,
+    ]
 
 
 def test_from_empty_arrow() -> None:


### PR DESCRIPTION
Started the grand `columns` deprecation, spotted the opportunity to remove a redundant chunk of pandas/arrow init code. It's already handled elsewhere, but was unnecessarily gated against an empty dataset; removing the `len(values) > 0` check allows us to then remove the redundant code that does the same thing - all paths now use common code.