### PR TITLE
fix(rust, python): arrow map dtype conversion

### DIFF
--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -716,6 +716,7 @@ impl PyExpr {
         self.clone().inner.str().rjust(width, fillchar).into()
     }
 
+    #[cfg(feature = "strings")]
     #[pyo3(signature = (pat, literal, strict))]
     pub fn str_contains(&self, pat: PyExpr, literal: Option<bool>, strict: bool) -> PyExpr {
         match literal {

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from datetime import datetime
 from typing import Any, cast, no_type_check
 
@@ -598,3 +599,22 @@ def test_from_pandas_null_struct_6412() -> None:
     ]
     df_pandas = pd.DataFrame(data)
     assert pl.from_pandas(df_pandas).to_dict(False) == {"a": [{"b": None}, {"b": None}]}
+
+
+@typing.no_type_check
+def test_from_pyarrow_map() -> None:
+    pa_table = pa.table(
+        [[1, 2], [[("a", "something")], [("a", "else"), ("b", "another key")]]],
+        schema=pa.schema(
+            [("idx", pa.int16()), ("mapping", pa.map_(pa.string(), pa.string()))]
+        ),
+    )
+
+    df = pl.from_arrow(pa_table)
+    assert df.to_dict(False) == {
+        "idx": [1, 2],
+        "mapping": [
+            [{"key": "a", "value": "something"}],
+            [{"key": "a", "value": "else"}, {"key": "b", "value": "another key"}],
+        ],
+    }


### PR DESCRIPTION
fixes #6712