### PR TITLE
fix(rust, python): fix schema of functions: 

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -187,6 +187,13 @@ impl GetOutput {
         }))
     }
 
+    pub fn float_type() -> Self {
+        Self::map_dtype(|dt| match dt {
+            DataType::Float32 => DataType::Float32,
+            _ => DataType::Float64,
+        })
+    }
+
     pub fn super_type() -> Self {
         Self::map_dtypes(|dtypes| {
             let mut st = dtypes[0].clone();

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -39,3 +39,7 @@ pub(super) fn diff(s: &Series, n: usize, null_behavior: NullBehavior) -> PolarsR
 pub(super) fn interpolate(s: &Series, method: InterpolationMethod) -> PolarsResult<Series> {
     Ok(polars_ops::prelude::interpolate(s, method))
 }
+#[cfg(feature = "dot_product")]
+pub(super) fn dot_impl(s: &[Series]) -> PolarsResult<Series> {
+    Ok((&s[0] * &s[1]).sum_as_series())
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -43,3 +43,14 @@ pub(super) fn interpolate(s: &Series, method: InterpolationMethod) -> PolarsResu
 pub(super) fn dot_impl(s: &[Series]) -> PolarsResult<Series> {
     Ok((&s[0] * &s[1]).sum_as_series())
 }
+
+#[cfg(feature = "log")]
+pub(super) fn entropy(s: &Series, base: f64, normalize: bool) -> PolarsResult<Series> {
+    let out = s.entropy(base, normalize);
+    if matches!(s.dtype(), DataType::Float32) {
+        let out = out.map(|v| v as f32);
+        Ok(Series::new(s.name(), [out]))
+    } else {
+        Ok(Series::new(s.name(), [out]))
+    }
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -117,6 +117,8 @@ pub enum FunctionExpr {
     Diff(usize, NullBehavior),
     #[cfg(feature = "interpolate")]
     Interpolate(InterpolationMethod),
+    #[cfg(feature = "dot_product")]
+    Dot,
 }
 
 impl Display for FunctionExpr {
@@ -180,6 +182,8 @@ impl Display for FunctionExpr {
             Diff(_, _) => "diff",
             #[cfg(feature = "interpolate")]
             Interpolate(_) => "interpolate",
+            #[cfg(feature = "dot_product")]
+            Dot => "dot",
         };
         write!(f, "{s}")
     }
@@ -360,6 +364,10 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "interpolate")]
             Interpolate(method) => {
                 map!(dispatch::interpolate, method)
+            }
+            #[cfg(feature = "dot_product")]
+            Dot => {
+                map_as_slice!(dispatch::dot_impl)
             }
         }
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -54,7 +54,7 @@ pub(super) use self::trigonometry::TrigonometricFunction;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Debug, Eq, Hash)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum FunctionExpr {
     NullCount,
     Pow,
@@ -119,6 +119,11 @@ pub enum FunctionExpr {
     Interpolate(InterpolationMethod),
     #[cfg(feature = "dot_product")]
     Dot,
+    #[cfg(feature = "log")]
+    Entropy {
+        base: f64,
+        normalize: bool,
+    },
 }
 
 impl Display for FunctionExpr {
@@ -184,6 +189,8 @@ impl Display for FunctionExpr {
             Interpolate(_) => "interpolate",
             #[cfg(feature = "dot_product")]
             Dot => "dot",
+            #[cfg(feature = "log")]
+            Entropy { .. } => "entropy",
         };
         write!(f, "{s}")
     }
@@ -369,6 +376,8 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             Dot => {
                 map_as_slice!(dispatch::dot_impl)
             }
+            #[cfg(feature = "log")]
+            Entropy { base, normalize } => map!(dispatch::entropy, base, normalize),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -269,6 +269,14 @@ impl FunctionExpr {
                     }
                 })
             }
+            #[cfg(feature = "dot_product")]
+            Dot => map_dtype(&|dt| {
+                use DataType::*;
+                match dt {
+                    Int8 | Int16 | UInt16 | UInt8 => Int64,
+                    _ => dt.clone(),
+                }
+            }),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -33,7 +33,7 @@ impl FunctionExpr {
             Ok(fld)
         };
 
-        #[cfg(any(feature = "rolling_window", feature = "trigonometry"))]
+        #[cfg(any(feature = "rolling_window", feature = "trigonometry", feature = "log"))]
         // set float supertype
         let float_dtype = || {
             map_dtype(&|dtype| match dtype {
@@ -277,6 +277,8 @@ impl FunctionExpr {
                     _ => dt.clone(),
                 }
             }),
+            #[cfg(feature = "log")]
+            Entropy { .. } => float_dtype(),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1277,10 +1277,7 @@ impl Expr {
 
     #[cfg(feature = "dot_product")]
     fn dot_impl(self, other: Expr) -> Expr {
-        let function = |s: &mut [Series]| Ok(Some((&s[0] * &s[1]).sum_as_series()));
-
-        self.apply_many(function, &[other], GetOutput::same_type())
-            .with_fmt("dot")
+        self.apply_many_private(FunctionExpr::Dot, &[other], true, true)
     }
 
     #[cfg(feature = "dot_product")]

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1389,6 +1389,7 @@ impl Expr {
         rolling_fn: Arc<
             dyn (Fn(&Series, RollingOptionsImpl) -> PolarsResult<Series>) + Send + Sync,
         >,
+        output_type: GetOutput,
     ) -> Expr {
         if let Some(ref by) = options.by {
             self.apply_many(
@@ -1427,7 +1428,7 @@ impl Expr {
                     rolling_fn(s, options).map(Some)
                 },
                 &[col(by)],
-                GetOutput::same_type(),
+                output_type,
             )
             .with_fmt(expr_name_by)
         } else {
@@ -1437,7 +1438,7 @@ impl Expr {
 
             self.apply(
                 move |s| rolling_fn(&s, options.clone().into()).map(Some),
-                GetOutput::same_type(),
+                output_type,
             )
             .with_fmt(expr_name)
         }
@@ -1452,6 +1453,7 @@ impl Expr {
             "rolling_min",
             "rolling_min_by",
             Arc::new(|s, options| s.rolling_min(options)),
+            GetOutput::same_type(),
         )
     }
 
@@ -1464,6 +1466,7 @@ impl Expr {
             "rolling_max",
             "rolling_max_by",
             Arc::new(|s, options| s.rolling_max(options)),
+            GetOutput::same_type(),
         )
     }
 
@@ -1476,6 +1479,7 @@ impl Expr {
             "rolling_mean",
             "rolling_mean_by",
             Arc::new(|s, options| s.rolling_mean(options)),
+            GetOutput::float_type(),
         )
     }
 
@@ -1488,6 +1492,7 @@ impl Expr {
             "rolling_sum",
             "rolling_sum_by",
             Arc::new(|s, options| s.rolling_sum(options)),
+            GetOutput::same_type(),
         )
     }
 
@@ -1500,6 +1505,7 @@ impl Expr {
             "rolling_median",
             "rolling_median_by",
             Arc::new(|s, options| s.rolling_median(options)),
+            GetOutput::same_type(),
         )
     }
 
@@ -1517,6 +1523,7 @@ impl Expr {
             "rolling_quantile",
             "rolling_quantile_by",
             Arc::new(move |s, options| s.rolling_quantile(quantile, interpolation, options)),
+            GetOutput::float_type(),
         )
     }
 
@@ -1528,6 +1535,7 @@ impl Expr {
             "rolling_var",
             "rolling_var_by",
             Arc::new(|s, options| s.rolling_var(options)),
+            GetOutput::float_type(),
         )
     }
 
@@ -1539,6 +1547,7 @@ impl Expr {
             "rolling_std",
             "rolling_std_by",
             Arc::new(|s, options| s.rolling_std(options)),
+            GetOutput::float_type(),
         )
     }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1997,6 +1997,10 @@ impl Expr {
     /// where `pk` are discrete probabilities.
     pub fn entropy(self, base: f64, normalize: bool) -> Self {
         self.apply_private(FunctionExpr::Entropy { base, normalize })
+            .with_function_options(|mut options| {
+                options.auto_explode = true;
+                options
+            })
     }
     /// Get the null count of the column/group
     pub fn null_count(self) -> Expr {

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1987,21 +1987,7 @@ impl Expr {
     /// Compute the entropy as `-sum(pk * log(pk)`.
     /// where `pk` are discrete probabilities.
     pub fn entropy(self, base: f64, normalize: bool) -> Self {
-        self.apply(
-            move |s| Ok(Some(Series::new(s.name(), [s.entropy(base, normalize)]))),
-            GetOutput::map_dtype(|dt| {
-                if matches!(dt, DataType::Float32) {
-                    DataType::Float32
-                } else {
-                    DataType::Float64
-                }
-            }),
-        )
-        .with_function_options(|mut options| {
-            options.fmt_str = "entropy";
-            options.auto_explode = true;
-            options
-        })
+        self.apply_private(FunctionExpr::Entropy { base, normalize })
     }
     /// Get the null count of the column/group
     pub fn null_count(self) -> Expr {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1457,12 +1457,7 @@ impl PyExpr {
     }
 
     pub fn rolling_skew(&self, window_size: usize, bias: bool) -> Self {
-        self.inner
-            .clone()
-            .rolling_apply_float(window_size, move |ca| {
-                ca.clone().into_series().skew(bias).unwrap()
-            })
-            .into()
+        self.inner.clone().rolling_skew(window_size, bias).into()
     }
 
     pub fn lower_bound(&self) -> Self {


### PR DESCRIPTION
- dot
- entropy
- rolling_mean
- rolling_quantile
- rolling_skew
- rolling_std
- rolling_var

Also moved functions to `private`. This should be done for every non-private apply.

#6814