### PR TITLE
feat(python): support clean/efficient iteration over `RecordBatches`

### DIFF
--- a/py-polars/tests/docs/run_doc_examples.py
+++ b/py-polars/tests/docs/run_doc_examples.py
@@ -33,6 +33,7 @@ import doctest
 import importlib
 import sys
 import unittest
+from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import ModuleType
@@ -96,7 +97,14 @@ if __name__ == "__main__":
         tests = [
             doctest.DocTestSuite(
                 m,
-                extraglobs={"pl": polars, "dirpath": Path(tmpdir)},
+                extraglobs={
+                    "pl": polars,
+                    "dirpath": Path(tmpdir),
+                    "datetime": datetime,
+                    "date": date,
+                    "time": time,
+                    "timedelta": timedelta,
+                },
                 optionflags=1,
                 tearDown=doctest_teardown,
             )

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2748,3 +2748,18 @@ def test_unique(
     result = df.unique(maintain_order=True, subset=subset, keep=keep)
     expected = df.filter(expected_mask)
     assert_frame_equal(result, expected)
+
+
+def test_iterbatches() -> None:
+    df = pl.DataFrame(
+        {
+            "a": range(95),
+            "b": date(2023, 1, 1),
+            "c": "klmnopqrstuvwxyz",
+        }
+    )
+    batches = list(df.iterbatches(batch_size=50))
+
+    assert len(batches[0]) == 50
+    assert len(batches[1]) == 45
+    assert [tuple(x.values()) for x in batches[1].to_pylist()] == df.slice(50).rows()


### PR DESCRIPTION
ref #6279.

This doesn't close the referenced issue, if I'm reading it correctly, but it does expose another generically useful piece of related functionality. 

Adds an `iterbatches()` method to `DataFrame` that offers zero-copy generator-based iteration over `RecordBatches`. There are definitely a few APIs out there that should become even easier to integrate with as a result.

**Example**:
```python
import polars as pl
df = pl.DataFrame(
    {
        "a": range(145_000),
        "b": date(2023,1,1),
        "c": "opqrstuvwxyz",
    }
)
for b in df.iterbatches():
    print(type(b), len(b))

# <class 'pyarrow.lib.RecordBatch'> 50000
# <class 'pyarrow.lib.RecordBatch'> 45000
```