### PR TITLE
fix(rust, python) validate utc, fmt, and tz-aware in strptime

### DIFF
--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -75,7 +75,12 @@ arange = []
 mode = ["polars-core/mode"]
 cum_agg = ["polars-core/cum_agg"]
 interpolate = ["polars-ops/interpolate"]
-rolling_window = ["polars-core/rolling_window", "polars-time/rolling_window", "polars-ops/rolling_window", "polars-time/rolling_window"]
+rolling_window = [
+  "polars-core/rolling_window",
+  "polars-time/rolling_window",
+  "polars-ops/rolling_window",
+  "polars-time/rolling_window",
+]
 rank = ["polars-core/rank"]
 diff = ["polars-core/diff", "polars-ops/diff"]
 pct_change = ["polars-core/pct_change"]

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -58,7 +58,7 @@ date_offset = ["polars-time"]
 list_take = ["polars-ops/list_take"]
 trigonometry = []
 sign = []
-timezones = ["polars-time/timezones", "polars-core/timezones"]
+timezones = ["polars-time/timezones", "polars-core/timezones", "regex"]
 
 true_div = []
 

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -11,6 +11,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 [dependencies]
 ahash.workspace = true
 futures = { version = "0.3.25", optional = true }
+once_cell.workspace = true
 polars-arrow = { version = "0.26.1", path = "../../polars-arrow" }
 polars-core = { version = "0.26.1", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.26.1", path = "../../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
@@ -74,12 +75,7 @@ arange = []
 mode = ["polars-core/mode"]
 cum_agg = ["polars-core/cum_agg"]
 interpolate = ["polars-ops/interpolate"]
-rolling_window = [
-  "polars-core/rolling_window",
-  "polars-time/rolling_window",
-  "polars-ops/rolling_window",
-  "polars-time/rolling_window",
-]
+rolling_window = ["polars-core/rolling_window", "polars-time/rolling_window", "polars-ops/rolling_window", "polars-time/rolling_window"]
 rank = ["polars-core/rank"]
 diff = ["polars-core/diff", "polars-ops/diff"]
 pct_change = ["polars-core/pct_change"]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -313,7 +313,6 @@ pub(super) fn count_match(s: &Series, pat: &str) -> PolarsResult<Series> {
 
 #[cfg(feature = "temporal")]
 pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Series> {
-    #[cfg(feature = "regex")]
     let tz_aware = match (options.tz_aware, &options.fmt) {
         (true, Some(_)) => true,
         (true, None) => {
@@ -322,8 +321,9 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
                     .into(),
             ));
         }
+        #[cfg(feature = "regex")]
         (false, Some(fmt)) => TZ_AWARE_RE.is_match(fmt),
-        (false, None) => false,
+        (false, _) => false,
     };
     if !tz_aware && options.utc {
         return Err(PolarsError::ComputeError(

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "regex")]
+#[cfg(feature = "timezones")]
 use once_cell::sync::Lazy;
 use polars_arrow::utils::CustomIterTools;
 #[cfg(feature = "regex")]
@@ -8,7 +8,7 @@ use regex::{escape, Regex};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "regex")]
+#[cfg(feature = "timezones")]
 static TZ_AWARE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(%z)|(%:z)|(%#z)|(^%\+$)").unwrap());
 
 use super::*;
@@ -325,6 +325,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
         (false, Some(fmt)) => TZ_AWARE_RE.is_match(fmt),
         (false, _) => false,
     };
+    #[cfg(feature = "timezones")]
     if !tz_aware && options.utc {
         return Err(PolarsError::ComputeError(
             "Cannot use 'utc=True' with tz-naive data. Parse the data as naive, and then use `.dt.with_time_zone('UTC').".into(),

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -382,7 +382,6 @@ pub trait Utf8Methods: AsUtf8 {
     }
 
     #[cfg(feature = "dtype-datetime")]
-    #[allow(unused_variables)] // `utc` is only used with timezones feature
     /// Parsing string values and return a [`DatetimeChunked`]
     fn as_datetime(
         &self,
@@ -390,7 +389,7 @@ pub trait Utf8Methods: AsUtf8 {
         tu: TimeUnit,
         cache: bool,
         tz_aware: bool,
-        utc: bool,
+        _utc: bool,
     ) -> PolarsResult<DatetimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {
@@ -416,7 +415,7 @@ pub trait Utf8Methods: AsUtf8 {
 
                 let mut convert = |s: &str| {
                     DateTime::parse_from_str(s, &fmt).ok().map(|dt| {
-                        if !utc {
+                        if !_utc {
                             match tz {
                                 None => tz = Some(dt.timezone()),
                                 Some(tz_found) => {
@@ -457,7 +456,7 @@ pub trait Utf8Methods: AsUtf8 {
                     .collect::<PolarsResult<_>>()?;
 
                 ca.rename(utf8_ca.name());
-                if !utc {
+                if !_utc {
                     let tz = tz.map(|of| format!("{of}"));
                     Ok(ca.into_datetime(tu, tz))
                 } else {

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -389,7 +389,7 @@ pub trait Utf8Methods: AsUtf8 {
         tu: TimeUnit,
         cache: bool,
         tz_aware: bool,
-        #[cfg(feature = "timezones")] utc: bool,
+        utc: bool,
     ) -> PolarsResult<DatetimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -382,6 +382,7 @@ pub trait Utf8Methods: AsUtf8 {
     }
 
     #[cfg(feature = "dtype-datetime")]
+    #[allow(unused_variables)] // `utc` is only used with timezones feature
     /// Parsing string values and return a [`DatetimeChunked`]
     fn as_datetime(
         &self,

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -389,7 +389,7 @@ pub trait Utf8Methods: AsUtf8 {
         tu: TimeUnit,
         cache: bool,
         tz_aware: bool,
-        utc: bool,
+        #[cfg(feature = "timezones")] utc: bool,
     ) -> PolarsResult<DatetimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1687,6 +1687,7 @@ name = "polars-plan"
 version = "0.26.1"
 dependencies = [
  "ahash",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-io",

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -2705,7 +2705,6 @@ def test_crossing_dst_tz_aware(fmt: str) -> None:
 
 
 def test_tz_aware_without_fmt() -> None:
-    ts = ["2021-03-27T23:59:59", "2021-03-28T23:59:59"]
     with pytest.raises(
         ComputeError,
         match=(
@@ -2713,12 +2712,11 @@ def test_tz_aware_without_fmt() -> None:
             r"Please specify 'fmt'.$"
         ),
     ):
-        pl.Series(ts).str.strptime(pl.Datetime, tz_aware=True)
+        pl.Series(["2020-01-01"]).str.strptime(pl.Datetime, tz_aware=True)
 
 
 @pytest.mark.parametrize("fmt", ["%Y-%m-%dT%H:%M:%S", None])
 def test_utc_with_tz_naive(fmt: str | None) -> None:
-    ts = ["2021-03-27T23:59:59", "2021-03-28T23:59:59"]
     with pytest.raises(
         ComputeError,
         match=(
@@ -2726,4 +2724,4 @@ def test_utc_with_tz_naive(fmt: str | None) -> None:
             r"Parse the data as naive, and then use `.dt.with_time_zone\('UTC'\).$"
         ),
     ):
-        pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=True)
+        pl.Series(["2020-01-01 00:00:00"]).str.strptime(pl.Datetime, fmt, utc=True)

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -2704,13 +2704,26 @@ def test_crossing_dst_tz_aware(fmt: str) -> None:
         pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=False)
 
 
-def test_utc_with_tz_naive() -> None:
+def test_tz_aware_without_fmt() -> None:
     ts = ["2021-03-27T23:59:59", "2021-03-28T23:59:59"]
     with pytest.raises(
         ComputeError,
         match=(
-            r"Cannot use 'utc=True' with tz-naive data. "
-            r"Parse the data as naive, and then use `.dt.with_time_zone\('UTC'\)"
+            r"^Passing 'tz_aware=True' without 'fmt' is not yet supported. "
+            r"Please specify 'fmt'.$"
         ),
     ):
-        pl.Series(ts).str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S", utc=True)
+        pl.Series(ts).str.strptime(pl.Datetime, tz_aware=True)
+
+
+@pytest.mark.parametrize("fmt", ["%Y-%m-%dT%H:%M:%S", None])
+def test_utc_with_tz_naive(fmt: str | None) -> None:
+    ts = ["2021-03-27T23:59:59", "2021-03-28T23:59:59"]
+    with pytest.raises(
+        ComputeError,
+        match=(
+            r"^Cannot use 'utc=True' with tz-naive data. "
+            r"Parse the data as naive, and then use `.dt.with_time_zone\('UTC'\).$"
+        ),
+    ):
+        pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=True)


### PR DESCRIPTION
closes #6549 

it should be possible to auto-detect tz-aware if `fmt` is None, but I'll try that separately if that's OK - for now I'd suggest just throwing an informative error 