### PR TITLE
chore(rust) disallow chunked datetime with_time_zone on tznaive, remove unnecessary with_time_zone

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -263,8 +263,16 @@ impl DatetimeChunked {
     }
     #[cfg(feature = "timezones")]
     pub fn with_time_zone(mut self, tz: TimeZone) -> PolarsResult<Self> {
-        self.set_time_zone(tz)?;
-        Ok(self)
+        match self.time_zone() {
+            Some(_) => {
+                self.set_time_zone(tz)?;
+                Ok(self)
+            }
+            _ => Err(PolarsError::ComputeError(
+                "Cannot call with_time_zone on tz-naive. Set a time zone first with cast_time_zone"
+                    .into(),
+            )),
+        }
     }
 }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -76,7 +76,7 @@ impl DateLikeNameSpace {
                     Ok(Some(ca.into_series()))
                 }
                 _ => Err(PolarsError::ComputeError(
-                    "Cannot call with_time_zone on tz-naive. Set a time zone first with tz_localize".into()
+                    "Cannot call with_time_zone on tz-naive. Set a time zone first with cast_time_zone".into()
                 )),
             },
             GetOutput::same_type(),

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
@@ -149,11 +149,8 @@ pub(super) fn tz_localize(s: &Series, tz: &str) -> PolarsResult<Series> {
         (Some(old_tz), _) if !old_tz.is_empty() => {
             Err(PolarsError::ComputeError("Cannot localize a tz-aware datetime. Consider using 'dt.with_time_zone' or 'dt.cast_time_zone'".into()))
         },
-        (_, "UTC") => {
-            Ok(ca.with_time_zone("UTC".into())?.into_series())
-        }
         (_, _) => {
-            Ok(ca.with_time_zone("UTC".to_string())?.cast_time_zone(Some(tz))?.into_series())
+            Ok(ca.cast_time_zone(Some(tz))?.into_series())
         }
     }
 }

--- a/polars/polars-time/src/date_range.rs
+++ b/polars/polars-time/src/date_range.rs
@@ -25,10 +25,7 @@ pub fn date_range_impl(
 
     #[cfg(feature = "timezones")]
     if let Some(tz) = _tz {
-        out = out
-            .with_time_zone("UTC".to_string())?
-            .cast_time_zone(Some(tz))
-            .unwrap()
+        out = out.cast_time_zone(Some(tz)).unwrap()
     }
     let s = if start > stop {
         IsSorted::Descending

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1713,7 +1713,7 @@ def test_with_time_zone_on_tz_naive() -> None:
     ts = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime)
     with pytest.raises(
         ComputeError,
-        match="Cannot call with_time_zone on tz-naive. Set a time zone first with tz_localize",
+        match="Cannot call with_time_zone on tz-naive. Set a time zone first with cast_time_zone",
     ):
         ts.dt.with_time_zone("Africa/Bamako")
 


### PR DESCRIPTION
a follow-up to https://github.com/pola-rs/polars/pull/6659

By disallowing `with_time_zone` on tz-naive, it becomes clear that there's an unnecessary and confusing `with_time_zone('UTC')` call within `date_range_impl`, which I've removed

This one's unnecessary as `out` was created with `.into_datetime(tu, None)`