### PR TITLE
feat(rust): deprecate tz_localize

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -88,6 +88,7 @@ impl DateLikeNameSpace {
     // This method takes a naive Datetime Series and makes this time zone aware.
     // It does not move the time to another time zone.
     #[cfg(feature = "timezones")]
+    #[deprecated(note = "use cast_time_zone")]
     pub fn tz_localize(self, tz: TimeZone) -> Expr {
         self.0
             .map_private(FunctionExpr::TemporalExpr(TemporalFunction::TzLocalize(tz)))

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
@@ -143,6 +143,7 @@ pub(super) fn cast_timezone(s: &Series, tz: Option<&str>) -> PolarsResult<Series
 }
 
 #[cfg(feature = "timezones")]
+#[deprecated(note = "use cast_time_zone")]
 pub(super) fn tz_localize(s: &Series, tz: &str) -> PolarsResult<Series> {
     let ca = s.datetime()?.clone();
     match (ca.time_zone(), tz) {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -431,6 +431,7 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
 }
 
 #[cfg(feature = "temporal")]
+#[allow(deprecated)] // tz_localize
 impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: TemporalFunction) -> Self {
         use TemporalFunction::*;

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1060,6 +1060,7 @@ impl PyExpr {
     }
 
     #[cfg(feature = "timezones")]
+    #[allow(deprecated)]
     pub fn dt_tz_localize(&self, tz: String) -> PyExpr {
         self.inner.clone().dt().tz_localize(tz).into()
     }


### PR DESCRIPTION
Follow-up from https://github.com/pola-rs/polars/pull/6649, I realised I hadn't marked tz_localize as deprecated in rust