### PR TITLE
feat(rust, python)!: show where error messages originated

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -47,8 +47,10 @@ impl From<LogicalPlan> for LogicalPlanBuilder {
 }
 
 fn format_err(msg: &str, input: &LogicalPlan) -> String {
-    format!("{msg}\n\n> Error originated just after operation: '{input:?}'\n\
-    This operation could not be added to the plan.",)
+    format!(
+        "{msg}\n\n> Error originated just after operation: '{input:?}'\n\
+    This operation could not be added to the plan.",
+    )
 }
 
 /// Returns every error or msg: &str as `ComputeError`.

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -47,7 +47,7 @@ impl From<LogicalPlan> for LogicalPlanBuilder {
 }
 
 fn format_err(msg: &str, input: &LogicalPlan) -> String {
-    format!("{msg}\n\n> Error originated in operation: '{input:?}'",)
+    format!("{msg}\n\n> Error originated just after operation: '{input:?}'",)
 }
 
 /// Returns every error or msg: &str as `ComputeError`.

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -46,17 +46,32 @@ impl From<LogicalPlan> for LogicalPlanBuilder {
     }
 }
 
+fn format_err(msg: &str, input: &LogicalPlan) -> String {
+    format!("{msg}\n\n> Error originated in operation: '{input:?}'",)
+}
+
+/// Returns every error or msg: &str as `ComputeError`.
+/// It also shows the logical plan node where the error
+/// originated.
+macro_rules! raise_err {
+    ($err:expr, $input:expr, $convert:ident) => {{
+        let format_err_outer = |msg: &str| format_err(msg, &$input);
+
+        let err = $err.wrap_msg(&format_err_outer);
+
+        LogicalPlan::Error {
+            input: Box::new($input.clone()),
+            err: err.into(),
+        }
+        .$convert()
+    }};
+}
+
 macro_rules! try_delayed {
     ($fallible:expr, $input:expr, $convert:ident) => {
         match $fallible {
             Ok(success) => success,
-            Err(err) => {
-                return LogicalPlan::Error {
-                    input: Box::new($input.clone()),
-                    err: err.into(),
-                }
-                .$convert()
-            }
+            Err(err) => return raise_err!(err, $input, $convert),
         }
     };
 }
@@ -394,7 +409,9 @@ impl LogicalPlanBuilder {
     pub fn filter(self, predicate: Expr) -> Self {
         let predicate = if has_expr(&predicate, |e| match e {
             Expr::Column(name) => name.starts_with('^') && name.ends_with('$'),
-            Expr::Wildcard | Expr::RenameAlias { .. } | Expr::Columns(_) => true,
+            Expr::Wildcard | Expr::RenameAlias { .. } | Expr::Columns(_) | Expr::DtypeColumn(_) => {
+                true
+            }
             _ => false,
         }) {
             let schema = try_delayed!(self.0.schema(), &self.0, into);
@@ -403,6 +420,12 @@ impl LogicalPlanBuilder {
                 &self.0,
                 into
             );
+            if rewritten.is_empty() {
+                let msg = "The predicate expanded to zero expressions. \
+                This may for example be caused by a regex not matching column names or\
+                a column dtype match not hitting any dtypes in the DataFrame";
+                return raise_err!(PolarsError::ComputeError(msg.into()), &self.0, into);
+            }
             combine_predicates_expr(rewritten.into_iter())
         } else {
             predicate

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -47,7 +47,8 @@ impl From<LogicalPlan> for LogicalPlanBuilder {
 }
 
 fn format_err(msg: &str, input: &LogicalPlan) -> String {
-    format!("{msg}\n\n> Error originated just after operation: '{input:?}'",)
+    format!("{msg}\n\n> Error originated just after operation: '{input:?}'\n\
+    This operation could not be added to the plan.",)
 }
 
 /// Returns every error or msg: &str as `ComputeError`.
@@ -422,7 +423,7 @@ impl LogicalPlanBuilder {
             );
             if rewritten.is_empty() {
                 let msg = "The predicate expanded to zero expressions. \
-                This may for example be caused by a regex not matching column names or\
+                This may for example be caused by a regex not matching column names or \
                 a column dtype match not hitting any dtypes in the DataFrame";
                 return raise_err!(PolarsError::ComputeError(msg.into()), &self.0, into);
             }

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -371,3 +371,18 @@ def test_sort_by_different_lengths() -> None:
                 pl.col("col1").sort_by(pl.col("col2").arg_unique()),
             ]
         )
+
+
+def test_err_filter_no_expansion() -> None:
+    # df contains floats
+    df = pl.DataFrame(
+        {
+            "a": [0.1, 0.2],
+        }
+    )
+
+    with pytest.raises(
+        pl.ComputeError, match=r"The predicate expanded to zero expressions"
+    ):
+        # we filter by ints
+        df.filter(pl.col(pl.Int16).min() < 0.1)


### PR DESCRIPTION
```python
# df contains floats
df = pl.DataFrame({
   "a": [0.1, 0.2],
})

# we filter by ints
df.filter(pl.col(pl.Int16).min() < 0.1)
```
```
ComputeError: The predicate expanded to zero expressions. This may for example be caused by a regex not matching column names ora column dtype match not hitting any dtypes in the DataFrame

> Error originated in operation: '  DF ["a"]; PROJECT */1 COLUMNS; SELECTION: "None"
'
```

closes #6476