### PR TITLE
chore(python): Update Cargo.lock

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "ahash",
  "bincode",


### PR DESCRIPTION
Would be nice if this could be done together with bumping the version in `Cargo.toml` when creating a new release.