### PR TITLE
feat(python): Improve numpy support: conversion of numpy arrays with …

### DIFF
--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -88,6 +88,7 @@ def _set_numpy_to_constructor() -> None:
         np.uint32: PySeries.new_u32,
         np.uint64: PySeries.new_u64,
         np.str_: PySeries.new_str,
+        np.bytes_: PySeries.new_binary,
         np.bool_: PySeries.new_bool,
         np.datetime64: PySeries.new_i64,
     }
@@ -97,7 +98,15 @@ def numpy_values_and_dtype(
     values: np.ndarray[Any, Any]
 ) -> tuple[np.ndarray[Any, Any], type]:
     """Return numpy values and their associated dtype, adjusting if required."""
-    dtype = values.dtype.type
+    # Create new dtype object from dtype base name so architecture specific
+    # dtypes (np.longlong np.ulonglong np.intc np.uintc np.longdouble, ...)
+    # get converted to their normalized dtype (np.int*, np.uint*, np.float*).
+    dtype = (
+        np.dtype(values.dtype.base.name).type
+        if values.dtype.kind in ("i", "u", "f")
+        else values.dtype.type
+    )
+
     if dtype == np.float16:
         values = values.astype(np.float32)
         dtype = values.dtype.type

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -141,12 +141,12 @@ impl<'a> FromPyObject<'a> for Wrap<Utf8Chunked> {
 
 impl<'a> FromPyObject<'a> for Wrap<BinaryChunked> {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
-        let (seq, len) = get_pyseq(obj)?;
+        let len = obj.len()?;
         let mut builder = BinaryChunkedBuilder::new("", len, len * 25);
 
-        for res in seq.iter()? {
+        for res in obj.iter()? {
             let item = res?;
-            match item.extract::<&str>() {
+            match item.extract::<&[u8]>() {
                 Ok(val) => builder.append_value(val),
                 Err(_) => builder.append_null(),
             }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -239,6 +239,13 @@ impl PySeries {
     }
 
     #[staticmethod]
+    pub fn new_binary(name: &str, val: Wrap<BinaryChunked>, _strict: bool) -> Self {
+        let mut s = val.0.into_series();
+        s.rename(name);
+        PySeries::new(s)
+    }
+
+    #[staticmethod]
     pub fn new_object(name: &str, val: Vec<ObjectValue>, _strict: bool) -> Self {
         #[cfg(feature = "object")]
         {

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -28,6 +28,8 @@ def test_df_from_numpy() -> None:
             "float16": np.array([21.7, 21.8, 21], dtype=np.float16),
             "float32": np.array([21.7, 21.8, 21], dtype=np.float32),
             "float64": np.array([21.7, 21.8, 21], dtype=np.float64),
+            "intc": np.array([1, 3, 2], dtype=np.intc),
+            "uintc": np.array([1, 3, 2], dtype=np.uintc),
             "str": np.array(["string1", "string2", "string3"], dtype=np.str_),
             "bytes": np.array(
                 ["byte_string1", "byte_string2", "byte_string3"], dtype=np.bytes_
@@ -47,8 +49,10 @@ def test_df_from_numpy() -> None:
         pl.datatypes.Float32,
         pl.datatypes.Float32,
         pl.datatypes.Float64,
+        pl.datatypes.Int32,
+        pl.datatypes.UInt32,
         pl.datatypes.Utf8,
-        pl.datatypes.Object,
+        pl.datatypes.Binary,
     ]
     assert out == df.dtypes
 


### PR DESCRIPTION
…architecture dependend dtypes to Polars series and support for np.bytes_ arrays to pl.Binary Polars series.

Improve numpy suppport:
  - Add support for converting numpy arrays with numeric dtypes, which are architecture dependend: e.g. np.longlong, np.ulonglong, np.intc, np.uintc, np.longdouble , to Polars series.

    For example on Windows, the following operation changes the dtype of the output array, which then failed to convert to an pl.UInt32 Polars series:

        arr = np.array([2,1,3], dtype=np.uint32)
        (arr % 2).dtype == np.intc

  - Rewrite logic for getting the correct Polars dtype when using numpy __ufunc__, so it does not need to check for the OS it is running on (same architecture dependend dtypes problem).
  - Add support for converting bytes numpy arrays (np.bytes_) to pl.Binary Polars series.