### PR TITLE
fix(python): respect maintain_order in groupby.apply

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -186,6 +186,9 @@ impl<'a> AggregationContext<'a> {
     pub(crate) fn is_aggregated(&self) -> bool {
         !self.is_not_aggregated()
     }
+    pub(crate) fn is_aggregated_flat(&self) -> bool {
+        matches!(self.state, AggState::AggregatedFlat(_))
+    }
     pub(crate) fn is_literal(&self) -> bool {
         matches!(self.state, AggState::Literal(_))
     }

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -219,7 +219,9 @@ class GroupBy(Generic[DF]):
         else:
             raise TypeError("Cannot call `apply` when grouping by an expression.")
 
-        return self.df.__class__._from_pydf(self.df._df.groupby_apply(by, f))
+        return self.df.__class__._from_pydf(
+            self.df._df.groupby_apply(by, f, self.maintain_order)
+        )
 
     def agg(self, aggs: IntoExpr | Iterable[IntoExpr]) -> pli.DataFrame:
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1046,8 +1046,19 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
-    pub fn groupby_apply(&self, by: Vec<&str>, lambda: PyObject) -> PyResult<Self> {
-        let gb = self.df.groupby(&by).map_err(PyPolarsErr::from)?;
+    pub fn groupby_apply(
+        &self,
+        by: Vec<&str>,
+        lambda: PyObject,
+        maintain_order: bool,
+    ) -> PyResult<Self> {
+        let gb = if maintain_order {
+            self.df.groupby_stable(&by)
+        } else {
+            self.df.groupby(&by)
+        }
+        .map_err(PyPolarsErr::from)?;
+
         let function = move |df: DataFrame| {
             Python::with_gil(|py| {
                 // get the pypolars module


### PR DESCRIPTION
On top of #6924 to prevent merge conflicts. 

So only last commit are the changes to consider.

closes #6907