### PR TITLE
fix(rust): fix arg_min/arg_max when sorted

### DIFF
--- a/polars/polars-ops/src/series/ops/arg_min_max.rs
+++ b/polars/polars-ops/src/series/ops/arg_min_max.rs
@@ -196,7 +196,7 @@ where
 {
     match ca.is_sorted_flag2() {
         IsSorted::Ascending => Some(0),
-        IsSorted::Descending => Some(ca.len()),
+        IsSorted::Descending => Some(ca.len() - 1),
         IsSorted::Not => ca
             .into_iter()
             .enumerate()
@@ -212,7 +212,7 @@ where
     <&'a ChunkedArray<T> as IntoIterator>::Item: PartialOrd,
 {
     match ca.is_sorted_flag2() {
-        IsSorted::Ascending => Some(ca.len()),
+        IsSorted::Ascending => Some(ca.len() - 1),
         IsSorted::Descending => Some(0),
         IsSorted::Not => ca
             .into_iter()
@@ -228,7 +228,7 @@ where
 {
     match is_sorted {
         IsSorted::Ascending => Some(0),
-        IsSorted::Descending => Some(vals.len()),
+        IsSorted::Descending => Some(vals.len() - 1),
         IsSorted::Not => vals
             .iter()
             .enumerate()
@@ -242,8 +242,8 @@ where
     T: PartialOrd,
 {
     match is_sorted {
-        IsSorted::Ascending => Some(0),
-        IsSorted::Descending => Some(vals.len()),
+        IsSorted::Ascending => Some(vals.len() - 1),
+        IsSorted::Descending => Some(0),
         IsSorted::Not => vals
             .iter()
             .enumerate()

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1653,6 +1653,18 @@ def test_arg_min_and_arg_max() -> None:
     assert s.arg_min() == 0
     assert s.arg_max() == 1
 
+    # test ascending and descending series
+    s = pl.Series("a", [1, 2, 3, 4, 5])
+    s.sort(in_place=True)  # set ascending sorted flag
+    assert s.flags == {"SORTED_ASC": True, "SORTED_DESC": False}
+    assert s.arg_min() == 0
+    assert s.arg_max() == 4
+    s = pl.Series("a", [5, 4, 3, 2, 1])
+    s.sort(reverse=True, in_place=True)  # set descing sorted flag
+    assert s.flags == {"SORTED_ASC": False, "SORTED_DESC": True}
+    assert s.arg_min() == 4
+    assert s.arg_max() == 0
+
 
 def test_is_null_is_not_null() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, None])


### PR DESCRIPTION
Fixes some (minor) bugs in the arg_min / arg_max Rust code when the sorted flags are set.