### PR TITLE
feat(rust, python): let cast_time_zone work on tz-naive and deprecate tz-localize

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -333,7 +333,7 @@ def sequence_to_pyseries(
             if dtype == Datetime and value.tzinfo is not None:
                 py_series = PySeries.new_from_anyvalues(name, values)
                 tz = str(value.tzinfo)
-                return pli.wrap_s(py_series).dt.tz_localize(tz)._s
+                return pli.wrap_s(py_series).dt.cast_time_zone(tz)._s
 
             # TODO: use anyvalues here (no need to require pyarrow for this).
             arrow_dtype = dtype_to_arrow_type(dtype)

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from datetime import time, timedelta
 from typing import TYPE_CHECKING
 
@@ -1247,6 +1248,10 @@ class ExprDateTimeNameSpace:
         This method takes a naive Datetime Series and makes this time zone aware.
         It does not move the time to another time zone.
 
+        .. deprecated:: 0.16.3
+            `with_column` will be removed in favor of the more generic `with_columns`
+            in version 0.18.0.
+
         Parameters
         ----------
         tz
@@ -1281,6 +1286,12 @@ class ExprDateTimeNameSpace:
         │ 2020-05-01 00:00:00 ┆ 2020-05-01 00:00:00 CEST       │
         └─────────────────────┴────────────────────────────────┘
         """
+        warnings.warn(
+            "`tz_localize` has been deprecated in favor of `cast_time_zone`."
+            " This method will be removed in version 0.18.0",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return pli.wrap_expr(self._pyexpr.dt_tz_localize(tz))
 
     def days(self) -> pli.Expr:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1127,7 +1127,7 @@ def lit(
         tu = "us"
         e = lit(_datetime_to_pl_timestamp(value, tu)).cast(Datetime(tu))
         if value.tzinfo is not None:
-            return e.dt.tz_localize(str(value.tzinfo))
+            return e.dt.cast_time_zone(str(value.tzinfo))
         else:
             return e
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
@@ -1045,12 +1046,27 @@ class DateTimeNameSpace:
         This method takes a naive Datetime Series and makes this time zone aware.
         It does not move the time to another time zone.
 
+        .. deprecated:: 0.16.3
+            `with_column` will be removed in favor of the more generic `with_columns`
+            in version 0.18.0.
+
         Parameters
         ----------
         tz
             Time zone for the `Datetime` Series.
-
         """
+        warnings.warn(
+            "`tz_localize` has been deprecated in favor of `cast_time_zone`."
+            " This method will be removed in version 0.18.0",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return (
+            pli.wrap_s(self._s)
+            .to_frame()
+            .select(pli.col(self._s.name()).dt.tz_localize(tz))
+            .to_series()
+        )
 
     def days(self) -> pli.Series:
         """


### PR DESCRIPTION
closes #6561
