### PR TITLE
test(python): Consistent handling of env vars

### DIFF
--- a/py-polars/tests/slow/test_streaming.py
+++ b/py-polars/tests/slow/test_streaming.py
@@ -1,5 +1,5 @@
-import os
 import time
+from typing import Any
 
 import numpy as np
 
@@ -17,10 +17,8 @@ def test_cross_join_stack() -> None:
     assert (t1 - t0) < 0.5
 
 
-def test_ooc_sort() -> None:
-    # not sure if monkeypatch will be visible in rust
-    env = "POLARS_FORCE_OOC_SORT"
-    os.environ[env] = "1"
+def test_ooc_sort(monkeypatch: Any) -> None:
+    monkeypatch.setenv("POLARS_FORCE_OOC_SORT", "1")
 
     s = pl.arange(0, 100_000, eager=True).rename("idx")
 
@@ -32,5 +30,3 @@ def test_ooc_sort() -> None:
         ).to_series()
 
         assert_series_equal(out, s.sort(reverse=reverse))
-
-    os.unsetenv(env)

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import pytest
-from _pytest.capture import CaptureFixture
-from _pytest.monkeypatch import MonkeyPatch
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -141,9 +139,7 @@ def test_row_count_schema(parquet_file_path: Path) -> None:
     ).dtypes == [pl.UInt32, pl.Utf8]
 
 
-def test_parquet_statistics(
-    capfd: CaptureFixture[str], monkeypatch: MonkeyPatch
-) -> None:
+def test_parquet_statistics(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 
     df = pl.DataFrame({"idx": pl.arange(0, 100, eager=True)}).with_columns(

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -414,12 +414,11 @@ def test_string_cache() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.xdist_group(name="group1")
 def test_config_load_save() -> None:
     # set some config options...
     pl.Config.set_tbl_cols(12)
     pl.Config.set_verbose(True)
-    assert os.environ["POLARS_VERBOSE"] == "1"
+    assert os.environ.get("POLARS_VERBOSE") == "1"
 
     cfg = pl.Config.save()
     assert isinstance(cfg, str)
@@ -428,14 +427,14 @@ def test_config_load_save() -> None:
     # ...modify the same options...
     pl.Config.set_tbl_cols(10)
     pl.Config.set_verbose(False)
-    assert os.environ["POLARS_VERBOSE"] == "0"
+    assert os.environ.get("POLARS_VERBOSE") == "0"
 
     # ...load back from config...
     pl.Config.load(cfg)
 
     # ...and confirm the saved options were set.
-    assert os.environ["POLARS_FMT_MAX_COLS"] == "12"
-    assert os.environ["POLARS_VERBOSE"] == "1"
+    assert os.environ.get("POLARS_FMT_MAX_COLS") == "12"
+    assert os.environ.get("POLARS_VERBOSE") == "1"
 
     # restore all default options (unsets from env)
     pl.Config.restore_defaults()

--- a/py-polars/tests/unit/test_interchange.py
+++ b/py-polars/tests/unit/test_interchange.py
@@ -1,8 +1,8 @@
 import sys
+from typing import Any
 
 import pandas as pd
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -18,7 +18,7 @@ def test_interchange() -> None:
     assert dfi.get_column_by_name("c").get_buffers()["data"][0].bufsize == 6
 
 
-def test_interchange_pyarrow_required(monkeypatch: MonkeyPatch) -> None:
+def test_interchange_pyarrow_required(monkeypatch: Any) -> None:
     monkeypatch.setattr(pl.internals.dataframe.frame, "_PYARROW_AVAILABLE", False)
 
     df = pl.DataFrame({"a": [1, 2]})
@@ -26,7 +26,7 @@ def test_interchange_pyarrow_required(monkeypatch: MonkeyPatch) -> None:
         df.__dataframe__()
 
 
-def test_interchange_pyarrow_min_version(monkeypatch: MonkeyPatch) -> None:
+def test_interchange_pyarrow_min_version(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         pl.internals.dataframe.frame.pa,  # type: ignore[attr-defined]
         "__version__",
@@ -93,7 +93,7 @@ def test_from_dataframe_invalid_type() -> None:
         pl.from_dataframe(df)
 
 
-def test_from_dataframe_pyarrow_required(monkeypatch: MonkeyPatch) -> None:
+def test_from_dataframe_pyarrow_required(monkeypatch: Any) -> None:
     monkeypatch.setattr(pl.convert, "_PYARROW_AVAILABLE", False)
 
     df = pl.DataFrame({"a": [1, 2]})
@@ -105,7 +105,7 @@ def test_from_dataframe_pyarrow_required(monkeypatch: MonkeyPatch) -> None:
     assert_frame_equal(result, df)
 
 
-def test_from_dataframe_pyarrow_min_version(monkeypatch: MonkeyPatch) -> None:
+def test_from_dataframe_pyarrow_min_version(monkeypatch: Any) -> None:
     dfi = pl.DataFrame({"a": [1, 2]}).__dataframe__()
 
     monkeypatch.setattr(

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import numpy as np
 import pandas as pd
-from _pytest.monkeypatch import MonkeyPatch
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -138,7 +138,7 @@ def test_maintain_order_after_sampling() -> None:
     ) == {"type": ["A", "B", "C", "D"], "value": [5, 8, 5, 7]}
 
 
-def test_sorted_groupby_optimization(monkeypatch: MonkeyPatch) -> None:
+def test_sorted_groupby_optimization(monkeypatch: Any) -> None:
     monkeypatch.setenv("POLARS_NO_STREAMING_GROUPBY", "1")
 
     df = pl.DataFrame({"a": np.random.randint(0, 5, 20)})

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -1,4 +1,3 @@
-import os
 from datetime import date
 from typing import Any
 
@@ -202,9 +201,8 @@ def test_streaming_block_on_literals_6054() -> None:
     ).sort("col_1").to_dict(False) == {"col_1": [0, 1], "col_2": [0, 5]}
 
 
-@pytest.mark.xdist_group(name="group1")
-def test_streaming_streamable_functions(capfd: Any) -> None:
-    os.environ["POLARS_VERBOSE"] = "1"
+def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
     assert (
         pl.DataFrame({"a": [1, 2, 3]})
         .lazy()
@@ -217,4 +215,3 @@ def test_streaming_streamable_functions(capfd: Any) -> None:
 
     (_, err) = capfd.readouterr()
     assert "df -> function -> ordered_sink" in err
-    os.unsetenv("POLARS_VERBOSE")


### PR DESCRIPTION
Changes:
* Use `monkeypatch.setenv` instead of `os.environ[...]`.
  *  This is the intended way to set temporary environment variables in pytest
  * It works perfectly fine for our purposes - not sure why there was doubt if this 'seen' by the Rust code. It can be verified easily by changing the flag in one of the tests and seeing it fail.
* Remove xdist group marker.
  * Not sure what prompted this addition, but I cannot get the tests to break even without this marker. Pytest seems to handle test isolation fine, no need to micromanage this. At least from what I've seen. I could be wrong though...
  * If we DO need to micromanage this, then having a dedicated group for anything that utilizes environment variables (and by extension the `pl.Config` object) indeed seems sensible. We could name it `env_vars` or something - that would be more descriptive than `group_one`.