### PR TITLE
fix(python): enable empty DataFrame (and Series) init from List of Structs/Lists schema/dtype

### DIFF
--- a/py-polars/polars/internals/slice.py
+++ b/py-polars/polars/internals/slice.py
@@ -106,8 +106,8 @@ class LazyPolarsSlice:
     """
     Apply python slice object to Polars LazyFrame.
 
-    Only slices with efficient computation paths mapping directly to existing lazy
-    methods are supported.
+    Only slices with efficient computation paths that map directly
+    to existing lazy methods are supported.
 
     """
 
@@ -138,7 +138,7 @@ class LazyPolarsSlice:
                 )
 
         # ---------------------------------------
-        # empty slice patterns.
+        # empty slice patterns
         # ---------------------------------------
         # [:0]
         # [i:<=i]
@@ -149,7 +149,7 @@ class LazyPolarsSlice:
             return self.obj.cleared()
 
         # ---------------------------------------
-        # straight-though mappings for "reverse"
+        # straight-through mappings for "reverse"
         # and/or "take_every"
         # ---------------------------------------
         # [:]    => clone()
@@ -171,7 +171,7 @@ class LazyPolarsSlice:
             return obj if (abs(step) == 1) else obj.take_every(abs(step))
 
         # ---------------------------------------
-        # straight-though mappings for "head"
+        # straight-through mappings for "head"
         # ---------------------------------------
         # [:j]    => head(j)
         # [:j:k]  => head(j).take_every(k)
@@ -180,7 +180,7 @@ class LazyPolarsSlice:
             return obj if (step == 1) else obj.take_every(step)
 
         # ---------------------------------------
-        # straight-though mappings for "tail"
+        # straight-through mappings for "tail"
         # ---------------------------------------
         # [-i:]    => tail(abs(i))
         # [-i::k]  => tail(abs(i)).take_every(k)
@@ -189,7 +189,7 @@ class LazyPolarsSlice:
             return obj if (step == 1) else obj.take_every(step)
 
         # ---------------------------------------
-        # straight-though mappings for "slice"
+        # straight-through mappings for "slice"
         # ---------------------------------------
         # [i:]     => slice(i)
         # [i:j]    => slice(i,j-i)

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -784,6 +784,18 @@ def test_from_records_nullable_structs() -> None:
             ],
         }
 
+    # check initialisation without any records
+    df = pl.DataFrame(schema=schema)
+    dict_schema = dict(schema)
+
+    assert df.to_dict(False) == {"id": [], "items": []}
+    assert df.schema == dict_schema
+
+    s = pl.Series("items", dtype=dict_schema["items"])
+    assert s.to_frame().to_dict(False) == {"items": []}
+    assert s.dtype == dict_schema["items"]
+    assert s.to_list() == []
+
 
 def test_from_categorical_in_struct_defined_by_schema() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -263,6 +263,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     df = pl.DataFrame({"a": np.arange(5, dtype=np.int64).reshape(1, -1)})
     assert df.dtypes == [pl.List(pl.Int64)]
     assert df.shape == (1, 1)
+
     df = pl.DataFrame({"a": np.arange(10, dtype=np.int64).reshape(2, -1)})
     assert df.dtypes == [pl.List(pl.Int64)]
     assert df.shape == (2, 1)
@@ -351,8 +352,15 @@ def test_init_series() -> None:
     assert df.rows() == [(1,), (2,), (3,)]
     assert df.schema == {"a": pl.UInt32}
 
-    # nested list
-    assert pl.Series([[[2, 2]]]).dtype == pl.List(pl.List(pl.Int64))
+    # nested list, with/without explicit dtype
+    s1 = pl.Series([[[2, 2]]])
+    assert s1.dtype == pl.List(pl.List(pl.Int64))
+
+    s2 = pl.Series([[[2, 2]]], dtype=pl.List(pl.List(pl.UInt8)))
+    assert s2.dtype == pl.List(pl.List(pl.UInt8))
+
+    s3 = pl.Series(dtype=pl.List(pl.List(pl.UInt8)))
+    assert s3.dtype == pl.List(pl.List(pl.UInt8))
 
     # numpy data containing NaN values
     s0 = pl.Series("n", [1.0, 2.5, float("nan")])


### PR DESCRIPTION
Closes #6429.

* Top-level dtype could be wrong on init of empty frame/series with compound/nested schema.
* Where the top-level dtype was correct the inner dtype could still be wrong.
 
Fixed both cases and added suitable test coverage.

## Example

**Setup** _(nested schemas)_

```python
import polars as pl

frame_schema = [
    ("id", pl.UInt32),
    (
        "items",
        pl.List(
            pl.Struct([
                pl.Field("item_id", pl.UInt32), 
                pl.Field("description", pl.Utf8),
            ])
        ),
    ),
]
series_schema = pl.List( pl.List(pl.UInt8) )
```
**Before**
```python
pl.DataFrame( schema=frame_schema )
# shape: (0, 2)
# ┌─────┬───────┐
# │ id  ┆ items │
# │ --- ┆ ---   │
# │ u32 ┆ i32   │  << incorrect/default dtype
# ╞═════╪═══════╡
# └─────┴───────┘
```
```python
pl.Series( dtype=series_schema ).dtype
# pl.Int32  << incorrect dtype

pl.Series( [[[1,2]]], dtype=series_schema ).dtype
# pl.List(pl.List(pl.Int64))  << incorrect inner dtype
```
**After**
```python
pl.DataFrame( schema=frame_schema )
# shape: (0, 2)
# ┌─────┬─────────────────┐
# │ id  ┆ items           │
# │ --- ┆ ---             │
# │ u32 ┆ list[struct[2]] │  << correct/nested dtype
# ╞═════╪═════════════════╡
# └─────┴─────────────────┘
```
```python
pl.Series( dtype=series_schema ).dtype
# pl.List(pl.List(pl.UInt8))  << correct dtype

pl.Series( [[[1,2]]], dtype=series_schema ).dtype
# pl.List(pl.List(pl.UInt8))  << correct inner dtype
```