### PR TITLE
feat(python): add `include_index` option on init from pandas frames

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -394,6 +394,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    *,
     include_index: bool = False,
 ) -> DataFrame:
     ...
@@ -405,6 +406,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    *,
     include_index: bool = False,
 ) -> Series:
     ...
@@ -416,6 +418,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    *,
     include_index: bool = False,
 ) -> DataFrame | Series:
     """

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -394,6 +394,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    include_index: bool = False,
 ) -> DataFrame:
     ...
 
@@ -404,6 +405,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    include_index: bool = False,
 ) -> Series:
     ...
 
@@ -414,6 +416,7 @@ def from_pandas(
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,
+    include_index: bool = False,
 ) -> DataFrame | Series:
     """
     Construct a Polars DataFrame or Series from a pandas DataFrame or Series.
@@ -432,6 +435,8 @@ def from_pandas(
         If data contains `NaN` values PyArrow will convert the ``NaN`` to ``None``
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
+    include_index : bool, default False
+        Load any non-default pandas indexes as columns.
 
     Returns
     -------
@@ -478,6 +483,7 @@ def from_pandas(
             rechunk=rechunk,
             nan_to_null=nan_to_null,
             schema_overrides=schema_overrides,
+            include_index=include_index,
         )
     else:
         raise ValueError(f"Expected pandas DataFrame or Series, got {type(df)}.")

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -610,6 +610,7 @@ class DataFrame:
         schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
         nan_to_null: bool = True,
+        include_index: bool = False,
     ) -> Self:
         """
         Construct a Polars DataFrame from a pandas DataFrame.
@@ -635,6 +636,8 @@ class DataFrame:
             Make sure that all data is in contiguous memory.
         nan_to_null : bool, default True
             If the data contains NaN values they will be converted to null/None.
+        include_index : bool, default False
+            Load any non-default pandas indexes as columns.
 
         Returns
         -------
@@ -648,6 +651,7 @@ class DataFrame:
                 schema_overrides=schema_overrides,
                 rechunk=rechunk,
                 nan_to_null=nan_to_null,
+                include_index=include_index,
             )
         )
 


### PR DESCRIPTION
Closes #6763.

Allows for optional loading of _non-default_ pandas frame indexes as columns; defaults to False to ensure no changes in behaviour - we can revisit that default later, if requested/desired.

**Setup**
```python
from datetime import datetime
import pandas as pd
import polars as pl

pdf = pd.DataFrame(
  {
    "dtm": [datetime(2023,1,1), datetime(2023,1,2)],
    "val": [100, 200],
    "misc": ["x", "y"],
  }
).set_index( ["dtm"] )

#             val misc
# dtm                 
# 2023-01-01  100    x
# 2023-01-02  200    y
```
**Before** _(caller has to manually reset the index if they want to load it)_
```python
pl.from_pandas( pdf )

# shape: (2, 2)
# ┌─────┬──────┐
# │ val ┆ misc │
# │ --- ┆ ---  │
# │ i64 ┆ str  │
# ╞═════╪══════╡
# │ 100 ┆ x    │
# │ 200 ┆ y    │
# └─────┴──────┘
```
**After** _(new param allows for easy/optimised index load)_
```python
pl.from_pandas( pdf, include_index=True )

# shape: (2, 3)
# ┌─────────────────────┬─────┬──────┐
# │ dtm                 ┆ val ┆ misc │
# │ ---                 ┆ --- ┆ ---  │
# │ datetime[ns]        ┆ i64 ┆ str  │
# ╞═════════════════════╪═════╪══════╡
# │ 2023-01-01 00:00:00 ┆ 100 ┆ x    │
# │ 2023-01-02 00:00:00 ┆ 200 ┆ y    │
# └─────────────────────┴─────┴──────┘
```
**Update**

Using this method is now optimal in comparison to the caller using `reset_index`, as we're able to avoid the pandas-side copy that would trigger.