### PR TITLE
fix(python): prevent external modules found on `PYTHONPATH` from bleeding into polars `venv`

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -1,5 +1,6 @@
 .DEFAULT_GOAL := help
 
+PYTHONPATH=
 SHELL=/bin/bash
 VENV = venv
 


### PR DESCRIPTION
Minor `Makefile` update that properly isolates the polars `venv` from arbitrary modules found in the system/user PYTHONPATH (this was causing havoc on one of my systems where I had some wildly different package versioning requirements; this one-liner completely fixes it).