### PR TITLE
docs(python): update `extend_constant` docs/typing (and test coverage)

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5621,33 +5621,31 @@ class Expr:
         alpha = _prepare_alpha(com, span, half_life, alpha)
         return wrap_expr(self._pyexpr.ewm_var(alpha, adjust, bias, min_periods))
 
-    def extend_constant(
-        self, value: int | float | str | bool | date | None, n: int
-    ) -> Expr:
+    def extend_constant(self, value: PythonLiteral | None, n: int) -> Expr:
         """
-        Extend the Series with given number of values.
+        Extremely fast method for extending the Series with 'n' copies of a value.
 
         Parameters
         ----------
         value
             A constant literal value (not an expression) with which to extend the
-            Series; can pass None to fill the Series with nulls.
+            expression result Series; can pass None to extend with nulls.
         n
-            The number of additional values that will be added into the Series.
+            The number of additional values that will be added.
 
         Examples
         --------
         >>> df = pl.DataFrame({"values": [1, 2, 3]})
-        >>> df.select(pl.col("values").extend_constant(99, n=2))
+        >>> df.select((pl.col("values") - 1).extend_constant(99, n=2))
         shape: (5, 1)
         ┌────────┐
         │ values │
         │ ---    │
         │ i64    │
         ╞════════╡
+        │ 0      │
         │ 1      │
         │ 2      │
-        │ 3      │
         │ 99     │
         │ 99     │
         └────────┘
@@ -5655,6 +5653,7 @@ class Expr:
         """
         if isinstance(value, Expr):
             raise TypeError(f"'value' must be a supported literal; found {value!r}")
+
         return wrap_expr(self._pyexpr.extend_constant(value, n))
 
     def value_counts(self, multithreaded: bool = False, sort: bool = False) -> Expr:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -97,6 +97,7 @@ if TYPE_CHECKING:
         FillNullStrategy,
         InterpolationMethod,
         NullBehavior,
+        PythonLiteral,
         RankMethod,
         RollingInterpolationMethod,
         SearchSortedSide,
@@ -4803,19 +4804,17 @@ class Series:
 
         """
 
-    def extend_constant(
-        self, value: int | float | str | bool | date | None, n: int
-    ) -> Series:
+    def extend_constant(self, value: PythonLiteral | None, n: int) -> Series:
         """
-        Extend the Series with given number of values.
+        Extremely fast method for extending the Series with 'n' copies of a value.
 
         Parameters
         ----------
         value
-            A constant literal value (not an expression) with which to extend the
-            Series; can pass None to fill the Series with nulls.
+            A constant literal value (not an expression) with which to extend
+            the Series; can pass None to extend with nulls.
         n
-            The number of additional values that will be added into the Series.
+            The number of additional values that will be added.
 
         Examples
         --------

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2215,9 +2215,14 @@ def test_ewm_param_validation() -> None:
     ("const", "dtype"),
     [
         (1, pl.Int8),
-        (date.today(), pl.Date),
-        ("xyz", pl.Utf8),
+        (4, pl.UInt32),
+        (4.5, pl.Float32),
         (None, pl.Float64),
+        ("白鵬翔", pl.Utf8),
+        (date.today(), pl.Date),
+        (datetime.now(), pl.Datetime("ns")),
+        (time(23, 59, 59), pl.Time),
+        (timedelta(hours=7, seconds=123), pl.Duration("ms")),
     ],
 )
 def test_extend_constant(const: Any, dtype: pl.PolarsDataType) -> None:


### PR DESCRIPTION
Noticed that `extend_constant` can handle additional literal types now, so updated the typing/docs (and coverage) accordingly.