### PR TITLE
fix(rust, python): let lhs determine struct order in supertype

### DIFF
--- a/polars/polars-core/src/utils/supertype.rs
+++ b/polars/polars-core/src/utils/supertype.rs
@@ -275,7 +275,9 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
 #[cfg(feature = "dtype-struct")]
 fn union_struct_fields(fields_a: &[Field], fields_b: &[Field]) -> Option<DataType> {
     let (longest, shortest) = {
-        if fields_a.len() > fields_b.len() {
+        // if equal length we also take the lhs
+        // so that the lhs determines the order of the fields
+        if fields_a.len() >= fields_b.len() {
             (fields_a, fields_b)
         } else {
             (fields_b, fields_a)

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_struct_various() -> None:
@@ -701,9 +702,10 @@ def test_concat_list_reverse_struct_fields() -> None:
             pl.struct(["nums", "letters"]).alias("reverse_combo"),
         ]
     )
-    assert df.select(pl.concat_list(["combo", "reverse_combo"])).frame_equal(
-        df.select(pl.concat_list(["combo", "combo"]))
-    )
+    result1 = df.select(pl.concat_list(["combo", "reverse_combo"]))
+    result2 = df.select(pl.concat_list(["combo", "combo"]))
+
+    assert_frame_equal(result1, result2)
 
 
 def test_struct_any_value_get_after_append() -> None:


### PR DESCRIPTION
fixes #6555