### PR TITLE
perf(rust): faster `str.contains` literal matching in the small-string regime

### DIFF
--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -159,19 +159,11 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         ca.apply(f)
     }
 
-    /// Check if strings contain a regex pattern; take literal fast-path if
-    /// no special chars and strlen <= 96 chars (otherwise regex faster).
+    /// Check if strings contain a regex pattern.
     fn contains(&self, pat: &str) -> PolarsResult<BooleanChunked> {
-        let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
         let ca = self.as_utf8();
         let reg = Regex::new(pat)?;
-        let f = |s: &str| {
-            if lit && (s.len() <= 96) {
-                s.contains(pat)
-            } else {
-                reg.is_match(s)
-            }
-        };
+        let f = |s: &str| reg.is_match(s);
         let mut out: BooleanChunked = if !ca.has_validity() {
             ca.into_no_null_iter().map(f).collect()
         } else {
@@ -183,6 +175,9 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
 
     /// Check if strings contain a given literal
     fn contains_literal(&self, lit: &str) -> PolarsResult<BooleanChunked> {
+        // note: benchmarking shows that the regex engine is actually
+        // faster at finding literal matches than str::contains.
+        // ref: https://github.com/pola-rs/polars/pull/6811
         self.contains(escape(lit).as_str())
     }
 
@@ -215,7 +210,8 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// Replace the leftmost literal (sub)string with another string
     fn replace_literal<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
         // note: benchmarking shows that using the regex engine for literal
-        // replacement is faster than str::replacen in almost all cases
+        // replacement is faster than str::replacen in almost all cases.
+        // ref: https://github.com/pola-rs/polars/pull/6777
         let reg = Regex::new(escape(pat).as_str())?;
         let f = |s: &'a str| reg.replace(s, NoExpand(val));
         let ca = self.as_utf8();


### PR DESCRIPTION
Follow-up (ref: #6777).

The benchmarks are in, and the regex crate is victorious again... Using `reg.is_match` in all cases gets us equivalent or faster matching vs `str::contains` for small (<=96 char) strings, and cleaner code. The difference is even more pronounced for larger strings, but we already use the regex crate in that regime, so no changes there...

## Benchmark results

<img width="813" alt="str_contains_bench" src="https://user-images.githubusercontent.com/2613171/218261516-1105c593-23c5-45ec-8ad6-b85a74b6bcc3.png">
