### PR TITLE
feat(python): 10% speedup for `to_dicts` method

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1830,13 +1830,8 @@ class DataFrame:
         [{'foo': 1, 'bar': 4}, {'foo': 2, 'bar': 5}, {'foo': 3, 'bar': 6}]
 
         """
-        pydf = self._df
-        names = self.columns
-
-        return [
-            {k: v for k, v in zip(names, pydf.row_tuple(i))}
-            for i in range(0, self.height)
-        ]
+        dict_, zip_, columns = dict, zip, self.columns
+        return [dict_(zip_(columns, row)) for row in self.iterrows()]
 
     def to_numpy(self) -> np.ndarray[Any, Any]:
         """


### PR DESCRIPTION
Note that we will be able to redirect to `iterrows(named=True)` once `0.16.0` is released, as that will build dictionaries using the same minor optimisation found here. 

Until then, here's a simple ~10% speedup on the current approach (as tested on a `-release` build).