### PR TITLE
doc(python): add example of consistent parsing, remove wrong zulu-time statement

### DIFF
--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -47,9 +47,6 @@ class ExprStringNameSpace:
             Format to use, refer to the `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
-            Note that the ``Z`` suffix for "Zulu time" in ISO8601 formats is not (yet!)
-            fully supported: you should first try ``"%+"`` and if that fails, insert a
-            ``Z`` in your ``fmt`` string and then use ``dt.convert_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact
@@ -72,6 +69,17 @@ class ExprStringNameSpace:
 
         Examples
         --------
+        Dealing with a consistent format:
+
+        >>> ts = ["2020-01-01 01:00Z", "2020-01-01 02:00Z"]
+        >>> pl.Series(ts).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M%#z")
+        shape: (2,)
+        Series: '' [datetime[μs, +00:00]]
+        [
+                2020-01-01 01:00:00 +00:00
+                2020-01-01 02:00:00 +00:00
+        ]
+
         Dealing with different formats.
 
         >>> s = pl.Series(

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -42,9 +42,6 @@ class StringNameSpace:
             `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
-            Note that the ``Z`` suffix for "Zulu time" in ISO8601 formats is not (yet!)
-            fully supported: you should first try ``"%+"`` and if that fails, insert a
-            ``Z`` in your ``fmt`` string and then use ``dt.convert_time_zone``.
         strict
             Raise an error if any conversion fails.
         exact
@@ -65,6 +62,17 @@ class StringNameSpace:
 
         Examples
         --------
+        Dealing with a consistent format:
+
+        >>> ts = ["2020-01-01 01:00Z", "2020-01-01 02:00Z"]
+        >>> pl.Series(ts).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M%#z")
+        shape: (2,)
+        Series: '' [datetime[μs, +00:00]]
+        [
+                2020-01-01 01:00:00 +00:00
+                2020-01-01 02:00:00 +00:00
+        ]
+
         Dealing with different formats.
 
         >>> s = pl.Series(


### PR DESCRIPTION
Turns out you can parse Z with `'%#z'` instead of `'%z'`, but it's not at all clear from the Chrono docs. Is it OK to add this as an example? The only example at the moment is the mixed-formats one, which is probably much rarer?