### PR TITLE
fix(python): dont incorrectly infer Zulu time

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -124,13 +124,9 @@ pub(super) static DATETIME_Y_M_D: &[&str] = &[
     // ---
     // other
     // ---
-    // 2019-04-18T02:45:55Z
-    "%Y-%m-%dT%H:%M:%SZ",
     // 21/12/31 12:54:48
     "%y/%m/%d %H:%M:%S",
     // 21/12/31 24:58:01
-    "%y/%m/%d %H:%M:%S",
-    //210319 23:58:50
     "%y%m%d %H:%M:%S",
     // 2021/12/31 11:54:48 PM
     "%Y/%m/%d %I:%M:%S %p",
@@ -139,11 +135,9 @@ pub(super) static DATETIME_Y_M_D: &[&str] = &[
     "%Y/%m/%d %I:%M %p",
     "%Y-%m-%d %I:%M %p",
     // ---
-    // not supported by polars' parser
-    // ---
-    "%+",
     // we cannot know this one, because polars needs to know
     // the length of the parsed fmt
+    // ---
     "%FT%H:%M:%S%.f",
 ];
 

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -47,7 +47,7 @@ class ExprStringNameSpace:
             for specification. Example: ``"%y-%m-%d"``.
             Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
             you should instead insert a ``Z`` in your ``fmt`` string and then
-            cast to UTC with ``dt.cast_time_zone``.
+            use with ``dt.with_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -45,6 +45,9 @@ class ExprStringNameSpace:
             Format to use, refer to the `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
+            Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
+            you should instead insert a ``Z`` in your ``fmt`` string and then
+            cast to UTC with ``dt.cast_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -47,7 +47,7 @@ class ExprStringNameSpace:
             for specification. Example: ``"%y-%m-%d"``.
             Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
             you should instead insert a ``Z`` in your ``fmt`` string and then
-            use with ``dt.with_time_zone``.
+            use ``dt.with_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -44,7 +44,7 @@ class StringNameSpace:
             for specification. Example: ``"%y-%m-%d"``.
             Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
             you should instead insert a ``Z`` in your ``fmt`` string and then
-            use with ``dt.with_time_zone``.
+            use ``dt.with_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -44,7 +44,7 @@ class StringNameSpace:
             for specification. Example: ``"%y-%m-%d"``.
             Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
             you should instead insert a ``Z`` in your ``fmt`` string and then
-            cast to UTC with ``dt.cast_time_zone``.
+            use with ``dt.with_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -42,6 +42,9 @@ class StringNameSpace:
             `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
+            Note that the ``Z`` suffix for "Zulu time" is not (yet!) supported:
+            you should instead insert a ``Z`` in your ``fmt`` string and then
+            cast to UTC with ``dt.cast_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1439,7 +1439,6 @@ def test_from_time_arrow() -> None:
         ("2018-09-05T04:24:01.9", datetime(2018, 9, 5, 4, 24, 1, 900000)),
         ("2018-09-05T04:24:02.11", datetime(2018, 9, 5, 4, 24, 2, 110000)),
         ("2018-09-05T14:24:02.123", datetime(2018, 9, 5, 14, 24, 2, 123000)),
-        ("2018-09-05T14:24:02.123Z", datetime(2018, 9, 5, 14, 24, 2, 123000)),
         ("2019-04-18T02:45:55.555000000", datetime(2019, 4, 18, 2, 45, 55, 555000)),
         ("2019-04-18T22:45:55.555123", datetime(2019, 4, 18, 22, 45, 55, 555123)),
     ],
@@ -1471,7 +1470,8 @@ def test_datetime_strptime_patterns_consistent() -> None:
             .alias("parsed"),
         ]
     )["parsed"]
-    assert s.null_count() == 0
+    assert s.null_count() == 1
+    assert s[5] is None
 
 
 def test_datetime_strptime_patterns_inconsistent() -> None:


### PR DESCRIPTION
closes #6375 

As mentioned in the issue, I don't think the current treatment of the `Z` suffix is correct (at least, it's inconsistent with the Python stdlib `datetime`), so rather than returning potentially unexpected results, I'd like to suggest it'd be better to not infer this and just raise - people can just specify `fmt` and set the timezone according to what they want

It would be nice to fix this, but I'd like to suggest to first remove the incorrect inference, and then to infer this properly (as tz-aware) in a separate PR: looks like chrono handles it properly already anyway:
```console
(.311venv) marcogorelli@DESKTOP-U8OKFP3:~/tmp$ cat src/main.rs
use chrono::{DateTime};


fn main() {
    let parse_from_str = DateTime::parse_from_str;
    let ts = "2000-01-01T01:23:34Z";
    let fmt = "%+";
    let parsed = parse_from_str(ts, fmt);
    println!("{:?}", parsed);
}
(.311venv) marcogorelli@DESKTOP-U8OKFP3:~/tmp$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/tmp`
Ok(2000-01-01T01:23:34+00:00)
```