### PR TITLE
test(rust): Clean up some warnings

### DIFF
--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -60,6 +60,7 @@ mod test {
                 SortOptions {
                     descending: false,
                     nulls_last: false,
+                    ..Default::default()
                 },
             )
             .collect()?;
@@ -77,6 +78,7 @@ mod test {
                 SortOptions {
                     descending: false,
                     nulls_last: false,
+                    ..Default::default()
                 },
             )
             .collect()?;

--- a/polars/tests/it/core/joins.rs
+++ b/polars/tests/it/core/joins.rs
@@ -251,7 +251,6 @@ fn test_join_multiple_columns() {
 #[cfg_attr(miri, ignore)]
 #[cfg(feature = "dtype-categorical")]
 fn test_join_categorical() {
-    use polars::toggle_string_cache;
     let _lock = IUseStringCache::new();
     let _lock = polars_core::SINGLE_LOCK.lock();
 

--- a/polars/tests/it/core/pivot.rs
+++ b/polars/tests/it/core/pivot.rs
@@ -1,4 +1,4 @@
-use polars::export::chrono::{NaiveDate, NaiveDateTime};
+use polars::export::chrono::NaiveDate;
 use polars::prelude::*;
 use polars_ops::pivot::{pivot, pivot_stable, PivotAgg};
 

--- a/polars/tests/it/core/series.rs
+++ b/polars/tests/it/core/series.rs
@@ -31,7 +31,7 @@ fn test_min_max_sorted_asc() {
 
 #[test]
 fn test_min_max_sorted_desc() {
-    let mut a = &mut Series::new("a", &[4, 3, 2, 1]);
+    let a = &mut Series::new("a", &[4, 3, 2, 1]);
     a.set_sorted_flag(IsSorted::Descending);
     assert_eq!(a.max(), Some(4));
     assert_eq!(a.min(), Some(1));

--- a/polars/tests/it/io/ipc_stream.rs
+++ b/polars/tests/it/io/ipc_stream.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 #[cfg(test)]
 mod test {
     use std::io::Cursor;

--- a/polars/tests/it/io/json.rs
+++ b/polars/tests/it/io/json.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::io::Cursor;
 
 use super::*;

--- a/polars/tests/it/lazy/aggregation.rs
+++ b/polars/tests/it/lazy/aggregation.rs
@@ -72,12 +72,12 @@ fn test_lazy_agg() {
 fn test_apply_multiple_error() {
     fn issue() -> Expr {
         apply_multiple(
-            move |columns| return Err(PolarsError::ComputeError("hardcoded error".into())),
+            move |_| return Err(PolarsError::ComputeError("hardcoded error".into())),
             &[col("x"), col("y")],
             GetOutput::from_type(DataType::Float64),
             true,
         )
-    };
+    }
 
     let df = df![
         "rf" => ["App", "App", "Gg", "App"],
@@ -87,7 +87,7 @@ fn test_apply_multiple_error() {
     ]
     .unwrap();
 
-    let res = df
+    let _res = df
         .lazy()
         .with_streaming(false)
         .groupby_stable([col("rf")])

--- a/polars/tests/it/lazy/groupby.rs
+++ b/polars/tests/it/lazy/groupby.rs
@@ -124,7 +124,7 @@ fn test_groupby_agg_list_with_not_aggregated() -> PolarsResult<()> {
 #[test]
 #[cfg(all(feature = "dtype-duration", feature = "dtype-struct"))]
 fn test_logical_mean_partitioned_groupby_block() -> PolarsResult<()> {
-    let guard = SINGLE_LOCK.lock();
+    let _guard = SINGLE_LOCK.lock();
     let df = df![
         "a" => [1, 1, 2],
         "duration" => [1000, 2000, 3000]


### PR DESCRIPTION
My IDE was complaining about these.

There are also a bunch of broken tests in `polars/polars/lazy/polars-plan/src/logical_plan`, and an issue with the example in `examples/read_csv/src/main.rs`. Any suggestion on what to do with those?