### PR TITLE
feat(python): Implement unary plus operation on exprs and series

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -280,6 +280,9 @@ class Expr:
     def __neg__(self) -> Expr:
         return pli.lit(0) - self
 
+    def __pos__(self) -> Expr:
+        return pli.lit(0) + self
+
     def __array_ufunc__(
         self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
     ) -> Expr:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -651,6 +651,9 @@ class Series:
     def __neg__(self) -> Series:
         return 0 - self
 
+    def __pos__(self) -> Series:
+        return 0 + self
+
     def __abs__(self) -> Series:
         return self.abs()
 

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -2,6 +2,7 @@ import typing
 from datetime import date
 
 import numpy as np
+import pytest
 
 import polars as pl
 
@@ -99,3 +100,6 @@ def test_unary_plus() -> None:
     data = [1, 2]
     df = pl.DataFrame({"x": data})
     assert df.select(+pl.col("x"))[:, 0].to_list() == data
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        pl.select(+pl.lit(""))

--- a/py-polars/tests/unit/test_arithmetic.py
+++ b/py-polars/tests/unit/test_arithmetic.py
@@ -93,3 +93,9 @@ def test_floor_division_float_int_consistency() -> None:
     assert (pl.Series(a, dtype=pl.Int32) // 5).to_list() == list(
         (a.astype(int) // 5).astype(int)
     )
+
+
+def test_unary_plus() -> None:
+    data = [1, 2]
+    df = pl.DataFrame({"x": data})
+    assert df.select(+pl.col("x"))[:, 0].to_list() == data

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -340,6 +340,11 @@ def test_arithmetic(s: pl.Series) -> None:
         2 % a
     with pytest.raises(ValueError):
         2**a
+    with pytest.raises(TypeError):  # https://github.com/pola-rs/polars/issues/6617
+        +a
+    a = pl.Series("a", [""])
+    with pytest.raises(ValueError):
+        +a
 
 
 def test_arithmetic_empty() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -310,6 +310,8 @@ def test_arithmetic(s: pl.Series) -> None:
     assert ((a % 1) == [0, 0]).sum() == 2
     # negate
     assert (-a == [-1, -2]).sum() == 2
+    # unary plus
+    assert (+a == a).all()
     # wrong dtypes in rhs operands
     assert ((1.0 - a) == [0.0, -1.0]).sum() == 2
     assert ((1.0 / a) == [1.0, 0.5]).sum() == 2


### PR DESCRIPTION
On arithmetic types, +x is a noop, otherwise a type error.

Introduced for symmetry with unary minus and consistency with C, Python and other languages.

## TODO

1. [x] Add tests for type error cases 