### PR TITLE
fix(rust, python): remove uses of rayon global thread pool

### DIFF
--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -106,9 +106,10 @@ where
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
-    let out = POOL
-        .install(|| {
-            (0..n_partitions).into_par_iter().map(|thread_no| {
+    let out = POOL.install(|| {
+        (0..n_partitions)
+            .into_par_iter()
+            .map(|thread_no| {
                 let mut hash_tbl: PlHashMap<T, (IdxSize, Vec<IdxSize>)> =
                     PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
 
@@ -149,8 +150,8 @@ where
                     .map(|(_k, v)| v)
                     .collect_trusted::<Vec<_>>()
             })
-        })
-        .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+    });
     finish_group_order(out, sorted)
 }
 
@@ -303,9 +304,10 @@ pub(crate) fn groupby_threaded_multiple_keys_flat(
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
-    let groups = POOL
-        .install(|| {
-            (0..n_partitions).into_par_iter().map(|thread_no| {
+    let groups = POOL.install(|| {
+        (0..n_partitions)
+            .into_par_iter()
+            .map(|thread_no| {
                 let hashes = &hashes;
 
                 let mut hash_tbl: HashMap<IdxHash, (IdxSize, Vec<IdxSize>), IdBuildHasher> =
@@ -339,7 +341,7 @@ pub(crate) fn groupby_threaded_multiple_keys_flat(
                 }
                 hash_tbl.into_iter().map(|(_k, v)| v).collect::<Vec<_>>()
             })
-        })
-        .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+    });
     Ok(finish_group_order(groups, sorted))
 }

--- a/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/dispatcher.rs
@@ -203,11 +203,12 @@ impl PipeLine {
                 }
             }
 
-            let mut reduced_sink = sink
-                .into_par_iter()
-                .reduce_with(|mut a, b| {
-                    a.combine(b);
-                    a
+            let mut reduced_sink = POOL
+                .install(|| {
+                    sink.into_par_iter().reduce_with(|mut a, b| {
+                        a.combine(b);
+                        a
+                    })
                 })
                 .unwrap();
             let sink_result = reduced_sink.finalize(ec)?;

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -105,8 +105,8 @@ fn run_partitions(
                 columns.extend_from_slice(&agg_columns);
 
                 DataFrame::new(columns)
-            })
-    }).collect()
+            }).collect()
+    })
 }
 
 fn estimate_unique_count(keys: &[Series], mut sample_size: usize) -> PolarsResult<usize> {


### PR DESCRIPTION
Found a few spots where the rayon global thread pool is being used, and swapped them out with the internal pool. I was able to track down the spots by using a local version of rayon and adding a panic statement in the `set_global_registry` method which is invoked whenever the global thread pool is constructed. I'm not sure what the best way to enforce this is. One idea is to use test fixtures, and we can check if the global pool was used at the end of each test. Another could be to patch rayon when testing similar to what I did to detect the errors.