### PR TITLE
fix(python): ensure that `iter_rows` always returns all values from all chunks/batches in accelerated codepath

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6924,7 +6924,7 @@ class DataFrame:
             for offset in range(0, self.height, buffer_size):
                 zerocopy_slice = self.slice(offset, buffer_size)
                 if load_pyarrow_dicts:
-                    yield from zerocopy_slice.to_arrow().to_batches()[0].to_pylist()
+                    yield from zerocopy_slice.to_arrow().to_pylist()
                 else:
                     rows_chunk = zerocopy_slice.rows(named=False)
                     if named:

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-
 import polars as pl
 from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, PolarsTemporalType
 from polars.exceptions import ComputeError, PanicException

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -119,12 +119,12 @@ def test_projection_update_schema_missing_column() -> None:
 def test_not_found_on_rename() -> None:
     df = pl.DataFrame({"exists": [1, 2, 3]})
 
-    with pytest.raises(pl.SchemaFieldNotFoundError):
-        df.rename(
-            {
-                "does_not_exist": "exists",
-            }
-        )
+    err_type = (pl.SchemaFieldNotFoundError, pl.ColumnNotFoundError)
+    with pytest.raises(err_type):
+        df.rename({"does_not_exist": "exists"})
+
+    with pytest.raises(err_type):
+        df.select(pl.col("does_not_exist").alias("new_name"))
 
 
 @typing.no_type_check

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -110,3 +110,19 @@ def test_iter_rows() -> None:
 
         with pytest.raises(StopIteration):
             next(it_named)
+
+    # test over chunked frame
+    df = pl.concat(
+        [
+            pl.DataFrame({"id": [0, 1], "values": ["a", "b"]}),
+            pl.DataFrame({"id": [2, 3], "values": ["c", "d"]}),
+        ],
+        rechunk=False,
+    )
+    assert df.n_chunks() == 2
+    assert df.to_dicts() == [
+        {"id": 0, "values": "a"},
+        {"id": 1, "values": "b"},
+        {"id": 2, "values": "c"},
+        {"id": 3, "values": "d"},
+    ]


### PR DESCRIPTION
Closes #6705.

Fixed the issue, added coverage (was a debugging line left in by mistake, argh...)
Thanks to @braaannigan for noticing!