### PR TITLE
feat(python): improved exceptions on attempt to use invalid schema/dtypes

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -601,7 +601,7 @@ def _unpack_schema(
     column_dtypes = {
         lookup.get(col[0], col[0]): col[1]
         for col in (schema or [])
-        if not isinstance(col, str) and col[1]
+        if not isinstance(col, str) and col[1] is not None
     }
     if schema_overrides:
         column_dtypes.update(schema_overrides)
@@ -609,6 +609,9 @@ def _unpack_schema(
             column_names = column_names + [
                 col for col in column_dtypes if col not in column_names
             ]
+    for col, dtype in column_dtypes.items():
+        if not is_polars_dtype(dtype, include_unknown=True) and dtype is not None:
+            column_dtypes[col] = py_type_to_dtype(dtype)
 
     return (
         column_names or None,  # type: ignore[return-value]


### PR DESCRIPTION
Closes #6648.

Enables centralised dtype sanity checking for schema params inside `_unpack_schema`, and raises more helpful errors in general for attempts to use invalid dtypes.

----

**Examples**:

* Use of invalid dtype in schema.
   ```python
   pl.DataFrame(
       data = {"words": [["hello", "hi"], ["polar", "bears"]]}, 
       schema = {"words": pl.list(pl.Categorical)},
   )
   ```
   Before
   ```
   ValueError: Since Expr are lazy, the truthiness of an Expr is ambiguous. Hint: use '&' or '|' to logically combine Expr, not 'and'/'or', and use 'x.is_in([y,z])' instead of 'x in [y,z]' to check membership.
   ```
   After
   ```
   ValueError: Cannot infer dtype from 'COLUMN OF DTYPE: [Categorical(None)].list()' (type: Expr)
   ```

* Use of invalid dtype in cast operation.
   ```python
   df1 = pl.DataFrame({"words": [["hello", "hi"], ["polar", "bears"]]})
   df1.select(pl.col("words").cast(pl.list(pl.Categorical)))
   ```
   Before
   ```
   ValueError: could not convert value 'Unknown' as a Literal
   ```
   After
   ```
   ValueError: Cannot infer dtype from 'COLUMN OF DTYPE: [Categorical(None)].list()' (type: Expr)
   ```
