### PR TITLE
test(python): Utilize pytest-xdist for faster unittests

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -65,7 +65,7 @@ jobs:
           maturin develop
 
       - name: Run tests and report coverage
-        run: pytest --cov
+        run: pytest --cov --numprocesses=auto
 
       - name: Run doctests
         run: python tests/docs/run_doc_examples.py
@@ -129,7 +129,7 @@ jobs:
           pip install target/wheels/polars-*.whl
 
       - name: Run tests
-        run: pytest
+        run: pytest --numprocesses=auto
 
       - name: Check import without optional dependencies
         run: |

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -42,7 +42,7 @@ pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
 test: venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest tests/unit/
+	$(VENV_BIN)/pytest tests/unit/ --numprocesses=auto
 
 .PHONY: doctest
 doctest: venv build  ## Run doctests
@@ -50,12 +50,12 @@ doctest: venv build  ## Run doctests
 
 .PHONY: test-all
 test-all: venv build  ## Run all tests
-	$(VENV_BIN)/pytest
+	$(VENV_BIN)/pytest --numprocesses=auto
 	$(VENV_BIN)/python tests/docs/run_doc_examples.py
 
 .PHONY: coverage
 coverage: venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov
+	$(VENV_BIN)/pytest --cov --numprocesses=auto
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -19,6 +19,7 @@ maturin==0.14.10
 mypy==0.991
 pytest==7.2.0
 pytest-cov==4.0.0
+pytest-xdist==3.1.0
 
 # Stub files
 pandas-stubs==1.2.0.62


### PR DESCRIPTION
Relates to https://github.com/pola-rs/polars/issues/6364

Changes:
* Utilize `pytest-xdist` for running the pytest test suite.
  * Added dev dependency
  * Updated pytest commands in Makefile
  * Updated pytest commands in CI test workflow

Note: For now, I did NOT add this as a default option in `pyproject.toml` for now, as quite often I'm utilizing `pytest` directly to mess around with a single test, which case spawning the workers takes longer than the actual test. We can change this later if desired.

### More info

We now have 1453 tests in our test suite. This number will only grow, so we need to make sure the runtime stays manageable. This tool allows us to do that.

Relevant docs:
https://pytest-xdist.readthedocs.io/en/latest/distribution.html

Some benchmarks on the `tests/unit` folder:
* Without parallelization: ~5.15 seconds
* With `-n auto` (for me, that's 6 workers): ~3.25 seconds
* With `-n logical` (for me, that's 12 workers): ~3.70 seconds

So right now, it's a speedup of about 55%. As our test suite grows larger, the speedup will become more significant as the initial cost of spinning up workers becomes relatively smaller.

Tests are distributed randomly across workers. We can control this with the `--dist` parameter to, for example, send all tests that utilize the string cache to the same worker. But for now, this does not seem necessary.

Note that this currently doesn't do much for running the slow tests, as the parametric tests take up pretty much all time and are auto-assigned to the same worker. `pytest-xdist` has introduced a new `--dist` mode (`worksteal`) that addresses this, but this is not yet released. But once that's out, we'll see real benefits there as well!