### PR TITLE
build(python)!: Drop Python 3.7 support

### DIFF
--- a/.github/workflows/create-python-release.yaml
+++ b/.github/workflows/create-python-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -184,7 +184,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.7'
+  #         python-version: '3.8'
 
   #     - name: Fix README symlink
   #       run: |

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
     defaults:
       run:
         working-directory: py-polars
@@ -94,4 +94,4 @@ jobs:
 
       # Allow untyped calls for older Python versions
       - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.8') && '--allow-untyped-calls' || '' }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -23,7 +23,7 @@ numpy = "0.18"
 once_cell = "1"
 polars-core = { path = "../polars/polars-core", features = ["python"], default-features = false }
 polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-features = false }
-pyo3 = { version = "0.18.0", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.18.0", features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.4", optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "^1.0"

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -2,13 +2,8 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from types import TracebackType
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 try:
     from polars.polars import set_float_fmt as _set_float_fmt

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -400,7 +400,7 @@ def from_pandas(
 
 @overload
 def from_pandas(
-    df: pd.Series | pd.DatetimeIndex,
+    df: pd.Series[Any] | pd.DatetimeIndex,
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
@@ -410,7 +410,7 @@ def from_pandas(
 
 @deprecated_alias(nan_to_none="nan_to_null")
 def from_pandas(
-    df: pd.DataFrame | pd.Series | pd.DatetimeIndex,
+    df: pd.DataFrame | pd.Series[Any] | pd.DatetimeIndex,
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     ForwardRef,
     Iterator,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -20,6 +21,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
     overload,
 )
 
@@ -33,17 +35,6 @@ try:
     _DOCUMENTING = False
 except ImportError:
     _DOCUMENTING = True
-
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, get_args
-else:
-    from typing_extensions import Literal
-
-    # pass-through (only impact is that under 3.7 we'll end-up doing
-    # standard inference for dataclass fields with an option/union)
-    def get_args(tp: Any) -> Any:
-        return tp
 
 
 OptionType = type(Optional[type])

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -469,7 +469,7 @@ def sequence_to_pyseries(
 
 @deprecated_alias(nan_to_none="nan_to_null")
 def _pandas_series_to_arrow(
-    values: pd.Series | pd.DatetimeIndex,
+    values: pd.Series[Any] | pd.DatetimeIndex,
     nan_to_null: bool = True,
     min_len: int | None = None,
 ) -> pa.Array:
@@ -512,7 +512,7 @@ def _pandas_series_to_arrow(
 
 @deprecated_alias(nan_to_none="nan_to_null")
 def pandas_to_pyseries(
-    name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
+    name: str, values: pd.Series[Any] | pd.DatetimeIndex, nan_to_null: bool = True
 ) -> PySeries:
     """Construct a PySeries from a pandas Series or DatetimeIndex."""
     # TODO: Change `if not name` to `if name is not None` once name is Optional[str]

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -18,6 +18,7 @@ from typing import (
     Generator,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     NoReturn,
     Sequence,
@@ -93,11 +94,6 @@ try:
     _DOCUMENTING = False
 except ImportError:
     _DOCUMENTING = True
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec, TypeAlias

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -63,11 +63,6 @@ try:
     _DOCUMENTING = False
 except ImportError:
     _DOCUMENTING = True
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -1910,7 +1905,7 @@ def duration(
     │ 00:00:00   ┆ 00:00:00   ┆                     ┆ 00:00:00.002 ┆                     │
     └────────────┴────────────┴─────────────────────┴──────────────┴─────────────────────┘
 
-    """  # noqa: W505
+    """
     if hours is not None:
         hours = pli.expr_to_lit_or_expr(hours, str_to_lit=False)._pyexpr
     if minutes is not None:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Sequence, overload
 
@@ -1905,7 +1904,7 @@ def duration(
     │ 00:00:00   ┆ 00:00:00   ┆                     ┆ 00:00:00.002 ┆                     │
     └────────────┴────────────┴─────────────────────┴──────────────┴─────────────────────┘
 
-    """
+    """  # noqa: W505
     if hours is not None:
         hours = pli.expr_to_lit_or_expr(hours, str_to_lit=False)._pyexpr
     if minutes is not None:

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -305,7 +305,10 @@ class Series:
     @classmethod
     @deprecated_alias(nan_to_none="nan_to_null")
     def _from_pandas(
-        cls, name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
+        cls,
+        name: str,
+        values: pd.Series[Any] | pd.DatetimeIndex,
+        nan_to_null: bool = True,
     ) -> Series:
         """Construct a Series from a pandas Series or DatetimeIndex."""
         return cls._from_pyseries(
@@ -2845,7 +2848,7 @@ class Series:
 
     def to_pandas(  # noqa: D417
         self, *args: Any, use_pyarrow_extension_array: bool = False, **kwargs: Any
-    ) -> pd.Series:
+    ) -> pd.Series[Any]:
         """
         Convert this Series to a pandas Series.
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import os
-import typing
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -568,8 +567,6 @@ class Series:
 
         return self.cast(Float64) / other
 
-    # python 3.7 is not happy. Remove this when we finally ditch that
-    @typing.no_type_check
     def __floordiv__(self, other: Any) -> Series:
         if self.is_datelike():
             raise ValueError("first cast to integer before dividing datelike dtypes")

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from typing import Literal
 
 from polars import internals as pli
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,7 +1,6 @@
 """Functions for reading and writing data."""
 from __future__ import annotations
 
-import sys
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
@@ -9,20 +8,15 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Literal,
     Mapping,
     TextIO,
     cast,
     overload,
 )
 
-from polars import BatchedCsvReader
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 import polars.internals as pli
+from polars import BatchedCsvReader
 from polars.convert import from_arrow
 from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, SchemaDict, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Ritchie Vink", email = "ritchie46@gmail.com" },
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "typing_extensions >= 4.0.1; python_version < '3.11'",
 ]
@@ -24,7 +24,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -96,7 +95,7 @@ module = ["polars.*"]
 warn_return_any = false
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 line-length = 88
 fix = true
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -21,4 +21,4 @@ pytest-cov==4.0.0
 pytest-xdist==3.1.0
 
 # Stub files
-pandas-stubs==1.2.0.62
+pandas-stubs==1.5.3.230203

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -440,7 +440,7 @@ def test_init_pandas(monkeypatch: Any) -> None:
     assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
     # subclassed pandas object, with/without data & overrides
-    class XSeries(pd.Series):
+    class XSeries(pd.Series):  # type: ignore[type-arg]
         @property
         def _constructor(self) -> type:
             return XSeries

--- a/py-polars/tests/unit/test_interchange.py
+++ b/py-polars/tests/unit/test_interchange.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 
 import pandas as pd
@@ -57,10 +56,6 @@ def test_from_dataframe() -> None:
     assert_frame_equal(result, df)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 8),
-    reason="Pandas does not implement the protocol on Python 3.7",
-)
 def test_from_dataframe_pandas() -> None:
     data = {"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]}
 
@@ -71,10 +66,6 @@ def test_from_dataframe_pandas() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 8),
-    reason="Pandas does not implement the protocol on Python 3.7",
-)
 def test_from_dataframe_allow_copy() -> None:
     # Zero copy only allowed when input is already a Polars dataframe
     df = pl.DataFrame({"a": [1, 2]})

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -928,18 +928,12 @@ def test_arithmetic() -> None:
 
 
 def test_ufunc() -> None:
-    # NOTE: unfortunately we must use cast instead of a type: ignore comment
-    #   1. CI job with Python 3.10, numpy==1.23.1 -> mypy complains about arg-type
-    #   2. so we try to resolve it with type: ignore[arg-type]
-    #   3. CI job with Python 3.7, numpy==1.21.6 -> mypy complains about
-    #       unused type: ignore comment
-    # for more information, see: https://github.com/python/mypy/issues/8823
     df = pl.DataFrame([pl.Series("a", [1, 2, 3, 4], dtype=pl.UInt8)])
     out = df.select(
         [
-            np.power(cast(Any, pl.col("a")), 2).alias("power_uint8"),
-            np.power(cast(Any, pl.col("a")), 2.0).alias("power_float64"),
-            np.power(cast(Any, pl.col("a")), 2, dtype=np.uint16).alias("power_uint16"),
+            np.power(pl.col("a"), 2).alias("power_uint8"),  # type: ignore[call-overload]
+            np.power(pl.col("a"), 2.0).alias("power_float64"),  # type: ignore[call-overload]
+            np.power(pl.col("a"), 2, dtype=np.uint16).alias("power_uint16"),  # type: ignore[call-overload]
         ]
     )
     expected = pl.DataFrame(


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

I realize this is a bit pre-mature, but I figured I might as well just set up a PR already.

Changes:
* Set required Python version to `>=3.8`
* Set ruff target version to 3.8
* Set PyO3 abi3 feature to Python 3.8
* Update CI to run on Python 3.8 instead of 3.7 (for release, test, and mypy jobs).
* Update some typing imports
* Remove some typing workarounds
* Update `pandas-stubs` version and update some pandas type hints

Notes:
* We still must allow untyped calls for `mypy` on Python 3.8 due to the `backports.zoneinfo` package having some [issues](https://github.com/pganssle/zoneinfo/issues/125).