### PR TITLE
build(python): Specify deltalake minimum version

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -49,7 +49,7 @@ numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
-deltalake = ["deltalake"]
+deltalake = ["deltalake >= 0.6.2"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 matplotlib = ["matplotlib"]
 all = [


### PR DESCRIPTION
`scan_delta` does not work properly on `deltalake` versions 0.6.1 and lower. This is because 0.6.2 introduced some features that are required for conversion to Polars.

Note: keeping this on "draft" for now, as our project is currently relying on `deltalake==0.6.1` because of some other issue introduced in `0.6.2` 😅 their version `0.7.0` should be released [soon](https://github.com/delta-io/delta-rs/issues/1073), which resolves the issues.