### PR TITLE
fix(rust, python): disallow alias in inline join expressions

### DIFF
--- a/polars/tests/it/io/json.rs
+++ b/polars/tests/it/io/json.rs
@@ -129,6 +129,7 @@ fn read_ndjson_with_trailing_newline() {
     assert!(expected.frame_equal(&df));
 }
 #[test]
+#[cfg(feature = "dtype-struct")]
 fn test_read_ndjson_iss_5875() {
     let jsonlines = r#"
     {"struct": {"int_inner": [1, 2, 3], "float_inner": 5.0, "str_inner": ["a", "b", "c"]}}
@@ -158,6 +159,7 @@ fn test_read_ndjson_iss_5875() {
 }
 
 #[test]
+#[cfg(feature = "dtype-struct")]
 fn test_read_ndjson_iss_5875_part2() {
     let jsonlines = r#"
     {"struct": {"int_list_inner": [4, 5, 6]}}
@@ -188,6 +190,7 @@ fn test_read_ndjson_iss_5875_part2() {
     assert_eq!(schema, df.unwrap().schema());
 }
 #[test]
+#[cfg(feature = "dtype-struct")]
 fn test_read_ndjson_iss_5875_part3() {
     let jsonlines = r#"
     {"key1":"value1", "key2": "value2", "key3": {"k1": 2, "k3": "value5", "k10": 5}}

--- a/polars/tests/it/joins.rs
+++ b/polars/tests/it/joins.rs
@@ -12,17 +12,17 @@ fn join_nans_outer() -> PolarsResult<()> {
         .lazy();
     let a1 = df1
         .clone()
-        .groupby(vec![col("w").alias("w"), col("t").alias("t")])
+        .groupby(vec![col("w").alias("w"), col("t")])
         .agg(vec![col("c").sum().alias("c_sum")]);
     let a2 = df1
-        .groupby(vec![col("w").alias("w"), col("t").alias("t")])
+        .groupby(vec![col("w").alias("w"), col("t")])
         .agg(vec![col("c").max().alias("c_max")]);
 
     let res = a1
         .join_builder()
         .with(a2)
-        .left_on(vec![col("w").alias("w"), col("t").alias("t")])
-        .right_on(vec![col("w").alias("w"), col("t").alias("t")])
+        .left_on(vec![col("w"), col("t")])
+        .right_on(vec![col("w"), col("t")])
         .how(JoinType::Outer)
         .finish()
         .collect()?;

--- a/polars/tests/it/lazy/projection_queries.rs
+++ b/polars/tests/it/lazy/projection_queries.rs
@@ -153,6 +153,7 @@ fn test_projection_5086() -> PolarsResult<()> {
 }
 
 #[test]
+#[cfg(feature = "dtype-struct")]
 fn test_unnest_pushdown() -> PolarsResult<()> {
     let df = df![
         "collection" => Series::full_null("", 1, &DataType::Int32),

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -334,3 +334,12 @@ def test_arr_eval_named_cols() -> None:
         pl.ComputeError,
     ):
         df.select(pl.col("B").arr.eval(pl.element().append(pl.col("A"))))
+
+
+def test_alias_in_join_keys() -> None:
+    df = pl.DataFrame({"A": ["a", "b"], "B": [["a", "b"], ["c", "d"]]})
+    with pytest.raises(
+        pl.ComputeError,
+        match=r"'alias' is not allowed in a join key. Use 'with_columns' first",
+    ):
+        df.join(df, on=pl.col("A").alias("foo"))


### PR DESCRIPTION
fixes #6309
fixes #6142
fixes #5920