### PR TITLE
python polars 0.15.17

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.15.16"
+version = "0.15.17"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The last planned `0.15.x` release. @stinodego @alexander-beedie FYI. I will start merging the breaking PR's shortly.