### PR TITLE
fix(rust, python): dedicated `rename` implementation.

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -237,6 +237,7 @@ impl ALogicalPlan {
             Melt { schema, .. } => schema,
             MapFunction { input, function } => {
                 let input_schema = arena.get(*input).schema(arena);
+
                 return match input_schema {
                     Cow::Owned(schema) => {
                         Cow::Owned(function.schema(&schema).unwrap().into_owned())

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -385,6 +385,14 @@ impl LogicalPlanBuilder {
         .into()
     }
 
+    pub fn add_err(self, err: PolarsError) -> Self {
+        LogicalPlan::Error {
+            input: Box::new(self.0),
+            err: err.into(),
+        }
+        .into()
+    }
+
     pub fn with_context(self, contexts: Vec<LogicalPlan>) -> Self {
         let mut schema = try_delayed!(self.0.schema(), &self.0, into)
             .as_ref()

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+pub(super) fn rename_impl(mut df: DataFrame, existing: &[String], new: &[String]) -> PolarsResult<DataFrame> {
+    let positions = existing
+        .iter()
+        .map(|old| df.try_find_idx_by_name(old))
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    for (pos, name) in positions.iter().zip(new.iter()) {
+        df.get_columns_mut()[*pos].rename(name);
+    }
+    // recreate dataframe so we check duplicates
+    let columns = std::mem::take(df.get_columns_mut());
+    DataFrame::new(columns)
+}
+
+pub(super) fn rename_schema<'a>(
+    input_schema: &'a SchemaRef,
+    existing: &[String],
+    new: &[String]
+) -> PolarsResult<Cow<'a, SchemaRef>> {
+    let mut new_schema = (**input_schema).clone();
+    for (old, new) in existing.iter().zip(new.iter()) {
+        let dtype = input_schema.try_get(old)?;
+        if new_schema.with_column(new.clone(), dtype.clone()).is_none() {
+            new_schema.remove(old);
+        }
+    }
+    Ok(Cow::Owned(Arc::new(new_schema)))
+}

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
@@ -1,13 +1,21 @@
 use super::*;
 
-pub(super) fn rename_impl(mut df: DataFrame, existing: &[String], new: &[String]) -> PolarsResult<DataFrame> {
+pub(super) fn rename_impl(
+    mut df: DataFrame,
+    existing: &[String],
+    new: &[String],
+) -> PolarsResult<DataFrame> {
     let positions = existing
         .iter()
-        .map(|old| df.try_find_idx_by_name(old))
-        .collect::<PolarsResult<Vec<_>>>()?;
+        .map(|old| df.find_idx_by_name(old))
+        .collect::<Vec<_>>();
 
     for (pos, name) in positions.iter().zip(new.iter()) {
-        df.get_columns_mut()[*pos].rename(name);
+        // the column might be removed due to projection pushdown
+        // so we only update if we can find it.
+        if let Some(pos) = pos {
+            df.get_columns_mut()[*pos].rename(name);
+        }
     }
     // recreate dataframe so we check duplicates
     let columns = std::mem::take(df.get_columns_mut());
@@ -17,7 +25,7 @@ pub(super) fn rename_impl(mut df: DataFrame, existing: &[String], new: &[String]
 pub(super) fn rename_schema<'a>(
     input_schema: &'a SchemaRef,
     existing: &[String],
-    new: &[String]
+    new: &[String],
 ) -> PolarsResult<Cow<'a, SchemaRef>> {
     let mut new_schema = (**input_schema).clone();
     for (old, new) in existing.iter().zip(new.iter()) {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/iterator.rs
@@ -97,7 +97,7 @@ macro_rules! push_expr {
 impl Expr {
     /// Expr::mutate().apply(fn())
     pub fn mutate(&mut self) -> ExprMut {
-        let mut stack = Vec::with_capacity(8);
+        let mut stack = Vec::with_capacity(4);
         stack.push(self);
         ExprMut { stack }
     }
@@ -151,7 +151,7 @@ impl<'a> IntoIterator for &'a Expr {
     type IntoIter = ExprIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let mut stack = Vec::with_capacity(8);
+        let mut stack = Vec::with_capacity(4);
         stack.push(self);
         ExprIter { stack }
     }
@@ -282,7 +282,7 @@ pub trait ArenaExprIter<'a> {
 
 impl<'a> ArenaExprIter<'a> for &'a Arena<AExpr> {
     fn iter(&self, root: Node) -> AExprIter<'a> {
-        let mut stack = Vec::with_capacity(8);
+        let mut stack = Vec::with_capacity(4);
         stack.push(root);
         AExprIter {
             stack,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/keys.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/keys.rs
@@ -1,0 +1,40 @@
+//! Keys in the `acc_predicates` hashmap.
+use super::*;
+
+// an invisible ascii token we use as delimiter
+const HIDDEN_DELIMITER: char = '\u{1D17A}';
+
+/// Determine the hashmap key by combining all the leaf column names of a predicate
+pub(super) fn predicate_to_key(predicate: Node, expr_arena: &Arena<AExpr>) -> Arc<str> {
+    let mut iter = aexpr_to_leaf_names_iter(predicate, expr_arena);
+    if let Some(first) = iter.next() {
+        if let Some(second) = iter.next() {
+            let mut new = String::with_capacity(32 * iter.size_hint().0);
+            new.push_str(&first);
+            new.push(HIDDEN_DELIMITER);
+            new.push_str(&second);
+
+            for name in iter {
+                new.push(HIDDEN_DELIMITER);
+                new.push_str(&name);
+            }
+            return Arc::from(new);
+        }
+        first
+    } else {
+        let mut s = String::new();
+        s.push(HIDDEN_DELIMITER);
+        Arc::from(s)
+    }
+}
+
+pub(super) fn key_has_name(key: &str, name: &str) -> bool {
+    if key.contains(HIDDEN_DELIMITER) {
+        for root_name in key.split(HIDDEN_DELIMITER) {
+            if root_name == name {
+                return true;
+            }
+        }
+    }
+    key == name
+}

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -1,3 +1,5 @@
+mod keys;
+mod rename;
 mod utils;
 
 use polars_core::datatypes::PlHashMap;
@@ -7,6 +9,7 @@ use utils::*;
 use super::*;
 use crate::dsl::function_expr::FunctionExpr;
 use crate::logical_plan::{optimizer, Context};
+use crate::prelude::optimizer::predicate_pushdown::rename::process_rename;
 use crate::utils::{aexprs_to_schema, check_input_node, has_aexpr};
 
 #[derive(Default)]
@@ -516,9 +519,25 @@ impl PredicatePushDown {
             MapFunction { ref function, .. } => {
                 if function.allow_predicate_pd()
                 {
-                    
+                    match function {
+                        FunctionNode::Rename {
+                            existing,
+                            new,
+                            ..
+                        } => {
+                            let local_predicates = process_rename(&mut acc_predicates,
+                             expr_arena,
+                                existing,
+                                new,
+                            )?;
+                            let lp = self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)?;
+                            Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
+                        }, _ => {
+                            self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
+                        }
+                    }
 
-                    self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
+
                 } else {
                     self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
                 }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -516,6 +516,8 @@ impl PredicatePushDown {
             MapFunction { ref function, .. } => {
                 if function.allow_predicate_pd()
                 {
+                    
+
                     self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
                 } else {
                     self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/rename.rs
@@ -1,0 +1,62 @@
+use super::*;
+use crate::prelude::optimizer::predicate_pushdown::keys::{key_has_name, predicate_to_key};
+
+fn remove_any_key_referencing_renamed(
+    new: &str,
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
+    local_predicates: &mut Vec<Node>,
+) {
+    let mut move_to_local = vec![];
+    for key in acc_predicates.keys() {
+        if key_has_name(key, new) {
+            move_to_local.push(key.clone())
+        }
+    }
+
+    for key in move_to_local {
+        local_predicates.push(acc_predicates.remove(&key).unwrap())
+    }
+}
+
+pub(super) fn process_rename(
+    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
+    expr_arena: &mut Arena<AExpr>,
+    existing: &[String],
+    new: &[String],
+) -> PolarsResult<Vec<Node>> {
+    let mut local_predicates = vec![];
+    for (existing, new) in existing.iter().zip(new.iter()) {
+        let has_existing = acc_predicates.contains_key(existing.as_str());
+        let has_new = acc_predicates.contains_key(new.as_str());
+        let has_both = has_existing && has_new;
+
+        // swapping path add to local for now
+        if has_both {
+            // Search for the key and add it to local because swapping is more complicated
+            if let Some(to_local) = acc_predicates.remove(new.as_str()) {
+                local_predicates.push(to_local);
+            } else {
+                // The keys can be combined eg. `a AND b AND c` in this case replacing/finding
+                // the key that should be renamed is more complicated, so for now
+                // we just move it to local.
+                remove_any_key_referencing_renamed(new, acc_predicates, &mut local_predicates)
+            }
+            continue;
+        }
+        // simple new name path
+        else {
+            // Find the key and update the predicate as well as the key
+            // This ensure the optimization is pushed down.
+            if let Some(node) = acc_predicates.remove(new.as_str()) {
+                let new_node = rename_matching_aexpr_leaf_names(node, expr_arena, new, existing);
+                acc_predicates.insert(predicate_to_key(new_node, expr_arena), new_node);
+            } else {
+                // The keys can be combined eg. `a AND b AND c` in this case replacing/finding
+                // the key that should be renamed is more complicated, so for now
+                // we just move it to local.
+                remove_any_key_referencing_renamed(new, acc_predicates, &mut local_predicates)
+            }
+        }
+    }
+    Ok(local_predicates)
+}

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -1,6 +1,7 @@
 use polars_core::datatypes::PlHashMap;
 use polars_core::prelude::*;
 
+use super::keys::*;
 use crate::logical_plan::Context;
 use crate::prelude::*;
 use crate::utils::{aexpr_to_leaf_names, check_input_node, has_aexpr, rename_aexpr_leaf_names};
@@ -73,44 +74,6 @@ pub(super) fn predicate_at_scan(
     } else {
         None
     }
-}
-
-// an invisible ascii token we use as delimiter
-const HIDDEN_DELIMITER: char = '\u{1D17A}';
-
-/// Determine the hashmap key by combining all the leaf column names of a predicate
-pub(super) fn predicate_to_key(predicate: Node, expr_arena: &Arena<AExpr>) -> Arc<str> {
-    let mut iter = aexpr_to_leaf_names_iter(predicate, expr_arena);
-    if let Some(first) = iter.next() {
-        if let Some(second) = iter.next() {
-            let mut new = String::with_capacity(32 * iter.size_hint().0);
-            new.push_str(&first);
-            new.push(HIDDEN_DELIMITER);
-            new.push_str(&second);
-
-            for name in iter {
-                new.push(HIDDEN_DELIMITER);
-                new.push_str(&name);
-            }
-            return Arc::from(new);
-        }
-        first
-    } else {
-        let mut s = String::new();
-        s.push(HIDDEN_DELIMITER);
-        Arc::from(s)
-    }
-}
-
-fn key_has_name(key: &str, name: &str) -> bool {
-    if key.contains(HIDDEN_DELIMITER) {
-        for root_name in key.split(HIDDEN_DELIMITER) {
-            if root_name == name {
-                return true;
-            }
-        }
-    }
-    key == name
 }
 
 // this checks if a predicate from a node upstream can pass

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
@@ -254,7 +254,7 @@ pub(super) fn process_join(
             if name.contains(suffix.as_ref()) && schema_after_join.get(&name).is_none() {
                 let new_name = &name.as_ref()[..name.len() - suffix.len()];
 
-                let renamed = aexpr_assign_renamed_root(*proj, expr_arena, &name, new_name);
+                let renamed = aexpr_assign_renamed_leaf(*proj, expr_arena, &name, new_name);
 
                 let aliased = expr_arena.add(AExpr::Alias(renamed, name));
                 *proj = aliased;

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -22,7 +22,7 @@ use crate::prelude::optimizer::projection_pushdown::melt::process_melt;
 use crate::prelude::optimizer::projection_pushdown::projection::process_projection;
 use crate::prelude::*;
 use crate::utils::{
-    aexpr_assign_renamed_root, aexpr_to_leaf_names, aexpr_to_leaf_nodes, check_input_node,
+    aexpr_assign_renamed_leaf, aexpr_to_leaf_names, aexpr_to_leaf_nodes, check_input_node,
     expr_is_projected_upstream,
 };
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+
 use super::*;
 
 fn iter_and_update_nodes(
@@ -6,7 +7,7 @@ fn iter_and_update_nodes(
     new: &str,
     acc_projections: &mut [Node],
     expr_arena: &mut Arena<AExpr>,
-    processed: &mut BTreeSet<usize>
+    processed: &mut BTreeSet<usize>,
 ) {
     for node in acc_projections.iter_mut() {
         if !processed.contains(&node.0) {
@@ -26,7 +27,7 @@ pub(super) fn process_rename(
     expr_arena: &mut Arena<AExpr>,
     existing: &[String],
     new: &[String],
-    swapping: bool
+    swapping: bool,
 ) -> PolarsResult<()> {
     let mut processed = BTreeSet::new();
     if swapping {
@@ -41,10 +42,12 @@ pub(super) fn process_rename(
                 // this must leave projected names intact, as we only swap
                 if has_both {
                     iter_and_update_nodes(
-                        existing, new,
+                        existing,
+                        new,
                         acc_projections,
                         expr_arena,
-                        &mut processed);
+                        &mut processed,
+                    );
                 }
                 // simple new name path
                 // this must add and remove names
@@ -53,10 +56,12 @@ pub(super) fn process_rename(
                     let name: Arc<str> = Arc::from(existing.as_str());
                     projected_names.insert(name);
                     iter_and_update_nodes(
-                        existing, new,
+                        existing,
+                        new,
                         acc_projections,
                         expr_arena,
-                        &mut processed);
+                        &mut processed,
+                    );
                 }
             }
         }
@@ -65,11 +70,7 @@ pub(super) fn process_rename(
             if projected_names.remove(new.as_str()) {
                 let name: Arc<str> = Arc::from(existing.as_str());
                 projected_names.insert(name);
-                iter_and_update_nodes(
-                    existing, new,
-                    acc_projections,
-                    expr_arena,
-                    &mut processed);
+                iter_and_update_nodes(existing, new, acc_projections, expr_arena, &mut processed);
             }
         }
     }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
@@ -1,0 +1,77 @@
+use std::collections::BTreeSet;
+use super::*;
+
+fn iter_and_update_nodes(
+    existing: &str,
+    new: &str,
+    acc_projections: &mut [Node],
+    expr_arena: &mut Arena<AExpr>,
+    processed: &mut BTreeSet<usize>
+) {
+    for node in acc_projections.iter_mut() {
+        if !processed.contains(&node.0) {
+            let new_node = rename_matching_aexpr_leaf_names(*node, expr_arena, new, existing);
+            if new_node != *node {
+                *node = new_node;
+                processed.insert(node.0);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn process_rename(
+    acc_projections: &mut [Node],
+    projected_names: &mut PlHashSet<Arc<str>>,
+    expr_arena: &mut Arena<AExpr>,
+    existing: &[String],
+    new: &[String],
+    swapping: bool
+) -> PolarsResult<()> {
+    let mut processed = BTreeSet::new();
+    if swapping {
+        for (existing, new) in existing.iter().zip(new.iter()) {
+            let has_existing = projected_names.contains(existing.as_str());
+            let has_new = projected_names.contains(new.as_str());
+            let has_both = has_existing && has_new;
+            let has_any = has_existing || has_new;
+
+            if has_any {
+                // swapping path
+                // this must leave projected names intact, as we only swap
+                if has_both {
+                    iter_and_update_nodes(
+                        existing, new,
+                        acc_projections,
+                        expr_arena,
+                        &mut processed);
+                }
+                // simple new name path
+                // this must add and remove names
+                else {
+                    projected_names.remove(new.as_str());
+                    let name: Arc<str> = Arc::from(existing.as_str());
+                    projected_names.insert(name);
+                    iter_and_update_nodes(
+                        existing, new,
+                        acc_projections,
+                        expr_arena,
+                        &mut processed);
+                }
+            }
+        }
+    } else {
+        for (existing, new) in existing.iter().zip(new.iter()) {
+            if projected_names.remove(new.as_str()) {
+                let name: Arc<str> = Arc::from(existing.as_str());
+                projected_names.insert(name);
+                iter_and_update_nodes(
+                    existing, new,
+                    acc_projections,
+                    expr_arena,
+                    &mut processed);
+            }
+        }
+    }
+    Ok(())
+}

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
@@ -29,7 +29,7 @@ impl OptimizationRule for SlicePushDown {
             let out = match expr_arena.get(*input) {
                 m @ Alias(..) | m @ Cast { .. } => {
                     let m = m.clone();
-                    let input = m.get_input();
+                    let input = m.get_input().first();
                     let new_input = pushdown(input, offset, length, expr_arena);
                     Some(m.replace_input(new_input))
                 }

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -258,17 +258,52 @@ pub(crate) fn rename_aexpr_leaf_names(
     to_aexpr(new_expr, arena)
 }
 
-/// Rename the root of the expression from `current` to `new` and assign to new node in arena.
-/// Returns `Node` on first successful rename.
-pub(crate) fn aexpr_assign_renamed_root(
+pub(crate) fn rename_matching_aexpr_leaf_names(
     node: Node,
     arena: &mut Arena<AExpr>,
     current: &str,
     new_name: &str,
 ) -> Node {
-    let roots = aexpr_to_leaf_nodes(node, arena);
+    let mut leafs = aexpr_to_leaf_nodes_iter(node, arena);
 
-    for node in roots {
+    if leafs.any(|node| {
+        match arena.get(node) {
+            AExpr::Column(name) if &**name == current => {
+                true
+            }
+            _ => false
+        }
+    }) {
+        // we convert to expression as we cannot easily copy the aexpr.
+        let mut new_expr = node_to_expr(node, arena);
+        new_expr.mutate().apply(|e| {
+            match e {
+                Expr::Column(name) if &**name == current => {
+                    *name = Arc::from(new_name);
+                    true
+                }
+                _ => true
+
+            }
+        });
+        to_aexpr(new_expr, arena)
+    } else {
+        node
+    }
+
+}
+
+/// Rename the root of the expression from `current` to `new` and assign to new node in arena.
+/// Returns `Node` on first successful rename.
+pub(crate) fn aexpr_assign_renamed_leaf(
+    node: Node,
+    arena: &mut Arena<AExpr>,
+    current: &str,
+    new_name: &str,
+) -> Node {
+    let leafs = aexpr_to_leaf_nodes_iter(node, arena);
+
+    for node in leafs {
         match arena.get(node) {
             AExpr::Column(name) if &**name == current => {
                 return arena.add(AExpr::Column(Arc::from(new_name)))

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -258,15 +258,17 @@ pub(crate) fn rename_aexpr_leaf_names(
     to_aexpr(new_expr, arena)
 }
 
+/// If the leaf names match `current`, the node will be replaced
+/// with a renamed expression.
 pub(crate) fn rename_matching_aexpr_leaf_names(
     node: Node,
     arena: &mut Arena<AExpr>,
     current: &str,
     new_name: &str,
 ) -> Node {
-    let mut leafs = aexpr_to_leaf_nodes_iter(node, arena);
+    let mut leaves = aexpr_to_leaf_nodes_iter(node, arena);
 
-    if leafs.any(|node| {
+    if leaves.any(|node| {
         match arena.get(node) {
             AExpr::Column(name) if &**name == current => {
                 true

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -268,31 +268,20 @@ pub(crate) fn rename_matching_aexpr_leaf_names(
 ) -> Node {
     let mut leaves = aexpr_to_leaf_nodes_iter(node, arena);
 
-    if leaves.any(|node| {
-        match arena.get(node) {
-            AExpr::Column(name) if &**name == current => {
-                true
-            }
-            _ => false
-        }
-    }) {
+    if leaves.any(|node| matches!(arena.get(node), AExpr::Column(name) if &**name == current)) {
         // we convert to expression as we cannot easily copy the aexpr.
         let mut new_expr = node_to_expr(node, arena);
-        new_expr.mutate().apply(|e| {
-            match e {
-                Expr::Column(name) if &**name == current => {
-                    *name = Arc::from(new_name);
-                    true
-                }
-                _ => true
-
+        new_expr.mutate().apply(|e| match e {
+            Expr::Column(name) if &**name == current => {
+                *name = Arc::from(new_name);
+                true
             }
+            _ => true,
         });
         to_aexpr(new_expr, arena)
     } else {
         node
     }
-
 }
 
 /// Rename the root of the expression from `current` to `new` and assign to new node in arena.

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -266,96 +266,6 @@ impl LazyFrame {
         self.select_local(vec![col("*").reverse()])
     }
 
-    fn rename_impl_swapping(self, existing: Vec<String>, new: Vec<String>) -> Self {
-        assert_eq!(new.len(), existing.len());
-
-        let existing2 = existing.clone();
-        let new2 = new.clone();
-        let udf_schema = move |old_schema: &Schema| {
-            let mut new_schema = old_schema.clone();
-
-            // schema after renaming
-            for (old, new) in existing2.iter().zip(new2.iter()) {
-                let dtype = old_schema.try_get(old)?;
-                if new_schema.with_column(new.clone(), dtype.clone()).is_none() {
-                    new_schema.remove(old);
-                }
-            }
-            Ok(Arc::new(new_schema))
-        };
-
-        self.map(
-            move |mut df: DataFrame| {
-                let positions = existing
-                    .iter()
-                    .map(|old| df.try_find_idx_by_name(old))
-                    .collect::<PolarsResult<Vec<_>>>()?;
-
-                for (pos, name) in positions.iter().zip(new.iter()) {
-                    df.get_columns_mut()[*pos].rename(name);
-                }
-                // recreate dataframe so we check duplicates
-                let columns = std::mem::take(df.get_columns_mut());
-                DataFrame::new(columns)
-            },
-            // Don't allow optimizations. Swapping names are opaque to the optimizer
-            AllowedOptimizations {
-                projection_pushdown: false,
-                predicate_pushdown: false,
-                streaming: true,
-                ..Default::default()
-            },
-            Some(Arc::new(udf_schema)),
-            Some("RENAME_SWAPPING"),
-        )
-    }
-
-    fn rename_impl(self, existing: Vec<String>, new: Vec<String>) -> Self {
-        let existing2 = existing.clone();
-        let new2 = new.clone();
-        let udf_schema = move |s: &Schema| {
-            let mut new_schema = s.clone();
-            for (old, new) in existing2.iter().zip(&new2) {
-                let _ = new_schema.rename(old, new.clone());
-            }
-            Ok(Arc::new(new_schema))
-        };
-
-        self.with_columns(
-            existing
-                .iter()
-                .zip(&new)
-                .map(|(old, new)| col(old).alias(new.as_ref()))
-                .collect::<Vec<_>>(),
-        )
-        .map(
-            move |mut df: DataFrame| {
-                let cols = df.get_columns_mut();
-                let mut removed_count = 0;
-                for (existing, new) in existing.iter().zip(new.iter()) {
-                    let idx_a = cols.iter().position(|s| s.name() == existing.as_str());
-                    let idx_b = cols.iter().position(|s| s.name() == new.as_str());
-
-                    match (idx_a, idx_b) {
-                        (Some(idx_a), Some(idx_b)) => {
-                            cols.swap(idx_a, idx_b);
-                        }
-                        // renamed columns are removed by predicate pushdown
-                        _ => {
-                            removed_count += 1;
-                            continue;
-                        }
-                    }
-                }
-                cols.truncate(cols.len() - (existing.len() - removed_count));
-                Ok(df)
-            },
-            Default::default(),
-            Some(Arc::new(udf_schema)),
-            Some("RENAME"),
-        )
-    }
-
     /// Rename columns in the DataFrame.
     pub fn rename<I, J, T, S>(self, existing: I, new: J) -> Self
     where
@@ -364,10 +274,6 @@ impl LazyFrame {
         T: AsRef<str>,
         S: AsRef<str>,
     {
-        // We dispatch to 2 implementations.
-        // 1 is swapping eg. rename a -> b and b -> a
-        // 2 is non-swapping eg. rename a -> new_name
-        // the latter allows predicate pushdown.
         let existing = existing
             .into_iter()
             .map(|a| a.as_ref().to_string())
@@ -377,25 +283,10 @@ impl LazyFrame {
             .map(|a| a.as_ref().to_string())
             .collect::<Vec<_>>();
 
-        fn inner(lf: LazyFrame, existing: Vec<String>, new: Vec<String>) -> LazyFrame {
-            // remove mappings that map to themselves.
-            let (existing, new): (Vec<_>, Vec<_>) = existing
-                .into_iter()
-                .zip(new)
-                .flat_map(|(a, b)| if a == b { None } else { Some((a, b)) })
-                .unzip();
-
-            // todo! make delayed
-            let schema = &*lf.schema().unwrap();
-            // a column gets swapped
-            if new.iter().any(|name| schema.get(name).is_some()) {
-                lf.rename_impl_swapping(existing, new)
-            } else {
-                lf.rename_impl(existing, new)
-            }
-        }
-
-        inner(self, existing, new)
+        self.map_private(FunctionNode::Rename {
+            existing: existing.into(),
+            new: new.into()
+        })
     }
 
     /// Removes columns from the DataFrame.

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -150,3 +150,21 @@ pub(crate) fn get_df() -> DataFrame {
         .unwrap();
     df
 }
+
+#[test]
+fn test_foo() -> PolarsResult<()> {
+
+    let df: DataFrame = df!["a" => [1],
+        "b" => [2],
+        "c" => [2]
+    ]?;
+
+    let out = df.lazy()
+        .rename(["a", "b"], ["a", "b"])
+        .select([col("a"), col("b")]).collect()?;
+
+    dbg!(out);
+
+    Ok(())
+
+}

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -153,18 +153,18 @@ pub(crate) fn get_df() -> DataFrame {
 
 #[test]
 fn test_foo() -> PolarsResult<()> {
-
     let df: DataFrame = df!["a" => [1],
         "b" => [2],
         "c" => [2]
     ]?;
 
-    let out = df.lazy()
+    let out = df
+        .lazy()
         .rename(["a", "b"], ["a", "b"])
-        .select([col("a"), col("b")]).collect()?;
+        .select([col("a"), col("b")])
+        .collect()?;
 
     dbg!(out);
 
     Ok(())
-
 }

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-
 import polars as pl
 from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, PolarsTemporalType
 from polars.exceptions import ComputeError, PanicException

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -313,3 +313,23 @@ def test_schema_true_divide_6643() -> None:
     df = pl.DataFrame({"a": [1]})
     a = pl.col("a")
     assert df.lazy().select(a / 2).select(pl.col(pl.Int64)).collect().shape == (0, 0)
+
+
+def test_rename_schema_order_6660() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [],
+            "b": [],
+            "c": [],
+            "d": [],
+        }
+    )
+
+    mapper = {"a": "1", "b": "2", "c": "3", "d": "4"}
+
+    renamed = df.lazy().rename(mapper)
+
+    computed = renamed.select([pl.all(), pl.col("4").alias("computed")])
+
+    assert renamed.schema == renamed.collect().schema
+    assert computed.schema == computed.collect().schema


### PR DESCRIPTION
Create a dedicated `rename` node in the query plan. This ensures we don't block as many optimizations because columns are renamed. 

Also fixes #6660