### PR TITLE
fix(python): Fix _repr_html_ double-height rows (#5645)

### DIFF
--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -119,7 +119,7 @@ class HTMLFormatter:
         self.elements.append(inner)
 
     def render(self) -> list[str]:
-        with Tag(self.elements, "table", {"border": "1", "class": "dataframe"}):
+        with Tag(self.elements, "table", {"border": "1", "class": "pl-dataframe"}):
             self.write_header()
             self.write_body()
         return self.elements
@@ -136,33 +136,20 @@ class NotebookFormatter(HTMLFormatter):
     def write_style(self) -> None:
         # SNIPPET Forked from pandas.
 
-        # We use the "scoped" attribute here so that the desired
-        # style properties for the data frame are not then applied
-        # throughout the entire notebook.
-        template_first = """\
-            <style scoped>"""
-        template_last = """\
-            </style>"""
-        template_select = """\
-                .dataframe %s {
-                    %s: %s;
-                }"""
-        element_props = [
-            ("tbody tr th:only-of-type", "vertical-align", "middle"),
-            ("tbody tr th", "vertical-align", "top"),
-            ("thead th", "text-align", "right"),
-            ("td", "white-space", "pre"),
-            ("td", "padding-top", "0"),
-            ("td", "padding-bottom", "0"),
-        ]
-        # vs code cannot deal with that css line
-        # see #4102
-        if not in_vscode_notebook():
-            element_props.append(("td", "line-height", "95%"))
+        style = """\
+            <style>
+            .pl-dataframe > thead > tr > th {
+              text-align: right;
+            }
+            .pl-dataframe > tr > td {
+              padding-top: 0;
+              padding-bottom: 0,
+              line-height: 95%;
+            }
+            </style>
+        """
 
-        template_mid = "\n\n".join(template_select % t for t in element_props)
-        template = dedent("\n".join((template_first, template_mid, template_last)))
-        self.write(template)
+        self.write(dedent(style))
 
     def render(self) -> list[str]:
         """Return the lines needed to render a HTML table."""
@@ -170,15 +157,3 @@ class NotebookFormatter(HTMLFormatter):
             self.write_style()
             super().render()
         return self.elements
-
-
-def in_vscode_notebook() -> bool:
-    try:
-        # autoimported by notebooks
-        get_ipython()  # type: ignore[name-defined]
-        os.environ["VSCODE_CWD"]
-    except NameError:
-        return False  # not in notebook
-    except KeyError:
-        return False  # not in VSCode
-    return True

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -134,21 +134,13 @@ class NotebookFormatter(HTMLFormatter):
     """
 
     def write_style(self) -> None:
-        # SNIPPET Forked from pandas.
-
         style = """\
             <style>
             .pl-dataframe > thead > tr > th {
               text-align: right;
             }
-            .pl-dataframe > tr > td {
-              padding-top: 0;
-              padding-bottom: 0,
-              line-height: 95%;
-            }
             </style>
         """
-
         self.write(dedent(style))
 
     def render(self) -> list[str]:


### PR DESCRIPTION
Fixes #5645

I've only changed the CSS:

1. removed `white-space: pre` - the rule causing double-height rows

2. removed `scoped` from `<style scoped>` attribute. It was dropped, no current browser implements it - https://stackoverflow.com/a/45692033

3. renamed `.dataframe` class to `.pl-dataframe` to prevent interactions with Pandas which also uses `.dataframe`. The interaction can be observed: add `color: red` to Polars HTML and you'll see the Pandas output change too.

4. removed `th:only-of-type` rule, `only-of-type` is not used by Polars (only Pandas).

5. removed `tbody tr th` rule, not used by Polars, possibly used by Pandas multi-index.

6. replace descendant selector (`thead tr th`) with child selector (`thead > tr > th`) - CSS best practice

7. removed VS Code bug workaround, and `line-height: 95%` rule.

Note that current Pandas styling is very similar to this PR.

Rows can be made more condensed (less vertical padding) by adding something like below. This is a visual design issue, not for me to decide.

Very condensed (no vertical padding):

```css
.pl-dataframe > tbody > tr > td {
  padding-top: 0;
  padding-bottom: 0,
}
```

More condensed (less vertical padding):

```css
.pl-dataframe > tbody > tr > td {
  padding-top: 2px;
  padding-bottom: 2px,
}
```

BEFORE:

![polars_html_original](https://user-images.githubusercontent.com/3753822/215285364-48276113-b88d-482d-88a5-7631211b1095.png)

AFTER:

![polars_html_fixed](https://user-images.githubusercontent.com/3753822/215285371-5faf7ea0-2351-4afe-a376-faef8be34386.png)
