### PR TITLE
fix(python): typing for `Series` methods that can return `None`

### DIFF
--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -707,7 +707,7 @@ def mean(column: pli.Series) -> float:
     ...
 
 
-def mean(column: str | pli.Series) -> pli.Expr | float:
+def mean(column: str | pli.Series) -> pli.Expr | float | None:
     """
     Get the mean value.
 
@@ -775,7 +775,7 @@ def median(column: pli.Series) -> float | int:
     ...
 
 
-def median(column: str | pli.Series) -> pli.Expr | float | int:
+def median(column: str | pli.Series) -> pli.Expr | float | int | None:
     """
     Get the median value.
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -71,7 +71,7 @@ class DateTimeNameSpace:
         """
         return pli.wrap_s(self._s).max()  # type: ignore[return-value]
 
-    def median(self) -> date | datetime | timedelta:
+    def median(self) -> date | datetime | timedelta | None:
         """
         Return median as python DateTime.
 
@@ -95,7 +95,7 @@ class DateTimeNameSpace:
         out = int(s.median())
         return _to_python_datetime(out, s.dtype, s.time_unit)
 
-    def mean(self) -> date | datetime:
+    def mean(self) -> date | datetime | None:
         """
         Return mean as python DateTime.
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -92,8 +92,9 @@ class DateTimeNameSpace:
 
         """
         s = pli.wrap_s(self._s)
-        out = int(s.median())
-        return _to_python_datetime(out, s.dtype, s.time_unit)
+        if out := s.median():
+            return _to_python_datetime(int(out), s.dtype, s.time_unit)
+        return None
 
     def mean(self) -> date | datetime | None:
         """
@@ -116,8 +117,9 @@ class DateTimeNameSpace:
 
         """
         s = pli.wrap_s(self._s)
-        out = int(s.mean())
-        return _to_python_datetime(out, s.dtype, s.time_unit)
+        if out := s.mean():
+            return _to_python_datetime(int(out), s.dtype, s.time_unit)
+        return None
 
     def strftime(self, fmt: str) -> pli.Series:
         """

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -92,7 +92,8 @@ class DateTimeNameSpace:
 
         """
         s = pli.wrap_s(self._s)
-        if out := s.median():
+        out = s.median()
+        if out is not None:
             return _to_python_datetime(int(out), s.dtype, s.time_unit)
         return None
 
@@ -117,7 +118,8 @@ class DateTimeNameSpace:
 
         """
         s = pli.wrap_s(self._s)
-        if out := s.mean():
+        out = s.mean()
+        if out is not None:
             return _to_python_datetime(int(out), s.dtype, s.time_unit)
         return None
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1194,7 +1194,7 @@ class Series:
             {"statistic": list(stats.keys()), "value": list(stats.values())}
         )
 
-    def sum(self) -> int | float | None:
+    def sum(self) -> int | float:
         """
         Reduce this Series to the sum value.
 
@@ -1225,7 +1225,7 @@ class Series:
         """
         return self._s.mean()
 
-    def product(self) -> int | float | None:
+    def product(self) -> int | float:
         """Reduce this Series to the product value."""
         return self.to_frame().select(pli.col(self.name).product()).to_series()[0]
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1194,7 +1194,7 @@ class Series:
             {"statistic": list(stats.keys()), "value": list(stats.values())}
         )
 
-    def sum(self) -> int | float:
+    def sum(self) -> int | float | None:
         """
         Reduce this Series to the sum value.
 
@@ -1212,7 +1212,7 @@ class Series:
         """
         return self._s.sum()
 
-    def mean(self) -> int | float:
+    def mean(self) -> int | float | None:
         """
         Reduce this Series to the mean value.
 
@@ -1225,11 +1225,11 @@ class Series:
         """
         return self._s.mean()
 
-    def product(self) -> int | float:
+    def product(self) -> int | float | None:
         """Reduce this Series to the product value."""
         return self.to_frame().select(pli.col(self.name).product()).to_series()[0]
 
-    def min(self) -> int | float | date | datetime | timedelta | str:
+    def min(self) -> int | float | date | datetime | timedelta | str | None:
         """
         Get the minimal value in this Series.
 
@@ -1242,7 +1242,7 @@ class Series:
         """
         return self._s.min()
 
-    def max(self) -> int | float | date | datetime | timedelta | str:
+    def max(self) -> int | float | date | datetime | timedelta | str | None:
         """
         Get the maximum value in this Series.
 
@@ -1319,7 +1319,7 @@ class Series:
             return None
         return self.to_frame().select(pli.col(self.name).var(ddof)).to_series()[0]
 
-    def median(self) -> float:
+    def median(self) -> float | None:
         """
         Get the median of this Series.
 
@@ -1334,7 +1334,7 @@ class Series:
 
     def quantile(
         self, quantile: float, interpolation: RollingInterpolationMethod = "nearest"
-    ) -> float:
+    ) -> float | None:
         """
         Get the quantile value of this Series.
 

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -24,9 +24,15 @@ assert np.isclose(
     ],
     mean,
 )
-assert np.isclose(
-    df.with_columns(pl.col("value").cast(pl.Int32)).get_column("value").mean(), mean
-)
+
+if (
+    calculated_mean := df.with_columns(pl.col("value").cast(pl.Int32))
+    .get_column("value")
+    .mean()
+):
+    assert np.isclose(calculated_mean, mean)
+else:
+    raise AssertionError("mean is None")
 
 # https://github.com/pola-rs/polars/issues/2850
 df = pl.DataFrame(

--- a/py-polars/tests/db-benchmark/various.py
+++ b/py-polars/tests/db-benchmark/various.py
@@ -25,11 +25,11 @@ assert np.isclose(
     mean,
 )
 
-if (
-    calculated_mean := df.with_columns(pl.col("value").cast(pl.Int32))
-    .get_column("value")
-    .mean()
-):
+calculated_mean = (
+    df.with_columns(pl.col("value").cast(pl.Int32)).get_column("value").mean()
+)
+
+if calculated_mean is not None:
     assert np.isclose(calculated_mean, mean)
 else:
     raise AssertionError("mean is None")

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -275,3 +275,13 @@ def test_weekday() -> None:
         assert s.dt.cast_time_unit(tu).dt.weekday()[0] == 1
 
     assert s.cast(pl.Date).dt.weekday()[0] == 1
+
+
+def test_median() -> None:
+    result = pl.date_range(datetime(1969, 12, 31), datetime(1970, 1, 2), "1d").dt.median()
+    assert result == datetime(1970, 1, 1)
+
+
+def test_mean() -> None:
+    result = pl.date_range(datetime(1969, 12, 31), datetime(1970, 1, 2), "1d").dt.mean()
+    assert result == datetime(1970, 1, 1)

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
@@ -277,23 +278,27 @@ def test_weekday() -> None:
     assert s.cast(pl.Date).dt.weekday()[0] == 1
 
 
-def test_median() -> None:
-    result = pl.date_range(
-        datetime(1969, 12, 31), datetime(1970, 1, 2), "1d"
-    ).dt.median()
-    assert result == datetime(1970, 1, 1)
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([datetime(1969, 12, 31), datetime(1970, 1, 2)], datetime(1970, 1, 1)),
+        ([None, None], None),
+    ],
+    ids=["datetime_dates", "Nones"],
+)
+def test_median(values: list[datetime | None], expected: datetime | None) -> None:
+    result = pl.Series(values).cast(pl.Datetime).dt.median()
+    assert result == expected
 
 
-def test_mean() -> None:
-    result = pl.date_range(datetime(1969, 12, 31), datetime(1970, 1, 2), "1d").dt.mean()
-    assert result == datetime(1970, 1, 1)
-
-
-def test_median_return_none() -> None:
-    result = pl.Series([None, None]).cast(pl.Datetime).median()
-    assert result is None
-
-
-def test_mean_return_none() -> None:
-    result = pl.Series([None, None]).cast(pl.Datetime).mean()
-    assert result is None
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([datetime(1969, 12, 31), datetime(1970, 1, 2)], datetime(1970, 1, 1)),
+        ([None, None], None),
+    ],
+    ids=["datetime_dates", "Nones"],
+)
+def test_mean(values: list[datetime | None], expected: datetime | None) -> None:
+    result = pl.Series(values).cast(pl.Datetime).dt.median()
+    assert result == expected

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -287,3 +287,13 @@ def test_median() -> None:
 def test_mean() -> None:
     result = pl.date_range(datetime(1969, 12, 31), datetime(1970, 1, 2), "1d").dt.mean()
     assert result == datetime(1970, 1, 1)
+
+
+def test_median_return_none() -> None:
+    result = pl.Series([None, None]).cast(pl.Datetime).median()
+    assert result is None
+
+
+def test_mean_return_none() -> None:
+    result = pl.Series([None, None]).cast(pl.Datetime).mean()
+    assert result is None

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -278,7 +278,9 @@ def test_weekday() -> None:
 
 
 def test_median() -> None:
-    result = pl.date_range(datetime(1969, 12, 31), datetime(1970, 1, 2), "1d").dt.median()
+    result = pl.date_range(
+        datetime(1969, 12, 31), datetime(1970, 1, 2), "1d"
+    ).dt.median()
     assert result == datetime(1970, 1, 1)
 
 

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-
 import polars as pl
 from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, PolarsTemporalType
 from polars.exceptions import ComputeError, PanicException


### PR DESCRIPTION
Resolves #6623 

Fix the type hints for some `Series` methods that return `None`.

Also Resolves this
```
In [4]: pl.Series([None]).cast(pl.Datetime).dt.median()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [4], line 1
----> 1 pl.Series([None]).cast(pl.Datetime).dt.median()

File ~/tmp/.venv/lib/python3.8/site-packages/polars/internals/series/datetime.py:94, in DateTimeNameSpace.median(self)
     74 """
     75 Return median as python DateTime.
     76
   (...)
     91
     92 """
     93 s = pli.wrap_s(self._s)
---> 94 out = int(s.median())
     95 return _to_python_datetime(out, s.dtype, s.time_unit)

TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```
This will now return `None` instead of raising an error.

Notes:

- methods affected are `min()`, `max()`, `mean()`, `median()`, and `quantile()`
- added unit tests for `median()` & `mean()` when used with datetime