### PR TITLE
test(python): Use `assert_series_equal` instead of `s.series_equal(...)`

### DIFF
--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -4,7 +4,7 @@ import copy
 from typing import cast
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_copy() -> None:
@@ -13,8 +13,8 @@ def test_copy() -> None:
     assert_frame_equal(copy.deepcopy(df), df)
 
     a = pl.Series("a", [1, 2])
-    assert copy.copy(a).series_equal(a, True)
-    assert copy.deepcopy(a).series_equal(a, True)
+    assert_series_equal(copy.copy(a), a)
+    assert_series_equal(copy.deepcopy(a), a)
 
 
 def test_categorical_round_trip() -> None:

--- a/py-polars/tests/unit/io/test_pickle.py
+++ b/py-polars/tests/unit/io/test_pickle.py
@@ -4,14 +4,14 @@ import io
 import pickle
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_pickle() -> None:
     a = pl.Series("a", [1, 2])
     b = pickle.dumps(a)
     out = pickle.loads(b)
-    assert a.series_equal(out)
+    assert_series_equal(a, out)
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
     b = pickle.dumps(df)
     out = pickle.loads(b)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -749,7 +749,7 @@ def test_concat() -> None:
 
 def test_arg_where() -> None:
     s = pl.Series([True, False, True, False])
-    assert pl.arg_where(s, eager=True).cast(int).series_equal(pl.Series([0, 2]))
+    assert_series_equal(pl.arg_where(s, eager=True).cast(int), pl.Series([0, 2]))
 
 
 def test_get_dummies() -> None:
@@ -810,14 +810,17 @@ def test_df_stats(df: pl.DataFrame) -> None:
 def test_df_fold() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
 
-    assert df.fold(lambda s1, s2: s1 + s2).series_equal(pl.Series("a", [4.0, 5.0, 9.0]))
-    assert df.fold(lambda s1, s2: s1.zip_with(s1 < s2, s2)).series_equal(
-        pl.Series("a", [1.0, 1.0, 3.0])
+    assert_series_equal(
+        df.fold(lambda s1, s2: s1 + s2), pl.Series("a", [4.0, 5.0, 9.0])
+    )
+    assert_series_equal(
+        df.fold(lambda s1, s2: s1.zip_with(s1 < s2, s2)),
+        pl.Series("a", [1.0, 1.0, 3.0]),
     )
 
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.fold(lambda s1, s2: s1 + s2)
-    out.series_equal(pl.Series("", ["foo11", "bar22", "233"]))
+    assert_series_equal(out, pl.Series("a", ["foo11.0", "bar22.0", "233.0"]))
 
     df = pl.DataFrame({"a": [3, 2, 1], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     # just check dispatch. values are tested on rust side.
@@ -827,7 +830,7 @@ def test_df_fold() -> None:
     assert len(df.max(axis=1)) == 3
 
     df_width_one = df[["a"]]
-    assert df_width_one.fold(lambda s1, s2: s1).series_equal(df["a"])
+    assert_series_equal(df_width_one.fold(lambda s1, s2: s1), df["a"])
 
 
 def test_df_apply() -> None:
@@ -1847,13 +1850,13 @@ def test_shift_and_fill() -> None:
 
 def test_is_duplicated() -> None:
     df = pl.DataFrame({"foo": [1, 2, 2], "bar": [6, 7, 7]})
-    assert df.is_duplicated().series_equal(pl.Series("", [False, True, True]))
+    assert_series_equal(df.is_duplicated(), pl.Series("", [False, True, True]))
 
 
 def test_is_unique() -> None:
     df = pl.DataFrame({"foo": [1, 2, 2], "bar": [6, 7, 7]})
 
-    assert df.is_unique().series_equal(pl.Series("", [True, False, False]))
+    assert_series_equal(df.is_unique(), pl.Series("", [True, False, False]))
     assert df.unique(maintain_order=True).rows() == [(1, 6), (2, 7)]
     assert df.n_unique() == 2
 
@@ -1979,7 +1982,7 @@ def test_get_item() -> None:
     assert_frame_equal(df[:, :], df)
 
     # str, always refers to a column name
-    assert df["a"].series_equal(pl.Series("a", [1.0, 2.0, 3.0, 4.0]))
+    assert_series_equal(df["a"], pl.Series("a", [1.0, 2.0, 3.0, 4.0]))
 
     # int, always refers to a row index (zero-based): index=1 => second row
     assert_frame_equal(df[1], pl.DataFrame({"a": [2.0], "b": [4]}))

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -100,7 +100,7 @@ def test_shuffle() -> None:
     result1 = pl.select(pl.lit(s).shuffle()).to_series()
     random.seed(1)
     result2 = pl.select(pl.lit(s).shuffle()).to_series()
-    assert result1.series_equal(result2)
+    assert_series_equal(result1, result2)
 
 
 def test_sample() -> None:
@@ -124,7 +124,7 @@ def test_sample() -> None:
     result1 = pl.select(pl.lit(a).sample(n=10)).to_series()
     random.seed(1)
     result2 = pl.select(pl.lit(a).sample(n=10)).to_series()
-    assert result1.series_equal(result2)
+    assert_series_equal(result1, result2)
 
 
 def test_map_alias() -> None:
@@ -474,7 +474,7 @@ def test_rank_so_4109() -> None:
 def test_unique_empty() -> None:
     for dt in [pl.Utf8, pl.Boolean, pl.Int32, pl.UInt32]:
         s = pl.Series([], dtype=dt)
-        assert s.unique().series_equal(s)
+        assert_series_equal(s.unique(), s)
 
 
 @typing.no_type_check

--- a/py-polars/tests/unit/test_folds.py
+++ b/py-polars/tests/unit/test_folds.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_series_equal
 
 
 def test_fold() -> None:
@@ -10,9 +11,9 @@ def test_fold() -> None:
             pl.min(["a", pl.col("b") ** 2]),
         ]
     )
-    assert out["sum"].series_equal(pl.Series("sum", [2.0, 4.0, 6.0]))
-    assert out["max"].series_equal(pl.Series("max", [1.0, 4.0, 9.0]))
-    assert out["min"].series_equal(pl.Series("min", [1.0, 2.0, 3.0]))
+    assert_series_equal(out["sum"], pl.Series("sum", [2.0, 4.0, 6.0]))
+    assert_series_equal(out["max"], pl.Series("max", [1.0, 4.0, 9.0]))
+    assert_series_equal(out["min"], pl.Series("min", [1.0, 2.0, 3.0]))
 
     out = df.select(
         pl.fold(acc=pl.lit(0), f=lambda acc, x: acc + x, exprs=pl.all()).alias("foo")

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_date_datetime() -> None:
@@ -23,8 +23,8 @@ def test_date_datetime() -> None:
             pl.date("year", "month", "day").dt.day().cast(int).alias("date"),
         ]
     )
-    assert out["date"].series_equal(df["day"].rename("date"))
-    assert out["h2"].series_equal(df["hour"].rename("h2"))
+    assert_series_equal(out["date"], df["day"].rename("date"))
+    assert_series_equal(out["h2"], df["hour"].rename("h2"))
 
 
 def test_diag_concat() -> None:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -10,6 +10,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes import dtype_to_py_type
+from polars.testing import assert_series_equal
 
 
 def test_df_from_numpy() -> None:
@@ -195,7 +196,7 @@ def test_arrow_dict_to_polars() -> None:
         values=["AAA", "BBB", "CCC", "DDD", "BBB", "AAA", "CCC", "DDD", "DDD", "CCC"],
     )
 
-    assert s.series_equal(pl.Series("pa_dict", pa_dict))
+    assert_series_equal(s, pl.Series("pa_dict", pa_dict))
 
 
 def test_arrow_list_chunked_array() -> None:
@@ -244,7 +245,7 @@ def test_from_dict() -> None:
     df = pl.from_dict(data)
     assert df.shape == (2, 2)
     for s1, s2 in zip(list(df), [pl.Series("a", [1, 2]), pl.Series("b", [3, 4])]):
-        assert s1.series_equal(s2)
+        assert_series_equal(s1, s2)
 
 
 def test_from_dict_struct() -> None:
@@ -555,7 +556,7 @@ def test_cat_int_types_3500() -> None:
 
         for t in [int_dict_type, uint_dict_type]:
             s = cast(pl.Series, pl.from_arrow(pyarrow_array.cast(t)))
-            assert s.series_equal(pl.Series(["a", "a", "b"]).cast(pl.Categorical))
+            assert_series_equal(s, pl.Series(["a", "a", "b"]).cast(pl.Categorical))
 
 
 def test_from_pyarrow_chunked_array() -> None:

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy
@@ -339,11 +339,11 @@ def test_join() -> None:
     )
 
     joined = df_left.join(df_right, left_on="a", right_on="a").sort("a")
-    assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2]))
+    assert_series_equal(joined["b"], pl.Series("b", [1, 3, 2, 2]))
 
     joined = df_left.join(df_right, left_on="a", right_on="a", how="left").sort("a")
     assert joined["c_right"].is_null().sum() == 1
-    assert joined["b"].series_equal(pl.Series("b", [1, 3, 2, 2, 4]))
+    assert_series_equal(joined["b"], pl.Series("b", [1, 3, 2, 2, 4]))
 
     joined = df_left.join(df_right, left_on="a", right_on="a", how="outer").sort("a")
     assert joined["c_right"].null_count() == 1

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -225,7 +225,7 @@ def test_groupby() -> None:
 def test_shift(fruits_cars: pl.DataFrame) -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
     out = df.select(col("a").shift(1))
-    assert out["a"].series_equal(pl.Series("a", [None, 1, 2, 3, 4]), null_equal=True)
+    assert_series_equal(out["a"], pl.Series("a", [None, 1, 2, 3, 4]))
 
     res = fruits_cars.lazy().shift(2).collect()
 
@@ -268,28 +268,25 @@ def test_arange() -> None:
 def test_arg_unique() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
     col_a_unique = df.select(col("a").arg_unique())["a"]
-    assert col_a_unique.series_equal(pl.Series("a", [0, 1]).cast(pl.UInt32))
+    assert_series_equal(col_a_unique, pl.Series("a", [0, 1]).cast(pl.UInt32))
 
 
 def test_is_unique() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
-    assert df.select(col("a").is_unique())["a"].series_equal(
-        pl.Series("a", [False, True, False])
-    )
+    result = df.select(col("a").is_unique())["a"]
+    assert_series_equal(result, pl.Series("a", [False, True, False]))
 
 
 def test_is_first() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
-    assert df.select(col("a").is_first())["a"].series_equal(
-        pl.Series("a", [True, True, False])
-    )
+    result = df.select(col("a").is_first())["a"]
+    assert_series_equal(result, pl.Series("a", [True, True, False]))
 
 
 def test_is_duplicated() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
-    assert df.select(col("a").is_duplicated())["a"].series_equal(
-        pl.Series("a", [True, False, True])
-    )
+    result = df.select(col("a").is_duplicated())["a"]
+    assert_series_equal(result, pl.Series("a", [True, False, True]))
 
 
 def test_arg_sort() -> None:
@@ -508,30 +505,30 @@ def test_len() -> None:
 
 def test_cum_agg() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 2]})
-    assert df.select(pl.col("a").cumsum())["a"].series_equal(
-        pl.Series("a", [1, 3, 6, 8])
+    assert_series_equal(
+        df.select(pl.col("a").cumsum())["a"], pl.Series("a", [1, 3, 6, 8])
     )
-    assert df.select(pl.col("a").cummin())["a"].series_equal(
-        pl.Series("a", [1, 1, 1, 1])
+    assert_series_equal(
+        df.select(pl.col("a").cummin())["a"], pl.Series("a", [1, 1, 1, 1])
     )
-    assert df.select(pl.col("a").cummax())["a"].series_equal(
-        pl.Series("a", [1, 2, 3, 3])
+    assert_series_equal(
+        df.select(pl.col("a").cummax())["a"], pl.Series("a", [1, 2, 3, 3])
     )
-    assert df.select(pl.col("a").cumprod())["a"].series_equal(
-        pl.Series("a", [1, 2, 6, 12])
+    assert_series_equal(
+        df.select(pl.col("a").cumprod())["a"], pl.Series("a", [1, 2, 6, 12])
     )
 
 
 def test_floor() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
     col_a_floor = df.select(pl.col("a").floor())["a"]
-    assert col_a_floor.series_equal(pl.Series("a", [1, 1, 3]).cast(pl.Float64))
+    assert_series_equal(col_a_floor, pl.Series("a", [1, 1, 3]).cast(pl.Float64))
 
 
 def test_round() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
     col_a_rounded = df.select(pl.col("a").round(decimals=0))["a"]
-    assert col_a_rounded.series_equal(pl.Series("a", [2, 1, 3]).cast(pl.Float64))
+    assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
 
 
 def test_dot() -> None:
@@ -541,7 +538,9 @@ def test_dot() -> None:
 
 def test_sort() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 2]})
-    assert df.select(pl.col("a").sort())["a"].series_equal(pl.Series("a", [1, 2, 2, 3]))
+    assert_series_equal(
+        df.select(pl.col("a").sort())["a"], pl.Series("a", [1, 2, 2, 3])
+    )
 
 
 def test_drop_nulls() -> None:
@@ -615,21 +614,15 @@ def test_interpolate() -> None:
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1.0, np.nan, 3.0]})
-    assert df.fill_nan(2.0)["a"].series_equal(pl.Series("a", [1.0, 2.0, 3.0]))
-    assert (
-        df.lazy()
-        .fill_nan(2.0)
-        .collect()["a"]
-        .series_equal(pl.Series("a", [1.0, 2.0, 3.0]))
+    assert_series_equal(df.fill_nan(2.0)["a"], pl.Series("a", [1.0, 2.0, 3.0]))
+    assert_series_equal(
+        df.lazy().fill_nan(2.0).collect()["a"], pl.Series("a", [1.0, 2.0, 3.0])
     )
-    assert (
-        df.lazy()
-        .fill_nan(None)
-        .collect()["a"]
-        .series_equal(pl.Series("a", [1.0, None, 3.0]), null_equal=True)
+    assert_series_equal(
+        df.lazy().fill_nan(None).collect()["a"], pl.Series("a", [1.0, None, 3.0])
     )
-    assert df.select(pl.col("a").fill_nan(2))["a"].series_equal(
-        pl.Series("a", [1.0, 2.0, 3.0])
+    assert_series_equal(
+        df.select(pl.col("a").fill_nan(2))["a"], pl.Series("a", [1.0, 2.0, 3.0])
     )
     # nearest
     assert pl.Series([None, 1, None, None, None, -8, None, None, 10]).interpolate(
@@ -654,7 +647,7 @@ def test_fill_null() -> None:
 def test_backward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
     col_a_backward_fill = df.select([pl.col("a").backward_fill()])["a"]
-    assert col_a_backward_fill.series_equal(pl.Series("a", [1, 3, 3]).cast(pl.Float64))
+    assert_series_equal(col_a_backward_fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
 
 def test_take(fruits_cars: pl.DataFrame) -> None:
@@ -1180,36 +1173,36 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
 
 def test_is_between(fruits_cars: pl.DataFrame) -> None:
     result = fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"]
-    assert result.series_equal(
-        pl.Series("is_between", [False, True, True, True, False])
+    assert_series_equal(
+        result, pl.Series("is_between", [False, True, True, True, False])
     )
 
     result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none"))[
         "is_between"
     ]
-    assert result.series_equal(
-        pl.Series("is_between", [False, False, True, False, False])
+    assert_series_equal(
+        result, pl.Series("is_between", [False, False, True, False, False])
     )
 
     result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both"))[
         "is_between"
     ]
-    assert result.series_equal(
-        pl.Series("is_between", [False, True, True, True, False])
+    assert_series_equal(
+        result, pl.Series("is_between", [False, True, True, True, False])
     )
 
     result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="right"))[
         "is_between"
     ]
-    assert result.series_equal(
-        pl.Series("is_between", [False, False, True, True, False])
+    assert_series_equal(
+        result, pl.Series("is_between", [False, False, True, True, False])
     )
 
     result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left"))[
         "is_between"
     ]
-    assert result.series_equal(
-        pl.Series("is_between", [False, True, True, False, False])
+    assert_series_equal(
+        result, pl.Series("is_between", [False, True, True, False, False])
     )
 
 
@@ -1285,41 +1278,41 @@ def test_lazy_concat(df: pl.DataFrame) -> None:
 
 def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.select(pl.max(["A", "B"]).alias("max"))
-    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
 
     res = fruits_cars.select(pl.min(["A", "B"]).alias("min"))
-    assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
 
 
 def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min(["*"]))
-    assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min([pl.all()]))
-    assert res.to_series(0).series_equal(pl.Series("min", [1, 2, 3, 2, 1]))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
 
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max(["*"]))
-    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max([pl.all()]))
-    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
 
     res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(
         pl.max([pl.all(), "A", "*"])
     )
-    assert res.to_series(0).series_equal(pl.Series("max", [5, 4, 3, 4, 5]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
 
 
 def test_head_tail(fruits_cars: pl.DataFrame) -> None:
     res_expr = fruits_cars.select([pl.head("A", 2)])
     res_series = pl.head(fruits_cars["A"], 2)
     expected = pl.Series("A", [1, 2])
-    assert res_expr.to_series(0).series_equal(expected)
-    assert res_series.series_equal(expected)
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)
 
     res_expr = fruits_cars.select([pl.tail("A", 2)])
     res_series = pl.tail(fruits_cars["A"], 2)
     expected = pl.Series("A", [4, 5])
-    assert res_expr.to_series(0).series_equal(expected)
-    assert res_series.series_equal(expected)
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)
 
 
 def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -17,12 +17,8 @@ def test_serde_lazy_frame_lp() -> None:
     lf = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).lazy().select(pl.col("a"))
     json = lf.write_json()
 
-    assert (
-        pl.LazyFrame.from_json(json)
-        .collect()
-        .to_series()
-        .series_equal(pl.Series("a", [1, 2, 3]))
-    )
+    result = pl.LazyFrame.from_json(json).collect().to_series()
+    assert_series_equal(result, pl.Series("a", [1, 2, 3]))
 
 
 def test_serde_time_unit() -> None:

--- a/py-polars/tests/unit/test_window.py
+++ b/py-polars/tests/unit/test_window.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64, pl.Int32])
@@ -129,7 +129,7 @@ def test_no_panic_on_nan_3067() -> None:
 
 
 def test_quantile_as_window() -> None:
-    assert (
+    result = (
         pl.DataFrame(
             {
                 "group": [0, 0, 1, 1],
@@ -138,8 +138,9 @@ def test_quantile_as_window() -> None:
         )
         .select(pl.quantile("value", 0.9).over("group"))
         .to_series()
-        .series_equal(pl.Series("value", [1.0, 1.0, 2.0, 2.0]))
     )
+    expected = pl.Series("value", [1.0, 1.0, 2.0, 2.0])
+    assert_series_equal(result, expected)
 
 
 def test_cumulative_eval_window_functions() -> None:


### PR DESCRIPTION
Relates to #6364

`assert_series_equal` is a more robust tool intended for for testing, so we should use this instead of `series_equal`.

No new bugs found, so that's good 😄 