### PR TITLE
feat(rust, python): Support an ignore_nulls param for EWM calculations. (#5749)

### DIFF
--- a/polars/polars-arrow/src/kernels/ewm/average.rs
+++ b/polars/polars-arrow/src/kernels/ewm/average.rs
@@ -1,4 +1,4 @@
-use std::ops::AddAssign;
+use std::ops::{AddAssign, MulAssign};
 
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
@@ -7,62 +7,48 @@ use num::Float;
 use crate::trusted_len::TrustedLen;
 use crate::utils::CustomIterTools;
 
-pub fn ewm_mean<I, T>(xs: I, alpha: T, adjust: bool, min_periods: usize) -> PrimitiveArray<T>
+pub fn ewm_mean<I, T>(
+    xs: I,
+    alpha: T,
+    adjust: bool,
+    min_periods: usize,
+    ignore_nulls: bool,
+) -> PrimitiveArray<T>
 where
     I: IntoIterator<Item = Option<T>>,
     I::IntoIter: TrustedLen,
-    T: Float + NativeType + AddAssign,
+    T: Float + NativeType + AddAssign + MulAssign,
 {
-    if alpha.is_one() {
-        return ewm_mean_alpha_equals_one(xs, min_periods);
-    }
-
-    let one_sub_alpha = T::one() - alpha;
-
-    let mut opt_mean = None;
+    let new_wt = if adjust { T::one() } else { alpha };
+    let old_wt_factor = T::one() - alpha;
+    let mut old_wt = T::one();
+    let mut weighted_avg = None;
     let mut non_null_cnt = 0usize;
 
-    let wgt = alpha;
-    let mut wgt_sum = if adjust { T::zero() } else { T::one() };
-
     xs.into_iter()
-        .map(|opt_x| {
-            if let Some(x) = opt_x {
+        .enumerate()
+        .map(|(i, opt_x)| {
+            if opt_x.is_some() {
                 non_null_cnt += 1;
-
-                let prev_mean = opt_mean.unwrap_or(x);
-
-                wgt_sum = one_sub_alpha * wgt_sum + wgt;
-
-                let curr_mean = prev_mean + (x - prev_mean) * wgt / wgt_sum;
-
-                opt_mean = Some(curr_mean);
+            }
+            match (i, weighted_avg) {
+                (0, _) | (_, None) => weighted_avg = opt_x,
+                (_, Some(w_avg)) => {
+                    if opt_x.is_some() || !ignore_nulls {
+                        old_wt *= old_wt_factor;
+                        if let Some(x) = opt_x {
+                            if w_avg != x {
+                                weighted_avg =
+                                    Some((old_wt * w_avg + new_wt * x) / (old_wt + new_wt));
+                            }
+                            old_wt = if adjust { old_wt + new_wt } else { T::one() };
+                        }
+                    }
+                }
             }
             match non_null_cnt < min_periods {
                 true => None,
-                false => opt_mean,
-            }
-        })
-        .collect_trusted()
-}
-
-/// To prevent numerical instability (and as a slight optimization), we
-/// special-case ``alpha=1``.
-fn ewm_mean_alpha_equals_one<I, T>(xs: I, min_periods: usize) -> PrimitiveArray<T>
-where
-    I: IntoIterator<Item = Option<T>>,
-    I::IntoIter: TrustedLen,
-    T: Float + NativeType + AddAssign,
-{
-    let mut non_null_count = 0usize;
-    xs.into_iter()
-        .map(|opt_x| {
-            if opt_x.is_some() {
-                non_null_count += 1;
-            }
-            match non_null_count < min_periods {
-                true => None,
-                false => opt_x,
+                false => weighted_avg,
             }
         })
         .collect_trusted()
@@ -70,119 +56,109 @@ where
 
 #[cfg(test)]
 mod test {
+    use super::super::assert_allclose;
     use super::*;
+    const ALPHA: f64 = 0.5;
+    const EPS: f64 = 1e-15;
 
     #[test]
     fn test_ewm_mean_without_null() {
-        let xs = vec![Some(1.0f32), Some(2.0f32), Some(3.0f32)];
-
+        let xs: Vec<Option<f64>> = vec![Some(1.0), Some(2.0), Some(3.0)];
         for adjust in [false, true] {
-            let result = ewm_mean(xs.clone().into_iter(), 0.5, adjust, 0);
-
-            let expected = match adjust {
-                false => PrimitiveArray::from([Some(1.0f32), Some(1.5f32), Some(2.25f32)]),
-                true => PrimitiveArray::from([
-                    Some(1.0f32),
-                    Some(1.6666667f32), // <-- pandas: 1.66666667
-                    Some(2.42857143),
-                ]),
-            };
-            assert_eq!(result, expected);
+            for ignore_nulls in [false, true] {
+                for min_periods in [0, 1] {
+                    let result = ewm_mean(xs.clone(), ALPHA, adjust, min_periods, ignore_nulls);
+                    let expected = match adjust {
+                        false => PrimitiveArray::from([Some(1.0f64), Some(1.5f64), Some(2.25f64)]),
+                        true => PrimitiveArray::from([
+                            Some(1.00000000000000000000),
+                            Some(1.66666666666666674068),
+                            Some(2.42857142857142838110),
+                        ]),
+                    };
+                    assert_allclose!(result, expected, 1e-15);
+                }
+                let result = ewm_mean(xs.clone(), ALPHA, adjust, 2, ignore_nulls);
+                let expected = match adjust {
+                    false => PrimitiveArray::from([None, Some(1.5f64), Some(2.25f64)]),
+                    true => PrimitiveArray::from([
+                        None,
+                        Some(1.66666666666666674068),
+                        Some(2.42857142857142838110),
+                    ]),
+                };
+                assert_allclose!(result, expected, EPS);
+            }
         }
     }
 
     #[test]
     fn test_ewm_mean_with_null() {
-        let xs = vec![Some(1.0f32), None, Some(1.0f32), Some(1.0f32)].into_iter();
-        let result = ewm_mean(xs, 0.5, false, 2);
-        let expected = PrimitiveArray::from([None, None, Some(1.0f32), Some(1.0f32)]);
-        assert_eq!(result, expected);
-
-        let xs = vec![None, None, Some(1.0f32), Some(1.0f32)].into_iter();
-        let result = ewm_mean(xs, 0.5, false, 1);
-        let expected = PrimitiveArray::from([None, None, Some(1.0f32), Some(1.0f32)]);
-        assert_eq!(result, expected);
-
-        let xs = vec![
-            Some(2.0f32),
-            Some(3.0f32),
-            Some(5.0f32),
-            Some(7.0f32),
+        let xs1 = vec![
             None,
             None,
+            Some(5.0f64),
+            Some(7.0f64),
             None,
-            Some(4.0f32),
+            Some(2.0f64),
+            Some(1.0f64),
+            Some(4.0f64),
         ];
-        let result = ewm_mean(xs, 0.5, false, 0);
-        let expected = PrimitiveArray::from([
-            Some(2.0f32),
-            Some(2.5f32),
-            Some(3.75f32),
-            Some(5.375f32),
-            Some(5.375f32),
-            Some(5.375f32),
-            Some(5.375f32),
-            Some(4.6875f32),
-        ]);
-        assert_eq!(result, expected);
-
-        let xs = vec![
-            None,
-            None,
-            Some(5.0f32),
-            Some(7.0f32),
-            None,
-            Some(2.0f32),
-            Some(1.0f32),
-            Some(4.0f32),
-        ];
-        let unadjusted_result = ewm_mean(xs.clone().into_iter(), 0.5, false, 1);
-        let unadjusted_expected = PrimitiveArray::from([
-            None,
-            None,
-            Some(5.0f32),
-            Some(6.0f32),
-            Some(6.0f32),
-            Some(4.0f32),
-            Some(2.5f32),
-            Some(3.25f32),
-        ]);
-        assert_eq!(unadjusted_result, unadjusted_expected);
-        let adjusted_result = ewm_mean(xs.clone().into_iter(), 0.5, true, 1);
-        let adjusted_expected = PrimitiveArray::from([
-            None,
-            None,
-            Some(5.0f32),
-            Some(6.33333333f32),
-            Some(6.33333333f32),
-            Some(3.85714286f32),
-            Some(2.3333335f32), // <-- pandas: 2.33333333
-            Some(3.19354839f32),
-        ]);
-        assert_eq!(adjusted_result, adjusted_expected);
-
-        let xs = vec![
-            None,
-            Some(1.0f32),
-            Some(5.0f32),
-            Some(7.0f32),
-            None,
-            Some(2.0f32),
-            Some(1.0f32),
-            Some(4.0f32),
-        ]
-        .into_iter();
-        let result = ewm_mean(xs, 0.5, true, 1);
-        let expected = PrimitiveArray::from([
-            None,
-            Some(1.0f32),
-            Some(3.66666667f32),
-            Some(5.57142857f32),
-            Some(5.57142857f32),
-            Some(3.66666667),
-            Some(2.2903228f32), // <-- pandas: 2.29032258
-            Some(3.15873016f32),
-        ]);
-        assert_eq!(result, expected);
+        assert_allclose!(
+            ewm_mean(xs1.clone(), 0.5, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                None,
+                Some(5.00000000000000000000),
+                Some(6.33333333333333303727),
+                Some(6.33333333333333303727),
+                Some(3.85714285714285720630),
+                Some(2.33333333333333348136),
+                Some(3.19354838709677402164),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_mean(xs1.clone(), 0.5, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                None,
+                Some(5.00000000000000000000),
+                Some(6.33333333333333303727),
+                Some(6.33333333333333303727),
+                Some(3.18181818181818165669),
+                Some(1.88888888888888883955),
+                Some(3.03389830508474567239),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_mean(xs1.clone(), 0.5, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                None,
+                Some(5.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(4.00000000000000000000),
+                Some(2.50000000000000000000),
+                Some(3.25000000000000000000),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_mean(xs1.clone(), 0.5, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                None,
+                Some(5.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(3.33333333333333348136),
+                Some(2.16666666666666696273),
+                Some(3.08333333333333348136),
+            ]),
+            EPS
+        );
     }
 }

--- a/polars/polars-arrow/src/kernels/ewm/variance.rs
+++ b/polars/polars-arrow/src/kernels/ewm/variance.rs
@@ -1,74 +1,155 @@
-use std::ops::AddAssign;
+use std::ops::{AddAssign, DivAssign, MulAssign};
 
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
-use num::{Float, One};
+use num::Float;
 
 use crate::trusted_len::TrustedLen;
 use crate::utils::CustomIterTools;
 
-pub fn ewm_std<I, T>(
+#[allow(clippy::too_many_arguments)]
+fn ewm_cov_internal<I, T>(
     xs: I,
+    ys: I,
     alpha: T,
     adjust: bool,
     bias: bool,
     min_periods: usize,
+    ignore_nulls: bool,
+    do_sqrt: bool,
 ) -> PrimitiveArray<T>
 where
     I: IntoIterator<Item = Option<T>>,
     I::IntoIter: TrustedLen,
-    T: Float + NativeType + AddAssign,
+    T: Float + NativeType + AddAssign + MulAssign + DivAssign,
 {
-    let one_sub_alpha = T::one() - alpha;
-    let two = T::one() + T::one();
+    let old_wt_factor = T::one() - alpha;
+    let new_wt = if adjust { T::one() } else { alpha };
+    let mut sum_wt = T::one();
+    let mut sum_wt2 = T::one();
+    let mut old_wt = T::one();
 
-    let mut opt_mean = None;
-    let mut opt_var = None;
-    let mut non_null_cnt = 0usize;
+    let mut opt_mean_x = None;
+    let mut opt_mean_y = None;
+    let mut cov = T::zero();
+    let mut non_na_cnt = 0usize;
+    let min_periods_fixed = if min_periods == 0 { 1 } else { min_periods };
 
-    let wgt = alpha;
-
-    let (mut wgt_sum, mut wgt_sum_sqr) = if adjust {
-        (T::zero(), T::zero())
-    } else {
-        // NOTE: we must ensure `wgt_sum` and `wgt_sum_sqr` are equal
-        // to 1 during the first iteration
-        (T::one(), (T::one() + alpha) / one_sub_alpha)
-    };
-
-    xs.into_iter()
-        .map(|opt_x| {
-            if let Some(x) = opt_x {
-                non_null_cnt += 1;
-
-                let prev_mean = opt_mean.unwrap_or(x);
-                let prev_var = opt_var.unwrap_or_else(T::zero);
-
-                wgt_sum = one_sub_alpha * wgt_sum + wgt;
-                wgt_sum_sqr = one_sub_alpha.powf(two) * wgt_sum_sqr + wgt.powf(two);
-
-                let curr_mean = prev_mean + (x - prev_mean) * wgt / wgt_sum;
-                let curr_var = (T::one() - wgt / wgt_sum)
-                    * (prev_var + wgt / wgt_sum * (x - prev_mean).powf(two));
-
-                opt_mean = Some(curr_mean);
-                opt_var = Some(curr_var);
+    let res = xs
+        .into_iter()
+        .zip(ys.into_iter())
+        .enumerate()
+        .map(|(i, (opt_x, opt_y))| {
+            let is_observation = opt_x.is_some() && opt_y.is_some();
+            if is_observation {
+                non_na_cnt += 1;
             }
-            match non_null_cnt < min_periods {
-                true => None,
-                false => opt_var.map(|var| {
-                    // NOTE: the `non_null_cnt.is_one()` condition prevents a NaN
-                    // from appearing in the first entry (it prevents a zero division)
-                    let correction = if bias || non_null_cnt.is_one() {
-                        T::one()
+            match (i, opt_mean_x, opt_mean_y) {
+                (0, _, _) => {
+                    if is_observation {
+                        opt_mean_x = opt_x;
+                        opt_mean_y = opt_y;
+                    }
+                }
+                (_, Some(mean_x), Some(mean_y)) => {
+                    if is_observation || !ignore_nulls {
+                        sum_wt *= old_wt_factor;
+                        sum_wt2 *= old_wt_factor * old_wt_factor;
+                        old_wt *= old_wt_factor;
+                        if is_observation {
+                            let x = opt_x.unwrap();
+                            let y = opt_y.unwrap();
+                            let old_mean_x = mean_x;
+                            let old_mean_y = mean_y;
+
+                            // avoid numerical errors on constant series
+                            if mean_x != x {
+                                opt_mean_x =
+                                    Some((old_wt * old_mean_x + new_wt * x) / (old_wt + new_wt));
+                            }
+
+                            // avoid numerical errors on constant series
+                            if mean_y != y {
+                                opt_mean_y =
+                                    Some((old_wt * old_mean_y + new_wt * y) / (old_wt + new_wt));
+                            }
+
+                            cov = ((old_wt
+                                * (cov
+                                    + ((old_mean_x - opt_mean_x.unwrap())
+                                        * (old_mean_y - opt_mean_y.unwrap()))))
+                                + (new_wt
+                                    * ((x - opt_mean_x.unwrap()) * (y - opt_mean_y.unwrap()))))
+                                / (old_wt + new_wt);
+
+                            sum_wt += new_wt;
+                            sum_wt2 += new_wt * new_wt;
+                            old_wt += new_wt;
+                            if !adjust {
+                                sum_wt /= old_wt;
+                                sum_wt2 /= old_wt * old_wt;
+                                old_wt = T::one();
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    if is_observation {
+                        opt_mean_x = opt_x;
+                        opt_mean_y = opt_y;
+                    }
+                }
+            }
+            match (non_na_cnt >= min_periods_fixed, bias) {
+                (false, _) => None,
+                (true, false) => {
+                    if non_na_cnt == 1 {
+                        Some(cov)
                     } else {
-                        T::one() - wgt_sum_sqr / wgt_sum.powf(two)
-                    };
-                    (var / correction).sqrt()
-                }),
+                        let numerator = sum_wt * sum_wt;
+                        let denominator = numerator - sum_wt2;
+                        if denominator > T::zero() {
+                            Some((numerator / denominator) * cov)
+                        } else {
+                            None
+                        }
+                    }
+                }
+                (true, true) => Some(cov),
             }
-        })
-        .collect_trusted()
+        });
+
+    if do_sqrt {
+        res.map(|opt_x| opt_x.map(|x| x.sqrt())).collect_trusted()
+    } else {
+        res.collect_trusted()
+    }
+}
+
+pub fn ewm_cov<I, T>(
+    xs: I,
+    ys: I,
+    alpha: T,
+    adjust: bool,
+    bias: bool,
+    min_periods: usize,
+    ignore_nulls: bool,
+) -> PrimitiveArray<T>
+where
+    I: IntoIterator<Item = Option<T>>,
+    I::IntoIter: TrustedLen,
+    T: Float + NativeType + AddAssign + MulAssign + DivAssign,
+{
+    ewm_cov_internal(
+        xs,
+        ys,
+        alpha,
+        adjust,
+        bias,
+        min_periods,
+        ignore_nulls,
+        false,
+    )
 }
 
 pub fn ewm_var<I, T>(
@@ -77,67 +158,56 @@ pub fn ewm_var<I, T>(
     adjust: bool,
     bias: bool,
     min_periods: usize,
+    ignore_nulls: bool,
 ) -> PrimitiveArray<T>
 where
-    I: IntoIterator<Item = Option<T>>,
+    I: IntoIterator<Item = Option<T>> + Clone,
     I::IntoIter: TrustedLen,
-    T: Float + NativeType + AddAssign,
+    T: Float + NativeType + AddAssign + MulAssign + DivAssign,
 {
-    let one_sub_alpha = T::one() - alpha;
-    let two = T::one() + T::one();
+    ewm_cov_internal(
+        xs.clone(),
+        xs,
+        alpha,
+        adjust,
+        bias,
+        min_periods,
+        ignore_nulls,
+        false,
+    )
+}
 
-    let mut opt_mean = None;
-    let mut opt_var = None;
-    let mut non_null_cnt = 0usize;
-
-    let wgt = alpha;
-
-    let (mut wgt_sum, mut wgt_sum_sqr) = if adjust {
-        (T::zero(), T::zero())
-    } else {
-        // NOTE: we must ensure `wgt_sum` and `wgt_sum_sqr` are equal
-        // to 1 during the first iteration
-        (T::one(), (T::one() + alpha) / one_sub_alpha)
-    };
-
-    xs.into_iter()
-        .map(|opt_x| {
-            if let Some(x) = opt_x {
-                non_null_cnt += 1;
-
-                let prev_mean = opt_mean.unwrap_or(x);
-                let prev_var = opt_var.unwrap_or_else(T::zero);
-
-                wgt_sum = one_sub_alpha * wgt_sum + wgt;
-                wgt_sum_sqr = one_sub_alpha.powf(two) * wgt_sum_sqr + wgt.powf(two);
-
-                let curr_mean = prev_mean + (x - prev_mean) * wgt / wgt_sum;
-                let curr_var = (T::one() - wgt / wgt_sum)
-                    * (prev_var + wgt / wgt_sum * (x - prev_mean).powf(two));
-
-                opt_mean = Some(curr_mean);
-                opt_var = Some(curr_var);
-            }
-            match non_null_cnt < min_periods {
-                true => None,
-                false => opt_var.map(|var| {
-                    // NOTE: the `non_null_cnt.is_one()` condition prevents a NaN
-                    // from appearing in the first entry (it prevents a zero division)
-                    let correction = if bias || non_null_cnt.is_one() {
-                        T::one()
-                    } else {
-                        T::one() - wgt_sum_sqr / wgt_sum.powf(two)
-                    };
-                    var / correction
-                }),
-            }
-        })
-        .collect_trusted()
+pub fn ewm_std<I, T>(
+    xs: I,
+    alpha: T,
+    adjust: bool,
+    bias: bool,
+    min_periods: usize,
+    ignore_nulls: bool,
+) -> PrimitiveArray<T>
+where
+    I: IntoIterator<Item = Option<T>> + Clone,
+    I::IntoIter: TrustedLen,
+    T: Float + NativeType + AddAssign + MulAssign + DivAssign,
+{
+    ewm_cov_internal(
+        xs.clone(),
+        xs,
+        alpha,
+        adjust,
+        bias,
+        min_periods,
+        ignore_nulls,
+        true,
+    )
 }
 
 #[cfg(test)]
 mod test {
+    use super::super::assert_allclose;
     use super::*;
+    const ALPHA: f64 = 0.5;
+    const EPS: f64 = 1e-15;
 
     const XS: [Option<f64>; 7] = [
         Some(1.0),
@@ -148,73 +218,593 @@ mod test {
         Some(1.0),
         Some(4.0),
     ];
-    const ALPHA: f64 = 0.5;
+    const YS: [Option<f64>; 7] = [None, Some(5.0), Some(7.0), None, None, Some(1.0), Some(4.0)];
 
     #[test]
-    fn test_emw_var_adjusted_biased() {
-        let xs = Vec::from(XS);
-        let polars_result = ewm_var(xs, ALPHA, true, true, 0);
-        let pandas_result = PrimitiveArray::from([
-            Some(0.0),
-            Some(3.555555555555556),
-            Some(4.244897959183674),
-            Some(7.182222222222221),
-            Some(3.796045785639958),
-            Some(2.4671201814058956), // <-- pandas: 2.467120181405896
-            Some(2.4760369520739043),
-        ]);
-        assert_eq!(polars_result, pandas_result);
+    fn test_ewm_var() {
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, true, true, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(3.55555555555555580227),
+                Some(4.24489795918367374128),
+                Some(7.18222222222222139720),
+                Some(3.79604578563995787022),
+                Some(2.46712018140589606219),
+                Some(2.47603695207390428479),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(3.55555555555555580227),
+                Some(4.24489795918367374128),
+                Some(7.18222222222222139720),
+                Some(3.79604578563995787022),
+                Some(2.46712018140589606219),
+                Some(2.47603695207390428479),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, true, false, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(8.00000000000000000000),
+                Some(7.42857142857142882519),
+                Some(11.54285714285714270488),
+                Some(5.88387096774193452120),
+                Some(3.76036866359447063957),
+                Some(3.74353205849268855232),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, true, false, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(8.00000000000000000000),
+                Some(7.42857142857142882519),
+                Some(11.54285714285714270488),
+                Some(5.88387096774193452120),
+                Some(3.76036866359447063957),
+                Some(3.74353205849268855232),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, false, true, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(4.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(7.00000000000000000000),
+                Some(3.75000000000000000000),
+                Some(2.43750000000000000000),
+                Some(2.48437500000000000000),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(4.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(7.00000000000000000000),
+                Some(3.75000000000000000000),
+                Some(2.43750000000000000000),
+                Some(2.48437500000000000000),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(4.00000000000000000000),
+                Some(6.00000000000000000000),
+                Some(7.00000000000000000000),
+                Some(3.75000000000000000000),
+                Some(2.43750000000000000000),
+                Some(2.48437500000000000000),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, false, false, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(8.00000000000000000000),
+                Some(9.60000000000000142109),
+                Some(10.66666666666666607455),
+                Some(5.64705882352941124225),
+                Some(3.65982404692082097242),
+                Some(3.72747252747252755256),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(XS.to_vec(), ALPHA, false, false, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(8.00000000000000000000),
+                Some(9.60000000000000142109),
+                Some(10.66666666666666607455),
+                Some(5.64705882352941124225),
+                Some(3.65982404692082097242),
+                Some(3.72747252747252755256),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(7.34693877551020335659),
+                Some(3.55555555555555535818),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(3.92243767313019331411),
+                Some(2.54978854286812728347),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(12.85714285714285587403),
+                Some(5.71428571428571441260),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(14.15999999999999658939),
+                Some(5.03951367781154946357),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, false, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(6.75000000000000000000),
+                Some(3.43750000000000000000),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(4.20000000000000017764),
+                Some(3.10000000000000008882),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, false, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(10.80000000000000071054),
+                Some(5.23809523809523813753),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, false, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(12.35294117647058875775),
+                Some(5.29914529914529985888),
+            ]),
+            EPS
+        );
     }
 
     #[test]
-    fn test_emw_var_adjusted_unbiased() {
-        let xs = Vec::from(XS);
-        let polars_result = ewm_var(xs, ALPHA, true, false, 0);
-        // NOTE: pandas actually returns `nan` for the first entry here, but that
-        // is inconsistent with the other var calculations.
-        let pandas_result = PrimitiveArray::from([
-            Some(0.0),
-            Some(8.000000000000002),  // <-- pandas: 8.0
-            Some(7.42857142857143),   // <-- pandas: 7.428571428571429
-            Some(11.542857142857141), // <-- pandas: 11.542857142857143
-            Some(5.8838709677419345),
-            Some(3.76036866359447),  // <-- pandas: 3.7603686635944706
-            Some(3.743532058492689), // <-- pandas: 3.7435320584926886
-        ]);
-        assert_eq!(polars_result, pandas_result);
+    fn test_ewm_cov() {
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, true, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(7.34693877551020335659),
+                Some(3.55555555555555535818)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(3.92243767313019331411),
+                Some(2.54978854286812728347)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, true, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(12.85714285714285587403),
+                Some(5.71428571428571441260)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, true, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(14.15999999999999658939),
+                Some(5.03951367781154946357)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, false, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(6.75000000000000000000),
+                Some(3.43750000000000000000)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(4.20000000000000017764),
+                Some(3.10000000000000008882)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, false, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(10.80000000000000071054),
+                Some(5.23809523809523813753)
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_cov(XS.to_vec(), YS.to_vec(), ALPHA, false, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(12.35294117647058875775),
+                Some(5.29914529914529985888)
+            ]),
+            EPS
+        );
     }
 
     #[test]
-    fn test_emw_var_unadjusted_biased() {
-        let xs = Vec::from(XS);
-        let polars_result = ewm_var(xs, ALPHA, false, true, 0);
-        let pandas_result = PrimitiveArray::from([
-            Some(0.0),
-            Some(4.0),
-            Some(6.0),
-            Some(7.0),
-            Some(3.75),
-            Some(2.4375),
-            Some(2.484375),
-        ]);
-        assert_eq!(polars_result, pandas_result);
+    fn test_ewm_std() {
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, true, true, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(1.88561808316412671260),
+                Some(2.06031501455085130914),
+                Some(2.67996683229890386713),
+                Some(1.94834437039245145229),
+                Some(1.57070690499720422295),
+                Some(1.57354280274605318191),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(1.88561808316412671260),
+                Some(2.06031501455085130914),
+                Some(2.67996683229890386713),
+                Some(1.94834437039245145229),
+                Some(1.57070690499720422295),
+                Some(1.57354280274605318191),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, true, false, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.82842712474619029095),
+                Some(2.72554057547698747044),
+                Some(3.39747805627308530063),
+                Some(2.42566917936925907640),
+                Some(1.93916700250248452697),
+                Some(1.93482093706179658632),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, true, false, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.82842712474619029095),
+                Some(2.72554057547698747044),
+                Some(3.39747805627308530063),
+                Some(2.42566917936925907640),
+                Some(1.93916700250248452697),
+                Some(1.93482093706179658632),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, false, true, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.44948974278317788134),
+                Some(2.64575131106459071617),
+                Some(1.93649167310370851069),
+                Some(1.56124949959959957724),
+                Some(1.57619002661481144578),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.00000000000000000000),
+                Some(2.44948974278317788134),
+                Some(2.64575131106459071617),
+                Some(1.93649167310370851069),
+                Some(1.56124949959959957724),
+                Some(1.57619002661481144578),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, false, false, 0, true),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.82842712474619029095),
+                Some(3.09838667696593361711),
+                Some(3.26598632371090413784),
+                Some(2.37635410314401829268),
+                Some(1.91306666034428118905),
+                Some(1.93066634286521066066),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(XS.to_vec(), ALPHA, false, false, 0, false),
+            PrimitiveArray::from([
+                Some(0.00000000000000000000),
+                Some(2.82842712474619029095),
+                Some(3.09838667696593361711),
+                Some(3.26598632371090413784),
+                Some(2.37635410314401829268),
+                Some(1.91306666034428118905),
+                Some(1.93066634286521066066),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, true, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.94280904158206335630),
+                Some(0.94280904158206335630),
+                Some(0.94280904158206335630),
+                Some(2.71052370871575343259),
+                Some(1.88561808316412671260),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.94280904158206335630),
+                Some(0.94280904158206335630),
+                Some(0.94280904158206335630),
+                Some(1.98051449707650295551),
+                Some(1.59680573109822199207),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, true, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(3.58568582800318091941),
+                Some(2.39045721866878713158),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, true, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(3.76297754444535526019),
+                Some(2.24488611689135586502),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, false, true, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(2.59807621135331601181),
+                Some(1.85404962177391574585),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, false, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(1.00000000000000000000),
+                Some(2.04939015319191986109),
+                Some(1.76068168616590092768),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, false, false, 0, true),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(3.28633534503099689061),
+                Some(2.28868854108531749603),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_std(YS.to_vec(), ALPHA, false, false, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(1.41421356237309514547),
+                Some(3.51467511677403665615),
+                Some(2.30198724999625037313),
+            ]),
+            EPS
+        );
     }
 
     #[test]
-    fn test_emw_var_unadjusted_unbiased() {
-        let xs = Vec::from(XS);
-        let polars_result = ewm_var(xs, ALPHA, false, false, 0);
-        // NOTE: pandas actually returns `nan` for the first entry here, but that
-        // is inconsistent with the other var calculations.
-        let pandas_result = PrimitiveArray::from([
-            Some(0.0),
-            Some(8.0),
-            Some(9.6), // <-- pandas: 9.600000000000001
-            Some(10.666666666666666),
-            Some(5.647058823529412), // <-- pandas: 5.647058823529411
-            Some(3.659824046920821),
-            Some(3.7274725274725276),
-        ]);
-        assert_eq!(polars_result, pandas_result);
+    fn test_ewm_min_periods() {
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, true, 0, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(3.92243767313019331411),
+                Some(2.54978854286812728347),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, true, 1, false),
+            PrimitiveArray::from([
+                None,
+                Some(0.00000000000000000000),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(3.92243767313019331411),
+                Some(2.54978854286812728347),
+            ]),
+            EPS
+        );
+        assert_allclose!(
+            ewm_var(YS.to_vec(), ALPHA, true, true, 2, false),
+            PrimitiveArray::from([
+                None,
+                None,
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(0.88888888888888895057),
+                Some(3.92243767313019331411),
+                Some(2.54978854286812728347),
+            ]),
+            EPS
+        );
     }
 }

--- a/polars/polars-core/src/series/ops/ewm.rs
+++ b/polars/polars-core/src/series/ops/ewm.rs
@@ -20,12 +20,19 @@ impl Series {
                     options.alpha as f32,
                     options.adjust,
                     options.min_periods,
+                    options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
             DataType::Float64 => {
                 let xs = self.f64().unwrap();
-                let result = ewm_mean(xs, options.alpha, options.adjust, options.min_periods);
+                let result = ewm_mean(
+                    xs,
+                    options.alpha,
+                    options.adjust,
+                    options.min_periods,
+                    options.ignore_nulls,
+                );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
             _ => self.cast(&DataType::Float64)?.ewm_mean(options),
@@ -47,6 +54,7 @@ impl Series {
                     options.adjust,
                     options.bias,
                     options.min_periods,
+                    options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
@@ -58,6 +66,7 @@ impl Series {
                     options.adjust,
                     options.bias,
                     options.min_periods,
+                    options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
@@ -80,6 +89,7 @@ impl Series {
                     options.adjust,
                     options.bias,
                     options.min_periods,
+                    options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }
@@ -91,6 +101,7 @@ impl Series {
                     options.adjust,
                     options.bias,
                     options.min_periods,
+                    options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
             }

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5424,6 +5424,7 @@ class Expr:
         alpha: float | None = None,
         adjust: bool = True,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Expr:
         r"""
         Exponentially-weighted moving average.
@@ -5463,6 +5464,24 @@ class Expr:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
+
 
         Examples
         --------
@@ -5481,7 +5500,9 @@ class Expr:
 
         """
         alpha = _prepare_alpha(com, span, half_life, alpha)
-        return wrap_expr(self._pyexpr.ewm_mean(alpha, adjust, min_periods))
+        return wrap_expr(
+            self._pyexpr.ewm_mean(alpha, adjust, min_periods, ignore_nulls)
+        )
 
     def ewm_std(
         self,
@@ -5492,6 +5513,7 @@ class Expr:
         adjust: bool = True,
         bias: bool = False,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Expr:
         r"""
         Exponentially-weighted moving standard deviation.
@@ -5534,6 +5556,23 @@ class Expr:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
         Examples
         --------
@@ -5552,7 +5591,9 @@ class Expr:
 
         """
         alpha = _prepare_alpha(com, span, half_life, alpha)
-        return wrap_expr(self._pyexpr.ewm_std(alpha, adjust, bias, min_periods))
+        return wrap_expr(
+            self._pyexpr.ewm_std(alpha, adjust, bias, min_periods, ignore_nulls)
+        )
 
     def ewm_var(
         self,
@@ -5563,6 +5604,7 @@ class Expr:
         adjust: bool = True,
         bias: bool = False,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Expr:
         r"""
         Exponentially-weighted moving variance.
@@ -5605,6 +5647,23 @@ class Expr:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
         Examples
         --------
@@ -5623,7 +5682,9 @@ class Expr:
 
         """
         alpha = _prepare_alpha(com, span, half_life, alpha)
-        return wrap_expr(self._pyexpr.ewm_var(alpha, adjust, bias, min_periods))
+        return wrap_expr(
+            self._pyexpr.ewm_var(alpha, adjust, bias, min_periods, ignore_nulls)
+        )
 
     def extend_constant(self, value: PythonLiteral | None, n: int) -> Expr:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4636,6 +4636,7 @@ class Series:
         alpha: float | None = None,
         adjust: bool = True,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Series:
         r"""
         Exponentially-weighted moving average.
@@ -4675,6 +4676,23 @@ class Series:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
         """
 
@@ -4687,6 +4705,7 @@ class Series:
         adjust: bool = True,
         bias: bool = False,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Series:
         r"""
         Exponentially-weighted moving standard deviation.
@@ -4729,6 +4748,23 @@ class Series:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
         Examples
         --------
@@ -4753,6 +4789,7 @@ class Series:
         adjust: bool = True,
         bias: bool = False,
         min_periods: int = 1,
+        ignore_nulls: bool = True,
     ) -> Series:
         r"""
         Exponentially-weighted moving variance.
@@ -4795,6 +4832,23 @@ class Series:
         min_periods
             Minimum number of observations in window required to have a value
             (otherwise result is null).
+        ignore_nulls
+            Ignore missing values when calculating weights.
+
+                - When ``ignore_nulls=False`` (default), weights are based on absolute
+                  positions.
+                  For example, the weights of :math:`x_0` and :math:`x_2` used in
+                  calculating the final weighted average of
+                  [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+                  :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+                - When ``ignore_nulls=True``, weights are based
+                  on relative positions. For example, the weights of
+                  :math:`x_0` and :math:`x_2` used in calculating the final weighted
+                  average of [:math:`x_0`, None, :math:`x_2`] are
+                  :math:`1-\alpha` and :math:`1` if ``adjust=True``,
+                  and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
         Examples
         --------

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1674,30 +1674,53 @@ impl PyExpr {
             .into()
     }
 
-    pub fn ewm_mean(&self, alpha: f64, adjust: bool, min_periods: usize) -> Self {
+    pub fn ewm_mean(
+        &self,
+        alpha: f64,
+        adjust: bool,
+        min_periods: usize,
+        ignore_nulls: bool,
+    ) -> Self {
         let options = EWMOptions {
             alpha,
             adjust,
             bias: false,
             min_periods,
+            ignore_nulls,
         };
         self.inner.clone().ewm_mean(options).into()
     }
-    pub fn ewm_std(&self, alpha: f64, adjust: bool, bias: bool, min_periods: usize) -> Self {
+    pub fn ewm_std(
+        &self,
+        alpha: f64,
+        adjust: bool,
+        bias: bool,
+        min_periods: usize,
+        ignore_nulls: bool,
+    ) -> Self {
         let options = EWMOptions {
             alpha,
             adjust,
             bias,
             min_periods,
+            ignore_nulls,
         };
         self.inner.clone().ewm_std(options).into()
     }
-    pub fn ewm_var(&self, alpha: f64, adjust: bool, bias: bool, min_periods: usize) -> Self {
+    pub fn ewm_var(
+        &self,
+        alpha: f64,
+        adjust: bool,
+        bias: bool,
+        min_periods: usize,
+        ignore_nulls: bool,
+    ) -> Self {
         let options = EWMOptions {
             alpha,
             adjust,
             bias,
             min_periods,
+            ignore_nulls,
         };
         self.inner.clone().ewm_var(options).into()
     }

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1873,21 +1873,40 @@ def test_ewm_mean() -> None:
     s = pl.Series([2, 5, 3])
 
     expected = pl.Series([2.0, 4.0, 3.4285714285714284])
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True), expected)
+    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True, ignore_nulls=True), expected)
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, ignore_nulls=False), expected
+    )
 
     expected = pl.Series([2.0, 3.8, 3.421053])
-    assert_series_equal(s.ewm_mean(com=2.0, adjust=True), expected)
+    assert_series_equal(s.ewm_mean(com=2.0, adjust=True, ignore_nulls=True), expected)
+    assert_series_equal(s.ewm_mean(com=2.0, adjust=True, ignore_nulls=False), expected)
 
     expected = pl.Series([2.0, 3.5, 3.25])
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=False), expected)
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=False, ignore_nulls=True), expected
+    )
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=False, ignore_nulls=False), expected
+    )
 
     s = pl.Series([2, 3, 5, 7, 4])
 
     expected = pl.Series([None, 2.666667, 4.0, 5.6, 4.774194])
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True, min_periods=2), expected)
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, min_periods=2, ignore_nulls=True), expected
+    )
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, min_periods=2, ignore_nulls=False), expected
+    )
 
     expected = pl.Series([None, None, 4.0, 5.6, 4.774194])
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True, min_periods=3), expected)
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, min_periods=3, ignore_nulls=True), expected
+    )
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, min_periods=3, ignore_nulls=False), expected
+    )
 
     s = pl.Series([None, 1.0, 5.0, 7.0, None, 2.0, 5.0, 4])
 
@@ -1903,10 +1922,32 @@ def test_ewm_mean() -> None:
             4.174603174603175,
         ],
     )
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True, min_periods=1), expected)
+    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=True, ignore_nulls=True), expected)
+    expected = pl.Series(
+        [
+            None,
+            1.0,
+            3.666666666666667,
+            5.571428571428571,
+            5.571428571428571,
+            3.08695652173913,
+            4.2,
+            4.092436974789916,
+        ]
+    )
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=True, ignore_nulls=False), expected
+    )
 
     expected = pl.Series([None, 1.0, 3.0, 5.0, 5.0, 3.5, 4.25, 4.125])
-    assert_series_equal(s.ewm_mean(alpha=0.5, adjust=False, min_periods=1), expected)
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=False, ignore_nulls=True), expected
+    )
+
+    expected = pl.Series([None, 1.0, 3.0, 5.0, 5.0, 3.0, 4.0, 4.0])
+    assert_series_equal(
+        s.ewm_mean(alpha=0.5, adjust=False, ignore_nulls=False), expected
+    )
 
 
 def test_ewm_mean_leading_nulls() -> None:
@@ -1934,21 +1975,31 @@ def test_ewm_mean_min_periods() -> None:
     series = pl.Series([1.0, None, 2.0, None, 3.0])
 
     ewm_mean = series.ewm_mean(alpha=0.5, min_periods=1)
-    assert ewm_mean.to_list() == [
-        1.0,
-        1.0,
-        1.6666666666666665,
-        1.6666666666666665,
-        2.4285714285714284,
-    ]
+    assert_series_equal(
+        ewm_mean,
+        pl.Series(
+            [
+                1.0,
+                1.0,
+                1.6666666666666665,
+                1.6666666666666665,
+                2.4285714285714284,
+            ]
+        ),
+    )
     ewm_mean = series.ewm_mean(alpha=0.5, min_periods=2)
-    assert ewm_mean.to_list() == [
-        None,
-        None,
-        1.6666666666666665,
-        1.6666666666666665,
-        2.4285714285714284,
-    ]
+    assert_series_equal(
+        ewm_mean,
+        pl.Series(
+            [
+                None,
+                None,
+                1.6666666666666665,
+                1.6666666666666665,
+                2.4285714285714284,
+            ]
+        ),
+    )
 
 
 def test_ewm_std_var() -> None:


### PR DESCRIPTION
- ported pandas' ewm numba based code for supporting `ignore_nulls`
- ewm_var & ewm_std is based on ewm_cov function which is not exposed to the API
  I am not familar with making a binary expression but ewm_cov can be readily added to the API