### PR TITLE
build(python): Update `mypy` to version `1.0.0`

### DIFF
--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
     )
     from polars.polars import PyDataFrame
 
-# A type variable used to refer to a polars.DataFrame or any subclass of it.
-# Used to annotate DataFrame methods which returns the same type as self.
+# A type variable used to refer to a polars.DataFrame or any subclass of it
 DF = TypeVar("DF", bound="pli.DataFrame")
 
 

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -14,9 +14,7 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
-# Used to type any type or subclass of LazyFrame.
-# Used to indicate when LazyFrame methods return the same type as self,
-# including sub-classes.
+# A type variable used to refer to a polars.LazyFrame or any subclass of it
 LDF = TypeVar("LDF", bound="pli.LazyFrame")
 
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -37,6 +37,13 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
+# This code block is due to a typing issue with backports.zoneinfo package:
+# https://github.com/pganssle/zoneinfo/issues/125
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+elif _ZONEINFO_AVAILABLE:
+    from backports.zoneinfo._zoneinfo import ZoneInfo
+
 if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeGuard
 else:
@@ -46,7 +53,6 @@ else:
 if sys.version_info >= (3, 11):
     _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
     _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
-
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import SizeUnit, TimeUnit
@@ -286,7 +292,7 @@ def _to_python_datetime(
                     "Install polars[timezone] to handle datetimes with timezones."
                 )
 
-            utc = zoneinfo.ZoneInfo("UTC")
+            utc = ZoneInfo("UTC")
             if tu == "ns":
                 # nanoseconds to seconds
                 dt = datetime.fromtimestamp(0, tz=utc) + timedelta(
@@ -326,7 +332,7 @@ def _parse_fixed_tz_offset(offset: str) -> tzinfo:
 def _localize(dt: datetime, tz: str) -> datetime:
     # zone info installation should already be checked
     try:
-        tzinfo = zoneinfo.ZoneInfo(tz)
+        tzinfo = ZoneInfo(tz)
     except zoneinfo.ZoneInfoNotFoundError:
         # try fixed offset, which is not supported by ZoneInfo
         tzinfo = _parse_fixed_tz_offset(tz)  # type: ignore[assignment]

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -16,7 +16,6 @@ from typing import (
     Iterable,
     Sequence,
     TypeVar,
-    cast,
     overload,
 )
 
@@ -45,10 +44,8 @@ else:
 
 # note: reversed views don't match as instances of MappingView
 if sys.version_info >= (3, 11):
-    _reverse_mapping_views = tuple(
-        type(reversed(cast(Reversible[Any], view)))
-        for view in ({}.keys(), {}.values(), {}.items())
-    )
+    _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
+    _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
 
 if TYPE_CHECKING:

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
-  "typing_extensions >= 4.0.0; python_version < '3.10'",
+  "typing_extensions >= 4.0.1; python_version < '3.11'",
 ]
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -16,7 +16,7 @@ deltalake
 # Tooling
 hypothesis==6.65.2
 maturin==0.14.10
-mypy==0.991
+mypy==1.0.0
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-xdist==3.1.0

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -12,9 +12,11 @@ from polars.internals.type_aliases import TimeUnit
 from polars.testing import assert_series_equal
 
 if sys.version_info >= (3, 9):
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 else:
-    from backports import zoneinfo
+    # Import from submodule due to typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def test_str_strptime() -> None:
@@ -327,12 +329,8 @@ def test_tz_aware_strptime(ts: str, fmt: str, expected: datetime) -> None:
 def test_crossing_dst(fmt: str) -> None:
     ts = ["2021-03-27T23:59:59+01:00", "2021-03-28T23:59:59+02:00"]
     result = pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=True)
-    assert result[0] == datetime(
-        2021, 3, 27, 22, 59, 59, tzinfo=zoneinfo.ZoneInfo(key="UTC")
-    )
-    assert result[1] == datetime(
-        2021, 3, 28, 21, 59, 59, tzinfo=zoneinfo.ZoneInfo(key="UTC")
-    )
+    assert result[0] == datetime(2021, 3, 27, 22, 59, 59, tzinfo=ZoneInfo(key="UTC"))
+    assert result[1] == datetime(2021, 3, 28, 21, 59, 59, tzinfo=ZoneInfo(key="UTC"))
 
 
 @pytest.mark.parametrize("fmt", ["%+", "%Y-%m-%dT%H:%M:%S%z"])

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -23,9 +23,11 @@ if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit
 
 if sys.version_info >= (3, 9):
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 else:
-    from backports import zoneinfo
+    # Import from submodule due to typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def test_fill_null() -> None:
@@ -809,11 +811,11 @@ def test_upsample() -> None:
     [
         (None, None),
         ("+01:00", timezone(timedelta(hours=1))),
-        ("Pacific/Rarotonga", zoneinfo.ZoneInfo("Pacific/Rarotonga")),
+        ("Pacific/Rarotonga", ZoneInfo("Pacific/Rarotonga")),
     ],
 )
 def test_upsample_time_zones(
-    time_zone: str | None, tzinfo: timezone | zoneinfo.ZoneInfo | None
+    time_zone: str | None, tzinfo: timezone | ZoneInfo | None
 ) -> None:
     df = pl.DataFrame(
         {
@@ -874,7 +876,7 @@ def test_read_utc_times_parquet() -> None:
     df.to_parquet(f)
     f.seek(0)
     df_in = pl.read_parquet(f)
-    tz = zoneinfo.ZoneInfo("UTC")
+    tz = ZoneInfo("UTC")
     assert df_in["Timestamp"][0] == datetime(2022, 1, 1, 0, 0, tzinfo=tz)
 
 
@@ -1598,7 +1600,7 @@ def test_supertype_timezones_4174() -> None:
 
 @pytest.mark.skip(reason="from_dicts cannot yet infer timezones")
 def test_from_dict_tu_consistency() -> None:
-    tz = zoneinfo.ZoneInfo("PRC")
+    tz = ZoneInfo("PRC")
     dt = datetime(2020, 8, 1, 12, 0, 0, tzinfo=tz)
     from_dict = pl.from_dict({"dt": [dt]})
     from_dicts = pl.from_dicts([{"dt": dt}])
@@ -1679,7 +1681,7 @@ def test_iso_year() -> None:
 
 
 def test_cast_timezone() -> None:
-    ny = zoneinfo.ZoneInfo("America/New_York")
+    ny = ZoneInfo("America/New_York")
     assert pl.DataFrame({"a": [datetime(2022, 9, 25, 14)]}).with_columns(
         pl.col("a").dt.cast_time_zone("America/New_York").alias("b")
     ).to_dict(False) == {
@@ -1692,7 +1694,7 @@ def test_cast_timezone() -> None:
     ("to_tz", "tzinfo"),
     [
         ("+01:00", timezone(timedelta(seconds=3600))),
-        ("America/Barbados", zoneinfo.ZoneInfo(key="America/Barbados")),
+        ("America/Barbados", ZoneInfo(key="America/Barbados")),
         (None, None),
     ],
 )
@@ -1701,7 +1703,7 @@ def test_cast_timezone() -> None:
 def test_cast_timezone_from_to(
     from_tz: str,
     to_tz: str,
-    tzinfo: timezone | zoneinfo.ZoneInfo,
+    tzinfo: timezone | ZoneInfo,
     tu: TimeUnit,
 ) -> None:
     ts = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime(tu))
@@ -1733,9 +1735,7 @@ def test_with_time_zone_fixed_offset() -> None:
 
 
 def test_tz_aware_get_idx_5010() -> None:
-    when = int(
-        datetime(2022, 1, 1, 12, tzinfo=zoneinfo.ZoneInfo("Asia/Shanghai")).timestamp()
-    )
+    when = int(datetime(2022, 1, 1, 12, tzinfo=ZoneInfo("Asia/Shanghai")).timestamp())
     a = pa.array([when]).cast(pa.timestamp("s", tz="Asia/Shanghai"))
     assert int(pl.from_arrow(a)[0].timestamp()) == when  # type: ignore[union-attr]
 
@@ -1749,7 +1749,7 @@ def test_tz_datetime_duration_arithm_5221() -> None:
         data={"run_datetime": run_datetimes},
         schema=[("run_datetime", pl.Datetime(time_zone="UTC"))],
     )
-    utc = zoneinfo.ZoneInfo("UTC")
+    utc = ZoneInfo("UTC")
     assert out.to_dict(False) == {
         "run_datetime": [
             datetime(2022, 1, 1, 0, 0, tzinfo=utc),
@@ -1759,24 +1759,24 @@ def test_tz_datetime_duration_arithm_5221() -> None:
 
 
 def test_auto_infer_time_zone() -> None:
-    dt = datetime(2022, 10, 17, 10, tzinfo=zoneinfo.ZoneInfo("Asia/Shanghai"))
+    dt = datetime(2022, 10, 17, 10, tzinfo=ZoneInfo("Asia/Shanghai"))
     s = pl.Series([dt])
     assert s.dtype == pl.Datetime("us", "Asia/Shanghai")
     assert s[0] == dt
 
 
 def test_timezone_aware_date_range() -> None:
-    low = datetime(2022, 10, 17, 10, tzinfo=zoneinfo.ZoneInfo("Asia/Shanghai"))
-    high = datetime(2022, 11, 17, 10, tzinfo=zoneinfo.ZoneInfo("Asia/Shanghai"))
+    low = datetime(2022, 10, 17, 10, tzinfo=ZoneInfo("Asia/Shanghai"))
+    high = datetime(2022, 11, 17, 10, tzinfo=ZoneInfo("Asia/Shanghai"))
 
     assert pl.date_range(low, high, interval=timedelta(days=5)).to_list() == [
-        datetime(2022, 10, 17, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 10, 22, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 10, 27, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 11, 1, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 11, 6, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 11, 11, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
-        datetime(2022, 11, 16, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 10, 17, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 10, 22, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 10, 27, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 11, 1, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 11, 6, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 11, 11, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
+        datetime(2022, 11, 16, 10, 0, tzinfo=ZoneInfo(key="Asia/Shanghai")),
     ]
 
     with pytest.raises(
@@ -1839,12 +1839,8 @@ def test_cast_time_zone_from_naive() -> None:
         pl.col("date").cast(pl.Datetime).dt.cast_time_zone("America/New_York")
     ).to_dict(False) == {
         "date": [
-            datetime(
-                2022, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 1, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
+            datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 1, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ]
     }
 
@@ -1887,50 +1883,22 @@ def test_tz_aware_truncate() -> None:
         False
     ) == {
         "dt": [
-            datetime(
-                2022, 11, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 1, 12, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 2, 12, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 3, 12, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 4, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
+            datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 1, 12, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 2, 12, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 3, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 3, 12, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 4, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ],
         "trunced": [
-            datetime(
-                2022, 11, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 4, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
+            datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 3, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 3, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 4, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ],
     }
 
@@ -1959,34 +1927,34 @@ def test_tz_aware_truncate() -> None:
             datetime(2022, 1, 1, 6, 0),
         ],
         "UTC": [
-            datetime(2021, 12, 31, 23, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 1, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 2, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 3, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 4, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 5, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
-            datetime(2022, 1, 1, 6, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")),
+            datetime(2021, 12, 31, 23, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 1, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 2, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 3, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 4, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 5, 0, tzinfo=ZoneInfo(key="UTC")),
+            datetime(2022, 1, 1, 6, 0, tzinfo=ZoneInfo(key="UTC")),
         ],
         "CST": [
-            datetime(2021, 12, 31, 17, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 18, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 19, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 20, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 21, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 22, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 23, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2022, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 17, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 18, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 19, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 20, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 21, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 22, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 23, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
         ],
         "CST truncated": [
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2021, 12, 31, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
-            datetime(2022, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2021, 12, 31, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
+            datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo(key="US/Central")),
         ],
     }
 
@@ -2003,18 +1971,10 @@ def test_tz_aware_strftime() -> None:
         False
     ) == {
         "dt": [
-            datetime(
-                2022, 11, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 3, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                2022, 11, 4, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
+            datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 3, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(2022, 11, 4, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ],
         "fmt": [
             "Tue Nov  1 00:00:00 2022",
@@ -2046,7 +2006,7 @@ def test_tz_aware_with_timezone_directive(
 def test_tz_aware_filter_lit() -> None:
     start = datetime(1970, 1, 1)
     stop = datetime(1970, 1, 1, 7)
-    dt = datetime(1970, 1, 1, 6, tzinfo=zoneinfo.ZoneInfo("America/New_York"))
+    dt = datetime(1970, 1, 1, 6, tzinfo=ZoneInfo("America/New_York"))
 
     assert (
         pl.DataFrame({"date": pl.date_range(start, stop, "1h")})
@@ -2062,24 +2022,12 @@ def test_tz_aware_filter_lit() -> None:
             datetime(1970, 1, 1, 5, 0),
         ],
         "nyc": [
-            datetime(
-                1970, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                1970, 1, 1, 1, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                1970, 1, 1, 2, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                1970, 1, 1, 3, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                1970, 1, 1, 4, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
-            datetime(
-                1970, 1, 1, 5, 0, tzinfo=zoneinfo.ZoneInfo(key="America/New_York")
-            ),
+            datetime(1970, 1, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(1970, 1, 1, 1, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(1970, 1, 1, 2, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(1970, 1, 1, 3, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(1970, 1, 1, 4, 0, tzinfo=ZoneInfo(key="America/New_York")),
+            datetime(1970, 1, 1, 5, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ],
     }
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -14,7 +14,6 @@ import pytest
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
-from polars.dependencies import zoneinfo
 from polars.internals.construction import iterable_to_pydf
 from polars.testing import (
     assert_frame_equal,
@@ -25,6 +24,13 @@ from polars.testing.parametric import columns
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy, UniqueKeepStrategy
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+else:
+    # Import from submodule due to typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def test_version() -> None:
@@ -2759,7 +2765,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_us = "America/New_York"
     tz_europe = "Europe/Amsterdam"
 
-    dtm = datetime(2022, 10, 12, 12, 30, tzinfo=zoneinfo.ZoneInfo("UTC"))
+    dtm = datetime(2022, 10, 12, 12, 30, tzinfo=ZoneInfo("UTC"))
     for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
         for type_overrides in (
             {
@@ -2782,8 +2788,8 @@ def test_init_datetimes_with_timezone() -> None:
             assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
             assert df.rows() == [
                 (
-                    datetime(2022, 10, 12, 8, 30, tzinfo=zoneinfo.ZoneInfo(tz_us)),
-                    datetime(2022, 10, 12, 14, 30, tzinfo=zoneinfo.ZoneInfo(tz_europe)),
+                    datetime(2022, 10, 12, 8, 30, tzinfo=ZoneInfo(tz_us)),
+                    datetime(2022, 10, 12, 14, 30, tzinfo=ZoneInfo(tz_europe)),
                 )
             ]
 
@@ -2805,8 +2811,8 @@ def test_init_physical_with_timezone() -> None:
         assert (df["d1"].to_physical() == df["d2"].to_physical()).all()
         assert df.rows() == [
             (
-                datetime(2022, 10, 12, 16, 30, tzinfo=zoneinfo.ZoneInfo(tz_uae)),
-                datetime(2022, 10, 12, 21, 30, tzinfo=zoneinfo.ZoneInfo(tz_asia)),
+                datetime(2022, 10, 12, 16, 30, tzinfo=ZoneInfo(tz_uae)),
+                datetime(2022, 10, 12, 21, 30, tzinfo=ZoneInfo(tz_asia)),
             )
         ]
 


### PR DESCRIPTION
Closes #6743

Changes:
* Use the new `Self` type for DataFrame/LazyFrame. This type was introduced in Python 3.11.
* Bump core dependencies accordingly
  * `typing-extensions` will now be required for anyone not on Python 3.11.
  * Version `4.0.1` contains a fix for the Self implementation, so this is now the minimum required version
* Add a workaround for a typing issue with `backports.timezone`. More info [here](https://github.com/pganssle/zoneinfo/issues/125). The repo is inactive so we'll just have to live with the workaround for now.