### PR TITLE
Use read() for StringIO & BytesIO

### DIFF
--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -96,11 +96,11 @@ def _prepare_file_arg(
             return BytesIO(file)
 
     if isinstance(file, StringIO):
-        return BytesIO(file.getvalue().encode("utf8"))
+        return BytesIO(file.read().encode("utf8"))
 
     if isinstance(file, BytesIO):
         if has_non_utf8_non_utf8_lossy_encoding:
-            return BytesIO(file.getvalue().decode(encoding_str).encode("utf8"))
+            return BytesIO(file.read().decode(encoding_str).encode("utf8"))
         return managed_file(file)
 
     if isinstance(file, Path):

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -175,6 +175,7 @@ def test_csv_missing_utf8_is_empty_string() -> None:
         (None, None, None, None, None, None, None),
     ]
 
+    f.seek(0)
     df = pl.read_csv(
         f,
         null_values=["na", r"\N"],
@@ -369,6 +370,7 @@ def test_read_csv_encoding() -> None:
         bytesio = io.BytesIO(bts)
 
         for use_pyarrow in (False, True):
+            bytesio.seek(0)
             for file in [file_path, file_str, bts, bytesio]:
                 assert_series_equal(
                     pl.read_csv(
@@ -981,6 +983,7 @@ def test_skip_rows_different_field_len() -> None:
         )
     )
     for empty_string, missing_value in ((True, ""), (False, None)):
+        csv.seek(0)
         assert pl.read_csv(
             csv, skip_rows_after_header=2, missing_utf8_is_empty_string=empty_string
         ).to_dict(False) == {


### PR DESCRIPTION
Use read() for when processing StringIO and BytesIO arguments in _prepare_file_arg(), instead of using getvalue(). This makes Polars skip any characters/bytes that have already been read from the stream.