### PR TITLE
ci(python): Run mypy as part of the lint workflow

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  lint-python:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -19,31 +19,79 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'py-polars/requirements-lint.txt'
+
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
           pip install -r requirements-lint.txt
+
       - name: Lint Python
         run: |
           black --check .
           blackdoc --check .
           ruff .
+
+
+  lint-rust:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: py-polars
+
+    steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-01-19
           components: rustfmt, clippy
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: py-polars
+
       - name: Lint Rust
         run: |
           cargo fmt --all -- --check
           make clippy
+
+  mypy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.11']
+    defaults:
+      run:
+        working-directory: py-polars
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            py-polars/requirements-dev.txt
+            py-polars/requirements-lint.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r requirements-lint.txt
+
+      # Allow untyped calls for older Python versions
+      - name: Run mypy
+        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -43,10 +43,6 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      # Allow untyped calls for older Python versions
-      - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
-
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -16,7 +16,6 @@ deltalake
 # Tooling
 hypothesis==6.65.2
 maturin==0.14.10
-mypy==1.0.0
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-xdist==3.1.0

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,3 +1,4 @@
 black==23.1.0
 blackdoc==0.3.7
+mypy==1.0.0
 ruff==0.0.237


### PR DESCRIPTION
Changes:

* Add separate jobs in the lint workflow for running `mypy` on Python 3.7 and 3.11.
* The part that of that workflow that lints the Rust code (`rustfmt` and `clippy`) is now a separate job

Advantages:
* If there is a `mypy` error, we still get to see whether our tests pass.
* It makes sense for `mypy` to be run as part of the lint workflow
* With the Rust part separated out, the overall runtime of the lint job is now about 30 seconds shorter. (which doesn't matter much, as the Windows test workflow is the bottleneck)

Disadvantages:
* Costs slightly more compute to run things this way, as we have to install dev dependencies twice. This is hopefully offset by the fact that people will require fewer iterations to pass all workflows, as test failures become apparent more quickly.