### PR TITLE
test(python): Remove `verify_series_and_expr_api` util

### DIFF
--- a/py-polars/polars/testing/_private.py
+++ b/py-polars/polars/testing/_private.py
@@ -1,32 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
 import polars.internals as pli
-from polars.testing.asserts import _getattr_multi, assert_series_equal
-
-
-def verify_series_and_expr_api(
-    input: pli.Series, expected: pli.Series | None, op: str, *args: Any, **kwargs: Any
-) -> None:
-    """
-    Test element-wise functions for both the series and expressions API.
-
-    Examples
-    --------
-    >>> s = pl.Series([1, 3, 2])
-    >>> expected = pl.Series([1, 2, 3])
-    >>> verify_series_and_expr_api(s, expected, "sort")
-
-    """
-    expr = _getattr_multi(pli.col("*"), op)(*args, **kwargs)
-    result_expr = input.to_frame().select(expr)[:, 0]
-    result_series = _getattr_multi(input, op)(*args, **kwargs)
-    if expected is None:
-        assert_series_equal(result_series, result_expr)
-    else:
-        assert_series_equal(result_expr, expected)
-        assert_series_equal(result_series, expected)
 
 
 def _to_rust_syntax(df: pli.DataFrame) -> str:

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import reduce
 from typing import Any
 
 import polars.internals as pli
@@ -378,18 +377,6 @@ def raise_assert_detail(
 [right]: {right}"""
 
     raise AssertionError(msg)
-
-
-def _getattr_multi(obj: object, op: str) -> Any:
-    """
-    Allow `op` to be multiple layers deep.
-
-    For example, op="str.lengths" will mean we first get the attribute "str", and then
-    the attribute "lengths".
-
-    """
-    op_list = op.split(".")
-    return reduce(lambda o, m: getattr(o, m), op_list, obj)
 
 
 def is_categorical_dtype(data_type: Any) -> bool:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -17,7 +17,6 @@ from polars.datatypes import (
     TEMPORAL_DTYPES,
 )
 from polars.testing import assert_series_equal
-from polars.testing._private import verify_series_and_expr_api
 
 
 def test_horizontal_agg(fruits_cars: pl.DataFrame) -> None:
@@ -79,7 +78,7 @@ def test_min_nulls_consistency() -> None:
 def test_list_join_strings() -> None:
     s = pl.Series("a", [["ab", "c", "d"], ["e", "f"], ["g"], []])
     expected = pl.Series("a", ["ab-c-d", "e-f", "g", ""])
-    verify_series_and_expr_api(s, expected, "arr.join", "-")
+    assert_series_equal(s.arr.join("-"), expected)
 
 
 def test_count_expr() -> None:
@@ -137,10 +136,9 @@ def test_map_alias() -> None:
 
 
 def test_unique_stable() -> None:
-    a = pl.Series("a", [1, 1, 1, 1, 2, 2, 2, 3, 3])
+    s = pl.Series("a", [1, 1, 1, 1, 2, 2, 2, 3, 3])
     expected = pl.Series("a", [1, 2, 3])
-
-    verify_series_and_expr_api(a, expected, "unique", True)
+    assert_series_equal(s.unique(maintain_order=True), expected)
 
 
 def test_wildcard_expansion() -> None:
@@ -241,7 +239,7 @@ def test_unique_and_drop_stability() -> None:
 def test_unique_counts() -> None:
     s = pl.Series("id", ["a", "b", "b", "c", "c", "c"])
     expected = pl.Series("id", [1, 2, 3], dtype=pl.UInt32)
-    verify_series_and_expr_api(s, expected, "unique_counts")
+    assert_series_equal(s.unique_counts(), expected)
 
 
 def test_entropy() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -9,7 +9,6 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_series_equal
-from polars.testing._private import verify_series_and_expr_api
 
 
 def test_list_arr_get() -> None:
@@ -229,9 +228,9 @@ def test_list_arr_empty() -> None:
 def test_list_argminmax() -> None:
     s = pl.Series("a", [[1, 2], [3, 2, 1]])
     expected = pl.Series("a", [0, 2], dtype=pl.UInt32)
-    verify_series_and_expr_api(s, expected, "arr.arg_min")
+    assert_series_equal(s.arr.arg_min(), expected)
     expected = pl.Series("a", [1, 0], dtype=pl.UInt32)
-    verify_series_and_expr_api(s, expected, "arr.arg_max")
+    assert_series_equal(s.arr.arg_max(), expected)
 
 
 def test_list_shift() -> None:


### PR DESCRIPTION
Relates to #6364

This util existed to facilitate easy testing of both the Series API and the identical Expr method. Because we have now formalized this relationship, we no longer need to explicitly test both every time. We simply call the Series method, which will call the Expr method under the hood.

Changes:
* Remove `verify_series_and_expr_api` util
* Update tests that used this util