### PR TITLE
fix(python): ensure pyarrow.compute module is loaded

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1178,9 +1178,11 @@ def pandas_to_pydf(
 
 
 def coerce_arrow(array: pa.Array, rechunk: bool = True) -> pa.Array:
+    import pyarrow.compute as pc
+
     # note: Decimal256 could not be cast to float
     if isinstance(array.type, pa.Decimal128Type):
-        array = pa.compute.cast(array, pa.float64())
+        array = pc.cast(array, pa.float64())
 
     if hasattr(array, "num_chunks") and array.num_chunks > 1 and rechunk:
         # small integer keys can often not be combined, so let's already cast
@@ -1192,7 +1194,7 @@ def coerce_arrow(array: pa.Array, rechunk: bool = True) -> pa.Array:
             or pa.types.is_uint16(array.type.index_type)
             or pa.types.is_int32(array.type.index_type)
         ):
-            array = pa.compute.cast(
+            array = pc.cast(
                 array, pa.dictionary(pa.uint32(), pa.large_string())
             ).combine_chunks()
     return array


### PR DESCRIPTION
# fix(python): ensure pyarrow.compute module is loaded

Stumbled across a pyarrow lazy loading race condition where `pa.compute` functions may not be available just yet. It's difficult to test in the test suite since another test may have triggered the module to be fully loaded hiding the bug.

I believe the [pyarrow docs recommend importing and using the compute module directly](https://arrow.apache.org/docs/python/compute.html) rather than depending on them to be loaded on the root package. This change adds an explicit lazy load dependency for that `pyarrow.compute` module.

## Reproduction Steps

```python
import pyarrow as pa
import pyarrow.feather as feather

col = pa.chunked_array([["foo"], ["bar"]], type=pa.dictionary(pa.int8(), pa.string()))
table = pa.table([col], names=["a"])
feather.write_feather(table, "example.ipc")
```

```python
import polars as pl
# import pyarrow.compute # enable workaround

pl.read_ipc("example.ipc", use_pyarrow=True)
```

```
Traceback (most recent call last):
  File "example.py", line 5, in <module>
    pl.read_ipc("example.ipc", use_pyarrow=True)
  File "polars/utils.py", line 394, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "polars/io.py", line 860, in read_ipc
    df = DataFrame._from_arrow(tbl, rechunk=rechunk)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polars/internals/dataframe/frame.py", line 470, in _from_arrow
    return cls._from_pydf(arrow_to_pydf(data, columns=columns, rechunk=rechunk))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polars/internals/construction.py", line 936, in arrow_to_pydf
    column = coerce_arrow(column)
             ^^^^^^^^^^^^^^^^^^^^
  File "polars/internals/construction.py", line 1105, in coerce_arrow
    array = pa.compute.cast(
            ^^^^^^^^^^
  File "polars/dependencies.py", line 82, in __getattr__
    return getattr(module, attr)
           ^^^^^^^^^^^^^^^^^^^^^
  File "pyarrow/__init__.py", line 335, in __getattr__
    raise AttributeError(
AttributeError: module 'pyarrow' has no attribute 'compute'
```
