### PR TITLE
feat(python): restore dataframe class

### DIFF
--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -119,7 +119,9 @@ class HTMLFormatter:
         self.elements.append(inner)
 
     def render(self) -> list[str]:
-        with Tag(self.elements, "table", {"border": "1", "class": "pl-dataframe"}):
+        with Tag(
+            self.elements, "table", {"border": "1", "class": "dataframe pl-dataframe"}
+        ):
             self.write_header()
             self.write_body()
         return self.elements


### PR DESCRIPTION
Via our discord we heard that #6534 made formatting much uglier in `quarto`. This class is likely used by many tools as many tools integrate with pandas and I don't expect anyone to search for  `pl-dataframe` yet. 

This allows us to piggy back on pandas integration. We like nice tables for free. :)