### PR TITLE
fix(python): ensure join frame types are consistent

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4227,6 +4227,11 @@ class DataFrame:
         └─────────────────────┴────────────┴──────┘
 
         """
+        if not isinstance(other, DataFrame):
+            raise TypeError(
+                f"Expected 'other' join table to be a DataFrame, not a {type(other).__name__}"
+            )
+
         return (
             self.lazy()
             .join_asof(
@@ -4358,6 +4363,11 @@ class DataFrame:
         For joining on columns with categorical data, see ``pl.StringCache()``.
 
         """
+        if not isinstance(other, DataFrame):
+            raise TypeError(
+                f"Expected 'other' join table to be a DataFrame, not a {type(other).__name__}"
+            )
+
         return (
             self.lazy()
             .join(

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2274,10 +2274,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 2019-05-12 00:00:00 ┆ 83.52      ┆ 4696 │
         └─────────────────────┴────────────┴──────┘
 
-
         """
         if not isinstance(other, LazyFrame):
-            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(other)}")
+            raise TypeError(
+                f"Expected 'other' join table to be a LazyFrame, not a {type(other).__name__}"
+            )
 
         if isinstance(on, str):
             left_on = on
@@ -2432,7 +2433,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         """
         if not isinstance(other, LazyFrame):
-            raise ValueError(f"Expected a `LazyFrame` as join table, got {type(other)}")
+            raise TypeError(
+                f"Expected 'other' join table to be a LazyFrame, not a {type(other).__name__}"
+            )
 
         if how == "cross":
             return self._from_pyldf(

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -84,20 +84,14 @@ def test_join_lazy_on_df() -> None:
     df_right = pl.DataFrame({"Id": [1, 3], "Tags": ["xxx", "yyy"]})
 
     with pytest.raises(
-        ValueError,
-        match=(
-            "Expected a `LazyFrame` as join table, got"
-            " <class 'polars.internals.dataframe.frame.DataFrame'>"
-        ),
+        TypeError,
+        match="Expected 'other' .* to be a LazyFrame.* not a DataFrame",
     ):
         df_left.lazy().join(df_right, on="Id")
 
     with pytest.raises(
-        ValueError,
-        match=(
-            "Expected a `LazyFrame` as join table, got"
-            " <class 'polars.internals.dataframe.frame.DataFrame'>"
-        ),
+        TypeError,
+        match="Expected 'other' .* to be a LazyFrame.* not a DataFrame",
     ):
         df_left.lazy().join_asof(df_right, on="Id")
 

--- a/py-polars/tests/unit/test_joins.py
+++ b/py-polars/tests/unit/test_joins.py
@@ -783,3 +783,18 @@ def test_update() -> None:
     df2 = pl.DataFrame({"a": [2, 3], "b": [8, 9]})
 
     assert df1.update(df2, on="a").to_dict(False) == {"a": [1, 2, 3], "b": [4, 8, 9]}
+
+
+@typing.no_type_check
+def test_join_frame_consistency() -> None:
+    df = pl.DataFrame({"A": [1, 2, 3]})
+    ldf = pl.DataFrame({"A": [1, 2, 5]}).lazy()
+
+    with pytest.raises(TypeError, match="Expected 'other'.* LazyFrame"):
+        _ = ldf.join(df, on="A")
+    with pytest.raises(TypeError, match="Expected 'other'.* DataFrame"):
+        _ = df.join(ldf, on="A")
+    with pytest.raises(TypeError, match="Expected 'other'.* LazyFrame"):
+        _ = ldf.join_asof(df, on="A")
+    with pytest.raises(TypeError, match="Expected 'other'.* DataFrame"):
+        _ = df.join_asof(ldf, on="A")


### PR DESCRIPTION
Closes #6264.

We shouldn't silently allow mixed frame types in join functions as it can promote lazy computations to eager mode, which may not be intentional - if not noticed, this could result in an unnecessary performance penalty for the caller.

* Updates eager `join` and `join_asof` methods with the same check already found in their lazy counterparts.
* Also, fixes the type of the raised exception (should be `TypeError`, not `ValueError`).