### PR TITLE
fix(python): use explicit type-arg for PythonDataType

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -22,6 +22,7 @@ from typing import (
     Union,
     overload,
 )
+from typing import List as ListType
 
 from polars.dependencies import pyarrow as pa
 
@@ -79,8 +80,8 @@ PythonDataType: TypeAlias = Union[
     Type[time],
     Type[datetime],
     Type[timedelta],
-    Type[list],
-    Type[tuple],  # type: ignore[type-arg]
+    Type[ListType[Any]],
+    Type[Tuple[Any, ...]],
     Type[bytes],
     Type[Decimal],
 ]


### PR DESCRIPTION
Bumped into this issue trying to use `pl.from_dicts`. Type checkers in strict modes seem to not like `SchemaDefinition` -> `PythonDataType` using `list` and `tuple` without explicit args. I believe passing `Any` is essentially the default behavior. This just makes that explicit. 

**Edit**

Switched to using `typing.List` and `typing.Tuple` for Python 3.7 compatible. This file also already contains a `List` class used for a different purpose.