### PR TITLE
feat(python): More ergonomic `with_columns` args

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -61,6 +61,5 @@ Manipulation/selection
     DataFrame.unstack
     DataFrame.upsample
     DataFrame.vstack
-    DataFrame.with_column
     DataFrame.with_columns
     DataFrame.with_row_count

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -38,7 +38,6 @@ Manipulation/selection
     LazyFrame.take_every
     LazyFrame.unique
     LazyFrame.unnest
-    LazyFrame.with_column
     LazyFrame.with_columns
     LazyFrame.with_context
     LazyFrame.with_row_count

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5678,10 +5678,11 @@ class DataFrame:
             | PolarsExprType
             | PythonLiteral
             | pli.Series
-            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series]
+            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
             | None
         ) = None,
-        **named_exprs: PolarsExprType | PythonLiteral | pli.Series | None,
+        *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+        **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
     ) -> DataFrame:
         """
         Return a new DataFrame with the columns added (if new), or replaced.
@@ -5695,6 +5696,8 @@ class DataFrame:
         ----------
         exprs
             List of expressions that evaluate to columns.
+        *more_exprs
+            ..
         **named_exprs
             Named column expressions, provided as kwargs.
 
@@ -5801,7 +5804,9 @@ class DataFrame:
 
         """
         return (
-            self.lazy().with_columns(exprs, **named_exprs).collect(no_optimization=True)
+            self.lazy()
+            .with_columns(exprs, *more_exprs, **named_exprs)
+            .collect(no_optimization=True)
         )
 
     @overload

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6,7 +6,6 @@ import os
 import random
 import sys
 import typing
-import warnings
 from collections.abc import Sized
 from datetime import timedelta
 from io import BytesIO, IOBase, StringIO
@@ -153,7 +152,12 @@ def wrap_df(df: PyDataFrame) -> DataFrame:
     return DataFrame._from_pydf(df)
 
 
-@redirect({"iterrows": "iter_rows"})
+@redirect(
+    {
+        "iterrows": "iter_rows",
+        "with_column": "with_columns",
+    }
+)
 class DataFrame:
     """
     Two-dimensional data structure representing data as a table with rows and columns.
@@ -4393,33 +4397,6 @@ class DataFrame:
             return self._from_pydf(out)
         else:
             return self._from_pydf(pli.wrap_s(out).to_frame()._df)
-
-    def with_column(self, column: pli.Series | pli.Expr) -> DataFrame:
-        """
-        Return a new DataFrame with the column added, if new, or replaced.
-
-        Notes
-        -----
-        Creating a new DataFrame using this method does not create a new copy of
-        existing data.
-
-        .. deprecated:: 0.15.14
-            `with_column` will be removed in favor of the more generic `with_columns`
-            in version 0.17.0.
-
-        Parameters
-        ----------
-        column
-            Series, where the name of the Series refers to the column in the DataFrame.
-
-        """
-        warnings.warn(
-            "`with_column` has been deprecated in favor of `with_columns`."
-            " This method will be removed in version 0.17.0",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.lazy().with_columns(column).collect(no_optimization=True)
 
     def hstack(
         self: DF,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import typing
-import warnings
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
@@ -55,6 +54,7 @@ from polars.utils import (
     _process_null_values,
     _timedelta_to_pl_duration,
     normalise_filepath,
+    redirect,
 )
 
 try:
@@ -98,6 +98,7 @@ def wrap_ldf(ldf: PyLazyFrame) -> LazyFrame:
     return LazyFrame._from_pyldf(ldf)
 
 
+@redirect({"with_column": "with_columns"})
 class LazyFrame:
     """
     Representation of a Lazy computation graph/query against a DataFrame.
@@ -2673,39 +2674,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             other = [other]
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
-
-    def with_column(self: LDF, column: pli.Series | pli.Expr) -> LDF:
-        """
-        Return a new LazyFrame with the column added, if new, or replaced.
-
-        Notes
-        -----
-        Creating a new LazyFrame using this method does not create a new copy of
-        existing data.
-
-        .. deprecated:: 0.15.14
-            `with_column` will be removed in favor of the more generic `with_columns`
-            in version 0.17.0.
-
-        Parameters
-        ----------
-        column
-            Expression that evaluates to column or a Series to use.
-
-        """
-        warnings.warn(
-            "`with_column` has been deprecated in favor of `with_columns`."
-            " This method will be removed in version 0.17.0",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if not isinstance(column, (pli.Expr, pli.Series)):
-            raise TypeError(
-                "`with_column` expects a single Expr or Series. "
-                "Consider using `with_columns` if you need multiple columns."
-            )
-        return self.with_columns([column])
 
     def drop(self: LDF, columns: str | list[str]) -> LDF:
         """

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2527,7 +2527,7 @@ def test_with_columns() -> None:
             "g": True,
             "h": pl.Series(values=[1, 1, 1, 1], dtype=pl.Int32),
             "i": 3.2,
-            "j": "d",
+            "j": [1, 2, 3, 4],
             "k": pl.Series(values=[None, None, None, None], dtype=pl.Boolean),
             "l": datetime.datetime(2001, 1, 1, 0, 0),
         }
@@ -2542,7 +2542,7 @@ def test_with_columns() -> None:
             pl.lit(True).alias("g"),
             pl.lit(1).alias("h"),
             pl.lit(3.2).alias("i"),
-            pl.lit("d").alias("j"),
+            pl.col("a").alias("j"),
             pl.lit(None).alias("k"),
             pl.lit(datetime.datetime(2001, 1, 1, 0, 0)).alias("l"),
         ]
@@ -2557,7 +2557,7 @@ def test_with_columns() -> None:
         g=True,
         h=1,
         i=3.2,
-        j="d",
+        j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
         k=None,
         l=datetime.datetime(2001, 1, 1, 0, 0),
     )
@@ -2571,7 +2571,7 @@ def test_with_columns() -> None:
         g=True,
         h=1,
         i=3.2,
-        j="d",
+        j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
         k=None,
         l=datetime.datetime(2001, 1, 1, 0, 0),
     )

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2549,7 +2549,21 @@ def test_with_columns() -> None:
     )
     assert_frame_equal(dx, expected)
 
-    # as **kwargs
+    # as positional arguments
+    dx = df.with_columns(
+        (pl.col("a") * pl.col("b")).alias("d"),
+        ~pl.col("c").alias("e"),
+        srs_named,
+        pl.lit(True).alias("g"),
+        pl.lit(1).alias("h"),
+        pl.lit(3.2).alias("i"),
+        pl.col("a").alias("j"),
+        pl.lit(None).alias("k"),
+        pl.lit(datetime.datetime(2001, 1, 1, 0, 0)).alias("l"),
+    )
+    assert_frame_equal(dx, expected)
+
+    # as keyword arguments
     dx = df.with_columns(
         d=pl.col("a") * pl.col("b"),
         e=~pl.col("c"),
@@ -2566,7 +2580,7 @@ def test_with_columns() -> None:
     # mixed
     dx = df.with_columns(
         [(pl.col("a") * pl.col("b")).alias("d")],
-        e=~pl.col("c"),
+        ~pl.col("c").alias("e"),
         f=srs_unnamed,
         g=True,
         h=1,


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/6451

Changes:
* `with_columns` now follows the exact same implementation logic as `select`.
* Docstring updates.
* This also fixes a bug where `.with_columns(newcol="a")` would interpret this as `pl.lit("a")` instead of `pl.col("a")`. This same bug had already been fixed recently for `select`.
* Use the new redirect functionality to redirect `with_column` to `with_columns`.