### PR TITLE
test(python): Enable some tests for Windows

### DIFF
--- a/py-polars/tests/slow/test_parquet.py
+++ b/py-polars/tests/slow/test_parquet.py
@@ -1,5 +1,4 @@
 import io
-import sys
 import tempfile
 import typing
 from pathlib import Path
@@ -7,14 +6,12 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pyarrow.dataset as ds
-import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
 
 
 @typing.no_type_check
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_struct_pyarrow_dataset_5796() -> None:
     num_rows = 2**17 + 1
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gzip
 import io
-import sys
 import tempfile
 import textwrap
 import zlib
@@ -1106,7 +1105,6 @@ def test_csv_statistics_offset() -> None:
     assert pl.read_csv(io.StringIO(csv), n_rows=N).height == 4999
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_csv_scan_categorical() -> None:
     N = 5_000
     df = pl.DataFrame({"x": ["A"] * N})

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -27,12 +27,13 @@ def test_from_to_buffer(df: pl.DataFrame, compression: IpcCompression) -> None:
     assert_frame_equal_local_categoricals(df, read_df)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 @pytest.mark.parametrize("path_type", [str, Path])
 def test_from_to_file(
     df: pl.DataFrame, compression: IpcCompression, path_type: type[str] | type[Path]
 ) -> None:
+    if sys.platform == "win32" and compression == "uncompressed":
+        pytest.skip("Writing uncompressed IPC does not work on Windows")
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"
         file_path_cast = path_type(file_path)
@@ -42,7 +43,10 @@ def test_from_to_file(
     assert_frame_equal_local_categoricals(df, df_read)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Writing uncompressed IPC to disk does not work on Windows",
+)
 def test_select_columns_from_file(df: pl.DataFrame) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"
@@ -100,7 +104,6 @@ def test_ipc_schema(compression: IpcCompression) -> None:
     assert pl.read_ipc_schema(f) == expected
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 @pytest.mark.parametrize("path_type", [str, Path])
 def test_ipc_schema_from_file(
@@ -108,6 +111,8 @@ def test_ipc_schema_from_file(
     compression: IpcCompression,
     path_type: type[str] | type[Path],
 ) -> None:
+    if sys.platform == "win32" and compression == "uncompressed":
+        pytest.skip("Writing uncompressed IPC does not work on Windows")
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"
         file_path_cast = path_type(file_path)
@@ -148,7 +153,10 @@ def test_ipc_column_order() -> None:
     assert pl.read_ipc(f, columns=columns).columns == columns
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Writing uncompressed IPC to disk does not work on Windows",
+)
 def test_glob_ipc(df: pl.DataFrame) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -177,7 +176,6 @@ def test_parquet_statistics(
     )
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_streaming_categorical() -> None:
     df = pl.DataFrame(
         [
@@ -204,7 +202,6 @@ def test_streaming_categorical() -> None:
             assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_parquet_struct_categorical() -> None:
     df = pl.DataFrame(
         [

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import sys
 import tempfile
 import typing
 from pathlib import Path
@@ -349,7 +348,6 @@ def test_parquet_nested_dictionaries_6217() -> None:
         assert read.frame_equal(df)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_sink_parquet(io_files_path: Path) -> None:
     file = io_files_path / "small.parquet"
 
@@ -365,7 +363,6 @@ def test_sink_parquet(io_files_path: Path) -> None:
             assert_frame_equal(result, df_read)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_sink_ipc(io_files_path: Path) -> None:
     file = io_files_path / "small.parquet"
 
@@ -381,7 +378,6 @@ def test_sink_ipc(io_files_path: Path) -> None:
             assert_frame_equal(result, df_read)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_fetch_union() -> None:
     df1 = pl.DataFrame({"a": [0, 1, 2], "b": [1, 2, 3]})
     df2 = pl.DataFrame({"a": [3, 4, 5], "b": [4, 5, 6]})

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import sys
 import tempfile
 import typing
 from pathlib import Path
 
 import pyarrow.dataset as ds
-import pytest
 
 import polars as pl
 
@@ -20,7 +18,6 @@ def helper_dataset_test(file_path: Path, query) -> None:
     assert out.frame_equal(expected)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_dataset(df: pl.DataFrame) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"


### PR DESCRIPTION
Using the temporary directory has solved most test incompatibilities with Windows, so we can remove the `xfail` markers.

The only thing that is still causes some tests to fail on Windows is the cases of writing uncompressed IPC files. This gives the error message below - any clue what could be causing this? It makes no sense to me. The same test runs fine when using other compression methods.

```
    @pytest.mark.parametrize("compression", COMPRESSIONS)
    @pytest.mark.parametrize("path_type", [str, Path])
    def test_from_to_file(
        df: pl.DataFrame, compression: IpcCompression, path_type: type[str] | type[Path]
    ) -> None:
>       with tempfile.TemporaryDirectory() as temp_dir:

tests\unit\io\test_ipc.py:35: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\tempfile.py:904: in __exit__
    self.cleanup()
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\tempfile.py:908: in cleanup
    self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\tempfile.py:890: in _rmtree
    _shutil.rmtree(name, onerror=onerror)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\shutil.py:759: in rmtree
    return _rmtree_unsafe(path, onerror)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\shutil.py:622: in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\tempfile.py:881: in onerror
    cls._rmtree(path, ignore_errors=ignore_errors)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\tempfile.py:890: in _rmtree
    _shutil.rmtree(name, onerror=onerror)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\shutil.py:759: in rmtree
    return _rmtree_unsafe(path, onerror)
C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\shutil.py:603: in _rmtree_unsafe
    onerror(os.scandir, path, sys.exc_info())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpm7qnu7mc\\small.ipc'
onerror = <function TemporaryDirectory._rmtree.<locals>.onerror at 0x000001F12C3F3600>

    def _rmtree_unsafe(path, onerror):
        try:
>           with os.scandir(path) as scandir_it:
E           NotADirectoryError: [WinError 267] The directory name is invalid: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpm7qnu7mc\\small.ipc'

C:\hostedtoolcache\windows\Python\3.11.1\x64\Lib\shutil.py:600: NotADirectoryError
```