### PR TITLE
feat(python): Parse JSON data in `Utf8` to polars dtype

### DIFF
--- a/py-polars/docs/source/reference/expressions/strings.rst
+++ b/py-polars/docs/source/reference/expressions/strings.rst
@@ -18,6 +18,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.explode
     Expr.str.extract
     Expr.str.extract_all
+    Expr.str.json_extract
     Expr.str.json_path_match
     Expr.str.lengths
     Expr.str.ljust

--- a/py-polars/docs/source/reference/series/strings.rst
+++ b/py-polars/docs/source/reference/series/strings.rst
@@ -18,6 +18,7 @@ The following methods are available under the `Series.str` attribute.
     Series.str.explode
     Series.str.extract
     Series.str.extract_all
+    Series.str.json_extract
     Series.str.json_path_match
     Series.str.lengths
     Series.str.ljust

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import PolarsTemporalType
+from polars.datatypes import PolarsDataType, PolarsTemporalType
 from polars.internals.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
@@ -315,6 +315,37 @@ class StringNameSpace:
             "626172"
             null
         ]
+
+        """
+
+    def json_extract(self, dtype: PolarsDataType | None = None) -> pli.Series:
+        """
+        Parse string values as JSON.
+
+        Throw errors if encounter invalid JSON strings.
+
+        Parameters
+        ----------
+        dtype
+            The dtype to cast the extracted value to. If None, the dtype will be
+            inferred from the JSON value.
+
+        Examples
+        --------
+        >>> s = pl.Series("json", ['{"a":1, "b": true}', None, '{"a":2, "b": false}'])
+        >>> s.str.json_extract()
+        shape: (3,)
+        Series: 'json' [struct[2]]
+        [
+                {1,true}
+                {null,null}
+                {2,false}
+        ]
+
+        See Also
+        --------
+        json_path_match : Extract the first match of json string with provided JSONPath
+            expression.
 
         """
 


### PR DESCRIPTION
I was looking for a native replacement for a simple `apply(json.loads)` UDF that also worked well on lazy frames. I saw `str.json_path_match` but I really wanted a parsed struct (or whatever dtype) back, not a string value.

It looks like some initial work on this started back in #3413 and got partially exposed in #5140. A private [`Utf8Chunked.json_extract`](https://github.com/pola-rs/polars/blob/c4ec824c5715971a587fadf778c8c9f1114949df/polars/polars-ops/src/chunked_array/strings/json_path.rs#L70-L85) helper was added, but it never was fully exposed publicly on the Py Series or Expr APIs. So this PR exposes it.

The API optionally supports dtype inference on eager frames and series. When used on a lazy frame, the default _unknown_ dtype will properly lead to an error. Additionally, a nice feature over `apply(json.loads)` is that a partial dtype can be supplied to omit struct keys you're not interested in decoding. Seems to be a nice property of using `read_ndjson` under the hood.

How does the name `json_extract` still sound? That's the existing name of the internal function so just went with it. `parse_json` might have been my first instinct, but deferring to the maintainers preference. 