### PR TITLE
chore(python): Disallow clippy borrow deref ref

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -35,7 +35,7 @@ fmt: venv  ## Run autoformatting and linting
 
 .PHONY: clippy
 clippy:  ## Run clippy
-	cargo clippy -- -D warnings -A clippy::borrow_deref_ref
+	cargo clippy -- -D warnings
 
 .PHONY: pre-commit
 pre-commit: fmt clippy  ## Run all code quality checks


### PR DESCRIPTION
Thanks to #6531 we no longer get spurious clippy warnings, and we can remove this setting.