### PR TITLE
feat(rust, python): formally support duration division

### DIFF
--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -161,12 +161,12 @@ macro_rules! impl_dyn_series {
             }
             fn divide(&self, _rhs: &Series) -> PolarsResult<Series> {
                 Err(PolarsError::ComputeError(
-                    "cannot do division on logical".into(),
+                    "Cannot divide Series of dtype: 'Date/Time'.".into(),
                 ))
             }
             fn remainder(&self, _rhs: &Series) -> PolarsResult<Series> {
                 Err(PolarsError::ComputeError(
-                    "cannot do remainder operation on logical".into(),
+                    "Cannot do remainder operation on Series of dtype: 'Date/Time'.".into(),
                 ))
             }
             fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -161,7 +161,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     }
     fn divide(&self, _rhs: &Series) -> PolarsResult<Series> {
         Err(PolarsError::ComputeError(
-            "cannot do division on logical".into(),
+            "Cannot divide Series of dtype: 'Datetime'.".into(),
         ))
     }
     fn remainder(&self, _rhs: &Series) -> PolarsResult<Series> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -188,9 +188,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         ))
     }
     fn divide(&self, _rhs: &Series) -> PolarsResult<Series> {
-        Err(PolarsError::ComputeError(
-            "cannot do division on logical".into(),
-        ))
+        self.0.deref().divide(_rhs.to_physical_repr().as_ref())
     }
     fn remainder(&self, _rhs: &Series) -> PolarsResult<Series> {
         Err(PolarsError::ComputeError(

--- a/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -242,6 +242,8 @@ fn get_truediv_field(
     let out_type = match left_field.data_type() {
         Float32 => Float32,
         dt if dt.is_numeric() => Float64,
+        #[cfg(feature = "dtype-duration")]
+        Duration(_) => Float64,
         // we don't know what to do here, best return the dtype
         dt => dt.clone(),
     };

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -150,21 +150,3 @@ pub(crate) fn get_df() -> DataFrame {
         .unwrap();
     df
 }
-
-#[test]
-fn test_foo() -> PolarsResult<()> {
-    let df: DataFrame = df!["a" => [1],
-        "b" => [2],
-        "c" => [2]
-    ]?;
-
-    let out = df
-        .lazy()
-        .rename(["a", "b"], ["a", "b"])
-        .select([col("a"), col("b")])
-        .collect()?;
-
-    dbg!(out);
-
-    Ok(())
-}

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -341,3 +341,15 @@ def test_from_dicts_all_cols_6716() -> None:
     with pytest.raises(pl.PanicException, match="Cannot extract numeric value from"):
         pl.from_dicts(dicts, infer_schema_length=20)
     assert pl.from_dicts(dicts, infer_schema_length=None).dtypes == [pl.Utf8]
+
+
+def test_duration_divison_schema() -> None:
+    df = pl.DataFrame({"a": [1]})
+    q = (
+        df.lazy()
+        .with_columns(pl.col("a").cast(pl.Duration))
+        .select(pl.col("a") / pl.col("a"))
+    )
+
+    assert q.schema == {"a": pl.Float64}
+    assert q.collect().to_dict(False) == {"a": [1.0]}


### PR DESCRIPTION
fixes #6662 where it accidentally allowed division, but lead to strange behavior downstream because the schema was incorrect. 