### PR TITLE
test(python): Fix test issue with tmp directory

### DIFF
--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1148,7 +1148,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def sink_parquet(
         self,
-        path: str,
+        path: str | Path,
         *,
         compression: str = "zstd",
         compression_level: int | None = None,
@@ -1248,7 +1248,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
     def sink_ipc(
         self,
-        path: str,
+        path: str | Path,
         *,
         compression: str | None = "zstd",
         maintain_order: bool = True,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1219,7 +1219,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Examples
         --------
         >>> ldf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
-        >>> ldf.sink_parquet("/tmp/out.parquet")  # doctest: +SKIP
+        >>> ldf.sink_parquet("out.parquet")  # doctest: +SKIP
 
         """
         if no_optimization:
@@ -1294,7 +1294,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Examples
         --------
         >>> ldf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
-        >>> ldf.sink_ipc("/tmp/out.arrow")  # doctest: +SKIP
+        >>> ldf.sink_ipc("out.arrow")  # doctest: +SKIP
 
         """
         if no_optimization:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import ParquetCompression
@@ -350,34 +350,55 @@ def test_parquet_nested_dictionaries_6217() -> None:
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
-def test_sink_parquet_ipc(io_files_path: Path) -> None:
+def test_sink_parquet(io_files_path: Path) -> None:
     file = io_files_path / "small.parquet"
 
-    dst = "/tmp/test_sink.parquet"
-    pl.scan_parquet(file).sink_parquet(dst)
-    with pl.StringCache():
-        assert pl.read_parquet(dst).frame_equal(pl.read_parquet(file))
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "sink.parquet"
 
-    dst = "/tmp/test_sink.ipc"
-    pl.scan_parquet(file).sink_ipc(dst)
-    with pl.StringCache():
-        assert pl.read_ipc(dst).frame_equal(pl.read_parquet(file))
+        df_scanned = pl.scan_parquet(file)
+        df_scanned.sink_parquet(file_path)
+
+        with pl.StringCache():
+            result = pl.read_parquet(file_path)
+            df_read = pl.read_parquet(file)
+            assert_frame_equal(result, df_read)
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
+def test_sink_ipc(io_files_path: Path) -> None:
+    file = io_files_path / "small.parquet"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "sink.ipc"
+
+        df_scanned = pl.scan_parquet(file)
+        df_scanned.sink_ipc(file_path)
+
+        with pl.StringCache():
+            result = pl.read_ipc(file_path)
+            df_read = pl.read_parquet(file)
+            assert_frame_equal(result, df_read)
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_fetch_union() -> None:
-    pl.DataFrame({"a": [0, 1, 2], "b": [1, 2, 3]}).write_parquet(
-        "/tmp/df_fetch_1.parquet"
-    )
-    pl.DataFrame({"a": [3, 4, 5], "b": [4, 5, 6]}).write_parquet(
-        "/tmp/df_fetch_2.parquet"
-    )
+    df1 = pl.DataFrame({"a": [0, 1, 2], "b": [1, 2, 3]})
+    df2 = pl.DataFrame({"a": [3, 4, 5], "b": [4, 5, 6]})
 
-    assert pl.scan_parquet("/tmp/df_fetch_1.parquet").fetch(1).to_dict(False) == {
-        "a": [0],
-        "b": [1],
-    }
-    assert pl.scan_parquet("/tmp/df_fetch_*.parquet").fetch(1).to_dict(False) == {
-        "a": [0, 3],
-        "b": [1, 4],
-    }
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path_1 = Path(temp_dir) / "df_fetch_1.parquet"
+        file_path_2 = Path(temp_dir) / "df_fetch_2.parquet"
+        file_path_glob = Path(temp_dir) / "df_fetch_*.parquet"
+
+        df1.write_parquet(file_path_1)
+        df2.write_parquet(file_path_2)
+
+        result_one = pl.scan_parquet(file_path_1).fetch(1)
+        result_glob = pl.scan_parquet(file_path_glob).fetch(1)
+
+    expected = pl.DataFrame({"a": [0], "b": [1]})
+    assert_frame_equal(result_one, expected)
+
+    expected = pl.DataFrame({"a": [0, 3], "b": [1, 4]})
+    assert_frame_equal(result_glob, expected)


### PR DESCRIPTION
Fixes #6499

Changes:
* Use `TemporaryDirectory` for a few tests that were still writing to disk
* Add the `Path` type hint for `sink` methods.