### PR TITLE
doc(python): show the possibility of using masks as input for df.filter

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5544,7 +5544,9 @@ class DataFrame:
                 false
                 true
         ]
+
         This mask can be used to visualize the duplicated lines like this:
+
         >>> df.filter(df.is_duplicated())
         shape: (2, 2)
         ┌─────┬─────┐
@@ -5579,7 +5581,9 @@ class DataFrame:
                 true
                 false
         ]
+
         This mask can be used to visualize the unique lines like this:
+
         >>> df.filter(df.is_unique())
         shape: (2, 2)
         ┌─────┬─────┐

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5544,7 +5544,17 @@ class DataFrame:
                 false
                 true
         ]
-
+        This mask can be used to visualize the duplicated lines like this:
+        >>> df.filter(df.is_duplicated())
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ x   │
+        │ 1   ┆ x   │
+        └─────┴─────┘
         """
         return pli.wrap_s(self._df.is_duplicated())
 
@@ -5569,7 +5579,17 @@ class DataFrame:
                 true
                 false
         ]
-
+        This mask can be used to visualize the unique lines like this:
+        >>> df.filter(df.is_unique())
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 2   ┆ y   │
+        │ 3   ┆ z   │
+        └─────┴─────┘
         """
         return pli.wrap_s(self._df.is_unique())
 


### PR DESCRIPTION
I've come across a lot of people on the web and on my job not knowing how to view the unique and duplicated lines of a DataFrame, I think we could insert this on our documentation to make it more clear.
If this is ok, I intend to make an PR on the Polars Book with more examples but I think this is important to be here because  I know a lot of people try to navigate the functionalities by the https://pola-rs.github.io/polars/py-polars/html/reference/index.html