### PR TITLE
feat(rust, python): parse timezone from Datetime

### DIFF
--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -45,7 +45,7 @@ pub(crate) fn cast_columns(
         (Utf8, Datetime(tu, _)) => s
             .utf8()
             .unwrap()
-            .as_datetime(None, *tu, false, false, false)
+            .as_datetime(None, *tu, false, false, false, None)
             .map(|ca| ca.into_series()),
         (_, dt) => s.cast(dt),
     };

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -259,7 +259,7 @@ pub(crate) fn to_datetime(
                 ca.set_time_unit(tu);
                 match tz {
                     #[cfg(feature = "timezones")]
-                    Some(tz) => Ok(ca.cast_time_zone(Some(&tz))?),
+                    Some(tz) => Ok(ca.cast_time_zone(Some(tz))?),
                     _ => Ok(ca),
                 }
             })?

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -230,9 +230,13 @@ fn infer_pattern_date_single(val: &str) -> Option<Pattern> {
 }
 
 #[cfg(feature = "dtype-datetime")]
-pub(crate) fn to_datetime(ca: &Utf8Chunked, tu: TimeUnit) -> PolarsResult<DatetimeChunked> {
+pub(crate) fn to_datetime(
+    ca: &Utf8Chunked,
+    tu: TimeUnit,
+    tz: Option<&TimeZone>,
+) -> PolarsResult<DatetimeChunked> {
     match ca.first_non_null() {
-        None => Ok(Int64Chunked::full_null(ca.name(), ca.len()).into_datetime(tu, None)),
+        None => Ok(Int64Chunked::full_null(ca.name(), ca.len()).into_datetime(tu, tz.cloned())),
         Some(idx) => {
             let subset = ca.slice(idx as i64, ca.len());
             let pattern = subset
@@ -253,8 +257,12 @@ pub(crate) fn to_datetime(ca: &Utf8Chunked, tu: TimeUnit) -> PolarsResult<Dateti
             infer.coerce_utf8(ca).datetime().map(|ca| {
                 let mut ca = ca.clone();
                 ca.set_time_unit(tu);
-                ca
-            })
+                match tz {
+                    #[cfg(feature = "timezones")]
+                    Some(tz) => Ok(ca.cast_time_zone(Some(&tz))?),
+                    _ => Ok(ca),
+                }
+            })?
         }
     }
 }

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -259,6 +259,7 @@ pub trait Utf8Methods: AsUtf8 {
         &self,
         fmt: Option<&str>,
         tu: TimeUnit,
+        tz: Option<&TimeZone>,
     ) -> PolarsResult<DatetimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {
@@ -303,7 +304,11 @@ pub trait Utf8Methods: AsUtf8 {
             })
             .collect_trusted();
         ca.rename(utf8_ca.name());
-        Ok(ca.into_datetime(tu, None))
+        match tz {
+            #[cfg(feature = "timezones")]
+            Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(&tz)),
+            _ => Ok(ca.into_datetime(tu, None)),
+        }
     }
 
     #[cfg(feature = "dtype-date")]
@@ -390,11 +395,12 @@ pub trait Utf8Methods: AsUtf8 {
         cache: bool,
         tz_aware: bool,
         _utc: bool,
+        tz: Option<&TimeZone>,
     ) -> PolarsResult<DatetimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {
             Some(fmt) => fmt,
-            None => return infer::to_datetime(utf8_ca, tu),
+            None => return infer::to_datetime(utf8_ca, tu, tz),
         };
         let fmt = self::strptime::compile_fmt(fmt);
         let cache = cache && utf8_ca.len() > 50;
@@ -522,7 +528,11 @@ pub trait Utf8Methods: AsUtf8 {
                         .collect_trusted()
                 };
             ca.rename(utf8_ca.name());
-            Ok(ca.into_datetime(tu, None))
+            match tz {
+                #[cfg(feature = "timezones")]
+                Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(&tz)),
+                _ => Ok(ca.into_datetime(tu, None)),
+            }
         }
     }
 }

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -306,7 +306,7 @@ pub trait Utf8Methods: AsUtf8 {
         ca.rename(utf8_ca.name());
         match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(&tz)),
+            Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(tz)),
             _ => Ok(ca.into_datetime(tu, None)),
         }
     }
@@ -530,7 +530,7 @@ pub trait Utf8Methods: AsUtf8 {
             ca.rename(utf8_ca.name());
             match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(&tz)),
+                Some(tz) => ca.into_datetime(tu, None).cast_time_zone(Some(tz)),
                 _ => Ok(ca.into_datetime(tu, None)),
             }
         }

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -567,7 +567,7 @@ mod test {
                     "2020-01-08 23:16:43",
                 ],
             )
-            .as_datetime(None, tu, false, false, false)?
+            .as_datetime(None, tu, false, false, false, None)?
             .into_series();
             let a = Series::new("a", [3, 7, 5, 9, 2, 1]);
             let df = DataFrame::new(vec![date, a.clone()])?;
@@ -605,7 +605,7 @@ mod test {
                 "2020-01-08 23:16:43",
             ],
         )
-        .as_datetime(None, TimeUnit::Milliseconds, false, false, false)?
+        .as_datetime(None, TimeUnit::Milliseconds, false, false, false, None)?
         .into_series();
         let a = Series::new("a", [3, 7, 5, 9, 2, 1]);
         let df = DataFrame::new(vec![date, a.clone()])?;

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -108,9 +108,17 @@ class ExprStringNameSpace:
             return pli.wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
         elif datatype == Datetime:
             tu = datatype.tu  # type: ignore[union-attr]
+            tz = datatype.tz  # type: ignore[union-attr]
             dtcol = pli.wrap_expr(
                 self._pyexpr.str_parse_datetime(
-                    fmt, strict, exact, cache, tz_aware, utc, tu
+                    fmt,
+                    strict,
+                    exact,
+                    cache,
+                    tz_aware,
+                    utc,
+                    tu,
+                    tz,
                 )
             )
             return dtcol if (tu is None) else dtcol.dt.cast_time_unit(tu)

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -563,7 +563,7 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (fmt, strict, exact, cache, tz_aware, utc, tu))]
+    #[pyo3(signature = (fmt, strict, exact, cache, tz_aware, utc, tu, tz))]
     #[allow(clippy::too_many_arguments)]
     pub fn str_parse_datetime(
         &self,
@@ -574,6 +574,7 @@ impl PyExpr {
         tz_aware: bool,
         utc: bool,
         tu: Option<Wrap<TimeUnit>>,
+        tz: Option<TimeZone>,
     ) -> PyExpr {
         let result_tu = match (&fmt, tu) {
             (_, Some(tu)) => tu.0,
@@ -596,7 +597,7 @@ impl PyExpr {
             .clone()
             .str()
             .strptime(StrpTimeOptions {
-                date_dtype: DataType::Datetime(result_tu, None),
+                date_dtype: DataType::Datetime(result_tu, tz),
                 fmt,
                 strict,
                 exact,

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -89,7 +89,7 @@ def test_utc_with_tz_naive(fmt: str | None) -> None:
         ComputeError,
         match=(
             r"^Cannot use 'utc=True' with tz-naive data. "
-            r"Parse the data as naive, and then use `.dt.with_time_zone\('UTC'\).$"
+            r"Parse the data as naive, and then use `.dt.with_time_zone\('UTC'\)`.$"
         ),
     ):
         pl.Series(["2020-01-01 00:00:00"]).str.strptime(pl.Datetime, fmt, utc=True)


### PR DESCRIPTION
closes #6762 

This should make things a bit more ergonomic:
```python
In [1]: pl.Series(["2020-01-01"]).str.strptime(pl.Datetime('us', 'America/Barbados'))
Out[1]: 
shape: (1,)
Series: '' [datetime[μs, America/Barbados]]
[
        2020-01-01 00:00:00 AST
]
````
vs
```python

In [3]: pl.Series(["2020-01-01"]).str.strptime(pl.Datetime).dt.cast_time_zone('America/Barbados')
Out[3]: 
shape: (1,)
Series: '' [datetime[μs, America/Barbados]]
[
        2020-01-01 00:00:00 AST
]
```