### PR TITLE
feat(rust, python): raise error on invalid aggregation expressions

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -168,13 +168,26 @@ impl PhysicalExpr for AggregationExpr {
                     rename_series(agg_s, &keep_name)
                 }
                 GroupByMethod::List => {
-                    let agg = ac.aggregated();
-
                     if state.unset_finalize_window_as_list() {
+                        let agg = ac.aggregated();
                         rename_series(agg, &keep_name)
                     } else {
-                        let ca = agg.list().unwrap();
-                        let s = run_list_agg(ca);
+                        // if the aggregation is already
+                        // in an aggregate flat state for instance by
+                        // a mean aggregation, we simply convert to list
+                        //
+                        // if it is not, we traverse the groups and create
+                        // a list per group.
+                        let s = match ac.agg_state() {
+                            // mean agg:
+                            // -> f64 -> list<f64>
+                            AggState::AggregatedFlat(s) => s.reshape(&[-1, 1]).unwrap(),
+                            _ => {
+                                let agg = ac.aggregated();
+                                let ca = agg.list().unwrap();
+                                run_list_agg(ca)
+                            }
+                        };
                         rename_series(s, &keep_name)
                     }
                 }

--- a/polars/polars-lazy/src/physical_plan/expressions/alias.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/alias.rs
@@ -50,7 +50,7 @@ impl PhysicalExpr for AliasExpr {
         if ac.is_literal() {
             ac.with_literal(s);
         } else {
-            ac.with_series(s, ac.is_aggregated());
+            ac.with_series(s, ac.is_aggregated(), Some(&self.expr))?;
         }
         Ok(ac)
     }

--- a/polars/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -49,7 +49,7 @@ impl PhysicalExpr for CastExpr {
         if ac.is_literal() {
             ac.with_literal(s);
         } else {
-            ac.with_series(s, false);
+            ac.with_series(s, false, None)?;
         }
 
         Ok(ac)

--- a/polars/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -62,7 +62,7 @@ impl PhysicalExpr for FilterExpr {
                     })
                     .collect::<PolarsResult<ListChunked>>()?;
                 out.rename(s.name());
-                ac_s.with_series(out.into_series(), true);
+                ac_s.with_series(out.into_series(), true, Some(&self.expr))?;
                 ac_s.update_groups = WithSeriesLen;
                 Ok(ac_s)
             }

--- a/polars/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -69,7 +69,7 @@ impl PhysicalExpr for SortExpr {
             AggState::AggregatedList(s) => {
                 let ca = s.list().unwrap();
                 let out = ca.lst_sort(self.options);
-                ac.with_series(out.into_series(), true);
+                ac.with_series(out.into_series(), true, Some(&self.expr))?;
             }
             _ => {
                 let series = ac.flat_naive().into_owned();

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -136,7 +136,7 @@ impl PhysicalExpr for SortByExpr {
                 .collect();
             ca.rename(s.name());
             let s = ca.into_series();
-            ac_in.with_series(s, true);
+            ac_in.with_series(s, true, Some(&self.expr))?;
             Ok(ac_in)
         } else {
             let reverse = prepare_reverse(&self.reverse, self.by.len());
@@ -259,7 +259,7 @@ impl PhysicalExpr for SortByExpr {
             // we must ensure that we are as well.
             if ordered_by_group_operation {
                 let s = ac_in.aggregated();
-                ac_in.with_series(s.explode().unwrap(), false);
+                ac_in.with_series(s.explode().unwrap(), false, None)?;
             }
 
             ac_in.with_groups(groups);

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -114,7 +114,7 @@ impl PhysicalExpr for TakeExpr {
                             }
                         };
                     let taken = ac.flat_naive().take(&idx)?;
-                    ac.with_series(taken, true);
+                    ac.with_series(taken, true, Some(&self.expr))?;
                     return Ok(ac);
                 }
                 AggState::AggregatedList(s) => s.list().unwrap().clone(),
@@ -157,7 +157,7 @@ impl PhysicalExpr for TakeExpr {
                                     }
                                 };
                                 let taken = ac.flat_naive().take(&idx.into_inner())?;
-                                ac.with_series(taken, true);
+                                ac.with_series(taken, true, Some(&self.expr))?;
                                 ac.with_update_groups(UpdateGroups::WithGroupsLen);
                                 Ok(ac)
                             }
@@ -169,7 +169,7 @@ impl PhysicalExpr for TakeExpr {
                             .unwrap()
                             .try_apply_amortized(|s| s.as_ref().take(idx))?;
 
-                        ac.with_series(out.into_series(), true);
+                        ac.with_series(out.into_series(), true, Some(&self.expr))?;
                         ac.with_update_groups(UpdateGroups::WithGroupsLen);
                         Ok(ac)
                     };
@@ -198,7 +198,7 @@ impl PhysicalExpr for TakeExpr {
 
         taken.rename(ac.series().name());
 
-        ac.with_series(taken.into_series(), true);
+        ac.with_series(taken.into_series(), true, Some(&self.expr))?;
         ac.with_update_groups(UpdateGroups::WithGroupsLen);
         Ok(ac)
     }

--- a/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -82,7 +82,7 @@ fn finish_as_iters<'a>(
         out = out.explode()?
     }
 
-    ac_truthy.with_series(out, true);
+    ac_truthy.with_series(out, true, None)?;
     Ok(ac_truthy)
 }
 
@@ -167,7 +167,7 @@ impl PhysicalExpr for TernaryExpr {
                 expand_lengths(&mut truthy, &mut falsy, &mut mask);
                 let mut out = truthy.zip_with(&mask, &falsy).unwrap();
                 out.rename(truthy.name());
-                ac_truthy.with_series(out, true);
+                ac_truthy.with_series(out, true, Some(&self.expr))?;
                 Ok(ac_truthy)
             }
 
@@ -208,7 +208,7 @@ impl PhysicalExpr for TernaryExpr {
                         })
                         .collect_trusted();
                     out.rename(ac_truthy.series().name());
-                    ac_truthy.with_series(out.into_series(), true);
+                    ac_truthy.with_series(out.into_series(), true, Some(&self.expr))?;
                     Ok(ac_truthy)
                 } else if ac_truthy.is_literal()
                     && self.truthy.as_expression().map(has_null) == Some(true)
@@ -226,7 +226,7 @@ impl PhysicalExpr for TernaryExpr {
                         })
                         .collect_trusted();
                     out.rename(ac_truthy.series().name());
-                    ac_truthy.with_series(out.into_series(), true);
+                    ac_truthy.with_series(out.into_series(), true, Some(&self.expr))?;
                     Ok(ac_truthy)
                 }
                 // then:
@@ -248,7 +248,7 @@ impl PhysicalExpr for TernaryExpr {
                         })
                         .collect_trusted();
                     out.rename(ac_truthy.series().name());
-                    ac_truthy.with_series(out.into_series(), true);
+                    ac_truthy.with_series(out.into_series(), true, Some(&self.expr))?;
                     Ok(ac_truthy)
                 } else {
                     let literal = ac_falsy.series();
@@ -265,7 +265,7 @@ impl PhysicalExpr for TernaryExpr {
                         })
                         .collect_trusted();
                     out.rename(ac_truthy.series().name());
-                    ac_truthy.with_series(out.into_series(), true);
+                    ac_truthy.with_series(out.into_series(), true, Some(&self.expr))?;
                     Ok(ac_truthy)
                 }
             }
@@ -313,7 +313,7 @@ impl PhysicalExpr for TernaryExpr {
                     ac_truthy.with_update_groups(UpdateGroups::No);
                 }
 
-                ac_truthy.with_series(out, false);
+                ac_truthy.with_series(out, false, None)?;
 
                 Ok(ac_truthy)
             }

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -735,6 +735,6 @@ def test_list_function_group_awareness() -> None:
 def test_flat_aggregation_to_list_conversion_6918() -> None:
     df = pl.DataFrame({"a": [1, 2, 2], "b": [[0, 1], [2, 3], [4, 5]]})
 
-    assert df.groupby("a").agg(
+    assert df.groupby("a", maintain_order=True).agg(
         pl.concat_list([pl.col("b").arr.get(i).mean().list() for i in range(2)])
     ).to_dict(False) == {"a": [1, 2], "b": [[[0.0, 1.0]], [[3.0, 4.0]]]}

--- a/py-polars/tests/unit/test_lists.py
+++ b/py-polars/tests/unit/test_lists.py
@@ -730,3 +730,11 @@ def test_list_function_group_awareness() -> None:
         "take": [[[100]], [[105]], [[100]]],
         "slice": [[[100, 103]], [[105, 106, 105]], [[100, 102]]],
     }
+
+
+def test_flat_aggregation_to_list_conversion_6918() -> None:
+    df = pl.DataFrame({"a": [1, 2, 2], "b": [[0, 1], [2, 3], [4, 5]]})
+
+    assert df.groupby("a").agg(
+        pl.concat_list([pl.col("b").arr.get(i).mean().list() for i in range(2)])
+    ).to_dict(False) == {"a": [1, 2], "b": [[[0.0, 1.0]], [[3.0, 4.0]]]}


### PR DESCRIPTION
closes #6918

An invalid aggregation will now throw a more informative error than a panic indicating which expression is flawed:

```python
df = pl.DataFrame({"a": [1, 2, 2], "b": [[0, 1], [2, 3], [4, 5]]})

df.groupby("a").agg(
    pl.concat_list([pl.col("b").arr.get(i).mean() for i in range(2)])
)

ComputeError: The aggregation expression 'col("b").get([0i32]).mean().concat([col("b").get([1i32]).mean()])' did produce a different number of elements than
the number of groups. This likely is an invalid expression.
Number of groups: 2
Number of elements: 0
```