### PR TITLE
perf(python): remove pySequence downcast

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -563,7 +563,7 @@ class Series:
             raise ValueError("first cast to integer before dividing datelike dtypes")
         if not isinstance(other, pli.Expr):
             other = pli.lit(other)
-        return self.to_frame().select(pli.lit(self) // other).to_series()
+        return self.to_frame().select(pli.col(self.name) // other).to_series()
 
     def __invert__(self) -> Series:
         if self.dtype == Boolean:

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -51,7 +51,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString};
 use pyo3::wrap_pyfunction;
 
-use crate::conversion::{get_df, get_lf, get_pyseq, get_series, Wrap};
+use crate::conversion::{get_df, get_lf, get_series, Wrap};
 use crate::dataframe::PyDataFrame;
 use crate::error::{
     ArrowErrorException, ColumnNotFoundError, ComputeError, DuplicateError, InvalidOperationError,
@@ -305,8 +305,7 @@ fn concat_df(dfs: &PyAny, py: Python) -> PyResult<PyDataFrame> {
     use polars_core::error::PolarsResult;
     use polars_core::utils::rayon::prelude::*;
 
-    let (seq, _len) = get_pyseq(dfs)?;
-    let mut iter = seq.iter()?;
+    let mut iter = dfs.iter()?;
     let first = iter.next().unwrap()?;
 
     let first_rdf = get_df(first)?;
@@ -343,8 +342,8 @@ fn concat_df(dfs: &PyAny, py: Python) -> PyResult<PyDataFrame> {
 }
 
 #[pyfunction]
-fn concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyFrame> {
-    let (seq, len) = get_pyseq(lfs)?;
+fn concat_lf(seq: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyFrame> {
+    let len = seq.len()?;
     let mut lfs = Vec::with_capacity(len);
 
     for res in seq.iter()? {
@@ -359,8 +358,7 @@ fn concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyFrame
 
 #[pyfunction]
 fn py_diag_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
-    let (seq, _len) = get_pyseq(dfs)?;
-    let iter = seq.iter()?;
+    let iter = dfs.iter()?;
 
     let dfs = iter
         .map(|item| {
@@ -375,8 +373,7 @@ fn py_diag_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 
 #[pyfunction]
 fn py_diag_concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyFrame> {
-    let (seq, _len) = get_pyseq(lfs)?;
-    let iter = seq.iter()?;
+    let iter = lfs.iter()?;
 
     let lfs = iter
         .map(|item| {
@@ -392,8 +389,7 @@ fn py_diag_concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyL
 
 #[pyfunction]
 fn py_hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
-    let (seq, _len) = get_pyseq(dfs)?;
-    let iter = seq.iter()?;
+    let iter = dfs.iter()?;
 
     let dfs = iter
         .map(|item| {
@@ -408,8 +404,7 @@ fn py_hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 
 #[pyfunction]
 fn concat_series(series: &PyAny) -> PyResult<PySeries> {
-    let (seq, _len) = get_pyseq(series)?;
-    let mut iter = seq.iter()?;
+    let mut iter = series.iter()?;
     let first = iter.next().unwrap()?;
 
     let mut s = get_series(first)?;

--- a/py-polars/src/list_construction.rs
+++ b/py-polars/src/list_construction.rs
@@ -2,17 +2,15 @@ use polars::prelude::*;
 use polars_core::utils::CustomIterTools;
 use pyo3::{PyAny, PyResult};
 
-use crate::conversion::get_pyseq;
-
 pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &DataType) -> PyResult<Series> {
-    let (seq, len) = get_pyseq(seq)?;
+    let len = seq.len()?;
     let s = match dtype {
         DataType::Int64 => {
             let mut builder =
                 ListPrimitiveChunkedBuilder::<Int64Type>::new(name, len, len * 5, DataType::Int64);
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
-                let (sub_seq, len) = get_pyseq(sub_seq)?;
+                let len = sub_seq.len()?;
 
                 // safety: we know the iterators len
                 let iter = unsafe {
@@ -41,7 +39,7 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &DataType) -> PyResult<Ser
             );
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
-                let (sub_seq, len) = get_pyseq(sub_seq)?;
+                let len = sub_seq.len()?;
                 // safety: we know the iterators len
                 let iter = unsafe {
                     sub_seq
@@ -64,7 +62,7 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &DataType) -> PyResult<Ser
             let mut builder = ListBooleanChunkedBuilder::new(name, len, len * 5);
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
-                let (sub_seq, len) = get_pyseq(sub_seq)?;
+                let len = sub_seq.len()?;
                 // safety: we know the iterators len
                 let iter = unsafe {
                     sub_seq
@@ -87,7 +85,7 @@ pub fn py_seq_to_list(name: &str, seq: &PyAny, dtype: &DataType) -> PyResult<Ser
             let mut builder = ListUtf8ChunkedBuilder::new(name, len, len * 5);
             for sub_seq in seq.iter()? {
                 let sub_seq = sub_seq?;
-                let (sub_seq, len) = get_pyseq(sub_seq)?;
+                let len = sub_seq.len()?;
                 // safety: we know the iterators len
                 let iter = unsafe {
                     sub_seq

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -128,10 +128,10 @@ impl PySeries {
 
     #[staticmethod]
     pub fn new_opt_bool(name: &str, obj: &PyAny, strict: bool) -> PyResult<PySeries> {
-        let (seq, len) = get_pyseq(obj)?;
+        let len = obj.len()?;
         let mut builder = BooleanChunkedBuilder::new(name, len);
 
-        for res in seq.iter()? {
+        for res in obj.iter()? {
             let item = res?;
             if item.is_none() {
                 builder.append_null()
@@ -160,10 +160,10 @@ where
     ChunkedArray<T>: IntoSeries,
     T::Native: FromPyObject<'a>,
 {
-    let (seq, len) = get_pyseq(obj)?;
+    let len = obj.len()?;
     let mut builder = PrimitiveChunkedBuilder::<T>::new(name, len);
 
-    for res in seq.iter()? {
+    for res in obj.iter()? {
         let item = res?;
 
         if item.is_none() {


### PR DESCRIPTION
The downcast was unneeded and was relatively expensive as it needed to check a lot. See: https://github.com/PyO3/pyo3/issues/2943#issuecomment-1426679483

fixes #6791