### PR TITLE
fix(rust, python): use consistent floor division for floats/ints

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -82,7 +82,7 @@ sort_multiple = ["polars-core/sort_multiple"]
 # extra operations
 is_in = ["polars-core/is_in", "polars-lazy/is_in"]
 zip_with = ["polars-core/zip_with"]
-round_series = ["polars-core/round_series", "polars-lazy/round_series"]
+round_series = ["polars-core/round_series", "polars-lazy/round_series", "polars-ops/round_series"]
 checked_arithmetic = ["polars-core/checked_arithmetic"]
 repeat_by = ["polars-core/repeat_by", "polars-lazy/repeat_by"]
 is_first = ["polars-core/is_first", "polars-lazy/is_first"]

--- a/polars/polars-core/src/series/arithmetic/borrowed.rs
+++ b/polars/polars-core/src/series/arithmetic/borrowed.rs
@@ -379,7 +379,7 @@ fn coerce_time_units<'a>(
 }
 
 #[cfg(feature = "dtype-struct")]
-fn struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
+pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
     s: &Series,
     rhs: &Series,
     mut func: F,
@@ -416,7 +416,7 @@ impl ops::Sub for &Series {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                struct_arithmetic(self, rhs, |a, b| a.sub(b))
+                _struct_arithmetic(self, rhs, |a, b| a.sub(b))
             }
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
@@ -431,7 +431,7 @@ impl Series {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                Ok(struct_arithmetic(self, rhs, |a, b| a.add(b)))
+                Ok(_struct_arithmetic(self, rhs, |a, b| a.add(b)))
             }
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
@@ -460,7 +460,7 @@ impl ops::Mul for &Series {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                struct_arithmetic(self, rhs, |a, b| a.mul(b))
+                _struct_arithmetic(self, rhs, |a, b| a.mul(b))
             }
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
@@ -482,7 +482,7 @@ impl ops::Div for &Series {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                struct_arithmetic(self, rhs, |a, b| a.div(b))
+                _struct_arithmetic(self, rhs, |a, b| a.div(b))
             }
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
@@ -504,7 +504,7 @@ impl ops::Rem for &Series {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                struct_arithmetic(self, rhs, |a, b| a.rem(b))
+                _struct_arithmetic(self, rhs, |a, b| a.rem(b))
             }
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -3,7 +3,7 @@ pub use crate::prelude::ChunkCompare;
 use crate::prelude::*;
 
 mod any_value;
-pub(crate) mod arithmetic;
+pub mod arithmetic;
 mod comparison;
 mod from;
 pub mod implementations;

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -664,7 +664,7 @@ where
     f(out)
 }
 
-pub(crate) fn align_chunks_binary<'a, T, B>(
+pub fn align_chunks_binary<'a, T, B>(
     left: &'a ChunkedArray<T>,
     right: &'a ChunkedArray<B>,
 ) -> (Cow<'a, ChunkedArray<T>>, Cow<'a, ChunkedArray<B>>)

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -70,7 +70,7 @@ true_div = ["polars-plan/true_div"]
 # operations
 is_in = ["polars-plan/is_in"]
 repeat_by = ["polars-plan/repeat_by"]
-round_series = ["polars-plan/round_series"]
+round_series = ["polars-plan/round_series", "polars-ops/round_series"]
 is_first = ["polars-plan/is_first"]
 cross_join = ["polars-plan/cross_join", "polars-pipe/cross_join"]
 asof_join = ["polars-plan/asof_join", "polars-time"]

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -38,6 +38,7 @@ object = ["polars-core/object"]
 propagate_nans = []
 performant = ["polars-core/performant"]
 big_idx = ["polars-core/bigidx"]
+round_series = []
 
 # extra utilities for BinaryChunked
 binary_encoding = ["base64", "hex", "dtype-binary"]

--- a/polars/polars-ops/src/series/ops/floor_divide.rs
+++ b/polars/polars-ops/src/series/ops/floor_divide.rs
@@ -5,6 +5,7 @@ use polars_arrow::utils::combine_validities;
 use polars_core::datatypes::PolarsNumericType;
 use polars_core::export::num;
 use polars_core::prelude::*;
+#[cfg(feature = "dtype-struct")]
 use polars_core::series::arithmetic::_struct_arithmetic;
 use polars_core::utils::align_chunks_binary;
 use polars_core::with_match_physical_numeric_polars_type;

--- a/polars/polars-ops/src/series/ops/floor_divide.rs
+++ b/polars/polars-ops/src/series/ops/floor_divide.rs
@@ -1,0 +1,118 @@
+use arrow::array::{Array, PrimitiveArray};
+use num::NumCast;
+use polars_arrow::prelude::ArrayRef;
+use polars_arrow::utils::combine_validities;
+use polars_core::datatypes::PolarsNumericType;
+use polars_core::export::num;
+use polars_core::prelude::*;
+use polars_core::series::arithmetic::_struct_arithmetic;
+use polars_core::utils::align_chunks_binary;
+use polars_core::with_match_physical_numeric_polars_type;
+
+#[inline]
+fn floor_div_element<T: NumericNative>(a: T, b: T) -> T {
+    // Safety: the casts of those primitives always succeed
+    unsafe {
+        let a: f64 = NumCast::from(a).unwrap_unchecked();
+        let b: f64 = NumCast::from(b).unwrap_unchecked();
+
+        let out = (a / b).floor();
+        let out: T = NumCast::from(out).unwrap_unchecked();
+        out
+    }
+}
+
+fn floor_div_array<T: NumericNative>(
+    a: &PrimitiveArray<T>,
+    b: &PrimitiveArray<T>,
+) -> PrimitiveArray<T> {
+    assert_eq!(a.len(), b.len());
+
+    if a.null_count() == 0 && b.null_count() == 0 {
+        let values = a
+            .values()
+            .as_slice()
+            .iter()
+            .copied()
+            .zip(b.values().as_slice().iter().copied())
+            .map(|(a, b)| floor_div_element(a, b))
+            .collect::<Vec<_>>();
+
+        let validity = combine_validities(a.validity(), b.validity());
+
+        PrimitiveArray::new(a.data_type().clone(), values.into(), validity)
+    } else {
+        let iter = a
+            .into_iter()
+            .zip(b.into_iter())
+            .map(|(opt_a, opt_b)| match (opt_a, opt_b) {
+                (Some(&a), Some(&b)) => Some(floor_div_element(a, b)),
+                _ => None,
+            });
+        PrimitiveArray::from_trusted_len_iter(iter)
+    }
+}
+
+fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) -> ChunkedArray<T> {
+    if a.len() == 1 {
+        let name = a.name();
+        return if let Some(a) = a.get(0) {
+            let mut out = if b.null_count() == 0 {
+                b.apply(|b| floor_div_element(a, b))
+            } else {
+                b.apply_on_opt(|b| b.map(|b| floor_div_element(a, b)))
+            };
+            out.rename(name);
+            out
+        } else {
+            ChunkedArray::full_null(a.name(), b.len())
+        };
+    }
+    if b.len() == 1 {
+        return if let Some(b) = b.get(0) {
+            if a.null_count() == 0 {
+                a.apply(|a| floor_div_element(a, b))
+            } else {
+                a.apply_on_opt(|a| a.map(|a| floor_div_element(a, b)))
+            }
+        } else {
+            ChunkedArray::full_null(a.name(), a.len())
+        };
+    }
+    let (a, b) = align_chunks_binary(a, b);
+
+    let chunks = a
+        .downcast_iter()
+        .zip(b.downcast_iter())
+        .map(|(a, b)| Box::new(floor_div_array(a, b)) as ArrayRef)
+        .collect();
+
+    // safety: same dtypes
+    unsafe { ChunkedArray::from_chunks(a.name(), chunks) }
+}
+
+pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
+    match (a.dtype(), b.dtype()) {
+        #[cfg(feature = "dtype-struct")]
+        (DataType::Struct(_), DataType::Struct(_)) => {
+            return Ok(_struct_arithmetic(a, b, |a, b| {
+                floor_div_series(a, b).unwrap()
+            }))
+        }
+        _ => {}
+    }
+
+    let logical_type = a.dtype();
+
+    let a = a.to_physical_repr();
+    let b = b.to_physical_repr();
+
+    let out = with_match_physical_numeric_polars_type!(a.dtype(), |$T| {
+        let a: &ChunkedArray<$T> = a.as_ref().as_ref().as_ref();
+        let b: &ChunkedArray<$T> = b.as_ref().as_ref().as_ref();
+
+        floor_div_ca(a, b).into_series()
+    });
+
+    out.cast(logical_type)
+}

--- a/polars/polars-ops/src/series/ops/mod.rs
+++ b/polars/polars-ops/src/series/ops/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "round_series")]
+mod floor_divide;
 #[cfg(feature = "log")]
 mod log;
 #[cfg(feature = "rolling_window")]
@@ -6,6 +8,8 @@ mod rolling;
 mod search_sorted;
 mod various;
 
+#[cfg(feature = "round_series")]
+pub use floor_divide::*;
 #[cfg(feature = "log")]
 pub use log::*;
 use polars_core::prelude::*;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.15.16"
+version = "0.15.17"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import os
+import typing
 import warnings
 from datetime import date, datetime, time, timedelta
 from typing import (
@@ -548,6 +549,8 @@ class Series:
 
         return self.cast(Float64) / other
 
+    # python 3.7 is not happy. Remove this when we finally ditch that
+    @typing.no_type_check
     def __floordiv__(self, other: Any) -> Series:
         if self.is_datelike():
             raise ValueError("first cast to integer before dividing datelike dtypes")

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -551,11 +551,9 @@ class Series:
     def __floordiv__(self, other: Any) -> Series:
         if self.is_datelike():
             raise ValueError("first cast to integer before dividing datelike dtypes")
-        result = self._arithmetic(other, "div", "div_<>")
-        # todo! in place, saves allocation
-        if self.is_float() or isinstance(other, float):
-            result = result.floor()
-        return result
+        if not isinstance(other, pli.Expr):
+            other = pli.lit(other)
+        return self.to_frame().select(pli.lit(self) // other).to_series()
 
     def __invert__(self) -> Series:
         if self.dtype == Boolean:

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -1,3 +1,4 @@
+import typing
 from datetime import date
 
 import numpy as np
@@ -84,6 +85,7 @@ def test_simd_float_sum_determinism() -> None:
     ]
 
 
+@typing.no_type_check
 def test_floor_division_float_int_consistency() -> None:
     a = np.random.randn(10) * 10
 

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import numpy as np
+
 import polars as pl
 
 
@@ -80,3 +82,12 @@ def test_simd_float_sum_determinism() -> None:
         0.6579683924555951,
         0.6579683924555951,
     ]
+
+
+def test_floor_division_float_int_consistency() -> None:
+    a = np.random.randn(10) * 10
+
+    assert (pl.Series(a) // 5).to_list() == list((a // 5))
+    assert (pl.Series(a, dtype=pl.Int32) // 5).to_list() == list(
+        (a.astype(int) // 5).astype(int)
+    )


### PR DESCRIPTION
fixes #6450