### PR TITLE
refactor(python): refactor `datelike` as `temporal`, and support Time dtype in `Series.to_numpy`

### DIFF
--- a/py-polars/docs/source/reference/series/descriptive.rst
+++ b/py-polars/docs/source/reference/series/descriptive.rst
@@ -11,7 +11,6 @@ Descriptive
     Series.estimated_size
     Series.has_validity
     Series.is_boolean
-    Series.is_datelike
     Series.is_duplicated
     Series.is_empty
     Series.is_finite
@@ -25,6 +24,7 @@ Descriptive
     Series.is_null
     Series.is_numeric
     Series.is_sorted
+    Series.is_temporal
     Series.is_unique
     Series.is_utf8
     Series.len


### PR DESCRIPTION
The Series method `is_datelike` is somewhat misleading, as neither Time nor Duration _are_ actually date-like, only Datetime and Date are. All four types are, however, _temporal_ (as the TEMPORAL_DTYPES `pl.datatypes` group would suggest).

## Update

* Used the `@redirect` facility to smoothly deprecate `is_datelike` in favour of `is_temporal`.
* Added a few lines to support use of Time dtype with `to_numpy` (plus test coverage).
* Renamed `test_datelike` to `test_temporal`.

----

FYI: this also brings things a little more in-sync with Rust, which already has an `is_temporal` fn:
```rust
  /// Check if this [`DataType`] is a temporal type
  pub fn is_temporal(&self) -> bool {
      use DataType::*;
      matches!(self, Date | Datetime(_, _) | Duration(_) | Time)
  }
```