### PR TITLE
docs(python): add explicit note about use of `Config` as a context manager

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -3,15 +3,15 @@ Config
 ============
 .. currentmodule:: polars
 
-Config options (set/unset)
---------------------------
+Config options
+--------------
 
 .. autosummary::
    :toctree: api/
 
     Config.set_ascii_tables
-    Config.set_fmt_str_lengths
     Config.set_fmt_float
+    Config.set_fmt_str_lengths
     Config.set_tbl_cell_alignment
     Config.set_tbl_cols
     Config.set_tbl_column_data_type_inline
@@ -34,3 +34,18 @@ Config load, save, and current state
     Config.save
     Config.state
     Config.restore_defaults
+
+Use as a context manager
+------------------------
+
+Note that ``Config`` supports setting context-scoped options. These options
+are valid *only* during scope lifetime, and are reset to their initial values
+(whatever they were before entering the new context) on scope exit.
+
+.. code-block:: python
+
+    with pl.Config() as cfg:
+        cfg.set_verbose(True)
+        do_various_things()
+
+    # on scope exit any modified settings are restored to their previous state


### PR DESCRIPTION
It's in the `Config` class docstring, but there was no mention of it in the online docs.