### PR TITLE
feat(rust, python): allow expressions as arguments in `str.ends_with`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -369,9 +369,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Contains { pat, literal } => {
                 map!(strings::contains, &pat, literal)
             }
-            EndsWith(sub) => {
-                map!(strings::ends_with, &sub)
-            }
+            EndsWith { .. } => map_as_slice!(strings::ends_with),
             StartsWith { .. } => map_as_slice!(strings::starts_with),
             Extract { pat, group_index } => {
                 map!(strings::extract, &pat, group_index)

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -122,7 +122,7 @@ impl FunctionExpr {
             StringExpr(s) => {
                 use StringFunction::*;
                 match s {
-                    Contains { .. } | EndsWith(_) | StartsWith => with_dtype(DataType::Boolean),
+                    Contains { .. } | EndsWith | StartsWith => with_dtype(DataType::Boolean),
                     Extract { .. } => same_type(),
                     ExtractAll => with_dtype(DataType::List(Box::new(DataType::Utf8))),
                     CountMatch(_) => with_dtype(DataType::UInt32),

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -16,7 +16,7 @@ pub enum StringFunction {
         literal: bool,
     },
     StartsWith,
-    EndsWith(String),
+    EndsWith,
     Extract {
         pat: String,
         group_index: usize,
@@ -60,7 +60,7 @@ impl Display for StringFunction {
         let s = match self {
             StringFunction::Contains { .. } => "contains",
             StringFunction::StartsWith { .. } => "starts_with",
-            StringFunction::EndsWith(_) => "ends_with",
+            StringFunction::EndsWith { .. } => "ends_with",
             StringFunction::Extract { .. } => "extract",
             #[cfg(feature = "string_justify")]
             StringFunction::Zfill(_) => "zfill",
@@ -108,10 +108,29 @@ pub(super) fn contains(s: &Series, pat: &str, literal: bool) -> PolarsResult<Ser
     }
 }
 
-pub(super) fn ends_with(s: &Series, sub: &str) -> PolarsResult<Series> {
-    let ca = s.utf8()?;
-    Ok(ca.ends_with(sub).into_series())
+pub(super) fn ends_with(s: &[Series]) -> PolarsResult<Series> {
+    let ca = &s[0].utf8()?;
+    let sub = &s[1].utf8()?;
+
+    let mut out: BooleanChunked = match sub.len() {
+        1 => match sub.get(0) {
+            Some(s) => ca.ends_with(s),
+            None => BooleanChunked::full(ca.name(), false, ca.len()),
+        },
+        _ => ca
+            .into_iter()
+            .zip(sub.into_iter())
+            .map(|(opt_src, opt_val)| match (opt_src, opt_val) {
+                (Some(src), Some(val)) => src.ends_with(val),
+                _ => false,
+            })
+            .collect_trusted(),
+    };
+
+    out.rename(ca.name());
+    Ok(out.into_series())
 }
+
 pub(super) fn starts_with(s: &[Series]) -> PolarsResult<Series> {
     let ca = &s[0].utf8()?;
     let sub = &s[1].utf8()?;

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -28,9 +28,12 @@ impl StringNameSpace {
     }
 
     /// Check if a string value ends with the `sub` string.
-    pub fn ends_with<S: AsRef<str>>(self, sub: S) -> Expr {
-        let sub = sub.as_ref().into();
-        self.0.map_private(StringFunction::EndsWith(sub).into())
+    pub fn ends_with(self, sub: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::EndsWith),
+            &[sub],
+            true,
+        )
     }
 
     /// Check if a string value starts with the `sub` string.

--- a/polars/polars-lazy/src/tests/tpch.rs
+++ b/polars/polars-lazy/src/tests/tpch.rs
@@ -56,7 +56,7 @@ fn test_q2() -> PolarsResult<()> {
         .inner_join(nation(), "s_nationkey", "n_nationkey")
         .inner_join(region(), "n_regionkey", "r_regionkey")
         .filter(col("p_size").eq(15))
-        .filter(col("p_type").str().ends_with("BRASS".into()));
+        .filter(col("p_type").str().ends_with(lit("BRASS".to_string())));
     let q = q1
         .clone()
         .groupby([col("p_partkey")])

--- a/polars/polars-lazy/src/tests/tpch.rs
+++ b/polars/polars-lazy/src/tests/tpch.rs
@@ -56,8 +56,7 @@ fn test_q2() -> PolarsResult<()> {
         .inner_join(nation(), "s_nationkey", "n_nationkey")
         .inner_join(region(), "n_regionkey", "r_regionkey")
         .filter(col("p_size").eq(15))
-        .filter(col("p_type").str().ends_with("BRASS"));
-
+        .filter(col("p_type").str().ends_with("BRASS".into()));
     let q = q1
         .clone()
         .groupby([col("p_partkey")])

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -531,7 +531,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_contains(pattern, literal))
 
-    def ends_with(self, sub: str) -> pli.Expr:
+    def ends_with(self, sub: str | pli.Expr) -> pli.Expr:
         """
         Check if string values end with a substring.
 
@@ -575,6 +575,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
+        sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_ends_with(sub))
 
     def starts_with(self, sub: str | pli.Expr) -> pli.Expr:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -709,8 +709,8 @@ impl PyExpr {
         }
     }
 
-    pub fn str_ends_with(&self, sub: String) -> PyExpr {
-        self.inner.clone().str().ends_with(sub).into()
+    pub fn str_ends_with(&self, sub: PyExpr) -> PyExpr {
+        self.inner.clone().str().ends_with(sub.inner).into()
     }
 
     pub fn str_starts_with(&self, sub: PyExpr) -> PyExpr {

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -227,19 +227,23 @@ def test_format_empty_df() -> None:
 
 def test_starts_ends_with() -> None:
     df = pl.DataFrame(
-        {"a": ["hamburger", "nuts", "lollypop"], "sub": ["ham", "foo", None]}
+        {"a": ["hamburger", "nuts", "lollypop"], "sub": ["ham", "ts", None]}
     )
 
     assert df.select(
         [
             # TODO allow Expr for ends_with
             pl.col("a").str.ends_with("pop").alias("ends_pop"),
+            pl.col("a").str.ends_with(pl.lit(None)).alias("ends_None"),
+            pl.col("a").str.ends_with(pl.col("sub")).alias("ends_sub"),
             pl.col("a").str.starts_with("ham").alias("starts_ham"),
             pl.col("a").str.starts_with(pl.lit(None)).alias("starts_None"),
             pl.col("a").str.starts_with(pl.col("sub")).alias("starts_sub"),
         ]
     ).to_dict(False) == {
         "ends_pop": [False, False, True],
+        "ends_None": [False, False, False],
+        "ends_sub": [False, True, False],
         "starts_ham": [True, False, False],
         "starts_None": [False, False, False],
         "starts_sub": [True, False, False],

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -232,7 +232,6 @@ def test_starts_ends_with() -> None:
 
     assert df.select(
         [
-            # TODO allow Expr for ends_with
             pl.col("a").str.ends_with("pop").alias("ends_pop"),
             pl.col("a").str.ends_with(pl.lit(None)).alias("ends_None"),
             pl.col("a").str.ends_with(pl.col("sub")).alias("ends_sub"),


### PR DESCRIPTION
Same as `startswith`