### PR TITLE
docs(python): Remove unnecessary brackets in doc examples

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3746,7 +3746,7 @@ class DataFrame:
         >>> df.groupby_dynamic("time", every="1h", closed="left").agg(
         ...     [
         ...         pl.col("time").count().alias("time_count"),
-        ...         pl.col("time").list().alias("time_agg_list"),
+        ...         pl.col("time").alias("time_agg_list"),
         ...     ]
         ... )
         shape: (4, 3)
@@ -3843,7 +3843,7 @@ class DataFrame:
         ...         period="3i",
         ...         include_boundaries=True,
         ...         closed="right",
-        ...     ).agg(pl.col("A").list().alias("A_agg_list"))
+        ...     ).agg(pl.col("A").alias("A_agg_list"))
         ... )
         shape: (3, 4)
         ┌─────────────────┬─────────────────┬─────┬─────────────────┐

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3668,9 +3668,10 @@ class DataFrame:
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday'}
             The strategy to determine the start of the first window by.
-            * 'window': Truncate the start of the window with the 'every' argument.
-            * 'datapoint': Start from the first encountered data point.
-            * 'monday': Start the window on the monday before the first data point.
+
+            - 'window': Truncate the start of the window with the 'every' argument.
+            - 'datapoint': Start from the first encountered data point.
+            - 'monday': Start the window on the monday before the first data point.
 
         Examples
         --------
@@ -3704,13 +3705,11 @@ class DataFrame:
 
         Group by windows of 1 hour starting at 2021-12-16 00:00:00.
 
-        >>> (
-        ...     df.groupby_dynamic("time", every="1h", closed="right").agg(
-        ...         [
-        ...             pl.col("time").min().alias("time_min"),
-        ...             pl.col("time").max().alias("time_max"),
-        ...         ]
-        ...     )
+        >>> df.groupby_dynamic("time", every="1h", closed="right").agg(
+        ...     [
+        ...         pl.col("time").min().alias("time_min"),
+        ...         pl.col("time").max().alias("time_max"),
+        ...     ]
         ... )
         shape: (4, 3)
         ┌─────────────────────┬─────────────────────┬─────────────────────┐
@@ -3726,11 +3725,9 @@ class DataFrame:
 
         The window boundaries can also be added to the aggregation result
 
-        >>> (
-        ...     df.groupby_dynamic(
-        ...         "time", every="1h", include_boundaries=True, closed="right"
-        ...     ).agg([pl.col("time").count().alias("time_count")])
-        ... )
+        >>> df.groupby_dynamic(
+        ...     "time", every="1h", include_boundaries=True, closed="right"
+        ... ).agg([pl.col("time").count().alias("time_count")])
         shape: (4, 4)
         ┌─────────────────────┬─────────────────────┬─────────────────────┬────────────┐
         │ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ time_count │
@@ -3746,13 +3743,11 @@ class DataFrame:
         When closed="left", should not include right end of interval
         [lower_bound, upper_bound)
 
-        >>> (
-        ...     df.groupby_dynamic("time", every="1h", closed="left").agg(
-        ...         [
-        ...             pl.col("time").count().alias("time_count"),
-        ...             pl.col("time").alias("time_agg_list"),
-        ...         ]
-        ...     )
+        >>> df.groupby_dynamic("time", every="1h", closed="left").agg(
+        ...     [
+        ...         pl.col("time").count().alias("time_count"),
+        ...         pl.col("time").list().alias("time_agg_list"),
+        ...     ]
         ... )
         shape: (4, 3)
         ┌─────────────────────┬────────────┬─────────────────────────────────────┐
@@ -3768,10 +3763,8 @@ class DataFrame:
 
         When closed="both" the time values at the window boundaries belong to 2 groups.
 
-        >>> (
-        ...     df.groupby_dynamic("time", every="1h", closed="both").agg(
-        ...         [pl.col("time").count().alias("time_count")]
-        ...     )
+        >>> df.groupby_dynamic("time", every="1h", closed="both").agg(
+        ...     [pl.col("time").count().alias("time_count")]
         ... )
         shape: (5, 2)
         ┌─────────────────────┬────────────┐
@@ -3813,15 +3806,13 @@ class DataFrame:
         │ 2021-12-16 02:30:00 ┆ a      │
         │ 2021-12-16 03:00:00 ┆ a      │
         └─────────────────────┴────────┘
-        >>> (
-        ...     df.groupby_dynamic(
-        ...         "time",
-        ...         every="1h",
-        ...         closed="both",
-        ...         by="groups",
-        ...         include_boundaries=True,
-        ...     ).agg([pl.col("time").count().alias("time_count")])
-        ... )
+        >>> df.groupby_dynamic(
+        ...     "time",
+        ...     every="1h",
+        ...     closed="both",
+        ...     by="groups",
+        ...     include_boundaries=True,
+        ... ).agg([pl.col("time").count().alias("time_count")])
         shape: (7, 5)
         ┌────────┬─────────────────────┬─────────────────────┬─────────────────────┬────────────┐
         │ groups ┆ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ time_count │
@@ -3852,7 +3843,7 @@ class DataFrame:
         ...         period="3i",
         ...         include_boundaries=True,
         ...         closed="right",
-        ...     ).agg(pl.col("A").alias("A_agg_list"))
+        ...     ).agg(pl.col("A").list().alias("A_agg_list"))
         ... )
         shape: (3, 4)
         ┌─────────────────┬─────────────────┬─────┬─────────────────┐
@@ -3940,11 +3931,9 @@ class DataFrame:
         ...         "values": [0, 1, 2, 3],
         ...     }
         ... )
-        >>> (
-        ...     df.upsample(
-        ...         time_column="time", every="1mo", by="groups", maintain_order=True
-        ...     ).select(pl.all().forward_fill())
-        ... )
+        >>> df.upsample(
+        ...     time_column="time", every="1mo", by="groups", maintain_order=True
+        ... ).select(pl.all().forward_fill())
         shape: (7, 3)
         ┌─────────────────────┬────────┬────────┐
         │ time                ┆ groups ┆ values │
@@ -4302,9 +4291,7 @@ class DataFrame:
 
         It is better to implement this with an expression:
 
-        >>> (
-        ...     df.select([pl.col("foo") * 2, pl.col("bar") * 3])
-        ... )  # doctest: +IGNORE_RESULT
+        >>> df.select([pl.col("foo") * 2, pl.col("bar") * 3])  # doctest: +IGNORE_RESULT
 
         Return a Series by mapping each row to a scalar:
 

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -175,8 +175,8 @@ class GroupBy(Generic[DF]):
 
         For each color group sample two rows:
 
-        >>> (
-        ...     df.groupby("color").apply(lambda group_df: group_df.sample(2))
+        >>> df.groupby("color").apply(
+        ...     lambda group_df: group_df.sample(2)
         ... )  # doctest: +IGNORE_RESULT
         shape: (4, 3)
         ┌─────┬───────┬──────────┐
@@ -192,8 +192,8 @@ class GroupBy(Generic[DF]):
 
         It is better to implement this with an expression:
 
-        >>> (
-        ...     df.filter(pl.arange(0, pl.count()).shuffle().over("color") < 2)
+        >>> df.filter(
+        ...     pl.arange(0, pl.count()).shuffle().over("color") < 2
         ... )  # doctest: +IGNORE_RESULT
 
         """
@@ -339,7 +339,7 @@ class GroupBy(Generic[DF]):
         │ a       ┆ 5   │
         │ b       ┆ 6   │
         └─────────┴─────┘
-        >>> (df.groupby("letters").tail(2).sort("letters"))
+        >>> df.groupby("letters").tail(2).sort("letters")
         shape: (5, 2)
         ┌─────────┬─────┐
         │ letters ┆ nrs │

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1170,8 +1170,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
-        >>> # Create a Series with 3 nulls, append column a then rechunk
-        >>> (df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk()))
+
+        Create a Series with 3 nulls, append column a then rechunk
+
+        >>> df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk())
         shape: (6, 1)
         ┌─────────┐
         │ literal │
@@ -2695,11 +2697,7 @@ class Expr:
         ...         "values": [1, 2, 3],
         ...     }
         ... )
-        >>> (
-        ...     df.with_columns(
-        ...         pl.col("values").max().over("groups").alias("max_by_group")
-        ...     )
-        ... )
+        >>> df.with_columns(pl.col("values").max().over("groups").alias("max_by_group"))
         shape: (3, 3)
         ┌────────┬────────┬──────────────┐
         │ groups ┆ values ┆ max_by_group │
@@ -2716,15 +2714,9 @@ class Expr:
         ...         "values": [1, 2, 3, 4, 5, 6, 7, 8, 8],
         ...     }
         ... )
-        >>> (
-        ...     df.lazy()
-        ...     .select(
-        ...         [
-        ...             pl.col("groups").sum().over("groups"),
-        ...         ]
-        ...     )
-        ...     .collect()
-        ... )
+        >>> df.lazy().select(
+        ...     pl.col("groups").sum().over("groups"),
+        ... ).collect()
         shape: (9, 1)
         ┌────────┐
         │ groups │
@@ -2754,7 +2746,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
-        >>> (df.select(pl.col("a").is_unique()))
+        >>> df.select(pl.col("a").is_unique())
         shape: (3, 1)
         ┌───────┐
         │ a     │
@@ -2784,7 +2776,7 @@ class Expr:
         ...         "num": [1, 2, 3, 1, 5],
         ...     }
         ... )
-        >>> (df.with_columns(pl.col("num").is_first().alias("is_first")))
+        >>> df.with_columns(pl.col("num").is_first().alias("is_first"))
         shape: (5, 2)
         ┌─────┬──────────┐
         │ num ┆ is_first │
@@ -2808,7 +2800,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
-        >>> (df.select(pl.col("a").is_duplicated()))
+        >>> df.select(pl.col("a").is_duplicated())
         shape: (3, 1)
         ┌───────┐
         │ a     │
@@ -2841,7 +2833,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [0, 1, 2, 3, 4, 5]})
-        >>> (df.select(pl.col("a").quantile(0.3)))
+        >>> df.select(pl.col("a").quantile(0.3))
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -2850,7 +2842,7 @@ class Expr:
         ╞═════╡
         │ 1.0 │
         └─────┘
-        >>> (df.select(pl.col("a").quantile(0.3, interpolation="higher")))
+        >>> df.select(pl.col("a").quantile(0.3, interpolation="higher"))
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -2859,7 +2851,7 @@ class Expr:
         ╞═════╡
         │ 2.0 │
         └─────┘
-        >>> (df.select(pl.col("a").quantile(0.3, interpolation="lower")))
+        >>> df.select(pl.col("a").quantile(0.3, interpolation="lower"))
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -2868,7 +2860,7 @@ class Expr:
         ╞═════╡
         │ 1.0 │
         └─────┘
-        >>> (df.select(pl.col("a").quantile(0.3, interpolation="midpoint")))
+        >>> df.select(pl.col("a").quantile(0.3, interpolation="midpoint"))
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -2877,7 +2869,7 @@ class Expr:
         ╞═════╡
         │ 1.5 │
         └─────┘
-        >>> (df.select(pl.col("a").quantile(0.3, interpolation="linear")))
+        >>> df.select(pl.col("a").quantile(0.3, interpolation="linear"))
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -2911,13 +2903,11 @@ class Expr:
         ...         "b": [1, 2, 3],
         ...     }
         ... )
-        >>> (
-        ...     df.groupby("group_col").agg(
-        ...         [
-        ...             pl.col("b").filter(pl.col("b") < 2).sum().alias("lt"),
-        ...             pl.col("b").filter(pl.col("b") >= 2).sum().alias("gte"),
-        ...         ]
-        ...     )
+        >>> df.groupby("group_col").agg(
+        ...     [
+        ...         pl.col("b").filter(pl.col("b") < 2).sum().alias("lt"),
+        ...         pl.col("b").filter(pl.col("b") >= 2).sum().alias("gte"),
+        ...     ]
         ... ).sort("group_col")
         shape: (2, 3)
         ┌───────────┬──────┬─────┐
@@ -2951,13 +2941,11 @@ class Expr:
         ...         "b": [1, 2, 3],
         ...     }
         ... )
-        >>> (
-        ...     df.groupby("group_col").agg(
-        ...         [
-        ...             pl.col("b").where(pl.col("b") < 2).sum().alias("lt"),
-        ...             pl.col("b").where(pl.col("b") >= 2).sum().alias("gte"),
-        ...         ]
-        ...     )
+        >>> df.groupby("group_col").agg(
+        ...     [
+        ...         pl.col("b").where(pl.col("b") < 2).sum().alias("lt"),
+        ...         pl.col("b").where(pl.col("b") >= 2).sum().alias("gte"),
+        ...     ]
         ... ).sort("group_col")
         shape: (2, 3)
         ┌───────────┬──────┬─────┐
@@ -3006,7 +2994,7 @@ class Expr:
         ...         "cosine": [1.0, 0.0, -1.0, 0.0],
         ...     }
         ... )
-        >>> (df.select(pl.all().map(lambda x: x.to_numpy().argmax())))
+        >>> df.select(pl.all().map(lambda x: x.to_numpy().argmax()))
         shape: (1, 2)
         ┌──────┬────────┐
         │ sine ┆ cosine │
@@ -3078,10 +3066,8 @@ class Expr:
 
         In a selection context, the function is applied by row.
 
-        >>> (
-        ...     df.with_columns(
-        ...         pl.col("a").apply(lambda x: x * 2).alias("a_times_2"),
-        ...     )
+        >>> df.with_columns(
+        ...     pl.col("a").apply(lambda x: x * 2).alias("a_times_2"),
         ... )
         shape: (4, 3)
         ┌─────┬─────┬───────────┐
@@ -3097,24 +3083,15 @@ class Expr:
 
         It is better to implement this with an expression:
 
-        >>> (
-        ...     df.with_columns(
-        ...         (pl.col("a") * 2).alias("a_times_2"),
-        ...     )
+        >>> df.with_columns(
+        ...     (pl.col("a") * 2).alias("a_times_2"),
         ... )  # doctest: +IGNORE_RESULT
 
         In a GroupBy context the function is applied by group:
 
-        >>> (
-        ...     df.lazy()
-        ...     .groupby("b", maintain_order=True)
-        ...     .agg(
-        ...         [
-        ...             pl.col("a").apply(lambda x: x.sum()),
-        ...         ]
-        ...     )
-        ...     .collect()
-        ... )
+        >>> df.lazy().groupby("b", maintain_order=True).agg(
+        ...     pl.col("a").apply(lambda x: x.sum())
+        ... ).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ b   ┆ a   │
@@ -3128,10 +3105,8 @@ class Expr:
 
         It is better to implement this with an expression:
 
-        >>> (
-        ...     df.groupby("b", maintain_order=True).agg(
-        ...         pl.col("a").sum(),
-        ...     )
+        >>> df.groupby("b", maintain_order=True).agg(
+        ...     pl.col("a").sum(),
         ... )  # doctest: +IGNORE_RESULT
 
         """
@@ -3178,6 +3153,39 @@ class Expr:
         │ a     ┆ [1, 2]    │
         │ b     ┆ [2, 3, 4] │
         └───────┴───────────┘
+
+        >>> df = pl.DataFrame({"foo": ["hello", "world"]})
+        >>> df.select(pl.col("foo").flatten())
+        shape: (10, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ h   │
+        │ e   │
+        │ l   │
+        │ l   │
+        │ ... │
+        │ o   │
+        │ r   │
+        │ l   │
+        │ d   │
+        └─────┘
+
+        This example turns each word into a separate row:
+
+        >>> df = pl.DataFrame({"foo": ["hello world"]})
+        >>> df.select(pl.col("foo").str.split(by=" ").flatten())
+        shape: (2, 1)
+        ┌───────┐
+        │ foo   │
+        │ ---   │
+        │ str   │
+        ╞═══════╡
+        │ hello │
+        │ world │
+        └───────┘
 
         """
         return wrap_expr(self._pyexpr.explode())
@@ -3343,7 +3351,7 @@ class Expr:
         >>> df = pl.DataFrame(
         ...     {"sets": [[1, 2, 3], [1, 2], [9, 10]], "optional_members": [1, 2, 3]}
         ... )
-        >>> (df.select([pl.col("optional_members").is_in("sets").alias("contains")]))
+        >>> df.select([pl.col("optional_members").is_in("sets").alias("contains")])
         shape: (3, 1)
         ┌──────────┐
         │ contains │
@@ -3636,11 +3644,9 @@ class Expr:
         ...     }
         ... )  # Interpolate from this to the new grid
         >>> df_new_grid = pl.DataFrame({"grid_points": range(1, 11)})
-        >>> (
-        ...     df_new_grid.join(
-        ...         df_original_grid, on="grid_points", how="left"
-        ...     ).with_columns(pl.col("values").interpolate())
-        ... )
+        >>> df_new_grid.join(
+        ...     df_original_grid, on="grid_points", how="left"
+        ... ).with_columns(pl.col("values").interpolate())
         shape: (10, 2)
         ┌─────────────┬────────┐
         │ grid_points ┆ values │
@@ -3726,12 +3732,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_min(window_size=2),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_min(window_size=2),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────┐
@@ -3822,12 +3826,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_max(window_size=2),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_max(window_size=2),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────┐
@@ -4012,12 +4014,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_sum(window_size=2),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_sum(window_size=2),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────┐
@@ -4108,12 +4108,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 6.0, 8.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_std(window_size=3),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_std(window_size=3),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────────┐
@@ -4204,12 +4202,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 6.0, 8.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_var(window_size=3),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_var(window_size=3),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────────┐
@@ -4296,12 +4292,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 6.0, 8.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_median(window_size=3),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_median(window_size=3),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────┐
@@ -4394,12 +4388,10 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 6.0, 8.0]})
-        >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("A").rolling_quantile(quantile=0.33, window_size=3),
-        ...         ]
-        ...     )
+        >>> df.select(
+        ...     [
+        ...         pl.col("A").rolling_quantile(quantile=0.33, window_size=3),
+        ...     ]
         ... )
         shape: (6, 1)
         ┌──────┐

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3154,39 +3154,6 @@ class Expr:
         │ b     ┆ [2, 3, 4] │
         └───────┴───────────┘
 
-        >>> df = pl.DataFrame({"foo": ["hello", "world"]})
-        >>> df.select(pl.col("foo").flatten())
-        shape: (10, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ str │
-        ╞═════╡
-        │ h   │
-        │ e   │
-        │ l   │
-        │ l   │
-        │ ... │
-        │ o   │
-        │ r   │
-        │ l   │
-        │ d   │
-        └─────┘
-
-        This example turns each word into a separate row:
-
-        >>> df = pl.DataFrame({"foo": ["hello world"]})
-        >>> df.select(pl.col("foo").str.split(by=" ").flatten())
-        shape: (2, 1)
-        ┌───────┐
-        │ foo   │
-        │ ---   │
-        │ str   │
-        ╞═══════╡
-        │ hello │
-        │ world │
-        └───────┘
-
         """
         return wrap_expr(self._pyexpr.explode())
 

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -81,16 +81,12 @@ class ExprStringNameSpace:
         ...         "Sun Jul  8 00:34:60 2001",
         ...     ],
         ... )
-        >>> (
-        ...     s.to_frame().with_columns(
-        ...         pl.col("date")
-        ...         .str.strptime(pl.Date, "%F", strict=False)
-        ...         .fill_null(
-        ...             pl.col("date").str.strptime(pl.Date, "%F %T", strict=False)
-        ...         )
-        ...         .fill_null(pl.col("date").str.strptime(pl.Date, "%D", strict=False))
-        ...         .fill_null(pl.col("date").str.strptime(pl.Date, "%c", strict=False))
-        ...     )
+        >>> s.to_frame().with_columns(
+        ...     pl.col("date")
+        ...     .str.strptime(pl.Date, "%F", strict=False)
+        ...     .fill_null(pl.col("date").str.strptime(pl.Date, "%F %T", strict=False))
+        ...     .fill_null(pl.col("date").str.strptime(pl.Date, "%D", strict=False))
+        ...     .fill_null(pl.col("date").str.strptime(pl.Date, "%c", strict=False))
         ... )
         shape: (4, 1)
         ┌────────────┐

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -794,11 +794,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         --------
         >>> df = pl.DataFrame({"foo": [1, 1, -2, 3]}).lazy()
         >>> (
-        ...     df.select(
-        ...         [
-        ...             pl.col("foo").cumsum().alias("bar"),
-        ...         ]
-        ...     )
+        ...     df.select(pl.col("foo").cumsum().alias("bar"))
         ...     .inspect()  # print the node before the filter
         ...     .filter(pl.col("bar") == pl.col("foo"))
         ... )  # doctest: +ELLIPSIS
@@ -1483,7 +1479,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ...         "c": [True, True, False, None],
         ...     }
         ... ).lazy()
-        >>> (df.clone())  # doctest: +ELLIPSIS
+        >>> df.clone()  # doctest: +ELLIPSIS
         <polars.LazyFrame object at ...>
 
         """
@@ -1889,6 +1885,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday'}
             The strategy to determine the start of the first window by.
+
             * 'window': Truncate the start of the window with the 'every' argument.
             * 'datapoint': Start from the first encountered data point.
             * 'monday': Start the window on the monday before the first data point.
@@ -1929,15 +1926,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Group by windows of 1 hour starting at 2021-12-16 00:00:00.
 
-        >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic("time", every="1h", closed="right")
-        ...     .agg(
-        ...         [
-        ...             pl.col("time").min().alias("time_min"),
-        ...             pl.col("time").max().alias("time_max"),
-        ...         ]
-        ...     )
+        >>> df.lazy().groupby_dynamic("time", every="1h", closed="right").agg(
+        ...     [
+        ...         pl.col("time").min().alias("time_min"),
+        ...         pl.col("time").max().alias("time_max"),
+        ...     ]
         ... ).collect()
         shape: (4, 3)
         ┌─────────────────────┬─────────────────────┬─────────────────────┐
@@ -1953,13 +1946,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         The window boundaries can also be added to the aggregation result
 
-        >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic(
-        ...         "time", every="1h", include_boundaries=True, closed="right"
-        ...     )
-        ...     .agg([pl.col("time").count().alias("time_count")])
-        ... ).collect()
+        >>> df.lazy().groupby_dynamic(
+        ...     "time", every="1h", include_boundaries=True, closed="right"
+        ... ).agg([pl.col("time").count().alias("time_count")]).collect()
         shape: (4, 4)
         ┌─────────────────────┬─────────────────────┬─────────────────────┬────────────┐
         │ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ time_count │
@@ -1975,15 +1964,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         When closed="left", should not include right end of interval
         [lower_bound, upper_bound)
 
-        >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic("time", every="1h", closed="left")
-        ...     .agg(
-        ...         [
-        ...             pl.col("time").count().alias("time_count"),
-        ...             pl.col("time").alias("time_agg_list"),
-        ...         ]
-        ...     )
+        >>> df.lazy().groupby_dynamic("time", every="1h", closed="left").agg(
+        ...     [
+        ...         pl.col("time").count().alias("time_count"),
+        ...         pl.col("time").alias("time_agg_list"),
+        ...     ]
         ... ).collect()
         shape: (4, 3)
         ┌─────────────────────┬────────────┬─────────────────────────────────────┐
@@ -1999,10 +1984,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         When closed="both" the time values at the window boundaries belong to 2 groups.
 
-        >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic("time", every="1h", closed="both")
-        ...     .agg([pl.col("time").count().alias("time_count")])
+        >>> df.lazy().groupby_dynamic("time", every="1h", closed="both").agg(
+        ...     pl.col("time").count().alias("time_count")
         ... ).collect()
         shape: (5, 2)
         ┌─────────────────────┬────────────┐
@@ -2045,16 +2028,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 2021-12-16 03:00:00 ┆ a      │
         └─────────────────────┴────────┘
         >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic(
+        ...     df.lazy().groupby_dynamic(
         ...         "time",
         ...         every="1h",
         ...         closed="both",
         ...         by="groups",
         ...         include_boundaries=True,
         ...     )
-        ...     .agg([pl.col("time").count().alias("time_count")])
-        ... ).collect()
+        ... ).agg([pl.col("time").count().alias("time_count")]).collect()
         shape: (7, 5)
         ┌────────┬─────────────────────┬─────────────────────┬─────────────────────┬────────────┐
         │ groups ┆ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ time_count │
@@ -2079,16 +2060,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ...     }
         ... )
         >>> (
-        ...     df.lazy()
-        ...     .groupby_dynamic(
+        ...     df.lazy().groupby_dynamic(
         ...         "idx",
         ...         every="2i",
         ...         period="3i",
         ...         include_boundaries=True,
         ...         closed="right",
         ...     )
-        ...     .agg(pl.col("A").alias("A_agg_list"))
-        ... ).collect()
+        ... ).agg(pl.col("A").alias("A_agg_list")).collect()
         shape: (3, 4)
         ┌─────────────────┬─────────────────┬─────┬─────────────────┐
         │ _lower_boundary ┆ _upper_boundary ┆ idx ┆ A_agg_list      │
@@ -2597,10 +2576,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         --------
         >>> df_a = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "c", None]}).lazy()
         >>> df_other = pl.DataFrame({"c": ["foo", "ham"]})
-        >>> (
-        ...     df_a.with_context(df_other.lazy()).select(
-        ...         [pl.col("b") + pl.col("c").first()]
-        ...     )
+        >>> df_a.with_context(df_other.lazy()).select(
+        ...     [pl.col("b") + pl.col("c").first()]
         ... ).collect()
         shape: (3, 1)
         ┌──────┐
@@ -2621,10 +2598,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         >>> test_df = pl.DataFrame(
         ...     {"feature_0": [-1.0, None, 1], "feature_1": [-1.0, 0, 1]}
         ... ).lazy()
-        >>> (
-        ...     test_df.with_context(train_df.select(pl.all().suffix("_train"))).select(
-        ...         pl.col("feature_0").fill_null(pl.col("feature_0_train").median())
-        ...     )
+        >>> test_df.with_context(train_df.select(pl.all().suffix("_train"))).select(
+        ...     pl.col("feature_0").fill_null(pl.col("feature_0_train").median())
         ... ).collect()
         shape: (3, 1)
         ┌───────────┐


### PR DESCRIPTION
Sometimes the brackets add readability as it allows you to lay out more vertically, but in most cases it adds a lot of clutter in my opinion. Feel free to disagree on individual cases.