### PR TITLE
feat(python): Make groupby rolling/dynamic iterable

### DIFF
--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -58,7 +58,7 @@ class GroupBy(Generic[DF]):
         df: PyDataFrame,
         by: str | pli.Expr | Sequence[str | pli.Expr],
         dataframe_class: type[DF],
-        maintain_order: bool = False,
+        maintain_order: bool,
     ):
         """
         Construct class representing a group by operation over the given dataframe.
@@ -758,8 +758,8 @@ class RollingGroupBy(Generic[DF]):
         index_column: str,
         period: str | timedelta,
         offset: str | timedelta | None,
-        closed: ClosedInterval = "none",
-        by: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        closed: ClosedInterval,
+        by: str | pli.Expr | Sequence[str | pli.Expr] | None,
     ):
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
@@ -801,11 +801,11 @@ class DynamicGroupBy(Generic[DF]):
         every: str | timedelta,
         period: str | timedelta | None,
         offset: str | timedelta | None,
-        truncate: bool = True,
-        include_boundaries: bool = True,
-        closed: ClosedInterval = "none",
-        by: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-        start_by: StartBy = "window",
+        truncate: bool,
+        include_boundaries: bool,
+        closed: ClosedInterval,
+        by: str | pli.Expr | Sequence[str | pli.Expr] | None,
+        start_by: StartBy,
     ):
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -862,6 +862,50 @@ class DynamicGroupBy(Generic[DF]):
         self.by = by
         self.start_by = start_by
 
+    def __iter__(self) -> GroupBy[DF]:
+        groups_df = (
+            self.df.lazy()
+            .with_row_count(name="indices")
+            .groupby_dynamic(
+                index_column=self.time_column,
+                every=self.every,
+                period=self.period,
+                offset=self.offset,
+                truncate=self.truncate,
+                include_boundaries=self.include_boundaries,
+                closed=self.closed,
+                by=self.by,
+                start_by=self.start_by,
+            )
+            .agg(pli.col("indices").list())
+            .collect(no_optimization=True)
+        )
+
+        group_names = groups_df.select(pli.all().exclude("indices"))
+
+        # When grouping by a single column, group name is a single value
+        # When grouping by multiple columns, group name is a tuple of values
+        self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
+        if self.by is None:
+            self._group_names = iter(group_names.to_series())
+        else:
+            self._group_names = group_names.iterrows()
+
+        self._group_indices = groups_df.select("indices").to_series()
+        self._current_index = 0
+
+        return self
+
+    def __next__(self) -> tuple[object, DF] | tuple[tuple[object, ...], DF]:
+        if self._current_index >= len(self._group_indices):
+            raise StopIteration
+
+        group_name = next(self._group_names)
+        group_data = self.df[self._group_indices[self._current_index]]
+        self._current_index += 1
+
+        return group_name, group_data
+
     def agg(self, aggs: pli.Expr | Sequence[pli.Expr]) -> pli.DataFrame:
         return (
             self.df.lazy()

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -771,7 +771,7 @@ class RollingGroupBy(Generic[DF]):
         self.closed = closed
         self.by = by
 
-    def __iter__(self) -> GroupBy[DF]:
+    def __iter__(self) -> RollingGroupBy[DF]:
         groups_df = (
             self.df.lazy()
             .with_row_count(name="indices")
@@ -862,7 +862,7 @@ class DynamicGroupBy(Generic[DF]):
         self.by = by
         self.start_by = start_by
 
-    def __iter__(self) -> GroupBy[DF]:
+    def __iter__(self) -> DynamicGroupBy[DF]:
         groups_df = (
             self.df.lazy()
             .with_row_count(name="indices")

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -445,3 +445,42 @@ def test_groupby_when_then_with_binary_and_agg_in_pred_6202() -> None:
         "code": ["a", "b"],
         "literal": [[False, True], [True, True, False]],
     }
+
+
+def test_groupby_dynamic_iter() -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": [
+                datetime(2020, 1, 1, 10, 0),
+                datetime(2020, 1, 1, 10, 50),
+                datetime(2020, 1, 1, 11, 10),
+            ],
+            "a": [1, 2, 2],
+            "b": [4, 5, 6],
+        }
+    )
+
+    # Without 'by' argument
+    result1 = [
+        (name, data.shape)
+        for name, data in df.groupby_dynamic("datetime", every="1h", closed="left")
+    ]
+    expected1 = [
+        (datetime(2020, 1, 1, 10), (2, 3)),
+        (datetime(2020, 1, 1, 11), (1, 3)),
+    ]
+    assert result1 == expected1
+
+    # With 'by' argument
+    result2 = [
+        (name, data.shape)
+        for name, data in df.groupby_dynamic(
+            "datetime", every="1h", closed="left", by="a"
+        )
+    ]
+    expected2 = [
+        ((1, datetime(2020, 1, 1, 10)), (1, 3)),
+        ((2, datetime(2020, 1, 1, 10)), (1, 3)),
+        ((2, datetime(2020, 1, 1, 11)), (1, 3)),
+    ]
+    assert result2 == expected2

--- a/py-polars/tests/unit/test_rolling.py
+++ b/py-polars/tests/unit/test_rolling.py
@@ -523,3 +523,37 @@ def test_groupby_dynamic_by_monday_and_offset_5444() -> None:
     )
     print(result_empty, result)
     assert result_empty.schema == result.schema
+
+
+def test_groupby_rolling_iter() -> None:
+    df = pl.DataFrame(
+        {
+            "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 5)],
+            "a": [1, 2, 2],
+            "b": [4, 5, 6],
+        }
+    )
+
+    # Without specifying 'by'
+    result1 = [
+        (name, data.shape)
+        for name, data in df.groupby_rolling(index_column="date", period="2d")
+    ]
+    expected1 = [
+        (date(2020, 1, 1), (1, 3)),
+        (date(2020, 1, 2), (2, 3)),
+        (date(2020, 1, 5), (1, 3)),
+    ]
+    assert result1 == expected1
+
+    # With specifying 'by'
+    result2 = [
+        (name, data.shape)
+        for name, data in df.groupby_rolling(index_column="date", period="2d", by="a")
+    ]
+    expected2 = [
+        ((1, date(2020, 1, 1)), (1, 3)),
+        ((2, date(2020, 1, 2)), (1, 3)),
+        ((2, date(2020, 1, 5)), (1, 3)),
+    ]
+    assert result2 == expected2

--- a/py-polars/tests/unit/test_rolling.py
+++ b/py-polars/tests/unit/test_rolling.py
@@ -534,7 +534,7 @@ def test_groupby_rolling_iter() -> None:
         }
     )
 
-    # Without specifying 'by'
+    # Without 'by' argument
     result1 = [
         (name, data.shape)
         for name, data in df.groupby_rolling(index_column="date", period="2d")
@@ -546,7 +546,7 @@ def test_groupby_rolling_iter() -> None:
     ]
     assert result1 == expected1
 
-    # With specifying 'by'
+    # With 'by' argument
     result2 = [
         (name, data.shape)
         for name, data in df.groupby_rolling(index_column="date", period="2d", by="a")


### PR DESCRIPTION
Resolves #5786

Question: while working on this, I noticed that `groupby_rolling` defaults to `closed=left`, while `groupby_dynamic` defaults to `closed=right`. Why is this? It would make sense to me to have both default to `closed=left`.