### PR TITLE
fix(python): Reject `None` input for `head`/`tail`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3089,7 +3089,7 @@ class DataFrame:
         """
         return self.head(n)
 
-    def head(self: DF, n: int | None = 5) -> DF:
+    def head(self: DF, n: int = 5) -> DF:
         """
         Get the first `n` rows (if negative, returns all rows except the last `n`).
 
@@ -3136,11 +3136,11 @@ class DataFrame:
         │ 2   ┆ 7   ┆ b   │
         └─────┴─────┴─────┘
         """
-        if n and n < 0:
+        if n < 0:
             n = len(self) + n
         return self._from_pydf(self._df.head(n))
 
-    def tail(self: DF, n: int | None = 5) -> DF:
+    def tail(self: DF, n: int = 5) -> DF:
         """
         Get the last `n` rows (if negative, returns all rows except the first `n`).
 
@@ -3187,7 +3187,7 @@ class DataFrame:
         │ 5   ┆ 10  ┆ e   │
         └─────┴─────┴─────┘
         """
-        if n and n < 0:
+        if n < 0:
             n = len(self) + n
         return self._from_pydf(self._df.tail(n))
 

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -964,12 +964,12 @@ def last(column: str | pli.Series | None = None) -> pli.Expr:
 
 
 @overload
-def head(column: str, n: int = 10) -> pli.Expr:
+def head(column: str, n: int = ...) -> pli.Expr:
     ...
 
 
 @overload
-def head(column: pli.Series, n: int = 10) -> pli.Series:
+def head(column: pli.Series, n: int = ...) -> pli.Series:
     ...
 
 
@@ -1023,12 +1023,12 @@ def head(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
 
 
 @overload
-def tail(column: str, n: int = 10) -> pli.Expr:
+def tail(column: str, n: int = ...) -> pli.Expr:
     ...
 
 
 @overload
-def tail(column: pli.Series, n: int = 10) -> pli.Series:
+def tail(column: pli.Series, n: int = ...) -> pli.Series:
     ...
 
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1021,13 +1021,13 @@ impl PyDataFrame {
         df.into()
     }
 
-    pub fn head(&self, length: Option<usize>) -> Self {
-        let df = self.df.head(length);
+    pub fn head(&self, n: usize) -> Self {
+        let df = self.df.head(Some(n));
         PyDataFrame::new(df)
     }
 
-    pub fn tail(&self, length: Option<usize>) -> Self {
-        let df = self.df.tail(length);
+    pub fn tail(&self, n: usize) -> Self {
+        let df = self.df.tail(Some(n));
         PyDataFrame::new(df)
     }
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -355,12 +355,12 @@ impl PyExpr {
             .with_fmt("take_every")
             .into()
     }
-    pub fn tail(&self, n: Option<usize>) -> PyExpr {
-        self.clone().inner.tail(n).into()
+    pub fn tail(&self, n: usize) -> PyExpr {
+        self.clone().inner.tail(Some(n)).into()
     }
 
-    pub fn head(&self, n: Option<usize>) -> PyExpr {
-        self.clone().inner.head(n).into()
+    pub fn head(&self, n: usize) -> PyExpr {
+        self.clone().inner.head(Some(n)).into()
     }
 
     pub fn slice(&self, offset: PyExpr, length: PyExpr) -> PyExpr {


### PR DESCRIPTION
Resolves #6323

Changes:
* `None` is no longer accepted as an input for `head`/`tail` on the Python side. This now raises a `TypeError`.

Not sure this should be a breaking change - `None` was listed as a type, but wasn't explained any further.