### PR TITLE
chore(rust): propagate error in date_range with invalid time zone

### DIFF
--- a/polars/polars-time/src/date_range.rs
+++ b/polars/polars-time/src/date_range.rs
@@ -25,7 +25,7 @@ pub fn date_range_impl(
 
     #[cfg(feature = "timezones")]
     if let Some(tz) = _tz {
-        out = out.cast_time_zone(Some(tz)).unwrap()
+        out = out.cast_time_zone(Some(tz))?
     }
     let s = if start > stop {
         IsSorted::Descending

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -84,8 +84,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.15.0"
-source = "git+https://github.com/ritchie46/arrow2?branch=mmap_slice2#685cf49da02a1c94a501aab65535f6fbbcd7cbd7"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4c5b03335bc1cb0fd9f5297f8fd3bbfd6fb04f3cb0bc7d6c91b7128cb8336a"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -592,6 +592,13 @@ def test_date_range_lazy_with_expressions(
     }
 
 
+def test_date_range_invalid_time_zone() -> None:
+    with pytest.raises(ComputeError, match="Could not parse time zone foo"):
+        pl.date_range(
+            datetime(2001, 1, 1), datetime(2001, 1, 3), interval="1d", time_zone="foo"
+        )
+
+
 @pytest.mark.parametrize(
     ("one", "two"),
     [


### PR DESCRIPTION
on 0.16.2:
```python
In [75]: pl.date_range(datetime(2001, 1, 1), datetime(2001, 1, 3), interval='1d', time_zone='foo')
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ComputeError(Owned("ComputeError(\"Could not parse time zone foo\")"))', /home/runner/work/polars/polars/polars/polars-time/src/date_range.rs:31:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
---------------------------------------------------------------------------
PanicException                            Traceback (most recent call last)
Cell In [75], line 1
----> 1 pl.date_range(datetime(2001, 1, 1), datetime(2001, 1, 3), interval='1d', time_zone='foo')

File ~/tmp/.venv/lib/python3.8/site-packages/polars/internals/functions.py:474, in date_range(low, high, interval, lazy, closed, name, time_unit, time_zone)
    471 start = _datetime_to_pl_timestamp(low, tu)
    472 stop = _datetime_to_pl_timestamp(high, tu)
    473 dt_range = pli.wrap_s(
--> 474     _py_date_range(start, stop, interval, closed, name, tu, time_zone)
    475 )
    476 if (
    477     low_is_date
    478     and high_is_date
    479     and not _interval_granularity(interval).endswith(("h", "m", "s"))
    480 ):
    481     dt_range = dt_range.cast(Date)

PanicException: called `Result::unwrap()` on an `Err` value: ComputeError(Owned("ComputeError(\"Could not parse time zone foo\")"))
```

here:
```python
In [1]: pl.date_range(datetime(2001, 1, 1), datetime(2001, 1, 3), interval='1d', time_zone='foo')
---------------------------------------------------------------------------
ComputeError                              Traceback (most recent call last)
Cell In[1], line 1
----> 1 pl.date_range(datetime(2001, 1, 1), datetime(2001, 1, 3), interval='1d', time_zone='foo')

File ~/polars-dev/py-polars/polars/internals/functions.py:474, in date_range(low, high, interval, lazy, closed, name, time_unit, time_zone)
    471 start = _datetime_to_pl_timestamp(low, tu)
    472 stop = _datetime_to_pl_timestamp(high, tu)
    473 dt_range = pli.wrap_s(
--> 474     _py_date_range(start, stop, interval, closed, name, tu, time_zone)
    475 )
    476 if (
    477     low_is_date
    478     and high_is_date
    479     and not _interval_granularity(interval).endswith(("h", "m", "s"))
    480 ):
    481     dt_range = dt_range.cast(Date)

ComputeError: ComputeError("Could not parse time zone foo")
```