### PR TITLE
refactor(python): deprecate `iterrows` in favour of `iter_rows`, add new `@redirect` class decorator 

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -27,8 +27,8 @@ Manipulation/selection
     DataFrame.insert_at_idx
     DataFrame.interpolate
     DataFrame.item
+    DataFrame.iter_rows
     DataFrame.iter_slices
-    DataFrame.iterrows
     DataFrame.join
     DataFrame.join_asof
     DataFrame.limit

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -84,6 +84,7 @@ from polars.utils import (
     is_str_sequence,
     normalise_filepath,
     range_to_slice,
+    redirect,
     scale_bytes,
 )
 
@@ -145,6 +146,7 @@ def wrap_df(df: PyDataFrame) -> DataFrame:
     return DataFrame._from_pydf(df)
 
 
+@redirect({"iterrows": "iter_rows"})
 class DataFrame:
     """
     Two-dimensional data structure representing data as a table with rows and columns.
@@ -1840,7 +1842,7 @@ class DataFrame:
 
         """
         dict_, zip_, columns = dict, zip, self.columns
-        return [dict_(zip_(columns, row)) for row in self.iterrows()]
+        return [dict_(zip_(columns, row)) for row in self.iter_rows()]
 
     def to_numpy(self) -> np.ndarray[Any, Any]:
         """
@@ -6604,7 +6606,7 @@ class DataFrame:
         Warning
         -------
         You should NEVER use this method to iterate over a DataFrame; if you absolutely
-        require row-iteration you should strongly prefer ``iterrows()`` instead.
+        require row-iteration you should strongly prefer ``iter_rows()`` instead.
 
         Examples
         --------
@@ -6632,7 +6634,7 @@ class DataFrame:
 
         See Also
         --------
-        iterrows : Row iterator over frame data (does not materialise all rows).
+        iter_rows : Row iterator over frame data (does not materialise all rows).
         rows : Materialises all frame data as a list of rows.
 
         """
@@ -6720,7 +6722,7 @@ class DataFrame:
 
         See Also
         --------
-        iterrows : Row iterator over frame data (does not materialise all rows).
+        iter_rows : Row iterator over frame data (does not materialise all rows).
 
         """
         if named:
@@ -6736,18 +6738,18 @@ class DataFrame:
             return self._df.row_tuples()
 
     @overload
-    def iterrows(
+    def iter_rows(
         self, named: Literal[False] = ..., buffer_size: int = ...
     ) -> Iterator[tuple[Any, ...]]:
         ...
 
     @overload
-    def iterrows(
+    def iter_rows(
         self, named: Literal[True] = ..., buffer_size: int = ...
     ) -> Iterator[Any]:
         ...
 
-    def iterrows(
+    def iter_rows(
         self, named: bool = False, buffer_size: int = 500
     ) -> Iterator[tuple[Any, ...]] | Iterator[Any]:
         """
@@ -6784,9 +6786,9 @@ class DataFrame:
         ...         "b": [2, 4, 6],
         ...     }
         ... )
-        >>> [row[0] for row in df.iterrows()]
+        >>> [row[0] for row in df.iter_rows()]
         [1, 3, 5]
-        >>> [row.b for row in df.iterrows(named=True)]
+        >>> [row.b for row in df.iter_rows(named=True)]
         [2, 4, 6]
 
         See Also
@@ -6866,7 +6868,7 @@ class DataFrame:
 
         See Also
         --------
-        iterrows : Row iterator over frame data (does not materialise all rows).
+        iter_rows : Row iterator over frame data (does not materialise all rows).
         partition_by : Split into multiple DataFrames, partitioned by groups.
 
         """

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -795,7 +795,7 @@ class RollingGroupBy(Generic[DF]):
         if self.by is None:
             self._group_names = iter(group_names.to_series())
         else:
-            self._group_names = group_names.iterrows()
+            self._group_names = group_names.iter_rows()
 
         self._group_indices = groups_df.select(temp_col).to_series()
         self._current_index = 0
@@ -891,7 +891,7 @@ class DynamicGroupBy(Generic[DF]):
         if self.by is None:
             self._group_names = iter(group_names.to_series())
         else:
-            self._group_names = group_names.iterrows()
+            self._group_names = group_names.iter_rows()
 
         self._group_indices = groups_df.select(temp_col).to_series()
         self._current_index = 0

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -409,9 +409,10 @@ def redirect(from_to: dict[str, str]) -> Callable[[type[T]], type[T]]:
         if isinstance(item, str) and item in from_to:
             new_item = from_to[item]
             warnings.warn(
-                f"`{type(obj).__name__}.{item}` has been renamed and this"
-                f" redirect is temporary; please use `.{new_item}` instead",
+                f"`{type(obj).__name__}.{item}` has been renamed; this"
+                f" redirect is temporary, please use `.{new_item}` instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             item = new_item
         return obj.__getattribute__(item)

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -397,6 +397,33 @@ def deprecated_alias(**aliases: str) -> Callable[[Callable[P, T]], Callable[P, T
     return deco
 
 
+def redirect(from_to: dict[str, str]) -> Callable[[type[T]], type[T]]:
+    """
+    Class decorator allowing deprecation/transition from one method name to another.
+
+    The parameters must be the same (unless they are being renamed, in
+    which case you can use this in conjunction with @deprecated_alias).
+    """
+
+    def _redirecting_getattr_(obj: T, item: Any) -> Any:
+        if isinstance(item, str) and item in from_to:
+            new_item = from_to[item]
+            warnings.warn(
+                f"`{type(obj).__name__}.{item}` has been renamed and this"
+                f" redirect is temporary; please use `.{new_item}` instead",
+                category=DeprecationWarning,
+            )
+            item = new_item
+        return obj.__getattribute__(item)
+
+    def _cls_(cls: type[T]) -> type[T]:
+        # note: __getattr__ is only invoked if item isn't found on the class
+        cls.__getattr__ = _redirecting_getattr_  # type: ignore[attr-defined]
+        return cls
+
+    return _cls_
+
+
 def _rename_kwargs(
     func_name: str, kwargs: dict[str, object], aliases: dict[str, str]
 ) -> None:

--- a/py-polars/tests/unit/test_fmt.py
+++ b/py-polars/tests/unit/test_fmt.py
@@ -119,9 +119,11 @@ def test_duration_smallest_units() -> None:
 
 
 def test_fmt_float_full() -> None:
-    pl.Config.set_fmt_float("full")
-    assert (
-        str(pl.Series([1.2304980958725870923]))
-        == "shape: (1,)\nSeries: '' [f64]\n[\n\t1.230498095872587\n]"
-    )
-    pl.Config.restore_defaults()
+    fmt_float_full = "shape: (1,)\nSeries: '' [f64]\n[\n\t1.230498095872587\n]"
+    s = pl.Series([1.2304980958725870923])
+
+    with pl.Config() as cfg:
+        cfg.set_fmt_float("full")
+        assert str(s) == fmt_float_full
+
+    assert str(s) != fmt_float_full

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -69,16 +69,18 @@ def test_iterrows() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [None, False, None]})
 
     # Default iterrows behaviour
-    it = df.iterrows()
-    assert next(it) == (1, None)
-    assert next(it) == (2, False)
-    assert next(it) == (3, None)
-    with pytest.raises(StopIteration):
-        next(it)
+    # TODO: remove reference to deprecated "iterrows" once it is retired
+    for iter_method in ("iter_rows", "iterrows"):
+        it = getattr(df, iter_method)()
+        assert next(it) == (1, None)
+        assert next(it) == (2, False)
+        assert next(it) == (3, None)
+        with pytest.raises(StopIteration):
+            next(it)
 
     # Apply explicit row-buffer size
     for sz in (0, 1, 2, 3, 4):
-        it = df.iterrows(buffer_size=sz)
+        it = df.iter_rows(buffer_size=sz)
         assert next(it) == (1, None)
         assert next(it) == (2, False)
         assert next(it) == (3, None)
@@ -86,7 +88,7 @@ def test_iterrows() -> None:
             next(it)
 
         # Return rows as namedtuples
-        it_named = df.iterrows(named=True, buffer_size=sz)
+        it_named = df.iter_rows(named=True, buffer_size=sz)
 
         row = next(it_named)
         assert row.a == 1


### PR DESCRIPTION
Renames `iterrows` to `iter_rows`, consistent with the new `iter_slices` method.

* Introduces new class decorator `@redirect` to help generically support a transition period for one or more renamed methods or attributes; triggers a `DeprecationWarning` on use, while transparently redirecting the underlying object's `__getattribute__` to the new method. 

* Note that the redirecting code is _only_ called if the requested method/attribute isn't found on the class (due to the differences in behaviour between `__getattr__` and `__getattribute__`) so it adds _zero_ overhead when invoking a method/attribute that exists.

----

**New decorator usage:**
```python
@redirect({"iterrows": "iter_rows"})
class DataFrame:
    ...
```

Feels pretty clean; we can support both the old/new name(s) ...

```python
list( pl.DataFrame([1,2,3]).iter_rows() )
# [(1,), (2,), (3,)]

list( pl.DataFrame([1,2,3]).iterrows() )
# [(1,), (2,), (3,)]
```
... while only having the newer method on the class:
```python
for attr in dir( pl.DataFrame ):
    if attr.startswith( "iter" ):
        print( attr )
        
# iter_rows
# iter_slices
```