### PR TITLE
fix(python, rust): Return empty batch for pl.read_csv_batched().next_…

### DIFF
--- a/polars/polars-io/src/csv/read_impl/batched.rs
+++ b/polars/polars-io/src/csv/read_impl/batched.rs
@@ -86,6 +86,9 @@ pub struct BatchedCsvReader<'a> {
 
 impl<'a> BatchedCsvReader<'a> {
     pub fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<(IdxSize, DataFrame)>>> {
+        if n == 0 {
+            return Ok(None);
+        }
         if self.chunk_offset == self.file_chunks.len() as IdxSize {
             return Ok(None);
         }

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1727,7 +1727,31 @@ def read_csv_batched(
     >>> reader = pl.read_csv_batched(
     ...     "./tpch/tables_scale_100/lineitem.tbl", sep="|", parse_dates=True
     ... )  # doctest: +SKIP
-    >>> reader.next_batches(5)  # doctest: +SKIP
+    >>> batches = reader.next_batches(5)  # doctest: +SKIP
+    >>> for df in batches:  # doctest: +SKIP
+    ...     print(df)
+    ...
+
+    Read big CSV file in batches and write a CSV file for each "group" of interest.
+
+    >>> seen_groups = set()
+    >>> reader = pl.read_csv_batched("big_file.csv")  # doctest: +SKIP
+    >>> batches = reader.next_batches(100)  # doctest: +SKIP
+
+    >>> while batches:  # doctest: +SKIP
+    ...     df_current_batches = pl.concat(batches)
+    ...     partition_dfs = df_current_batches.partition_by("group", as_dict=True)
+    ...
+    ...     for group, df in partition_dfs.items():
+    ...         if group in seen_groups:
+    ...             with open(f"./data/{group}.csv", "a") as fh:
+    ...                 fh.write(df.write_csv(file=None, has_header=False))
+    ...         else:
+    ...             df.write_csv(file=f"./data/{group}.csv", has_header=True)
+    ...         seen_groups.add(group)
+    ...
+    ...     batches = reader.next_batches(100)
+    ...
 
     Parameters
     ----------

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1032,6 +1032,13 @@ def test_batched_csv_reader_all_batches(foods_csv: str) -> None:
         assert_frame_equal(out, batched_concat_df)
 
 
+def test_batched_csv_reader_no_batches(foods_csv: str) -> None:
+    reader = pl.read_csv_batched(foods_csv, batch_size=4)
+    batches = reader.next_batches(0)
+
+    assert batches is None
+
+
 def test_csv_single_categorical_null() -> None:
     f = io.BytesIO()
     pl.DataFrame(


### PR DESCRIPTION
…batches(0)

Return empty batch for pl.read_csv_batched().next_batches(0) instead of giving an index out of bounds error.

Also add a more useful read_csv_batched docstring example.