### PR TITLE
refactor(python): make `structify` behaviour experimental, while also extending it to aliased expressions

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5630,11 +5630,16 @@ class DataFrame:
         │ 10      │
         └─────────┘
 
-        Note that, when using kwargs syntax, expressions with multiple
-        outputs are automatically instantiated as Struct columns:
+        Expressions with multiple outputs can be automatically instantiated as Structs
+        by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
         >>> from polars.datatypes import INTEGER_DTYPES
-        >>> df.select(is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"))
+        >>> with pl.Config() as cfg:
+        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        ...     df.select(
+        ...         is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"),
+        ...     )
+        ...
         shape: (3, 1)
         ┌───────────┐
         │ is_odd    │
@@ -5751,12 +5756,15 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
 
-        Note that, when using kwargs syntax, expressions with multiple
-        outputs are automatically instantiated as Struct columns:
+        Expressions with multiple outputs can be automatically instantiated as Structs
+        by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> df.drop("c").with_columns(
-        ...     diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
-        ... )
+        >>> with pl.Config() as cfg:
+        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        ...     df.drop("c").with_columns(
+        ...         diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
+        ...     )
+        ...
         shape: (4, 3)
         ┌─────┬──────┬─────────────┐
         │ a   ┆ b    ┆ diffs       │

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import typing
@@ -56,7 +57,7 @@ from polars.utils import (
 )
 
 try:
-    from polars.polars import PyLazyFrame
+    from polars.polars import PyExpr, PyLazyFrame
 
     _DOCUMENTING = False
 except ImportError:
@@ -1575,14 +1576,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Examples
         --------
-        >>> df = pl.DataFrame(
+        >>> ldf = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
         ...         "bar": [6, 7, 8],
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... ).lazy()
-        >>> df.select("foo").collect()
+        >>> ldf.select("foo").collect()
         shape: (3, 1)
         ┌─────┐
         │ foo │
@@ -1593,7 +1594,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 2   │
         │ 3   │
         └─────┘
-        >>> df.select(["foo", "bar"]).collect()
+        >>> ldf.select(["foo", "bar"]).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
@@ -1605,7 +1606,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 3   ┆ 8   │
         └─────┴─────┘
 
-        >>> df.select(pl.col("foo") + 1).collect()
+        >>> ldf.select(pl.col("foo") + 1).collect()
         shape: (3, 1)
         ┌─────┐
         │ foo │
@@ -1617,7 +1618,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   │
         └─────┘
 
-        >>> df.select([pl.col("foo") + 1, pl.col("bar") + 1]).collect()
+        >>> ldf.select([pl.col("foo") + 1, pl.col("bar") + 1]).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
@@ -1629,23 +1630,30 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 9   │
         └─────┴─────┘
 
-        >>> df.select(pl.when(pl.col("foo") > 2).then(10).otherwise(0)).collect()
+        >>> ldf.select(
+        ...     value=pl.when(pl.col("foo") > 2).then(10).otherwise(0),
+        ... ).collect()
         shape: (3, 1)
-        ┌─────────┐
-        │ literal │
-        │ ---     │
-        │ i32     │
-        ╞═════════╡
-        │ 0       │
-        │ 0       │
-        │ 10      │
-        └─────────┘
+        ┌───────┐
+        │ value │
+        │ ---   │
+        │ i32   │
+        ╞═══════╡
+        │ 0     │
+        │ 0     │
+        │ 10    │
+        └───────┘
 
-        Note that, when using kwargs syntax, expressions with multiple
-        outputs are automatically instantiated as Struct columns:
+        Expressions with multiple outputs can be automatically instantiated as Structs
+        by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
         >>> from polars.datatypes import INTEGER_DTYPES
-        >>> df.select(is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd")).collect()
+        >>> with pl.Config() as cfg:
+        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        ...     ldf.select(
+        ...         is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"),
+        ...     ).collect()
+        ...
         shape: (3, 1)
         ┌───────────┐
         │ is_odd    │
@@ -1663,9 +1671,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         elif exprs is None:
             exprs = []
 
-        exprs = pli.selection_to_pyexpr_list(exprs)
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+        exprs = pli.selection_to_pyexpr_list(exprs, structify=structify)
         exprs.extend(
-            pli.expr_to_lit_or_expr(expr, structify=True)._pyexpr.alias(name)
+            pli.expr_to_lit_or_expr(
+                expr, structify=structify, name=name, str_to_lit=False
+            )._pyexpr
             for name, expr in named_exprs.items()
         )
         return self._from_pyldf(self._ldf.select(exprs))
@@ -2547,12 +2558,15 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 4   ┆ 13.0 ┆ true  ┆ 52.0 ┆ false │
         └─────┴──────┴───────┴──────┴───────┘
 
-        Note that, when using kwargs syntax, expressions with multiple
-        outputs are automatically instantiated as Struct columns:
+        Expressions with multiple outputs can be automatically instantiated as Structs
+        by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> ldf.drop("c").with_columns(
-        ...     diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
-        ... ).collect()
+        >>> with pl.Config() as cfg:
+        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        ...     ldf.drop("c").with_columns(
+        ...         diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
+        ...     ).collect()
+        ...
         shape: (4, 3)
         ┌─────┬──────┬─────────────┐
         │ a   ┆ b    ┆ diffs       │
@@ -2568,22 +2582,18 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         if exprs is None and not named_exprs:
             raise ValueError("Expected at least one of 'exprs' or **named_exprs")
-        elif exprs is None:
-            exprs = []
-        elif isinstance(exprs, pli.Expr):
-            exprs = [exprs]
-        elif isinstance(exprs, pli.Series):
-            exprs = [pli.lit(exprs)]
-        else:
-            exprs = list(exprs)
 
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+        exprs = pli.selection_to_pyexpr_list(exprs, structify=structify)
         exprs.extend(
-            pli.expr_to_lit_or_expr(expr, structify=True).alias(name)
+            pli.expr_to_lit_or_expr(expr, structify=structify, name=name)
             for name, expr in named_exprs.items()
         )
         pyexprs = []
         for e in exprs:
-            if isinstance(e, pli.Expr):
+            if isinstance(e, PyExpr):
+                pyexprs.append(e)
+            elif isinstance(e, pli.Expr):
                 pyexprs.append(e._pyexpr)
             elif isinstance(e, pli.Series):
                 pyexprs.append(pli.lit(e)._pyexpr)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1557,10 +1557,15 @@ def test_select_by_dtype(df: pl.DataFrame) -> None:
     assert out.columns == ["strings", "strings_nulls", "bools", "bools_nulls"]
     out = df.select(pl.col(INTEGER_DTYPES))
     assert out.columns == ["int", "int_nulls"]
-    out = df.select(ints=pl.col(INTEGER_DTYPES))
-    assert out.schema == {
-        "ints": pl.Struct([pl.Field("int", pl.Int64), pl.Field("int_nulls", pl.Int64)])
-    }
+
+    with pl.Config() as cfg:
+        cfg.set_auto_structify(True)
+        out = df.select(ints=pl.col(INTEGER_DTYPES))
+        assert out.schema == {
+            "ints": pl.Struct(
+                [pl.Field("int", pl.Int64), pl.Field("int_nulls", pl.Int64)]
+            )
+        }
 
 
 def test_with_row_count() -> None:
@@ -2380,31 +2385,34 @@ def test_selection_regex_and_multicol() -> None:
     }
 
     # kwargs
-    df = test_df.select(
-        re=pl.col("^\\w$"),
-        odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"),
-        maxes=pl.all().max().suffix("_max"),
-    ).head(2)
-    # ┌───────────┬───────────┬─────────────┐
-    # │ re        ┆ odd       ┆ maxes       │
-    # │ ---       ┆ ---       ┆ ---         │
-    # │ struct[3] ┆ struct[4] ┆ struct[4]   │
-    # ╞═══════════╪═══════════╪═════════════╡
-    # │ {1,5,9}   ┆ {1,1,1,1} ┆ {4,8,12,16} │
-    # │ {2,6,10}  ┆ {0,0,0,0} ┆ {4,8,12,16} │
-    # └───────────┴───────────┴─────────────┘
-    assert df.rows() == [
-        (
-            {"a": 1, "b": 5, "c": 9},
-            {"a_is_odd": 1, "b_is_odd": 1, "c_is_odd": 1, "foo_is_odd": 1},
-            {"a_max": 4, "b_max": 8, "c_max": 12, "foo_max": 16},
-        ),
-        (
-            {"a": 2, "b": 6, "c": 10},
-            {"a_is_odd": 0, "b_is_odd": 0, "c_is_odd": 0, "foo_is_odd": 0},
-            {"a_max": 4, "b_max": 8, "c_max": 12, "foo_max": 16},
-        ),
-    ]
+    with pl.Config() as cfg:
+        cfg.set_auto_structify(True)
+
+        df = test_df.select(
+            pl.col("^\\w$").alias("re"),
+            odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"),
+            maxes=pl.all().max().suffix("_max"),
+        ).head(2)
+        # ┌───────────┬───────────┬─────────────┐
+        # │ re        ┆ odd       ┆ maxes       │
+        # │ ---       ┆ ---       ┆ ---         │
+        # │ struct[3] ┆ struct[4] ┆ struct[4]   │
+        # ╞═══════════╪═══════════╪═════════════╡
+        # │ {1,5,9}   ┆ {1,1,1,1} ┆ {4,8,12,16} │
+        # │ {2,6,10}  ┆ {0,0,0,0} ┆ {4,8,12,16} │
+        # └───────────┴───────────┴─────────────┘
+        assert df.rows() == [
+            (
+                {"a": 1, "b": 5, "c": 9},
+                {"a_is_odd": 1, "b_is_odd": 1, "c_is_odd": 1, "foo_is_odd": 1},
+                {"a_max": 4, "b_max": 8, "c_max": 12, "foo_max": 16},
+            ),
+            (
+                {"a": 2, "b": 6, "c": 10},
+                {"a_is_odd": 0, "b_is_odd": 0, "c_is_odd": 0, "foo_is_odd": 0},
+                {"a_max": 4, "b_max": 8, "c_max": 12, "foo_max": 16},
+            ),
+        ]
 
 
 def test_with_columns() -> None:
@@ -2482,47 +2490,50 @@ def test_with_columns() -> None:
     assert_frame_equal(dx, expected)
 
     # automatically upconvert multi-output expressions to struct
-    ldf = (
-        pl.DataFrame({"x1": [1, 2, 6], "x2": [1, 2, 3]})
-        .lazy()
-        .with_columns(
-            pct_change=pl.col(["x1", "x2"]).pct_change(),
-            maxes=pl.all().max().suffix("_max"),
-            xcols=pl.col("^x.*$"),
+    with pl.Config() as cfg:
+        cfg.set_auto_structify(True)
+
+        ldf = (
+            pl.DataFrame({"x1": [1, 2, 6], "x2": [1, 2, 3]})
+            .lazy()
+            .with_columns(
+                pl.col(["x1", "x2"]).pct_change().alias("pct_change"),
+                maxes=pl.all().max().suffix("_max"),
+                xcols=pl.col("^x.*$"),
+            )
         )
-    )
-    # ┌─────┬─────┬─────────────┬───────────┬───────────┐
-    # │ x1  ┆ x2  ┆ pct_change  ┆ maxes     ┆ xcols     │
-    # │ --- ┆ --- ┆ ---         ┆ ---       ┆ ---       │
-    # │ i64 ┆ i64 ┆ struct[2]   ┆ struct[2] ┆ struct[2] │
-    # ╞═════╪═════╪═════════════╪═══════════╪═══════════╡
-    # │ 1   ┆ 1   ┆ {null,null} ┆ {6,3}     ┆ {1,1}     │
-    # │ 2   ┆ 2   ┆ {1.0,1.0}   ┆ {6,3}     ┆ {2,2}     │
-    # │ 6   ┆ 3   ┆ {2.0,0.5}   ┆ {6,3}     ┆ {6,3}     │
-    # └─────┴─────┴─────────────┴───────────┴───────────┘
-    assert ldf.collect().to_dicts() == [
-        {
-            "x1": 1,
-            "x2": 1,
-            "pct_change": {"x1": None, "x2": None},
-            "maxes": {"x1_max": 6, "x2_max": 3},
-            "xcols": {"x1": 1, "x2": 1},
-        },
-        {
-            "x1": 2,
-            "x2": 2,
-            "pct_change": {"x1": 1.0, "x2": 1.0},
-            "maxes": {"x1_max": 6, "x2_max": 3},
-            "xcols": {"x1": 2, "x2": 2},
-        },
-        {
-            "x1": 6,
-            "x2": 3,
-            "pct_change": {"x1": 2.0, "x2": 0.5},
-            "maxes": {"x1_max": 6, "x2_max": 3},
-            "xcols": {"x1": 6, "x2": 3},
-        },
-    ]
+        # ┌─────┬─────┬─────────────┬───────────┬───────────┐
+        # │ x1  ┆ x2  ┆ pct_change  ┆ maxes     ┆ xcols     │
+        # │ --- ┆ --- ┆ ---         ┆ ---       ┆ ---       │
+        # │ i64 ┆ i64 ┆ struct[2]   ┆ struct[2] ┆ struct[2] │
+        # ╞═════╪═════╪═════════════╪═══════════╪═══════════╡
+        # │ 1   ┆ 1   ┆ {null,null} ┆ {6,3}     ┆ {1,1}     │
+        # │ 2   ┆ 2   ┆ {1.0,1.0}   ┆ {6,3}     ┆ {2,2}     │
+        # │ 6   ┆ 3   ┆ {2.0,0.5}   ┆ {6,3}     ┆ {6,3}     │
+        # └─────┴─────┴─────────────┴───────────┴───────────┘
+        assert ldf.collect().to_dicts() == [
+            {
+                "x1": 1,
+                "x2": 1,
+                "pct_change": {"x1": None, "x2": None},
+                "maxes": {"x1_max": 6, "x2_max": 3},
+                "xcols": {"x1": 1, "x2": 1},
+            },
+            {
+                "x1": 2,
+                "x2": 2,
+                "pct_change": {"x1": 1.0, "x2": 1.0},
+                "maxes": {"x1_max": 6, "x2_max": 3},
+                "xcols": {"x1": 2, "x2": 2},
+            },
+            {
+                "x1": 6,
+                "x2": 3,
+                "pct_change": {"x1": 2.0, "x2": 0.5},
+                "maxes": {"x1_max": 6, "x2_max": 3},
+                "xcols": {"x1": 6, "x2": 3},
+            },
+        ]
 
     # require at least one of exprs / **named_exprs
     with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #6594.

Pending additional consideration (and moving the logic into Rust), auto-structification of multi-output expressions has been...

* moved behind an experimental `Config` setting.
* extended to regular aliased expressions, in addition to kwargs.

**Example**:

```python
import polars as pl
pl.Config.set_auto_structify(True)

df = pl.DataFrame({
    "x1": [1,4,5],
    "x2": [1,2,3],
}).with_columns(
    pl.col(["x1","x2"]).pct_change().alias("pct_change"),
)

# shape: (3, 3)
# ┌─────┬─────┬─────────────┐
# │ x1  ┆ x2  ┆ pct_change  │
# │ --- ┆ --- ┆ ---         │
# │ i64 ┆ i64 ┆ struct[2]   │
# ╞═════╪═════╪═════════════╡
# │ 1   ┆ 1   ┆ {null,null} │
# │ 4   ┆ 2   ┆ {3.0,1.0}   │
# │ 5   ┆ 3   ┆ {0.25,0.5}  │
# └─────┴─────┴─────────────┘
```

**Update**: 

Also fixes inconsistent str-to-col behaviour between kwarg / non-kwarg exprs, caused by a missing `str_to_lit=False` param.
