### PR TITLE
fix(rust): correct error message in cast_time_zone

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -69,7 +69,7 @@ impl DatetimeChunked {
 
         if let Some(from) = self.time_zone() {
             let old: Tz = from.parse().map_err(|_| {
-                PolarsError::ComputeError(format!("Could not parse timezone: '{tz}'").into())
+                PolarsError::ComputeError(format!("Could not parse timezone: '{from}'").into())
             })?;
             let new: Tz = tz.parse().map_err(|_| {
                 PolarsError::ComputeError(format!("Could not parse timezone: '{tz}'").into())

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -10,6 +10,8 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
+from polars.exceptions import ComputeError
+
 if sys.version_info >= (3, 9):
     import zoneinfo
 else:
@@ -2027,6 +2029,15 @@ def test_cast_timezone() -> None:
         "a": [datetime(2022, 9, 25, 14, 0)],
         "b": [datetime(2022, 9, 25, 14, 0, tzinfo=ny)],
     }
+
+
+def test_cast_timezone_from_fixed_offset() -> None:
+    ts = pl.Series(["2020-01-01 00:00:00+01:00"]).str.strptime(
+        pl.Datetime, "%Y-%m-%d %H:%M:%S%z"
+    )
+    # TODO: don't raise at all? https://github.com/pola-rs/polars/issues/6410
+    with pytest.raises(ComputeError, match=r"Could not parse timezone: '\+01:00'"):
+        ts.dt.cast_time_zone("Europe/Brussels")
 
 
 def test_with_time_zone_none() -> None:


### PR DESCRIPTION
xref #6410 

Ideally this  wouldn't raise at all, but in the meantime, the error message can at least refer to the object which is responsible for the error 😄 