### PR TITLE
refactor(python): Consistently parse column name inputs

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1213,7 +1213,7 @@ class Expr:
 
     def drop_nulls(self) -> Self:
         """
-        Drop null values.
+        Drop all null values.
 
         Warnings
         --------

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -33,7 +33,10 @@ if TYPE_CHECKING:
 
 
 def get_dummies(
-    df: pli.DataFrame, *, columns: list[str] | None = None, separator: str = "_"
+    df: pli.DataFrame,
+    *,
+    columns: str | Sequence[str] | None = None,
+    separator: str = "_",
 ) -> pli.DataFrame:
     """
     Convert categorical variables into dummy/indicator variables.
@@ -43,8 +46,8 @@ def get_dummies(
     df
         DataFrame to convert.
     columns
-        A subset of columns to convert to dummy variables. ``None`` means
-        "all columns".
+        Name of the column(s) that should be converted to dummy variables.
+        If set to ``None`` (default), convert all columns.
     separator
         Separator/delimiter used when generating column names.
 

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2708,15 +2708,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
-    def drop(self, columns: str | list[str]) -> Self:
+    def drop(self, columns: str | Sequence[str]) -> Self:
         """
-        Remove one or multiple columns from a DataFrame.
+        Remove columns from the dataframe.
 
         Parameters
         ----------
         columns
-            - Name of the column that should be removed.
-            - List of column names.
+            Name of the column(s) that should be removed from the dataframe.
 
         Examples
         --------
@@ -3556,11 +3555,16 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
 
     def explode(
-        self,
-        columns: str | Sequence[str] | pli.Expr | Sequence[pli.Expr],
+        self, columns: str | Sequence[str] | pli.Expr | Sequence[pli.Expr]
     ) -> Self:
         """
-        Explode lists to long format.
+        Explode the dataframe to long format by exploding the given columns.
+
+        Parameters
+        ----------
+        columns
+            Name of the column(s) to explode. Columns must be of datatype List or Utf8.
+            Accepts ``col`` expressions as input as well.
 
         Examples
         --------
@@ -3604,7 +3608,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         keep: UniqueKeepStrategy = "first",
     ) -> Self:
         """
-        Drop duplicate rows from this DataFrame.
+        Drop duplicate rows from this dataframe.
 
         Parameters
         ----------
@@ -3612,8 +3616,8 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             Keep the same order as the original DataFrame. This is more expensive to
             compute.
         subset
-            Columns to consider for identifying duplicates. Defaults to using all
-            columns.
+            Column name(s) to consider when identifying duplicates.
+            If set to ``None`` (default), use all columns.
         keep : {'first', 'last', 'none'}
             Which of the duplicate rows to keep.
 
@@ -3668,22 +3672,21 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         └─────┴─────┴─────┘
 
         """
-        if subset is not None:
-            if isinstance(subset, str):
-                subset = [subset]
-            elif not isinstance(subset, list):
-                subset = list(subset)
-
+        if isinstance(subset, str):
+            subset = [subset]
         return self._from_pyldf(self._ldf.unique(maintain_order, subset, keep))
 
-    def drop_nulls(self, subset: list[str] | str | None = None) -> Self:
+    def drop_nulls(self, subset: str | Sequence[str] | None = None) -> Self:
         """
-        Return a new LazyFrame where rows with null values are dropped.
+        Drop all rows that contain null values.
+
+        Returns a new LazyFrame.
 
         Parameters
         ----------
         subset
-            Subset of column(s) for which null values are considered.
+            Column name(s) for which null values are considered.
+            If set to ``None`` (default), use all columns.
 
         Examples
         --------
@@ -3745,7 +3748,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         └──────┴─────┴──────┘
 
         """
-        if subset is not None and not isinstance(subset, list):
+        if isinstance(subset, str):
             subset = [subset]
         return self._from_pyldf(self._ldf.drop_nulls(subset))
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1087,7 +1087,11 @@ class Series:
         """Compute the exponential, element-wise."""
 
     def drop_nulls(self) -> Series:
-        """Create a new Series that copies data from this Series without null values."""
+        """
+        Drop all null values.
+
+        Creates a new Series that copies data from this Series without null values.
+        """
 
     def drop_nans(self) -> Series:
         """Drop NaN values."""
@@ -1381,7 +1385,7 @@ class Series:
     @deprecate_nonkeyword_arguments()
     def to_dummies(self, separator: str = "_") -> pli.DataFrame:
         """
-        Get dummy variables.
+        Get dummy/indicator variables.
 
         Parameters
         ----------

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -932,19 +932,6 @@ impl PyDataFrame {
         Ok(PySeries { series: s })
     }
 
-    pub fn drop_nulls(&self, subset: Option<Vec<String>>) -> PyResult<Self> {
-        let df = self
-            .df
-            .drop_nulls(subset.as_ref().map(|s| s.as_ref()))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
-    }
-
-    pub fn drop(&self, name: &str) -> PyResult<Self> {
-        let df = self.df.drop(name).map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
-    }
-
     pub fn select_at_idx(&self, idx: usize) -> Option<PySeries> {
         self.df.select_at_idx(idx).map(|s| PySeries::new(s.clone()))
     }
@@ -1162,25 +1149,6 @@ impl PyDataFrame {
 
     pub fn shift(&self, periods: i64) -> Self {
         self.df.shift(periods).into()
-    }
-
-    #[pyo3(signature = (maintain_order, subset, keep))]
-    pub fn unique(
-        &self,
-        py: Python,
-        maintain_order: bool,
-        subset: Option<Vec<String>>,
-        keep: Wrap<UniqueKeepStrategy>,
-    ) -> PyResult<Self> {
-        let df = py.allow_threads(|| {
-            let subset = subset.as_ref().map(|v| v.as_ref());
-            match maintain_order {
-                true => self.df.unique_stable(subset, keep.0),
-                false => self.df.unique(subset, keep.0),
-            }
-            .map_err(PyPolarsErr::from)
-        })?;
-        Ok(df.into())
     }
 
     pub fn lazy(&self) -> PyLazyFrame {


### PR DESCRIPTION
Changes:
* Dispatch the following DataFrame methods to the LazyFrame equivalent:
  * drop_nulls
  * drop
  * unique
* Make sure all methods that specify a column name or list of column names are handled consistently:
  * Similar type hints
  * Similar parsing
  * Similar docstring description
