### PR TITLE
feat(python): ~30% faster `iter_rows(named=True)` and `to_dicts()`, if pyarrow available

### DIFF
--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1009,7 +1009,7 @@ def read_sql(
     """
     Read a SQL query into a DataFrame.
 
-    A range of databases are supported, such as PostgreSQL, Redshift, MySQL, MariaDB,
+    Supports a range of databases, such as PostgreSQL, Redshift, MySQL, MariaDB,
     Clickhouse, Oracle, BigQuery, SQL Server, and so on. For an up-to-date list
     please see the connectorx docs:
 
@@ -1018,9 +1018,9 @@ def read_sql(
     Parameters
     ----------
     sql
-        Raw SQL query / queries.
+        Raw SQL query (or queries).
     connection_uri
-        Connectorx connection uri, for example
+        A connectorx compatible connection uri, for example
 
         * "postgresql://username:password@server:port/database"
     partition_on


### PR DESCRIPTION
This is on top of the [previous](https://github.com/pola-rs/polars/pull/6415) 10% speedup for `to_dicts`, but _only_ if `pyarrow` is available. Speedup varies with dict composition but is always significant (I'm seeing 25-45% gains with a freshly-compiled release build).

Also:
* Repointed `to_dicts` internally to use `iter_rows(named=True)`.
* Added some `Struct` coverage to the `iter_rows` unit test.

----

The degree of speedup  makes me think I should look at generating the iter-values down in Rust with `pyo3` after all; python loops are notoriously slow compared to lower-level languages, and it seems there is some low-hanging fruit here...
