### PR TITLE
refactor(python)!: make `schema`, `schema_overrides`, and `orient` consistent on all user-facing interfaces

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -176,10 +176,10 @@ def from_dicts(
 def from_records(
     data: Sequence[Sequence[Any]],
     schema: Sequence[str] | None = None,
-    orient: Orientation | None = None,
     *,
-    infer_schema_length: int | None = N_INFER_DEFAULT,
     schema_overrides: SchemaDict | None = None,
+    orient: Orientation | None = None,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> DataFrame:
     """
     Construct a DataFrame from a sequence of sequences. This operation clones data.
@@ -200,6 +200,9 @@ def from_records(
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the columns param will be overridden.
     orient : {None, 'col', 'row'}
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -207,9 +210,6 @@ def from_records(
     infer_schema_length
         How many dictionaries/rows to scan to determine the data types
         if set to `None` all rows are scanned. This will be slow.
-    schema_overrides : dict, default None
-        Support type specification or override of one or more columns; note that
-        any dtypes inferred from the columns param will be overridden.
 
     Returns
     -------
@@ -245,8 +245,9 @@ def from_records(
 def from_numpy(
     data: np.ndarray[Any, Any],
     schema: SchemaDefinition | None = None,
-    orient: Orientation | None = None,
+    *,
     schema_overrides: SchemaDict | None = None,
+    orient: Orientation | None = None,
 ) -> DataFrame:
     """
     Construct a DataFrame from a numpy ndarray. This operation clones data.
@@ -267,13 +268,13 @@ def from_numpy(
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the columns param will be overridden.
     orient : {None, 'col', 'row'}
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
         this does not yield conclusive results, column orientation is used.
-    schema_overrides : dict, default None
-        Support type specification or override of one or more columns; note that
-        any dtypes inferred from the columns param will be overridden.
 
     Returns
     -------
@@ -334,7 +335,6 @@ def from_arrow(
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
-
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -162,6 +162,11 @@ class DataFrame:
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
         If you supply a list of column names that does not match the names in the
+        underlying data, the names given here will overwrite them. The number
+        of names given in the schema should match the underlying data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the schema param will be overridden.
         underlying data, the names given here will overwrite them.
 
         The number of entries in the schema should match the underlying data
@@ -174,9 +179,6 @@ class DataFrame:
     infer_schema_length : int, default None
         Maximum number of rows to read for schema inference; only applies if the input
         data is a sequence or generator of rows; other input is read as-is.
-    schema_overrides : dict, default None
-        Support type specification or override of one or more columns; note that
-        any dtypes inferred from the schema param will be overridden.
 
     Examples
     --------
@@ -309,10 +311,10 @@ class DataFrame:
             | None
         ) = None,
         schema: SchemaDefinition | None = None,
-        orient: Orientation | None = None,
         *,
-        infer_schema_length: int | None = N_INFER_DEFAULT,
         schema_overrides: SchemaDict | None = None,
+        orient: Orientation | None = None,
+        infer_schema_length: int | None = N_INFER_DEFAULT,
     ):
         if data is None:
             self._df = dict_to_pydf(


### PR DESCRIPTION
As per earlier discussion (@stinodego :), here's the final update in the "columns deprecation" trilogy. As suggested, there is _very_ slightly more use of kwargs-only params (`schema_overrides` and `orient`) to help normalise the parameter order of all the user-facing interfaces for `DataFrame` init. (Internal interfaces were made consistent when `schema` and `schema_overrides` were added).

Extremely minimal changes required, as half of the methods were already conformant, and the two kwargs-only params are likely to already be used via kwargs in most cases anyway... So, I'd anticipate close to zero impact, but it is technically a breaking change so let's leave for `0.16.0`.
