### PR TITLE
refactor(python): unify `nan_to_null` and `nan_to_none` parameter names, expose to DataFrame init, add test coverage

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -392,7 +392,7 @@ def from_arrow(
 def from_pandas(
     df: pd.DataFrame,
     rechunk: bool = True,
-    nan_to_none: bool = True,
+    nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
 ) -> DataFrame:
     ...
@@ -402,16 +402,17 @@ def from_pandas(
 def from_pandas(
     df: pd.Series | pd.DatetimeIndex,
     rechunk: bool = True,
-    nan_to_none: bool = True,
+    nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
 ) -> Series:
     ...
 
 
+@deprecated_alias(nan_to_none="nan_to_null")
 def from_pandas(
     df: pd.DataFrame | pd.Series | pd.DatetimeIndex,
     rechunk: bool = True,
-    nan_to_none: bool = True,
+    nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
 ) -> DataFrame | Series:
     """
@@ -427,7 +428,7 @@ def from_pandas(
         Data represented as a pandas DataFrame, Series, or DatetimeIndex.
     rechunk : bool, default True
         Make sure that all data is in contiguous memory.
-    nan_to_none : bool, default True
+    nan_to_null : bool, default True
         If data contains `NaN` values PyArrow will convert the ``NaN`` to ``None``
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
@@ -470,12 +471,12 @@ def from_pandas(
 
     """
     if isinstance(df, (pd.Series, pd.DatetimeIndex)):
-        return Series._from_pandas("", df, nan_to_none=nan_to_none)
+        return Series._from_pandas("", df, nan_to_null=nan_to_null)
     elif isinstance(df, pd.DataFrame):
         return DataFrame._from_pandas(
             df,
             rechunk=rechunk,
-            nan_to_none=nan_to_none,
+            nan_to_null=nan_to_null,
             schema_overrides=schema_overrides,
         )
     else:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -188,6 +188,9 @@ class DataFrame:
     infer_schema_length : int, default None
         Maximum number of rows to read for schema inference; only applies if the input
         data is a sequence or generator of rows; other input is read as-is.
+    nan_to_null : bool, default False
+        If the data comes from one or more numpy arrays, can optionally convert input
+        data np.nan values to null instead. This is a no-op for all other input data.
 
     Examples
     --------
@@ -324,6 +327,7 @@ class DataFrame:
         schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
+        nan_to_null: bool = False,
     ):
         if data is None:
             self._df = dict_to_pydf(
@@ -332,7 +336,10 @@ class DataFrame:
 
         elif isinstance(data, dict):
             self._df = dict_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides
+                data,
+                schema=schema,
+                schema_overrides=schema_overrides,
+                nan_to_null=nan_to_null,
             )
 
         elif isinstance(data, (list, tuple, Sequence)):
@@ -350,7 +357,11 @@ class DataFrame:
 
         elif _check_for_numpy(data) and isinstance(data, np.ndarray):
             self._df = numpy_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides, orient=orient
+                data,
+                schema=schema,
+                schema_overrides=schema_overrides,
+                orient=orient,
+                nan_to_null=nan_to_null,
             )
 
         elif _check_for_pyarrow(data) and isinstance(data, pa.Table):
@@ -585,14 +596,14 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema")
+    @deprecated_alias(columns="schema", nan_to_none="nan_to_null")
     def _from_pandas(
         cls: type[DF],
         data: pd.DataFrame,
         schema: SchemaDefinition | None = None,
         schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
-        nan_to_none: bool = True,
+        nan_to_null: bool = True,
     ) -> DF:
         """
         Construct a Polars DataFrame from a pandas DataFrame.
@@ -616,8 +627,8 @@ class DataFrame:
             any dtypes inferred from the columns param will be overridden.
         rechunk : bool, default True
             Make sure that all data is in contiguous memory.
-        nan_to_none : bool, default True
-            If data contains NaN values PyArrow will convert the NaN to None
+        nan_to_null : bool, default True
+            If the data contains NaN values they will be converted to null/None.
 
         Returns
         -------
@@ -630,7 +641,7 @@ class DataFrame:
                 schema=schema,
                 schema_overrides=schema_overrides,
                 rechunk=rechunk,
-                nan_to_none=nan_to_none,
+                nan_to_null=nan_to_null,
             )
         )
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -75,6 +75,7 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _is_generator,
     _time_to_pl_time,
+    deprecated_alias,
     is_int_sequence,
     range_to_series,
     range_to_slice,
@@ -141,7 +142,7 @@ class Series:
         Throw error on numeric overflow.
     nan_to_null
         In case a numpy array is used to create this Series, indicate how to deal
-        with np.nan values.
+        with np.nan values. (This parameter is a no-op on non-numpy data).
     dtype_if_empty=dtype_if_empty : DataType, default None
         If no dtype is specified and values contains None or an empty list,
         set the Polars dtype of the Series data. If not specified, Float32 is used.
@@ -301,12 +302,13 @@ class Series:
         return cls._from_pyseries(arrow_to_pyseries(name, values, rechunk))
 
     @classmethod
+    @deprecated_alias(nan_to_none="nan_to_null")
     def _from_pandas(
-        cls, name: str, values: pd.Series | pd.DatetimeIndex, nan_to_none: bool = True
+        cls, name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
     ) -> Series:
         """Construct a Series from a pandas Series or DatetimeIndex."""
         return cls._from_pyseries(
-            pandas_to_pyseries(name, values, nan_to_none=nan_to_none)
+            pandas_to_pyseries(name, values, nan_to_null=nan_to_null)
         )
 
     def _get_ptr(self) -> int:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -127,7 +127,7 @@ def test_from_pandas() -> None:
         assert out.schema[col] == dtype
 
 
-def test_from_pandas_nan_to_none() -> None:
+def test_from_pandas_nan_to_null() -> None:
     df = pd.DataFrame(
         {
             "bools_nulls": [None, True, False],
@@ -138,13 +138,13 @@ def test_from_pandas_nan_to_none() -> None:
         }
     )
     out_true = pl.from_pandas(df)
-    out_false = pl.from_pandas(df, nan_to_none=False)
+    out_false = pl.from_pandas(df, nan_to_null=False)
     assert all(val is None for val in out_true["nulls"])
     assert all(np.isnan(val) for val in out_false["nulls"][1:])
 
     df = pd.Series([2, np.nan, None], name="pd")  # type: ignore[assignment]
     out_true = pl.from_pandas(df)
-    out_false = pl.from_pandas(df, nan_to_none=False)
+    out_false = pl.from_pandas(df, nan_to_null=False)
     assert [val is None for val in out_true]
     assert [np.isnan(val) for val in out_false[1:]]
 


### PR DESCRIPTION
Closes #6634.

* Deprecates `nan_to_none` in favour of  `nan_to_null`.
* Exposes this param to `DataFrame` init for numpy arrays.
* Adds some missing test coverage to validate `nan_to_null` behaviour.