### PR TITLE
feat(python): add datetime/duration dtype selector groups covering the different timeunits

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -442,6 +442,21 @@ TEMPORAL_DTYPES: frozenset[PolarsDataType] = frozenset(
         Duration("ns"),
     ]
 )
+DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
+    [
+        # TODO: ideally need a mechanism to wildcard timezones here too
+        Datetime("ms"),
+        Datetime("us"),
+        Datetime("ns"),
+    ]
+)
+DURATION_DTYPES: frozenset[PolarsDataType] = frozenset(
+    [
+        Duration("ms"),
+        Duration("us"),
+        Duration("ns"),
+    ]
+)
 INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
         UInt8,

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -9,6 +9,8 @@ import pytest
 
 import polars as pl
 from polars.datatypes import (
+    DATETIME_DTYPES,
+    DURATION_DTYPES,
     FLOAT_DTYPES,
     INTEGER_DTYPES,
     NUMERIC_DTYPES,
@@ -333,6 +335,18 @@ def test_dtype_col_selection() -> None:
         "a4",
         "b",
         "c",
+        "d1",
+        "d2",
+        "d3",
+        "d4",
+    }
+    assert set(df.select(pl.col(DATETIME_DTYPES)).columns) == {
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+    }
+    assert set(df.select(pl.col(DURATION_DTYPES)).columns) == {
         "d1",
         "d2",
         "d3",


### PR DESCRIPTION
ref: #6422

Extends the available selector groups added in https://github.com/pola-rs/polars/pull/6295, with `DATETIME_DTYPES` and `DURATION_DTYPES`; these each cover the `ms`, `us`, and `ns` time units so you can more ergonomically select _any_ datetime/duration col without having to specify them explicitly (note: ideally we still need a wildcard for timezones - "to be continued...")