### PR TITLE
feat(python): expose efficient iterator over `DataFrame` slices

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6805,8 +6805,8 @@ class DataFrame:
             for i in range(self.height):
                 yield self.row(i)
 
-    def iterslices(self, n_rows: int = 10_000) -> Iterator[DataFrame]:
-        """
+    def iter_slices(self, n_rows: int = 10_000) -> Iterator[DataFrame]:
+        r"""
         Returns a non-copying iterator of slices over the underlying DataFrame.
 
         Parameters
@@ -6825,27 +6825,29 @@ class DataFrame:
         ...     },
         ...     schema_overrides={"a": pl.Int32},
         ... )
-        >>> for idx, frame in enumerate(df.iterslices()):
+        >>> for idx, frame in enumerate(df.iter_slices()):
         ...     print(f"{type(frame).__name__}:[{idx}]:{len(frame)}")
         ...
         DataFrame:[0]:10000
         DataFrame:[1]:7500
 
-        Working with ``iterslices`` is an efficient way to chunk-iterate over DataFrames
-        and any supported frame export/conversion types; for example, as RecordBatches:
+        Using ``iter_slices`` is an efficient way to chunk-iterate over DataFrames and
+        any supported frame export/conversion types; for example, as RecordBatches:
 
-        >>> for frame in df.iterslices(n_rows=15_000):
+        >>> for frame in df.iter_slices(n_rows=15_000):
         ...     record_batch = frame.to_arrow().to_batches()[0]
-        ...     print(record_batch, len(record_batch))
+        ...     print(record_batch, "\n<< ", len(record_batch))
         ...
         pyarrow.RecordBatch
         a: int32
         b: date32[day]
-        c: large_string 15000
+        c: large_string
+        << 15000
         pyarrow.RecordBatch
         a: int32
         b: date32[day]
-        c: large_string 2500
+        c: large_string
+        << 2500
 
         See Also
         --------

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6805,6 +6805,57 @@ class DataFrame:
             for i in range(self.height):
                 yield self.row(i)
 
+    def iterslices(self, n_rows: int = 10_000) -> Iterator[DataFrame]:
+        """
+        Returns a non-copying iterator of slices over the underlying DataFrame.
+
+        Parameters
+        ----------
+        n_rows
+            Determines the number of rows contained in each DataFrame slice.
+
+        Examples
+        --------
+        >>> from datetime import date
+        >>> df = pl.DataFrame(
+        ...     data={
+        ...         "a": range(17_500),
+        ...         "b": date(2023, 1, 1),
+        ...         "c": "klmnoopqrstuvwxyz",
+        ...     },
+        ...     schema_overrides={"a": pl.Int32},
+        ... )
+        >>> for idx, frame in enumerate(df.iterslices()):
+        ...     print(f"{type(frame).__name__}:[{idx}]:{len(frame)}")
+        ...
+        DataFrame:[0]:10000
+        DataFrame:[1]:7500
+
+        Working with ``iterslices`` is an efficient way to chunk-iterate over DataFrames
+        and any supported frame export/conversion types; for example, as RecordBatches:
+
+        >>> for frame in df.iterslices(n_rows=15_000):
+        ...     record_batch = frame.to_arrow().to_batches()[0]
+        ...     print(record_batch, len(record_batch))
+        ...
+        pyarrow.RecordBatch
+        a: int32
+        b: date32[day]
+        c: large_string 15000
+        pyarrow.RecordBatch
+        a: int32
+        b: date32[day]
+        c: large_string 2500
+
+        See Also
+        --------
+        iterrows : Row iterator over frame data (does not materialise all rows).
+        partition_by : Split into multiple DataFrames, partitioned by groups.
+
+        """
+        for offset in range(0, self.height, n_rows):
+            yield self.slice(offset, n_rows)
+
     def shrink_to_fit(self: DF, in_place: bool = False) -> DF:
         """
         Shrink DataFrame memory usage.

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2748,3 +2748,18 @@ def test_unique(
     result = df.unique(maintain_order=True, subset=subset, keep=keep)
     expected = df.filter(expected_mask)
     assert_frame_equal(result, expected)
+
+
+def test_iterslices() -> None:
+    df = pl.DataFrame(
+        {
+            "a": range(95),
+            "b": date(2023, 1, 1),
+            "c": "klmnopqrstuvwxyz",
+        }
+    )
+    batches = list(df.iterslices(n_rows=50))
+
+    assert len(batches[0]) == 50
+    assert len(batches[1]) == 45
+    assert batches[1].rows() == df[50:].rows()

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2750,7 +2750,7 @@ def test_unique(
     assert_frame_equal(result, expected)
 
 
-def test_iterslices() -> None:
+def test_iter_slices() -> None:
     df = pl.DataFrame(
         {
             "a": range(95),
@@ -2758,7 +2758,7 @@ def test_iterslices() -> None:
             "c": "klmnopqrstuvwxyz",
         }
     )
-    batches = list(df.iterslices(n_rows=50))
+    batches = list(df.iter_slices(n_rows=50))
 
     assert len(batches[0]) == 50
     assert len(batches[1]) == 45


### PR DESCRIPTION
(Take two 🎬)

The previous effort was clearly (oops :) at the wrong level, but I couldn't get this pattern out of my head; while the functionality and implementation is obviously straightforward, it has value as a first-class method.

Yielding zero-copy slices as frames that can be further operated on by the caller allows for simple/efficient iteration over batches of _anything_ that `DataFrame` supports.

**Example**:

Redoing the previous example, RecordBatch iteration would now represent a trivial usage of `iterslices()` -

```python
from datetime import date
import polars as pl

df = pl.DataFrame(
    {
        "x": range(17_500),
        "y": date(2023,1,1),
        "z": "abcdefghijklm",
    }
)

for frame in df.iterslices(n_rows=15_000):
    record_batch = frame.to_arrow().to_batches()[0]
```