### PR TITLE
feat(python): More ergonomic `sort` args

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -132,8 +132,6 @@ if TYPE_CHECKING:
         ParallelStrategy,
         ParquetCompression,
         PivotAgg,
-        PolarsExprType,
-        PythonLiteral,
         RollingInterpolationMethod,
         SizeUnit,
         StartBy,
@@ -3060,71 +3058,99 @@ class DataFrame:
 
     def sort(
         self,
-        by: str | pli.Expr | Sequence[str] | Sequence[pli.Expr],
-        *,
-        reverse: bool | list[bool] = False,
+        by: IntoExpr | Iterable[IntoExpr],
+        *more_by: IntoExpr,
+        reverse: bool | Sequence[bool] = False,
         nulls_last: bool = False,
     ) -> Self:
         """
-        Sort the DataFrame by column.
+        Sort the dataframe by the given columns.
 
         Parameters
         ----------
         by
-            By which column to sort. Only accepts string.
+            Column(s) to sort by. Accepts expression input. Strings are parsed as column
+            names.
+        *more_by
+            Additional columns to sort by, specified as positional arguments.
         reverse
-            Reverse/descending sort.
+            Sort in descending order. When sorting by multiple columns, can be specified
+            per column by passing a sequence of booleans.
         nulls_last
-            Place null values last. Can only be used if sorted by a single column.
+            Place null values last. Can only be used when sorting by a single column.
 
         Examples
         --------
+        Pass a single column name to sort by that column.
+
         >>> df = pl.DataFrame(
         ...     {
-        ...         "foo": [1, 2, 3],
-        ...         "bar": [6.0, 7.0, 8.0],
-        ...         "ham": ["a", "b", "c"],
+        ...         "a": [1, 2, None],
+        ...         "b": [6.0, 5.0, 4.0],
+        ...         "c": ["a", "c", "b"],
         ...     }
         ... )
-        >>> df.sort("foo", reverse=True)
+        >>> df.sort("a")
         shape: (3, 3)
-        ┌─────┬─────┬─────┐
-        │ foo ┆ bar ┆ ham │
-        │ --- ┆ --- ┆ --- │
-        │ i64 ┆ f64 ┆ str │
-        ╞═════╪═════╪═════╡
-        │ 3   ┆ 8.0 ┆ c   │
-        │ 2   ┆ 7.0 ┆ b   │
-        │ 1   ┆ 6.0 ┆ a   │
-        └─────┴─────┴─────┘
+        ┌──────┬─────┬─────┐
+        │ a    ┆ b   ┆ c   │
+        │ ---  ┆ --- ┆ --- │
+        │ i64  ┆ f64 ┆ str │
+        ╞══════╪═════╪═════╡
+        │ null ┆ 4.0 ┆ b   │
+        │ 1    ┆ 6.0 ┆ a   │
+        │ 2    ┆ 5.0 ┆ c   │
+        └──────┴─────┴─────┘
 
-        **Sort by multiple columns.**
-        For multiple columns we can also use expression syntax.
+        Sorting by expressions is also supported.
 
-        >>> df.sort(
-        ...     [pl.col("foo"), pl.col("bar") ** 2],
-        ...     reverse=[True, False],
-        ... )
+        >>> df.sort(pl.col("a") + pl.col("b") * 2, nulls_last=True)
         shape: (3, 3)
-        ┌─────┬─────┬─────┐
-        │ foo ┆ bar ┆ ham │
-        │ --- ┆ --- ┆ --- │
-        │ i64 ┆ f64 ┆ str │
-        ╞═════╪═════╪═════╡
-        │ 3   ┆ 8.0 ┆ c   │
-        │ 2   ┆ 7.0 ┆ b   │
-        │ 1   ┆ 6.0 ┆ a   │
-        └─────┴─────┴─────┘
+        ┌──────┬─────┬─────┐
+        │ a    ┆ b   ┆ c   │
+        │ ---  ┆ --- ┆ --- │
+        │ i64  ┆ f64 ┆ str │
+        ╞══════╪═════╪═════╡
+        │ 2    ┆ 5.0 ┆ c   │
+        │ 1    ┆ 6.0 ┆ a   │
+        │ null ┆ 4.0 ┆ b   │
+        └──────┴─────┴─────┘
+
+        Sort by multiple columns by passing a list of columns.
+
+        >>> df.sort(["c", "a"], reverse=True)
+        shape: (3, 3)
+        ┌──────┬─────┬─────┐
+        │ a    ┆ b   ┆ c   │
+        │ ---  ┆ --- ┆ --- │
+        │ i64  ┆ f64 ┆ str │
+        ╞══════╪═════╪═════╡
+        │ 2    ┆ 5.0 ┆ c   │
+        │ null ┆ 4.0 ┆ b   │
+        │ 1    ┆ 6.0 ┆ a   │
+        └──────┴─────┴─────┘
+
+        Or use positional arguments to sort by multiple columns in the same way.
+
+        >>> df.sort("c", "a", reverse=[False, True])
+        shape: (3, 3)
+        ┌──────┬─────┬─────┐
+        │ a    ┆ b   ┆ c   │
+        │ ---  ┆ --- ┆ --- │
+        │ i64  ┆ f64 ┆ str │
+        ╞══════╪═════╪═════╡
+        │ 1    ┆ 6.0 ┆ a   │
+        │ null ┆ 4.0 ┆ b   │
+        │ 2    ┆ 5.0 ┆ c   │
+        └──────┴─────┴─────┘
 
         """
-        if not isinstance(by, str) and isinstance(by, (Sequence, pli.Expr)):
-            df = (
-                self.lazy()
-                .sort(by, reverse=reverse, nulls_last=nulls_last)
-                .collect(no_optimization=True)
-            )
-            return self._from_pydf(df._df)
-        return self._from_pydf(self._df.sort(by, reverse, nulls_last))
+        return self._from_pydf(
+            self.lazy()
+            .sort(by, *more_by, reverse=reverse, nulls_last=nulls_last)
+            .collect(no_optimization=True)
+            ._df
+        )
 
     def frame_equal(self, other: DataFrame, null_equal: bool = True) -> bool:
         """
@@ -5731,16 +5757,9 @@ class DataFrame:
 
     def select(
         self,
-        exprs: (
-            str
-            | PolarsExprType
-            | PythonLiteral
-            | pli.Series
-            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
-            | None
-        ) = None,
-        *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
-        **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+        exprs: IntoExpr | Iterable[IntoExpr] | None = None,
+        *more_exprs: IntoExpr,
+        **named_exprs: IntoExpr,
     ) -> Self:
         """
         Select columns from this DataFrame.
@@ -5748,8 +5767,8 @@ class DataFrame:
         Parameters
         ----------
         exprs
-            Column or columns to select. Accepts expression input. Strings are parsed
-            as column names, other non-expression inputs are parsed as literals.
+            Column(s) to select. Accepts expression input. Strings are parsed as column
+            names, other non-expression inputs are parsed as literals.
         *more_exprs
             Additional columns to select, specified as positional arguments.
         **named_exprs

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars.internals as pli
+from polars.utils import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
@@ -123,9 +124,15 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_mean())
 
+    @deprecate_nonkeyword_arguments()
     def sort(self, reverse: bool = False) -> pli.Expr:
         """
-        Sort the arrays in the list.
+        Sort the arrays in this column.
+
+        Parameters
+        ----------
+        reverse
+            Sort in descending order.
 
         Examples
         --------
@@ -143,6 +150,16 @@ class ExprListNameSpace:
         ╞═══════════╡
         │ [1, 2, 3] │
         │ [1, 2, 9] │
+        └───────────┘
+        >>> df.select(pl.col("a").arr.sort(reverse=True))
+        shape: (2, 1)
+        ┌───────────┐
+        │ a         │
+        │ ---       │
+        │ list[i64] │
+        ╞═══════════╡
+        │ [3, 2, 1] │
+        │ [9, 2, 1] │
         └───────────┘
 
         """

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
+from polars.utils import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
@@ -49,8 +50,41 @@ class ListNameSpace:
     def mean(self) -> pli.Series:
         """Compute the mean value of the arrays in the list."""
 
+    @deprecate_nonkeyword_arguments()
     def sort(self, reverse: bool = False) -> pli.Series:
-        """Sort the arrays in the list."""
+        """
+        Sort the arrays in this column.
+
+        Parameters
+        ----------
+        reverse
+            Sort in descending order.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]])
+        >>> s.arr.sort()
+        shape: (2,)
+        Series: 'a' [list[i64]]
+        [
+                [1, 2, 3]
+                [1, 2, 9]
+        ]
+        >>> s.arr.sort(reverse=True)
+        shape: (2,)
+        Series: 'a' [list[i64]]
+        [
+                [3, 2, 1]
+                [9, 2, 1]
+        ]
+
+        """
+        return (
+            pli.wrap_s(self._s)
+            .to_frame()
+            .select(pli.col(self._s.name()).arr.sort(reverse=reverse))
+            .to_series()
+        )
 
     def reverse(self) -> pli.Series:
         """Reverse the arrays in the list."""

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1921,16 +1921,17 @@ class Series:
 
         """
 
-    def sort(self, reverse: bool = False, *, in_place: bool = False) -> Series:
+    @deprecate_nonkeyword_arguments()
+    def sort(self, reverse: bool = False, *, in_place: bool = False) -> Self:
         """
         Sort this Series.
 
         Parameters
         ----------
         reverse
-            Reverse sort.
+            Sort in descending order.
         in_place
-            Sort in place.
+            Sort in-place.
 
         Examples
         --------
@@ -1959,7 +1960,7 @@ class Series:
             self._s = self._s.sort(reverse)
             return self
         else:
-            return wrap_s(self._s.sort(reverse))
+            return self._from_pyseries(self._s.sort(reverse))
 
     def top_k(self, k: int = 5, reverse: bool = False) -> Series:
         r"""

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -967,21 +967,6 @@ impl PyDataFrame {
         Ok(PyDataFrame::new(df))
     }
 
-    pub fn sort(&self, by_column: &str, reverse: bool, nulls_last: bool) -> PyResult<Self> {
-        let df = self
-            .df
-            .sort_with_options(
-                by_column,
-                SortOptions {
-                    descending: reverse,
-                    nulls_last,
-                    multithreaded: true,
-                },
-            )
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
-    }
-
     pub fn replace(&mut self, column: &str, new_col: PySeries) -> PyResult<()> {
         self.df
             .replace(column, new_col.series)

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -417,14 +417,15 @@ impl PyLazyFrame {
 
     pub fn sort_by_exprs(
         &self,
-        by_column: Vec<PyExpr>,
+        by: Vec<PyExpr>,
         reverse: Vec<bool>,
         nulls_last: bool,
     ) -> PyLazyFrame {
         let ldf = self.ldf.clone();
-        let exprs = py_exprs_to_exprs(by_column);
+        let exprs = py_exprs_to_exprs(by);
         ldf.sort_by_exprs(exprs, reverse, nulls_last).into()
     }
+
     pub fn cache(&self) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         ldf.cache().into()


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/6451

Update docstrings and type hints for the following methods:
* `DataFrame.sort`
* `LazyFrame.sort`
* `Series.sort`
* `Expr.sort`
* `Expr.sort_by`
* `Series.arr.sort`
* `Expr.arr.sort`

Other changes:
* Dispatch `DataFrame.sort` to `LazyFrame.sort`
* Clean up argument parsing logic
* Add `*args` option for DataFrame/Lazyframe.sort and Expr.sort_by + add some tests
* Make `reverse` keyword-only everywhere (using the deprecation util)
* Raise an error when `nulls_last` is supplied while sorting by multiple arguments