### PR TITLE
chore(rust,python): Update dprint config excludes

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -1,12 +1,13 @@
 {
-  "incremental": true,
-  "toml": {},
   "includes": [
     "**/*.{md,toml}"
   ],
-  "excludes": [],
+  "excludes": [
+    "**/target",
+    "py-polars/venv"
+  ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.14.1.wasm"
-    "https://plugins.dprint.dev/toml-0.5.4.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }


### PR DESCRIPTION
Changes:
* dprint was formatting Markdown files of dependencies in the `target` folders and in the `venv` folders. I updated the config to exclude those folders.
* I also removed the `incremental = true` option as it's set that way by default, and the `toml` config options as it wasn't being used.