### PR TITLE
docs(python): Fix docstring of series.interpolate

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4303,7 +4303,7 @@ class Series:
 
         Parameters
         ----------
-        method : {'linear', 'linear'}
+        method : {'linear', 'nearest'}
             Interpolation method
 
         Examples


### PR DESCRIPTION
This PR replaces a wrong set of method values `{'linear', 'linear'}` with a correct one `{'linear', 'nearest'}` based on https://github.com/pola-rs/polars/blob/master/py-polars/polars/internals/type_aliases.py#L68