### PR TITLE
perf(rust, python): optimize `arg_min/arg_max`

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -493,7 +493,7 @@ where
         if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
             Ok(self.downcast_iter().next().map(|arr| arr.values()).unwrap())
         } else {
-            Err(PolarsError::ComputeError("cannot take slice".into()))
+            Err(PolarsError::ComputeError("no_slice".into()))
         }
     }
 

--- a/polars/polars-ops/src/series/ops/arg_min_max.rs
+++ b/polars/polars-ops/src/series/ops/arg_min_max.rs
@@ -1,3 +1,5 @@
+use arrow::bitmap::utils::{BitChunkIterExact, BitChunksExact};
+use arrow::bitmap::Bitmap;
 use polars_core::series::IsSorted;
 use polars_core::with_match_physical_numeric_polars_type;
 
@@ -22,12 +24,16 @@ impl ArgAgg for Series {
             }
             Boolean => {
                 let ca = s.bool().unwrap();
-                arg_min(ca)
+                arg_min_bool(ca)
             }
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    arg_min(ca)
+                    if let Ok(vals) = ca.cont_slice() {
+                        arg_min_slice(vals, ca.is_sorted_flag2())
+                    } else {
+                        arg_min(ca)
+                    }
                 })
             }
             _ => None,
@@ -44,16 +50,141 @@ impl ArgAgg for Series {
             }
             Boolean => {
                 let ca = s.bool().unwrap();
-                arg_max(ca)
+                arg_max_bool(ca)
             }
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    arg_max(ca)
+                    if let Ok(vals) = ca.cont_slice() {
+                        arg_max_slice(vals, ca.is_sorted_flag2())
+                    } else {
+                        arg_max(ca)
+                    }
                 })
             }
             _ => None,
         }
+    }
+}
+
+fn arg_max_bool(ca: &BooleanChunked) -> Option<usize> {
+    if ca.is_empty() {
+        None
+    } else if ca.null_count() == ca.len() {
+        Some(0)
+    }
+    // don't check for any, that on itself is already an argmax search
+    else if ca.null_count() == 0 && ca.chunks().len() == 1 {
+        let arr = ca.downcast_iter().next().unwrap();
+        let mask = arr.values();
+        Some(first_set_bit(mask))
+    } else {
+        ca.into_iter()
+            .position(|opt_val| matches!(opt_val, Some(true)))
+    }
+}
+
+fn arg_min_bool(ca: &BooleanChunked) -> Option<usize> {
+    if ca.is_empty() || ca.null_count() == ca.len() || ca.all() {
+        Some(0)
+    } else if ca.null_count() == 0 && ca.chunks().len() == 1 {
+        let arr = ca.downcast_iter().next().unwrap();
+        let mask = arr.values();
+        Some(first_unset_bit(mask))
+    } else {
+        // also null as we see that as lower in ordering than a set value
+        ca.into_iter()
+            .position(|opt_val| matches!(opt_val, Some(false) | None))
+    }
+}
+
+#[inline]
+fn get_leading_zeroes(chunk: u64) -> u32 {
+    if cfg!(target_endian = "little") {
+        chunk.trailing_zeros()
+    } else {
+        chunk.leading_zeros()
+    }
+}
+
+#[inline]
+fn get_leading_ones(chunk: u64) -> u32 {
+    if cfg!(target_endian = "little") {
+        chunk.trailing_ones()
+    } else {
+        chunk.leading_ones()
+    }
+}
+
+fn first_set_bit_impl<I>(mut mask_chunks: I) -> usize
+where
+    I: BitChunkIterExact<u64>,
+{
+    let mut total = 0usize;
+    let size = 64;
+    for chunk in &mut mask_chunks {
+        let pos = get_leading_zeroes(chunk);
+        if pos != size {
+            return total + pos as usize;
+        } else {
+            total += size as usize
+        }
+    }
+    if let Some(pos) = mask_chunks.remainder_iter().position(|v| v) {
+        total += pos;
+        return total;
+    }
+    // all null, return the first
+    0
+}
+
+fn first_set_bit(mask: &Bitmap) -> usize {
+    if mask.unset_bits() == 0 || mask.unset_bits() == mask.len() {
+        return 0;
+    }
+    let (slice, offset, length) = mask.as_slice();
+    if offset == 0 {
+        let mask_chunks = BitChunksExact::<u64>::new(slice, length);
+        first_set_bit_impl(mask_chunks)
+    } else {
+        let mask_chunks = mask.chunks::<u64>();
+        first_set_bit_impl(mask_chunks)
+    }
+}
+
+fn first_unset_bit_impl<I>(mut mask_chunks: I) -> usize
+where
+    I: BitChunkIterExact<u64>,
+{
+    let mut total = 0usize;
+    let size = 64;
+    for chunk in &mut mask_chunks {
+        let pos = get_leading_ones(chunk);
+        if pos != size {
+            return total + pos as usize;
+        } else {
+            total += size as usize
+        }
+    }
+    if let Some(pos) = mask_chunks.remainder_iter().position(|v| !v) {
+        total += pos;
+        return total;
+    }
+    // all null, return the first
+    0
+}
+
+fn first_unset_bit(mask: &Bitmap) -> usize {
+    if mask.unset_bits() == 0 || mask.unset_bits() == mask.len() {
+        return 0;
+    }
+    let (slice, offset, length) = mask.as_slice();
+    if offset == 0 {
+        let mask_chunks = BitChunksExact::<u64>::new(slice, length);
+        first_unset_bit_impl(mask_chunks)
+    } else {
+        let mask_chunks = mask.chunks::<u64>();
+        first_unset_bit_impl(mask_chunks)
     }
 }
 
@@ -85,6 +216,36 @@ where
         IsSorted::Descending => Some(0),
         IsSorted::Not => ca
             .into_iter()
+            .enumerate()
+            .reduce(|acc, (idx, val)| if acc.1 < val { (idx, val) } else { acc })
+            .map(|tpl| tpl.0),
+    }
+}
+
+fn arg_min_slice<T>(vals: &[T], is_sorted: IsSorted) -> Option<usize>
+where
+    T: PartialOrd,
+{
+    match is_sorted {
+        IsSorted::Ascending => Some(0),
+        IsSorted::Descending => Some(vals.len()),
+        IsSorted::Not => vals
+            .iter()
+            .enumerate()
+            .reduce(|acc, (idx, val)| if acc.1 > val { (idx, val) } else { acc })
+            .map(|tpl| tpl.0),
+    }
+}
+
+fn arg_max_slice<T>(vals: &[T], is_sorted: IsSorted) -> Option<usize>
+where
+    T: PartialOrd,
+{
+    match is_sorted {
+        IsSorted::Ascending => Some(0),
+        IsSorted::Descending => Some(vals.len()),
+        IsSorted::Not => vals
+            .iter()
             .enumerate()
             .reduce(|acc, (idx, val)| if acc.1 < val { (idx, val) } else { acc })
             .map(|tpl| tpl.0),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "arrow2",
  "chrono",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "arrow2",
  "base64 0.21.0",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "crossbeam-channel",
  "enum_dispatch",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "ahash",
  "once_cell",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "chrono-tz 0.8.1",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.26.1"
+version = "0.27.1"
 dependencies = [
  "once_cell",
  "rayon",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/tests/unit/test_bool.py
+++ b/py-polars/tests/unit/test_bool.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.slow()
+def test_bool_arg_min_max() -> None:
+    # masks that ensures we take more than u64 chunks
+    # and slicing and dicing to ensure the offsets work
+    for _ in range(100):
+        offset = np.random.randint(0, 100)
+        sample = np.random.rand(1000)
+        a = sample > 0.99
+        idx = a[offset:].argmax()
+        assert idx == pl.Series(a)[offset:].arg_max()
+        idx = a[offset:].argmin()
+        assert idx == pl.Series(a)[offset:].arg_min()
+
+        a = sample > 0.01
+        idx = a[offset:].argmax()
+        assert idx == pl.Series(a)[offset:].arg_max()
+        idx = a[offset:].argmin()
+        assert idx == pl.Series(a)[offset:].arg_min()


### PR DESCRIPTION
Fixes a regression introduced in latest release (will patch today).

And also optimized them while I was there. Most perf increase to be expected for boolean values.

fixes #6794