### PR TITLE
docs(python): various minor docstring rendering fixes

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1306,6 +1306,7 @@ class Expr:
         └─────┴───────────┘
 
         Null values are excluded, but can also be filled by calling ``forward_fill``.
+
         >>> df = pl.DataFrame({"values": [None, 10, None, 8, 9, None, 16, None]})
         >>> df.with_columns(
         ...     [
@@ -1437,6 +1438,7 @@ class Expr:
         └─────┴───────────┘
 
         Null values are excluded, but can also be filled by calling ``forward_fill``.
+
         >>> df = pl.DataFrame({"values": [None, 10, None, 8, 9, None, 16, None]})
         >>> df.with_columns(
         ...     [
@@ -6056,6 +6058,7 @@ class Expr:
         │ 2      ┆ ES           │
         │ 3      ┆ DE           │
         └────────┴──────────────┘
+
         >>> df.with_columns(
         ...     pl.col("country_code").map_dict(country_code_dict).alias("remapped")
         ... )
@@ -6072,6 +6075,7 @@ class Expr:
         └────────┴──────────────┴───────────────┘
 
         Set a default value for values that couldn't be mapped.
+
         >>> df.with_columns(
         ...     pl.col("country_code")
         ...     .map_dict(country_code_dict, default="unknown")
@@ -6090,6 +6094,7 @@ class Expr:
         └────────┴──────────────┴───────────────┘
 
         Keep the original value for values that couldn't be mapped.
+
         >>> df.with_columns(
         ...     pl.col("country_code")
         ...     .map_dict(country_code_dict, default=pl.col("country_code"))
@@ -6111,6 +6116,7 @@ class Expr:
         couldn't be mapped, a struct needs to be constructed, with in the first field
         the column that you want to remap and the rest of the fields the other columns
         you use in the default expression.
+
         >>> df.with_columns(
         ...     pl.struct(pl.col(["country_code", "row_nr"])).map_dict(
         ...         remapping=country_code_dict,

--- a/py-polars/polars/internals/expr/struct.py
+++ b/py-polars/polars/internals/expr/struct.py
@@ -84,6 +84,7 @@ class ExprStructNameSpace:
         ... )
 
         Note that the following syntax no longer works:
+
         >>> df.select(pl.col("my_struct").struct.field("int"))  # doctest: +SKIP
         StructFieldNotFoundError: int
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1725,6 +1725,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         └─────┴─────┘
 
         Note that the following syntax does NOT work:
+
         >>> ldf.groupby("a")["b"].sum().collect()
         Traceback (most recent call last):
         ...

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -487,18 +487,27 @@ class Series:
         return self._comp(other, "lt_eq")
 
     def le(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series <= other``."""
         return self.__le__(other)
 
+    def lt(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series < other``."""
+        return self.__lt__(other)
+
     def eq(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series == other``."""
         return self.__eq__(other)
 
     def ne(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series != other``."""
         return self.__ne__(other)
 
-    def lt(self, other: Any) -> Series:
-        return self.__lt__(other)
+    def ge(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series >= other``."""
+        return self.__ge__(other)
 
     def gt(self, other: Any) -> Series:
+        """Method equivalent of operator expression ``series > other``."""
         return self.__gt__(other)
 
     def _arithmetic(self, other: Any, op_s: str, op_ffi: str) -> Series:


### PR DESCRIPTION
ref: https://github.com/pola-rs/polars/issues/6815#issuecomment-1427000238

Fixes the appearances of several method docstrings in the online help.
Thanks to @takaiyuk and @cmdlineluser for bringing them to our attention!

(Also; spotted that the `Series.ge` operator-method was missing, so added that...)