### PR TITLE
feat(python): automagically upconvert `with_columns` kwarg expressions with multiple output names to struct; extend `**named_kwargs` support to `select`

### DIFF
--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -38,7 +38,7 @@ POLARS_CFG_ENV_VARS = {
     "POLARS_VERBOSE",
 }
 # register Config-local attributes (with their defaults) here
-POLARS_CFG_LOCAL_VARS = {"with_columns_kwargs": False}
+POLARS_CFG_LOCAL_VARS = {"with_columns_kwargs": True}
 
 
 class Config:
@@ -74,7 +74,7 @@ class Config:
 
     # note: class-local attributes can be used for options that don't have
     # a Rust component (so, no need to register environment variables).
-    with_columns_kwargs: bool = False
+    with_columns_kwargs: bool = True
 
     @classmethod
     def load(cls, cfg: str) -> type[Config]:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5506,7 +5506,9 @@ class DataFrame:
             | pli.Expr
             | pli.Series
             | Iterable[str | pli.Expr | pli.Series | pli.WhenThen | pli.WhenThenThen]
-        ),
+            | None
+        ) = None,
+        **named_exprs: Any,
     ) -> DF:
         """
         Select columns from this DataFrame.
@@ -5515,6 +5517,8 @@ class DataFrame:
         ----------
         exprs
             Column or columns to select.
+        **named_exprs
+            Named column expressions, provided as kwargs.
 
         Examples
         --------
@@ -5587,7 +5591,7 @@ class DataFrame:
 
         """
         return self._from_pydf(
-            self.lazy().select(exprs).collect(no_optimization=True)._df
+            self.lazy().select(exprs, **named_exprs).collect(no_optimization=True)._df
         )
 
     def with_columns(
@@ -5606,9 +5610,9 @@ class DataFrame:
         Parameters
         ----------
         exprs
-            List of Expressions that evaluate to columns.
+            List of expressions that evaluate to columns.
         **named_exprs
-            Named column Expressions, provided as kwargs.
+            Named column expressions, provided as kwargs.
 
         Examples
         --------

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5589,6 +5589,22 @@ class DataFrame:
         │ 10      │
         └─────────┘
 
+        Note that, when using kwargs syntax, expressions with multiple
+        outputs are automatically instantiated as Struct columns:
+
+        >>> from polars.datatypes import INTEGER_DTYPES
+        >>> df.select(is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"))
+        shape: (3, 1)
+        ┌───────────┐
+        │ is_odd    │
+        │ ---       │
+        │ struct[2] │
+        ╞═══════════╡
+        │ {1,0}     │
+        │ {0,1}     │
+        │ {1,0}     │
+        └───────────┘
+
         """
         return self._from_pydf(
             self.lazy().select(exprs, **named_exprs).collect(no_optimization=True)._df
@@ -5694,7 +5710,7 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
 
-        Note that, when using kwarg syntax, expressions with multiple
+        Note that, when using kwargs syntax, expressions with multiple
         outputs are automatically instantiated as Struct columns:
 
         >>> df.drop("c").with_columns(

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5596,12 +5596,12 @@ class DataFrame:
         **named_exprs: Any,
     ) -> DataFrame:
         """
-        Return a new DataFrame with the columns added, if new, or replaced.
+        Return a new DataFrame with the columns added (if new), or replaced.
 
         Notes
         -----
-        Creating a new DataFrame using this method does not create a new copy of
-        existing data.
+        Creating a new DataFrame using this method does not create a new copy
+        of existing data.
 
         Parameters
         ----------
@@ -5620,7 +5620,7 @@ class DataFrame:
         ...     }
         ... )
 
-        Passing in a single expression, adding the column as we give it a new name:
+        Passing in a single expression, adding (and naming) a new column:
 
         >>> df.with_columns((pl.col("a") ** 2).alias("a^2"))
         shape: (4, 4)
@@ -5635,8 +5635,8 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 │
         └─────┴──────┴───────┴──────┘
 
-        We can also override a column, by giving the expression a name that already
-        exists:
+        We can also override an existing column by giving the expression
+        a name that already exists:
 
         >>> df.with_columns((pl.col("a") ** 2).alias("c"))
         shape: (4, 3)
@@ -5651,7 +5651,7 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ 16.0 │
         └─────┴──────┴──────┘
 
-        Passing in multiple expressions as a list:
+        Multiple expressions can be passed in as both a list...
 
         >>> df.with_columns(
         ...     [
@@ -5672,17 +5672,15 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
 
-        Support for kwarg expressions is considered EXPERIMENTAL. Currently
-        requires opt-in via `pl.Config` boolean flag:
+        ...or via kwarg expressions:
 
-        >>> pl.Config.with_columns_kwargs = True
         >>> df.with_columns(
-        ...     d=pl.col("a") * pl.col("b"),
-        ...     e=pl.col("c").is_not(),
+        ...     ab=pl.col("a") * pl.col("b"),
+        ...     not_c=pl.col("c").is_not(),
         ... )
         shape: (4, 5)
         ┌─────┬──────┬───────┬──────┬───────┐
-        │ a   ┆ b    ┆ c     ┆ d    ┆ e     │
+        │ a   ┆ b    ┆ c     ┆ ab   ┆ not_c │
         │ --- ┆ ---  ┆ ---   ┆ ---  ┆ ---   │
         │ i64 ┆ f64  ┆ bool  ┆ f64  ┆ bool  │
         ╞═════╪══════╪═══════╪══════╪═══════╡
@@ -5691,6 +5689,24 @@ class DataFrame:
         │ 3   ┆ 10.0 ┆ false ┆ 30.0 ┆ true  │
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
+
+        Note that, when using kwarg syntax, expressions with multiple
+        outputs are automatically instantiated as Struct columns:
+
+        >>> df.drop("c").with_columns(
+        ...     diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
+        ... )
+        shape: (4, 3)
+        ┌─────┬──────┬─────────────┐
+        │ a   ┆ b    ┆ diffs       │
+        │ --- ┆ ---  ┆ ---         │
+        │ i64 ┆ f64  ┆ struct[2]   │
+        ╞═════╪══════╪═════════════╡
+        │ 1   ┆ 0.5  ┆ {null,null} │
+        │ 2   ┆ 4.0  ┆ {1,3.5}     │
+        │ 3   ┆ 10.0 ┆ {1,6.0}     │
+        │ 4   ┆ 13.0 ┆ {1,3.0}     │
+        └─────┴──────┴─────────────┘
 
         """
         return (

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -90,6 +90,7 @@ def expr_to_lit_or_expr(
         | Sequence[int | float | str | None]
     ),
     str_to_lit: bool = True,
+    structify: bool = False,
 ) -> Expr:
     """
     Convert args to expressions.
@@ -101,6 +102,9 @@ def expr_to_lit_or_expr(
     str_to_lit
         If True string argument `"foo"` will be converted to `lit("foo")`,
         If False it will be converted to `col("foo")`
+    structify
+        If the final unaliased expression has multiple output names,
+        automagically convert it to struct.
 
     Returns
     -------
@@ -108,24 +112,30 @@ def expr_to_lit_or_expr(
 
     """
     if isinstance(expr, str) and not str_to_lit:
-        return pli.col(expr)
+        expr = pli.col(expr)
     elif (
         isinstance(expr, (int, float, str, pli.Series, datetime, date, time, timedelta))
         or expr is None
     ):
-        return pli.lit(expr)
-    elif isinstance(expr, Expr):
-        return expr
+        expr = pli.lit(expr)
+        structify = False
     elif isinstance(expr, list):
-        return pli.lit(pli.Series("", [expr]))
+        expr = pli.lit(pli.Series("", [expr]))
+        structify = False
     elif isinstance(expr, (pli.WhenThen, pli.WhenThenThen)):
-        # implicitly add the null branch.
-        return expr.otherwise(None)
-    else:
+        expr = expr.otherwise(None)  # implicitly add the null branch.
+    elif not isinstance(expr, Expr):
         raise ValueError(
             f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with"
             " pl.lit or pl.col"
         )
+
+    if structify:
+        unaliased_expr = expr.meta.undo_aliases()
+        if unaliased_expr.meta.has_multiple_outputs():
+            expr = cast(Expr, pli.struct(expr))
+
+    return expr
 
 
 def wrap_expr(pyexpr: PyExpr) -> Expr:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2247,6 +2247,7 @@ def collect_all(
 
 def select(
     exprs: str | pli.Expr | Sequence[str | pli.Expr] | pli.Series,
+    **named_exprs: Any,
 ) -> pli.DataFrame:
     """
     Run polars expressions without a context.
@@ -2257,6 +2258,8 @@ def select(
     ----------
     exprs
         Expressions to run
+    **named_exprs
+        Named expressions, provided as kwargs.
 
     Returns
     -------
@@ -2283,7 +2286,7 @@ def select(
     └─────┘
 
     """
-    return pli.DataFrame([]).select(exprs)
+    return pli.DataFrame([]).select(exprs, **named_exprs)
 
 
 @overload

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1641,6 +1641,22 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 10      │
         └─────────┘
 
+        Note that, when using kwargs syntax, expressions with multiple
+        outputs are automatically instantiated as Struct columns:
+
+        >>> from polars.datatypes import INTEGER_DTYPES
+        >>> df.select(is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd")).collect()
+        shape: (3, 1)
+        ┌───────────┐
+        │ is_odd    │
+        │ ---       │
+        │ struct[2] │
+        ╞═══════════╡
+        │ {1,0}     │
+        │ {0,1}     │
+        │ {1,0}     │
+        └───────────┘
+
         """
         if exprs is None and not named_exprs:
             raise ValueError("Expected at least one of 'exprs' or **named_exprs")
@@ -2537,7 +2553,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
 
-        Note that, when using kwarg syntax, expressions with multiple
+        Note that, when using kwargs syntax, expressions with multiple
         outputs are automatically instantiated as Struct columns:
 
         >>> ldf.drop("c").with_columns(

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2454,7 +2454,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ...     }
         ... ).lazy()
 
-        Passing in a single expression, adding the column as we give it a new name:
+        Passing in a single expression, adding (and naming) a new column:
 
         >>> ldf.with_columns((pl.col("a") ** 2).alias("a^2")).collect()
         shape: (4, 4)
@@ -2469,8 +2469,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 │
         └─────┴──────┴───────┴──────┘
 
-        We can also override a column, by giving the expression a name that already
-        exists:
+        We can also override an existing column by giving the expression
+        a name that already exists:
 
         >>> ldf.with_columns((pl.col("a") ** 2).alias("c")).collect()
         shape: (4, 3)
@@ -2485,7 +2485,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ 16.0 │
         └─────┴──────┴──────┘
 
-        Passing in multiple expressions as a list:
+        Multiple expressions can be passed in as both a list...
 
         >>> ldf.with_columns(
         ...     [
@@ -2506,17 +2506,15 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ true  ┆ 16.0 ┆ 6.5  ┆ false │
         └─────┴──────┴───────┴──────┴──────┴───────┘
 
-        Support for kwarg expressions is considered EXPERIMENTAL. Currently
-        requires opt-in via `pl.Config` boolean flag:
+        ...or via kwarg expressions:
 
-        >>> pl.Config.with_columns_kwargs = True
         >>> ldf.with_columns(
-        ...     d=pl.col("a") * pl.col("b"),
-        ...     e=pl.col("c").is_not(),
+        ...     ab=pl.col("a") * pl.col("b"),
+        ...     not_c=pl.col("c").is_not(),
         ... ).collect()
         shape: (4, 5)
         ┌─────┬──────┬───────┬──────┬───────┐
-        │ a   ┆ b    ┆ c     ┆ d    ┆ e     │
+        │ a   ┆ b    ┆ c     ┆ ab   ┆ not_c │
         │ --- ┆ ---  ┆ ---   ┆ ---  ┆ ---   │
         │ i64 ┆ f64  ┆ bool  ┆ f64  ┆ bool  │
         ╞═════╪══════╪═══════╪══════╪═══════╡
@@ -2525,6 +2523,24 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 3   ┆ 10.0 ┆ false ┆ 30.0 ┆ true  │
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
+
+        Note that, when using kwarg syntax, expressions with multiple
+        outputs are automatically instantiated as Struct columns:
+
+        >>> ldf.drop("c").with_columns(
+        ...     diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
+        ... ).collect()
+        shape: (4, 3)
+        ┌─────┬──────┬─────────────┐
+        │ a   ┆ b    ┆ diffs       │
+        │ --- ┆ ---  ┆ ---         │
+        │ i64 ┆ f64  ┆ struct[2]   │
+        ╞═════╪══════╪═════════════╡
+        │ 1   ┆ 0.5  ┆ {null,null} │
+        │ 2   ┆ 4.0  ┆ {1,3.5}     │
+        │ 3   ┆ 10.0 ┆ {1,6.0}     │
+        │ 4   ┆ 13.0 ┆ {1,3.0}     │
+        └─────┴──────┴─────────────┘
 
         """
         if named_exprs and not Config.with_columns_kwargs:
@@ -2545,7 +2561,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             exprs = list(exprs)
 
         exprs.extend(
-            pli.expr_to_lit_or_expr(expr).alias(name)
+            pli.expr_to_lit_or_expr(expr, structify=True).alias(name)
             for name, expr in named_exprs.items()
         )
         pyexprs = []

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -411,8 +411,8 @@ def test_string_cache() -> None:
 
 
 def test_config_load_save() -> None:
-    # set some config options
-    pl.Config.with_columns_kwargs = True
+    # set some config options...
+    pl.Config.with_columns_kwargs = False
     pl.Config.set_verbose(True)
     assert os.environ["POLARS_VERBOSE"] == "1"
 
@@ -420,24 +420,24 @@ def test_config_load_save() -> None:
     assert isinstance(cfg, str)
     assert "POLARS_VERBOSE" in pl.Config.state(if_set=True)
 
-    # unset the saved options
-    pl.Config.with_columns_kwargs = False
+    # ...modify the same options...
+    pl.Config.with_columns_kwargs = True
     pl.Config.set_verbose(False)
     assert os.environ["POLARS_VERBOSE"] == "0"
 
-    # now load back from config...
+    # ...load back from config...
     pl.Config.load(cfg)
 
-    # ...and confirm the saved options were set
+    # ...and confirm the saved options were set.
     assert os.environ["POLARS_VERBOSE"] == "1"
-    assert pl.Config.with_columns_kwargs is True
+    assert pl.Config.with_columns_kwargs is False
 
-    # restore explicitly-set config options (unsets from env)
+    # restore all default options (unsets from env)
     pl.Config.restore_defaults()
     assert "POLARS_VERBOSE" not in pl.Config.state(if_set=True)
     assert "POLARS_VERBOSE" in pl.Config.state()
     assert os.environ.get("POLARS_VERBOSE") is None
-    assert pl.Config.with_columns_kwargs is False
+    assert pl.Config.with_columns_kwargs is True
 
 
 def test_config_scope() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2481,9 +2481,52 @@ def test_with_columns() -> None:
     )
     assert_frame_equal(dx, expected)
 
-    # at least one of exprs/**named_exprs required
+    # automatically upconvert multi-output expressions to struct
+    ldf = (
+        pl.DataFrame({"x1": [1, 2, 6], "x2": [1, 2, 3]})
+        .lazy()
+        .with_columns(
+            pct_change=pl.col(["x1", "x2"]).pct_change(),
+            maxes=pl.all().max().suffix("_max"),
+            xcols=pl.col("^x.*$"),
+        )
+    )
+    # ┌─────┬─────┬─────────────┬───────────┬───────────┐
+    # │ x1  ┆ x2  ┆ pct_change  ┆ maxes     ┆ xcols     │
+    # │ --- ┆ --- ┆ ---         ┆ ---       ┆ ---       │
+    # │ i64 ┆ i64 ┆ struct[2]   ┆ struct[2] ┆ struct[2] │
+    # ╞═════╪═════╪═════════════╪═══════════╪═══════════╡
+    # │ 1   ┆ 1   ┆ {null,null} ┆ {6,3}     ┆ {1,1}     │
+    # │ 2   ┆ 2   ┆ {1.0,1.0}   ┆ {6,3}     ┆ {2,2}     │
+    # │ 6   ┆ 3   ┆ {2.0,0.5}   ┆ {6,3}     ┆ {6,3}     │
+    # └─────┴─────┴─────────────┴───────────┴───────────┘
+    assert ldf.collect().to_dicts() == [
+        {
+            "x1": 1,
+            "x2": 1,
+            "pct_change": {"x1": None, "x2": None},
+            "maxes": {"x1_max": 6, "x2_max": 3},
+            "xcols": {"x1": 1, "x2": 1},
+        },
+        {
+            "x1": 2,
+            "x2": 2,
+            "pct_change": {"x1": 1.0, "x2": 1.0},
+            "maxes": {"x1_max": 6, "x2_max": 3},
+            "xcols": {"x1": 2, "x2": 2},
+        },
+        {
+            "x1": 6,
+            "x2": 3,
+            "pct_change": {"x1": 2.0, "x2": 0.5},
+            "maxes": {"x1_max": 6, "x2_max": 3},
+            "xcols": {"x1": 6, "x2": 3},
+        },
+    ]
+
+    # require at least one of exprs / **named_exprs
     with pytest.raises(ValueError):
-        _ = df.with_columns()
+        _ = ldf.with_columns()
 
 
 def test_len_compute(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_meta.py
+++ b/py-polars/tests/unit/test_meta.py
@@ -58,3 +58,4 @@ def test_meta_has_multiple_outputs() -> None:
 def test_meta_is_regex_projection() -> None:
     e = pl.col("^.*$").alias("bar")
     assert e.meta.is_regex_projection()
+    assert e.meta.has_multiple_outputs()


### PR DESCRIPTION
Closes #6486, and removes the "experimental" status from `with_columns` kwargs.

**Example**:
```python
df = pl.DataFrame(
    data = {
        "x1": [1,2,6],
        "x2": [1,2,3],
    }
).with_columns(
    pct_change = pl.col(["x1","x2"]).pct_change(),
)
# ┌─────┬─────┬────────────────┐
# │ x1  ┆ x2  ┆ pct_change     │
# │ --- ┆ --- ┆ ---            │
# │ i64 ┆ i64 ┆ struct[2]      │
# ╞═════╪═════╪════════════════╡
# │ 1   ┆ 1   ┆ {null,null}    │
# │ 2   ┆ 2   ┆ {1.0,1.0}      │
# │ 6   ┆ 3   ┆ {2.0,0.5}      │
# └─────┴─────┴────────────────┘
```