### PR TITLE
feat(python): Move `explode` to namespaces

### DIFF
--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -15,6 +15,7 @@ The following methods are available under the `expr.arr` attribute.
     Expr.arr.contains
     Expr.arr.diff
     Expr.arr.eval
+    Expr.arr.explode
     Expr.arr.first
     Expr.arr.get
     Expr.arr.head

--- a/py-polars/docs/source/reference/expressions/strings.rst
+++ b/py-polars/docs/source/reference/expressions/strings.rst
@@ -15,6 +15,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.decode
     Expr.str.encode
     Expr.str.ends_with
+    Expr.str.explode
     Expr.str.extract
     Expr.str.extract_all
     Expr.str.json_path_match

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -15,6 +15,7 @@ The following methods are available under the `Series.arr` attribute.
     Series.arr.contains
     Series.arr.diff
     Series.arr.eval
+    Series.arr.explode
     Series.arr.first
     Series.arr.get
     Series.arr.head

--- a/py-polars/docs/source/reference/series/strings.rst
+++ b/py-polars/docs/source/reference/series/strings.rst
@@ -15,6 +15,7 @@ The following methods are available under the `Series.str` attribute.
     Series.str.decode
     Series.str.encode
     Series.str.ends_with
+    Series.str.explode
     Series.str.extract
     Series.str.extract_all
     Series.str.json_path_match

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3208,29 +3208,27 @@ class Expr:
 
         This means that every item is expanded to a new row.
 
+        .. deprecated:: 0.15.16
+            `Expr.explode` will be removed in favour of `Expr.arr.explode` and
+            `Expr.str.explode`.
+
         Returns
         -------
         Exploded Series of same dtype
 
-        Examples
+        See Also
         --------
-        >>> df = pl.DataFrame({"b": [[1, 2, 3], [4, 5, 6]]})
-        >>> df.select(pl.col("b").explode())
-        shape: (6, 1)
-        ┌─────┐
-        │ b   │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ 1   │
-        │ 2   │
-        │ 3   │
-        │ 4   │
-        │ 5   │
-        │ 6   │
-        └─────┘
+        ExprListNameSpace.explode : Explode a list column
+        ExprStringNameSpace.explode : Explode a string column
 
         """
+        warnings.warn(
+            "`Series/Expr.explode()` is deprecated in favor of the identical method"
+            " under the list and string namespaces. Use `.arr.explode()` or"
+            " `.str.explode()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return wrap_expr(self._pyexpr.explode())
 
     def take_every(self, n: int) -> Expr:

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3158,6 +3158,10 @@ class Expr:
         Explode a list or utf8 Series. This means that every item is expanded to a new
         row.
 
+        .. deprecated:: 0.15.16
+            `Expr.flatten` will be removed in favour of `Expr.arr.explode` and
+            `Expr.str.explode`.
+
         Returns
         -------
         Exploded Series of same dtype
@@ -3200,6 +3204,13 @@ class Expr:
         └───────┘
 
         """
+        warnings.warn(
+            "`Expr.flatten()` is deprecated in favor of `explode`"
+            " under the list and string namespaces. Use `.arr.explode()` or"
+            " `.str.explode()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return wrap_expr(self._pyexpr.explode())
 
     def explode(self) -> Expr:

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -598,6 +598,35 @@ class ExprListNameSpace:
         offset = -pli.expr_to_lit_or_expr(n, str_to_lit=False)
         return self.slice(offset, n)
 
+    def explode(self) -> pli.Expr:
+        """
+        Returns a new row for each element in the list.
+
+        Returns
+        -------
+        Exploded column with the datatype of the list elements.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [[1, 2, 3], [4, 5, 6]]})
+        >>> df.select(pl.col("a").arr.explode())
+        shape: (6, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        │ 2   │
+        │ 3   │
+        │ 4   │
+        │ 5   │
+        │ 6   │
+        └─────┘
+
+        """
+        return pli.wrap_expr(self._pyexpr.explode())
+
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -600,7 +600,7 @@ class ExprListNameSpace:
 
     def explode(self) -> pli.Expr:
         """
-        Returns a new row for each element in the list.
+        Returns a column with a separate row for every list element.
 
         Returns
         -------

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -1165,7 +1165,7 @@ class ExprStringNameSpace:
         ┌─────┐
         │ a   │
         │ --- │
-        │ i64 │
+        │ str │
         ╞═════╡
         │ f   │
         │ o   │

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -1151,7 +1151,7 @@ class ExprStringNameSpace:
 
     def explode(self) -> pli.Expr:
         """
-        Returns a new row for each character in the string.
+        Returns a column with a separate row for every string character.
 
         Returns
         -------

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -1148,3 +1148,32 @@ class ExprStringNameSpace:
 
         """
         return pli.wrap_expr(self._pyexpr.str_slice(offset, length))
+
+    def explode(self) -> pli.Expr:
+        """
+        Returns a new row for each character in the string.
+
+        Returns
+        -------
+        Exploded column with string datatype.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": ["foo", "bar"]})
+        >>> df.select(pl.col("a").str.explode())
+        shape: (6, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ f   │
+        │ o   │
+        │ o   │
+        │ b   │
+        │ a   │
+        │ r   │
+        └─────┘
+
+        """
+        return pli.wrap_expr(self._pyexpr.explode())

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -294,7 +294,7 @@ class ListNameSpace:
 
     def explode(self) -> pli.Series:
         """
-        Returns a new row for each element in the list.
+        Returns a column with a separate row for every list element.
 
         Returns
         -------

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -292,6 +292,31 @@ class ListNameSpace:
 
         """
 
+    def explode(self) -> pli.Series:
+        """
+        Returns a new row for each element in the list.
+
+        Returns
+        -------
+        Exploded column with the datatype of the list elements.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[1, 2, 3], [4, 5, 6]])
+        >>> s.arr.explode()
+        shape: (6,)
+        Series: 'b' [i64]
+        [
+                1
+                2
+                3
+                4
+                5
+                6
+        ]
+
+        """
+
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -305,14 +305,14 @@ class ListNameSpace:
         >>> s = pl.Series("a", [[1, 2, 3], [4, 5, 6]])
         >>> s.arr.explode()
         shape: (6,)
-        Series: 'b' [i64]
+        Series: 'a' [i64]
         [
-                1
-                2
-                3
-                4
-                5
-                6
+            1
+            2
+            3
+            4
+            5
+            6
         ]
 
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2462,24 +2462,18 @@ class Series:
 
         This means that every item is expanded to a new row.
 
-        Examples
-        --------
-        >>> s = pl.Series("a", [[1, 2], [3, 4], [9, 10]])
-        >>> s.explode()
-        shape: (6,)
-        Series: 'a' [i64]
-        [
-                1
-                2
-                3
-                4
-                9
-                10
-        ]
+        .. deprecated:: 0.15.16
+            `Series.explode` will be removed in favour of `Series.arr.explode` and
+            `Series.str.explode`.
 
         Returns
         -------
         Exploded Series of same dtype
+
+        See Also
+        --------
+        ListNameSpace.explode : Explode a list column
+        StringNameSpace.explode : Explode a string column
 
         """
 

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -876,3 +876,28 @@ class StringNameSpace:
         return (
             s.to_frame().select(pli.col(s.name).str.slice(offset, length)).to_series()
         )
+
+    def explode(self) -> pli.Series:
+        """
+        Returns a new row for each character in the string.
+
+        Returns
+        -------
+        Exploded column with string datatype.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", ["foo", "bar"])
+        >>> s.str.explode()
+        shape: (6,)
+        Series: 'a' [str]
+        [
+                "f"
+                "o"
+                "o"
+                "b"
+                "a"
+                "r"
+        ]
+
+        """

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -879,7 +879,7 @@ class StringNameSpace:
 
     def explode(self) -> pli.Series:
         """
-        Returns a new row for each character in the string.
+        Returns a column with a separate row for every string character.
 
         Returns
         -------

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1545,7 +1545,7 @@ def test_groupby_cat_list() -> None:
         .agg([pl.col("cat_column")])["cat_column"]
     )
 
-    out = grouped.explode()
+    out = grouped.str.explode()
     assert out.dtype == pl.Categorical
     assert out[0] == "a"
 
@@ -1679,12 +1679,12 @@ def test_extension() -> None:
 
     out = df.groupby("groups", maintain_order=True).agg(pl.col("a").list().alias("a"))
     assert sys.getrefcount(foos[0]) == base_count + 2
-    s = out["a"].explode()
+    s = out["a"].arr.explode()
     assert sys.getrefcount(foos[0]) == base_count + 3
     del s
     assert sys.getrefcount(foos[0]) == base_count + 2
 
-    assert out["a"].explode().to_list() == foos
+    assert out["a"].arr.explode().to_list() == foos
     assert sys.getrefcount(foos[0]) == base_count + 2
     del out
     assert sys.getrefcount(foos[0]) == base_count + 1

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -63,17 +63,6 @@ def test_filter_where() -> None:
     assert result_filter.frame_equal(expected)
 
 
-def test_flatten_explode() -> None:
-    df = pl.Series("a", ["Hello", "World"])
-    expected = pl.Series("a", ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"])
-
-    result = df.to_frame().select(pl.col("a").flatten())[:, 0]
-    assert_series_equal(result, expected)
-
-    result = df.to_frame().select(pl.col("a").explode())[:, 0]
-    assert_series_equal(result, expected)
-
-
 def test_min_nulls_consistency() -> None:
     df = pl.DataFrame({"a": [None, 2, 3], "b": [4, None, 6], "c": [7, 5, 0]})
     out = df.select([pl.min(["a", "b", "c"])]).to_series()

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1474,18 +1474,6 @@ def test_predicate_count_vstack() -> None:
     ].to_list() == [3, 2, 5, 7]
 
 
-def test_explode_inner_lists_3985() -> None:
-    df = pl.DataFrame(
-        data={"id": [1, 1, 1], "categories": [["a"], ["b"], ["a", "c"]]}
-    ).lazy()
-
-    assert (
-        df.groupby("id")
-        .agg(pl.col("categories"))
-        .with_column(pl.col("categories").arr.eval(pl.element().explode()))
-    ).collect().to_dict(False) == {"id": [1], "categories": [["a", "b", "a", "c"]]}
-
-
 def test_lazy_method() -> None:
     # We want to support `.lazy()` on a Lazy DataFrame as to allow more generic user
     # code.

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -74,14 +74,14 @@ def test_window_function_cache() -> None:
             pl.col("values")
             .list()
             .over("groups")
-            .flatten()
+            .arr.explode()
             .alias("values_flat"),  # aggregation to list + explode and concat back
             pl.col("values")
             .reverse()
             .list()
             .over("groups")
-            .flatten()
-            .alias("values_rev"),  # use flatten to reverse within a group
+            .arr.explode()
+            .alias("values_rev"),  # use explode to reverse within a group
         ]
     )
 


### PR DESCRIPTION
Partially addresses #6340

Changes:
* Deprecate the following:
  * `Series.explode`
  * `Expr.explode`
  * `Expr.flatten`
* Add the following:
  * `Series.arr.explode`
  * `Series.str.explode`
  * `Expr.arr.explode`
  * `Expr.str.explode`
* Update tests accordingly

Should this be changed on the Rust side too? Splitting the functionality for lists and strings?