### PR TITLE
feat(rust): introduce async at the top level

### DIFF
--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -15,6 +15,8 @@ serde_json = "1"
 [dependencies]
 ahash.workspace = true
 bitflags.workspace = true
+futures = { version = "0.3.25" }
+tokio = { version = "1.22.0", features = ["rt-multi-thread", "net"] }
 glob = "0.3"
 polars-arrow = { version = "0.27.2", path = "../polars-arrow" }
 polars-core = { version = "0.27.2", path = "../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }

--- a/polars/polars-lazy/src/physical_plan/executors/executor.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/executor.rs
@@ -1,3 +1,5 @@
+use futures::future::BoxFuture;
+
 use super::*;
 
 // Executor are the executors of the physical plan and produce DataFrames. They
@@ -9,6 +11,13 @@ use super::*;
 /// physical plan until the last executor is evaluated.
 pub trait Executor: Send {
     fn execute(&mut self, cache: &mut ExecutionState) -> PolarsResult<DataFrame>;
+
+    fn async_execute(
+        &mut self,
+        cache: &mut ExecutionState,
+    ) -> BoxFuture<'static, PolarsResult<DataFrame>> {
+        Box::pin(futures::future::ready(self.execute(cache)))
+    }
 }
 
 pub struct Dummy {}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1641,6 +1641,7 @@ version = "0.27.2"
 dependencies = [
  "ahash",
  "bitflags",
+ "futures",
  "glob",
  "polars-arrow",
  "polars-core",
@@ -1652,6 +1653,7 @@ dependencies = [
  "polars-utils",
  "pyo3",
  "rayon",
+ "tokio",
 ]
 
 [[package]]
@@ -2150,6 +2152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2310,21 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "toml"
@@ -2518,6 +2545,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
 name = "windows-sys"


### PR DESCRIPTION
@ritchie46 I have been looking for ways to make progress on the object_store integration. This PR provides more of a high level proof of concept, I kept it simple to make it easier to see the proposed change.

I think that the fundamental problem is that we need the Tokio runtime to be initialize much closer to the root of tree of the `Executors`, at least in order to enable `async`.  This will allow all async tasks to be part of one run time and data flow-in the Execution tree as it is being fetched.

I propose in this PR a possible way forward:

1. instead of starting threads use a Tokio runtime - internally it will also start threads. It seems that the main entry point from Python is the Union executor so this PR starts there.
2. use the Tokio primitives
3. define an `execute_async` function in the `Executor` thread, we can provide a default implementation for the async method on top of the regular `execute` method
4. Parquet and other executors can override the default implementation and use async code, on the async path. This change is not part of this PR, if you like the overall approach I can merge this in my earlier [PR-6426](https://github.com/pola-rs/polars/pull/6426), or chain the 2 PRs together.

What do you think about this approach? With something like this we can make more progress integrating cloud storage in Polars. 