### PR TITLE
feat(rust, python): add native sqrt and cbrt functions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/arithmetic.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/arithmetic.rs
@@ -61,6 +61,30 @@ impl Expr {
         }
     }
 
+    /// Compute the square root of the given expression
+    pub fn sqrt(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Root(RootFunction::Sqrt),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Compute the cubic root of the given expression
+    pub fn cbrt(self) -> Self {
+        Expr::Function {
+            input: vec![self],
+            function: FunctionExpr::Root(RootFunction::Cbrt),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ApplyFlat,
+                ..Default::default()
+            },
+        }
+    }
+
     /// Compute the sine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn sin(self) -> Self {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/root.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/root.rs
@@ -1,0 +1,75 @@
+use num::Float;
+use polars_core::export::num;
+
+use super::*;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
+pub enum RootFunction {
+    Sqrt,
+    Cbrt,
+}
+
+impl Display for RootFunction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use self::*;
+        match self {
+            RootFunction::Sqrt => write!(f, "sqrt"),
+            RootFunction::Cbrt => write!(f, "cbrt"),
+        }
+    }
+}
+
+pub(super) fn apply_root_function(s: &Series, root_function: RootFunction) -> PolarsResult<Series> {
+    use DataType::*;
+    match s.dtype() {
+        Float32 => {
+            let ca = s.f32().unwrap();
+            apply_root_function_to_float(ca, root_function)
+        }
+        Float64 => {
+            let ca = s.f64().unwrap();
+            apply_root_function_to_float(ca, root_function)
+        }
+        dt if dt.is_numeric() => {
+            let s = s.cast(&DataType::Float64)?;
+            apply_root_function(&s, root_function)
+        }
+        dt => Err(PolarsError::ComputeError(
+            format!("cannot use root function on Series of dtype: {dt:?}",).into(),
+        )),
+    }
+}
+
+fn apply_root_function_to_float<T>(
+    ca: &ChunkedArray<T>,
+    root_function: RootFunction,
+) -> PolarsResult<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    match root_function {
+        RootFunction::Sqrt => sqrt(ca),
+        RootFunction::Cbrt => cbrt(ca),
+    }
+}
+
+fn sqrt<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.sqrt()).into_series())
+}
+
+fn cbrt<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
+where
+    T: PolarsFloatType,
+    T::Native: num::Float,
+    ChunkedArray<T>: IntoSeries,
+{
+    Ok(ca.apply(|v| v.cbrt()).into_series())
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -33,7 +33,6 @@ impl FunctionExpr {
             Ok(fld)
         };
 
-        #[cfg(any(feature = "rolling_window", feature = "trigonometry", feature = "log"))]
         // set float supertype
         let float_dtype = || {
             map_dtype(&|dtype| match dtype {
@@ -269,6 +268,7 @@ impl FunctionExpr {
                     }
                 })
             }
+            Root(_) => float_dtype(),
             #[cfg(feature = "dot_product")]
             Dot => map_dtype(&|dt| {
                 use DataType::*;

--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -14,6 +14,7 @@ Computation
     Expr.arctan
     Expr.arctanh
     Expr.arg_unique
+    Expr.cbrt
     Expr.cos
     Expr.cosh
     Expr.cumcount

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -15,6 +15,7 @@ Computation
     Series.arctanh
     Series.arg_true
     Series.arg_unique
+    Series.cbrt
     Series.cos
     Series.cosh
     Series.cummax

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -424,7 +424,29 @@ class Expr:
         └──────────┘
 
         """
-        return self**0.5
+        return wrap_expr(self._pyexpr.sqrt())
+
+    def cbrt(self) -> Expr:
+        """
+        Compute the cubic root of the elements.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"values": [1.0, 2.0, 4.0]})
+        >>> df.select(pl.col("values").cbrt())
+        shape: (3, 1)
+        ┌──────────┐
+        │ values   │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 1.0      │
+        │ 1.259921 │
+        │ 1.587401 │
+        └──────────┘
+
+        """
+        return wrap_expr(self._pyexpr.cbrt())
 
     def log10(self) -> Self:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1045,14 +1045,34 @@ class Series:
         """
         Compute the square root of the elements.
 
-        Syntactic sugar for
-
-        >>> pl.Series([1, 2]) ** 0.5
-        shape: (2,)
-        Series: '' [f64]
+        Examples
+        --------
+        >>> s = pl.Series("a", [1.0, 2.0, -1.0])
+        >>> s.sqrt()
+        shape: (3,)
+        Series: 'a' [f64]
         [
             1.0
             1.414214
+            NaN
+        ]
+
+        """
+
+    def cbrt(self) -> Series:
+        """
+        Compute the cubic root of the elements.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1.0, 2.0, -1.0])
+        >>> s.cbrt()
+        shape: (3,)
+        Series: 'a' [f64]
+        [
+            1.0
+            1.259921
+            -1.0
         ]
 
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -416,6 +416,14 @@ impl PyExpr {
         self.clone().inner.abs().into()
     }
 
+    pub fn sqrt(&self) -> PyExpr {
+        self.clone().inner.sqrt().into()
+    }
+
+    pub fn cbrt(&self) -> PyExpr {
+        self.clone().inner.cbrt().into()
+    }
+
     #[cfg(feature = "trigonometry")]
     pub fn sin(&self) -> PyExpr {
         self.clone().inner.sin().into()

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -391,7 +391,7 @@ def test_groupby_dynamic_overlapping_groups_flat_apply_multiple_5038() -> None:
             )
             .lazy()
             .groupby_dynamic("a", every=every, period=period)
-            .agg([pl.col("b").var().sqrt().alias("corr")])
+            .agg([pl.col("b").std().alias("corr")])
         ).collect().sum().to_dict(False) == pytest.approx(
             {"a": [None], "corr": [6.988674024215477]}
         )

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -536,6 +536,15 @@ def test_round() -> None:
     col_a_rounded = df.select(pl.col("a").round(decimals=0))["a"]
     assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
 
+def test_sqrt() -> None:
+    df = pl.DataFrame({"a": [1.0, 2.0, -1.0]})
+    col_a_sqrt = df.select(pl.col("a").sqrt())["a"]
+    assert_series_equal(col_a_sqrt, pl.Series("a", [1.0, np.sqrt(2), np.nan]))
+
+def test_cbrt() -> None:
+    df = pl.DataFrame({"a": [1.0, 2.0, -1.0]})
+    col_a_cbrt = df.select(pl.col("a").cbrt())["a"]
+    assert_series_equal(col_a_cbrt, pl.Series("a", [1.0, np.cbrt(2), -1.0]))
 
 def test_dot() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0], "b": [3.2, 1, 2]})

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1269,6 +1269,13 @@ def test_sqrt() -> None:
         df.select(pl.col("a").sqrt())["a"], pl.Series("a", [1.0, np.sqrt(2)])
     )
 
+def test_cbrt() -> None:
+    s = pl.Series("a", [1, 2])
+    assert_series_equal(s.cbrt(), pl.Series("a", [1.0, np.cbrt(2)]))
+    df = pl.DataFrame([s])
+    assert_series_equal(
+        df.select(pl.col("a").cbrt())["a"], pl.Series("a", [1.0, np.cbrt(2)])
+    )
 
 def test_range() -> None:
     s1 = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])


### PR DESCRIPTION
Part of #6814

This PR adds native rust `sqrt` and `cbrt` functions, that are also available in `LazyFrame`.
Replacing `Expr.sqrt` in Python to the native one caused a test error (same as #6904) in py-polars/tests/unit/test_groupby.py.
So for now I rewrote it to equivalent program.