### PR TITLE
fix(rust,python): return correct display/repr names for NaN-related expressions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -150,7 +150,11 @@ impl Display for FunctionExpr {
             #[cfg(all(feature = "rolling_window", feature = "moment"))]
             RollingSkew { .. } => "rolling_skew",
             ShiftAndFill { .. } => "shift_and_fill",
-            Nan(_) => "nan",
+            Nan(func) => match func {
+                NanFunction::IsNan => "is_nan",
+                NanFunction::IsNotNan => "is_not_nan",
+                NanFunction::DropNans => "drop_nans",
+            },
             #[cfg(feature = "round_series")]
             Clip { min, max } => match (min, max) {
                 (Some(_), Some(_)) => "clip",


### PR DESCRIPTION
**Before**  _(not distinguishable; all display as `expr.nan()`)_
```python
str( pl.col('colx').is_nan() )
# 'col("colx").nan()'

str( pl.col('colx').is_not_nan() )
# 'col("colx").nan()'

str( pl.col('colx').drop_nans() )
# 'col("colx").nan()'
```
**After** _(individual expression reprs)_
```python
str( pl.col('colx').is_nan() )
# 'col("colx").is_nan()'

str( pl.col('colx').is_not_nan() )
# 'col("colx").is_not_nan()'

str( pl.col('colx').drop_nans() )
# 'col("colx").drop_nans()'
```