### PR TITLE
feat(rust): faster frame-init from list of dicts (when omitting fields), and ensure fields are read according to the declared schema

### DIFF
--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1,5 +1,6 @@
 import typing
 from datetime import date, datetime
+from random import shuffle
 from typing import Any
 
 import numpy as np
@@ -393,13 +394,39 @@ def test_init_records() -> None:
     expected = pl.DataFrame({"c": [1, 2, 1], "d": [2, 1, 2]})
     assert df_cd.frame_equal(expected)
 
-    df_xy = pl.DataFrame(dicts, schema=[("x", pl.UInt32), ("y", pl.UInt32)])
-    expected = pl.DataFrame({"x": [1, 2, 1], "y": [2, 1, 2]}).with_columns(
-        [pl.col("x").cast(pl.UInt32), pl.col("y").cast(pl.UInt32)]
-    )
-    assert df_xy.frame_equal(expected)
-    assert df_xy.schema == {"x": pl.UInt32, "y": pl.UInt32}
-    assert df_xy.rows() == [(1, 2), (2, 1), (1, 2)]
+
+def test_init_records_schema_order() -> None:
+    cols: list[str] = ["a", "b", "c", "d"]
+    data: list[dict[str, int]] = [
+        {"c": 3, "b": 2, "a": 1},
+        {"b": 2, "d": 4},
+        {},
+        {"a": 1, "b": 2, "c": 3},
+        {"d": 4, "b": 2, "a": 1},
+        {"c": 3, "b": 2},
+    ]
+    lookup = {"a": 1, "b": 2, "c": 3, "d": 4, "e": None}
+
+    # ensure field values are loaded according to the declared schema order
+    for _ in range(8):
+        shuffle(data)
+        shuffle(cols)
+
+        df = pl.from_dicts(dicts=data, schema=cols)
+        for col in df.columns:
+            assert all(  # type: ignore[var-annotated]
+                (value == lookup[col]) for value in filter(None, df[col])
+            )
+
+    # have schema override inferred types, omit some columns, add a new one
+    schema = {"a": pl.Int8, "c": pl.Int16, "e": pl.Int32}
+    df = pl.from_dicts(dicts=data, schema=schema)
+
+    assert df.schema == schema
+    for col in df.columns:
+        assert all(  # type: ignore[var-annotated]
+            (value == lookup[col]) for value in filter(None, df[col])
+        )
 
 
 def test_init_only_columns() -> None:
@@ -560,12 +587,6 @@ def test_from_dicts_schema() -> None:
             "b": [4, 5, 6],
             "c": [None, None, None],
         }
-
-    df = pl.from_dicts(data, schema=["x", "y"])
-    assert df.to_dict(False) == {
-        "x": [1, 2, 3],
-        "y": [4, 5, 6],
-    }
 
 
 def test_nested_read_dict_4143() -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 from datetime import date, datetime
 from random import shuffle
@@ -414,9 +416,7 @@ def test_init_records_schema_order() -> None:
 
         df = pl.from_dicts(dicts=data, schema=cols)
         for col in df.columns:
-            assert all(  # type: ignore[var-annotated]
-                (value == lookup[col]) for value in filter(None, df[col])
-            )
+            assert all((value in (None, lookup[col]) for value in df[col].to_list()))
 
     # have schema override inferred types, omit some columns, add a new one
     schema = {"a": pl.Int8, "c": pl.Int16, "e": pl.Int32}
@@ -424,9 +424,7 @@ def test_init_records_schema_order() -> None:
 
     assert df.schema == schema
     for col in df.columns:
-        assert all(  # type: ignore[var-annotated]
-            (value == lookup[col]) for value in filter(None, df[col])
-        )
+        assert all((value in (None, lookup[col]) for value in df[col].to_list()))
 
 
 def test_init_only_columns() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -629,9 +629,9 @@ def test_fast_explode_on_list_struct_6208() -> None:
             "label": "l",
             "tag": "t",
             "ref": 1,
-            "parent": [{"ref": 1, "tag": "t", "ratio": 62.3}],
+            "parents": [{"ref": 1, "tag": "t", "ratio": 62.3}],
         },
-        {"label": "l", "tag": "t", "ref": 1, "parent": None},
+        {"label": "l", "tag": "t", "ref": 1, "parents": None},
     ]
 
     df = pl.DataFrame(


### PR DESCRIPTION
Closes #6437.

A feature (more speed when omitting fields), and a fix (ensure fields are read in the declared schema order).

**Optimisation**

Currently _all_ dictionary values are read, even if we declare that we only want a subset of the available fields; rather than drop the column data after load, this optimisation simply never loads the omitted data.

**Fix**

Dictionaries are not guaranteed to be passed into `pl.from_dicts` (or to `pl.DataFrame` init) with data stored in the same key order. Consequently a declared schema can end-up reordering/renaming the loaded columns and/or moving values between columns if the keys do not initially present in the same order as the schema, or if the first dictionary is missing one or more fields.

* Setup:
  ```python
  import polars as pl

  d1 = {"a":1, "b":2, "c":3}
  d2 = {"b":2, "a":1, "c":3}
  d3 = {"c":3, "b":2}
  ```
* First dict loaded has the keys in schema order; we get the expected result:
  ```python
  pl.from_dicts( [d1,d2,d3], schema=["a","b","c"] )
  # shape: (3, 3)
  # ┌──────┬─────┬─────┐
  # │ a    ┆ b   ┆ c   │
  # │ ---  ┆ --- ┆ --- │
  # │ i64  ┆ i64 ┆ i64 │
  # ╞══════╪═════╪═════╡
  # │ 1    ┆ 2   ┆ 3   │
  # │ 1    ┆ 2   ┆ 3   │
  # │ null ┆ 2   ┆ 3   │
  # └──────┴─────┴─────┘
  ```
* Initial dictionary keys don't match schema order, values get read into different columns:
  ```python
  pl.from_dicts( [d2,d1,d3], schema=["a","b","c"] )
  # shape: (3, 3)
  # ┌─────┬──────┬─────┐
  # │ a   ┆ b    ┆ c   │
  # │ --- ┆ ---  ┆ --- │
  # │ i64 ┆ i64  ┆ i64 │
  # ╞═════╪══════╪═════╡
  # │ 2   ┆ 1    ┆ 3   │
  # │ 2   ┆ 1    ┆ 3   │
  # │ 2   ┆ null ┆ 3   │
  # └─────┴──────┴─────┘
  ```
* Same again; value order now completely reversed from schema order:
  ```python
  pl.from_dicts( [d3,d2,d1], schema=["a","b","c"] )
  # shape: (3, 3)
  # ┌─────┬─────┬──────┐
  # │ a   ┆ b   ┆ c    │
  # │ --- ┆ --- ┆ ---  │
  # │ i64 ┆ i64 ┆ i64  │
  # ╞═════╪═════╪══════╡
  # │ 3   ┆ 2   ┆ null │
  # │ 3   ┆ 2   ┆ 1    │
  # │ 3   ┆ 2   ┆ 1    │
  # └─────┴─────┴──────┘
  ```

This came about because `schema_overwrite` _row_ behaviour (where the values are in a fixed order and are not named) was being applied to _dict_ behaviour (where the fields are named and are not guaranteed to be in a fixed order).

I don't think we should ever be overwriting field names of incoming _dicts_ with the `schema` param, as it is unstable - we should be honouring the schema as declared, reading the values in the given field order, and potentially applying dtypes; if the caller ever does want to do a rename, that is an easy second-step. 