### PR TITLE
feat(python): minor improvement to auto-detection of ambiguous data orientation

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -785,8 +785,19 @@ def sequence_to_pydf(
             elif orient is None:
                 orient = "row"
 
-        if orient is None and schema is not None:
-            orient = "col" if len(schema) == len(data) else "row"
+        if orient is None:
+            # note: limit type-checking to smaller data; larger values are much more
+            # likely to indicate col orientation anyway, so minimise extra checks.
+            if len(data[0]) > 1000:
+                orient = "col" if columns and len(columns) == len(data) else "row"
+            elif (columns is not None and len(columns) == len(data)) or not columns:
+                # check if element types in the first 'row' resolve to a single dtype.
+                row_types = {type(value) for value in data[0] if value is not None}
+                if int in row_types and float in row_types:
+                    row_types.discard(int)
+                orient = "col" if len(row_types) == 1 else "row"
+            else:
+                orient = "row"
 
         if orient == "row":
             column_names, schema_overrides = _unpack_schema(

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -789,8 +789,8 @@ def sequence_to_pydf(
             # note: limit type-checking to smaller data; larger values are much more
             # likely to indicate col orientation anyway, so minimise extra checks.
             if len(data[0]) > 1000:
-                orient = "col" if columns and len(columns) == len(data) else "row"
-            elif (columns is not None and len(columns) == len(data)) or not columns:
+                orient = "col" if schema and len(schema) == len(data) else "row"
+            elif (schema is not None and len(schema) == len(data)) or not schema:
                 # check if element types in the first 'row' resolve to a single dtype.
                 row_types = {type(value) for value in data[0] if value is not None}
                 if int in row_types and float in row_types:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1300,7 +1300,7 @@ def test_from_generator_or_iterable() -> None:
 
 
 def test_from_rows() -> None:
-    df = pl.from_records([[1, 2, "foo"], [2, 3, "bar"]], orient="row")
+    df = pl.from_records([[1, 2, "foo"], [2, 3, "bar"]])
     assert df.frame_equal(
         pl.DataFrame(
             {"column_0": [1, 2], "column_1": [2, 3], "column_2": ["foo", "bar"]}
@@ -1312,6 +1312,11 @@ def test_from_rows() -> None:
         orient="row",
     )
     assert df.dtypes == [pl.UInt32, pl.Datetime]
+
+    # auto-inference with same num rows/cols
+    data = [(1, 2, "foo"), (2, 3, "bar"), (3, 4, "baz")]
+    df = pl.from_records(data)
+    assert data == df.rows()
 
 
 def test_repeat_by() -> None:


### PR DESCRIPTION
Closes #6368.

Improves the likelihood of correct `orient` inference if that param is not explicitly supplied (at `DataFrame` init time) and the number of rows/cols makes the determination ambiguous.

**Example / setup**:
```python
import polars as pl
pl.DataFrame( 
    data = [(1,2,"foo"),(2,3,"bar"),(3,4,"baz")], 
    columns = ["x","y","z"],
)
```
**Before**:
```python
# shape: (3, 3)
# ┌──────┬──────┬──────┐
# │ x    ┆ y    ┆ z    │
# │ ---  ┆ ---  ┆ ---  │
# │ str  ┆ str  ┆ str  │
# ╞══════╪══════╪══════╡
# │ null ┆ null ┆ null │
# │ null ┆ null ┆ null │
# │ foo  ┆ bar  ┆ baz  │
# └──────┴──────┴──────┘
```
**After**:
```python
# shape: (3, 3)
# ┌─────┬─────┬─────┐
# │ x   ┆ y   ┆ z   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ str │
# ╞═════╪═════╪═════╡
# │ 1   ┆ 2   ┆ foo │
# │ 2   ┆ 3   ┆ bar │
# │ 3   ┆ 4   ┆ baz │
# └─────┴─────┴─────┘
```