### PR TITLE
fix(python): fix regression with `date` => `object` typing in `to_pandas` method

### DIFF
--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -479,29 +479,34 @@ def test_to_pandas() -> None:
         {
             "a": [1, 2, 3],
             "b": [6, None, 8],
-            "c": [date(2023, 7, 5), None, date(1999, 12, 13)],
-            "d": ["a", "b", "c"],
-            "e": [None, "e", "f"],
-        }
+            "c": [10.0, 25.0, 50.5],
+            "d": [date(2023, 7, 5), None, date(1999, 12, 13)],
+            "e": ["a", "b", "c"],
+            "f": [None, "e", "f"],
+            "g": [datetime.now(), datetime.now(), None],
+        },
+        schema_overrides={"a": pl.UInt8},
     ).with_columns(
         [
-            pl.col("d").cast(pl.Categorical).alias("f"),
-            pl.col("e").cast(pl.Categorical).alias("g"),
+            pl.col("e").cast(pl.Categorical).alias("h"),
+            pl.col("f").cast(pl.Categorical).alias("i"),
         ]
     )
     pd_out = df.to_pandas()
     pd_out_dtypes_expected = [
-        np.int64,
+        np.uint8,
+        np.float64,
         np.float64,
         np.dtype("datetime64[ns]"),
         np.object_,
         np.object_,
+        np.dtype("datetime64[ns]"),
         pd.CategoricalDtype(categories=["a", "b", "c"], ordered=False),
         pd.CategoricalDtype(categories=["e", "f"], ordered=False),
     ]
     assert pd_out_dtypes_expected == pd_out.dtypes.to_list()
 
-    pd_out_dtypes_expected[2] = np.dtype("O")
+    pd_out_dtypes_expected[3] = np.dtype("O")
     pd_out = df.to_pandas(date_as_object=True)
     assert pd_out_dtypes_expected == pd_out.dtypes.to_list()
 
@@ -509,11 +514,13 @@ def test_to_pandas() -> None:
         pd_pa_out = df.to_pandas(use_pyarrow_extension_array=True)
         pd_pa_dtypes_names = [dtype.name for dtype in pd_pa_out.dtypes]
         pd_pa_dtypes_names_expected = [
+            "uint8[pyarrow]",
             "int64[pyarrow]",
-            "int64[pyarrow]",
+            "double[pyarrow]",
             "date32[day][pyarrow]",
             "large_string[pyarrow]",
             "large_string[pyarrow]",
+            "timestamp[us][pyarrow]",
             "dictionary<values=large_string, indices=int64, ordered=0>[pyarrow]",
             "dictionary<values=large_string, indices=int64, ordered=0>[pyarrow]",
         ]

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, cast, no_type_check
 
 import numpy as np
@@ -476,24 +476,34 @@ def test_cat_to_pandas() -> None:
 
 def test_to_pandas() -> None:
     df = pl.DataFrame(
-        {"a": [1, 2, 3], "b": [6, None, 8], "c": ["a", "b", "c"], "d": [None, "e", "f"]}
-    )
-    df = df.with_columns(
+        {
+            "a": [1, 2, 3],
+            "b": [6, None, 8],
+            "c": [date(2023, 7, 5), None, date(1999, 12, 13)],
+            "d": ["a", "b", "c"],
+            "e": [None, "e", "f"],
+        }
+    ).with_columns(
         [
-            pl.col("c").cast(pl.Categorical).alias("e"),
             pl.col("d").cast(pl.Categorical).alias("f"),
+            pl.col("e").cast(pl.Categorical).alias("g"),
         ]
     )
     pd_out = df.to_pandas()
     pd_out_dtypes_expected = [
         np.int64,
         np.float64,
+        np.dtype("datetime64[ns]"),
         np.object_,
         np.object_,
         pd.CategoricalDtype(categories=["a", "b", "c"], ordered=False),
         pd.CategoricalDtype(categories=["e", "f"], ordered=False),
     ]
-    assert pd_out.dtypes.to_list() == pd_out_dtypes_expected
+    assert pd_out_dtypes_expected == pd_out.dtypes.to_list()
+
+    pd_out_dtypes_expected[2] = np.dtype("O")
+    pd_out = df.to_pandas(date_as_object=True)
+    assert pd_out_dtypes_expected == pd_out.dtypes.to_list()
 
     try:
         pd_pa_out = df.to_pandas(use_pyarrow_extension_array=True)
@@ -501,6 +511,7 @@ def test_to_pandas() -> None:
         pd_pa_dtypes_names_expected = [
             "int64[pyarrow]",
             "int64[pyarrow]",
+            "date32[day][pyarrow]",
             "large_string[pyarrow]",
             "large_string[pyarrow]",
             "dictionary<values=large_string, indices=int64, ordered=0>[pyarrow]",
@@ -547,6 +558,7 @@ def test_from_empty_pandas_with_dtypes() -> None:
             "e": pl.Utf8,
         },
     ).to_pandas()
+
     assert pl.from_pandas(df).dtypes == [
         pl.Int32,
         pl.Datetime,


### PR DESCRIPTION
Closes #6900.

The default behaviour of `date_as_object` was inadvertently changed in #6756, and we didn't have any test coverage that would have spotted it... Have fixed the regression, cleaned it up a little, and extended coverage to additional dtypes.

(By chance I was already working on a fix, as this hit us at work today... ;)