### PR TITLE
feat(rust, python): supported nested fixedsizebinary conversion

### DIFF
--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -430,6 +430,11 @@ fn convert_inner_types(arr: &ArrayRef) -> ArrayRef {
             let out = cast(&**arr, &ArrowDataType::LargeList(field.clone())).unwrap();
             convert_inner_types(&out)
         }
+        #[cfg(feature = "dtype-binary")]
+        ArrowDataType::FixedSizeBinary(_) | ArrowDataType::Binary => {
+            let out = cast(&**arr, &ArrowDataType::LargeBinary).unwrap();
+            convert_inner_types(&out)
+        }
         ArrowDataType::LargeList(_) => {
             let arr = arr.as_any().downcast_ref::<ListArray<i64>>().unwrap();
             let values = convert_inner_types(arr.values());

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -730,3 +730,12 @@ def test_to_numpy_datelike() -> None:
             dtype="datetime64[us]",
         )
     )
+
+
+@typing.no_type_check
+def test_from_fixed_size_binary_list() -> None:
+    val = [[b"63A0B1C66575DD5708E1EB2B"]]
+    arrow_array = pa.array(val, type=pa.list_(pa.binary(24)))
+    s = pl.from_arrow(arrow_array)
+    assert s.dtype == pl.List(pl.Binary)
+    assert s.to_list() == val


### PR DESCRIPTION
closes #6884