### PR TITLE
test(python): Fail tests on warning

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -25,7 +25,7 @@ from polars.internals.expr.list import ExprListNameSpace
 from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
-from polars.internals.type_aliases import PolarsExprType, PythonLiteral
+from polars.internals.type_aliases import PythonLiteral
 from polars.utils import (
     _timedelta_to_pl_duration,
     deprecate_nonkeyword_arguments,

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -157,6 +157,8 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 addopts = [
+  "--strict-config",
+  "--strict-markers",
   "--import-mode=importlib",
   # Default to running fast tests only. To run ALL tests, run: pytest -m ""
   "-m not slow and not hypothesis and not benchmark",
@@ -165,6 +167,7 @@ markers = [
   "slow: Tests with a longer than average runtime.",
   "benchmark: Tests that should be run on a Polars release build.",
 ]
+filterwarnings = "error" # Fail on warnings
 
 [tool.coverage.run]
 source = ["polars"]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1641,7 +1641,7 @@ def test_arg_sort() -> None:
     assert_series_equal(s.arg_sort(), expected)
 
     expected_reverse = pl.Series("a", [0, 2, 1, 4, 3], dtype=UInt32)
-    assert_series_equal(s.arg_sort(True), expected_reverse)
+    assert_series_equal(s.arg_sort(reverse=True), expected_reverse)
 
 
 def test_arg_min_and_arg_max() -> None:


### PR DESCRIPTION
Some DeprecationWarnings slip into our tests every now and then. Better to just fail the tests when this happens, then this can be addressed before making it to the `master` branch.

For reference, expected DeprecationWarnings can be addressed by using `with pytest.deprecated_call()`.
You can also use `filterwarnings` either per test or on the config level, for example if a new pandas version adds a FutureWarning.

For more, see the [pytest docs](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#:~:text=Disabling%20warnings%20summary,from%20the%20test%20run%20output.).