### PR TITLE
feat(rust, python): accept expr in `str.starts_with`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -372,9 +372,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             EndsWith(sub) => {
                 map!(strings::ends_with, &sub)
             }
-            StartsWith(sub) => {
-                map!(strings::starts_with, &sub)
-            }
+            StartsWith { .. } => map_as_slice!(strings::starts_with),
             Extract { pat, group_index } => {
                 map!(strings::extract, &pat, group_index)
             }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -122,7 +122,7 @@ impl FunctionExpr {
             StringExpr(s) => {
                 use StringFunction::*;
                 match s {
-                    Contains { .. } | EndsWith(_) | StartsWith(_) => with_dtype(DataType::Boolean),
+                    Contains { .. } | EndsWith(_) | StartsWith => with_dtype(DataType::Boolean),
                     Extract { .. } => same_type(),
                     ExtractAll => with_dtype(DataType::List(Box::new(DataType::Utf8))),
                     CountMatch(_) => with_dtype(DataType::UInt32),

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -15,7 +15,7 @@ pub enum StringFunction {
         pat: String,
         literal: bool,
     },
-    StartsWith(String),
+    StartsWith,
     EndsWith(String),
     Extract {
         pat: String,
@@ -59,7 +59,7 @@ impl Display for StringFunction {
         use self::*;
         let s = match self {
             StringFunction::Contains { .. } => "contains",
-            StringFunction::StartsWith(_) => "starts_with",
+            StringFunction::StartsWith { .. } => "starts_with",
             StringFunction::EndsWith(_) => "ends_with",
             StringFunction::Extract { .. } => "extract",
             #[cfg(feature = "string_justify")]
@@ -112,9 +112,31 @@ pub(super) fn ends_with(s: &Series, sub: &str) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     Ok(ca.ends_with(sub).into_series())
 }
-pub(super) fn starts_with(s: &Series, sub: &str) -> PolarsResult<Series> {
-    let ca = s.utf8()?;
-    Ok(ca.starts_with(sub).into_series())
+pub(super) fn starts_with(s: &[Series]) -> PolarsResult<Series> {
+    let ca = &s[0].utf8()?;
+    let sub = &s[1].utf8()?;
+
+    match sub.len() {
+        1 => {
+            let out: BooleanChunked = match sub.get(0) {
+                Some(s) => ca.starts_with(s),
+                None => BooleanChunked::new(ca.name(), vec![None; ca.len()]),
+            };
+            Ok(out.into_series())
+        }
+        _ => {
+            let out: BooleanChunked = ca
+                .into_iter()
+                .zip(sub.into_iter())
+                .map(|(opt_src, opt_val)| match (opt_src, opt_val) {
+                    (Some(src), Some(val)) => Some(src.starts_with(val)),
+                    _ => None,
+                })
+                .collect();
+
+            Ok(out.into_series())
+        }
+    }
 }
 
 /// Extract a regex pattern from the a string value.

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -34,9 +34,12 @@ impl StringNameSpace {
     }
 
     /// Check if a string value starts with the `sub` string.
-    pub fn starts_with<S: AsRef<str>>(self, sub: S) -> Expr {
-        let sub = sub.as_ref().into();
-        self.0.map_private(StringFunction::StartsWith(sub).into())
+    pub fn starts_with(self, sub: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::StartsWith),
+            &[sub],
+            true,
+        )
     }
 
     /// Extract a regex pattern from the a string value.

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -577,7 +577,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_ends_with(sub))
 
-    def starts_with(self, sub: str) -> pli.Expr:
+    def starts_with(self, sub: str | pli.Expr) -> pli.Expr:
         """
         Check if string values start with a substring.
 
@@ -621,6 +621,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
+        sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_starts_with(sub))
 
     def json_path_match(self, json_path: str) -> pli.Expr:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -713,8 +713,8 @@ impl PyExpr {
         self.inner.clone().str().ends_with(sub).into()
     }
 
-    pub fn str_starts_with(&self, sub: String) -> PyExpr {
-        self.inner.clone().str().starts_with(sub).into()
+    pub fn str_starts_with(&self, sub: PyExpr) -> PyExpr {
+        self.inner.clone().str().starts_with(sub.inner).into()
     }
 
     pub fn binary_contains(&self, lit: Vec<u8>) -> PyExpr {

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -241,6 +241,6 @@ def test_starts_ends_with() -> None:
     ).to_dict(False) == {
         "ends_pop": [False, False, True],
         "starts_ham": [True, False, False],
-        "starts_None": [None, None, None],
-        "starts_sub": [True, False, None],
+        "starts_None": [False, False, False],
+        "starts_sub": [True, False, False],
     }

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -226,9 +226,21 @@ def test_format_empty_df() -> None:
 
 
 def test_starts_ends_with() -> None:
-    assert pl.DataFrame({"a": ["hamburger", "nuts", "lollypop"]}).select(
+    df = pl.DataFrame(
+        {"a": ["hamburger", "nuts", "lollypop"], "sub": ["ham", "foo", None]}
+    )
+
+    assert df.select(
         [
-            pl.col("a").str.ends_with("pop").alias("pop"),
-            pl.col("a").str.starts_with("ham").alias("ham"),
+            # TODO allow Expr for ends_with
+            pl.col("a").str.ends_with("pop").alias("ends_pop"),
+            pl.col("a").str.starts_with("ham").alias("starts_ham"),
+            pl.col("a").str.starts_with(pl.lit(None)).alias("starts_None"),
+            pl.col("a").str.starts_with(pl.col("sub")).alias("starts_sub"),
         ]
-    ).to_dict(False) == {"pop": [False, False, True], "ham": [True, False, False]}
+    ).to_dict(False) == {
+        "ends_pop": [False, False, True],
+        "starts_ham": [True, False, False],
+        "starts_None": [None, None, None],
+        "starts_sub": [True, False, None],
+    }


### PR DESCRIPTION
fixes #6293

Look carefully at the PR, first time coding in rust 😬

I will do `ends_with`, when `starts_with` is validated