### PR TITLE
fix(python): Preserve Expr name in `is_between`

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3414,7 +3414,7 @@ class Expr:
         Examples
         --------
         >>> df = pl.DataFrame({"num": [1, 2, 3, 4, 5]})
-        >>> df.with_columns(pl.col("num").is_between(2, 4))
+        >>> df.with_columns(pl.col("num").is_between(2, 4).alias("is_between"))
         shape: (5, 2)
         ┌─────┬────────────┐
         │ num ┆ is_between │
@@ -3430,7 +3430,9 @@ class Expr:
 
         Use the ``closed`` argument to include or exclude the values at the bounds:
 
-        >>> df.with_columns(pl.col("num").is_between(2, 4, closed="left"))
+        >>> df.with_columns(
+        ...     pl.col("num").is_between(2, 4, closed="left").alias("is_between")
+        ... )
         shape: (5, 2)
         ┌─────┬────────────┐
         │ num ┆ is_between │
@@ -3444,13 +3446,15 @@ class Expr:
         │ 5   ┆ false      │
         └─────┴────────────┘
 
-        Can also use strings as well as numeric/temporal values (note: ensure that
+        You can also use strings as well as numeric/temporal values (note: ensure that
         string literals are wrapped with ``lit`` so as not to conflate them with
         column names):
 
         >>> df = pl.DataFrame({"a": ["a", "b", "c", "d", "e"]})
         >>> df.with_columns(
-        ...     pl.col("a").is_between(pl.lit("a"), pl.lit("c"), closed="both")
+        ...     pl.col("a")
+        ...     .is_between(pl.lit("a"), pl.lit("c"), closed="both")
+        ...     .alias("is_between")
         ... )
         shape: (5, 2)
         ┌─────┬────────────┐
@@ -3469,13 +3473,13 @@ class Expr:
         end = expr_to_lit_or_expr(end, str_to_lit=False)
 
         if closed == "none":
-            return ((self > start) & (self < end)).alias("is_between")
+            return (self > start) & (self < end)
         elif closed == "both":
-            return ((self >= start) & (self <= end)).alias("is_between")
+            return (self >= start) & (self <= end)
         elif closed == "right":
-            return ((self > start) & (self <= end)).alias("is_between")
+            return (self > start) & (self <= end)
         elif closed == "left":
-            return ((self >= start) & (self < end)).alias("is_between")
+            return (self >= start) & (self < end)
         else:
             raise ValueError(
                 "closed must be one of {'left', 'right', 'both', 'none'},"

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1178,38 +1178,22 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_is_between(fruits_cars: pl.DataFrame) -> None:
-    result = fruits_cars.select(pl.col("A").is_between(2, 4))["is_between"]
-    assert_series_equal(
-        result, pl.Series("is_between", [False, True, True, True, False])
-    )
+    result = fruits_cars.select(pl.col("A").is_between(2, 4)).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none"))[
-        "is_between"
-    ]
-    assert_series_equal(
-        result, pl.Series("is_between", [False, False, True, False, False])
-    )
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, False, True, False, False]))
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both"))[
-        "is_between"
-    ]
-    assert_series_equal(
-        result, pl.Series("is_between", [False, True, True, True, False])
-    )
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="right"))[
-        "is_between"
-    ]
-    assert_series_equal(
-        result, pl.Series("is_between", [False, False, True, True, False])
-    )
+    result = fruits_cars.select(
+        pl.col("A").is_between(2, 4, closed="right")
+    ).to_series()
+    assert_series_equal(result, pl.Series("A", [False, False, True, True, False]))
 
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left"))[
-        "is_between"
-    ]
-    assert_series_equal(
-        result, pl.Series("is_between", [False, True, True, False, False])
-    )
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, False, False]))
 
 
 def test_is_between_data_types() -> None:
@@ -1231,15 +1215,15 @@ def test_is_between_data_types() -> None:
     # on purpose, for float and int, we pass in a mixture of bound data types
     assert_series_equal(
         df.select(pl.col("flt").is_between(1, 2.3))[:, 0],
-        pl.Series("is_between", [True, True, False]),
+        pl.Series("flt", [True, True, False]),
     )
     assert_series_equal(
         df.select(pl.col("int").is_between(1.5, 3))[:, 0],
-        pl.Series("is_between", [True, True, False]),
+        pl.Series("int", [True, True, False]),
     )
     assert_series_equal(
         df.select(pl.col("date").is_between(date(2019, 1, 1), date(2020, 2, 5)))[:, 0],
-        pl.Series("is_between", [True, True, False]),
+        pl.Series("date", [True, True, False]),
     )
     assert_series_equal(
         df.select(
@@ -1247,13 +1231,13 @@ def test_is_between_data_types() -> None:
                 datetime(2020, 1, 1, 5, 0, 0), datetime(2020, 1, 1, 11, 0, 0)
             )
         )[:, 0],
-        pl.Series("is_between", [False, True, False]),
+        pl.Series("datetime", [False, True, False]),
     )
     assert_series_equal(
         df.select(
             pl.col("str").is_between(pl.lit("str"), pl.lit("zzz"), closed="left")
         )[:, 0],
-        pl.Series("is_between", [True, True, False]),
+        pl.Series("str", [True, True, False]),
     )
     assert_series_equal(
         df.select(

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2053,8 +2053,8 @@ def test_is_between_datetime() -> None:
     expected = pl.Series("a", [False, True])
 
     # only on the expression api
-    result = s.to_frame().with_columns(pl.col("*").is_between(start, end))["is_between"]
-    assert_series_equal(result.rename("a"), expected)
+    result = s.to_frame().with_columns(pl.col("*").is_between(start, end)).to_series()
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #6654

This might be breaking for some people, but then again it can also be seen as a bug fix... Up to you how to handle this!