### PR TITLE
chore: Use `documentation` label instead of `docs`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,7 +14,7 @@ categories:
       - build
       - chore
       - ci
-      - docs
+      - documentation
       - refactor
       - revert
       - style
@@ -55,7 +55,7 @@ autolabeler:
   - label: ci
     title:
       - '/^ci/'
-  - label: docs
+  - label: documentation
     title:
       - '/^docs/'
   - label: enhancement


### PR DESCRIPTION
We had two labels describing the same thing. Let's use `documentation`.