### PR TITLE
refactor(python): deprecate `columns` param for `DataFrame` init; transitioning to `schema`

### DIFF
--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -89,7 +89,7 @@ def register_expr_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     ...     def nearest(self, p: int) -> pl.Expr:
     ...         return (p ** (self._expr.log(p)).round(0).cast(pl.Int64)).cast(pl.Int64)
     >>>
-    >>> df = pl.DataFrame([1.4, 24.3, 55.0, 64.001], columns=["n"])
+    >>> df = pl.DataFrame([1.4, 24.3, 55.0, 64.001], schema=["n"])
     >>> df.select(
     ...     [
     ...         pl.col("n"),
@@ -152,7 +152,7 @@ def register_dataframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     >>>
     >>> df = pl.DataFrame(
     ...     data=[["xx", 2, 3, 4], ["xy", 4, 5, 6], ["yy", 5, 6, 7], ["yz", 6, 7, 8]],
-    ...     columns=["a1", "a2", "b1", "b2"],
+    ...     schema=["a1", "a2", "b1", "b2"],
     ...     orient="row",
     ... )
     >>> df
@@ -248,7 +248,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     >>>
     >>> ldf = pl.DataFrame(
     ...     data={"a": [1, 2], "b": [3, 4], "c": [5.6, 6.7]},
-    ...     columns=[("a", pl.Int16), ("b", pl.Int32), ("c", pl.Float32)],
+    ...     schema=[("a", pl.Int16), ("b", pl.Int32), ("c", pl.Float32)],
     ... ).lazy()
     >>>
     >>> ldf.collect()
@@ -274,7 +274,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     >>>
     >>> ldf = pl.DataFrame(
     ...     data=[["xx", 2, 3, 4], ["xy", 4, 5, 6], ["yy", 5, 6, 7], ["yz", 6, 7, 8]],
-    ...     columns=["a1", "a2", "b1", "b2"],
+    ...     schema=["a1", "a2", "b1", "b2"],
     ...     orient="row",
     ... ).lazy()
     >>>

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2543,7 +2543,7 @@ def coalesce(
     ...         (None, None, 3.0),
     ...         (None, None, None),
     ...     ],
-    ...     columns=[("a", pl.Float64), ("b", pl.Float64), ("c", pl.Float64)],
+    ...     schema=[("a", pl.Float64), ("b", pl.Float64), ("c", pl.Float64)],
     ... )
     >>> df.with_column(pl.coalesce(["a", "b", "c", 99.9]).alias("d"))
     shape: (4, 4)

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1485,7 +1485,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         └─────┴─────┴──────┘
 
         """
-        return pli.DataFrame(columns=self.schema).lazy()
+        return pli.DataFrame(schema=self.schema).lazy()
 
     def clone(self: LDF) -> LDF:
         """

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -176,10 +176,9 @@ class LazyGroupBy(Generic[LDF]):
         f
             Function to apply over each group of the `LazyFrame`.
         schema
-            Schema of the output function. This has to be known statically.
-            If the schema provided is incorrect, this is a bug in the callers
-            query and may lead to errors.
-            If set to None, polars assumes the schema is unchanged.
+            Schema of the output function. This has to be known statically. If the
+            given schema is incorrect, this is a bug in the caller's query and may
+            lead to errors. If set to None, polars assumes the schema is unchanged.
 
 
         Examples

--- a/py-polars/polars/internals/slice.py
+++ b/py-polars/polars/internals/slice.py
@@ -32,7 +32,7 @@ class PolarsSlice:
     @staticmethod
     def _lazify(obj: FrameOrSeries) -> "pli.LazyFrame":
         """Make lazy to ensure efficient/consistent handling."""
-        return obj.lazy() if isinstance(obj, pli.DataFrame) else obj.to_frame().lazy()
+        return obj.to_frame().lazy() if isinstance(obj, pli.Series) else obj.lazy()
 
     def _slice_positive(self, obj: "pli.LazyFrame") -> "pli.LazyFrame":
         """Logic for slices with positive stride."""

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -251,8 +251,8 @@ def columns(
     >>> from string import punctuation
     >>>
     >>> def test_special_char_colname_init() -> None:
-    ...     cols = [(c.name, c.dtype) for c in columns(punctuation)]
-    ...     df = pl.DataFrame(columns=cols)
+    ...     schema = [(c.name, c.dtype) for c in columns(punctuation)]
+    ...     df = pl.DataFrame(schema=schema)
     ...     assert len(cols) == len(df.columns)
     ...     assert 0 == len(df.rows())
     ...
@@ -617,7 +617,7 @@ def dataframes(
                 )
                 for c in coldefs
             },
-            columns=frame_columns,  # type: ignore[arg-type]
+            schema=frame_columns,  # type: ignore[arg-type]
         )
         # optionally generate frames with n_chunks > 1
         if series_size > 1 and chunked is True:

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -15,7 +15,7 @@ assert (time.time() - t0) < 1
 # test mean overflow issues
 np.random.seed(1)
 mean = 769.5607652
-df = pl.DataFrame(np.random.randint(500, 1040, 5000000), columns=["value"])
+df = pl.DataFrame(np.random.randint(500, 1040, 5000000), schema=["value"])
 assert np.isclose(df.with_column(pl.mean("value"))[0, 0], mean)
 assert np.isclose(
     df.with_column(pl.col("value").cast(pl.Int32)).with_column(pl.mean("value"))[0, 0],

--- a/py-polars/tests/parametric/test_dataframe.py
+++ b/py-polars/tests/parametric/test_dataframe.py
@@ -23,7 +23,7 @@ def test_repr(df: pl.DataFrame) -> None:
         min_size=1, min_cols=1, null_probability=0.25, excluded_dtypes=[pl.Utf8]
     )
 )
-@example(df=pl.DataFrame(columns=["x", "y", "z"]))
+@example(df=pl.DataFrame(schema=["x", "y", "z"]))
 @example(df=pl.DataFrame())
 def test_null_count(df: pl.DataFrame) -> None:
     # note: the zero-row and zero-col cases are always passed as explicit examples

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -887,7 +887,7 @@ def test_datetime_format_inferred_precision(
             "x": [datetime(2022, 9, 4, 10, 30, 45, 123000)],
             "y": [datetime(2022, 9, 4, 10, 30, 45, 123000)],
         },
-        columns=[
+        schema=[
             ("x", pl.Datetime(tu1)),
             ("y", pl.Datetime(tu2)),
         ],

--- a/py-polars/tests/unit/test_api.py
+++ b/py-polars/tests/unit/test_api.py
@@ -26,7 +26,7 @@ def test_custom_df_namespace() -> None:
 
     df = pl.DataFrame(
         data=[["xx", 2, 3, 4], ["xy", 4, 5, 6], ["yy", 5, 6, 7], ["yz", 6, 7, 8]],
-        columns=["a1", "a2", "b1", "b2"],
+        schema=["a1", "a2", "b1", "b2"],
         orient="row",
     )
 
@@ -58,7 +58,7 @@ def test_custom_expr_namespace() -> None:
         def nearest(self, p: int) -> pl.Expr:
             return (p ** (self._expr.log(p)).round(0).cast(pl.Int64)).cast(pl.Int64)
 
-    df = pl.DataFrame([1.4, 24.3, 55.0, 64.001], columns=["n"])
+    df = pl.DataFrame([1.4, 24.3, 55.0, 64.001], schema=["n"])
     assert df.select(
         [
             pl.col("n"),
@@ -88,18 +88,18 @@ def test_custom_lazy_namespace() -> None:
 
     ldf = pl.DataFrame(
         data=[["xx", 2, 3, 4], ["xy", 4, 5, 6], ["yy", 5, 6, 7], ["yz", 6, 7, 8]],
-        columns=["a1", "a2", "b1", "b2"],
+        schema=["a1", "a2", "b1", "b2"],
         orient="row",
     ).lazy()
 
     df1, df2 = (d.collect() for d in ldf.split.by_column_dtypes())
     assert_frame_equal(
-        df1, pl.DataFrame([("xx",), ("xy",), ("yy",), ("yz",)], columns=["a1"])
+        df1, pl.DataFrame([("xx",), ("xy",), ("yy",), ("yz",)], schema=["a1"])
     )
     assert_frame_equal(
         df2,
         pl.DataFrame(
-            [(2, 3, 4), (4, 5, 6), (5, 6, 7), (6, 7, 8)], columns=["a2", "b1", "b2"]
+            [(2, 3, 4), (4, 5, 6), (5, 6, 7), (6, 7, 8)], schema=["a2", "b1", "b2"]
         ),
     )
 

--- a/py-polars/tests/unit/test_binary.py
+++ b/py-polars/tests/unit/test_binary.py
@@ -22,7 +22,7 @@ def test_contains() -> None:
             (2, b"(with) special\n * chars"),
             (3, b"**etc...?$"),
         ],
-        columns=["idx", "bin"],
+        schema=["idx", "bin"],
     )
     for pattern, expected in (
         (b"e * ", [True, False, False]),

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -128,7 +128,7 @@ def test_cat_to_dummies() -> None:
 def test_comp_categorical_lit_dtype() -> None:
     df = pl.DataFrame(
         data={"column": ["a", "b", "e"], "values": [1, 5, 9]},
-        columns=[("column", pl.Categorical), ("more", pl.Int32)],
+        schema=[("column", pl.Categorical), ("more", pl.Int32)],
     )
 
     assert df.with_column(

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -41,7 +41,7 @@ def test_cse_schema_6081() -> None:
             [date(2022, 12, 12), 1, 2],
             [date(2022, 12, 13), 5, 2],
         ],
-        columns=["date", "id", "value"],
+        schema=["date", "id", "value"],
         orient="row",
     ).lazy()
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -64,7 +64,7 @@ def test_fill_null_temporal() -> None:
             [dtm, dtm_ms, dtm, dtm, dt, tm, td, td, td, td],
             [None] * 10,
         ],
-        columns=[
+        schema=[
             ("a", pl.Datetime),
             ("b", pl.Datetime("ms")),
             ("c", pl.Datetime("us")),
@@ -1325,7 +1325,7 @@ def test_asof_join() -> None:
 def test_temporal_dtypes_apply() -> None:
     df = pl.DataFrame(
         {"timestamp": [1284286794000, None, 1234567890000]},
-        columns=[("timestamp", pl.Datetime("ms"))],
+        schema=[("timestamp", pl.Datetime("ms"))],
     )
     const_dtm = datetime(2010, 9, 12)
 
@@ -1354,7 +1354,7 @@ def test_temporal_dtypes_apply() -> None:
                     time(23, 31, 30),
                 ),
             ],
-            columns={
+            schema={
                 "timestamp": pl.Datetime("ms"),
                 "const_dtm": pl.Datetime("us"),
                 "date": pl.Date,
@@ -1380,7 +1380,7 @@ def test_timedelta_timeunit_init() -> None:
 
     df = pl.DataFrame(
         [[td_us, td_us, td_us]],
-        columns=[
+        schema=[
             ("x", pl.Duration("ms")),
             ("y", pl.Duration("us")),
             ("z", pl.Duration("ns")),
@@ -1597,7 +1597,7 @@ def test_datetime_instance_selection() -> None:
     }
     df = pl.DataFrame(
         data=test_data,
-        columns=[
+        schema=[
             ("ns", pl.Datetime("ns")),
             ("us", pl.Datetime("us")),
             ("ms", pl.Datetime("ms")),
@@ -1919,7 +1919,7 @@ def test_shift_and_fill_group_logicals() -> None:
             (date(2001, 1, 3), "B"),
             (date(2001, 1, 4), "B"),
         ],
-        columns=["d", "s"],
+        schema=["d", "s"],
     )
     assert df.select(
         pl.col("d").shift_and_fill(-1, pl.col("d").max()).over("s")
@@ -1958,7 +1958,7 @@ def test_datetime_string_casts() -> None:
             "y": [1661855445123456],
             "z": [1661855445123456789],
         },
-        columns=[
+        schema=[
             ("x", pl.Datetime("ms")),
             ("y", pl.Datetime("us")),
             ("z", pl.Datetime("ns")),
@@ -2053,7 +2053,7 @@ def test_tz_datetime_duration_arithm_5221() -> None:
     ]
     out = pl.DataFrame(
         data={"run_datetime": run_datetimes},
-        columns=[("run_datetime", pl.Datetime(time_zone="UTC"))],
+        schema=[("run_datetime", pl.Datetime(time_zone="UTC"))],
     )
     utc = zoneinfo.ZoneInfo("UTC")
     assert out.to_dict(False) == {

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -2,7 +2,7 @@ import polars as pl
 
 
 def test_empty_str_concat_lit() -> None:
-    df = pl.DataFrame({"a": [], "b": []}, columns=[("a", pl.Utf8), ("b", pl.Utf8)])
+    df = pl.DataFrame({"a": [], "b": []}, schema=[("a", pl.Utf8), ("b", pl.Utf8)])
     assert df.with_column(pl.lit("asd") + pl.col("a")).schema == {
         "a": pl.Utf8,
         "b": pl.Utf8,

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -40,7 +40,7 @@ def test_prefix(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_cumcount() -> None:
-    df = pl.DataFrame([["a"], ["a"], ["a"], ["b"], ["b"], ["a"]], columns=["A"])
+    df = pl.DataFrame([["a"], ["a"], ["a"], ["b"], ["b"], ["a"]], schema=["A"])
 
     out = df.groupby("A", maintain_order=True).agg(
         [pl.col("A").cumcount(reverse=False).alias("foo")]
@@ -280,7 +280,7 @@ def test_dot_in_groupby() -> None:
 def test_dtype_col_selection() -> None:
     df = pl.DataFrame(
         data=[],
-        columns={
+        schema={
             "a1": pl.Datetime,
             "a2": pl.Datetime("ms"),
             "a3": pl.Datetime("ms"),
@@ -526,7 +526,7 @@ def test_ewm_with_multiple_chunks() -> None:
             ("y", 4.0, 3.0),
             ("z", 3.0, 4.0),
         ],
-        columns=["a", "b", "c"],
+        schema=["a", "b", "c"],
     ).with_columns(
         [
             pl.col(pl.Float64).log().diff().prefix("ld_"),

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -73,7 +73,7 @@ def test_all_any_horizontally() -> None:
             [False, None, True],
             [None, None, False],
         ],
-        columns=["var1", "var2", "var3"],
+        schema=["var1", "var2", "var3"],
     )
     expected = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -296,7 +296,7 @@ def test_from_dicts_schema_override() -> None:
     for n_infer in (0, 3, 5, 8, 10, 100):
         df = pl.DataFrame(
             data=(data1 + data2),
-            columns=schema,  # type: ignore[arg-type]
+            schema=schema,  # type: ignore[arg-type]
             infer_schema_length=n_infer,
         )
         assert df.schema == schema
@@ -332,7 +332,7 @@ def test_from_dicts_struct() -> None:
 
 def test_from_records() -> None:
     data = [[1, 2, 3], [4, 5, 6]]
-    df = pl.from_records(data, columns=["a", "b"])
+    df = pl.from_records(data, schema=["a", "b"])
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]
 
@@ -341,7 +341,7 @@ def test_from_numpy() -> None:
     data = np.array([[1, 2, 3], [4, 5, 6]])
     df = pl.from_numpy(
         data,
-        columns=["a", "b"],
+        schema=["a", "b"],
         orient="col",
         schema_overrides={"a": pl.UInt32, "b": pl.UInt32},
     )
@@ -393,7 +393,7 @@ def test_from_optional_not_available() -> None:
 
     np = _LazyModule("numpy", module_available=False)
     with pytest.raises(ImportError, match=r"np\.array requires 'numpy'"):
-        pl.from_numpy(np.array([[1, 2], [3, 4]]), columns=["a", "b"])
+        pl.from_numpy(np.array([[1, 2], [3, 4]]), schema=["a", "b"])
 
     pa = _LazyModule("pyarrow", module_available=False)
     with pytest.raises(ImportError, match=r"pa\.table requires 'pyarrow'"):
@@ -467,7 +467,7 @@ def test_from_empty_pandas_with_dtypes() -> None:
 
     df = pl.DataFrame(
         data=[],
-        columns={
+        schema={
             "a": pl.Int32,
             "b": pl.Datetime,
             "c": pl.Float32,

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -64,7 +64,7 @@ def test_semi_anti_join() -> None:
 def test_join_same_cat_src() -> None:
     df = pl.DataFrame(
         data={"column": ["a", "a", "b"], "more": [1, 2, 3]},
-        columns=[("column", pl.Categorical), ("more", pl.Int32)],
+        schema=[("column", pl.Categorical), ("more", pl.Int32)],
     )
     df_agg = df.groupby("column").agg(pl.col("more").mean())
     assert df.join(df_agg, on="column").to_dict(False) == {

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1543,10 +1543,8 @@ def test_lazy_cache_hit(capfd: Any) -> None:
 
 
 def test_quadratic_behavior_4736() -> None:
-    # we don't assert anything.
-    # If this function does not stall
-    # our tests it has passed.
-    df = pl.DataFrame(columns=list(ascii_letters))
+    # no assert; if this function does not stall our tests it has passed!
+    df = pl.DataFrame(schema=list(ascii_letters))
     df.lazy().select(reduce(add, (pl.col(fld) for fld in df.columns)))
 
 

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -85,7 +85,7 @@ def test_dtype() -> None:
             "dt": [[date(2022, 12, 31)]],
             "dtm": [[datetime(2022, 12, 31, 1, 2, 3)]],
         },
-        columns=[
+        schema=[
             ("i", pl.List(pl.Int8)),
             ("tm", pl.List(pl.Time)),
             ("dt", pl.List(pl.Date)),
@@ -355,7 +355,7 @@ def test_empty_list_construction() -> None:
         False
     ) == {"array": [[]], "not_array": [1234]}
 
-    df = pl.DataFrame(columns=[("col", pl.List)])
+    df = pl.DataFrame(schema=[("col", pl.List)])
     assert df.schema == {"col": pl.List}
     assert df.rows() == []
 
@@ -636,7 +636,7 @@ def test_fast_explode_on_list_struct_6208() -> None:
 
     df = pl.DataFrame(
         data,
-        columns={
+        schema={
             "label": pl.Utf8,
             "tag": pl.Utf8,
             "ref": pl.Int64,

--- a/py-polars/tests/unit/test_object.py
+++ b/py-polars/tests/unit/test_object.py
@@ -24,7 +24,7 @@ def test_object_empty_filter_5911() -> None:
         data=[
             (1, "dog", {}),
         ],
-        columns=[
+        schema=[
             ("pet_id", pl.Int64),
             ("pet_type", pl.Categorical),
             ("pet_obj", pl.Object),
@@ -57,7 +57,7 @@ def test_empty_sort() -> None:
             ({"name": "bar", "sort_key": 2},),
             ({"name": "foo", "sort_key": 1},),
         ],
-        columns=[
+        schema=[
             ("blob", pl.Object),
         ],
         orient="row",

--- a/py-polars/tests/unit/test_pivot.py
+++ b/py-polars/tests/unit/test_pivot.py
@@ -27,7 +27,7 @@ def test_pivot() -> None:
             ("B", None, None, 2, 4, None),
             ("C", None, None, None, None, 2),
         ],
-        columns=["foo", "k", "l", "m", "n", "o"],
+        schema=["foo", "k", "l", "m", "n", "o"],
     )
     assert_frame_equal(result, expected)
 
@@ -122,7 +122,7 @@ def test_pivot_categorical_3968() -> None:
 def test_pivot_categorical_index() -> None:
     df = pl.DataFrame(
         {"A": ["Fire", "Water", "Water", "Fire"], "B": ["Car", "Car", "Car", "Ship"]},
-        columns=[("A", pl.Categorical), ("B", pl.Categorical)],
+        schema=[("A", pl.Categorical), ("B", pl.Categorical)],
     )
 
     result = df.pivot(values="B", index=["A"], columns="B", aggregate_fn="count")
@@ -139,7 +139,7 @@ def test_pivot_categorical_index() -> None:
             "B": ["Car", "Car", "Car", "Ship"],
             "C": ["Paper", "Paper", "Paper", "Paper"],
         },
-        columns=[("A", pl.Categorical), ("B", pl.Categorical), ("C", pl.Categorical)],
+        schema=[("A", pl.Categorical), ("B", pl.Categorical), ("C", pl.Categorical)],
     )
     result = df.pivot(values="B", index=["A", "C"], columns="B", aggregate_fn="count")
     expected = {

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -177,7 +177,7 @@ def test_groupby_agg_equals_zero_3535() -> None:
             ("cc", -99, 10.5),
             ("cc", None, 0.0),
         ],
-        columns=[
+        schema=[
             ("key", pl.Utf8),
             ("val1", pl.Int16),
             ("val2", pl.Float32),

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -283,7 +283,7 @@ def test_schema_owned_arithmetic_5669() -> None:
 
 def test_fill_null_f32_with_lit() -> None:
     # ensure the literal integer does not upcast the f32 to an f64
-    df = pl.DataFrame({"a": [1.1, 1.2]}, columns=[("a", pl.Float32)])
+    df = pl.DataFrame({"a": [1.1, 1.2]}, schema=[("a", pl.Float32)])
     assert df.fill_null(value=0).dtypes == [pl.Float32]
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -136,7 +136,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
     # numpy not available
     monkeypatch.setattr(pl.internals.series.series, "_check_for_numpy", lambda x: False)
     with pytest.raises(ValueError):
-        pl.DataFrame(np.array([1, 2, 3]), columns=["a"])
+        pl.DataFrame(np.array([1, 2, 3]), schema=["a"])
 
 
 def test_init_dataclass_namedtuple() -> None:

--- a/py-polars/tests/unit/test_strings.py
+++ b/py-polars/tests/unit/test_strings.py
@@ -27,7 +27,7 @@ def test_auto_explode() -> None:
 def test_contains() -> None:
     df = pl.DataFrame(
         data=[(1, "some * * text"), (2, "(with) special\n * chars"), (3, "**etc...?$")],
-        columns=["idx", "text"],
+        schema=["idx", "text"],
     )
     for pattern, as_literal, expected in (
         (r"\* \*", False, [True, False, False]),
@@ -67,7 +67,7 @@ def test_null_comparisons() -> None:
 def test_replace() -> None:
     df = pl.DataFrame(
         data=[(1, "* * text"), (2, "(with) special\n * chars **etc...?$")],
-        columns=["idx", "text"],
+        schema=["idx", "text"],
         orient="row",
     )
     for pattern, replacement, as_literal, expected in (
@@ -97,7 +97,7 @@ def test_replace() -> None:
 def test_replace_all() -> None:
     df = pl.DataFrame(
         data=[(1, "* * text"), (2, "(with) special * chars **etc...?$")],
-        columns=["idx", "text"],
+        schema=["idx", "text"],
         orient="row",
     )
     for pattern, replacement, as_literal, expected in (

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -773,7 +773,7 @@ def test_empty_with_schema_struct() -> None:
         for frame_data in (dict_data, dataclass_data):
             df = pl.DataFrame(
                 data=frame_data,
-                columns=frame_schema,  # type: ignore[arg-type]
+                schema=frame_schema,  # type: ignore[arg-type]
             )
             assert df.schema == frame_schema
             assert df.unnest("y").columns == ["x", "a", "b", "c"]

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -142,13 +142,13 @@ def test_compare_frame_equal_nans() -> None:
 
     df1 = pl.DataFrame(
         data={"x": [1.0, nan], "y": [nan, 2.0]},
-        columns=[("x", pl.Float32), ("y", pl.Float64)],
+        schema=[("x", pl.Float32), ("y", pl.Float64)],
     )
     assert_frame_equal(df1, df1, check_exact=True)
 
     df2 = pl.DataFrame(
         data={"x": [1.0, nan], "y": [None, 2.0]},
-        columns=[("x", pl.Float32), ("y", pl.Float64)],
+        schema=[("x", pl.Float32), ("y", pl.Float64)],
     )
     with pytest.raises(
         AssertionError, match="DataFrames are different\n\nExact value mismatch"


### PR DESCRIPTION
Here we go... deprecating `columns` in favour of `schema` for `DataFrame` init, tying in with the recent addition of `schema_overrides`. Can continue to use `columns` while we transition (which we may want to do over an extended period, given how ubiquitous it is). 

* Transition is managed via the usual `@deprecate_alias` decorator.
* Updated external and internal interfaces.
* Updated/improved docstrings.
* Updated tests.

This can release at any time, as it's not a breaking change.

For the next _breaking_ release, I'll make a slight param reorder so that `schema` and `schema_overrides` are adjacent in all constructor methods.