### PR TITLE
chore(rust): avoid unnecessary mut

### DIFF
--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -37,7 +37,7 @@ where
         if self.header {
             write_impl::write_header(&mut self.buffer, &names, &self.options)?;
         }
-        write_impl::write(&mut self.buffer, df, self.batch_size, &mut self.options)
+        write_impl::write(&mut self.buffer, df, self.batch_size, &self.options)
     }
 }
 

--- a/polars/polars-io/src/csv/write_impl.rs
+++ b/polars/polars-io/src/csv/write_impl.rs
@@ -178,7 +178,7 @@ pub(crate) fn write<W: Write>(
     writer: &mut W,
     df: &DataFrame,
     chunk_size: usize,
-    options: &mut SerializeOptions,
+    options: &SerializeOptions,
 ) -> PolarsResult<()> {
     for s in df.get_columns() {
         let nested = match s.dtype() {


### PR DESCRIPTION
`write` no longer modifies `options.datetime_format`