### PR TITLE
fix(python): ensure `from_dicts` and `DataFrame` init from list of dicts behave consistently, update/improve related docstrings

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -99,7 +99,9 @@ def from_dicts(
         to rename after loading the frame.
 
         If you want to drop some of the fields found in the input dictionaries, a
-        _partial_ schema can be declared; omitted fields will not be loaded.
+        _partial_ schema can be declared, in which case omitted fields will not be
+        loaded. Similarly you can extend the loaded frame with empty columns by adding
+        them to the schema.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
 
@@ -123,27 +125,50 @@ def from_dicts(
     │ 3   ┆ 6   │
     └─────┴─────┘
 
-    >>> # let polars infer the first two column dtypes, and
-    >>> # explicitly inform the constructor about a third column
-    >>> pl.from_dicts(data, schema=["a", "b"], schema_overrides={"c": pl.Int32})
-    shape: (3, 3)
-    ┌─────┬─────┬──────┐
-    │ a   ┆ b   ┆ c    │
-    │ --- ┆ --- ┆ ---  │
-    │ i64 ┆ i64 ┆ i32  │
-    ╞═════╪═════╪══════╡
-    │ 1   ┆ 4   ┆ null │
-    │ 2   ┆ 5   ┆ null │
-    │ 3   ┆ 6   ┆ null │
-    └─────┴─────┴──────┘
+    Declaring a partial ``schema`` will drop the omitted columns.
+
+    >>> df = pl.from_dicts(data, schema={"a": pl.Int32})
+    >>> df
+    shape: (3, 1)
+    ┌─────┐
+    │ a   │
+    │ --- │
+    │ i32 │
+    ╞═════╡
+    │ 1   │
+    │ 2   │
+    │ 3   │
+    └─────┘
+
+    Can also use the ``schema`` param to extend the loaded columns with one
+    or more additional (empty) columns that are not present in the input dicts:
+
+    >>> pl.from_dicts(
+    ...     data,
+    ...     schema=["a", "b", "c", "d"],
+    ...     schema_overrides={"c": pl.Float64, "d": pl.Utf8},
+    ... )
+    shape: (3, 4)
+    ┌─────┬─────┬──────┬──────┐
+    │ a   ┆ b   ┆ c    ┆ d    │
+    │ --- ┆ --- ┆ ---  ┆ ---  │
+    │ i64 ┆ i64 ┆ f64  ┆ str  │
+    ╞═════╪═════╪══════╪══════╡
+    │ 1   ┆ 4   ┆ null ┆ null │
+    │ 2   ┆ 5   ┆ null ┆ null │
+    │ 3   ┆ 6   ┆ null ┆ null │
+    └─────┴─────┴──────┴──────┘
 
     """
-    columns, schema = _unpack_schema(
+    column_names, schema = _unpack_schema(
         schema, schema_overrides=schema_overrides, include_overrides_in_columns=True
     )
-    schema_overrides = include_unknowns(schema, columns or list(schema))
+    schema = include_unknowns(schema, column_names or list(schema))
     return DataFrame._from_dicts(
-        dicts, infer_schema_length, schema_overrides=schema_overrides
+        dicts,
+        infer_schema_length,
+        schema=(column_names and schema),
+        schema_overrides=schema_overrides,
     )
 
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -93,9 +93,13 @@ def from_dicts(
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
-        If you supply a list of column names that does not match the names in the
-        underlying data, the names given here will overwrite them. The number
-        of names given in the schema should match the underlying data dimensions.
+        If a list of column names is supplied that does NOT match the names in the
+        underlying data, the names given here will overwrite the actual fields in
+        the order that they appear - however, in this case it is typically clearer
+        to rename after loading the frame.
+
+        If you want to drop some of the fields found in the input dictionaries, a
+        _partial_ schema can be declared; omitted fields will not be loaded.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -560,7 +560,7 @@ def _post_apply_columns(
             column_casts.append(pli.col(col).cast(Categorical)._pyexpr)
         elif structs and col in structs and structs[col] != pydf_dtypes[i]:
             column_casts.append(pli.col(col).cast(structs[col])._pyexpr)
-        elif col in dtypes and dtypes[col] != pydf_dtypes[i]:
+        elif dtypes.get(col) not in (None, Unknown) and dtypes[col] != pydf_dtypes[i]:
             column_casts.append(pli.col(col).cast(dtypes[col])._pyexpr)
 
     if column_casts or column_subset:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -62,6 +62,7 @@ from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoRowsReturned, TooManyRowsReturned
 from polars.internals.construction import (
+    _post_apply_columns,
     arrow_to_pydf,
     dict_to_pydf,
     iterable_to_pydf,
@@ -376,9 +377,14 @@ class DataFrame:
         cls: type[DF],
         data: Sequence[dict[str, Any]],
         infer_schema_length: int | None = N_INFER_DEFAULT,
+        schema: SchemaDefinition | None = None,
         schema_overrides: SchemaDict | None = None,
     ) -> DF:
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length, schema_overrides)
+        pydf = PyDataFrame.read_dicts(data, infer_schema_length, schema)
+        if schema or schema_overrides:
+            pydf = _post_apply_columns(
+                pydf, list(schema or pydf.columns()), schema_overrides=schema_overrides
+            )
         return cls._from_pydf(pydf)
 
     @classmethod

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -161,8 +161,11 @@ class DataFrame:
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
         If you supply a list of column names that does not match the names in the
-        underlying data, the names given here will overwrite them. The number
-        of names given in the schema should match the underlying data dimensions.
+        underlying data, the names given here will overwrite them.
+
+        The number of entries in the schema should match the underlying data
+        dimensions, unless a sequence of dictionaries is being passed, in which case
+        a _partial_ schema can be declared to prevent specific fields from being loaded.
     orient : {'col', 'row'}, default None
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -544,16 +544,15 @@ def test_from_dicts_schema() -> None:
     data = [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
 
     # let polars infer the dtypes, but inform it about a 3rd column.
-    # can supply as schema, or as mixed schema/overrides.
     for schema, overrides in (
-        (None, {"a": None, "b": pl.Unknown, "c": pl.Int32}),
-        ({"a": None, "b": pl.Unknown, "c": pl.Int32}, None),
-        ({"a": None, "b": pl.Unknown}, {"c": pl.Int32}),
+        ({"a": pl.Unknown, "b": pl.Unknown, "c": pl.Int32}, None),
+        ({"a": None, "b": None, "c": None}, {"c": pl.Int32}),
+        (["a", "b", ("c", pl.Int32)], None),
     ):
         df = pl.from_dicts(
             data,
             schema=schema,  # type: ignore[arg-type]
-            schema_overrides=overrides,  # type: ignore[arg-type]
+            schema_overrides=overrides,
         )
         assert df.dtypes == [pl.Int64, pl.Int64, pl.Int32]
         assert df.to_dict(False) == {

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1324,20 +1324,22 @@ def test_from_rows_of_dicts() -> None:
         {"id": 1, "value": 100, "_meta": "a"},
         {"id": 2, "value": 101, "_meta": "b"},
     ]
-    df1 = pl.DataFrame(records)
-    assert df1.rows() == [(1, 100, "a"), (2, 101, "b")]
+    df_init: Callable[..., Any]
+    for df_init in (pl.from_dicts, pl.DataFrame):  # type:ignore[assignment]
+        df1 = df_init(records)
+        assert df1.rows() == [(1, 100, "a"), (2, 101, "b")]
 
-    overrides = {
-        "id": pl.Int16,
-        "value": pl.Int32,
-    }
-    df2 = pl.DataFrame(records, schema_overrides=overrides)
-    assert df2.rows() == [(1, 100, "a"), (2, 101, "b")]
-    assert df2.schema == {"id": pl.Int16, "value": pl.Int32, "_meta": pl.Utf8}
+        overrides = {
+            "id": pl.Int16,
+            "value": pl.Int32,
+        }
+        df2 = df_init(records, schema_overrides=overrides)
+        assert df2.rows() == [(1, 100, "a"), (2, 101, "b")]
+        assert df2.schema == {"id": pl.Int16, "value": pl.Int32, "_meta": pl.Utf8}
 
-    df3 = pl.DataFrame(records, schema=overrides)
-    assert df3.rows() == [(1, 100), (2, 101)]
-    assert df3.schema == {"id": pl.Int16, "value": pl.Int32}
+        df3 = df_init(records, schema=overrides)
+        assert df3.rows() == [(1, 100), (2, 101)]
+        assert df3.schema == {"id": pl.Int16, "value": pl.Int32}
 
 
 def test_repeat_by() -> None:


### PR DESCRIPTION
* Fixed `pl.from_dicts` being slightly inconsistent with `DataFrame` init from list of dicts (wasn't properly applying `schema_overrides`), and added some extra unit tests to validate the two codepaths.
* Added docstring examples to `pl.from_dicts` showing omission/addition of columns using `schema` param. 
* Similarly updated `DataFrame` init docstring.

----

TODO: in a separate PR - allow schema omission/extension for other named init/constructor methods, for consistency.
^^ @stinodego 