### PR TITLE
test(python): Use `assert_frame_equal` instead of `assert df.frame_equal(...)`

### DIFF
--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -403,6 +403,6 @@ def assert_frame_equal_local_categoricals(
             raise AssertionError
 
     cat_to_str = pli.col(Categorical).cast(str)
-    assert df_a.with_columns(cat_to_str).frame_equal(df_b.with_columns(cat_to_str))
+    assert_frame_equal(df_a.with_columns(cat_to_str), df_b.with_columns(cat_to_str))
     cat_to_phys = pli.col(Categorical).to_physical()
-    assert df_a.with_columns(cat_to_phys).frame_equal(df_b.with_columns(cat_to_phys))
+    assert_frame_equal(df_a.with_columns(cat_to_phys), df_b.with_columns(cat_to_phys))

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -6,6 +6,7 @@ from typing import cast
 import numpy as np
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 # https://github.com/pola-rs/polars/issues/1942
 t0 = time.time()
@@ -84,7 +85,7 @@ def test_cross_join() -> None:
     df2 = pl.DataFrame({"frame2": pl.arange(0, 100, eager=True)})
     out = df2.join(df1, how="cross")
     df2 = pl.DataFrame({"frame2": pl.arange(0, 101, eager=True)})
-    assert df2.join(df1, how="cross").slice(0, 100).frame_equal(out)
+    assert_frame_equal(df2.join(df1, how="cross").slice(0, 100), out)
 
 
 def test_cross_join_slice_pushdown() -> None:

--- a/py-polars/tests/slow/test_parquet.py
+++ b/py-polars/tests/slow/test_parquet.py
@@ -47,4 +47,4 @@ def test_parquet_chunks_545() -> None:
 
         # read it with polars
         polars_df = pl.read_parquet(f)
-        assert pl.DataFrame(df).frame_equal(polars_df)
+        assert_frame_equal(pl.DataFrame(df), polars_df)

--- a/py-polars/tests/unit/io/test_avro.py
+++ b/py-polars/tests/unit/io/test_avro.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import AvroCompression
@@ -49,7 +50,7 @@ def test_select_columns() -> None:
     f.seek(0)
 
     read_df = pl.read_avro(f, columns=["b", "c"])
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)
 
 
 def test_select_projection() -> None:
@@ -61,4 +62,4 @@ def test_select_projection() -> None:
     f.seek(0)
 
     read_df = pl.read_avro(f, columns=[1, 2])
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)

--- a/py-polars/tests/unit/io/test_avro.py
+++ b/py-polars/tests/unit/io/test_avro.py
@@ -28,7 +28,7 @@ def test_from_to_buffer(example_df: pl.DataFrame, compression: AvroCompression) 
     buf.seek(0)
 
     read_df = pl.read_avro(buf)
-    assert example_df.frame_equal(read_df)
+    assert_frame_equal(example_df, read_df)
 
 
 @pytest.mark.parametrize("compression", COMPRESSIONS)
@@ -38,7 +38,7 @@ def test_from_to_file(example_df: pl.DataFrame, compression: AvroCompression) ->
         example_df.write_avro(file_path, compression=compression)
         df_read = pl.read_avro(file_path)
 
-    assert example_df.frame_equal(df_read)
+    assert_frame_equal(example_df, df_read)
 
 
 def test_select_columns() -> None:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -464,7 +464,7 @@ def test_compressed_csv(io_files_path: Path) -> None:
     f2 = io.BytesIO(b"a,b\n1,2\n")
     out2 = pl.read_csv(f2)
     expected = pl.DataFrame({"a": [1], "b": [2]})
-    assert out2.frame_equal(expected)
+    assert_frame_equal(out2, expected)
 
 
 def test_partial_decompression(foods_file_path: Path) -> None:
@@ -540,7 +540,7 @@ def test_csv_quote_char() -> None:
             rolling_stones.encode(), quote_char=None, use_pyarrow=use_pyarrow
         )
         assert out.shape == (9, 3)
-        out.frame_equal(expected)
+        assert_frame_equal(out, expected)
 
 
 def test_csv_empty_quotes_char_1622() -> None:
@@ -710,7 +710,7 @@ def test_quoting_round_trip() -> None:
     f.seek(0)
     read_df = pl.read_csv(f)
 
-    assert read_df.frame_equal(df)
+    assert_frame_equal(read_df, df)
 
 
 def test_fallback_chrono_parser() -> None:
@@ -732,7 +732,7 @@ def test_csv_string_escaping() -> None:
     df.write_csv(f)
     f.seek(0)
     df_read = pl.read_csv(f)
-    assert df_read.frame_equal(df)
+    assert_frame_equal(df_read, df)
 
 
 def test_glob_csv(df_no_lists: pl.DataFrame) -> None:
@@ -790,7 +790,7 @@ def test_csv_multiple_null_values() -> None:
         }
     )
 
-    assert df2.frame_equal(expected)
+    assert_frame_equal(df2, expected)
 
 
 def test_different_eol_char() -> None:
@@ -798,8 +798,8 @@ def test_different_eol_char() -> None:
     expected = pl.DataFrame(
         {"column_1": ["a", "b", "c"], "column_2": [1, 2, 3], "column_3": [10, 20, 30]}
     )
-    assert pl.read_csv(csv.encode(), eol_char=";", has_header=False).frame_equal(
-        expected
+    assert_frame_equal(
+        pl.read_csv(csv.encode(), eol_char=";", has_header=False), expected
     )
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -440,17 +440,17 @@ def test_compressed_csv(io_files_path: Path) -> None:
     expected = pl.DataFrame(
         {"a": [1, 2, 3], "b": ["a", "b", "c"], "c": [1.0, 2.0, 3.0]}
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # now from disk
     csv_file = io_files_path / "gzipped.csv"
     out = pl.read_csv(str(csv_file))
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # now with column projection
     out = pl.read_csv(csv_bytes, columns=["a", "b"])
     expected = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # zlib compression
     csv_bytes = zlib.compress(csv.encode())
@@ -458,7 +458,7 @@ def test_compressed_csv(io_files_path: Path) -> None:
     expected = pl.DataFrame(
         {"a": [1, 2, 3], "b": ["a", "b", "c"], "c": [1.0, 2.0, 3.0]}
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # no compression
     f2 = io.BytesIO(b"a,b\n1,2\n")
@@ -591,10 +591,10 @@ def test_csv_date_handling() -> None:
         }
     )
     out = pl.read_csv(csv.encode(), parse_dates=True)
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
     dtypes = {"date": pl.Date}
     out = pl.read_csv(csv.encode(), dtypes=dtypes)
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
 
 def test_csv_globbing(io_files_path: Path) -> None:
@@ -665,7 +665,7 @@ def test_empty_string_missing_round_trip() -> None:
         df.write_csv(f, null_value=null)
         f.seek(0)
         df_read = pl.read_csv(f, null_values=null)
-        assert df.frame_equal(df_read)
+        assert_frame_equal(df, df_read)
 
 
 def test_write_csv_delimiter() -> None:
@@ -809,7 +809,7 @@ def test_csv_write_escape_newlines() -> None:
     df.write_csv(f)
     f.seek(0)
     read_df = pl.read_csv(f)
-    assert df.frame_equal(read_df)
+    assert_frame_equal(df, read_df)
 
 
 def test_skip_new_line_embedded_lines() -> None:

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -4,7 +4,7 @@ import pyarrow.fs
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_frame_not_equal
 
 
 @pytest.fixture()
@@ -23,7 +23,7 @@ def test_scan_delta_version(delta_table_path: Path) -> None:
     df1 = pl.scan_delta(str(delta_table_path), version=0).collect()
     df2 = pl.scan_delta(str(delta_table_path), version=1).collect()
 
-    assert not df1.frame_equal(df2)
+    assert_frame_not_equal(df1, df2)
 
 
 def test_scan_delta_columns(delta_table_path: Path) -> None:
@@ -50,7 +50,7 @@ def test_scan_delta_relative(delta_table_path: Path) -> None:
     assert_frame_equal(expected, ldf.collect(), check_dtype=False)
 
     ldf = pl.scan_delta(rel_delta_table_path, version=1)
-    assert not expected.frame_equal(ldf.collect())
+    assert_frame_not_equal(expected, ldf.collect())
 
 
 def test_read_delta(delta_table_path: Path) -> None:
@@ -64,7 +64,7 @@ def test_read_delta_version(delta_table_path: Path) -> None:
     df1 = pl.read_delta(str(delta_table_path), version=0)
     df2 = pl.read_delta(str(delta_table_path), version=1)
 
-    assert not df1.frame_equal(df2)
+    assert_frame_not_equal(df1, df2)
 
 
 def test_read_delta_columns(delta_table_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -85,7 +85,7 @@ def test_compressed_simple(compression: IpcCompression) -> None:
     f.seek(0)
 
     df_read = pl.read_ipc(f, use_pyarrow=False)
-    assert df_read.frame_equal(df)
+    assert_frame_equal(df_read, df)
 
 
 @pytest.mark.parametrize("compression", COMPRESSIONS)

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import IpcCompression
@@ -61,7 +61,7 @@ def test_select_columns_from_buffer() -> None:
     f.seek(0)
 
     read_df = pl.read_ipc(f, columns=["b", "c"], use_pyarrow=False)
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)
 
 
 def test_select_columns_projection() -> None:
@@ -73,7 +73,7 @@ def test_select_columns_projection() -> None:
     f.seek(0)
 
     read_df = pl.read_ipc(f, columns=[1, 2], use_pyarrow=False)
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)
 
 
 @pytest.mark.parametrize("compression", COMPRESSIONS)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -4,12 +4,13 @@ import copy
 from typing import cast
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_copy() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
-    assert copy.copy(df).frame_equal(df, True)
-    assert copy.deepcopy(df).frame_equal(df, True)
+    assert_frame_equal(copy.copy(df), df, True)
+    assert_frame_equal(copy.deepcopy(df), df, True)
 
     a = pl.Series("a", [1, 2])
     assert copy.copy(a).series_equal(a, True)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -9,8 +9,8 @@ from polars.testing import assert_frame_equal
 
 def test_copy() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
-    assert_frame_equal(copy.copy(df), df, True)
-    assert_frame_equal(copy.deepcopy(df), df, True)
+    assert_frame_equal(copy.copy(df), df)
+    assert_frame_equal(copy.deepcopy(df), df)
 
     a = pl.Series("a", [1, 2])
     assert copy.copy(a).series_equal(a, True)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -198,7 +198,7 @@ def test_chunked_round_trip() -> None:
     f = io.BytesIO()
     df.write_parquet(f)
     f.seek(0)
-    assert pl.read_parquet(f).frame_equal(df)
+    assert_frame_equal(pl.read_parquet(f), df)
 
 
 def test_lazy_self_join_file_cache_prop_3979(df: pl.DataFrame) -> None:
@@ -248,7 +248,7 @@ def test_row_group_size_saturation() -> None:
     # request larger chunk than rows in df
     df.write_parquet(f, row_group_size=1024)
     f.seek(0)
-    assert pl.read_parquet(f).frame_equal(df)
+    assert_frame_equal(pl.read_parquet(f), df)
 
 
 def test_nested_sliced() -> None:
@@ -262,7 +262,7 @@ def test_nested_sliced() -> None:
         f = io.BytesIO()
         df.write_parquet(f)
         f.seek(0)
-        assert pl.read_parquet(f).frame_equal(df)
+        assert_frame_equal(pl.read_parquet(f), df)
 
 
 def test_parquet_5795() -> None:
@@ -295,7 +295,7 @@ def test_parquet_5795() -> None:
     f = io.BytesIO()
     df_pd.to_parquet(f)
     f.seek(0)
-    assert pl.read_parquet(f).frame_equal(pl.from_pandas(df_pd))
+    assert_frame_equal(pl.read_parquet(f), pl.from_pandas(df_pd))
 
 
 @typing.no_type_check
@@ -322,7 +322,7 @@ def test_parquet_nesting_structs_list() -> None:
     df.write_parquet(f)
     f.seek(0)
 
-    assert pl.read_parquet(f).frame_equal(df)
+    assert_frame_equal(pl.read_parquet(f), df)
 
 
 @typing.no_type_check

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -103,7 +103,7 @@ def test_select_columns() -> None:
     f.seek(0)
 
     read_df = pl.read_parquet(f, columns=["b", "c"], use_pyarrow=False)
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)
 
 
 def test_select_projection() -> None:
@@ -114,7 +114,7 @@ def test_select_projection() -> None:
     f.seek(0)
 
     read_df = pl.read_parquet(f, columns=[1, 2], use_pyarrow=False)
-    assert expected.frame_equal(read_df)
+    assert_frame_equal(expected, read_df)
 
 
 @pytest.mark.parametrize("compression", COMPRESSIONS)
@@ -139,7 +139,7 @@ def test_parquet_datetime(compression: ParquetCompression, use_pyarrow: bool) ->
     df.write_parquet(f, use_pyarrow=use_pyarrow, compression=compression)
     f.seek(0)
     read = pl.read_parquet(f)
-    assert read.frame_equal(df)
+    assert_frame_equal(read, df)
 
 
 def test_nested_parquet() -> None:
@@ -238,7 +238,7 @@ def test_nested_dictionary() -> None:
         f.seek(0)
 
         read_df = pl.read_parquet(f)
-        assert df.frame_equal(read_df)
+        assert_frame_equal(df, read_df)
 
 
 def test_row_group_size_saturation() -> None:
@@ -346,7 +346,7 @@ def test_parquet_nested_dictionaries_6217() -> None:
         pq.write_table(table, f, compression="snappy")
         f.seek(0)
         read = pl.read_parquet(f)
-        assert read.frame_equal(df)
+        assert_frame_equal(read, df)
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")

--- a/py-polars/tests/unit/io/test_pickle.py
+++ b/py-polars/tests/unit/io/test_pickle.py
@@ -4,6 +4,7 @@ import io
 import pickle
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_pickle() -> None:
@@ -14,7 +15,7 @@ def test_pickle() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
     b = pickle.dumps(df)
     out = pickle.loads(b)
-    assert df.frame_equal(out, null_equal=True)
+    assert_frame_equal(df, out)
 
 
 def test_pickle_expr() -> None:

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -9,6 +9,7 @@ import pyarrow.dataset as ds
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 @typing.no_type_check
@@ -17,7 +18,7 @@ def helper_dataset_test(file_path: Path, query) -> None:
 
     expected = query(pl.scan_ipc(file_path))
     out = query(pl.scan_ds(dset))
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")

--- a/py-polars/tests/unit/test_aggregations.py
+++ b/py-polars/tests/unit/test_aggregations.py
@@ -1,13 +1,15 @@
 from datetime import datetime, timedelta
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_quantile_expr_input() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [0, 0, 0.3, 0.2, 0]})
 
-    assert df.select([pl.col("a").quantile(pl.col("b").sum() + 0.1)]).frame_equal(
-        df.select(pl.col("a").quantile(0.6))
+    assert_frame_equal(
+        df.select([pl.col("a").quantile(pl.col("b").sum() + 0.1)]),
+        df.select(pl.col("a").quantile(0.6)),
     )
 
 

--- a/py-polars/tests/unit/test_apply.py
+++ b/py-polars/tests/unit/test_apply.py
@@ -8,6 +8,7 @@ from typing import Sequence, no_type_check
 import numpy as np
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_apply_none() -> None:
@@ -119,7 +120,7 @@ def test_apply_struct() -> None:
         }
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_apply_numpy_out_3057() -> None:

--- a/py-polars/tests/unit/test_apply.py
+++ b/py-polars/tests/unit/test_apply.py
@@ -131,32 +131,29 @@ def test_apply_numpy_out_3057() -> None:
             "y": [0.0, 1, 1.3, 2, 3, 4],
         }
     )
-
-    assert (
-        df.groupby("id", maintain_order=True)
-        .agg(
-            pl.apply(["y", "t"], lambda lst: np.trapz(y=lst[0], x=lst[1])).alias(
-                "result"
-            )
-        )
-        .frame_equal(pl.DataFrame({"id": [0, 1], "result": [1.955, 13.0]}))
+    result = df.groupby("id", maintain_order=True).agg(
+        pl.apply(["y", "t"], lambda lst: np.trapz(y=lst[0], x=lst[1])).alias("result")
     )
+    expected = pl.DataFrame({"id": [0, 1], "result": [1.955, 13.0]})
+    assert_frame_equal(result, expected)
 
 
 def test_apply_numpy_int_out() -> None:
     df = pl.DataFrame({"col1": [2, 4, 8, 16]})
-    assert df.with_columns(
+    result = df.with_columns(
         pl.col("col1").apply(lambda x: np.left_shift(x, 8)).alias("result")
-    ).frame_equal(
-        pl.DataFrame({"col1": [2, 4, 8, 16], "result": [512, 1024, 2048, 4096]})
     )
-    df = pl.DataFrame({"col1": [2, 4, 8, 16], "shift": [1, 1, 2, 2]})
+    expected = pl.DataFrame({"col1": [2, 4, 8, 16], "result": [512, 1024, 2048, 4096]})
+    assert_frame_equal(result, expected)
 
-    assert df.select(
+    df = pl.DataFrame({"col1": [2, 4, 8, 16], "shift": [1, 1, 2, 2]})
+    result = df.select(
         pl.struct(["col1", "shift"])
         .apply(lambda cols: np.left_shift(cols["col1"], cols["shift"]))
         .alias("result")
-    ).frame_equal(pl.DataFrame({"result": [4, 8, 32, 64]}))
+    )
+    expected = pl.DataFrame({"result": [4, 8, 32, 64]})
+    assert_frame_equal(result, expected)
 
 
 def test_datelike_identity() -> None:

--- a/py-polars/tests/unit/test_arity.py
+++ b/py-polars/tests/unit/test_arity.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_nested_when_then_and_wildcard_expansion_6284() -> None:
@@ -25,7 +26,7 @@ def test_nested_when_then_and_wildcard_expansion_6284() -> None:
         .alias("result")
     )
 
-    assert out0.frame_equal(out1)
+    assert_frame_equal(out0, out1)
     assert out0.to_dict(False) == {
         "1": ["a", "b"],
         "2": ["c", "d"],

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -75,18 +75,18 @@ def test_categorical_lexical_sort() -> None:
     expected = pl.DataFrame(
         {"cats": ["a", "b", "k", "z", "z"], "vals": [2, 3, 2, 3, 1]}
     )
-    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert_frame_equal(out.with_columns(pl.col("cats").cast(pl.Utf8)), expected)
     out = df.sort(["cats", "vals"])
     expected = pl.DataFrame(
         {"cats": ["a", "b", "k", "z", "z"], "vals": [2, 3, 2, 1, 3]}
     )
-    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert_frame_equal(out.with_columns(pl.col("cats").cast(pl.Utf8)), expected)
     out = df.sort(["vals", "cats"])
 
     expected = pl.DataFrame(
         {"cats": ["z", "a", "k", "b", "z"], "vals": [1, 2, 2, 3, 3]}
     )
-    assert out.with_columns(pl.col("cats").cast(pl.Utf8)).frame_equal(expected)
+    assert_frame_equal(out.with_columns(pl.col("cats").cast(pl.Utf8)), expected)
 
 
 def test_categorical_lexical_ordering_after_concat() -> None:

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -5,6 +5,7 @@ import io
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_categorical_outer_join() -> None:
@@ -28,7 +29,7 @@ def test_categorical_outer_join() -> None:
     out = df1.join(df2, on=["key1", "key2"], how="outer").collect()
     expected = pl.DataFrame({"key1": [42], "key2": ["bar"], "val1": [1], "val2": [2]})
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     with pl.StringCache():
         dfa = pl.DataFrame(
             [

--- a/py-polars/tests/unit/test_categorical.py
+++ b/py-polars/tests/unit/test_categorical.py
@@ -26,10 +26,14 @@ def test_categorical_outer_join() -> None:
             ]
         ).lazy()
 
-    out = df1.join(df2, on=["key1", "key2"], how="outer").collect()
-    expected = pl.DataFrame({"key1": [42], "key2": ["bar"], "val1": [1], "val2": [2]})
+        expected = pl.DataFrame(
+            {"key1": [42], "key2": ["bar"], "val1": [1], "val2": [2]},
+            schema_overrides={"key2": pl.Categorical},
+        )
 
+    out = df1.join(df2, on=["key1", "key2"], how="outer").collect()
     assert_frame_equal(out, expected)
+
     with pl.StringCache():
         dfa = pl.DataFrame(
             [

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -6,6 +6,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 @pytest.fixture(autouse=True)
@@ -407,7 +408,7 @@ def test_string_cache() -> None:
     df1b = df1.with_columns(pl.col("a").cast(pl.Categorical))
     df2b = df2.with_columns(pl.col("a").cast(pl.Categorical))
     out = df1b.join(df2b, on="a", how="inner")
-    assert out.frame_equal(pl.DataFrame({"a": ["foo"], "b": [1], "c": [3]}))
+    assert_frame_equal(out, pl.DataFrame({"a": ["foo"], "b": [1], "c": [3]}))
 
 
 def test_config_load_save() -> None:

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -408,7 +408,11 @@ def test_string_cache() -> None:
     df1b = df1.with_columns(pl.col("a").cast(pl.Categorical))
     df2b = df2.with_columns(pl.col("a").cast(pl.Categorical))
     out = df1b.join(df2b, on="a", how="inner")
-    assert_frame_equal(out, pl.DataFrame({"a": ["foo"], "b": [1], "c": [3]}))
+
+    expected = pl.DataFrame(
+        {"a": ["foo"], "b": [1], "c": [3]}, schema_overrides={"a": pl.Categorical}
+    )
+    assert_frame_equal(out, expected)
 
 
 def test_config_load_save() -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_init_dict() -> None:
@@ -167,28 +168,28 @@ def test_init_dataclasses_and_namedtuple() -> None:
 def test_init_ndarray(monkeypatch: Any) -> None:
     # Empty array
     df = pl.DataFrame(np.array([]))
-    assert df.frame_equal(pl.DataFrame())
+    assert_frame_equal(df, pl.DataFrame())
 
     # 1D array
     df = pl.DataFrame(np.array([1, 2, 3]), schema=["a"])
     expected = pl.DataFrame({"a": [1, 2, 3]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(np.array([1, 2, 3]), schema=[("a", pl.Int32)])
     expected = pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").cast(pl.Int32))
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # 2D array (or 2x 1D array) - should default to column orientation
     for data in (np.array([[1, 2], [3, 4]]), [np.array([1, 2]), np.array([3, 4])]):
         df = pl.DataFrame(data, orient="col")
         expected = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
-        assert df.frame_equal(expected)
+        assert_frame_equal(df, expected)
 
     df = pl.DataFrame([[1, 2.0, "a"], [None, None, None]], orient="row")
     expected = pl.DataFrame(
         {"column_0": [1, None], "column_1": [2.0, None], "column_2": ["a", None]}
     )
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
         data=[[1, 2.0, "a"], [None, None, None]],
@@ -201,7 +202,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     # 2D array - default to column orientation
     df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
     expected = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # no orientation is numpy convention
     df = pl.DataFrame(np.ones((3, 1)))
@@ -210,12 +211,12 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     # 2D array - row orientation inferred
     df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), schema=["a", "b", "c"])
     expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # 2D array - column orientation inferred
     df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), schema=["a", "b"])
     expected = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # 2D array - orientation conflicts with columns
     with pytest.raises(ValueError):
@@ -265,12 +266,12 @@ def test_init_arrow() -> None:
     # Handle unnamed column
     df = pl.DataFrame(pa.table({"a": [1, 2], None: [3, 4]}))
     expected = pl.DataFrame({"a": [1, 2], "None": [3, 4]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # Rename columns
     df = pl.DataFrame(pa.table({"a": [1, 2], "b": [3, 4]}), schema=["c", "d"])
     expected = pl.DataFrame({"c": [1, 2], "d": [3, 4]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
         pa.table({"a": [1, 2], None: [3, 4]}),
@@ -288,11 +289,11 @@ def test_init_series() -> None:
     # List of Series
     df = pl.DataFrame([pl.Series("a", [1, 2, 3]), pl.Series("b", [4, 5, 6])])
     expected = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # Tuple of Series
     df = pl.DataFrame((pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))))
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
         (pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))),
@@ -306,7 +307,7 @@ def test_init_series() -> None:
     expected = pl.DataFrame(
         [pl.Series("column_0", [1, 2, 3]), pl.Series("column_1", [4, 5, 6])]
     )
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame([pl.Series([0.0]), pl.Series([1.0])])
     assert df.schema == {"column_0": pl.Float64, "column_1": pl.Float64}
@@ -323,7 +324,7 @@ def test_init_series() -> None:
     df = pl.DataFrame(pl.Series("a", [1, 2, 3]))
     expected = pl.DataFrame({"a": [1, 2, 3]})
     assert df.schema == {"a": pl.Int64}
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(pl.Series("a", [1, 2, 3]), schema=[("a", pl.UInt32)])
     assert df.rows() == [(1,), (2,), (3,)]
@@ -337,7 +338,7 @@ def test_init_seq_of_seq() -> None:
     # List of lists
     df = pl.DataFrame([[1, 2, 3], [4, 5, 6]], schema=["a", "b", "c"])
     expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
         [[1, 2, 3], [4, 5, 6]],
@@ -349,12 +350,12 @@ def test_init_seq_of_seq() -> None:
     # Tuple of tuples, default to column orientation
     df = pl.DataFrame(((1, 2, 3), (4, 5, 6)))
     expected = pl.DataFrame({"column_0": [1, 2, 3], "column_1": [4, 5, 6]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     # Row orientation
     df = pl.DataFrame(((1, 2), (3, 4)), schema=("a", "b"), orient="row")
     expected = pl.DataFrame({"a": [1, 3], "b": [2, 4]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
         ((1, 2), (3, 4)), schema=(("a", pl.Float32), ("b", pl.Float32)), orient="row"
@@ -370,14 +371,14 @@ def test_init_seq_of_seq() -> None:
 def test_init_1d_sequence() -> None:
     # Empty list
     df = pl.DataFrame([])
-    assert df.frame_equal(pl.DataFrame())
+    assert_frame_equal(df, pl.DataFrame())
 
     # List/array of strings
     data = ["a", "b", "c"]
     for a in (data, np.array(data)):
         df = pl.DataFrame(a, schema=["s"])
         expected = pl.DataFrame({"s": data})
-        assert df.frame_equal(expected)
+        assert_frame_equal(df, expected)
 
     df = pl.DataFrame([None, True, False], schema=[("xx", pl.Int8)])
     assert df.schema == {"xx": pl.Int8}
@@ -393,7 +394,7 @@ def test_init_pandas(monkeypatch: Any) -> None:
     # integer column names
     df = pl.DataFrame(pandas_df)
     expected = pl.DataFrame({"1": [1, 3], "2": [2, 4]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
     assert df.schema == {"1": pl.Int64, "2": pl.Int64}
 
     # override column names, types
@@ -460,7 +461,7 @@ def test_init_records() -> None:
     ]
     df = pl.DataFrame(dicts)
     expected = pl.DataFrame({"a": [1, 2, 1], "b": [2, 1, 2]})
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
     assert df.to_dicts() == dicts
 
     df_cd = pl.DataFrame(dicts, schema=["c", "d"])
@@ -501,9 +502,7 @@ def test_init_records_schema_order() -> None:
 def test_init_only_columns() -> None:
     df = pl.DataFrame(schema=["a", "b", "c"])
     expected = pl.DataFrame({"a": [], "b": [], "c": []})
-    assert df.shape == (0, 3)
-    assert df.frame_equal(expected, null_equal=True)
-    assert df.dtypes == [pl.Float32, pl.Float32, pl.Float32]
+    assert_frame_equal(df, expected)
 
     # Validate construction with various flavours of no/empty data
     no_data: Any
@@ -527,7 +526,7 @@ def test_init_only_columns() -> None:
         expected.insert_at_idx(3, pl.Series("d", [], pl.List(pl.UInt8)))
 
         assert df.shape == (0, 4)
-        assert df.frame_equal(expected, null_equal=True)
+        assert_frame_equal(df, expected)
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert df.schema["d"].inner == pl.UInt8  # type: ignore[union-attr]
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -171,7 +171,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert_frame_equal(df, pl.DataFrame())
 
     # 1D array
-    df = pl.DataFrame(np.array([1, 2, 3]), schema=["a"])
+    df = pl.DataFrame(np.array([1, 2, 3], dtype=np.int64), schema=["a"])
     expected = pl.DataFrame({"a": [1, 2, 3]})
     assert_frame_equal(df, expected)
 
@@ -180,7 +180,10 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert_frame_equal(df, expected)
 
     # 2D array (or 2x 1D array) - should default to column orientation
-    for data in (np.array([[1, 2], [3, 4]]), [np.array([1, 2]), np.array([3, 4])]):
+    for data in (
+        np.array([[1, 2], [3, 4]], dtype=np.int64),
+        [np.array([1, 2], dtype=np.int64), np.array([3, 4], dtype=np.int64)],
+    ):
         df = pl.DataFrame(data, orient="col")
         expected = pl.DataFrame({"column_0": [1, 2], "column_1": [3, 4]})
         assert_frame_equal(df, expected)
@@ -200,21 +203,25 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert df.schema == {"x": pl.Boolean, "y": pl.Int32, "z": pl.Utf8}
 
     # 2D array - default to column orientation
-    df = pl.DataFrame(np.array([[1, 2], [3, 4]]))
+    df = pl.DataFrame(np.array([[1, 2], [3, 4]], dtype=np.int64))
     expected = pl.DataFrame({"column_0": [1, 3], "column_1": [2, 4]})
     assert_frame_equal(df, expected)
 
     # no orientation is numpy convention
-    df = pl.DataFrame(np.ones((3, 1)))
+    df = pl.DataFrame(np.ones((3, 1), dtype=np.int64))
     assert df.shape == (3, 1)
 
     # 2D array - row orientation inferred
-    df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), schema=["a", "b", "c"])
+    df = pl.DataFrame(
+        np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64), schema=["a", "b", "c"]
+    )
     expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
     assert_frame_equal(df, expected)
 
     # 2D array - column orientation inferred
-    df = pl.DataFrame(np.array([[1, 2, 3], [4, 5, 6]]), schema=["a", "b"])
+    df = pl.DataFrame(
+        np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64), schema=["a", "b"]
+    )
     expected = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     assert_frame_equal(df, expected)
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -466,7 +466,7 @@ def test_init_records() -> None:
 
     df_cd = pl.DataFrame(dicts, schema=["c", "d"])
     expected = pl.DataFrame({"c": [1, 2, 1], "d": [2, 1, 2]})
-    assert df_cd.frame_equal(expected)
+    assert_frame_equal(df_cd, expected)
 
 
 def test_init_records_schema_order() -> None:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1516,7 +1516,7 @@ def test_timedelta_from() -> None:
             "B": timedelta(seconds=50),
         },
     ]
-    assert pl.DataFrame(as_dict).frame_equal(pl.DataFrame(as_rows))
+    assert_frame_equal(pl.DataFrame(as_dict), pl.DataFrame(as_rows))
 
 
 def test_duration_aggregations() -> None:
@@ -1701,7 +1701,7 @@ def test_groupby_rolling_by_() -> None:
         .groupby_rolling(index_column="datetime", by="group", period="3d")
         .agg([pl.count().alias("count")])
     )
-    assert out.sort(["group", "datetime"]).frame_equal(expected)
+    assert_frame_equal(out.sort(["group", "datetime"]), expected)
     assert out.to_dict(False) == {
         "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
         "datetime": [

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -852,7 +852,7 @@ def test_upsample() -> None:
         }
     ).with_columns(pl.col("time").dt.with_time_zone("UTC"))
 
-    assert up.frame_equal(expected)
+    assert_frame_equal(up, expected)
 
 
 def test_microseconds_accuracy() -> None:
@@ -937,7 +937,7 @@ def test_default_negative_every_offset_dynamic_groupby() -> None:
             "idx": [[0], [1, 2], [3]],
         }
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_strptime_dates_datetimes() -> None:
@@ -1008,7 +1008,7 @@ def test_asof_join_tolerance_grouper() -> None:
         }
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_datetime_duration_offset() -> None:
@@ -1062,7 +1062,7 @@ def test_datetime_duration_offset() -> None:
             ],
         }
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_date_duration_offset() -> None:
@@ -1180,7 +1180,7 @@ def test_rolling_groupby_by_argument() -> None:
         }
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_groupby_rolling_mean_3020() -> None:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1201,26 +1201,24 @@ def test_groupby_rolling_mean_3020() -> None:
 
     period: str | timedelta
     for period in ("1w", timedelta(days=7)):  # type: ignore[assignment]
-        assert (
-            df.groupby_rolling(index_column="Date", period=period)
-            .agg(pl.col("val").mean().alias("val_mean"))
-            .frame_equal(
-                pl.DataFrame(
-                    {
-                        "Date": [
-                            date(1998, 4, 12),
-                            date(1998, 4, 19),
-                            date(1998, 4, 26),
-                            date(1998, 5, 3),
-                            date(1998, 5, 10),
-                            date(1998, 5, 17),
-                            date(1998, 5, 24),
-                        ],
-                        "val_mean": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-                    }
-                )
-            )
+        result = df.groupby_rolling(index_column="Date", period=period).agg(
+            pl.col("val").mean().alias("val_mean")
         )
+        expected = pl.DataFrame(
+            {
+                "Date": [
+                    date(1998, 4, 12),
+                    date(1998, 4, 19),
+                    date(1998, 4, 26),
+                    date(1998, 5, 3),
+                    date(1998, 5, 10),
+                    date(1998, 5, 17),
+                    date(1998, 5, 24),
+                ],
+                "val_mean": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }
+        )
+        assert_frame_equal(result, expected)
 
 
 def test_asof_join() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -793,7 +793,7 @@ def test_from_arrow_table() -> None:
     tbl = pa.table(data)
 
     df = cast(pl.DataFrame, pl.from_arrow(tbl))
-    df.frame_equal(pl.DataFrame(data))
+    assert_frame_equal(df, pl.DataFrame(data))
 
 
 def test_df_stats(df: pl.DataFrame) -> None:
@@ -919,14 +919,15 @@ def test_multiple_column_sort() -> None:
 
     df = pl.DataFrame({"a": np.arange(1, 4), "b": ["a", "a", "b"]})
 
-    df.sort("a", reverse=True).frame_equal(
-        pl.DataFrame({"a": [3, 2, 1], "b": ["b", "a", "a"]})
+    assert_frame_equal(
+        df.sort("a", reverse=True), pl.DataFrame({"a": [3, 2, 1], "b": ["b", "a", "a"]})
     )
-    df.sort("b", reverse=True).frame_equal(
-        pl.DataFrame({"a": [3, 1, 2], "b": ["b", "a", "a"]})
+    assert_frame_equal(
+        df.sort("b", reverse=True), pl.DataFrame({"a": [3, 1, 2], "b": ["b", "a", "a"]})
     )
-    df.sort(["b", "a"], reverse=[False, True]).frame_equal(
-        pl.DataFrame({"a": [2, 1, 3], "b": ["a", "a", "b"]})
+    assert_frame_equal(
+        df.sort(["b", "a"], reverse=[False, True]),
+        pl.DataFrame({"a": [2, 1, 3], "b": ["a", "a", "b"]}),
     )
 
 
@@ -1009,9 +1010,8 @@ def test_string_cache_eager_lazy() -> None:
             }
         ).with_columns(pl.col("region_ids").cast(pl.Categorical))
 
-        assert df1.join(
-            df2, left_on="region_ids", right_on="seq_name", how="left"
-        ).frame_equal(expected, null_equal=True)
+        result = df1.join(df2, left_on="region_ids", right_on="seq_name", how="left")
+        assert_frame_equal(result, expected)
 
         # also check row-wise categorical insert.
         # (column-wise is preferred, but this shouldn't fail)
@@ -2228,11 +2228,11 @@ def test_asof_by_multiple_keys() -> None:
         }
     )
 
-    assert (
-        lhs.join_asof(rhs, on="a", by=["by", "by2"], strategy="backward")
-        .select(["a", "by"])
-        .frame_equal(pl.DataFrame({"a": [-20, -19, 8, 12, 14], "by": [1, 1, 2, 2, 2]}))
+    result = lhs.join_asof(rhs, on="a", by=["by", "by2"], strategy="backward").select(
+        ["a", "by"]
     )
+    expected = pl.DataFrame({"a": [-20, -19, 8, 12, 14], "by": [1, 1, 2, 2, 2]})
+    assert_frame_equal(result, expected)
 
 
 @typing.no_type_check

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2827,3 +2827,49 @@ def test_iter_slices() -> None:
     assert len(batches[0]) == 50
     assert len(batches[1]) == 45
     assert batches[1].rows() == df[50:].rows()
+
+
+def test_frame_equal() -> None:
+    # Values are checked
+    df1 = pl.DataFrame(
+        {
+            "foo": [1, 2, 3],
+            "bar": [6.0, 7.0, 8.0],
+            "ham": ["a", "b", "c"],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "foo": [3, 2, 1],
+            "bar": [8.0, 7.0, 6.0],
+            "ham": ["c", "b", "a"],
+        }
+    )
+
+    assert df1.frame_equal(df1)
+    assert not df1.frame_equal(df2)
+
+    # Column names are checked
+    df3 = pl.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [6.0, 7.0, 8.0],
+            "c": ["a", "b", "c"],
+        }
+    )
+    assert not df1.frame_equal(df3)
+
+    # Datatypes are NOT checked
+    df = pl.DataFrame(
+        {
+            "foo": [1, 2, None],
+            "bar": [6.0, 7.0, None],
+            "ham": ["a", "b", None],
+        }
+    )
+    assert df.frame_equal(df.with_columns(pl.col("foo").cast(pl.Int8)))
+    assert df.frame_equal(df.with_columns(pl.col("ham").cast(pl.Categorical)))
+
+    # The null_equal parameter determines if None values are considered equal
+    assert df.frame_equal(df)
+    assert not df.frame_equal(df, null_equal=False)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -369,7 +369,7 @@ def test_replace() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     s = pl.Series("c", [True, False, True])
     df.replace("a", s)
-    assert df.frame_equal(pl.DataFrame({"a": [True, False, True], "b": [1, 2, 3]}))
+    assert_frame_equal(df, pl.DataFrame({"a": [True, False, True], "b": [1, 2, 3]}))
 
 
 def test_assignment() -> None:
@@ -485,11 +485,11 @@ def test_drop_nulls() -> None:
             "ham": ["a", "c"],
         }
     )
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
     # below we only drop entries if they are null in the column 'foo'
     result = df.drop_nulls("foo")
-    assert result.frame_equal(df)
+    assert_frame_equal(result, df)
 
 
 def test_pipe() -> None:
@@ -500,7 +500,7 @@ def test_pipe() -> None:
 
     result = df.pipe(_multiply, mul=3)
 
-    assert result.frame_equal(df * 3)
+    assert_frame_equal(result, df * 3)
 
 
 def test_explode() -> None:
@@ -548,7 +548,7 @@ def test_hstack_dataframe(in_place: bool) -> None:
     )
     if in_place:
         df.hstack(df2, in_place=True)
-        assert df.frame_equal(expected)
+        assert_frame_equal(df, expected)
     else:
         df_out = df.hstack(df2, in_place=False)
         assert df_out.frame_equal(expected)
@@ -567,7 +567,7 @@ def test_vstack(in_place: bool) -> None:
     if in_place:
         assert df1.frame_equal(expected)
     else:
-        assert out.frame_equal(expected)
+        assert_frame_equal(out, expected)
 
 
 def test_extend() -> None:
@@ -697,7 +697,7 @@ def test_shift() -> None:
     b = pl.DataFrame(
         {"A": [None, "a", "b"], "B": [None, 1, 3]},
     )
-    assert a.frame_equal(b, null_equal=True)
+    assert_frame_equal(a, b)
 
 
 def test_to_dummies() -> None:
@@ -758,7 +758,7 @@ def test_get_dummies() -> None:
     expected = pl.DataFrame(
         {"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]}
     ).with_columns(pl.all().cast(pl.UInt8))
-    assert res.frame_equal(expected)
+    assert_frame_equal(res, expected)
 
     df = pl.DataFrame(
         {"i": [1, 2, 3], "category": ["dog", "cat", "cat"]},
@@ -773,7 +773,7 @@ def test_get_dummies() -> None:
         schema={"i": pl.Int32, "category_cat": pl.UInt8, "category_dog": pl.UInt8},
     )
     result = pl.get_dummies(df, columns=["category"])
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_to_pandas(df: pl.DataFrame) -> None:
@@ -1242,10 +1242,11 @@ def test_from_generator_or_iterable() -> None:
 
 def test_from_rows() -> None:
     df = pl.from_records([[1, 2, "foo"], [2, 3, "bar"]])
-    assert df.frame_equal(
+    assert_frame_equal(
+        df,
         pl.DataFrame(
             {"column_0": [1, 2], "column_1": [2, 3], "column_2": ["foo", "bar"]}
-        )
+        ),
     )
     df = pl.from_records(
         [[1, datetime.fromtimestamp(100)], [2, datetime.fromtimestamp(2398754908)]],
@@ -1438,7 +1439,7 @@ def test_unique_unit_rows() -> None:
     df = pl.DataFrame({"a": [1], "b": [None]})
 
     # 'unique' one-row frame should be equal to the original frame
-    assert df.frame_equal(df.unique(subset="a"))
+    assert_frame_equal(df, df.unique(subset="a"))
     for col in df.columns:
         assert df.n_unique(subset=[col]) == 1
 
@@ -1503,7 +1504,7 @@ def test_apply_dataframe_return() -> None:
             "column_3": ["c", "d", None],
         }
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
 
 def test_groupby_cat_list() -> None:
@@ -1593,7 +1594,7 @@ def test_transpose() -> None:
         }
     )
     out = df.transpose(include_header=True)
-    assert expected.frame_equal(out)
+    assert_frame_equal(expected, out)
 
     out = df.transpose(include_header=False, column_names=["a", "b", "c"])
     expected = pl.DataFrame(
@@ -1603,7 +1604,7 @@ def test_transpose() -> None:
             "c": [3, 3],
         }
     )
-    assert expected.frame_equal(out)
+    assert_frame_equal(expected, out)
 
     out = df.transpose(
         include_header=True, header_name="foo", column_names=["a", "b", "c"]
@@ -1616,7 +1617,7 @@ def test_transpose() -> None:
             "c": [3, 3],
         }
     )
-    assert expected.frame_equal(out)
+    assert_frame_equal(expected, out)
 
     def name_generator() -> Iterator[str]:
         base_name = "my_column_"
@@ -1633,7 +1634,7 @@ def test_transpose() -> None:
             "my_column_2": [3, 3],
         }
     )
-    assert expected.frame_equal(out)
+    assert_frame_equal(expected, out)
 
 
 def test_extension() -> None:
@@ -1713,7 +1714,7 @@ def test_with_column_renamed() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     result = df.rename({"b": "c"})
     expected = pl.DataFrame({"a": [1, 2], "c": [3, 4]})
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_rename_swap() -> None:
@@ -1731,7 +1732,7 @@ def test_rename_swap() -> None:
             "a": [5, 4, 3, 2, 1],
         }
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # 6195
     ldf = pl.DataFrame(
@@ -1830,7 +1831,7 @@ def test_shift_and_fill() -> None:
             "ham": ["0", "a", "b"],
         }
     )
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_is_duplicated() -> None:
@@ -1910,31 +1911,31 @@ def test_arithmetic() -> None:
     expected = pl.DataFrame({"a": [11.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
     out = df - df2
     expected = pl.DataFrame({"a": [-9.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
     out = df / df2
     expected = pl.DataFrame({"a": [0.1, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
     out = df * df2
     expected = pl.DataFrame({"a": [10.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
     out = df % df2
     expected = pl.DataFrame({"a": [1.0, None], "b": [None, None]}).with_columns(
         pl.col("b").cast(pl.Float64)
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
     # cannot do arithmetic with a sequence
     with pytest.raises(ValueError, match="Operation not supported"):
@@ -2133,7 +2134,7 @@ def test_groupby_slice_expression_args() -> None:
     expected = pl.DataFrame(
         {"groups": ["a", "a", "b", "b", "b", "b"], "vals": [1, 2, 12, 13, 14, 15]}
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_join_suffixes() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -917,7 +917,8 @@ def test_multiple_column_sort() -> None:
     assert list(out["c"]) == [2.0, 1.0, 3.0]
     assert list(out["b"]) == [2, 2, 3]
 
-    df = pl.DataFrame({"a": np.arange(1, 4), "b": ["a", "a", "b"]})
+    # Explicitly specify numpy dtype because of different defaults on Windows
+    df = pl.DataFrame({"a": np.arange(1, 4, dtype=np.int64), "b": ["a", "a", "b"]})
 
     assert_frame_equal(
         df.sort("a", reverse=True), pl.DataFrame({"a": [3, 2, 1], "b": ["b", "a", "a"]})

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -122,24 +122,24 @@ def test_selection() -> None:
     assert df["c"].to_list() == ["a", "b", "c"]
 
     # row selection by integers(s) in first dimension
-    assert df[0].frame_equal(pl.DataFrame({"a": [1], "b": [1.0], "c": ["a"]}))
-    assert df[-1].frame_equal(pl.DataFrame({"a": [3], "b": [3.0], "c": ["c"]}))
+    assert_frame_equal(df[0], pl.DataFrame({"a": [1], "b": [1.0], "c": ["a"]}))
+    assert_frame_equal(df[-1], pl.DataFrame({"a": [3], "b": [3.0], "c": ["c"]}))
 
     # row, column selection when using two dimensions
     assert df[:, 0].to_list() == [1, 2, 3]
     assert df[:, 1].to_list() == [1.0, 2.0, 3.0]
     assert df[:2, 2].to_list() == ["a", "b"]
 
-    assert df[[1, 2]].frame_equal(
-        pl.DataFrame({"a": [2, 3], "b": [2.0, 3.0], "c": ["b", "c"]})
+    assert_frame_equal(
+        df[[1, 2]], pl.DataFrame({"a": [2, 3], "b": [2.0, 3.0], "c": ["b", "c"]})
     )
-    assert df[[-1, -2]].frame_equal(
-        pl.DataFrame({"a": [3, 2], "b": [3.0, 2.0], "c": ["c", "b"]})
+    assert_frame_equal(
+        df[[-1, -2]], pl.DataFrame({"a": [3, 2], "b": [3.0, 2.0], "c": ["c", "b"]})
     )
 
     assert df[["a", "b"]].columns == ["a", "b"]
-    assert df[[1, 2], [1, 2]].frame_equal(
-        pl.DataFrame({"b": [2.0, 3.0], "c": ["b", "c"]})
+    assert_frame_equal(
+        df[[1, 2], [1, 2]], pl.DataFrame({"b": [2.0, 3.0], "c": ["b", "c"]})
     )
     assert typing.cast(str, df[1, 2]) == "b"
     assert typing.cast(float, df[1, 1]) == 2.0
@@ -153,9 +153,9 @@ def test_selection() -> None:
     assert df[:, "a":"b"].rows() == [(1, 1.0), (2, 2.0), (3, 3.0)]  # type: ignore[misc]
     assert df[:, "a":"c"].columns == ["a", "b", "c"]  # type: ignore[misc]
     expect = pl.DataFrame({"c": ["b"]})
-    assert df[1, [2]].frame_equal(expect)
+    assert_frame_equal(df[1, [2]], expect)
     expect = pl.DataFrame({"b": [1.0, 3.0]})
-    assert df[[0, 2], [1]].frame_equal(expect)
+    assert_frame_equal(df[[0, 2], [1]], expect)
     assert typing.cast(str, df[0, "c"]) == "a"
     assert typing.cast(str, df[1, "c"]) == "b"
     assert typing.cast(str, df[2, "c"]) == "c"
@@ -163,12 +163,12 @@ def test_selection() -> None:
 
     # more slicing
     expect = pl.DataFrame({"a": [3, 2, 1], "b": [3.0, 2.0, 1.0], "c": ["c", "b", "a"]})
-    assert df[::-1].frame_equal(expect)
+    assert_frame_equal(df[::-1], expect)
     expect = pl.DataFrame({"a": [1, 2], "b": [1.0, 2.0], "c": ["a", "b"]})
-    assert df[:-1].frame_equal(expect)
+    assert_frame_equal(df[:-1], expect)
 
     expect = pl.DataFrame({"a": [1, 3], "b": [1.0, 3.0], "c": ["a", "c"]})
-    assert df[::2].frame_equal(expect)
+    assert_frame_equal(df[::2], expect)
 
     # only allow boolean values in column position
     df = pl.DataFrame(
@@ -359,9 +359,9 @@ def test_dataframe_membership_operator() -> None:
 
 def test_sort() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
-    assert df.sort("a").frame_equal(pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
-    assert df.sort(["a", "b"]).frame_equal(
-        pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
+    assert_frame_equal(df.sort("a"), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]}))
+    assert_frame_equal(
+        df.sort(["a", "b"]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
 
 
@@ -432,7 +432,7 @@ def test_slice() -> None:
         [1, 2],  # slice == len(df)
         [1],  # optional len
     ):
-        assert df.slice(*slice_params).frame_equal(expected)
+        assert_frame_equal(df.slice(*slice_params), expected)
 
     for py_slice in (
         slice(1, 2),
@@ -450,9 +450,9 @@ def test_head_tail_limit() -> None:
     df = pl.DataFrame({"a": range(10), "b": range(10)})
 
     assert df.head(5).rows() == [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
-    assert df.limit(5).frame_equal(df.head(5))
+    assert_frame_equal(df.limit(5), df.head(5))
     assert df.tail(5).rows() == [(5, 5), (6, 6), (7, 7), (8, 8), (9, 9)]
-    assert not df.head(5).frame_equal(df.tail(5))
+    assert_frame_not_equal(df.head(5), df.tail(5))
 
     # check if it doesn't fail when out of bounds
     assert df.head(100).height == 10
@@ -460,7 +460,7 @@ def test_head_tail_limit() -> None:
     assert df.tail(100).height == 10
 
     # limit is an alias of head
-    assert df.head(5).frame_equal(df.limit(5))
+    assert_frame_equal(df.head(5), df.limit(5))
 
     # negative values
     assert df.head(-7).rows() == [(0, 0), (1, 1), (2, 2)]
@@ -551,7 +551,7 @@ def test_hstack_dataframe(in_place: bool) -> None:
         assert_frame_equal(df, expected)
     else:
         df_out = df.hstack(df2, in_place=False)
-        assert df_out.frame_equal(expected)
+        assert_frame_equal(df_out, expected)
 
 
 @pytest.mark.parametrize("in_place", [True, False])
@@ -565,7 +565,7 @@ def test_vstack(in_place: bool) -> None:
 
     out = df1.vstack(df2, in_place=in_place)
     if in_place:
-        assert df1.frame_equal(expected)
+        assert_frame_equal(df1, expected)
     else:
         assert_frame_equal(out, expected)
 
@@ -616,7 +616,7 @@ def test_extend() -> None:
         ).with_columns(
             pl.col("cat").cast(pl.Categorical),
         )
-        assert df1.frame_equal(expected)
+        assert_frame_equal(df1, expected)
 
 
 def test_drop() -> None:
@@ -1675,10 +1675,16 @@ def test_extension() -> None:
 
 def test_groupby_order_dispatch() -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
-    expected = pl.DataFrame({"x": ["b", "a"], "count": [2, 1]})
-    assert df.groupby("x", maintain_order=True).count().frame_equal(expected)
+
+    result = df.groupby("x", maintain_order=True).count()
+    expected = pl.DataFrame(
+        {"x": ["b", "a"], "count": [2, 1]}, schema_overrides={"count": pl.UInt32}
+    )
+    assert_frame_equal(result, expected)
+
+    result = df.groupby("x", maintain_order=True).agg_list()
     expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})
-    assert df.groupby("x", maintain_order=True).agg_list().frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_partitioned_groupby_order() -> None:
@@ -1795,16 +1801,22 @@ def test_rename_same_name() -> None:
 
 def test_fill_null() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, None]})
-    assert df.fill_null(4).frame_equal(pl.DataFrame({"a": [1, 2], "b": [3, 4]}))
-    assert df.fill_null(strategy="max").frame_equal(
-        pl.DataFrame({"a": [1, 2], "b": [3, 3]})
+    assert_frame_equal(df.fill_null(4), pl.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    assert_frame_equal(
+        df.fill_null(strategy="max"), pl.DataFrame({"a": [1, 2], "b": [3, 3]})
     )
 
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("nan")]})
-    assert df.fill_nan(4).frame_equal(pl.DataFrame({"a": [1, 2], "b": [3, 4]}))
-    assert df.fill_nan(None).frame_equal(pl.DataFrame({"a": [1, 2], "b": [3, None]}))
+    assert_frame_equal(
+        df.fill_nan(4),
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}),
+    )
+    assert_frame_equal(
+        df.fill_nan(None),
+        pl.DataFrame({"a": [1, 2], "b": [3.0, None]}),
+    )
     assert df["b"].fill_nan(5.0).to_list() == [3.0, 5.0]
     df = pl.DataFrame(
         {
@@ -1879,31 +1891,31 @@ def test_shrink_to_fit() -> None:
 
     assert df.shrink_to_fit(in_place=True) is df
     assert df.shrink_to_fit(in_place=False) is not df
-    assert df.shrink_to_fit(in_place=False).frame_equal(df)
+    assert_frame_equal(df.shrink_to_fit(in_place=False), df)
 
 
 def test_arithmetic() -> None:
     df = pl.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
 
     for df_mul in (df * 2, 2 * df):
-        expected = pl.DataFrame({"a": [2, 4], "b": [6, 8]})
-        assert df_mul.frame_equal(expected)
+        expected = pl.DataFrame({"a": [2.0, 4.0], "b": [6.0, 8.0]})
+        assert_frame_equal(df_mul, expected)
 
     for df_plus in (df + 2, 2 + df):
-        expected = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
-        assert df_plus.frame_equal(expected)
+        expected = pl.DataFrame({"a": [3.0, 4.0], "b": [5.0, 6.0]})
+        assert_frame_equal(df_plus, expected)
 
     df_div = df / 2
     expected = pl.DataFrame({"a": [0.5, 1.0], "b": [1.5, 2.0]})
-    assert df_div.frame_equal(expected)
+    assert_frame_equal(df_div, expected)
 
     df_minus = df - 2
-    expected = pl.DataFrame({"a": [-1, 0], "b": [1, 2]})
-    assert df_minus.frame_equal(expected)
+    expected = pl.DataFrame({"a": [-1.0, 0.0], "b": [1.0, 2.0]})
+    assert_frame_equal(df_minus, expected)
 
     df_mod = df % 2
     expected = pl.DataFrame({"a": [1.0, 0.0], "b": [1.0, 0.0]})
-    assert df_mod.frame_equal(expected)
+    assert_frame_equal(df_mod, expected)
 
     df2 = pl.DataFrame({"c": [10]})
 
@@ -1947,12 +1959,12 @@ def test_add_string() -> None:
     expected = pl.DataFrame(
         {"a": ["hi hello", "there hello"], "b": ["hello hello", "world hello"]}
     )
-    assert (df + " hello").frame_equal(expected)
+    assert_frame_equal((df + " hello"), expected)
 
     expected = pl.DataFrame(
         {"a": ["hello hi", "hello there"], "b": ["hello hello", "hello world"]}
     )
-    assert ("hello " + df).frame_equal(expected)
+    assert_frame_equal(("hello " + df), expected)
 
 
 def test_get_item() -> None:
@@ -1960,22 +1972,24 @@ def test_get_item() -> None:
     df = pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0], "b": [3, 4, 5, 6]})
 
     # expression
-    assert df.select(pl.col("a")).frame_equal(pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]}))
+    assert_frame_equal(
+        df.select(pl.col("a")), pl.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
+    )
 
     # tuple. The first element refers to the rows, the second element to columns
-    assert df[:, :].frame_equal(df)
+    assert_frame_equal(df[:, :], df)
 
     # str, always refers to a column name
     assert df["a"].series_equal(pl.Series("a", [1.0, 2.0, 3.0, 4.0]))
 
     # int, always refers to a row index (zero-based): index=1 => second row
-    assert df[1].frame_equal(pl.DataFrame({"a": [2.0], "b": [4]}))
+    assert_frame_equal(df[1], pl.DataFrame({"a": [2.0], "b": [4]}))
 
     # range, refers to rows
-    assert df[range(1, 3)].frame_equal(pl.DataFrame({"a": [2.0, 3.0], "b": [4, 5]}))
+    assert_frame_equal(df[range(1, 3)], pl.DataFrame({"a": [2.0, 3.0], "b": [4, 5]}))
 
     # slice. Below an example of taking every second row
-    assert df[1::2].frame_equal(pl.DataFrame({"a": [2.0, 4.0], "b": [4, 6]}))
+    assert_frame_equal(df[1::2], pl.DataFrame({"a": [2.0, 4.0], "b": [4, 6]}))
 
     # numpy array: assumed to be row indices if integers, or columns if strings
 
@@ -1990,14 +2004,20 @@ def test_get_item() -> None:
         np.uint32,
         np.uint64,
     ):
-        assert df[np.array([1, 0, 3, 2, 3, 0], dtype=np_dtype)].frame_equal(
-            pl.DataFrame({"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]})
+        assert_frame_equal(
+            df[np.array([1, 0, 3, 2, 3, 0], dtype=np_dtype)],
+            pl.DataFrame(
+                {"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]}
+            ),
         )
 
     # numpy array: positive and negative idxs.
     for np_dtype in (np.int8, np.int16, np.int32, np.int64):
-        assert df[np.array([-1, 0, -3, -2, 3, -4], dtype=np_dtype)].frame_equal(
-            pl.DataFrame({"a": [4.0, 1.0, 2.0, 3.0, 4.0, 1.0], "b": [6, 3, 4, 5, 6, 3]})
+        assert_frame_equal(
+            df[np.array([-1, 0, -3, -2, 3, -4], dtype=np_dtype)],
+            pl.DataFrame(
+                {"a": [4.0, 1.0, 2.0, 3.0, 4.0, 1.0], "b": [6, 3, 4, 5, 6, 3]}
+            ),
         )
 
     # note that we cannot use floats (even if they could be casted to integer without
@@ -2009,14 +2029,15 @@ def test_get_item() -> None:
     # if strings or list of expressions, assumed to be column names
     # if bools, assumed to be a row mask
     # if integers, assumed to be row indices
-    assert df[["a", "b"]].frame_equal(df)
-    assert df.select([pl.col("a"), pl.col("b")]).frame_equal(df)
-    assert df[[1, -4, -1, 2, 1]].frame_equal(
-        pl.DataFrame({"a": [2.0, 1.0, 4.0, 3.0, 2.0], "b": [4, 3, 6, 5, 4]})
+    assert_frame_equal(df[["a", "b"]], df)
+    assert_frame_equal(df.select([pl.col("a"), pl.col("b")]), df)
+    assert_frame_equal(
+        df[[1, -4, -1, 2, 1]],
+        pl.DataFrame({"a": [2.0, 1.0, 4.0, 3.0, 2.0], "b": [4, 3, 6, 5, 4]}),
     )
 
     # pl.Series: strings for column selections.
-    assert df[pl.Series("", ["a", "b"])].frame_equal(df)
+    assert_frame_equal(df[pl.Series("", ["a", "b"])], df)
 
     # pl.Series: positive idxs for row selection.
     for pl_dtype in (
@@ -2029,14 +2050,20 @@ def test_get_item() -> None:
         pl.UInt32,
         pl.UInt64,
     ):
-        assert df[pl.Series("", [1, 0, 3, 2, 3, 0], dtype=pl_dtype)].frame_equal(
-            pl.DataFrame({"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]})
+        assert_frame_equal(
+            df[pl.Series("", [1, 0, 3, 2, 3, 0], dtype=pl_dtype)],
+            pl.DataFrame(
+                {"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]}
+            ),
         )
 
     # pl.Series: positive and negative idxs for row selection.
     for pl_dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
-        assert df[pl.Series("", [-1, 0, -3, -2, 3, -4], dtype=pl_dtype)].frame_equal(
-            pl.DataFrame({"a": [4.0, 1.0, 2.0, 3.0, 4.0, 1.0], "b": [6, 3, 4, 5, 6, 3]})
+        assert_frame_equal(
+            df[pl.Series("", [-1, 0, -3, -2, 3, -4], dtype=pl_dtype)],
+            pl.DataFrame(
+                {"a": [4.0, 1.0, 2.0, 3.0, 4.0, 1.0], "b": [6, 3, 4, 5, 6, 3]}
+            ),
         )
 
     # Boolean masks not supported
@@ -2056,8 +2083,8 @@ def test_get_item() -> None:
     )
     assert df[4, 4] == 256
     assert df[4, 5] == 1024
-    assert df[4, [2]].frame_equal(pl.DataFrame({"fo2": [16]}))
-    assert df[4, [5]].frame_equal(pl.DataFrame({"fo5": [1024]}))
+    assert_frame_equal(df[4, [2]], pl.DataFrame({"fo2": [16]}))
+    assert_frame_equal(df[4, [5]], pl.DataFrame({"fo5": [1024]}))
 
 
 @pytest.mark.parametrize(
@@ -2170,8 +2197,9 @@ def test_explode_empty() -> None:
     assert df.explode("y").to_dict(False) == {"x": ["a", "b"], "y": [None, None]}
 
     df = pl.DataFrame({"x": ["1", "2", "4"], "y": [["a", "b", "c"], ["d"], []]})
-    assert df.explode("y").frame_equal(
-        pl.DataFrame({"x": ["1", "1", "1", "2", "4"], "y": ["a", "b", "c", "d", None]})
+    assert_frame_equal(
+        df.explode("y"),
+        pl.DataFrame({"x": ["1", "1", "1", "2", "4"], "y": ["a", "b", "c", "d", None]}),
     )
 
     df = pl.DataFrame(

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_empty_str_concat_lit() -> None:
@@ -13,4 +14,4 @@ def test_empty_str_concat_lit() -> None:
 def test_top_k_empty() -> None:
     df = pl.DataFrame({"test": []})
 
-    assert df.select([pl.col("test").top_k(2)]).frame_equal(df)
+    assert_frame_equal(df.select([pl.col("test").top_k(2)]), df)

--- a/py-polars/tests/unit/test_explode.py
+++ b/py-polars/tests/unit/test_explode.py
@@ -58,7 +58,7 @@ def test_explode_empty_df_3902() -> None:
             "second": ["a", None, "b", "c", None, "d", "f", "g"],
         }
     )
-    assert df.explode("second").frame_equal(expected)
+    assert_frame_equal(df.explode("second"), expected)
 
 
 def test_explode_empty_list_4003() -> None:
@@ -106,9 +106,10 @@ def test_explode_correct_for_slice() -> None:
             "row_nr": [0, 0, 0, 1, 1, 2, 3, 3, 3, 4, 5, 5, 5, 6, 6, 7, 8, 8, 8, 9],
             "group": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
             "b": [1, 2, 3, 2, 3, 4, 1, 2, 3, 0, 1, 2, 3, 2, 3, 4, 1, 2, 3, 0],
-        }
+        },
+        schema_overrides={"row_nr": pl.UInt32},
     )
-    assert df.slice(0, 10).explode(["b"]).frame_equal(expected)
+    assert_frame_equal(df.slice(0, 10).explode(["b"]), expected)
 
 
 def test_sliced_null_explode() -> None:

--- a/py-polars/tests/unit/test_expr_multi_cols.py
+++ b/py-polars/tests/unit/test_expr_multi_cols.py
@@ -1,11 +1,13 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_exclude_name_from_dtypes() -> None:
     df = pl.DataFrame({"a": ["a"], "b": ["b"]})
 
-    assert df.with_columns(pl.col(pl.Utf8).exclude("a").suffix("_foo")).frame_equal(
-        pl.DataFrame({"a": ["a"], "b": ["b"], "b_foo": ["b"]})
+    assert_frame_equal(
+        df.with_columns(pl.col(pl.Utf8).exclude("a").suffix("_foo")),
+        pl.DataFrame({"a": ["a"], "b": ["b"], "b_foo": ["b"]}),
     )
 
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -196,13 +196,8 @@ def test_split_exact() -> None:
     )
 
     assert_frame_equal(out, expected)
-    assert (
-        df["x"]
-        .str.split_exact("_", 2, inclusive=False)
-        .to_frame()
-        .unnest("x")
-        .frame_equal(expected)
-    )
+    out2 = df["x"].str.split_exact("_", 2, inclusive=False).to_frame().unnest("x")
+    assert_frame_equal(out2, expected)
 
     out = df.select([pl.col("x").str.split_exact("_", 1, inclusive=True)]).unnest("x")
 
@@ -249,16 +244,13 @@ def test_entropy() -> None:
             "id": [1, 2, 1, 4, 5, 4, 6],
         }
     )
-
-    assert (
-        df.groupby("group", maintain_order=True).agg(
-            pl.col("id").entropy(normalize=True)
-        )
-    ).frame_equal(
-        pl.DataFrame(
-            {"group": ["A", "B"], "id": [1.0397207708399179, 1.371381017771811]}
-        )
+    result = df.groupby("group", maintain_order=True).agg(
+        pl.col("id").entropy(normalize=True)
     )
+    expected = pl.DataFrame(
+        {"group": ["A", "B"], "id": [1.0397207708399179, 1.371381017771811]}
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_dot_in_groupby() -> None:
@@ -270,11 +262,11 @@ def test_dot_in_groupby() -> None:
         }
     )
 
-    assert (
-        df.groupby("group", maintain_order=True)
-        .agg(pl.col("x").dot("y").alias("dot"))
-        .frame_equal(pl.DataFrame({"group": ["a", "b"], "dot": [6, 15]}))
+    result = df.groupby("group", maintain_order=True).agg(
+        pl.col("x").dot("y").alias("dot")
     )
+    expected = pl.DataFrame({"group": ["a", "b"], "dot": [6, 15]})
+    assert_frame_equal(result, expected)
 
 
 def test_dtype_col_selection() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -16,7 +16,7 @@ from polars.datatypes import (
     NUMERIC_DTYPES,
     TEMPORAL_DTYPES,
 )
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_horizontal_agg(fruits_cars: pl.DataFrame) -> None:
@@ -132,7 +132,7 @@ def test_map_alias() -> None:
         (pl.col("foo") * 2).map_alias(lambda name: f"{name}{name}")
     )
     expected = pl.DataFrame({"foofoo": [2, 4, 6]})
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_unique_stable() -> None:
@@ -165,7 +165,7 @@ def test_split() -> None:
         ]
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert df["x"].str.split("_").to_frame().frame_equal(expected)
 
     out = df.select([pl.col("x").str.split("_", inclusive=True)])
@@ -179,7 +179,7 @@ def test_split() -> None:
         ]
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert df["x"].str.split("_", inclusive=True).to_frame().frame_equal(expected)
 
 
@@ -195,7 +195,7 @@ def test_split_exact() -> None:
         }
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert (
         df["x"]
         .str.split_exact("_", 2, inclusive=False)
@@ -209,7 +209,7 @@ def test_split_exact() -> None:
     expected = pl.DataFrame(
         {"field_0": ["a_", None, "b", "c_"], "field_1": ["a", None, None, "c"]}
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert df["x"].str.split_exact("_", 1).dtype == pl.Struct
     assert df["x"].str.split_exact("_", 1, inclusive=False).dtype == pl.Struct
 
@@ -222,7 +222,7 @@ def test_splitn() -> None:
         {"field_0": ["a", None, "b", "c"], "field_1": ["a", None, None, "c_c"]}
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert df["x"].str.splitn("_", 2).to_frame().unnest("x").frame_equal(expected)
 
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -60,8 +60,8 @@ def test_filter_where() -> None:
         pl.col("b").filter(pl.col("b") > 4).alias("c")
     )
     expected = pl.DataFrame({"a": [1, 2, 3], "c": [[7], [5, 8], [6, 9]]})
-    assert result_where.frame_equal(expected)
-    assert result_filter.frame_equal(expected)
+    assert_frame_equal(result_where, expected)
+    assert_frame_equal(result_filter, expected)
 
 
 def test_min_nulls_consistency() -> None:
@@ -166,7 +166,7 @@ def test_split() -> None:
     )
 
     assert_frame_equal(out, expected)
-    assert df["x"].str.split("_").to_frame().frame_equal(expected)
+    assert_frame_equal(df["x"].str.split("_").to_frame(), expected)
 
     out = df.select([pl.col("x").str.split("_", inclusive=True)])
 
@@ -180,7 +180,7 @@ def test_split() -> None:
     )
 
     assert_frame_equal(out, expected)
-    assert df["x"].str.split("_", inclusive=True).to_frame().frame_equal(expected)
+    assert_frame_equal(df["x"].str.split("_", inclusive=True).to_frame(), expected)
 
 
 def test_split_exact() -> None:
@@ -223,7 +223,7 @@ def test_splitn() -> None:
     )
 
     assert_frame_equal(out, expected)
-    assert df["x"].str.splitn("_", 2).to_frame().unnest("x").frame_equal(expected)
+    assert_frame_equal(df["x"].str.splitn("_", 2).to_frame().unnest("x"), expected)
 
 
 def test_unique_and_drop_stability() -> None:

--- a/py-polars/tests/unit/test_filter.py
+++ b/py-polars/tests/unit/test_filter.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_simplify_expression_lit_true_4376() -> None:
@@ -33,18 +34,18 @@ def test_filter_is_in_4572() -> None:
     expected = (
         df.groupby("id").agg(pl.col("k").filter(pl.col("k") == "a").list()).sort("id")
     )
-    assert (
+    result = (
         df.groupby("id")
         .agg(pl.col("k").filter(pl.col("k").is_in(["a"])).list())
         .sort("id")
-        .frame_equal(expected)
     )
-    assert (
+    assert_frame_equal(result, expected)
+    result = (
         df.sort("id")
         .groupby("id")
         .agg(pl.col("k").filter(pl.col("k").is_in(["a"])).list())
-        .frame_equal(expected)
     )
+    assert_frame_equal(result, expected)
 
 
 def test_filter_aggregation_any() -> None:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -186,7 +186,7 @@ def test_align_frames() -> None:
         .insert_at_idx(0, pf1["date"])
     )
     # confirm we match the same operation in pandas
-    assert pl_dot.frame_equal(pl.from_pandas(pd_dot))
+    assert_frame_equal(pl_dot, pl.from_pandas(pd_dot))
     pd.testing.assert_frame_equal(pd_dot, pl_dot.to_pandas())
 
     # (also: confirm alignment function works with lazyframes)
@@ -196,8 +196,8 @@ def test_align_frames() -> None:
         on="date",
     )
     assert isinstance(lf1, pl.LazyFrame)
-    assert lf1.collect().frame_equal(pf1)
-    assert lf2.collect().frame_equal(pf2)
+    assert_frame_equal(lf1.collect(), pf1)
+    assert_frame_equal(lf2.collect(), pf2)
 
     # misc
     assert [] == pl.align_frames(on="date")

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_date_datetime() -> None:
@@ -44,7 +45,7 @@ def test_diag_concat() -> None:
             }
         )
 
-        assert out.frame_equal(expected, null_equal=True)
+        assert_frame_equal(out, expected)
 
 
 def test_concat_horizontal() -> None:
@@ -61,7 +62,7 @@ def test_concat_horizontal() -> None:
             "e": [1, 2, 1, 2],
         }
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_all_any_horizontally() -> None:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -82,12 +82,13 @@ def test_all_any_horizontally() -> None:
             "all": [False, False, False, None, False],
         }
     )
-    assert df.select(
+    result = df.select(
         [
             pl.any([pl.col("var2"), pl.col("var3")]),
             pl.all([pl.col("var2"), pl.col("var3")]),
         ]
-    ).frame_equal(expected)
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_cut() -> None:

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -408,7 +408,7 @@ def test_groupby_all_masked_out() -> None:
     )
     parts = df.partition_by("val")
     assert len(parts) == 1
-    assert parts[0].frame_equal(df)
+    assert_frame_equal(parts[0], df)
 
 
 def test_groupby_min_max_string_type() -> None:

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-import polars.testing
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy
@@ -564,7 +564,7 @@ def test_jit_sort_joins() -> None:
         pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"])
 
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
-        assert a.frame_equal(pl_result, null_equal=True)
+        assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 
         # left key sorted right is not
@@ -573,7 +573,7 @@ def test_jit_sort_joins() -> None:
         pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"])
 
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
-        assert a.frame_equal(pl_result, null_equal=True)
+        assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 
 

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -105,7 +105,7 @@ def test_sorted_merge_joins() -> None:
                     df_b_.with_columns(pl.col("a").set_sorted(reverse)), on="a", how=how
                 )
 
-                assert out_hash_join.frame_equal(out_sorted_merge_join)
+                assert_frame_equal(out_hash_join, out_sorted_merge_join)
 
 
 def test_join_negative_integers() -> None:
@@ -373,7 +373,7 @@ def test_join() -> None:
 
     cols = ["a", "b", "bar", "ham"]
     assert lazy_join.shape == eager_join.shape
-    assert lazy_join.sort(by=cols).frame_equal(eager_join.sort(by=cols))
+    assert_frame_equal(lazy_join.sort(by=cols), eager_join.sort(by=cols))
 
 
 def test_joins_dispatch() -> None:
@@ -617,7 +617,7 @@ def test_asof_join_schema_5684() -> None:
     projected_result = q.select(pl.all()).collect()
     result = q.collect()
 
-    assert projected_result.frame_equal(result)
+    assert_frame_equal(projected_result, result)
     assert (
         q.schema
         == projected_result.schema

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -539,18 +539,19 @@ def test_sorted_flag_after_joins() -> None:
 @typing.no_type_check
 def test_jit_sort_joins() -> None:
     n = 200
+    # Explicitly specify numpy dtype because of different defaults on Windows
     dfa = pd.DataFrame(
         {
-            "a": np.random.randint(0, 100, n),
-            "b": np.arange(0, n),
+            "a": np.random.randint(0, 100, n, dtype=np.int64),
+            "b": np.arange(0, n, dtype=np.int64),
         }
     )
 
     n = 40
     dfb = pd.DataFrame(
         {
-            "a": np.random.randint(0, 100, n),
-            "b": np.arange(0, n),
+            "a": np.random.randint(0, 100, n, dtype=np.int64),
+            "b": np.arange(0, n, dtype=np.int64),
         }
     )
     dfa_pl = pl.from_pandas(dfa).sort("a")

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -68,7 +68,7 @@ def test_apply() -> None:
     new = df.lazy().with_columns(col("a").map(lambda s: s * 2).alias("foo")).collect()
 
     expected = df.clone().with_columns((pl.col("a") * 2).alias("foo"))
-    assert new.frame_equal(expected)
+    assert_frame_equal(new, expected)
 
 
 def test_add_eager_column() -> None:
@@ -163,11 +163,11 @@ def test_filter_str() -> None:
     # last row based on a filter
     result = q.filter(pl.col("bools")).select(pl.last("*")).collect()
     expected = pl.DataFrame({"time": ["11:13:00"], "bools": [True]})
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
     # last row based on a filter
     result = q.filter("bools").select(pl.last("*")).collect()
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_apply_custom_function() -> None:
@@ -206,7 +206,7 @@ def test_apply_custom_function() -> None:
         }
     )
     expected = expected.with_columns(pl.col("cars_count").cast(pl.UInt32))
-    assert a.frame_equal(expected)
+    assert_frame_equal(a, expected)
 
 
 def test_groupby() -> None:
@@ -262,7 +262,7 @@ def test_arange() -> None:
     df = pl.DataFrame({"a": [1, 1, 1]}).lazy()
     result = df.filter(pl.col("a") >= pl.arange(0, 3)).collect()
     expected = pl.DataFrame({"a": [1, 1]})
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_arg_unique() -> None:
@@ -353,7 +353,7 @@ def test_inspect(capsys: CaptureFixture[str]) -> None:
 
 def test_fetch(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.lazy().select("*").fetch(2)
-    assert res.frame_equal(res[:2])
+    assert_frame_equal(res, res[:2])
 
 
 def test_window_deadlock() -> None:
@@ -472,12 +472,14 @@ def test_head_groupby() -> None:
         {"letters": ["c", "c", "a", "c", "a", "b"], "nrs": [1, 2, 3, 4, 5, 6]}
     )
     out = df.groupby("letters").tail(2).sort("letters")
-    assert out.frame_equal(
-        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 2, 4]})
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 2, 4]}),
     )
     out = df.groupby("letters").head(2).sort("letters")
-    assert out.frame_equal(
-        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 1, 2]})
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 1, 2]}),
     )
 
 
@@ -713,7 +715,8 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
         ]
     )
 
-    assert out.frame_equal(
+    assert_frame_equal(
+        out,
         pl.DataFrame(
             {
                 "1": [1, 1, 1, 2, 3],
@@ -727,7 +730,7 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
                 "std": [None, None, 1.0, 1.0, 1.0],
                 "var": [None, None, 1.0, 1.0, 1.0],
             }
-        )
+        ),
     )
 
     out_single_val_variance = df.select(
@@ -863,7 +866,7 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             ],
         }
     )
-    assert out.frame_equal(expected, null_equal=True)
+    assert_frame_equal(out, expected)
 
 
 def test_arithmetic() -> None:
@@ -899,7 +902,7 @@ def test_arithmetic() -> None:
             "11": [-1, -2, -3],
         }
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     # floating point floor divide
     x = 10.4
@@ -930,7 +933,7 @@ def test_ufunc() -> None:
             pl.Series("power_uint16", [1, 4, 9, 16], dtype=pl.UInt16),
         ]
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
     assert out.dtypes == expected.dtypes
 
 
@@ -1282,7 +1285,7 @@ def test_lazy_concat(df: pl.DataFrame) -> None:
 
     out = pl.concat([df.lazy(), df.lazy()]).collect()
     assert out.shape == shape
-    assert out.frame_equal(df.vstack(df.clone()), null_equal=True)
+    assert_frame_equal(out, df.vstack(df.clone()))
 
 
 def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -215,11 +215,11 @@ def test_groupby() -> None:
     expected = pl.DataFrame({"groups": ["a", "b"], "a": [1.0, 3.5]})
 
     out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
-    assert out.sort(by="groups").frame_equal(expected)
+    assert_frame_equal(out.sort(by="groups"), expected)
 
     # refer to column via pl.Expr
     out = df.lazy().groupby(pl.col("groups")).agg(pl.mean("a")).collect()
-    assert out.sort(by="groups").frame_equal(expected)
+    assert_frame_equal(out.sort(by="groups"), expected)
 
 
 def test_shift(fruits_cars: pl.DataFrame) -> None:
@@ -237,7 +237,7 @@ def test_shift(fruits_cars: pl.DataFrame) -> None:
             "cars": [None, None, "beetle", "audi", "beetle"],
         }
     )
-    res.frame_equal(expected, null_equal=True)
+    assert_frame_equal(res, expected)
 
     # negative value
     res = fruits_cars.lazy().shift(-2).collect()
@@ -557,7 +557,7 @@ def test_drop_nulls() -> None:
 
 def test_all_expr() -> None:
     df = pl.DataFrame({"nrs": [1, 2, 3, 4, 5, None]})
-    assert df.select([pl.all()]).frame_equal(df)
+    assert_frame_equal(df.select([pl.all()]), df)
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:
@@ -1015,19 +1015,19 @@ def test_with_columns_single_series() -> None:
 def test_reverse() -> None:
     out = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).lazy().reverse()
     expected = pl.DataFrame({"a": [2, 1], "b": [4, 3]})
-    assert out.collect().frame_equal(expected)
+    assert_frame_equal(out.collect(), expected)
 
 
 def test_limit(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().limit(1).collect().frame_equal(fruits_cars[0, :])
+    assert_frame_equal(fruits_cars.lazy().limit(1).collect(), fruits_cars[0, :])
 
 
 def test_head(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().head(2).collect().frame_equal(fruits_cars[:2, :])
+    assert_frame_equal(fruits_cars.lazy().head(2).collect(), fruits_cars[:2, :])
 
 
 def test_tail(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().tail(2).collect().frame_equal(fruits_cars[3:, :])
+    assert_frame_equal(fruits_cars.lazy().tail(2).collect(), fruits_cars[3:, :])
 
 
 def test_last(fruits_cars: pl.DataFrame) -> None:
@@ -1040,7 +1040,7 @@ def test_last(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_first(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().first().collect().frame_equal(fruits_cars[0, :])
+    assert_frame_equal(fruits_cars.lazy().first().collect(), fruits_cars[0, :])
 
 
 def test_join_suffix() -> None:
@@ -1257,7 +1257,7 @@ def test_unique() -> None:
     df = pl.DataFrame({"a": [1, 2, 2], "b": [3, 3, 3]})
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 3]})
-    assert df.lazy().unique(maintain_order=True).collect().frame_equal(expected)
+    assert_frame_equal(df.lazy().unique(maintain_order=True).collect(), expected)
 
     expected = pl.DataFrame({"a": [1], "b": [3]})
     assert (

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_list_arr_get() -> None:
@@ -236,7 +236,7 @@ def test_list_arr_empty() -> None:
     expected = pl.DataFrame(
         {"cars_first": [1, 2, 4, None], "cars_literal": [2, 1, 3, 3]}
     )
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_list_argminmax() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -544,21 +544,14 @@ def test_list_sliced_get_5186() -> None:
         }
     )
 
-    assert df.select(
-        [
-            "ind",
-            pl.col("inds").arr.first().alias("first_element"),
-            pl.col("inds").arr.last().alias("last_element"),
-        ]
-    )[10:20].frame_equal(
-        df[10:20].select(
-            [
-                "ind",
-                pl.col("inds").arr.first().alias("first_element"),
-                pl.col("inds").arr.last().alias("last_element"),
-            ]
-        )
-    )
+    exprs = [
+        "ind",
+        pl.col("inds").arr.first().alias("first_element"),
+        pl.col("inds").arr.last().alias("last_element"),
+    ]
+    out1 = df.select(exprs)[10:20]
+    out2 = df[10:20].select(exprs)
+    assert_frame_equal(out1, out2)
 
 
 def test_empty_eval_dtype_5546() -> None:

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -698,7 +698,7 @@ def test_concat_list_in_agg_6397() -> None:
 
 
 def test_list_eval_all_null() -> None:
-    df = pl.DataFrame({"foo": [1, 2, 3], "bar": [None, None, None]}).with_column(
+    df = pl.DataFrame({"foo": [1, 2, 3], "bar": [None, None, None]}).with_columns(
         pl.col("bar").cast(pl.List(pl.Utf8))
     )
 

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -234,7 +234,8 @@ def test_list_arr_empty() -> None:
         ]
     )
     expected = pl.DataFrame(
-        {"cars_first": [1, 2, 4, None], "cars_literal": [2, 1, 3, 3]}
+        {"cars_first": [1, 2, 4, None], "cars_literal": [2, 1, 3, 3]},
+        schema_overrides={"cars_literal": pl.Int32},  # Literals default to Int32
     )
     assert_frame_equal(out, expected)
 

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -137,6 +138,7 @@ def test_maintain_order_after_sampling() -> None:
     ) == {"type": ["A", "B", "C", "D"], "value": [5, 8, 5, 7]}
 
 
+@pytest.mark.xfail(reason="Currently bugged, see issue #6556")
 def test_sorted_groupby_optimization() -> None:
     df = pl.DataFrame({"a": np.random.randint(0, 5, 20)})
 
@@ -148,9 +150,8 @@ def test_sorted_groupby_optimization() -> None:
             .groupby("a")
             .agg(pl.count())
         )
-
         sorted_explicit = df.groupby("a").agg(pl.count()).sort("a", reverse=reverse)
-        sorted_explicit.frame_equal(sorted_implicit)
+        assert_frame_equal(sorted_explicit, sorted_implicit)
 
 
 def test_median_on_shifted_col_3522() -> None:

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
-import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -138,8 +138,9 @@ def test_maintain_order_after_sampling() -> None:
     ) == {"type": ["A", "B", "C", "D"], "value": [5, 8, 5, 7]}
 
 
-@pytest.mark.xfail(reason="Currently bugged, see issue #6556")
-def test_sorted_groupby_optimization() -> None:
+def test_sorted_groupby_optimization(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("POLARS_NO_STREAMING_GROUPBY", "1")
+
     df = pl.DataFrame({"a": np.random.randint(0, 5, 20)})
 
     # the sorted optimization should not randomize the

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_sort_by_bools() -> None:
@@ -77,7 +78,7 @@ def test_agg_after_head() -> None:
         if not maintain_order:
             out = out.sort("a")
 
-        assert out.frame_equal(expected)
+        assert_frame_equal(out, expected)
 
 
 def test_overflow_uint16_agg_mean() -> None:

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_schema_on_agg() -> None:
@@ -116,7 +117,7 @@ def test_lazy_map_schema() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
 
     # identity
-    assert df.lazy().map(lambda x: x).collect().frame_equal(df)
+    assert_frame_equal(df.lazy().map(lambda x: x).collect(), df)
 
     def custom(df: pl.DataFrame) -> pl.Series:
         return df["a"]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1596,7 +1596,11 @@ def test_abs() -> None:
 def test_to_dummies() -> None:
     s = pl.Series("a", [1, 2, 3])
     result = s.to_dummies()
-    expected = pl.DataFrame({"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]})
+    expected = pl.DataFrame(
+        {"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]},
+        schema={"a_1": pl.UInt8, "a_2": pl.UInt8, "a_3": pl.UInt8},
+    )
+    print(result)
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1597,7 +1597,7 @@ def test_to_dummies() -> None:
     s = pl.Series("a", [1, 2, 3])
     result = s.to_dummies()
     expected = pl.DataFrame({"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]})
-    assert result.frame_equal(expected)
+    assert_frame_equal(result, expected)
 
 
 def test_value_counts() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1600,7 +1600,6 @@ def test_to_dummies() -> None:
         {"a_1": [1, 0, 0], "a_2": [0, 1, 0], "a_3": [0, 0, 1]},
         schema={"a_1": pl.UInt8, "a_2": pl.UInt8, "a_3": pl.UInt8},
     )
-    print(result)
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1315,7 +1315,7 @@ def test_range() -> None:
     assert s3.dtype == pl.List(pl.List(pl.Int64))
 
     df = pl.DataFrame([s1])
-    assert df[2:5].frame_equal(df[range(2, 5)])
+    assert_frame_equal(df[2:5], df[range(2, 5)])
 
 
 def test_strict_cast() -> None:
@@ -1606,9 +1606,11 @@ def test_to_dummies() -> None:
 def test_value_counts() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     result = s.value_counts()
-    expected = pl.DataFrame({"a": [1, 2, 3], "counts": [1, 2, 1]})
-    result_sorted: pl.DataFrame = result.sort("a")
-    assert result_sorted.frame_equal(expected)
+    expected = pl.DataFrame(
+        {"a": [1, 2, 3], "counts": [1, 2, 1]}, schema_overrides={"counts": pl.UInt32}
+    )
+    result_sorted = result.sort("a")
+    assert_frame_equal(result_sorted, expected)
 
 
 def test_chunk_lengths() -> None:

--- a/py-polars/tests/unit/test_sort.py
+++ b/py-polars/tests/unit/test_sort.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_sort_dates_multiples() -> None:
@@ -168,7 +169,7 @@ def test_sort_aggregation_fast_paths() -> None:
                     .suffix("_min"),
                 ]
             )
-            assert out.frame_equal(expected)
+            assert_frame_equal(out, expected)
 
 
 def test_sorted_join_and_dtypes() -> None:

--- a/py-polars/tests/unit/test_sort.py
+++ b/py-polars/tests/unit/test_sort.py
@@ -239,7 +239,7 @@ def test_top_k() -> None:
 
     # 5886
     df = pl.DataFrame({"test": [4, 3, 2, 1]})
-    assert df.select(pl.col("test").top_k(10)).frame_equal(df)
+    assert_frame_equal(df.select(pl.col("test").top_k(10)), df)
 
 
 def test_sorted_flag_unset_by_arithmetic_4937() -> None:

--- a/py-polars/tests/unit/test_sort.py
+++ b/py-polars/tests/unit/test_sort.py
@@ -295,13 +295,11 @@ def test_sort_slice_fast_path_5245() -> None:
 
 def test_explicit_list_agg_sort_in_groupby() -> None:
     df = pl.DataFrame({"A": ["a", "a", "a", "b", "b", "a"], "B": [1, 2, 3, 4, 5, 6]})
-    assert (
-        df.groupby("A")
-        # this was col().list().sort() before we changed the logic
-        .agg(pl.col("B").sort(reverse=True))
-        .sort("A")
-        .frame_equal(df.groupby("A").agg(pl.col("B").sort(reverse=True)).sort("A"))
-    )
+
+    # this was col().list().sort() before we changed the logic
+    result = df.groupby("A").agg(pl.col("B").sort(reverse=True)).sort("A")
+    expected = df.groupby("A").agg(pl.col("B").sort(reverse=True)).sort("A")
+    assert_frame_equal(result, expected)
 
 
 def test_sorted_join_query_5406() -> None:

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_streaming_groupby_types() -> None:
@@ -119,14 +120,14 @@ def test_streaming_non_streaming_gb() -> None:
     n = 100
     df = pl.DataFrame({"a": np.random.randint(0, 20, n)})
     q = df.lazy().groupby("a").agg(pl.count()).sort("a")
-    assert q.collect(streaming=True).frame_equal(q.collect())
+    assert_frame_equal(q.collect(streaming=True), q.collect())
 
     q = df.lazy().with_columns(pl.col("a").cast(pl.Utf8))
     q = q.groupby("a").agg(pl.count()).sort("a")
-    assert q.collect(streaming=True).frame_equal(q.collect())
+    assert_frame_equal(q.collect(streaming=True), q.collect())
     q = df.lazy().with_columns(pl.col("a").alias("b"))
     q = q.groupby(["a", "b"]).agg(pl.count()).sort("a")
-    assert q.collect(streaming=True).frame_equal(q.collect())
+    assert_frame_equal(q.collect(streaming=True), q.collect())
 
 
 def test_streaming_groupby_sorted_fast_path() -> None:
@@ -162,7 +163,7 @@ def test_streaming_groupby_sorted_fast_path() -> None:
             )
             results.append(out)
 
-        assert results[0].frame_equal(results[1])
+        assert_frame_equal(results[0], results[1])
 
 
 def test_streaming_categoricals_5921() -> None:

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -54,7 +54,7 @@ def test_apply_unnest() -> None:
         }
     )
 
-    assert df.frame_equal(expected)
+    assert_frame_equal(df, expected)
 
 
 def test_rename_fields() -> None:
@@ -86,7 +86,7 @@ def test_struct_unnesting() -> None:
         }
     )
 
-    assert out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
     out = (
         df.lazy()

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -24,7 +24,7 @@ def test_struct_various() -> None:
     assert s.struct.field("list").to_list() == [[1, 2], [3]]
     assert s.struct.field("int").to_list() == [1, 2]
 
-    assert df.to_struct("my_struct").struct.unnest().frame_equal(df)
+    assert_frame_equal(df.to_struct("my_struct").struct.unnest(), df)
     assert s.struct._ipython_key_completions_() == s.struct.fields
 
 
@@ -102,7 +102,7 @@ def test_struct_unnesting() -> None:
         .unnest("foo")
         .collect()
     )
-    out.frame_equal(expected)
+    assert_frame_equal(out, expected)
 
 
 def test_struct_function_expansion() -> None:
@@ -704,7 +704,6 @@ def test_concat_list_reverse_struct_fields() -> None:
     )
     result1 = df.select(pl.concat_list(["combo", "reverse_combo"]))
     result2 = df.select(pl.concat_list(["combo", "combo"]))
-
     assert_frame_equal(result1, result2)
 
 

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -101,7 +101,6 @@ def test_arange_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
     expr = pl.arange(0, pl.count()).over("x")  # type: ignore[union-attr]
     out = df.with_columns(expr)
-    print(out)
     assert_frame_equal(
         out, pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "arange": [0, 1, 0, 1, 0, 1]})
     )

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64, pl.Int32])
@@ -100,14 +101,16 @@ def test_arange_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
     expr = pl.arange(0, pl.count()).over("x")  # type: ignore[union-attr]
     out = df.with_columns(expr)
-    assert out.frame_equal(
-        pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "arange": [0, 1, 0, 1, 0, 1]})
+    assert_frame_equal(
+        out, pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "arange": [0, 1, 0, 1, 0, 1]})
     )
 
     df = pl.DataFrame({"x": []})
     out = df.with_columns(expr)
-    assert out.frame_equal(pl.DataFrame({"x": [], "arange": []}))
-    assert out.schema == {"x": pl.Float32, "arange": pl.Int64}
+    expected = pl.DataFrame(
+        {"x": [], "arange": []}, schema={"x": pl.Float32, "arange": pl.Int64}
+    )
+    assert_frame_equal(out, expected)
 
 
 def test_no_panic_on_nan_3067() -> None:

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -244,7 +244,7 @@ def test_sorted_window_expression() -> None:
     df = df.sort("b")
     out2 = df.with_columns(expr)
 
-    assert out1.frame_equal(out2)
+    assert_frame_equal(out1, out2)
 
 
 def test_nested_aggregation_window_expression() -> None:

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -101,6 +101,7 @@ def test_arange_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
     expr = pl.arange(0, pl.count()).over("x")  # type: ignore[union-attr]
     out = df.with_columns(expr)
+    print(out)
     assert_frame_equal(
         out, pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "arange": [0, 1, 0, 1, 0, 1]})
     )


### PR DESCRIPTION
Relates to https://github.com/pola-rs/polars/issues/6364

`assert_frame_equal` is more powerful as it checks dtypes as well, and has better error messages.

I found a few bugs (these are now fixed in different PRs), as well as found a few tests that weren't asserting the equality (simply `df.frame_equal(expected)` without the assert 😄 )

### Random interesting tidbit

Different default dtypes for numpy arrays between Linux/Windows

```
# On Windows
>>> np.array([1, 2, 3]).dtype
dtype('int32')

# On Linux
>>> np.array([1, 2, 3]).dtype
dtype('int64')
```

This broke some tests, which I fixed by explicitly specifying the numpy dtype as `np.int64`.