### PR TITLE
refactor(python): improved error message from Expr on incorrect usage in boolean context

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -161,7 +161,8 @@ class Expr:
     def __bool__(self) -> NoReturn:
         raise ValueError(
             "Since Expr are lazy, the truthiness of an Expr is ambiguous. "
-            "Hint: use '&' or '|' to chain Expr together, not and/or."
+            "Hint: use '&' or '|' to logically combine Expr, not 'and'/'or', and "
+            "use 'x.is_in([y,z])' instead of 'x in [y,z]' to check membership."
         )
 
     def __abs__(self) -> Expr:


### PR DESCRIPTION
ref #6458.

Not the first time this has come up, so I've slightly enhanced the error that gets raised to point the caller in the right direction when accidentally writing `x in [y,z]` instead of `x.is_in([y,z])`.