### PR TITLE
fix(python): ensure column-exclusion works with the new `dtype` groups, and improve some related typing

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -501,11 +501,11 @@ class Expr:
         self,
         columns: (
             str
+            | PolarsDataType
             | Sequence[str]
-            | DataType
-            | type[DataType]
-            | DataType
-            | Sequence[DataType | type[DataType]]
+            | Sequence[PolarsDataType]
+            | set[PolarsDataType]
+            | frozenset[PolarsDataType]
         ),
     ) -> Expr:
         """
@@ -591,6 +591,8 @@ class Expr:
         if isinstance(columns, str):
             columns = [columns]
             return wrap_expr(self._pyexpr.exclude(columns))
+        elif isinstance(columns, (set, frozenset)):
+            return wrap_expr(self._pyexpr.exclude_dtype(list(columns)))
         elif not isinstance(columns, Sequence) or isinstance(columns, DataType):
             columns = [columns]
             return wrap_expr(self._pyexpr.exclude_dtype(columns))

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, BinaryIO, ContextManager, Iterator, TextIO, overload
 
 import polars.internals as pli
-from polars.datatypes import DataType
+from polars.datatypes import PolarsDataType
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.utils import normalise_filepath
 
@@ -141,7 +141,7 @@ def _prepare_file_arg(
     return managed_file(file)
 
 
-def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, type[DataType]]:
+def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
     """
     Get a schema of the IPC file without reading data.
 
@@ -163,7 +163,7 @@ def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, type[DataT
 
 def read_parquet_schema(
     file: str | BinaryIO | Path | bytes,
-) -> dict[str, type[DataType]]:
+) -> dict[str, PolarsDataType]:
     """
     Get a schema of the Parquet file without reading data.
 

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1082,7 +1082,7 @@ def tail(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
 
 
 def lit(
-    value: Any, dtype: type[DataType] | None = None, allow_object: bool = False
+    value: Any, dtype: PolarsDataType | None = None, allow_object: bool = False
 ) -> pli.Expr:
     """
     Return an expression representing a literal value.
@@ -1383,7 +1383,7 @@ def cov(
 def map(
     exprs: Sequence[str] | Sequence[pli.Expr],
     f: Callable[[Sequence[pli.Series]], pli.Series],
-    return_dtype: type[DataType] | None = None,
+    return_dtype: PolarsDataType | None = None,
 ) -> pli.Expr:
     """
     Map a custom function over multiple columns/expressions.
@@ -1413,7 +1413,7 @@ def map(
 def apply(
     exprs: Sequence[str | pli.Expr],
     f: Callable[[Sequence[pli.Series]], pli.Series | Any],
-    return_dtype: type[DataType] | None = None,
+    return_dtype: PolarsDataType | None = None,
     returns_scalar: bool = True,
 ) -> pli.Expr:
     """
@@ -1591,11 +1591,11 @@ def any(name: str | Sequence[str] | Sequence[pli.Expr] | pli.Expr) -> pli.Expr:
 def exclude(
     columns: (
         str
+        | PolarsDataType
         | Sequence[str]
-        | DataType
-        | type[DataType]
-        | DataType
-        | Sequence[DataType | type[DataType]]
+        | Sequence[PolarsDataType]
+        | set[PolarsDataType]
+        | frozenset[PolarsDataType]
     ),
 ) -> pli.Expr:
     """

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -24,7 +24,6 @@ from polars.datatypes import (
     N_INFER_DEFAULT,
     Boolean,
     Categorical,
-    DataType,
     Date,
     Datetime,
     Duration,
@@ -352,7 +351,7 @@ class LazyFrame:
     @classmethod
     def _scan_python_function(
         cls,
-        schema: pa.schema | dict[str, type[DataType]],
+        schema: pa.schema | dict[str, PolarsDataType],
         scan_fn: bytes,
         pyarrow: bool = False,
     ) -> LazyFrame:
@@ -393,7 +392,7 @@ class LazyFrame:
         return self._ldf.columns()
 
     @property
-    def dtypes(self) -> list[type[DataType]]:
+    def dtypes(self) -> list[PolarsDataType]:
         """
         Get dtypes of columns in LazyFrame.
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -19,7 +19,6 @@ from polars import internals as pli
 from polars.datatypes import (
     Boolean,
     Categorical,
-    DataType,
     Date,
     Datetime,
     Duration,
@@ -294,7 +293,7 @@ class Series:
 
     @classmethod
     def _repeat(
-        cls, name: str, val: int | float | str | bool, n: int, dtype: type[DataType]
+        cls, name: str, val: int | float | str | bool, n: int, dtype: PolarsDataType
     ) -> Series:
         return cls._from_pyseries(PySeries.repeat(name, val, n, dtype))
 
@@ -323,7 +322,7 @@ class Series:
         return self._s.get_ptr()
 
     @property
-    def dtype(self) -> type[DataType]:
+    def dtype(self) -> PolarsDataType:
         """
         Get the data type of this Series.
 
@@ -355,7 +354,7 @@ class Series:
         return out
 
     @property
-    def inner_dtype(self) -> type[DataType] | None:
+    def inner_dtype(self) -> PolarsDataType | None:
         """
         Get the inner dtype in of a List typed Series.
 

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -25,7 +25,7 @@ else:
 
 import polars.internals as pli
 from polars.convert import from_arrow
-from polars.datatypes import N_INFER_DEFAULT, DataType, SchemaDict, Utf8
+from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, SchemaDict, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
@@ -69,7 +69,7 @@ def read_csv(
     comment_char: str | None = None,
     quote_char: str | None = r'"',
     skip_rows: int = 0,
-    dtypes: Mapping[str, type[DataType]] | list[type[DataType]] | None = None,
+    dtypes: Mapping[str, PolarsDataType] | list[PolarsDataType] | None = None,
     null_values: str | list[str] | dict[str, str] | None = None,
     missing_utf8_is_empty_string: bool = False,
     ignore_errors: bool = False,
@@ -295,7 +295,7 @@ def read_csv(
 
         # Fix list of dtypes when used together with projection as polars CSV reader
         # wants a list of dtypes for the x first columns before it does the projection.
-        dtypes_list: list[type[DataType]] = [Utf8] * (max(projection) + 1)
+        dtypes_list: list[PolarsDataType] = [Utf8] * (max(projection) + 1)
 
         for idx, column_idx in enumerate(projection):
             if idx < len(dtypes):
@@ -1696,7 +1696,7 @@ def read_csv_batched(
     comment_char: str | None = None,
     quote_char: str | None = r'"',
     skip_rows: int = 0,
-    dtypes: Mapping[str, type[DataType]] | list[type[DataType]] | None = None,
+    dtypes: Mapping[str, PolarsDataType] | list[PolarsDataType] | None = None,
     null_values: str | list[str] | dict[str, str] | None = None,
     missing_utf8_is_empty_string: bool = False,
     ignore_errors: bool = False,
@@ -1871,7 +1871,7 @@ def read_csv_batched(
 
         # Fix list of dtypes when used together with projection as polars CSV reader
         # wants a list of dtypes for the x first columns before it does the projection.
-        dtypes_list: list[type[DataType]] = [Utf8] * (max(projection) + 1)
+        dtypes_list: list[PolarsDataType] = [Utf8] * (max(projection) + 1)
 
         for idx, column_idx in enumerate(projection):
             if idx < len(dtypes):

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -22,7 +22,6 @@ from typing import (
 
 import polars.internals as pli
 from polars.datatypes import (
-    DataType,
     Date,
     Datetime,
     Int64,
@@ -261,7 +260,7 @@ EPOCH = datetime(1970, 1, 1).replace(tzinfo=None)
 
 def _to_python_datetime(
     value: int | float,
-    dtype: type[DataType],
+    dtype: PolarsDataType,
     tu: TimeUnit | None = "ns",
     tz: str | None = None,
 ) -> date | datetime:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -18,7 +18,7 @@ else:
     from backports import zoneinfo
 
 import polars as pl
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, PolarsTemporalType
+from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, PolarsTemporalType
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing._private import verify_series_and_expr_api
 
@@ -513,7 +513,7 @@ def test_date_range() -> None:
         datetime(2022, 1, 1), datetime(2022, 1, 1, 0, 1), "987456321ns"
     )
     assert len(result) == 61
-    assert result.dtype.tu == "ns"  # type: ignore[attr-defined]
+    assert result.dtype.tu == "ns"  # type: ignore[union-attr]
     assert result.dt.second()[-1] == 59
     assert result.cast(pl.Utf8)[-1] == "2022-01-01 00:00:59.247379260"
 
@@ -1609,6 +1609,8 @@ def test_datetime_instance_selection() -> None:
         res = df.select(pl.col([pl.Datetime(tu)])).dtypes
         assert res == [pl.Datetime(tu)]
         assert len(df.filter(pl.col(tu) == test_data[tu][0])) == 1
+
+    assert [] == list(df.select(pl.exclude(DATETIME_DTYPES)))
 
 
 def test_unique_counts_on_dates() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -14,7 +14,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
 from polars.dependencies import zoneinfo
 from polars.internals.construction import iterable_to_pydf
 from polars.testing import (
@@ -1611,6 +1611,8 @@ def test_select_by_dtype(df: pl.DataFrame) -> None:
     assert out.columns == ["strings", "strings_nulls"]
     out = df.select(pl.col([pl.Utf8, pl.Boolean]))
     assert out.columns == ["strings", "strings_nulls", "bools", "bools_nulls"]
+    out = df.select(pl.col(INTEGER_DTYPES))
+    assert out.columns == ["int", "int_nulls"]
 
 
 def test_with_row_count() -> None:
@@ -2397,9 +2399,11 @@ def test_selection_regex_and_multicol() -> None:
     assert test_df.select(pl.col(["a", "b", "c"]) * pl.col(["a", "b", "c"])).to_dict(
         False
     ) == {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
-    assert test_df.select(pl.all().exclude("foo") * pl.all().exclude("foo")).to_dict(
-        False
-    ) == {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
+    assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(False) == {
+        "a": [1, 4, 9, 16],
+        "b": [25, 36, 49, 64],
+        "c": [81, 100, 121, 144],
+    }
     assert test_df.select(pl.col("^\\w$") * pl.col("^\\w$")).to_dict(False) == {
         "a": [1, 4, 9, 16],
         "b": [25, 36, 49, 64],

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -13,7 +13,7 @@ from _pytest.capture import CaptureFixture
 
 import polars as pl
 from polars import col, lit, when
-from polars.datatypes import PolarsDataType
+from polars.datatypes import NUMERIC_DTYPES, PolarsDataType
 from polars.testing import assert_frame_equal
 from polars.testing.asserts import assert_series_equal
 
@@ -592,6 +592,7 @@ def test_exclude_selection() -> None:
     assert df.select([pl.exclude("a")]).columns == ["b", "c"]
     assert df.select(pl.all().exclude(pl.Boolean)).columns == ["a", "b"]
     assert df.select(pl.all().exclude([pl.Boolean])).columns == ["a", "b"]
+    assert df.select(pl.all().exclude(NUMERIC_DTYPES)).columns == ["c"]
 
 
 def test_col_series_selection() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -75,7 +75,7 @@ def test_dtype() -> None:
     a = pl.Series("a", [[1, 2, 3], [2, 5], [6, 7, 8, 9]])
     assert a.dtype == pl.List
     assert a.inner_dtype == pl.Int64
-    assert a.dtype.inner == pl.Int64  # type: ignore[attr-defined]
+    assert a.dtype.inner == pl.Int64  # type: ignore[union-attr]
 
     # explicit
     df = pl.DataFrame(
@@ -266,7 +266,7 @@ def test_cast_inner() -> None:
     # this creates an inner null type
     df = pl.from_pandas(pd.DataFrame(data=[[[]], [[]]], columns=["A"]))
     assert (
-        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore[attr-defined]
+        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore[union-attr]
     )
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -116,10 +116,10 @@ def test_init_inputs(monkeypatch: Any) -> None:
         s = pl.Series("dates", d64, dtype)
         assert s.to_list() == expected
         assert Datetime == s.dtype
-        assert s.dtype.tu == "ns"  # type: ignore[attr-defined]
+        assert s.dtype.tu == "ns"  # type: ignore[union-attr]
 
     s = pl.Series(values=d64.astype("<M8[ms]"))
-    assert s.dtype.tu == "ms"  # type: ignore[attr-defined]
+    assert s.dtype.tu == "ms"  # type: ignore[union-attr]
     assert expected == s.to_list()
 
     # pandas
@@ -163,7 +163,7 @@ def test_init_dataclass_namedtuple() -> None:
         s = pl.Series("t", [t0, t1])
 
         assert isinstance(s, pl.Series)
-        assert s.dtype.fields == [  # type: ignore[attr-defined]
+        assert s.dtype.fields == [  # type: ignore[union-attr]
             Field("exporter", pl.Utf8),
             Field("importer", pl.Utf8),
             Field("product", pl.Utf8),


### PR DESCRIPTION
Seems that `exclude` wasn't recognising the `*_DTYPE` groups available from `polars.datatypes`; was simple to fix, and made some minor typing improvements while I was at it.