### PR TITLE
fix(python): on frame-init from generator, initial `chunk_size` cannot be smaller than `infer_schema_length`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -99,8 +99,8 @@ def expr_to_lit_or_expr(
     expr
         Any argument.
     str_to_lit
-        If True string argument `"foo"` will be converted to `lit("foo")`,
-        If False it will be converted to `col("foo")`
+        If True string argument `"foo"` will be converted to `lit("foo")`.
+        If False it will be converted to `col("foo")`.
 
     Returns
     -------

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1265,6 +1265,14 @@ def test_from_generator_or_iterable() -> None:
         assert expected_data == d.row_tuples()
         assert expected_schema == list(zip(d.columns(), d.dtypes()))
 
+    # ref: issue #6489 (initial chunk_size cannot be smaller than 'infer_schema_length')
+    df = pl.DataFrame(
+        data=iter(([{"col": None}] * 1000) + [{"col": ["a", "b", "c"]}]),
+        infer_schema_length=1001,
+    )
+    assert df.schema == {"col": pl.List(pl.Utf8)}
+    assert df[-2:]["col"].to_list() == [None, ["a", "b", "c"]]
+
     # empty iterator
     assert_frame_equal(
         pl.DataFrame(data=gen(0), schema=["a", "b", "c", "d"]),


### PR DESCRIPTION
Closes #6489.

Connectivity up here in the sky is _truly_ awful :) ✈️