### PR TITLE
feat(python): Rename `Series.struct.to_frame` to `.struct.unnest`

### DIFF
--- a/py-polars/docs/source/reference/series/struct.rst
+++ b/py-polars/docs/source/reference/series/struct.rst
@@ -12,6 +12,7 @@ The following methods are available under the `Series.struct` attribute.
     Series.struct.field
     Series.struct.rename_fields
     Series.struct.to_frame
+    Series.struct.unnest
 
 .. autosummary::
    :toctree: api/

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
@@ -33,10 +34,6 @@ class StructNameSpace:
     def _ipython_key_completions_(self) -> list[str]:
         return self.fields
 
-    def to_frame(self) -> pli.DataFrame:
-        """Convert this Struct Series to a DataFrame."""
-        return pli.wrap_df(self._s.struct_to_frame())
-
     @property
     def fields(self) -> list[str]:
         """Get the names of the fields."""
@@ -65,3 +62,34 @@ class StructNameSpace:
             New names in the order of the struct's fields
 
         """
+
+    def to_frame(self) -> pli.DataFrame:
+        """Convert this Struct Series to a DataFrame."""
+        warnings.warn(
+            "`Series.struct.to_frame` has been renamed to `Series.struct.unnest`."
+            " Use the new method name to silence this warning.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return pli.wrap_df(self._s.struct_unnest())
+
+    def unnest(self) -> pli.DataFrame:
+        """
+        Convert this struct Series to a DataFrame with a separate column for each field.
+
+        Examples
+        --------
+        >>> s = pl.Series([{"a": 1, "b": 2}, {"a": 3, "b": 4}])
+        >>> s.struct.unnest()
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 2   │
+        │ 3   ┆ 4   │
+        └─────┴─────┘
+
+        """
+        return pli.wrap_df(self._s.struct_unnest())

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -99,7 +99,7 @@ impl PySeries {
         })
     }
 
-    pub fn struct_to_frame(&self) -> PyResult<PyDataFrame> {
+    pub fn struct_unnest(&self) -> PyResult<PyDataFrame> {
         let ca = self.series.struct_().map_err(PyPolarsErr::from)?;
         let df: DataFrame = ca.clone().into();
         Ok(df.into())

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -23,7 +23,7 @@ def test_struct_various() -> None:
     assert s.struct.field("list").to_list() == [[1, 2], [3]]
     assert s.struct.field("int").to_list() == [1, 2]
 
-    assert df.to_struct("my_struct").struct.to_frame().frame_equal(df)
+    assert df.to_struct("my_struct").struct.unnest().frame_equal(df)
     assert s.struct._ipython_key_completions_() == s.struct.fields
 
 
@@ -36,11 +36,11 @@ def test_struct_to_list() -> None:
     ]
 
 
-def test_apply_to_struct() -> None:
+def test_apply_unnest() -> None:
     df = (
         pl.Series([None, 2, 3, 4])
         .apply(lambda x: {"a": x, "b": x * 2, "c": True, "d": [1, 2], "e": "foo"})
-        .struct.to_frame()
+        .struct.unnest()
     )
 
     expected = pl.DataFrame(


### PR DESCRIPTION
Partially addresses #6340

Changes:
* Deprecate `Series.struct.to_frame`
* Add `Series.struct.unnest` with the same functionality