### PR TITLE
refactor(python): unify constructor logic when initialising from a sequence of dicts

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -7,8 +7,8 @@ from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
+from polars.exceptions import NoDataError
 from polars.internals import DataFrame, Series
-from polars.internals.construction import _unpack_schema, include_unknowns
 from polars.utils import deprecated_alias
 
 if TYPE_CHECKING:
@@ -161,15 +161,14 @@ def from_dicts(
     └─────┴─────┴──────┴──────┘
 
     """
-    column_names, schema = _unpack_schema(
-        schema, schema_overrides=schema_overrides, include_overrides_in_columns=True
-    )
-    schema = include_unknowns(schema, column_names or list(schema))
-    return DataFrame._from_dicts(
-        dicts,
-        infer_schema_length,
-        schema=(column_names and schema),
+    if not dicts and not (schema or schema_overrides):
+        raise NoDataError("No rows. Cannot infer schema.")
+
+    return DataFrame(
+        data=dicts,
+        schema=schema,
         schema_overrides=schema_overrides,
+        infer_schema_length=infer_schema_length,
     )
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -789,12 +789,15 @@ def sequence_to_pydf(
         column_names, schema_overrides = _unpack_schema(
             schema, schema_overrides=schema_overrides
         )
-        dtypes = (
-            include_unknowns(schema_overrides, column_names)
+        dicts_schema = (
+            include_unknowns(schema_overrides, column_names or list(schema_overrides))
             if schema_overrides and column_names
             else None
         )
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length, dtypes)
+        pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
+
+        if column_names and set(column_names).intersection(pydf.columns()):
+            column_names = None
         if column_names or schema_overrides:
             pydf = _post_apply_columns(
                 pydf,

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -168,8 +168,8 @@ class DataFrame:
     Parameters
     ----------
     data : dict, Sequence, ndarray, Series, or pandas.DataFrame
-        Two-dimensional data in various forms. dict must contain Sequences.
-        Sequence may contain Series or other Sequences.
+        Two-dimensional data in various forms; dict input must contain Sequences,
+        Generators, or a ``range``. Sequence may contain Series or other Sequences.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 


### PR DESCRIPTION
We have two methods for initialising from dicts:

* `DataFrame( dicts )`
* `pl.from_dicts( dicts )`

The calls have now been unified (one just calls the other internally now) so that we don't have redundant/copied logic. 

This also largely closes #6876, as it makes the behaviour of nested schema consistent between the two methods; each method had one edge-case that was covered by the other - now the two methods are unified, each edge-case is covered by both.

All unit tests for both methods continue to pass without requiring any changes.