### PR TITLE
perf(rust, python): speedup quantile/median `~2x`

### DIFF
--- a/polars/polars-arrow/src/floats/mod.rs
+++ b/polars/polars-arrow/src/floats/mod.rs
@@ -1,0 +1,3 @@
+mod ord;
+
+pub use ord::*;

--- a/polars/polars-arrow/src/floats/ord.rs
+++ b/polars/polars-arrow/src/floats/ord.rs
@@ -1,0 +1,92 @@
+use std::cmp::Ordering;
+
+use crate::data_types::IsFloat;
+use crate::kernels::rolling::compare_fn_nan_max;
+
+/// A utility type that make floats Ord by
+/// nan == nan == true
+/// nan > float::max == true
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct OrdFloat<T>(T);
+
+impl<T: IsFloat + PartialEq + PartialOrd> PartialOrd for OrdFloat<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(compare_fn_nan_max(&self.0, &other.0))
+    }
+}
+
+impl<T: IsFloat + PartialEq + PartialOrd> Ord for OrdFloat<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_fn_nan_max(&self.0, &other.0)
+    }
+}
+
+impl<T: IsFloat + PartialEq> PartialEq for OrdFloat<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.0.is_nan(), other.0.is_nan()) {
+            (true, true) => true,
+            _ => self.0 == other.0,
+        }
+    }
+}
+
+impl<T: PartialEq + IsFloat> Eq for OrdFloat<T> {}
+
+impl<T: num::ToPrimitive> num::ToPrimitive for OrdFloat<T> {
+    fn to_isize(&self) -> Option<isize> {
+        self.0.to_isize()
+    }
+
+    fn to_i8(&self) -> Option<i8> {
+        self.0.to_i8()
+    }
+
+    fn to_i16(&self) -> Option<i16> {
+        self.0.to_i16()
+    }
+
+    fn to_i32(&self) -> Option<i32> {
+        self.0.to_i32()
+    }
+
+    fn to_i64(&self) -> Option<i64> {
+        self.0.to_i64()
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        self.0.to_usize()
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        self.0.to_u8()
+    }
+
+    fn to_u16(&self) -> Option<u16> {
+        self.0.to_u16()
+    }
+
+    fn to_u32(&self) -> Option<u32> {
+        self.0.to_u32()
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        self.0.to_u64()
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        self.0.to_f32()
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        self.0.to_f64()
+    }
+}
+
+pub fn f32_to_ordablef32(vals: &mut [f32]) -> &mut [OrdFloat<f32>] {
+    unsafe { std::mem::transmute(vals) }
+}
+
+pub fn f64_to_ordablef64(vals: &mut [f64]) -> &mut [OrdFloat<f64>] {
+    unsafe { std::mem::transmute(vals) }
+}

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -6,6 +6,7 @@ pub mod conversion;
 pub mod data_types;
 pub mod error;
 pub mod export;
+pub mod floats;
 pub mod index;
 pub mod is_valid;
 pub mod kernels;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -496,6 +496,16 @@ where
             Err(PolarsError::ComputeError("no_slice".into()))
         }
     }
+    /// Contiguous mutable slice
+    pub(crate) fn cont_slice_mut(&mut self) -> Option<&mut [T::Native]> {
+        if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
+            // Safety, we will not swap the PrimitiveArray.
+            let arr = unsafe { self.downcast_iter_mut().next().unwrap() };
+            arr.get_mut_values()
+        } else {
+            None
+        }
+    }
 
     /// Get slices of the underlying arrow data.
     /// NOTE: null values should be taken into account by the user of these slices as they are handled

--- a/polars/polars-core/src/chunked_array/ops/aggregate/quantile.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/quantile.rs
@@ -19,35 +19,42 @@ fn quantile_idx(
     length: usize,
     null_count: usize,
     interpol: QuantileInterpolOptions,
-) -> (i64, f64, i64) {
+) -> (usize, f64, usize) {
     let mut base_idx = match interpol {
         QuantileInterpolOptions::Nearest => {
-            (((length - null_count) as f64) * quantile + null_count as f64) as i64
+            (((length - null_count) as f64) * quantile + null_count as f64) as usize
         }
         QuantileInterpolOptions::Lower
         | QuantileInterpolOptions::Midpoint
         | QuantileInterpolOptions::Linear => {
-            (((length - null_count) as f64 - 1.0) * quantile + null_count as f64) as i64
+            (((length - null_count) as f64 - 1.0) * quantile + null_count as f64) as usize
         }
         QuantileInterpolOptions::Higher => {
-            (((length - null_count) as f64 - 1.0) * quantile + null_count as f64).ceil() as i64
+            (((length - null_count) as f64 - 1.0) * quantile + null_count as f64).ceil() as usize
         }
     };
 
-    base_idx = base_idx.clamp(0, (length - 1) as i64);
+    base_idx = base_idx.clamp(0, length - 1);
     let float_idx = ((length - null_count) as f64 - 1.0) * quantile + null_count as f64;
-    let top_idx = f64::ceil(float_idx) as i64;
+    let top_idx = f64::ceil(float_idx) as usize;
 
     (base_idx, float_idx, top_idx)
 }
 
 /// helper
-fn linear_interpol<T: Float>(bounds: &[Option<T>], idx: i64, float_idx: f64) -> Option<T> {
-    if bounds[0] == bounds[1] {
-        Some(bounds[0].unwrap())
+fn linear_interpol<T: Float>(lower: T, upper: T, idx: usize, float_idx: f64) -> T {
+    if lower == upper {
+        lower
     } else {
         let proportion: T = T::from(float_idx).unwrap() - T::from(idx).unwrap();
-        Some(proportion * (bounds[1].unwrap() - bounds[0].unwrap()) + bounds[0].unwrap())
+        proportion * (upper - lower) + lower
+    }
+}
+fn midpoint_interpol<T: Float>(lower: T, upper: T) -> T {
+    if lower == upper {
+        lower
+    } else {
+        (lower + upper) / (T::one() + T::one())
     }
 }
 
@@ -77,8 +84,50 @@ impl Sortable for Float64Chunked {
     }
 }
 
+fn quantile_slice<T: ToPrimitive + Ord>(
+    vals: &mut [T],
+    quantile: f64,
+    interpol: QuantileInterpolOptions,
+) -> PolarsResult<Option<f64>> {
+    if !(0.0..=1.0).contains(&quantile) {
+        return Err(PolarsError::ComputeError(
+            "quantile should be between 0.0 and 1.0".into(),
+        ));
+    }
+    if vals.is_empty() {
+        return Ok(None);
+    }
+    let (idx, float_idx, top_idx) = quantile_idx(quantile, vals.len(), 0, interpol);
+
+    let (_lhs, lower, rhs) = vals.select_nth_unstable(idx);
+    if idx == top_idx {
+        Ok(lower.to_f64())
+    } else {
+        match interpol {
+            QuantileInterpolOptions::Midpoint => {
+                let (_, upper, _) = rhs.select_nth_unstable(0);
+                Ok(Some(midpoint_interpol(
+                    lower.to_f64().unwrap(),
+                    upper.to_f64().unwrap(),
+                )))
+            }
+            QuantileInterpolOptions::Linear => {
+                let (_, upper, _) = rhs.select_nth_unstable(0);
+                Ok(linear_interpol(
+                    lower.to_f64().unwrap(),
+                    upper.to_f64().unwrap(),
+                    idx,
+                    float_idx,
+                )
+                .to_f64())
+            }
+            _ => Ok(lower.to_f64()),
+        }
+    }
+}
+
 fn generic_quantile<T>(
-    ca: &ChunkedArray<T>,
+    ca: ChunkedArray<T>,
     quantile: f64,
     interpol: QuantileInterpolOptions,
 ) -> PolarsResult<Option<f64>>
@@ -100,53 +149,28 @@ where
     }
 
     let (idx, float_idx, top_idx) = quantile_idx(quantile, length, null_count, interpol);
+    let sorted = ca.sort();
+    let lower = sorted.get(idx).map(|v| v.to_f64().unwrap());
 
     let opt = match interpol {
         QuantileInterpolOptions::Midpoint => {
             if top_idx == idx {
-                ca.sort()
-                    .slice(idx, 1)
-                    .apply_cast_numeric::<_, Float64Type>(|value| value.to_f64().unwrap())
-                    .into_iter()
-                    .next()
-                    .flatten()
+                lower
             } else {
-                let bounds: Vec<Option<f64>> = ca
-                    .sort()
-                    .slice(idx, 2)
-                    .apply_cast_numeric::<_, Float64Type>(|value| value.to_f64().unwrap())
-                    .into_iter()
-                    .collect();
-
-                Some((bounds[0].unwrap() + bounds[1].unwrap()) / 2.0f64)
+                let upper = sorted.get(idx + 1).map(|v| v.to_f64().unwrap());
+                midpoint_interpol(lower.unwrap(), upper.unwrap()).to_f64()
             }
         }
         QuantileInterpolOptions::Linear => {
             if top_idx == idx {
-                ca.sort()
-                    .slice(idx, 1)
-                    .apply_cast_numeric::<_, Float64Type>(|value| value.to_f64().unwrap())
-                    .into_iter()
-                    .next()
-                    .flatten()
+                lower
             } else {
-                let bounds: Vec<Option<f64>> = ca
-                    .sort()
-                    .slice(idx, 2)
-                    .apply_cast_numeric::<_, Float64Type>(|value| value.to_f64().unwrap())
-                    .into_iter()
-                    .collect();
+                let upper = sorted.get(idx + 1).map(|v| v.to_f64().unwrap());
 
-                linear_interpol(&bounds, idx, float_idx)
+                linear_interpol(lower.unwrap(), upper.unwrap(), idx, float_idx).to_f64()
             }
         }
-        _ => ca
-            .sort()
-            .slice(idx, 1)
-            .apply_cast_numeric::<_, Float64Type>(|value| value.to_f64().unwrap())
-            .into_iter()
-            .next()
-            .flatten(),
+        _ => lower,
     };
     Ok(opt)
 }
@@ -155,20 +179,46 @@ impl<T> ChunkQuantile<f64> for ChunkedArray<T>
 where
     T: PolarsIntegerType,
     T::Native: Ord,
-    <T::Native as Simd>::Simd: Add<Output = <T::Native as Simd>::Simd>
-        + compute::aggregate::Sum<T::Native>
-        + compute::aggregate::SimdOrd<T::Native>,
 {
     fn quantile(
         &self,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
-        generic_quantile(self, quantile, interpol)
+        if let Ok(slice) = self.cont_slice() {
+            let mut owned = slice.to_vec();
+            quantile_slice(&mut owned, quantile, interpol)
+        } else {
+            generic_quantile(self.clone(), quantile, interpol)
+        }
     }
 
     fn median(&self) -> Option<f64> {
         self.quantile(0.5, QuantileInterpolOptions::Linear).unwrap() // unwrap fine since quantile in range
+    }
+}
+
+// Version of quantile/median that don't need a memcpy
+impl<T> ChunkedArray<T>
+where
+    T: PolarsIntegerType,
+    T::Native: Ord,
+{
+    pub(crate) fn quantile_faster(
+        mut self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Option<f64>> {
+        if let Some(slice) = self.cont_slice_mut() {
+            quantile_slice(slice, quantile, interpol)
+        } else {
+            self.quantile(quantile, interpol)
+        }
+    }
+
+    pub(crate) fn median_faster(self) -> Option<f64> {
+        self.quantile_faster(0.5, QuantileInterpolOptions::Linear)
+            .unwrap()
     }
 }
 
@@ -178,7 +228,7 @@ impl ChunkQuantile<f32> for Float32Chunked {
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f32>> {
-        generic_quantile(self, quantile, interpol).map(|v| v.map(|v| v as f32))
+        generic_quantile(self.clone(), quantile, interpol).map(|v| v.map(|v| v as f32))
     }
 
     fn median(&self) -> Option<f32> {
@@ -192,7 +242,7 @@ impl ChunkQuantile<f64> for Float64Chunked {
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
-        generic_quantile(self, quantile, interpol)
+        generic_quantile(self.clone(), quantile, interpol)
     }
 
     fn median(&self) -> Option<f64> {

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -57,7 +57,7 @@ where
     /// # Safety
     /// The caller must ensure:
     ///     * the length remains correct.
-    ///     * the flags (sorted, etc) are correct.
+    ///     * the flags (sorted, etc) remain correct.
     pub unsafe fn downcast_iter_mut(
         &mut self,
     ) -> impl Iterator<Item = &mut PrimitiveArray<T::Native>> + DoubleEndedIterator {

--- a/polars/polars-core/src/frame/groupby/aggregations/dispatch.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/dispatch.rs
@@ -138,12 +138,8 @@ impl Series {
         use DataType::*;
 
         match self.dtype() {
-            Float32 => {
-                SeriesWrap(self.f32().unwrap().clone()).agg_quantile(groups, quantile, interpol)
-            }
-            Float64 => {
-                SeriesWrap(self.f64().unwrap().clone()).agg_quantile(groups, quantile, interpol)
-            }
+            Float32 => self.f32().unwrap().agg_quantile(groups, quantile, interpol),
+            Float64 => self.f64().unwrap().agg_quantile(groups, quantile, interpol),
             dt if dt.is_numeric() || dt.is_temporal() => {
                 let ca = self.to_physical_repr();
                 let physical_type = ca.dtype();

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -439,6 +439,149 @@ fn take_max<T: PartialOrd>(a: T, b: T) -> T {
     }
 }
 
+/// Intermediate helper trait so we can have a single generic implementation
+/// This trait will ensure the specific dispatch works without complicating
+/// the trait bounds.
+trait QuantileDispatcher<K> {
+    fn _quantile(self, quantile: f64, interpol: QuantileInterpolOptions)
+        -> PolarsResult<Option<K>>;
+
+    fn _median(self) -> Option<K>;
+}
+
+impl<T> QuantileDispatcher<f64> for ChunkedArray<T>
+where
+    T: PolarsIntegerType,
+    T::Native: Ord,
+    ChunkedArray<T>: IntoSeries,
+{
+    fn _quantile(
+        self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Option<f64>> {
+        self.quantile_faster(quantile, interpol)
+    }
+    fn _median(self) -> Option<f64> {
+        self.median_faster()
+    }
+}
+
+impl QuantileDispatcher<f32> for Float32Chunked {
+    fn _quantile(
+        self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Option<f32>> {
+        self.quantile_faster(quantile, interpol)
+    }
+    fn _median(self) -> Option<f32> {
+        self.median_faster()
+    }
+}
+impl QuantileDispatcher<f64> for Float64Chunked {
+    fn _quantile(
+        self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Option<f64>> {
+        self.quantile_faster(quantile, interpol)
+    }
+    fn _median(self) -> Option<f64> {
+        self.median_faster()
+    }
+}
+
+unsafe fn agg_quantile_generic<T, K>(
+    ca: &ChunkedArray<T>,
+    groups: &GroupsProxy,
+    quantile: f64,
+    interpol: QuantileInterpolOptions,
+) -> Series
+where
+    T: PolarsNumericType,
+    ChunkedArray<T>: QuantileDispatcher<K::Native>,
+    ChunkedArray<K>: IntoSeries,
+    K: PolarsNumericType,
+{
+    let invalid_quantile = !(0.0..=1.0).contains(&quantile);
+    if invalid_quantile {
+        return Series::full_null(ca.name(), groups.len(), ca.dtype());
+    }
+    match groups {
+        GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<K, _>(groups, |idx| {
+            debug_assert!(idx.len() <= ca.len());
+            if idx.is_empty() {
+                return None;
+            }
+            let take = { ca.take_unchecked(idx.into()) };
+            // checked with invalid quantile check
+            take._quantile(quantile, interpol).unwrap_unchecked()
+        }),
+        GroupsProxy::Slice { groups, .. } => {
+            if _use_rolling_kernels(groups, ca.chunks()) {
+                let arr = ca.downcast_iter().next().unwrap();
+                let values = arr.values().as_slice();
+                let offset_iter = groups.iter().map(|[first, len]| (*first, *len));
+                let arr = match arr.validity() {
+                    None => rolling::no_nulls::rolling_quantile_by_iter(
+                        values,
+                        quantile,
+                        interpol,
+                        offset_iter,
+                    ),
+                    Some(validity) => rolling::nulls::rolling_quantile_by_iter(
+                        values,
+                        validity,
+                        quantile,
+                        interpol,
+                        offset_iter,
+                    ),
+                };
+                ChunkedArray::<K>::from_chunks("", vec![arr]).into_series()
+            } else {
+                _agg_helper_slice::<K, _>(groups, |[first, len]| {
+                    debug_assert!(first + len <= ca.len() as IdxSize);
+                    match len {
+                        0 => None,
+                        1 => ca.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                        _ => {
+                            let arr_group = _slice_from_offsets(ca, first, len);
+                            // unwrap checked with invalid quantile check
+                            arr_group
+                                ._quantile(quantile, interpol)
+                                .unwrap_unchecked()
+                                .map(|flt| NumCast::from(flt).unwrap_unchecked())
+                        }
+                    }
+                })
+            }
+        }
+    }
+}
+
+unsafe fn agg_median_generic<T, K>(ca: &ChunkedArray<T>, groups: &GroupsProxy) -> Series
+where
+    T: PolarsNumericType,
+    ChunkedArray<T>: QuantileDispatcher<K::Native>,
+    ChunkedArray<K>: IntoSeries,
+    K: PolarsNumericType,
+{
+    match groups {
+        GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<K, _>(groups, |idx| {
+            debug_assert!(idx.len() <= ca.len());
+            if idx.is_empty() {
+                return None;
+            }
+            let take = { ca.take_unchecked(idx.into()) };
+            take._median()
+        }),
+        GroupsProxy::Slice { .. } => {
+            agg_quantile_generic::<T, K>(ca, groups, 0.5, QuantileInterpolOptions::Linear)
+        }
+    }
+}
+
 impl<T> ChunkedArray<T>
 where
     T: PolarsNumericType + Sync,
@@ -857,84 +1000,32 @@ where
             }
         }
     }
+}
 
+impl Float32Chunked {
     pub(crate) unsafe fn agg_quantile(
         &self,
         groups: &GroupsProxy,
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Series {
-        let ca = &self.0;
-        let invalid_quantile = !(0.0..=1.0).contains(&quantile);
-        if invalid_quantile {
-            return Series::full_null(self.name(), groups.len(), self.dtype());
-        }
-        match groups {
-            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<T, _>(groups, |idx| {
-                debug_assert!(idx.len() <= ca.len());
-                if idx.is_empty() {
-                    return None;
-                }
-                let take = { ca.take_unchecked(idx.into()) };
-                // checked with invalid quantile check
-                take.quantile(quantile, interpol).unwrap_unchecked()
-            }),
-            GroupsProxy::Slice { groups, .. } => {
-                if _use_rolling_kernels(groups, self.chunks()) {
-                    let arr = self.downcast_iter().next().unwrap();
-                    let values = arr.values().as_slice();
-                    let offset_iter = groups.iter().map(|[first, len]| (*first, *len));
-                    let arr = match arr.validity() {
-                        None => rolling::no_nulls::rolling_quantile_by_iter(
-                            values,
-                            quantile,
-                            interpol,
-                            offset_iter,
-                        ),
-                        Some(validity) => rolling::nulls::rolling_quantile_by_iter(
-                            values,
-                            validity,
-                            quantile,
-                            interpol,
-                            offset_iter,
-                        ),
-                    };
-                    ChunkedArray::<T>::from_chunks("", vec![arr]).into_series()
-                } else {
-                    _agg_helper_slice::<T, _>(groups, |[first, len]| {
-                        debug_assert!(first + len <= self.len() as IdxSize);
-                        match len {
-                            0 => None,
-                            1 => self.get(first as usize),
-                            _ => {
-                                let arr_group = _slice_from_offsets(self, first, len);
-                                // unwrap checked with invalid quantile check
-                                arr_group
-                                    .quantile(quantile, interpol)
-                                    .unwrap_unchecked()
-                                    .map(|flt| NumCast::from(flt).unwrap())
-                            }
-                        }
-                    })
-                }
-            }
-        }
+        agg_quantile_generic::<_, Float32Type>(self, groups, quantile, interpol)
     }
     pub(crate) unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
-        let ca = &self.0;
-        match groups {
-            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<T, _>(groups, |idx| {
-                debug_assert!(idx.len() <= ca.len());
-                if idx.is_empty() {
-                    return None;
-                }
-                let take = { ca.take_unchecked(idx.into()) };
-                take.median()
-            }),
-            GroupsProxy::Slice { .. } => {
-                self.agg_quantile(groups, 0.5, QuantileInterpolOptions::Linear)
-            }
-        }
+        agg_median_generic::<_, Float32Type>(self, groups)
+    }
+}
+impl Float64Chunked {
+    pub(crate) unsafe fn agg_quantile(
+        &self,
+        groups: &GroupsProxy,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> Series {
+        agg_quantile_generic::<_, Float64Type>(self, groups, quantile, interpol)
+    }
+    pub(crate) unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
+        agg_median_generic::<_, Float64Type>(self, groups)
     }
 }
 
@@ -1097,74 +1188,10 @@ where
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> Series {
-        let invalid_quantile = !(0.0..=1.0).contains(&quantile);
-        if invalid_quantile {
-            return Series::full_null(self.name(), groups.len(), self.dtype());
-        }
-        match groups {
-            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<Float64Type, _>(groups, |idx| {
-                debug_assert!(idx.len() <= self.len());
-                if idx.is_empty() {
-                    return None;
-                }
-                let take = self.take_unchecked(idx.into());
-                take.quantile_faster(quantile, interpol).unwrap_unchecked() // checked with invalid quantile check
-            }),
-            GroupsProxy::Slice {
-                groups: groups_slice,
-                ..
-            } => {
-                if _use_rolling_kernels(groups_slice, self.chunks()) {
-                    let ca = self.cast(&DataType::Float64).unwrap();
-                    ca.agg_quantile(groups, quantile, interpol)
-                } else {
-                    _agg_helper_slice::<Float64Type, _>(groups_slice, |[first, len]| {
-                        debug_assert!(len <= self.len() as IdxSize);
-                        match len {
-                            0 => None,
-                            1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
-                            _ => {
-                                let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.quantile_faster(quantile, interpol).unwrap()
-                            }
-                        }
-                    })
-                }
-            }
-        }
+        agg_quantile_generic::<_, Float64Type>(self, groups, quantile, interpol)
     }
     pub(crate) unsafe fn agg_median(&self, groups: &GroupsProxy) -> Series {
-        match groups {
-            GroupsProxy::Idx(groups) => agg_helper_idx_on_all::<Float64Type, _>(groups, |idx| {
-                debug_assert!(idx.len() <= self.len());
-                if idx.is_empty() {
-                    return None;
-                }
-                let take = self.take_unchecked(idx.into());
-                take.median_faster()
-            }),
-            GroupsProxy::Slice {
-                groups: groups_slice,
-                ..
-            } => {
-                if _use_rolling_kernels(groups_slice, self.chunks()) {
-                    let ca = self.cast(&DataType::Float64).unwrap();
-                    ca.agg_median(groups)
-                } else {
-                    _agg_helper_slice::<Float64Type, _>(groups_slice, |[first, len]| {
-                        debug_assert!(len <= self.len() as IdxSize);
-                        match len {
-                            0 => None,
-                            1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
-                            _ => {
-                                let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.median_faster()
-                            }
-                        }
-                    })
-                }
-            }
-        }
+        agg_median_generic::<_, Float64Type>(self, groups)
     }
 }
 

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -520,6 +520,9 @@ where
         }),
         GroupsProxy::Slice { groups, .. } => {
             if _use_rolling_kernels(groups, ca.chunks()) {
+                // this cast is a no-op for floats
+                let s = ca.cast(&K::get_dtype()).unwrap();
+                let ca: &ChunkedArray<K> = s.as_ref().as_ref();
                 let arr = ca.downcast_iter().next().unwrap();
                 let values = arr.values().as_slice();
                 let offset_iter = groups.iter().map(|[first, len]| (*first, *len));
@@ -538,6 +541,8 @@ where
                         offset_iter,
                     ),
                 };
+                // the rolling kernels works on the dtype, this is not yet the float
+                // output type we need.
                 ChunkedArray::<K>::from_chunks("", vec![arr]).into_series()
             } else {
                 _agg_helper_slice::<K, _>(groups, |[first, len]| {

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -1108,7 +1108,7 @@ where
                     return None;
                 }
                 let take = self.take_unchecked(idx.into());
-                take.quantile(quantile, interpol).unwrap_unchecked() // checked with invalid quantile check
+                take.quantile_faster(quantile, interpol).unwrap_unchecked() // checked with invalid quantile check
             }),
             GroupsProxy::Slice {
                 groups: groups_slice,
@@ -1125,7 +1125,7 @@ where
                             1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.quantile(quantile, interpol).unwrap()
+                                arr_group.quantile_faster(quantile, interpol).unwrap()
                             }
                         }
                     })
@@ -1141,7 +1141,7 @@ where
                     return None;
                 }
                 let take = self.take_unchecked(idx.into());
-                take.median()
+                take.median_faster()
             }),
             GroupsProxy::Slice {
                 groups: groups_slice,
@@ -1158,7 +1158,7 @@ where
                             1 => self.get(first as usize).map(|v| NumCast::from(v).unwrap()),
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.median()
+                                arr_group.median_faster()
                             }
                         }
                     })

--- a/polars/polars-utils/src/slice.rs
+++ b/polars/polars-utils/src/slice.rs
@@ -1,4 +1,22 @@
 use core::slice::SliceIndex;
+use std::cmp::Ordering;
+
+pub trait Extrema<T> {
+    fn min_value(&self) -> Option<&T>;
+    fn max_value(&self) -> Option<&T>;
+}
+
+impl<T: PartialOrd> Extrema<T> for [T] {
+    fn min_value(&self) -> Option<&T> {
+        self.iter()
+            .min_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+    }
+
+    fn max_value(&self) -> Option<&T> {
+        self.iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))
+    }
+}
 
 pub trait GetSaferUnchecked<T> {
     /// # Safety

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -964,18 +964,6 @@ def test_repeat() -> None:
     assert s.len() == 5
 
 
-def test_median() -> None:
-    s = pl.Series([1, 2, 3])
-    assert s.median() == 2
-
-
-def test_quantile() -> None:
-    s = pl.Series([1, 2, 3])
-    assert s.quantile(0.5, "nearest") == 2
-    assert s.quantile(0.5, "lower") == 2
-    assert s.quantile(0.5, "higher") == 2
-
-
 def test_shape() -> None:
     s = pl.Series([1, 2, 3])
     assert s.shape == (3,)


### PR DESCRIPTION
If there are no null values we will now use `quickselect` instead first completely sorting the array. This is faster and single threaded! 

This means that doing `quantile` computation in the groupby operation will have much less thread contention and will likely be much faster. 

Another large speedup is that when a groupby materializes the group for the `quantile` computation it elides a full memcpy of all the data.

closes #6565
