### PR TITLE
feat(rust): guarantee schema-stable `col(dtype)` selection

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
@@ -208,17 +208,17 @@ fn expand_dtypes(
     dtypes: &[DataType],
     exclude: &[Arc<str>],
 ) -> PolarsResult<()> {
-    for field in schema.iter_fields() {
-        if dtypes.contains(&field.dtype) {
-            let name = field.name();
-            if exclude.iter().any(|excl| excl.as_ref() == name.as_str()) {
-                continue; // skip excluded names
-            }
-            let new_expr = expr.clone();
-            let new_expr = replace_dtype_with_column(new_expr, Arc::from(name.as_str()));
-            let new_expr = rewrite_special_aliases(new_expr)?;
-            result.push(new_expr)
+    // note: we loop over the schema to guarantee that we return a stable
+    // field-order, irrespective of which dtypes are filtered against
+    for field in schema.iter_fields().filter(|f| dtypes.contains(&f.dtype)) {
+        let name = field.name();
+        if exclude.iter().any(|excl| excl.as_ref() == name.as_str()) {
+            continue; // skip excluded names
         }
+        let new_expr = expr.clone();
+        let new_expr = replace_dtype_with_column(new_expr, Arc::from(name.as_str()));
+        let new_expr = rewrite_special_aliases(new_expr)?;
+        result.push(new_expr)
     }
     Ok(())
 }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
@@ -208,15 +208,12 @@ fn expand_dtypes(
     dtypes: &[DataType],
     exclude: &[Arc<str>],
 ) -> PolarsResult<()> {
-    for dtype in dtypes {
-        for field in schema.iter_fields().filter(|f| f.data_type() == dtype) {
+    for field in schema.iter_fields() {
+        if dtypes.contains(&field.dtype) {
             let name = field.name();
-
-            // skip excluded names
             if exclude.iter().any(|excl| excl.as_ref() == name.as_str()) {
-                continue;
+                continue; // skip excluded names
             }
-
             let new_expr = expr.clone();
             let new_expr = replace_dtype_with_column(new_expr, Arc::from(name.as_str()));
             let new_expr = rewrite_special_aliases(new_expr)?;

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -1590,7 +1590,7 @@ pub fn test_select_by_dtypes() -> PolarsResult<()> {
         .lazy()
         .select([dtype_cols([DataType::Float32, DataType::Utf8])])
         .collect()?;
-    assert_eq!(out.dtypes(), &[DataType::Float32, DataType::Utf8]);
+    assert_eq!(out.dtypes(), &[DataType::Utf8, DataType::Float32]);
 
     Ok(())
 }

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1578,7 +1578,7 @@ def test_select_by_dtype(df: pl.DataFrame) -> None:
     out = df.select(pl.col(pl.Utf8))
     assert out.columns == ["strings", "strings_nulls"]
     out = df.select(pl.col([pl.Utf8, pl.Boolean]))
-    assert out.columns == ["strings", "strings_nulls", "bools", "bools_nulls"]
+    assert out.columns == ["bools", "bools_nulls", "strings", "strings_nulls"]
     out = df.select(pl.col(INTEGER_DTYPES))
     assert out.columns == ["int", "int_nulls"]
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -215,7 +215,7 @@ def test_dtype_col_selection() -> None:
             "n": pl.UInt64,
         },
     )
-    assert set(df.select(pl.col(INTEGER_DTYPES)).columns) == {
+    assert df.select(pl.col(INTEGER_DTYPES)).columns == [
         "e",
         "f",
         "g",
@@ -224,9 +224,9 @@ def test_dtype_col_selection() -> None:
         "l",
         "m",
         "n",
-    }
-    assert set(df.select(pl.col(FLOAT_DTYPES)).columns) == {"i", "j"}
-    assert set(df.select(pl.col(NUMERIC_DTYPES)).columns) == {
+    ]
+    assert df.select(pl.col(FLOAT_DTYPES)).columns == ["i", "j"]
+    assert df.select(pl.col(NUMERIC_DTYPES)).columns == [
         "e",
         "f",
         "g",
@@ -237,8 +237,8 @@ def test_dtype_col_selection() -> None:
         "l",
         "m",
         "n",
-    }
-    assert set(df.select(pl.col(TEMPORAL_DTYPES)).columns) == {
+    ]
+    assert df.select(pl.col(TEMPORAL_DTYPES)).columns == [
         "a1",
         "a2",
         "a3",
@@ -249,19 +249,19 @@ def test_dtype_col_selection() -> None:
         "d2",
         "d3",
         "d4",
-    }
-    assert set(df.select(pl.col(DATETIME_DTYPES)).columns) == {
+    ]
+    assert df.select(pl.col(DATETIME_DTYPES)).columns == [
         "a1",
         "a2",
         "a3",
         "a4",
-    }
-    assert set(df.select(pl.col(DURATION_DTYPES)).columns) == {
+    ]
+    assert df.select(pl.col(DURATION_DTYPES)).columns == [
         "d1",
         "d2",
         "d3",
         "d4",
-    }
+    ]
 
 
 def test_list_eval_expression() -> None:


### PR DESCRIPTION
## Issue

* Using dtype-based column selection with more than one dtype (eg: `polars.datatypes.NUMERIC_DTYPES`) was not guaranteed to be stable between sessions/platforms/etc, as those dtype groups are set-based. 
* Other (non-set) multi-dtype selections return columns in dtype-order, not schema-order.

## Solution

Switch the inner/outer filter-order in `expand_dtypes` when determining which columns match.
Guarantees stable column selection while maintaining the underlying schema-order.

## Example

```python
from polars.datatypes import NUMERIC_DTYPES
import polars as pl

df = pl.DataFrame(
    data=[],
    schema={
        "a": pl.Int8,
        "b": pl.Int16,
        "c": pl.Int32,
        "d": pl.Int64,
        "e": pl.Float32,
        "f": pl.Float64,
        "g": pl.UInt8,
        "h": pl.UInt16,
        "i": pl.UInt32,
        "j": pl.UInt64,
    },
)
```

**Before**: _(unstable column order - changes between sessions)_
```python
df.select( pl.col(NUMERIC_DTYPES) )
# ┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
# │ f   ┆ c   ┆ e   ┆ b   ┆ j   ┆ a   ┆ i   ┆ h   ┆ g   ┆ d   │
# │ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- │
# │ f64 ┆ i32 ┆ f32 ┆ i16 ┆ u64 ┆ i8  ┆ u32 ┆ u16 ┆ u8  ┆ i64 │
# ╞═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╡
# └─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
```
**After**: _(stable, and schema-ordered)_
```python
df.select( pl.col(NUMERIC_DTYPES) )
# ┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   ┆ d   ┆ e   ┆ f   ┆ g   ┆ h   ┆ i   ┆ j   │
# │ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- │
# │ i8  ┆ i16 ┆ i32 ┆ i64 ┆ f32 ┆ f64 ┆ u8  ┆ u16 ┆ u32 ┆ u64 │
# ╞═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╡
# └─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
```

## Note

Selection in dtype order remains trivial (_and_ each set of matching cols is also now stable), eg:
```python
df.select( [pl.col(FLOAT_DTYPES), pl.col(INTEGER_DTYPES), ...] )
```