### PR TITLE
refactor(python): Deprecate non-keyword args for some functions

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4105,6 +4105,7 @@ class DataFrame:
             self._df.upsample(by, time_column, every, offset, maintain_order)
         )
 
+    @deprecate_nonkeyword_arguments()
     def join_asof(
         self,
         other: DataFrame,

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5031,6 +5031,9 @@ class DataFrame:
         """
         return self.lazy().explode(columns).collect(no_optimization=True)
 
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self", "values", "index", "columns", "aggregate_fn"]
+    )
     def pivot(
         self,
         values: Sequence[str] | str,

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4389,7 +4389,7 @@ class DataFrame:
             .collect(no_optimization=True)
         )
 
-    @deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "f", "return_dtype"])
     def apply(
         self,
         f: Callable[[tuple[Any, ...]], Any],

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4255,7 +4255,7 @@ class DataFrame:
     @deprecate_nonkeyword_arguments(
         message=(
             "All arguments of DataFrame.join except for 'other', 'on', and 'how' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this message."
+            " Use keyword arguments to silence this warning."
         )
     )
     def join(
@@ -6428,6 +6428,12 @@ class DataFrame:
             columns = [columns]
         return self._from_pydf(self._df.to_dummies(columns, separator))
 
+    @deprecate_nonkeyword_arguments(
+        message=(
+            "All arguments of DataFrame.unique except for 'subset' will be keyword-only in the next breaking release."
+            " Use keyword arguments to silence this warning."
+        )
+    )
     def unique(
         self,
         maintain_order: bool = True,

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4389,6 +4389,7 @@ class DataFrame:
             .collect(no_optimization=True)
         )
 
+    @deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
     def apply(
         self,
         f: Callable[[tuple[Any, ...]], Any],

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -6390,7 +6390,7 @@ class DataFrame:
         return self._from_pydf(self._df.quantile(quantile, interpolation))
 
     def to_dummies(
-        self, *, columns: Sequence[str] | None = None, separator: str = "_"
+        self, columns: Sequence[str] | None = None, *, separator: str = "_"
     ) -> Self:
         """
         Get one hot encoded dummy variables.

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3035,7 +3035,7 @@ class Expr:
             return_dtype = py_type_to_dtype(return_dtype)
         return wrap_expr(self._pyexpr.map(f, return_dtype, agg_list))
 
-    @deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "f", "return_dtype"])
     def apply(
         self,
         f: Callable[[pli.Series], pli.Series] | Callable[[Any], Any],

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -26,7 +26,11 @@ from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
 from polars.internals.type_aliases import PolarsExprType, PythonLiteral
-from polars.utils import _timedelta_to_pl_duration, sphinx_accessor
+from polars.utils import (
+    _timedelta_to_pl_duration,
+    deprecate_nonkeyword_arguments,
+    sphinx_accessor,
+)
 
 try:
     from polars.polars import PyExpr
@@ -2980,6 +2984,7 @@ class Expr:
         """
         return self.filter(predicate)
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "f", "return_dtype"])
     def map(
         self,
         f: Callable[[pli.Series], pli.Series | Any],

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -3034,6 +3034,7 @@ class Expr:
             return_dtype = py_type_to_dtype(return_dtype)
         return wrap_expr(self._pyexpr.map(f, return_dtype, agg_list))
 
+    @deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
     def apply(
         self,
         f: Callable[[pli.Series], pli.Series] | Callable[[Any], Any],

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1808,6 +1808,7 @@ class Expr:
         """
         return wrap_expr(self._pyexpr.top_k(k, reverse))
 
+    @deprecate_nonkeyword_arguments()
     def arg_sort(self, reverse: bool = False, nulls_last: bool = False) -> Expr:
         """
         Get the index values that would sort this column.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1516,6 +1516,7 @@ def reduce(
     return pli.wrap_expr(pyreduce(f, exprs))
 
 
+@deprecate_nonkeyword_arguments()
 def cumfold(
     acc: IntoExpr,
     f: Callable[[pli.Series, pli.Series], pli.Series],

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1412,6 +1412,7 @@ def map(
     )
 
 
+@deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
 def apply(
     exprs: Sequence[str | pli.Expr],
     f: Callable[[Sequence[pli.Series]], pli.Series | Any],

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -29,6 +29,7 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
+    deprecate_nonkeyword_arguments,
 )
 
 try:
@@ -2058,6 +2059,7 @@ def _date(
     return _datetime(year, month, day).cast(Date).alias("date")
 
 
+@deprecate_nonkeyword_arguments()
 def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli.Expr:
     """
     Horizontally concat Utf8 Series in linear time. Non-Utf8 columns are cast to Utf8.

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1836,6 +1836,7 @@ def arange(
         )
 
 
+@deprecate_nonkeyword_arguments()
 def arg_sort_by(
     exprs: pli.Expr | str | Sequence[pli.Expr | str],
     reverse: Sequence[bool] | bool = False,

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2357,6 +2357,7 @@ def struct(
     ...
 
 
+@deprecate_nonkeyword_arguments()
 def struct(
     exprs: Sequence[pli.Expr | str | pli.Series] | pli.Expr | pli.Series,
     eager: bool = False,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -3815,6 +3815,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             self._ldf.melt(id_vars, value_vars, value_name, variable_name)
         )
 
+    @deprecate_nonkeyword_arguments()
     def map(
         self,
         f: Callable[[pli.DataFrame], pli.DataFrame],

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2329,7 +2329,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
     @deprecate_nonkeyword_arguments(
         message=(
             "All arguments of LazyFrame.join except for 'other', 'on', and 'how' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this message."
+            " Use keyword arguments to silence this warning."
         )
     )
     def join(
@@ -3590,6 +3590,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         columns = pli.selection_to_pyexpr_list(columns)
         return self._from_pyldf(self._ldf.explode(columns))
 
+    @deprecate_nonkeyword_arguments(
+        message=(
+            "All arguments of LazyFrame.unique except for 'subset' will be keyword-only in the next breaking release."
+            " Use keyword arguments to silence this warning."
+        )
+    )
     def unique(
         self,
         maintain_order: bool = True,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2155,6 +2155,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         )
         return LazyGroupBy(lgb, lazyframe_class=self.__class__)
 
+    @deprecate_nonkeyword_arguments()
     def join_asof(
         self,
         other: LazyFrame,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -75,6 +75,7 @@ from polars.utils import (
     _datetime_to_pl_timestamp,
     _is_generator,
     _time_to_pl_time,
+    deprecate_nonkeyword_arguments,
     deprecated_alias,
     is_int_sequence,
     range_to_series,
@@ -1370,6 +1371,7 @@ class Series:
         """
         return self._s.quantile(quantile, interpolation)
 
+    @deprecate_nonkeyword_arguments()
     def to_dummies(self, separator: str = "_") -> pli.DataFrame:
         """
         Get dummy variables.

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3538,6 +3538,7 @@ class Series:
 
         """
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "func", "return_dtype"])
     def apply(
         self,
         func: Callable[[Any], Any],

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1967,6 +1967,7 @@ class Series:
 
         """
 
+    @deprecate_nonkeyword_arguments()
     def arg_sort(self, reverse: bool = False, nulls_last: bool = False) -> Series:
         """
         Get the index values that would sort this Series.
@@ -1993,6 +1994,14 @@ class Series:
         ]
 
         """
+        return (
+            pli.wrap_s(self._s)
+            .to_frame()
+            .select(
+                pli.col(self._s.name()).arg_sort(reverse=reverse, nulls_last=nulls_last)
+            )
+            .to_series()
+        )
 
     def argsort(self, reverse: bool = False, nulls_last: bool = False) -> Series:
         """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -503,7 +503,7 @@ def deprecate_nonkeyword_arguments(
         if message is None:
             msg_format = (
                 f"All arguments of {fn.__qualname__}{{except_args}} will be keyword-only in the next breaking release."
-                " Use keyword arguments to silence this message."
+                " Use keyword arguments to silence this warning."
             )
             msg = msg_format.format(except_args=_format_argument_list(allow_args))
         else:

--- a/py-polars/tests/unit/test_utils.py
+++ b/py-polars/tests/unit/test_utils.py
@@ -93,7 +93,7 @@ def test_deprecate_nonkeyword_arguments_method_signature() -> None:
 def test_deprecate_nonkeyword_arguments_method_warning() -> None:
     msg = (
         r"All arguments of Foo\.bar except for \'baz\' will be keyword-only in the next breaking release."
-        r" Use keyword arguments to silence this message."
+        r" Use keyword arguments to silence this warning."
     )
     with pytest.deprecated_call(match=msg):
         Foo().bar("qux", "quox")


### PR DESCRIPTION
### Keyword-only strategy

My philosophy for marking arguments as keyword-only is as follows, roughly in order of priority:

#### 1. If parameters clash, at least one of the parameters should be keyword-only.
  * Example: `join(left_on, right_on, on)` -> either `on` must be keyword-only, or `left_on` and `right_on`.
  * Reason: We want to avoid syntax like `join(None, None, "a")`

#### 2. Boolean flags should always be keyword-only
  * Example: `sort(reverse=False, nulls_last=False)`
  * Reason 1: positional syntax is not very readable here, e.g. `sort(True, False)` -> which flags mean what?
  * Reason 2: flag parameters are relatively prone to re-ordering - this will not be breaking if the args are keyword-only

#### 3. Keyword arguments that are rarely used or only used for very specific use cases should be keyword-only
  * Example: `read_csv(sample_size=1024)`
  * Reason: These arguments are more subject to reordering, renaming, or removal than other parameters. Having them keyword-only makes this easier to do.

#### 4. Arguments after "single or sequence" arguments should be keyword-only
  * Example: `unique(subset, keep, maintain_order)` -> `keep` and `maintain_order` will be keyword-only
  * Reason 1: stops users from accidentally passing list arguments to subsequent arguments, e.g. `unique("a", "b")` -> "b" will be passed to `keep`
  * Reason 2: Allows the option to adopt `*args` syntax, see #6451 for examples.

#### 5. Newly added flags or experimental args should be keyword-only
  * Example: `to_dummies(separator)` (recent addition)
  * Reason: We don't always get it right straight away. It's easier to change or deprecate arguments when they are keyword-only.

#### Bonus. Arguments that do not match these criteria SHOULD NOT BE KEYWORD-ONLY.
  * Example: `join(other, on, how, *, left_on, right_on)`
  * Reason: There are valid use cases for positional arguments. -> For example, when arguments are passed as variables, the duplication can get ugly: `join(other, on=on, how=how)`. Let users decide their preferred syntax in this case (keyword or positional).
  * If keyword-only arguments do not concretely help the user or the Polars developers, they should not be used.

Your input here is very welcome!

### Changes

With this in mind, I made deprecation changes to the following functions/methods:
* to_dummies
* unique
* concat_str
* struct
* join_asof
* map
* apply
* cumfold
* arg_sort_by
* arg_sort
* pivot

### Next steps

There are definitely more to do. I figured I'd open this PR to run my 'philosphy' by you, and then do another pass with whatever strategy we come up with together.

I've also spotted quite a few parameter renaming opportunities, I'll do that next.

And then after that, I will do another PR where I remove the deprecations and apply the breaking changes. That can sit for a while until we go for `0.17.0`.