### PR TITLE
fix(rust, python): don't cast nulls before trying normal cast

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -228,11 +228,16 @@ impl Series {
 
     /// Cast `[Series]` to another `[DataType]`
     pub fn cast(&self, dtype: &DataType) -> PolarsResult<Self> {
-        let len = self.len();
-        if self.null_count() == len {
-            Ok(Series::full_null(self.name(), len, dtype))
-        } else {
-            self.0.cast(dtype)
+        match self.0.cast(dtype) {
+            Ok(out) => Ok(out),
+            Err(err) => {
+                let len = self.len();
+                if self.null_count() == len {
+                    Ok(Series::full_null(self.name(), len, dtype))
+                } else {
+                    Err(err)
+                }
+            }
         }
     }
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -626,3 +626,32 @@ def test_nested_read_dict_4143() -> None:
             ],
         ],
     }
+
+
+@typing.no_type_check
+def test_from_records_nullable_structs() -> None:
+    records = [
+        {"id": 1, "items": [{"item_id": 100, "description": None}]},
+        {"id": 1, "items": [{"item_id": 100, "description": "hi"}]},
+    ]
+
+    schema = [
+        ("id", pl.UInt16),
+        (
+            "items",
+            pl.List(
+                pl.Struct(
+                    [pl.Field("item_id", pl.UInt32), pl.Field("description", pl.Utf8)]
+                )
+            ),
+        ),
+    ]
+
+    for columns in [schema, None]:
+        assert pl.DataFrame(records, orient="row", columns=columns).to_dict(False) == {
+            "id": [1, 1],
+            "items": [
+                [{"item_id": 100, "description": None}],
+                [{"item_id": 100, "description": "hi"}],
+            ],
+        }


### PR DESCRIPTION
fixes #6335 