### PR TITLE
feat(python): More precise pipe type annotation

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -100,9 +100,9 @@ else:
     from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
-    from typing import TypeAlias
+    from typing import Concatenate, ParamSpec, TypeAlias
 else:
-    from typing_extensions import TypeAlias
+    from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -135,6 +135,9 @@ if TYPE_CHECKING:
     MultiColSelector: TypeAlias = (
         "slice | range | list[int] | list[str] | list[bool] | pli.Series"
     )
+
+    T = TypeVar("T")
+    P = ParamSpec("P")
 
 # A type variable used to refer to a polars.DataFrame or any subclass of it.
 # Used to annotate DataFrame methods which returns the same type as self.
@@ -3328,7 +3331,12 @@ class DataFrame:
             subset = [subset]
         return self._from_pydf(self._df.drop_nulls(subset))
 
-    def pipe(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def pipe(
+        self,
+        func: Callable[Concatenate[DataFrame, P], T],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> T:
         """
         Offers a structured way to apply a sequence of user-defined functions (UDFs).
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import typing
 import warnings
 from datetime import date, datetime, time, timedelta
@@ -64,6 +65,11 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
+
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -77,6 +83,9 @@ if TYPE_CHECKING:
         StartBy,
         UniqueKeepStrategy,
     )
+
+    T = TypeVar("T")
+    P = ParamSpec("P")
 
 
 # Used to type any type or subclass of LazyFrame.
@@ -581,7 +590,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             self._ldf.write_json(file)
         return None
 
-    def pipe(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def pipe(
+        self,
+        func: Callable[Concatenate[LazyFrame, P], T],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> T:
         """
         Offers a structured way to apply a sequence of user-defined functions (UDFs).
 


### PR DESCRIPTION
Use `ParamSpec` from [PEP 612](https://peps.python.org/pep-0612/) to improve `DataFrame.pipe`'s annotation. Mostly happy that the return type matches the UDF so chained functions don't accidentally become `Any` at the end.