### PR TITLE
feat(python): allow low memory df.to_pandas()

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1952,8 +1952,10 @@ class DataFrame:
             Arguments will be sent to :meth:`pyarrow.Table.to_pandas`.
         date_as_object
             Cast dates to objects. If ``False``, convert to ``datetime64[ns]`` dtype.
+        deduplicate_objects
+            defaults to False and will be send :meth:`pyarrow.Table.to_pandas`.
         kwargs
-            Arguments will be sent to :meth:`pyarrow.Table.to_pandas`.
+            Arguments will be send to :meth:`pyarrow.Table.to_pandas`.
 
         Returns
         -------
@@ -1974,6 +1976,7 @@ class DataFrame:
         <class 'pandas.core.frame.DataFrame'>
 
         """
+        kwargs.setdefault("deduplicate_objects", False)
         record_batches = self._df.to_pandas()
         tbl = pa.Table.from_batches(record_batches)
         return tbl.to_pandas(*args, date_as_object=date_as_object, **kwargs)


### PR DESCRIPTION
`df.to_pandas()` takes lot of memory, more than it should (benchmark attached)
current `to_pandas()` takes ~14000 MB for a ~6000MB df the new version takes around ~6700MB
This change allows running it faster and with lower memory, but it deletes the original data.
Although its not ideal to delete the original data, if the choice is between OOM (therefore not using polars) and allowing this, i believe its a good choice.
I don't know the codebase well sorry if i made any bad assumptions.

![to_pandas_profile](https://user-images.githubusercontent.com/4346513/217379737-96c372f9-ae48-440d-9bdc-47735bd47bb9.png)

code used for profiling (note this is a bit different than the committed code but it shouldn't make a big difference)
```
def current_to_pandas():
    df = pl.read_csv(path, sep="\t")
    df = df.to_pandas()

def low_mem_to_pandas():
    df = pl.read_csv(path, sep="\t")    
    new_df = pd.DataFrame()
    for column in df.columns:
        new_df.loc[:,column] = df[column].to_arrow()
        df._df.drop_in_place(column)

def profile_to_pandas():
    current_to_pandas()
    time.sleep(1)
    low_mem_to_pandas()
   
```