### PR TITLE
docs(rust): fix a typo in csv read example

### DIFF
--- a/polars/polars-io/src/csv/read.rs
+++ b/polars/polars-io/src/csv/read.rs
@@ -85,7 +85,7 @@ impl NullValues {
 /// use std::fs::File;
 ///
 /// fn example() -> PolarsResult<DataFrame> {
-///     CsvReader::from_path("iris_csv")?
+///     CsvReader::from_path("iris.csv")?
 ///             .has_header(true)
 ///             .finish()
 /// }


### PR DESCRIPTION
It was probably meant to be `iris.csv` and not `iris_csv`