### PR TITLE
docs(python): Example of filtering partitioned delta tables

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.15"
+version = "0.15.16"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1370,6 +1370,7 @@ def scan_delta(
         Additional keyword arguments while reading a Delta lake Table.
     pyarrow_options
         Keyword arguments while converting a Delta lake Table to pyarrow table.
+        Use this parameter when filtering on partitioned columns.
 
     Returns
     -------
@@ -1383,10 +1384,18 @@ def scan_delta(
     >>> table_path = "/path/to/delta-table/"
     >>> pl.scan_delta(table_path).collect()  # doctest: +SKIP
 
+    Use the `pyarrow_options` parameter to read only certain partitions.
+    Note: This should be preferred over using an equivalent `.filter()` on the resulting
+    dataframe, as this avoids reading the data at all.
+
+    >>> pl.scan_delta(  # doctest: +SKIP
+    ...     table_path,
+    ...     pyarrow_options={"partitions": [("year", "=", "2021")]},
+    ... )
+
     Creates a scan for a specific version of the Delta table from local filesystem.
     Note: This will fail if the provided version of the delta table does not exist.
 
-    >>> table_path = "/path/to/delta-table/"
     >>> pl.scan_delta(table_path, version=1).collect()  # doctest: +SKIP
 
     Creates a scan for a Delta table from AWS S3.
@@ -1538,6 +1547,7 @@ def read_delta(
         Additional keyword arguments while reading a Delta lake Table.
     pyarrow_options
         Keyword arguments while converting a Delta lake Table to pyarrow table.
+        Use this parameter when filtering on partitioned columns.
 
     Returns
     -------
@@ -1551,10 +1561,18 @@ def read_delta(
     >>> table_path = "/path/to/delta-table/"
     >>> pl.read_delta(table_path)  # doctest: +SKIP
 
+    Use the `pyarrow_options` parameter to read only certain partitions.
+    Note: This should be preferred over using an equivalent `.filter()` on the resulting
+    dataframe, as this avoids reading the data at all.
+
+    >>> pl.read_delta(  # doctest: +SKIP
+    ...     table_path,
+    ...     pyarrow_options={"partitions": [("year", "=", "2021")]},
+    ... )
+
     Reads a specific version of the Delta table from local filesystem.
     Note: This will fail if the provided version of the delta table does not exist.
 
-    >>> table_path = "/path/to/delta-table/"
     >>> pl.read_delta(table_path, version=1)  # doctest: +SKIP
 
     Reads a Delta table from AWS S3.


### PR DESCRIPTION
Changes:
* Add example of reading partitioned Delta tables. This is a common use case and not exactly intuitive from our current API.

Not 100% sure this is the way to go, as our docs will now become outdated if `deltalake` changes their API. But I think it's important to have this example in there.