### PR TITLE
feat(python): infer ISO8601 datetimes

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -55,46 +55,90 @@ pub(super) static DATETIME_D_M_Y: &[&str] = &[
 /// NOTE: don't use single letter dates like %F
 /// polars parsers does not support them, so it will be slower
 pub(super) static DATETIME_Y_M_D: &[&str] = &[
+    // ---
+    // ISO8601, generated via the `iso8601_format` test fixture
+    // ---
+    "%Y/%m/%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y%m%dT%H:%M:%S",
+    "%Y/%m/%dT%H%M%S",
+    "%Y-%m-%dT%H%M%S",
+    "%Y%m%dT%H%M%S",
+    "%Y/%m/%dT%H:%M",
+    "%Y-%m-%dT%H:%M",
+    "%Y%m%dT%H:%M",
+    "%Y/%m/%dT%H%M",
+    "%Y-%m-%dT%H%M",
+    "%Y%m%dT%H%M",
+    "%Y/%m/%dT%H:%M:%S.%9f",
+    "%Y-%m-%dT%H:%M:%S.%9f",
+    "%Y%m%dT%H:%M:%S.%9f",
+    "%Y/%m/%dT%H:%M:%S.%6f",
+    "%Y-%m-%dT%H:%M:%S.%6f",
+    "%Y%m%dT%H:%M:%S.%6f",
+    "%Y/%m/%dT%H:%M:%S.%3f",
+    "%Y-%m-%dT%H:%M:%S.%3f",
+    "%Y%m%dT%H:%M:%S.%3f",
+    "%Y/%m/%dT%H%M%S.%9f",
+    "%Y-%m-%dT%H%M%S.%9f",
+    "%Y%m%dT%H%M%S.%9f",
+    "%Y/%m/%dT%H%M%S.%6f",
+    "%Y-%m-%dT%H%M%S.%6f",
+    "%Y%m%dT%H%M%S.%6f",
+    "%Y/%m/%dT%H%M%S.%3f",
+    "%Y-%m-%dT%H%M%S.%3f",
+    "%Y%m%dT%H%M%S.%3f",
+    "%Y/%m/%d",
+    "%Y-%m-%d",
+    "%Y%m%d",
+    "%Y/%m/%d %H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y%m%d %H:%M:%S",
+    "%Y/%m/%d %H%M%S",
+    "%Y-%m-%d %H%M%S",
+    "%Y%m%d %H%M%S",
+    "%Y/%m/%d %H:%M",
+    "%Y-%m-%d %H:%M",
+    "%Y%m%d %H:%M",
+    "%Y/%m/%d %H%M",
+    "%Y-%m-%d %H%M",
+    "%Y%m%d %H%M",
+    "%Y/%m/%d %H:%M:%S.%9f",
+    "%Y-%m-%d %H:%M:%S.%9f",
+    "%Y%m%d %H:%M:%S.%9f",
+    "%Y/%m/%d %H:%M:%S.%6f",
+    "%Y-%m-%d %H:%M:%S.%6f",
+    "%Y%m%d %H:%M:%S.%6f",
+    "%Y/%m/%d %H:%M:%S.%3f",
+    "%Y-%m-%d %H:%M:%S.%3f",
+    "%Y%m%d %H:%M:%S.%3f",
+    "%Y/%m/%d %H%M%S.%9f",
+    "%Y-%m-%d %H%M%S.%9f",
+    "%Y%m%d %H%M%S.%9f",
+    "%Y/%m/%d %H%M%S.%6f",
+    "%Y-%m-%d %H%M%S.%6f",
+    "%Y%m%d %H%M%S.%6f",
+    "%Y/%m/%d %H%M%S.%3f",
+    "%Y-%m-%d %H%M%S.%3f",
+    "%Y%m%d %H%M%S.%3f",
+    // ---
+    // other
+    // ---
+    // 2019-04-18T02:45:55Z
+    "%Y-%m-%dT%H:%M:%SZ",
     // 21/12/31 12:54:48
     "%y/%m/%d %H:%M:%S",
-    // 2021-12-31 24:58:01
-    "%Y-%m-%d %H:%M:%S",
     // 21/12/31 24:58:01
     "%y/%m/%d %H:%M:%S",
     //210319 23:58:50
     "%y%m%d %H:%M:%S",
-    // 2019-04-18T02:45:55
-    // 2021/12/31 12:54:98
-    "%Y/%m/%d %H:%M:%S",
-    // 2021-12-31 24:58:01
-    "%Y-%m-%d %H:%M:%S",
-    // 2021/12/31 24:58:01
-    "%Y/%m/%d %H:%M:%S",
-    // 20210319 23:58:50
-    "%Y%m%d %H:%M:%S",
-    // 2019-04-18T02:45:55
-    "%Y-%m-%dT%H:%M:%S",
-    "%Y-%m-%dT%H:%M:%SZ",
-    // 2019-04-18T02:45:55.555[000000]
-    // nanoseconds
-    "%Y-%m-%d %H:%M:%S.%9f",
-    "%Y-%m-%dT%H:%M:%S.%9f",
-    // microseconds
-    "%Y-%m-%d %H:%M:%S.%6f",
-    "%Y-%m-%dT%H:%M:%S.%6f",
-    // milliseconds
-    "%Y-%m-%d %H:%M:%S.%3f",
-    "%Y-%m-%dT%H:%M:%S.%3f",
-    // no times
-    "%Y-%m-%d",
-    "%Y/%m/%d",
     // 2021/12/31 11:54:48 PM
     "%Y/%m/%d %I:%M:%S %p",
     "%Y-%m-%d %I:%M:%S %p",
     // 2021/12/31 11:54 PM
     "%Y/%m/%d %I:%M %p",
     "%Y-%m-%d %I:%M %p",
-    // --
+    // ---
     // not supported by polars' parser
     // ---
     "%+",

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import List, cast
 
 import pytest
 
@@ -139,3 +140,26 @@ def fruits_cars() -> pl.DataFrame:
             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
         }
     )
+
+
+ISO8601_FORMATS = []
+for T in ["T", " "]:
+    for hms in (
+        [
+            f"{T}%H:%M:%S",
+            f"{T}%H%M%S",
+            f"{T}%H:%M",
+            f"{T}%H%M",
+        ]
+        + [f"{T}%H:%M:%S.{fraction}" for fraction in ["%9f", "%6f", "%3f"]]
+        + [f"{T}%H%M%S.{fraction}" for fraction in ["%9f", "%6f", "%3f"]]
+        + [""]
+    ):
+        for date_sep in ("/", "-", ""):
+            fmt = f"%Y{date_sep}%m{date_sep}%d{hms}"
+            ISO8601_FORMATS.append(fmt)
+
+
+@pytest.fixture(params=ISO8601_FORMATS)
+def iso8601_format(request: pytest.FixtureRequest) -> list[str]:
+    return cast(List[str], request.param)

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -2575,3 +2575,35 @@ def test_rolling_groupby_empty_groups_by_take_6330() -> None:
         "Date": [1, 2, 3, 4, 1, 2, 3, 4],
         "count": [0, 1, 2, 2, 0, 1, 2, 2],
     }
+
+
+def test_infer_iso8601(iso8601_format: str) -> None:
+    # construct an example time string
+    time_string = (
+        iso8601_format.replace("%Y", "2134")
+        .replace("%m", "12")
+        .replace("%d", "13")
+        .replace("%H", "01")
+        .replace("%M", "12")
+        .replace("%S", "34")
+        .replace("%3f", "123")
+        .replace("%6f", "123456")
+        .replace("%9f", "123456789")
+        .replace("%Z", "Z")
+    )
+    parsed = pl.Series([time_string]).str.strptime(pl.Datetime("ns"))
+    assert parsed.dt.year().item() == 2134
+    assert parsed.dt.month().item() == 12
+    assert parsed.dt.day().item() == 13
+    if "%H" in iso8601_format:
+        assert parsed.dt.hour().item() == 1
+    if "%M" in iso8601_format:
+        assert parsed.dt.minute().item() == 12
+    if "%S" in iso8601_format:
+        assert parsed.dt.second().item() == 34
+    if "%9f" in iso8601_format:
+        assert parsed.dt.nanosecond().item() == 123456789
+    if "%6f" in iso8601_format:
+        assert parsed.dt.nanosecond().item() == 123456000
+    if "%3f" in iso8601_format:
+        assert parsed.dt.nanosecond().item() == 123000000


### PR DESCRIPTION
closes #6356

This contains the same formats as on `master`, but with plenty of added ones. No format has been removed (though I am suggesting to remove a couple in https://github.com/pola-rs/polars/pull/6378)

Where I ran the benchmarks: https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=117053341

[will fill out below when it completes]

## parsing a single element:
```python
from IPython import get_ipython
ipython = get_ipython()
import polars as pl

ipython.run_line_magic("timeit", "pl.Series(['1900/01/01 12:00:00 AM']).str.strptime(pl.Datetime)")
```

On this branch (with `make build-release`):
```python
192 µs ± 7.01 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
192 µs ± 10.7 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
189 µs ± 8.4 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

On `master` (with `make build-release`, after having deleted all non-tracked files):
```python
161 µs ± 15.3 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
160 µs ± 7.67 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
173 µs ± 7.92 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

## parsing multiple elements (with consistent format):

```python
from IPython import get_ipython
from datetime import datetime
ipython = get_ipython()
import polars as pl

date_range = pl.date_range(low=datetime(1300, 1, 1), high=datetime(2300, 1, 1), interval="12h").dt.strftime('%Y/%m/%d %I:%M:%S %p')

ipython.run_line_magic("timeit", "date_range.str.strptime(pl.Datetime)")
```


On this branch (with `make build-release`):
```python
295 ms ± 808 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
296 ms ± 820 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
302 ms ± 7.28 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

On `master` (with `make build-release`, after having deleted non-tracked files):
```python
295 ms ± 985 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
301 ms ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
295 ms ± 1.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
