### PR TITLE
docs(python): Add docs and tests to `Expr.flatten`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3153,18 +3153,28 @@ class Expr:
 
     def flatten(self) -> Expr:
         """
+        Flatten a list or string column.
+
         Alias for :func:`polars.internals.expr.list.ExprListNameSpace.explode`.
-
-        Explode a list or utf8 Series. This means that every item is expanded to a new
-        row.
-
-        Returns
-        -------
-        Exploded Series of same dtype
 
         Examples
         --------
-        ...
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "group": ["a", "b", "b"],
+        ...         "values": [[1, 2], [2, 3], [4]],
+        ...     }
+        ... )
+        >>> df.groupby("group").agg(pl.col("values").flatten())  # doctest: +SKIP
+        shape: (2, 2)
+        ┌───────┬───────────┐
+        │ group ┆ values    │
+        │ ---   ┆ ---       │
+        │ str   ┆ list[i64] │
+        ╞═══════╪═══════════╡
+        │ a     ┆ [1, 2]    │
+        │ b     ┆ [2, 3, 4] │
+        └───────┴───────────┘
 
         """
         return wrap_expr(self._pyexpr.explode())

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3153,14 +3153,10 @@ class Expr:
 
     def flatten(self) -> Expr:
         """
-        Alias for :func:`explode`.
+        Alias for :func:`polars.internals.expr.list.ExprListNameSpace.explode`.
 
         Explode a list or utf8 Series. This means that every item is expanded to a new
         row.
-
-        .. deprecated:: 0.15.16
-            `Expr.flatten` will be removed in favour of `Expr.arr.explode` and
-            `Expr.str.explode`.
 
         Returns
         -------
@@ -3168,49 +3164,9 @@ class Expr:
 
         Examples
         --------
-        The following example turns each character into a separate row:
-
-        >>> df = pl.DataFrame({"foo": ["hello", "world"]})
-        >>> (df.select(pl.col("foo").flatten()))
-        shape: (10, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ str │
-        ╞═════╡
-        │ h   │
-        │ e   │
-        │ l   │
-        │ l   │
-        │ ... │
-        │ o   │
-        │ r   │
-        │ l   │
-        │ d   │
-        └─────┘
-
-        This example turns each word into a separate row:
-
-        >>> df = pl.DataFrame({"foo": ["hello world"]})
-        >>> (df.select(pl.col("foo").str.split(by=" ").flatten()))
-        shape: (2, 1)
-        ┌───────┐
-        │ foo   │
-        │ ---   │
-        │ str   │
-        ╞═══════╡
-        │ hello │
-        │ world │
-        └───────┘
+        ...
 
         """
-        warnings.warn(
-            "`Expr.flatten()` is deprecated in favor of `explode`"
-            " under the list and string namespaces. Use `.arr.explode()` or"
-            " `.str.explode()` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return wrap_expr(self._pyexpr.explode())
 
     def explode(self) -> Expr:

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -74,14 +74,14 @@ def test_window_function_cache() -> None:
             pl.col("values")
             .list()
             .over("groups")
-            .arr.explode()
+            .flatten()
             .alias("values_flat"),  # aggregation to list + explode and concat back
             pl.col("values")
             .reverse()
             .list()
             .over("groups")
-            .arr.explode()
-            .alias("values_rev"),  # use explode to reverse within a group
+            .flatten()
+            .alias("values_rev"),  # use flatten to reverse within a group
         ]
     )
 


### PR DESCRIPTION
Reverts the deprecation of `Expr.flatten` introduced in #6351 (unreleased)

Adds a doc example and some tests to the method.

Found a bug while working on this: #6369
The related test is already in the code, just needs to be un-skipped.