### PR TITLE
fix(python): Tiny improvement of `Field` repr

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -369,7 +369,7 @@ class Field:
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}({self.name!r}: {self.dtype})"
+        return f"{class_name}({self.name!r}, {self.dtype})"
 
 
 class Struct(NestedType):

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -80,7 +80,7 @@ def test_dtypes_hashable() -> None:
         (pl.Struct, "Struct"),
         (
             pl.Struct({"name": pl.Utf8, "ids": pl.List(pl.UInt32)}),
-            "Struct([Field('name': Utf8), Field('ids': List(UInt32))])",
+            "Struct([Field('name', Utf8), Field('ids', List(UInt32))])",
         ),
     ],
 )


### PR DESCRIPTION
Field should be represented with `Field('name', UInt32)`. When I wrote the `__repr__` code I got confused by dict representations and used a `:` instead.

This change will make the resulting string representation 'copy-pasteable' as an input data type, which is nice.