### PR TITLE
feat(python): More ergonomic `select` args

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5572,15 +5572,18 @@ class DataFrame:
         Parameters
         ----------
         exprs
-            Column or columns to select.
+            Column or columns to select. Accepts expression input. Strings are parsed
+            as column names, other non-expression inputs are parsed as literals.
         *more_exprs
-            Additional column expression(s) to select, specified as positional
-            parameters.
+            Additional columns to select, specified as positional arguments.
         **named_exprs
-            Named column expressions, provided as kwargs.
+            Additional columns to select, specified as keyword arguments. The columns
+            will be renamed to the keyword used.
 
         Examples
         --------
+        Pass the name of a column to select that column.
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -5600,6 +5603,8 @@ class DataFrame:
         │ 3   │
         └─────┘
 
+        Multiple columns can be selected by passing a list of column names.
+
         >>> df.select(["foo", "bar"])
         shape: (3, 2)
         ┌─────┬─────┐
@@ -5612,41 +5617,34 @@ class DataFrame:
         │ 3   ┆ 8   │
         └─────┴─────┘
 
-        >>> df.select(pl.col("foo") + 1)
-        shape: (3, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ 2   │
-        │ 3   │
-        │ 4   │
-        └─────┘
+        Multiple columns can also be selected using positional arguments instead of a
+        list. Expressions are also accepted.
 
-        >>> df.select([pl.col("foo") + 1, pl.col("bar") + 1])
+        >>> df.select(pl.col("foo"), pl.col("bar") + 1)
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
         │ --- ┆ --- │
         │ i64 ┆ i64 │
         ╞═════╪═════╡
-        │ 2   ┆ 7   │
-        │ 3   ┆ 8   │
-        │ 4   ┆ 9   │
+        │ 1   ┆ 7   │
+        │ 2   ┆ 8   │
+        │ 3   ┆ 9   │
         └─────┴─────┘
 
-        >>> df.select(pl.when(pl.col("foo") > 2).then(10).otherwise(0))
+        Use keyword arguments to easily name your expression inputs.
+
+        >>> df.select(threshold=pl.when(pl.col("foo") > 2).then(10).otherwise(0))
         shape: (3, 1)
-        ┌─────────┐
-        │ literal │
-        │ ---     │
-        │ i32     │
-        ╞═════════╡
-        │ 0       │
-        │ 0       │
-        │ 10      │
-        └─────────┘
+        ┌───────────┐
+        │ threshold │
+        │ ---       │
+        │ i32       │
+        ╞═══════════╡
+        │ 0         │
+        │ 0         │
+        │ 10        │
+        └───────────┘
 
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5560,10 +5560,11 @@ class DataFrame:
             | PolarsExprType
             | PythonLiteral
             | pli.Series
-            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series]
+            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
             | None
         ) = None,
-        **named_exprs: PolarsExprType | PythonLiteral | pli.Series | None,
+        *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+        **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
     ) -> DF:
         """
         Select columns from this DataFrame.
@@ -5572,6 +5573,9 @@ class DataFrame:
         ----------
         exprs
             Column or columns to select.
+        *more_exprs
+            Additional column expression(s) to select, specified as positional
+            parameters.
         **named_exprs
             Named column expressions, provided as kwargs.
 
@@ -5667,7 +5671,10 @@ class DataFrame:
 
         """
         return self._from_pydf(
-            self.lazy().select(exprs, **named_exprs).collect(no_optimization=True)._df
+            self.lazy()
+            .select(exprs, *more_exprs, **named_exprs)
+            .collect(no_optimization=True)
+            ._df
         )
 
     def with_columns(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -53,7 +53,7 @@ def selection_to_pyexpr_list(
         PolarsExprType
         | PythonLiteral
         | pli.Series
-        | Iterable[PolarsExprType | PythonLiteral | pli.Series]
+        | Iterable[PolarsExprType | PythonLiteral | pli.Series | None]
         | None
     ),
     structify: bool = False,

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2261,17 +2261,17 @@ def select(
     """
     Run polars expressions without a context.
 
-    This is syntactic sugar for running `df.select` on an empty DataFrame.
+    This is syntactic sugar for running ``df.select`` on an empty DataFrame.
 
     Parameters
     ----------
     exprs
-        Expressions to run
+        Expression or expressions to run.
     *more_exprs
-        Additional column expression(s) to select, specified as positional
-        parameters.
+        Additional expressions to run, specified as positional arguments.
     **named_exprs
-        Named expressions, provided as kwargs.
+        Additional expressions to run, specified as keyword arguments. The expressions
+        will be renamed to the keyword used.
 
     Returns
     -------
@@ -2281,11 +2281,7 @@ def select(
     --------
     >>> foo = pl.Series("foo", [1, 2, 3])
     >>> bar = pl.Series("bar", [3, 2, 1])
-    >>> pl.select(
-    ...     [
-    ...         pl.min([foo, bar]),
-    ...     ]
-    ... )
+    >>> pl.select(pl.min([foo, bar]))
     shape: (3, 1)
     ┌─────┐
     │ min │

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2252,10 +2252,11 @@ def select(
         | PolarsExprType
         | PythonLiteral
         | pli.Series
-        | Iterable[str | PolarsExprType | PythonLiteral | pli.Series]
+        | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
         | None
     ) = None,
-    **named_exprs: PolarsExprType | PythonLiteral | pli.Series | None,
+    *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+    **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
 ) -> pli.DataFrame:
     """
     Run polars expressions without a context.
@@ -2266,6 +2267,9 @@ def select(
     ----------
     exprs
         Expressions to run
+    *more_exprs
+        Additional column expression(s) to select, specified as positional
+        parameters.
     **named_exprs
         Named expressions, provided as kwargs.
 
@@ -2294,7 +2298,7 @@ def select(
     └─────┘
 
     """
-    return pli.DataFrame([]).select(exprs, **named_exprs)
+    return pli.DataFrame().select(exprs, *more_exprs, **named_exprs)
 
 
 @overload

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1574,15 +1574,18 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Parameters
         ----------
         exprs
-            Column expression(s) to select.
+            Column or columns to select. Accepts expression input. Strings are parsed
+            as column names, other non-expression inputs are parsed as literals.
         *more_exprs
-            Additional column expression(s) to select, specified as positional
-            parameters.
+            Additional columns to select, specified as positional arguments.
         **named_exprs
-            Named column expressions, provided as kwargs.
+            Additional columns to select, specified as keyword arguments. The columns
+            will be renamed to the keyword used.
 
         Examples
         --------
+        Pass the name of a column to select that column.
+
         >>> ldf = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -1601,6 +1604,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 2   │
         │ 3   │
         └─────┘
+
+        Multiple columns can be selected by passing a list of column names.
+
         >>> ldf.select(["foo", "bar"]).collect()
         shape: (3, 2)
         ┌─────┬─────┐
@@ -1613,43 +1619,36 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 3   ┆ 8   │
         └─────┴─────┘
 
-        >>> ldf.select(pl.col("foo") + 1).collect()
-        shape: (3, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ 2   │
-        │ 3   │
-        │ 4   │
-        └─────┘
+        Multiple columns can also be selected using positional arguments instead of a
+        list. Expressions are also accepted.
 
-        >>> ldf.select([pl.col("foo") + 1, pl.col("bar") + 1]).collect()
+        >>> ldf.select(pl.col("foo"), pl.col("bar") + 1).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
         │ --- ┆ --- │
         │ i64 ┆ i64 │
         ╞═════╪═════╡
-        │ 2   ┆ 7   │
-        │ 3   ┆ 8   │
-        │ 4   ┆ 9   │
+        │ 1   ┆ 7   │
+        │ 2   ┆ 8   │
+        │ 3   ┆ 9   │
         └─────┴─────┘
 
+        Use keyword arguments to easily name your expression inputs.
+
         >>> ldf.select(
-        ...     value=pl.when(pl.col("foo") > 2).then(10).otherwise(0),
+        ...     threshold=pl.when(pl.col("foo") > 2).then(10).otherwise(0)
         ... ).collect()
         shape: (3, 1)
-        ┌───────┐
-        │ value │
-        │ ---   │
-        │ i32   │
-        ╞═══════╡
-        │ 0     │
-        │ 0     │
-        │ 10    │
-        └───────┘
+        ┌───────────┐
+        │ threshold │
+        │ ---       │
+        │ i32       │
+        ╞═══════════╡
+        │ 0         │
+        │ 0         │
+        │ 10        │
+        └───────────┘
 
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -691,10 +691,38 @@ def test_take(fruits_cars: pl.DataFrame) -> None:
 
 def test_select_by_col_list(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
-    out = df.select(col(["A", "B"]).sum())
-    assert out.columns == ["A", "B"]
-    assert out.shape == (1, 2)
-    assert out.row(0) == (15, 15)
+    result = df.select(col(["A", "B"]).sum())
+    expected = pl.DataFrame({"A": 15, "B": 15})
+    assert_frame_equal(result, expected)
+
+
+def test_select_args_kwargs() -> None:
+    df = pl.DataFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
+
+    # Single column name
+    result = df.select("foo")
+    expected = pl.DataFrame({"foo": [1, 2]})
+    assert_frame_equal(result, expected)
+
+    # Column names as list
+    result = df.select(["foo", "bar"])
+    expected = pl.DataFrame({"foo": [1, 2], "bar": [3, 4]})
+    assert_frame_equal(result, expected)
+
+    # Column names as positional arguments
+    result = df.select("foo", "bar", "ham")
+    expected = df
+    assert_frame_equal(result, expected)
+
+    # Keyword arguments
+    result = df.select(oof="foo")
+    expected = pl.DataFrame({"oof": [1, 2]})
+    assert_frame_equal(result, expected)
+
+    # Mixed
+    result = df.select(["bar"], "foo", oof="foo")
+    expected = pl.DataFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
+    assert_frame_equal(result, expected)
 
 
 def test_rolling(fruits_cars: pl.DataFrame) -> None:


### PR DESCRIPTION
Partially addresses #6451

Changes:
* Add a `*more_exprs` parameter to `select`. It allows for writing `df.select("a", "b")` instead of `df.select(["a", "b"])`.
* Updated docstrings & examples.
* Added a test for the new functionality.

This is completely non-breaking. Everything you could do before, you can still do now.

The additional logic is literally only 1 line of code. So not much that can go wrong here, I think!

If this gets merged, I'll continue to add this to `with_columns`, `groupby`, etc.