### PR TITLE
feat(rust, python): avoid panic error in strftime with invalid format

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -210,26 +210,21 @@ impl DatetimeChunked {
         let mut fmted = String::new();
         match self.time_zone() {
             #[cfg(feature = "timezones")]
-            Some(_) => match write!(
+            Some(_) => write!(
                 fmted,
                 "{}",
                 Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)
-            ) {
-                Ok(_) => (),
-                Err(_) => {
-                    return Err(PolarsError::ComputeError(
-                        format!("Cannot format DateTime with format '{fmt}'.").into(),
-                    ));
-                }
-            },
-            _ => match write!(fmted, "{}", dt.format(fmt)) {
-                Ok(_) => (),
-                Err(_) => {
-                    return Err(PolarsError::ComputeError(
-                        format!("Cannot format NaiveDateTime with format '{fmt}'.").into(),
-                    ));
-                }
-            },
+            )
+            .map_err(|_| {
+                PolarsError::ComputeError(
+                    format!("Cannot format DateTime with format '{fmt}'.").into(),
+                )
+            })?,
+            _ => write!(fmted, "{}", dt.format(fmt)).map_err(|_| {
+                PolarsError::ComputeError(
+                    format!("Cannot format NaiveDateTime with format '{fmt}'.").into(),
+                )
+            })?,
         };
         let fmted = fmted; // discard mut
 

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -231,7 +231,7 @@ impl DatetimeChunked {
                 }
             },
         };
-        let fmted = fmted;
+        let fmted = fmted; // discard mut
 
         let mut ca: Utf8Chunked = match self.time_zone() {
             #[cfg(feature = "timezones")]

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -210,10 +210,7 @@ impl DatetimeChunked {
         let mut fmted = String::new();
         match self.time_zone() {
             #[cfg(feature = "timezones")]
-            Some(_) => match fmted.write_fmt(format_args!(
-                "{}",
-                Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)
-            )) {
+            Some(_) => match write!(fmted, "{}", Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)) {
                 Ok(_) => (),
                 Err(_) => {
                     return Err(PolarsError::ComputeError(
@@ -221,7 +218,7 @@ impl DatetimeChunked {
                     ));
                 }
             },
-            _ => match fmted.write_fmt(format_args!("{}", dt.format(fmt))) {
+            _ => match write!(fmted, "{}", dt.format(fmt)) {
                 Ok(_) => (),
                 Err(_) => {
                     return Err(PolarsError::ComputeError(

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -210,7 +210,11 @@ impl DatetimeChunked {
         let mut fmted = String::new();
         match self.time_zone() {
             #[cfg(feature = "timezones")]
-            Some(_) => match write!(fmted, "{}", Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)) {
+            Some(_) => match write!(
+                fmted,
+                "{}",
+                Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)
+            ) {
                 Ok(_) => (),
                 Err(_) => {
                     return Err(PolarsError::ComputeError(

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -342,13 +342,13 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn cast(&self, data_type: &DataType) -> PolarsResult<Series> {
         match (data_type, self.0.time_unit()) {
             (DataType::Utf8, TimeUnit::Milliseconds) => {
-                Ok(self.0.strftime("%F %T%.3f").into_series())
+                Ok(self.0.strftime("%F %T%.3f")?.into_series())
             }
             (DataType::Utf8, TimeUnit::Microseconds) => {
-                Ok(self.0.strftime("%F %T%.6f").into_series())
+                Ok(self.0.strftime("%F %T%.6f")?.into_series())
             }
             (DataType::Utf8, TimeUnit::Nanoseconds) => {
-                Ok(self.0.strftime("%F %T%.9f").into_series())
+                Ok(self.0.strftime("%F %T%.9f")?.into_series())
             }
             _ => self.0.cast(data_type),
         }

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -324,7 +324,9 @@ pub trait TemporalMethods: AsSeries {
             #[cfg(feature = "dtype-date")]
             DataType::Date => s.date().map(|ca| ca.strftime(fmt).into_series()),
             #[cfg(feature = "dtype-datetime")]
-            DataType::Datetime(_, _) => s.datetime().map(|ca| ca.strftime(fmt).into_series()),
+            DataType::Datetime(_, _) => {
+                s.datetime().map(|ca| Ok(ca.strftime(fmt)?.into_series()))?
+            }
             #[cfg(feature = "dtype-time")]
             DataType::Time => s.time().map(|ca| ca.strftime(fmt).into_series()),
             _ => Err(PolarsError::InvalidOperation(

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/tests/unit/test_datelike.py
+++ b/py-polars/tests/unit/test_datelike.py
@@ -1996,6 +1996,16 @@ def test_tz_aware_truncate() -> None:
     }
 
 
+def test_strftime_invalid_format() -> None:
+    tz_naive = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime)
+    with pytest.raises(
+        ComputeError, match="Cannot format NaiveDateTime with format '%z'"
+    ):
+        tz_naive.dt.strftime("%z")
+    with pytest.raises(ComputeError, match="Cannot format DateTime with format '%q'"):
+        tz_naive.dt.replace_time_zone("UTC").dt.strftime("%q")
+
+
 def test_tz_aware_strftime() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
On the latest release it looks like this:
```python-traceback
In [32]: pl.Series(["2020-01-01"]).str.strptime(pl.Datetime).dt.strftime('%z')
thread '<unnamed>' panicked at 'a formatting trait implementation returned an error: Error', library/alloc/src/fmt.rs:612:32
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
---------------------------------------------------------------------------
PanicException                            Traceback (most recent call last)
Cell In [32], line 1
----> 1 pl.Series(["2020-01-01"]).str.strptime(pl.Datetime).dt.strftime('%z')

File ~/tmp/.venv/lib/python3.8/site-packages/polars/internals/series/utils.py:98, in call_expr.<locals>.wrapper(self, *args, **kwargs)
     96     expr = getattr(expr, namespace)
     97 f = getattr(expr, func.__name__)
---> 98 return s.to_frame().select(f(*args, **kwargs)).to_series()

File ~/tmp/.venv/lib/python3.8/site-packages/polars/internals/dataframe/frame.py:5732, in DataFrame.select(self, exprs, *more_exprs, **named_exprs)
   5616 def select(
   5617     self,
   5618     exprs: (
   (...)
   5627     **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
   5628 ) -> Self:
   5629     """
   5630     Select columns from this DataFrame.
   5631
   (...)
   5729
   5730     """
   5731     return self._from_pydf(
-> 5732         self.lazy()
   5733         .select(exprs, *more_exprs, **named_exprs)
   5734         .collect(no_optimization=True)
   5735         ._df
   5736     )

File ~/tmp/.venv/lib/python3.8/site-packages/polars/internals/lazyframe/frame.py:1145, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, no_optimization, slice_pushdown, common_subplan_elimination, streaming)
   1134     common_subplan_elimination = False
   1136 ldf = self._ldf.optimization_toggle(
   1137     type_coercion,
   1138     predicate_pushdown,
   (...)
   1143     streaming,
   1144 )
-> 1145 return pli.wrap_df(ldf.collect())

PanicException: a formatting trait implementation returned an error: Error
```

Here:
```python-traceback
In [1]: pl.Series(["2020-01-01"]).str.strptime(pl.Datetime).dt.strftime('%z')
thread '<unnamed>' panicked at 'a formatting trait implementation returned an error: Error', library/alloc/src/fmt.rs:612:32
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
---------------------------------------------------------------------------
ComputeError                              Traceback (most recent call last)
Cell In[1], line 1
----> 1 pl.Series(["2020-01-01"]).str.strptime(pl.Datetime).dt.strftime('%z')

File ~/polars-dev/py-polars/polars/internals/series/utils.py:98, in call_expr.<locals>.wrapper(self, *args, **kwargs)
     96     expr = getattr(expr, namespace)
     97 f = getattr(expr, func.__name__)
---> 98 return s.to_frame().select(f(*args, **kwargs)).to_series()

File ~/polars-dev/py-polars/polars/internals/dataframe/frame.py:5766, in DataFrame.select(self, exprs, *more_exprs, **named_exprs)
   5650 def select(
   5651     self,
   5652     exprs: (
   (...)
   5661     **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
   5662 ) -> Self:
   5663     """
   5664     Select columns from this DataFrame.
   5665 
   (...)
   5763 
   5764     """
   5765     return self._from_pydf(
-> 5766         self.lazy()
   5767         .select(exprs, *more_exprs, **named_exprs)
   5768         .collect(no_optimization=True)
   5769         ._df
   5770     )

File ~/polars-dev/py-polars/polars/internals/lazyframe/frame.py:1145, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, no_optimization, slice_pushdown, common_subplan_elimination, streaming)
   1134     common_subplan_elimination = False
   1136 ldf = self._ldf.optimization_toggle(
   1137     type_coercion,
   1138     predicate_pushdown,
   (...)
   1143     streaming,
   1144 )
-> 1145 return pli.wrap_df(ldf.collect())

ComputeError: Cannot format NaiveDateTime with format '%z'.
```