### PR TITLE
refactor(rust, python): Rename kwarg reverse to descending

### DIFF
--- a/polars/polars-arrow/src/kernels/sort_partition.rs
+++ b/polars/polars-arrow/src/kernels/sort_partition.rs
@@ -5,13 +5,13 @@ use arrow::types::NativeType;
 use crate::index::IdxSize;
 
 /// Find partition indexes such that every partition contains unique groups.
-fn find_partition_points<T>(values: &[T], n: usize, reverse: bool) -> Vec<usize>
+fn find_partition_points<T>(values: &[T], n: usize, descending: bool) -> Vec<usize>
 where
     T: Debug + NativeType + PartialOrd,
 {
     let len = values.len();
     if n > len {
-        return find_partition_points(values, len / 2, reverse);
+        return find_partition_points(values, len / 2, descending);
     }
     if n < 2 {
         return vec![];
@@ -31,7 +31,7 @@ where
         let part = &values[start_idx..end_idx];
 
         let latest_val = values[end_idx];
-        let idx = if reverse {
+        let idx = if descending {
             part.partition_point(|v| *v > latest_val)
         } else {
             part.partition_point(|v| *v < latest_val)
@@ -46,11 +46,11 @@ where
     partition_points
 }
 
-pub fn create_clean_partitions<T>(values: &[T], n: usize, reverse: bool) -> Vec<&[T]>
+pub fn create_clean_partitions<T>(values: &[T], n: usize, descending: bool) -> Vec<&[T]>
 where
     T: Debug + NativeType + PartialOrd,
 {
-    let part_idx = find_partition_points(values, n, reverse);
+    let part_idx = find_partition_points(values, n, descending);
     let mut out = Vec::with_capacity(n + 1);
 
     let mut start_idx = 0_usize;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -158,11 +158,11 @@ bitflags! {
 }}
 
 impl<T: PolarsDataType> ChunkedArray<T> {
-    pub(crate) fn is_sorted_flag(&self) -> bool {
+    pub(crate) fn is_sorted_ascending_flag(&self) -> bool {
         self.bit_settings.contains(Settings::SORTED_ASC)
     }
 
-    pub(crate) fn is_sorted_reverse_flag(&self) -> bool {
+    pub(crate) fn is_sorted_descending_flag(&self) -> bool {
         self.bit_settings.contains(Settings::SORTED_DSC)
     }
 
@@ -171,9 +171,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     pub fn is_sorted_flag2(&self) -> IsSorted {
-        if self.is_sorted_flag() {
+        if self.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.is_sorted_reverse_flag() {
+        } else if self.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not
@@ -188,15 +188,15 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     .remove(Settings::SORTED_ASC | Settings::SORTED_DSC);
             }
             IsSorted::Ascending => {
-                // // unset reverse sorted
+                // // unset descending sorted
                 self.bit_settings.remove(Settings::SORTED_DSC);
-                // set sorted
+                // set ascending sorted
                 self.bit_settings.insert(Settings::SORTED_ASC)
             }
             IsSorted::Descending => {
-                // unset sorted
+                // unset ascending sorted
                 self.bit_settings.remove(Settings::SORTED_ASC);
-                // set reverse sorted
+                // set descending sorted
                 self.bit_settings.insert(Settings::SORTED_DSC)
             }
         }
@@ -648,7 +648,7 @@ pub(crate) mod test {
         let a = a.sort(false);
         let b = a.into_iter().collect::<Vec<_>>();
         assert_eq!(b, [Some("a"), Some("b"), Some("c")]);
-        assert_eq!(a.is_sorted_flag(), true);
+        assert_eq!(a.is_sorted_ascending_flag(), true);
     }
 
     #[test]

--- a/polars/polars-core/src/chunked_array/ops/aggregate/quantile.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/quantile.rs
@@ -192,7 +192,7 @@ where
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_flag()) {
+        if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_ascending_flag()) {
             let mut owned = slice.to_vec();
             quantile_slice(&mut owned, quantile, interpol)
         } else {
@@ -217,7 +217,7 @@ where
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        let is_sorted = self.is_sorted_flag();
+        let is_sorted = self.is_sorted_ascending_flag();
         if let (Some(slice), false) = (self.cont_slice_mut(), is_sorted) {
             quantile_slice(slice, quantile, interpol)
         } else {
@@ -238,7 +238,7 @@ impl ChunkQuantile<f32> for Float32Chunked {
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f32>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        let out = if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_flag()) {
+        let out = if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_ascending_flag()) {
             let mut owned = slice.to_vec();
             let owned = f32_to_ordablef32(&mut owned);
             quantile_slice(owned, quantile, interpol)
@@ -260,7 +260,7 @@ impl ChunkQuantile<f64> for Float64Chunked {
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_flag()) {
+        if let (Ok(slice), false) = (self.cont_slice(), self.is_sorted_ascending_flag()) {
             let mut owned = slice.to_vec();
             let owned = f64_to_ordablef64(&mut owned);
             quantile_slice(owned, quantile, interpol)
@@ -281,7 +281,7 @@ impl Float64Chunked {
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f64>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        let is_sorted = self.is_sorted_flag();
+        let is_sorted = self.is_sorted_ascending_flag();
         if let (Some(slice), false) = (self.cont_slice_mut(), is_sorted) {
             let slice = f64_to_ordablef64(slice);
             quantile_slice(slice, quantile, interpol)
@@ -303,7 +303,7 @@ impl Float32Chunked {
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Option<f32>> {
         // in case of sorted data, the sort is free, so don't take quickselect route
-        let is_sorted = self.is_sorted_flag();
+        let is_sorted = self.is_sorted_ascending_flag();
         if let (Some(slice), false) = (self.cont_slice_mut(), is_sorted) {
             let slice = f32_to_ordablef32(slice);
             quantile_slice(slice, quantile, interpol).map(|v| v.map(|v| v as f32))

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -493,13 +493,13 @@ pub trait ChunkSort<T: PolarsDataType> {
     fn sort_with(&self, options: SortOptions) -> ChunkedArray<T>;
 
     /// Returned a sorted `ChunkedArray`.
-    fn sort(&self, reverse: bool) -> ChunkedArray<T>;
+    fn sort(&self, descending: bool) -> ChunkedArray<T>;
 
     /// Retrieve the indexes needed to sort this array.
     fn arg_sort(&self, options: SortOptions) -> IdxCa;
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    fn arg_sort_multiple(&self, _other: &[Series], _reverse: &[bool]) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(&self, _other: &[Series], _descending: &[bool]) -> PolarsResult<IdxCa> {
         Err(PolarsError::InvalidOperation(
             "arg_sort_multiple not implemented for this dtype".into(),
         ))

--- a/polars/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -1,12 +1,12 @@
 use super::*;
 
 #[inline]
-fn default_order<T: PartialOrd + IsFloat>(a: &(IdxSize, T), b: &(IdxSize, T)) -> Ordering {
+fn ascending_order<T: PartialOrd + IsFloat>(a: &(IdxSize, T), b: &(IdxSize, T)) -> Ordering {
     compare_fn_nan_max(&a.1, &b.1)
 }
 
 #[inline]
-fn reverse_order<T: PartialOrd + IsFloat>(a: &(IdxSize, T), b: &(IdxSize, T)) -> Ordering {
+fn descending_order<T: PartialOrd + IsFloat>(a: &(IdxSize, T), b: &(IdxSize, T)) -> Ordering {
     compare_fn_nan_max(&b.1, &a.1)
 }
 
@@ -22,14 +22,14 @@ where
     J: IntoIterator<Item = Option<T>>,
     T: PartialOrd + Send + Sync + IsFloat,
 {
-    let reverse = options.descending;
+    let descending = options.descending;
     let nulls_last = options.nulls_last;
 
     let mut vals = Vec::with_capacity(len - null_count);
 
-    // if we sort reverse, the nulls are last
-    // and need to be extended to the indices in reverse order
-    let null_cap = if reverse || nulls_last {
+    // if we sort descending, the nulls are last
+    // and need to be extended to the indices in descending order
+    let null_cap = if descending || nulls_last {
         null_count
         // if we sort normally, the nulls are first
         // and can be extended with the sorted indices
@@ -58,14 +58,14 @@ where
 
     arg_sort_branch(
         vals.as_mut_slice(),
-        reverse,
-        default_order,
-        reverse_order,
+        descending,
+        ascending_order,
+        descending_order,
         options.multithreaded,
     );
 
     let iter = vals.into_iter().map(|(idx, _v)| idx);
-    let idx = if reverse || nulls_last {
+    let idx = if descending || nulls_last {
         let mut idx = Vec::with_capacity(len);
         idx.extend(iter);
         idx.extend(nulls_idx.into_iter().rev());

--- a/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -5,47 +5,52 @@ use super::*;
 pub(crate) fn args_validate<T: PolarsDataType>(
     ca: &ChunkedArray<T>,
     other: &[Series],
-    reverse: &[bool],
+    descending: &[bool],
 ) -> PolarsResult<()> {
     for s in other {
         assert_eq!(ca.len(), s.len());
     }
-    if other.len() != (reverse.len() - 1) {
+    if other.len() != (descending.len() - 1) {
         return Err(PolarsError::ComputeError(
             format!(
                 "The amount of ordering booleans: {} does not match that no. of Series: {}",
-                reverse.len(),
+                descending.len(),
                 other.len() + 1
             )
             .into(),
         ));
     }
 
-    assert_eq!(other.len(), reverse.len() - 1);
+    assert_eq!(other.len(), descending.len() - 1);
     Ok(())
 }
 
 pub(crate) fn arg_sort_multiple_impl<T: PartialOrd + Send + IsFloat + Copy>(
     mut vals: Vec<(IdxSize, T)>,
     other: &[Series],
-    reverse: &[bool],
+    descending: &[bool],
 ) -> PolarsResult<IdxCa> {
-    assert_eq!(reverse.len() - 1, other.len());
+    assert_eq!(descending.len() - 1, other.len());
     let compare_inner: Vec<_> = other
         .iter()
         .map(|s| s.into_partial_ord_inner())
         .collect_trusted();
 
-    let first_reverse = reverse[0];
+    let first_descending = descending[0];
     vals.par_sort_by(|tpl_a, tpl_b| {
-        match (first_reverse, compare_fn_nan_max(&tpl_a.1, &tpl_b.1)) {
+        match (first_descending, compare_fn_nan_max(&tpl_a.1, &tpl_b.1)) {
             // if ordering is equal, we check the other arrays until we find a non-equal ordering
             // if we have exhausted all arrays, we keep the equal ordering.
             (_, Ordering::Equal) => {
                 let idx_a = tpl_a.0 as usize;
                 let idx_b = tpl_b.0 as usize;
                 unsafe {
-                    ordering_other_columns(&compare_inner, reverse.get_unchecked(1..), idx_a, idx_b)
+                    ordering_other_columns(
+                        &compare_inner,
+                        descending.get_unchecked(1..),
+                        idx_a,
+                        idx_b,
+                    )
                 }
             }
             (true, Ordering::Less) => Ordering::Greater,

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -104,7 +104,8 @@ where
 
         let n_threads = POOL.current_num_threads();
         let groups = if multithreaded && n_threads > 1 {
-            let parts = create_clean_partitions(values, n_threads, self.is_sorted_reverse_flag());
+            let parts =
+                create_clean_partitions(values, n_threads, self.is_sorted_descending_flag());
             let n_parts = parts.len();
 
             let first_ptr = &values[0] as *const T::Native as usize;
@@ -152,7 +153,9 @@ where
 {
     fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
         // sorted path
-        if self.is_sorted_flag() || self.is_sorted_reverse_flag() && self.chunks().len() == 1 {
+        if self.is_sorted_ascending_flag()
+            || self.is_sorted_descending_flag() && self.chunks().len() == 1
+        {
             // don't have to pass `sorted` arg, GroupSlice is always sorted.
             return Ok(GroupsProxy::Slice {
                 groups: self.create_groups_from_sorted(multithreaded),

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -207,7 +207,7 @@ pub fn _sort_or_hash_inner(
         }
         (IsSorted::Ascending, _) if is_numeric && size_factor_rhs < size_factor_acceptable => {
             if verbose {
-                eprintln!("right key will be reverse sorted in inner join operation.")
+                eprintln!("right key will be descending sorted in inner join operation.")
             }
 
             let sort_idx = s_right.arg_sort(SortOptions {
@@ -231,7 +231,7 @@ pub fn _sort_or_hash_inner(
         }
         (_, IsSorted::Ascending) if is_numeric && size_factor_lhs < size_factor_acceptable => {
             if verbose {
-                eprintln!("left key will be reverse sorted in inner join operation.")
+                eprintln!("left key will be descending sorted in inner join operation.")
             }
 
             let sort_idx = s_left.arg_sort(SortOptions {
@@ -251,7 +251,7 @@ pub fn _sort_or_hash_inner(
                 });
             });
 
-            // set sorted to `false` as we reverse sorted the left key.
+            // set sorted to `false` as we descending sorted the left key.
             ((left, right), false)
         }
         _ => s_left.hash_join_inner(s_right),

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -99,19 +99,19 @@ where
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
-pub fn arg_sort_by(by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-    if by.len() != reverse.len() {
+pub fn arg_sort_by(by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+    if by.len() != descending.len() {
         return Err(PolarsError::ComputeError(
             format!(
                 "The amount of ordering booleans: {} does not match amount of Series: {}",
-                reverse.len(),
+                descending.len(),
                 by.len()
             )
             .into(),
         ));
     }
-    let (first, by, reverse) = prepare_arg_sort(by.to_vec(), reverse.to_vec()).unwrap();
-    first.arg_sort_multiple(&by, &reverse)
+    let (first, by, descending) = prepare_arg_sort(by.to_vec(), descending.to_vec()).unwrap();
+    first.arg_sort_multiple(&by, &descending)
 }
 
 // utility to be able to also add literals to concat_str function

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -89,16 +89,16 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<BinaryChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_flag() {
+        if self.0.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.is_sorted_reverse_flag() {
+        } else if self.0.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not
@@ -194,7 +194,9 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
 
         let mut out = ChunkTake::take_unchecked(&self.0, (&*idx).into());
 
-        if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag()) {
+        if self.0.is_sorted_ascending_flag()
+            && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
+        {
             out.set_sorted_flag(idx.is_sorted_flag2())
         }
 

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -100,16 +100,16 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_flag() {
+        if self.0.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.is_sorted_reverse_flag() {
+        } else if self.0.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -140,16 +140,16 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.logical().is_sorted_flag() {
+        if self.0.logical().is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.logical().is_sorted_reverse_flag() {
+        } else if self.0.logical().is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -173,16 +173,16 @@ macro_rules! impl_dyn_series {
                 self.0.group_tuples(multithreaded, sorted)
             }
             #[cfg(feature = "sort_multiple")]
-            fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.deref().arg_sort_multiple(by, reverse)
+            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+                self.0.deref().arg_sort_multiple(by, descending)
             }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
             fn is_sorted_flag(&self) -> IsSorted {
-                if self.0.is_sorted_flag() {
+                if self.0.is_sorted_ascending_flag() {
                     IsSorted::Ascending
-                } else if self.0.is_sorted_reverse_flag() {
+                } else if self.0.is_sorted_descending_flag() {
                     IsSorted::Descending
                 } else {
                     IsSorted::Not
@@ -292,7 +292,8 @@ macro_rules! impl_dyn_series {
             unsafe fn take_unchecked(&self, idx: &IdxCa) -> PolarsResult<Series> {
                 let mut out = ChunkTake::take_unchecked(self.0.deref(), idx.into());
 
-                if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag())
+                if self.0.is_sorted_ascending_flag()
+                    && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
                 {
                     out.set_sorted_flag(idx.is_sorted_flag2())
                 }

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -173,16 +173,16 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_flag() {
+        if self.0.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.is_sorted_reverse_flag() {
+        } else if self.0.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not
@@ -298,7 +298,9 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     unsafe fn take_unchecked(&self, idx: &IdxCa) -> PolarsResult<Series> {
         let mut out = ChunkTake::take_unchecked(self.0.deref(), idx.into());
 
-        if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag()) {
+        if self.0.is_sorted_ascending_flag()
+            && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
+        {
             out.set_sorted_flag(idx.is_sorted_flag2())
         }
 

--- a/polars/polars-core/src/series/implementations/decimal.rs
+++ b/polars/polars-core/src/series/implementations/decimal.rs
@@ -102,7 +102,9 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
     unsafe fn take_unchecked(&self, idx: &IdxCa) -> PolarsResult<Series> {
         let mut out = ChunkTake::take_unchecked(self.0.deref(), idx.into());
 
-        if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag()) {
+        if self.0.is_sorted_ascending_flag()
+            && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
+        {
             out.set_sorted_flag(idx.is_sorted_flag2())
         }
 

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -199,16 +199,16 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_flag() {
+        if self.0.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.is_sorted_reverse_flag() {
+        } else if self.0.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not
@@ -317,7 +317,9 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     unsafe fn take_unchecked(&self, idx: &IdxCa) -> PolarsResult<Series> {
         let mut out = ChunkTake::take_unchecked(self.0.deref(), idx.into());
 
-        if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag()) {
+        if self.0.is_sorted_ascending_flag()
+            && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
+        {
             out.set_sorted_flag(idx.is_sorted_flag2())
         }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -139,16 +139,16 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "sort_multiple")]
-            fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(by, reverse)
+            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(by, descending)
             }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
             fn is_sorted_flag(&self) -> IsSorted {
-                if self.0.is_sorted_flag() {
+                if self.0.is_sorted_ascending_flag() {
                     IsSorted::Ascending
-                } else if self.0.is_sorted_reverse_flag() {
+                } else if self.0.is_sorted_descending_flag() {
                     IsSorted::Descending
                 } else {
                     IsSorted::Not
@@ -260,7 +260,8 @@ macro_rules! impl_dyn_series {
 
                 let mut out = ChunkTake::take_unchecked(&self.0, (&*idx).into());
 
-                if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag())
+                if self.0.is_sorted_ascending_flag()
+                    && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
                 {
                     out.set_sorted_flag(idx.is_sorted_flag2())
                 }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -203,16 +203,16 @@ macro_rules! impl_dyn_series {
             }
 
             #[cfg(feature = "sort_multiple")]
-            fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(by, reverse)
+            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(by, descending)
             }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
             fn is_sorted_flag(&self) -> IsSorted {
-                if self.0.is_sorted_flag() {
+                if self.0.is_sorted_ascending_flag() {
                     IsSorted::Ascending
-                } else if self.0.is_sorted_reverse_flag() {
+                } else if self.0.is_sorted_descending_flag() {
                     IsSorted::Descending
                 } else {
                     IsSorted::Not
@@ -352,7 +352,8 @@ macro_rules! impl_dyn_series {
                     Cow::Borrowed(idx)
                 };
                 let mut out = ChunkTake::take_unchecked(&self.0, (&*idx).into());
-                if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag())
+                if self.0.is_sorted_ascending_flag()
+                    && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
                 {
                     out.set_sorted_flag(idx.is_sorted_flag2())
                 }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -97,16 +97,16 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     }
 
     #[cfg(feature = "sort_multiple")]
-    fn arg_sort_multiple(&self, by: &[Series], reverse: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, reverse)
+    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, descending)
     }
 }
 
 impl SeriesTrait for SeriesWrap<Utf8Chunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_flag() {
+        if self.0.is_sorted_ascending_flag() {
             IsSorted::Ascending
-        } else if self.0.is_sorted_reverse_flag() {
+        } else if self.0.is_sorted_descending_flag() {
             IsSorted::Descending
         } else {
             IsSorted::Not
@@ -202,7 +202,9 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
 
         let mut out = ChunkTake::take_unchecked(&self.0, (&*idx).into());
 
-        if self.0.is_sorted_flag() && (idx.is_sorted_flag() || idx.is_sorted_reverse_flag()) {
+        if self.0.is_sorted_ascending_flag()
+            && (idx.is_sorted_ascending_flag() || idx.is_sorted_descending_flag())
+        {
             out.set_sorted_flag(idx.is_sorted_flag2())
         }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -214,9 +214,9 @@ impl Series {
         Ok(self)
     }
 
-    pub fn sort(&self, reverse: bool) -> Self {
+    pub fn sort(&self, descending: bool) -> Self {
         self.sort_with(SortOptions {
-            descending: reverse,
+            descending,
             ..Default::default()
         })
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -178,7 +178,7 @@ pub(crate) mod private {
             invalid_operation_panic!(self)
         }
         #[cfg(feature = "sort_multiple")]
-        fn arg_sort_multiple(&self, _by: &[Series], _reverse: &[bool]) -> PolarsResult<IdxCa> {
+        fn arg_sort_multiple(&self, _by: &[Series], _descending: &[bool]) -> PolarsResult<IdxCa> {
             Err(PolarsError::InvalidOperation(
                 "arg_sort_multiple is not implemented for this Series".into(),
             ))

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/source.rs
@@ -14,7 +14,7 @@ pub struct SortSource {
     files: std::vec::IntoIter<(u32, PathBuf)>,
     n_threads: usize,
     sort_idx: usize,
-    reverse: bool,
+    descending: bool,
     chunk_offset: IdxSize,
     slice: Option<(i64, usize)>,
     finished: bool,
@@ -35,7 +35,7 @@ impl SortSource {
     pub(super) fn new(
         mut files: Vec<(u32, PathBuf)>,
         sort_idx: usize,
-        reverse: bool,
+        descending: bool,
         slice: Option<(i64, usize)>,
         partitions: Series,
     ) -> Self {
@@ -48,7 +48,7 @@ impl SortSource {
             files,
             n_threads,
             sort_idx,
-            reverse,
+            descending,
             chunk_offset: 0,
             slice,
             finished: false,
@@ -154,7 +154,7 @@ impl Source for SortSource {
                 // sort a single partition
                 let current_slice = self.slice;
                 let mut df = match &mut self.slice {
-                    None => sort_accumulated(df, self.sort_idx, self.reverse, None),
+                    None => sort_accumulated(df, self.sort_idx, self.descending, None),
                     Some((offset, len)) => {
                         let df_len = df.height();
                         assert!(*offset >= 0);
@@ -163,7 +163,7 @@ impl Source for SortSource {
                             Ok(df.slice(0, 0))
                         } else {
                             let out =
-                                sort_accumulated(df, self.sort_idx, self.reverse, current_slice);
+                                sort_accumulated(df, self.sort_idx, self.descending, current_slice);
                             *len = len.saturating_sub(df_len);
                             *offset = 0;
                             out

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -199,7 +199,7 @@ where
 
             let sort_sink = SortSink::new(
                 index,
-                args.reverse[0],
+                args.descending[0],
                 input_schema.into_owned(),
                 args.slice,
             );

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -309,7 +309,7 @@ pub enum Expr {
     SortBy {
         expr: Box<Expr>,
         by: Vec<Expr>,
-        reverse: Vec<bool>,
+        descending: Vec<bool>,
     },
     Agg(AggExpr),
     /// A ternary operation

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -102,7 +102,7 @@ pub enum FunctionExpr {
     #[cfg(feature = "top_k")]
     TopK {
         k: usize,
-        reverse: bool,
+        descending: bool,
     },
     Shift(i64),
     Reverse,
@@ -361,8 +361,8 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 }
             }
             #[cfg(feature = "top_k")]
-            TopK { k, reverse } => {
-                map!(top_k, k, reverse)
+            TopK { k, descending } => {
+                map!(top_k, k, descending)
             }
             Shift(periods) => map!(dispatch::shift, periods),
             Reverse => map!(dispatch::reverse),

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -233,10 +233,10 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> E
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
-pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, reverse: &[bool]) -> Expr {
-    let reverse = reverse.to_vec();
+pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
+    let descending = descending.to_vec();
     let function = SpecialEq::new(Arc::new(move |by: &mut [Series]| {
-        polars_core::functions::arg_sort_by(by, &reverse).map(|ca| Some(ca.into_series()))
+        polars_core::functions::arg_sort_by(by, &descending).map(|ca| Some(ca.into_series()))
     }) as Arc<dyn SeriesUdf>);
 
     Expr::AnonymousFunction {

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -592,11 +592,11 @@ impl Expr {
     }
 
     /// Sort in increasing order. See [the eager implementation](Series::sort).
-    pub fn sort(self, reverse: bool) -> Self {
+    pub fn sort(self, descending: bool) -> Self {
         Expr::Sort {
             expr: Box::new(self),
             options: SortOptions {
-                descending: reverse,
+                descending,
                 ..Default::default()
             },
         }
@@ -614,8 +614,8 @@ impl Expr {
     ///
     /// This has time complexity `O(n + k log(n))`.
     #[cfg(feature = "top_k")]
-    pub fn top_k(self, k: usize, reverse: bool) -> Self {
-        self.apply_private(FunctionExpr::TopK { k, reverse })
+    pub fn top_k(self, k: usize, descending: bool) -> Self {
+        self.apply_private(FunctionExpr::TopK { k, descending })
     }
 
     /// Reverse column
@@ -1231,14 +1231,14 @@ impl Expr {
     pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone, R: AsRef<[bool]>>(
         self,
         by: E,
-        reverse: R,
+        descending: R,
     ) -> Expr {
         let by = by.as_ref().iter().map(|e| e.clone().into()).collect();
-        let reverse = reverse.as_ref().to_vec();
+        let descending = descending.as_ref().to_vec();
         Expr::SortBy {
             expr: Box::new(self),
             by,
-            reverse,
+            descending,
         }
     }
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -69,7 +69,7 @@ pub enum AExpr {
     SortBy {
         expr: Node,
         by: Vec<Node>,
-        reverse: Vec<bool>,
+        descending: Vec<bool>,
     },
     Filter {
         input: Node,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -556,14 +556,14 @@ impl LogicalPlanBuilder {
         .into()
     }
 
-    pub fn sort(self, by_column: Vec<Expr>, reverse: Vec<bool>, null_last: bool) -> Self {
+    pub fn sort(self, by_column: Vec<Expr>, descending: Vec<bool>, null_last: bool) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
         let by_column = try_delayed!(rewrite_projections(by_column, &schema, &[]), &self.0, into);
         LogicalPlan::Sort {
             input: Box::new(self.0),
             by_column,
             args: SortArguments {
-                reverse,
+                descending,
                 nulls_last: null_last,
                 slice: None,
             },

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -39,10 +39,14 @@ pub fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             expr: to_aexpr(*expr, arena),
             options,
         },
-        Expr::SortBy { expr, by, reverse } => AExpr::SortBy {
+        Expr::SortBy {
+            expr,
+            by,
+            descending,
+        } => AExpr::SortBy {
             expr: to_aexpr(*expr, arena),
             by: by.into_iter().map(|e| to_aexpr(e, arena)).collect(),
-            reverse,
+            descending,
         },
         Expr::Filter { input, by } => AExpr::Filter {
             input: to_aexpr(*input, arena),
@@ -475,7 +479,11 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 idx: Box::new(idx),
             }
         }
-        AExpr::SortBy { expr, by, reverse } => {
+        AExpr::SortBy {
+            expr,
+            by,
+            descending,
+        } => {
             let expr = node_to_expr(expr, expr_arena);
             let by = by
                 .iter()
@@ -484,7 +492,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             Expr::SortBy {
                 expr: Box::new(expr),
                 by,
-                reverse,
+                descending,
             }
         }
         AExpr::Filter { input, by } => {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -306,8 +306,12 @@ impl fmt::Debug for Expr {
                 true => write!(f, "{expr:?} DESC"),
                 false => write!(f, "{expr:?} ASC"),
             },
-            SortBy { expr, by, reverse } => {
-                write!(f, "SORT {expr:?} BY {by:?} REVERSE ORDERING {reverse:?}",)
+            SortBy {
+                expr,
+                by,
+                descending,
+            } => {
+                write!(f, "SORT {expr:?} BY {by:?} REVERSE ORDERING {descending:?}",)
             }
             Filter { input, by } => {
                 write!(f, "{input:?}\nFILTER WHERE {by:?}")

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -610,10 +610,14 @@ impl OptimizationRule for SimplifyExprRule {
                             options,
                         })
                     }
-                    AExpr::SortBy { expr, by, reverse } => Some(AExpr::SortBy {
+                    AExpr::SortBy {
+                        expr,
+                        by,
+                        descending,
+                    } => Some(AExpr::SortBy {
                         expr: *expr,
                         by: by.clone(),
-                        reverse: reverse.iter().map(|r| !*r).collect(),
+                        descending: descending.iter().map(|r| !*r).collect(),
                     }),
                     // TODO: add support for cumsum and other operation that allow reversing.
                     _ => None,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
@@ -253,7 +253,7 @@ pub struct LogicalPlanUdfOptions {
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SortArguments {
-    pub reverse: Vec<bool>,
+    pub descending: Vec<bool>,
     // Can only be true in case of a single column.
     pub nulls_last: bool,
     pub slice: Option<(i64, usize)>,

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -206,13 +206,13 @@ impl LazyFrame {
     /// }
     /// ```
     pub fn sort(self, by_column: &str, options: SortOptions) -> Self {
-        let reverse = options.descending;
+        let descending = options.descending;
         let nulls_last = options.nulls_last;
 
         let opt_state = self.get_opt_state();
         let lp = self
             .get_plan_builder()
-            .sort(vec![col(by_column)], vec![reverse], nulls_last)
+            .sort(vec![col(by_column)], vec![descending], nulls_last)
             .build();
         Self::from_logical_plan(lp, opt_state)
     }
@@ -234,18 +234,18 @@ impl LazyFrame {
     pub fn sort_by_exprs<E: AsRef<[Expr]>, B: AsRef<[bool]>>(
         self,
         by_exprs: E,
-        reverse: B,
+        descending: B,
         nulls_last: bool,
     ) -> Self {
         let by_exprs = by_exprs.as_ref().to_vec();
-        let reverse = reverse.as_ref().to_vec();
+        let descending = descending.as_ref().to_vec();
         if by_exprs.is_empty() {
             self
         } else {
             let opt_state = self.get_opt_state();
             let lp = self
                 .get_plan_builder()
-                .sort(by_exprs, reverse, nulls_last)
+                .sort(by_exprs, descending, nulls_last)
                 .build();
             Self::from_logical_plan(lp, opt_state)
         }

--- a/polars/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/sort.rs
@@ -33,7 +33,7 @@ impl SortExec {
 
         df.sort_impl(
             by_columns,
-            std::mem::take(&mut self.args.reverse),
+            std::mem::take(&mut self.args.descending),
             self.args.nulls_last,
             self.args.slice,
             true,

--- a/polars/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/expr.rs
@@ -114,13 +114,17 @@ pub(crate) fn create_physical_expr(
                 expr: node_to_expr(expression, expr_arena),
             }))
         }
-        SortBy { expr, by, reverse } => {
+        SortBy {
+            expr,
+            by,
+            descending,
+        } => {
             let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema)?;
             let phys_by = create_physical_expressions(&by, ctxt, expr_arena, schema)?;
             Ok(Arc::new(SortByExpr::new(
                 phys_expr,
                 phys_by,
-                reverse,
+                descending,
                 node_to_expr(expression, expr_arena),
             )))
         }

--- a/polars/polars-ops/src/chunked_array/top_k.rs
+++ b/polars/polars-ops/src/chunked_array/top_k.rs
@@ -60,7 +60,7 @@ where
     Ok(out)
 }
 
-pub fn top_k(s: &Series, k: usize, reverse: bool) -> PolarsResult<Series> {
+pub fn top_k(s: &Series, k: usize, descending: bool) -> PolarsResult<Series> {
     if s.is_empty() {
         return Ok(s.clone());
     }
@@ -70,7 +70,7 @@ pub fn top_k(s: &Series, k: usize, reverse: bool) -> PolarsResult<Series> {
 
     macro_rules! dispatch {
         ($ca:expr) => {{
-            let mult_order = if reverse { -1 } else { 1 };
+            let mult_order = if descending { -1 } else { 1 };
             top_k_impl($ca, k, NumCast::from(mult_order).unwrap()).map(|ca| ca.into_series())
         }};
     }

--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -235,14 +235,14 @@ impl SQLContext {
 
     fn process_order_by(&self, lf: LazyFrame, ob: &[OrderByExpr]) -> PolarsResult<LazyFrame> {
         let mut by = Vec::with_capacity(ob.len());
-        let mut reverse = Vec::with_capacity(ob.len());
+        let mut descending = Vec::with_capacity(ob.len());
 
         for ob in ob {
             by.push(parse_sql_expr(&ob.expr)?);
             if let Some(false) = ob.asc {
-                reverse.push(true)
+                descending.push(true)
             } else {
-                reverse.push(false)
+                descending.push(false)
             }
 
             if ob.nulls_first.is_some() {
@@ -252,7 +252,7 @@ impl SQLContext {
             }
         }
 
-        Ok(lf.sort_by_exprs(&by, reverse, false))
+        Ok(lf.sort_by_exprs(&by, descending, false))
     }
 
     fn process_groupby(

--- a/polars/src/docs/eager.rs
+++ b/polars/src/docs/eager.rs
@@ -345,11 +345,11 @@
 //! // sort this DataFrame by multiple columns
 //!
 //! // ordering of the columns
-//! let reverse = vec![true, false];
+//! let descending = vec![true, false];
 //! // columns to sort by
 //! let by = &["b", "a"];
 //! // do the sort operation
-//! let sorted = df.sort(by, reverse)?;
+//! let sorted = df.sort(by, descending)?;
 //!
 //! // sorted:
 //!

--- a/polars/src/docs/lazy.rs
+++ b/polars/src/docs/lazy.rs
@@ -82,10 +82,10 @@
 //! // sort this DataFrame by multiple columns
 //!
 //! // ordering of the columns
-//! let reverse = vec![true, false];
+//! let descending = vec![true, false];
 //!
 //! let sorted = df.lazy()
-//!     .sort_by_exprs(vec![col("b"), col("a")], reverse, false)
+//!     .sort_by_exprs(vec![col("b"), col("a")], descending, false)
 //!     .collect()?;
 //!
 //! // sorted:

--- a/polars/tests/it/core/groupby.rs
+++ b/polars/tests/it/core/groupby.rs
@@ -31,7 +31,7 @@ fn test_sorted_groupby() -> PolarsResult<()> {
         assert_eq!(out.unwrap_slice(), &[[0, 3], [3, 2], [5, 1]]);
     }
 
-    // nulls first reverse sorted
+    // nulls first descending sorted
     let mut s = Series::new(
         "a",
         &[
@@ -51,7 +51,7 @@ fn test_sorted_groupby() -> PolarsResult<()> {
         assert_eq!(out.unwrap_slice(), &[[0, 2], [2, 2], [4, 3], [7, 1]]);
     }
 
-    // nulls last reverse sorted
+    // nulls last descending sorted
     let mut s = Series::new(
         "a",
         &[

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3054,11 +3054,12 @@ class DataFrame:
         self._df.replace_at_idx(index, series._s)
         return self
 
+    @deprecated_alias(reverse="descending")
     def sort(
         self,
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
-        reverse: bool | Sequence[bool] = False,
+        descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
     ) -> Self:
         """
@@ -3071,7 +3072,7 @@ class DataFrame:
             names.
         *more_by
             Additional columns to sort by, specified as positional arguments.
-        reverse
+        descending
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
@@ -3116,7 +3117,7 @@ class DataFrame:
 
         Sort by multiple columns by passing a list of columns.
 
-        >>> df.sort(["c", "a"], reverse=True)
+        >>> df.sort(["c", "a"], descending=True)
         shape: (3, 3)
         ┌──────┬─────┬─────┐
         │ a    ┆ b   ┆ c   │
@@ -3130,7 +3131,7 @@ class DataFrame:
 
         Or use positional arguments to sort by multiple columns in the same way.
 
-        >>> df.sort("c", "a", reverse=[False, True])
+        >>> df.sort("c", "a", descending=[False, True])
         shape: (3, 3)
         ┌──────┬─────┬─────┐
         │ a    ┆ b   ┆ c   │
@@ -3145,7 +3146,7 @@ class DataFrame:
         """
         return self._from_pydf(
             self.lazy()
-            .sort(by, *more_by, reverse=reverse, nulls_last=nulls_last)
+            .sort(by, *more_by, descending=descending, nulls_last=nulls_last)
             .collect(no_optimization=True)
             ._df
         )

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1694,8 +1694,9 @@ class Expr:
         dtype = py_type_to_dtype(dtype)
         return self._from_pyexpr(self._pyexpr.cast(dtype, strict))
 
+    @deprecated_alias(reverse="descending")
     @deprecate_nonkeyword_arguments()
-    def sort(self, reverse: bool = False, nulls_last: bool = False) -> Self:
+    def sort(self, descending: bool = False, nulls_last: bool = False) -> Self:
         """
         Sort this column.
 
@@ -1704,7 +1705,7 @@ class Expr:
 
         Parameters
         ----------
-        reverse
+        descending
             Sort in descending order.
         nulls_last
             Place null values last.
@@ -1728,7 +1729,7 @@ class Expr:
         │ 2    │
         │ 3    │
         └──────┘
-        >>> df.select(pl.col("a").sort(reverse=True))
+        >>> df.select(pl.col("a").sort(descending=True))
         shape: (4, 1)
         ┌──────┐
         │ a    │
@@ -1774,13 +1775,14 @@ class Expr:
         └───────┴────────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.sort_with(reverse, nulls_last))
+        return self._from_pyexpr(self._pyexpr.sort_with(descending, nulls_last))
 
-    def top_k(self, k: int = 5, reverse: bool = False) -> Self:
+    @deprecated_alias(reverse="descending")
+    def top_k(self, k: int = 5, descending: bool = False) -> Self:
         r"""
         Return the `k` largest elements.
 
-        If 'reverse=True` the smallest elements will be given.
+        If 'descending=True` the smallest elements will be given.
 
         This has time complexity:
 
@@ -1790,7 +1792,7 @@ class Expr:
         ----------
         k
             Number of elements to return.
-        reverse
+        descending
             Return the smallest elements.
 
         Examples
@@ -1803,7 +1805,7 @@ class Expr:
         >>> df.select(
         ...     [
         ...         pl.col("value").top_k().alias("top_k"),
-        ...         pl.col("value").top_k(reverse=True).alias("bottom_k"),
+        ...         pl.col("value").top_k(descending=True).alias("bottom_k"),
         ...     ]
         ... )
         shape: (5, 2)
@@ -1820,17 +1822,18 @@ class Expr:
         └───────┴──────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.top_k(k, reverse))
+        return self._from_pyexpr(self._pyexpr.top_k(k, descending))
 
+    @deprecated_alias(reverse="descending")
     @deprecate_nonkeyword_arguments()
-    def arg_sort(self, reverse: bool = False, nulls_last: bool = False) -> Self:
+    def arg_sort(self, descending: bool = False, nulls_last: bool = False) -> Self:
         """
         Get the index values that would sort this column.
 
         Parameters
         ----------
-        reverse
-            Sort in reverse (descending) order.
+        descending
+            Sort in descending (descending) order.
         nulls_last
             Place null values last instead of first.
 
@@ -1859,7 +1862,7 @@ class Expr:
         └─────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.arg_sort(reverse, nulls_last))
+        return self._from_pyexpr(self._pyexpr.arg_sort(descending, nulls_last))
 
     def arg_max(self) -> Self:
         """
@@ -1953,11 +1956,12 @@ class Expr:
         element = expr_to_lit_or_expr(element, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
 
+    @deprecated_alias(reverse="descending")
     def sort_by(
         self,
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
-        reverse: bool | Sequence[bool] = False,
+        descending: bool | Sequence[bool] = False,
     ) -> Self:
         """
         Sort this column by the ordering of other columns.
@@ -1972,7 +1976,7 @@ class Expr:
             names.
         *more_by
             Additional columns to sort by, specified as positional arguments.
-        reverse
+        descending
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
 
@@ -2017,7 +2021,7 @@ class Expr:
 
         Sort by multiple columns by passing a list of columns.
 
-        >>> df.select(pl.col("group").sort_by(["value1", "value2"], reverse=True))
+        >>> df.select(pl.col("group").sort_by(["value1", "value2"], descending=True))
         shape: (4, 1)
         ┌───────┐
         │ group │
@@ -2061,12 +2065,12 @@ class Expr:
         └───────┴───────────┘
 
         """
-        if isinstance(reverse, bool):
-            reverse = [reverse]
+        if isinstance(descending, bool):
+            descending = [descending]
         by = selection_to_pyexpr_list(by)
         if more_by:
             by.extend(pli.selection_to_pyexpr_list(more_by))
-        return self._from_pyexpr(self._pyexpr.sort_by(by, reverse))
+        return self._from_pyexpr(self._pyexpr.sort_by(by, descending))
 
     def take(
         self, indices: int | list[int] | Expr | pli.Series | np.ndarray[Any, Any]
@@ -4666,7 +4670,8 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.abs())
 
-    def argsort(self, reverse: bool = False, nulls_last: bool = False) -> Self:
+    @deprecated_alias(reverse="descending")
+    def argsort(self, descending: bool = False, nulls_last: bool = False) -> Self:
         """
         Get the index values that would sort this column.
 
@@ -4677,8 +4682,8 @@ class Expr:
 
         Parameters
         ----------
-        reverse
-            Sort in reverse (descending) order.
+        descending
+            Sort in descending order.
         nulls_last
             Place null values last instead of first.
 
@@ -4712,9 +4717,10 @@ class Expr:
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.arg_sort(reverse, nulls_last)
+        return self.arg_sort(descending, nulls_last)
 
-    def rank(self, method: RankMethod = "average", reverse: bool = False) -> Self:
+    @deprecated_alias(reverse="descending")
+    def rank(self, method: RankMethod = "average", descending: bool = False) -> Self:
         """
         Assign ranks to data, dealing with ties appropriately.
 
@@ -4738,8 +4744,8 @@ class Expr:
               the order that the values occur in the Series.
             - 'random' : Like 'ordinal', but the rank for ties is not dependent
               on the order that the values occur in the Series.
-        reverse
-            Reverse the operation.
+        descending
+            Rank in descending order.
 
         Examples
         --------
@@ -4778,7 +4784,7 @@ class Expr:
         └─────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.rank(method, reverse))
+        return self._from_pyexpr(self._pyexpr.rank(method, descending))
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Self:
         """
@@ -6054,7 +6060,8 @@ class Expr:
             self._pyexpr.cumulative_eval(expr._pyexpr, min_periods, parallel)
         )
 
-    def set_sorted(self, reverse: bool = False) -> Self:
+    @deprecated_alias(reverse="descending")
+    def set_sorted(self, descending: bool = False) -> Self:
         """
         Flags the expression as 'sorted'.
 
@@ -6062,8 +6069,8 @@ class Expr:
 
         Parameters
         ----------
-        reverse
-            If the `Series` order is reversed, e.g. descending.
+        descending
+            Whether the `Series` order is descending.
 
         Warnings
         --------
@@ -6084,7 +6091,7 @@ class Expr:
         └────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.set_sorted_flag(reverse))
+        return self._from_pyexpr(self._pyexpr.set_sorted_flag(descending))
 
     # Keep the `list` and `str` methods below at the end of the definition of Expr,
     # as to not confuse mypy with the type annotation `str` and `list`

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars.internals as pli
-from polars.utils import deprecate_nonkeyword_arguments
+from polars.utils import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
@@ -125,13 +125,14 @@ class ExprListNameSpace:
         return pli.wrap_expr(self._pyexpr.lst_mean())
 
     @deprecate_nonkeyword_arguments()
-    def sort(self, reverse: bool = False) -> pli.Expr:
+    @deprecated_alias(reverse="descending")
+    def sort(self, descending: bool = False) -> pli.Expr:
         """
         Sort the arrays in this column.
 
         Parameters
         ----------
-        reverse
+        descending
             Sort in descending order.
 
         Examples
@@ -163,7 +164,7 @@ class ExprListNameSpace:
         └───────────┘
 
         """
-        return pli.wrap_expr(self._pyexpr.lst_sort(reverse))
+        return pli.wrap_expr(self._pyexpr.lst_sort(descending))
 
     def reverse(self) -> pli.Expr:
         """

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, Iterable, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Categorical, Date, Float64, PolarsDataType
-from polars.utils import _datetime_to_pl_timestamp, _timedelta_to_pl_duration
+from polars.utils import (
+    _datetime_to_pl_timestamp,
+    _timedelta_to_pl_duration,
+    deprecated_alias,
+)
 
 if sys.version_info >= (3, 10):
     from typing import Literal
@@ -590,7 +594,7 @@ def align_frames(
     *frames: pli.DataFrame,
     on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
     select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-    reverse: bool | Sequence[bool] = False,
+    descending: bool | Sequence[bool] = False,
 ) -> list[pli.DataFrame]:
     ...
 
@@ -600,16 +604,17 @@ def align_frames(
     *frames: pli.LazyFrame,
     on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
     select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-    reverse: bool | Sequence[bool] = False,
+    descending: bool | Sequence[bool] = False,
 ) -> list[pli.LazyFrame]:
     ...
 
 
+@deprecated_alias(reverse="descending")
 def align_frames(
     *frames: pli.DataFrame | pli.LazyFrame,
     on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
     select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-    reverse: bool | Sequence[bool] = False,
+    descending: bool | Sequence[bool] = False,
 ) -> list[pli.DataFrame] | list[pli.LazyFrame]:
     r"""
     Align a sequence of frames using the unique values from one or more columns as a key.
@@ -633,7 +638,7 @@ def align_frames(
     select
         optional post-alignment column select to constrain and/or order
         the columns returned from the newly aligned frames.
-    reverse
+    descending
         sort the alignment column values in descending order; can be a single
         boolean or a list of booleans associated with each column in ``on``.
 
@@ -743,7 +748,7 @@ def align_frames(
     alignment_frame = (
         concat([df.lazy().select(on) for df in frames])
         .unique(maintain_order=False)
-        .sort(by=on, reverse=reverse)
+        .sort(by=on, descending=descending)
     )
     alignment_frame = (
         alignment_frame.collect().lazy() if eager else alignment_frame.cache()

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1886,10 +1886,11 @@ def arange(
         )
 
 
+@deprecated_alias(reverse="descending")
 @deprecate_nonkeyword_arguments()
 def arg_sort_by(
     exprs: pli.Expr | str | Sequence[pli.Expr | str],
-    reverse: Sequence[bool] | bool = False,
+    descending: Sequence[bool] | bool = False,
 ) -> pli.Expr:
     """
     Find the indexes that would sort the columns.
@@ -1902,21 +1903,22 @@ def arg_sort_by(
     ----------
     exprs
         Columns use to determine the ordering.
-    reverse
-        Default is ascending.
+    descending
+        Sort descending; default is ascending.
 
     """
     if isinstance(exprs, str) or not isinstance(exprs, Sequence):
         exprs = [exprs]
-    if isinstance(reverse, bool):
-        reverse = [reverse] * len(exprs)
+    if isinstance(descending, bool):
+        descending = [descending] * len(exprs)
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(py_arg_sort_by(exprs, reverse))
+    return pli.wrap_expr(py_arg_sort_by(exprs, descending))
 
 
+@deprecated_alias(reverse="descending")
 def argsort_by(
     exprs: pli.Expr | str | Sequence[pli.Expr | str],
-    reverse: Sequence[bool] | bool = False,
+    descending: Sequence[bool] | bool = False,
 ) -> pli.Expr:
     """
     Find the indexes that would sort the columns.
@@ -1932,8 +1934,8 @@ def argsort_by(
     ----------
     exprs
         Columns use to determine the ordering.
-    reverse
-        Default is ascending.
+    descending
+        Sort in descending order; default is ascending.
 
     """
     warnings.warn(
@@ -1941,7 +1943,7 @@ def argsort_by(
         DeprecationWarning,
         stacklevel=2,
     )
-    return pli.arg_sort_by(exprs, reverse)
+    return pli.arg_sort_by(exprs, descending)
 
 
 def duration(

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -813,11 +813,12 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return self.map(inspect, predicate_pushdown=True, projection_pushdown=True)
 
+    @deprecated_alias(reverse="descending")
     def sort(
         self,
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
-        reverse: bool | Sequence[bool] = False,
+        descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
     ) -> Self:
         """
@@ -830,7 +831,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             names.
         *more_by
             Additional columns to sort by, specified as positional arguments.
-        reverse
+        descending
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
@@ -875,7 +876,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Sort by multiple columns by passing a list of columns.
 
-        >>> ldf.sort(["c", "a"], reverse=True).collect()
+        >>> ldf.sort(["c", "a"], descending=True).collect()
         shape: (3, 3)
         ┌──────┬─────┬─────┐
         │ a    ┆ b   ┆ c   │
@@ -889,7 +890,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Or use positional arguments to sort by multiple columns in the same way.
 
-        >>> ldf.sort("c", "a", reverse=[False, True]).collect()
+        >>> ldf.sort("c", "a", descending=[False, True]).collect()
         shape: (3, 3)
         ┌──────┬─────┬─────┐
         │ a    ┆ b   ┆ c   │
@@ -904,7 +905,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
-            return self._from_pyldf(self._ldf.sort(by, reverse, nulls_last))
+            return self._from_pyldf(self._ldf.sort(by, descending, nulls_last))
 
         by = pli.selection_to_pyexpr_list(by)
         if more_by:
@@ -916,9 +917,9 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
                 "`nulls_last=True` only works when sorting by a single column"
             )
 
-        if isinstance(reverse, bool):
-            reverse = [reverse]
-        return self._from_pyldf(self._ldf.sort_by_exprs(by, reverse, nulls_last))
+        if isinstance(descending, bool):
+            descending = [descending]
+        return self._from_pyldf(self._ldf.sort_by_exprs(by, descending, nulls_last))
 
     def profile(
         self,

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -51,13 +51,13 @@ class ListNameSpace:
         """Compute the mean value of the arrays in the list."""
 
     @deprecate_nonkeyword_arguments()
-    def sort(self, reverse: bool = False) -> pli.Series:
+    def sort(self, descending: bool = False) -> pli.Series:
         """
         Sort the arrays in this column.
 
         Parameters
         ----------
-        reverse
+        descending
             Sort in descending order.
 
         Examples
@@ -70,7 +70,7 @@ class ListNameSpace:
                 [1, 2, 3]
                 [1, 2, 9]
         ]
-        >>> s.arr.sort(reverse=True)
+        >>> s.arr.sort(descending=True)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -82,7 +82,7 @@ class ListNameSpace:
         return (
             pli.wrap_s(self._s)
             .to_frame()
-            .select(pli.col(self._s.name()).arr.sort(reverse=reverse))
+            .select(pli.col(self._s.name()).arr.sort(descending=descending))
             .to_series()
         )
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -358,8 +358,8 @@ class Series:
 
         """
         out = {
-            "SORTED_ASC": self._s.is_sorted_flag(),
-            "SORTED_DESC": self._s.is_sorted_reverse_flag(),
+            "SORTED_ASC": self._s.is_sorted_ascending_flag(),
+            "SORTED_DESC": self._s.is_sorted_descending_flag(),
         }
         if self.dtype == List:
             out["FAST_EXPLODE"] = self._s.can_fast_explode_flag()
@@ -1926,13 +1926,13 @@ class Series:
         """
 
     @deprecate_nonkeyword_arguments()
-    def sort(self, reverse: bool = False, *, in_place: bool = False) -> Self:
+    def sort(self, descending: bool = False, *, in_place: bool = False) -> Self:
         """
         Sort this Series.
 
         Parameters
         ----------
-        reverse
+        descending
             Sort in descending order.
         in_place
             Sort in-place.
@@ -1949,7 +1949,7 @@ class Series:
                 3
                 4
         ]
-        >>> s.sort(reverse=True)
+        >>> s.sort(descending=True)
         shape: (4,)
         Series: 'a' [i64]
         [
@@ -1961,16 +1961,17 @@ class Series:
 
         """
         if in_place:
-            self._s = self._s.sort(reverse)
+            self._s = self._s.sort(descending)
             return self
         else:
-            return self._from_pyseries(self._s.sort(reverse))
+            return self._from_pyseries(self._s.sort(descending))
 
-    def top_k(self, k: int = 5, reverse: bool = False) -> Series:
+    @deprecated_alias(reverse="descending")
+    def top_k(self, k: int = 5, descending: bool = False) -> Series:
         r"""
         Return the `k` largest elements.
 
-        If 'reverse=True` the smallest elements will be given.
+        If 'descending=True` the smallest elements will be given.
 
         This has time complexity:
 
@@ -1980,20 +1981,27 @@ class Series:
         ----------
         k
             Number of elements to return.
-        reverse
+        descending
             Return the smallest elements.
 
         """
+        return (
+            pli.wrap_s(self._s)
+            .to_frame()
+            .select(pli.col(self._s.name()).top_k(k=k, descending=descending))
+            .to_series()
+        )
 
+    @deprecated_alias(reverse="descending")
     @deprecate_nonkeyword_arguments()
-    def arg_sort(self, reverse: bool = False, nulls_last: bool = False) -> Series:
+    def arg_sort(self, descending: bool = False, nulls_last: bool = False) -> Series:
         """
         Get the index values that would sort this Series.
 
         Parameters
         ----------
-        reverse
-            Sort in reverse (descending) order.
+        descending
+            Sort in descending order.
         nulls_last
             Place null values last instead of first.
 
@@ -2016,12 +2024,15 @@ class Series:
             pli.wrap_s(self._s)
             .to_frame()
             .select(
-                pli.col(self._s.name()).arg_sort(reverse=reverse, nulls_last=nulls_last)
+                pli.col(self._s.name()).arg_sort(
+                    descending=descending, nulls_last=nulls_last
+                )
             )
             .to_series()
         )
 
-    def argsort(self, reverse: bool = False, nulls_last: bool = False) -> Series:
+    @deprecated_alias(reverse="descending")
+    def argsort(self, descending: bool = False, nulls_last: bool = False) -> Series:
         """
         Get the index values that would sort this Series.
 
@@ -2032,8 +2043,8 @@ class Series:
 
         Parameters
         ----------
-        reverse
-            Sort in reverse (descending) order.
+        descending
+            Sort in descending order.
         nulls_last
             Place null values last instead of first.
 
@@ -2207,17 +2218,18 @@ class Series:
         """
         return self.len() == 0
 
-    def is_sorted(self, reverse: bool = False) -> bool:
+    @deprecated_alias(reverse="descending")
+    def is_sorted(self, descending: bool = False) -> bool:
         """
         Check if the Series is sorted.
 
         Parameters
         ----------
-        reverse
+        descending
             Check if the Series is sorted in descending order
 
         """
-        return self._s.is_sorted(reverse)
+        return self._s.is_sorted(descending)
 
     def is_null(self) -> Series:
         """
@@ -4502,7 +4514,8 @@ class Series:
         Same as `abs(series)`.
         """
 
-    def rank(self, method: RankMethod = "average", reverse: bool = False) -> Series:
+    @deprecated_alias(reverse="descending")
+    def rank(self, method: RankMethod = "average", descending: bool = False) -> Series:
         """
         Assign ranks to data, dealing with ties appropriately.
 
@@ -4526,8 +4539,8 @@ class Series:
               the order that the values occur in the Series.
             - 'random' : Like 'ordinal', but the rank for ties is not dependent
               on the order that the values occur in the Series.
-        reverse
-            Reverse the operation.
+        descending
+            Rank in descending order.
 
         Examples
         --------
@@ -4560,6 +4573,12 @@ class Series:
         ]
 
         """
+        return (
+            pli.wrap_s(self._s)
+            .to_frame()
+            .select(pli.col(self._s.name()).rank(method=method, descending=descending))
+            .to_series()
+        )
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
@@ -5199,7 +5218,8 @@ class Series:
 
         """
 
-    def set_sorted(self, reverse: bool = False) -> Series:
+    @deprecated_alias(reverse="descending")
+    def set_sorted(self, descending: bool = False) -> Series:
         """
         Flags the Series as 'sorted'.
 
@@ -5207,8 +5227,8 @@ class Series:
 
         Parameters
         ----------
-        reverse
-            If the `Series` order is reversed, e.g. descending.
+        descending
+            If the `Series` order is descending.
 
         Warnings
         --------
@@ -5222,7 +5242,7 @@ class Series:
         3
 
         """
-        return wrap_s(self._s.set_sorted_flag(reverse))
+        return wrap_s(self._s.set_sorted_flag(descending))
 
     def new_from_index(self, index: int, length: int) -> pli.Series:
         """Create a new Series filled with values from the given index."""

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -402,12 +402,12 @@ impl PyLazyFrame {
         ldf.into()
     }
 
-    pub fn sort(&self, by_column: &str, reverse: bool, nulls_last: bool) -> PyLazyFrame {
+    pub fn sort(&self, by_column: &str, descending: bool, nulls_last: bool) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         ldf.sort(
             by_column,
             SortOptions {
-                descending: reverse,
+                descending,
                 nulls_last,
                 multithreaded: true,
             },
@@ -418,12 +418,12 @@ impl PyLazyFrame {
     pub fn sort_by_exprs(
         &self,
         by: Vec<PyExpr>,
-        reverse: Vec<bool>,
+        descending: Vec<bool>,
         nulls_last: bool,
     ) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         let exprs = py_exprs_to_exprs(by);
-        ldf.sort_by_exprs(exprs, reverse, nulls_last).into()
+        ldf.sort_by_exprs(exprs, descending, nulls_last).into()
     }
 
     pub fn cache(&self) -> PyLazyFrame {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -237,11 +237,11 @@ impl PyExpr {
             .into()
     }
 
-    pub fn arg_sort(&self, reverse: bool, nulls_last: bool) -> PyExpr {
+    pub fn arg_sort(&self, descending: bool, nulls_last: bool) -> PyExpr {
         self.clone()
             .inner
             .arg_sort(SortOptions {
-                descending: reverse,
+                descending,
                 nulls_last,
                 multithreaded: true,
             })
@@ -249,8 +249,8 @@ impl PyExpr {
     }
 
     #[cfg(feature = "top_k")]
-    pub fn top_k(&self, k: usize, reverse: bool) -> PyExpr {
-        self.inner.clone().top_k(k, reverse).into()
+    pub fn top_k(&self, k: usize, descending: bool) -> PyExpr {
+        self.inner.clone().top_k(k, descending).into()
     }
 
     pub fn arg_max(&self) -> PyExpr {
@@ -271,9 +271,9 @@ impl PyExpr {
         self.clone().inner.take(idx.inner).into()
     }
 
-    pub fn sort_by(&self, by: Vec<PyExpr>, reverse: Vec<bool>) -> PyExpr {
+    pub fn sort_by(&self, by: Vec<PyExpr>, descending: Vec<bool>) -> PyExpr {
         let by = by.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-        self.clone().inner.sort_by(by, reverse).into()
+        self.clone().inner.sort_by(by, descending).into()
     }
 
     pub fn backward_fill(&self, limit: FillNullLimit) -> PyExpr {
@@ -1507,12 +1507,12 @@ impl PyExpr {
         self.inner.clone().arr().mean().with_fmt("arr.mean").into()
     }
 
-    fn lst_sort(&self, reverse: bool) -> Self {
+    fn lst_sort(&self, descending: bool) -> Self {
         self.inner
             .clone()
             .arr()
             .sort(SortOptions {
-                descending: reverse,
+                descending,
                 ..Default::default()
             })
             .with_fmt("arr.sort")
@@ -1618,10 +1618,10 @@ impl PyExpr {
             .into())
     }
 
-    fn rank(&self, method: Wrap<RankMethod>, reverse: bool) -> Self {
+    fn rank(&self, method: Wrap<RankMethod>, descending: bool) -> Self {
         let options = RankOptions {
             method: method.0,
-            descending: reverse,
+            descending,
         };
         self.inner.clone().rank(options).into()
     }
@@ -1798,8 +1798,8 @@ impl PyExpr {
     pub fn hash(&self, seed: u64, seed_1: u64, seed_2: u64, seed_3: u64) -> Self {
         self.inner.clone().hash(seed, seed_1, seed_2, seed_3).into()
     }
-    pub fn set_sorted_flag(&self, reverse: bool) -> Self {
-        let is_sorted = if reverse {
+    pub fn set_sorted_flag(&self, descending: bool) -> Self {
+        let is_sorted = if descending {
             IsSorted::Descending
         } else {
             IsSorted::Ascending

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -205,12 +205,12 @@ fn cov(a: dsl::PyExpr, b: dsl::PyExpr) -> dsl::PyExpr {
 }
 
 #[pyfunction]
-fn arg_sort_by(by: Vec<dsl::PyExpr>, reverse: Vec<bool>) -> dsl::PyExpr {
+fn arg_sort_by(by: Vec<dsl::PyExpr>, descending: Vec<bool>) -> dsl::PyExpr {
     let by = by
         .into_iter()
         .map(|e| e.inner)
         .collect::<Vec<polars_rs::lazy::dsl::Expr>>();
-    polars_rs::lazy::dsl::arg_sort_by(by, &reverse).into()
+    polars_rs::lazy::dsl::arg_sort_by(by, &descending).into()
 }
 
 #[pyfunction]

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -113,10 +113,10 @@ impl PySeries {
 
 #[pymethods]
 impl PySeries {
-    pub fn is_sorted_flag(&self) -> bool {
+    pub fn is_sorted_ascending_flag(&self) -> bool {
         matches!(self.series.is_sorted_flag(), IsSorted::Ascending)
     }
-    pub fn is_sorted_reverse_flag(&self) -> bool {
+    pub fn is_sorted_descending_flag(&self) -> bool {
         matches!(self.series.is_sorted_flag(), IsSorted::Descending)
     }
     pub fn can_fast_explode_flag(&self) -> bool {
@@ -434,9 +434,9 @@ impl PySeries {
             .map(|dt| Wrap(dt.clone()).to_object(py))
     }
 
-    fn set_sorted_flag(&self, reverse: bool) -> Self {
+    fn set_sorted_flag(&self, descending: bool) -> Self {
         let mut out = self.series.clone();
-        if reverse {
+        if descending {
             out.set_sorted_flag(IsSorted::Descending);
         } else {
             out.set_sorted_flag(IsSorted::Ascending)
@@ -544,8 +544,8 @@ impl PySeries {
         (&self.series % &other.series).into()
     }
 
-    pub fn sort(&mut self, reverse: bool) -> Self {
-        PySeries::new(self.series.sort(reverse))
+    pub fn sort(&mut self, descending: bool) -> Self {
+        PySeries::new(self.series.sort(descending))
     }
 
     pub fn value_counts(&self, sorted: bool) -> PyResult<PyDataFrame> {
@@ -1145,10 +1145,10 @@ impl PySeries {
         })
     }
 
-    pub fn is_sorted(&self, reverse: bool) -> bool {
+    pub fn is_sorted(&self, descending: bool) -> bool {
         let options = SortOptions {
-            descending: reverse,
-            nulls_last: reverse,
+            descending,
+            nulls_last: descending,
             multithreaded: true,
         };
         self.series.is_sorted(options)

--- a/py-polars/tests/benchmark/run_h2oai_benchmark.py
+++ b/py-polars/tests/benchmark/run_h2oai_benchmark.py
@@ -261,7 +261,7 @@ t0 = time.time()
 print("q8")
 out = (
     x.drop_nulls("v3")
-    .sort("v3", reverse=True)
+    .sort("v3", descending=True)
     .groupby("id6")
     .agg(pl.col("v3").head(2).alias("largest2_v3"))
     .explode("largest2_v3")

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -155,7 +155,7 @@ def test_list_eval_dtype_inference() -> None:
         }
     )
 
-    rank_pct = pl.col("").rank(reverse=True) / pl.col("").count().cast(pl.UInt16)
+    rank_pct = pl.col("").rank(descending=True) / pl.col("").count().cast(pl.UInt16)
 
     # the .arr.first() would fail if .arr.eval did not correctly infer the output type
     assert grades.with_columns(

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -50,17 +50,17 @@ def test_sort_by() -> None:
     out = df.select(pl.col("a").sort_by("b", "c"))
     assert out["a"].to_list() == [3, 1, 2, 5, 4]
 
-    out = df.select(pl.col("a").sort_by(by, reverse=[False]))
+    out = df.select(pl.col("a").sort_by(by, descending=[False]))
     assert out["a"].to_list() == [3, 1, 2, 5, 4]
 
-    out = df.select(pl.col("a").sort_by(by, reverse=[True]))
+    out = df.select(pl.col("a").sort_by(by, descending=[True]))
     assert out["a"].to_list() == [4, 5, 2, 1, 3]
 
-    out = df.select(pl.col("a").sort_by(by, reverse=[True, False]))
+    out = df.select(pl.col("a").sort_by(by, descending=[True, False]))
     assert out["a"].to_list() == [5, 4, 3, 1, 2]
 
     # by can also be a single column
-    out = df.select(pl.col("a").sort_by("b", reverse=[False]))
+    out = df.select(pl.col("a").sort_by("b", descending=[False]))
     assert out["a"].to_list() == [1, 2, 3, 4, 5]
 
 
@@ -161,16 +161,16 @@ def test_sort_aggregation_fast_paths() -> None:
         "f_min": [1],
     }
 
-    for reverse in [True, False]:
+    for descending in [True, False]:
         for null_last in [True, False]:
             out = df.select(
                 [
                     pl.all()
-                    .sort(reverse=reverse, nulls_last=null_last)
+                    .sort(descending=descending, nulls_last=null_last)
                     .max()
                     .suffix("_max"),
                     pl.all()
-                    .sort(reverse=reverse, nulls_last=null_last)
+                    .sort(descending=descending, nulls_last=null_last)
                     .min()
                     .suffix("_min"),
                 ]
@@ -217,15 +217,15 @@ def test_sorted_flag() -> None:
 
 def test_sorted_fast_paths() -> None:
     s = pl.Series([1, 2, 3]).sort()
-    rev = s.sort(reverse=True)
+    rev = s.sort(descending=True)
 
     assert rev.to_list() == [3, 2, 1]
     assert s.sort().to_list() == [1, 2, 3]
 
     s = pl.Series([None, 1, 2, 3]).sort()
-    rev = s.sort(reverse=True)
+    rev = s.sort(descending=True)
     assert rev.to_list() == [None, 3, 2, 1]
-    assert rev.sort(reverse=True).to_list() == [None, 3, 2, 1]
+    assert rev.sort(descending=True).to_list() == [None, 3, 2, 1]
     assert rev.sort().to_list() == [None, 1, 2, 3]
 
 
@@ -250,7 +250,7 @@ def test_top_k() -> None:
     s = pl.Series([3, 1, 2, 5, 8])
 
     assert s.top_k(3).to_list() == [8, 5, 3]
-    assert s.top_k(4, reverse=True).to_list() == [1, 2, 3, 5]
+    assert s.top_k(4, descending=True).to_list() == [1, 2, 3, 5]
 
     # 5886
     df = pl.DataFrame({"test": [4, 3, 2, 1]})
@@ -312,8 +312,8 @@ def test_explicit_list_agg_sort_in_groupby() -> None:
     df = pl.DataFrame({"A": ["a", "a", "a", "b", "b", "a"], "B": [1, 2, 3, 4, 5, 6]})
 
     # this was col().list().sort() before we changed the logic
-    result = df.groupby("A").agg(pl.col("B").sort(reverse=True)).sort("A")
-    expected = df.groupby("A").agg(pl.col("B").sort(reverse=True)).sort("A")
+    result = df.groupby("A").agg(pl.col("B").sort(descending=True)).sort("A")
+    expected = df.groupby("A").agg(pl.col("B").sort(descending=True)).sort("A")
     assert_frame_equal(result, expected)
 
 
@@ -341,7 +341,7 @@ def test_sorted_join_query_5406() -> None:
 
     filter1 = (
         df1.groupby(["Datetime", "Group"])
-        .agg([pl.all().sort_by("Value", reverse=True).first()])
+        .agg([pl.all().sort_by("Value", descending=True).first()])
         .sort(["Datetime", "RowId"])
     )
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -929,13 +929,15 @@ def test_multiple_column_sort() -> None:
     df = pl.DataFrame({"a": np.arange(1, 4, dtype=np.int64), "b": ["a", "a", "b"]})
 
     assert_frame_equal(
-        df.sort("a", reverse=True), pl.DataFrame({"a": [3, 2, 1], "b": ["b", "a", "a"]})
+        df.sort("a", descending=True),
+        pl.DataFrame({"a": [3, 2, 1], "b": ["b", "a", "a"]}),
     )
     assert_frame_equal(
-        df.sort("b", reverse=True), pl.DataFrame({"a": [3, 1, 2], "b": ["b", "a", "a"]})
+        df.sort("b", descending=True),
+        pl.DataFrame({"a": [3, 1, 2], "b": ["b", "a", "a"]}),
     )
     assert_frame_equal(
-        df.sort(["b", "a"], reverse=[False, True]),
+        df.sort(["b", "a"], descending=[False, True]),
         pl.DataFrame({"a": [2, 1, 3], "b": ["a", "a", "b"]}),
     )
 
@@ -1051,21 +1053,21 @@ def test_to_numpy() -> None:
 
 def test_arg_sort_by(df: pl.DataFrame) -> None:
     idx_df = df.select(
-        pl.arg_sort_by(["int_nulls", "floats"], reverse=[False, True]).alias("idx")
+        pl.arg_sort_by(["int_nulls", "floats"], descending=[False, True]).alias("idx")
     )
     assert (idx_df["idx"] == [1, 0, 2]).all()
 
     idx_df = df.select(
-        pl.arg_sort_by(["int_nulls", "floats"], reverse=False).alias("idx")
+        pl.arg_sort_by(["int_nulls", "floats"], descending=False).alias("idx")
     )
     assert (idx_df["idx"] == [1, 0, 2]).all()
 
     df = pl.DataFrame({"x": [0, 0, 0, 1, 1, 2], "y": [9, 9, 8, 7, 6, 6]})
     for expr, expected in (
         (pl.arg_sort_by(["x", "y"]), [2, 0, 1, 4, 3, 5]),
-        (pl.arg_sort_by(["x", "y"], reverse=[True, True]), [5, 3, 4, 0, 1, 2]),
-        (pl.arg_sort_by(["x", "y"], reverse=[True, False]), [5, 4, 3, 2, 0, 1]),
-        (pl.arg_sort_by(["x", "y"], reverse=[False, True]), [0, 1, 2, 3, 4, 5]),
+        (pl.arg_sort_by(["x", "y"], descending=[True, True]), [5, 3, 4, 0, 1, 2]),
+        (pl.arg_sort_by(["x", "y"], descending=[True, False]), [5, 4, 3, 2, 0, 1]),
+        (pl.arg_sort_by(["x", "y"], descending=[False, True]), [0, 1, 2, 3, 4, 5]),
     ):
         assert (df.select(expr.alias("idx"))["idx"] == expected).all()
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -285,7 +285,7 @@ def test_invalid_sort_by() -> None:
         pl.ComputeError,
         match="The sortby operation produced a different length than the Series that has to be sorted.",
     ):
-        df.select(pl.col("a").filter(pl.col("b") == "M").sort_by("c", reverse=True))
+        df.select(pl.col("a").filter(pl.col("b") == "M").sort_by("c", descending=True))
 
 
 def test_epoch_time_type() -> None:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -211,12 +211,12 @@ def test_align_frames() -> None:
             on="date",
         )
 
-    # reverse
+    # descending
     pf1, pf2 = pl.align_frames(
         pl.DataFrame([[3, 5, 6], [5, 8, 9]], orient="row"),
         pl.DataFrame([[2, 5, 6], [3, 8, 9], [4, 2, 0]], orient="row"),
         on="column_0",
-        reverse=True,
+        descending=True,
     )
     assert pf1.rows() == [(5, 8, 9), (4, None, None), (3, 5, 6), (2, None, None)]
     assert pf2.rows() == [(5, None, None), (4, 2, 0), (3, 8, 9), (2, 5, 6)]

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -194,7 +194,7 @@ def test_apply_custom_function() -> None:
                 pl.count("cars").alias("cars_count"),
             ]
         )
-        .sort("custom_1", reverse=True)
+        .sort("custom_1", descending=True)
     ).collect()
     expected = pl.DataFrame(
         {
@@ -456,7 +456,7 @@ def test_head_groupby() -> None:
     # this query flexes the wildcard exclusion quite a bit.
     keys = ["commodity", "location"]
     out = (
-        df.sort(by="price", reverse=True)
+        df.sort(by="price", descending=True)
         .groupby(keys, maintain_order=True)
         .agg([col("*").exclude(keys).head(2).keep_name()])
         .explode(col("*").exclude(keys))
@@ -971,20 +971,6 @@ def test_ufunc_expr_not_first() -> None:
         ]
     )
     assert_frame_equal(out, expected)
-
-
-def test_ufunc_multiple_expr() -> None:
-    df = pl.DataFrame(
-        [
-            pl.Series("a", [1, 2, 3], dtype=pl.Float64),
-            pl.Series("b", [4, 5, 6], dtype=pl.Float64),
-        ]
-    )
-
-    with pytest.raises(
-        ValueError, match="Numpy ufunc can only be used with one expression, 2 given"
-    ):
-        df.select(np.arctan2(pl.col("a"), pl.col("b")))  # type: ignore[call-overload]
 
 
 def test_clip() -> None:

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -145,13 +145,15 @@ def test_sorted_groupby_optimization(monkeypatch: Any) -> None:
 
     # the sorted optimization should not randomize the
     # groups, so this is tests that we hit the sorted optimization
-    for reverse in [True, False]:
+    for descending in [True, False]:
         sorted_implicit = (
-            df.with_columns(pl.col("a").sort(reverse=reverse))
+            df.with_columns(pl.col("a").sort(descending=descending))
             .groupby("a")
             .agg(pl.count())
         )
-        sorted_explicit = df.groupby("a").agg(pl.count()).sort("a", reverse=reverse)
+        sorted_explicit = (
+            df.groupby("a").agg(pl.count()).sort("a", descending=descending)
+        )
         assert_frame_equal(sorted_explicit, sorted_implicit)
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -505,7 +505,7 @@ def test_to_python() -> None:
 def test_sort() -> None:
     a = pl.Series("a", [2, 1, 3])
     assert_series_equal(a.sort(), pl.Series("a", [1, 2, 3]))
-    assert_series_equal(a.sort(reverse=True), pl.Series("a", [3, 2, 1]))
+    assert_series_equal(a.sort(descending=True), pl.Series("a", [3, 2, 1]))
 
 
 def test_rechunk() -> None:
@@ -1188,7 +1188,7 @@ def test_rank() -> None:
     assert df.select(pl.col("a").rank("dense"))["a"].to_list() == [2, 3, 4, 3, 3, 4, 1]
 
     assert_series_equal(
-        s.rank("dense", reverse=True),
+        s.rank("dense", descending=True),
         pl.Series("a", [3, 2, 1, 2, 2, 1, 4], dtype=UInt32),
     )
 
@@ -1628,8 +1628,8 @@ def test_arg_sort() -> None:
 
     assert_series_equal(s.arg_sort(), expected)
 
-    expected_reverse = pl.Series("a", [0, 2, 1, 4, 3], dtype=UInt32)
-    assert_series_equal(s.arg_sort(reverse=True), expected_reverse)
+    expected_descending = pl.Series("a", [0, 2, 1, 4, 3], dtype=UInt32)
+    assert_series_equal(s.arg_sort(descending=True), expected_descending)
 
 
 def test_arg_min_and_arg_max() -> None:
@@ -1660,7 +1660,7 @@ def test_arg_min_and_arg_max() -> None:
     assert s.arg_min() == 0
     assert s.arg_max() == 4
     s = pl.Series("a", [5, 4, 3, 2, 1])
-    s.sort(reverse=True, in_place=True)  # set descing sorted flag
+    s.sort(descending=True, in_place=True)  # set descing sorted flag
     assert s.flags == {"SORTED_ASC": False, "SORTED_DESC": True}
     assert s.arg_min() == 4
     assert s.arg_max() == 0

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -237,12 +237,12 @@ def test_ooc_sort(monkeypatch: Any) -> None:
 
     df = s.shuffle().to_frame()
 
-    for reverse in [True, False]:
+    for descending in [True, False]:
         out = (
-            df.lazy().sort("idx", reverse=reverse).collect(streaming=True)
+            df.lazy().sort("idx", descending=descending).collect(streaming=True)
         ).to_series()
 
-        assert_series_equal(out, s.sort(reverse=reverse))
+        assert_series_equal(out, s.sort(descending=descending))
 
 
 def test_streaming_literal_expansion() -> None:


### PR DESCRIPTION
This will trigger a lot of deprecation warnings in Python, and possibly errors on the Rust side.

Closes #5429.

