### PR TITLE
chore(python): Properly deprecate GroupBy.agg_list

### DIFF
--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -12,7 +12,7 @@ from typing import (
 )
 
 import polars.internals as pli
-from polars.utils import _timedelta_to_pl_duration
+from polars.utils import _timedelta_to_pl_duration, redirect
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 DF = TypeVar("DF", bound="pli.DataFrame")
 
 
+@redirect({"agg_list": "all"})
 class GroupBy(Generic[DF]):
     """Starts a new GroupBy operation."""
 
@@ -673,30 +674,6 @@ class GroupBy(Generic[DF]):
 
         """
         return self.agg(pli.all().median())
-
-    def agg_list(self) -> pli.DataFrame:
-        """
-        Aggregate the groups into Series.
-
-        .. deprecated:: 0.16.0
-            Use ```all()``
-
-        Examples
-        --------
-        >>> df = pl.DataFrame({"a": ["one", "two", "one", "two"], "b": [1, 2, 3, 4]})
-        >>> df.groupby("a", maintain_order=True).agg_list()
-        shape: (2, 2)
-        ┌─────┬───────────┐
-        │ a   ┆ b         │
-        │ --- ┆ ---       │
-        │ str ┆ list[i64] │
-        ╞═════╪═══════════╡
-        │ one ┆ [1, 3]    │
-        │ two ┆ [2, 4]    │
-        └─────┴───────────┘
-
-        """
-        return self.agg(pli.all())
 
     def all(self) -> pli.DataFrame:
         """

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1694,7 +1694,7 @@ def test_groupby_order_dispatch() -> None:
     )
     assert_frame_equal(result, expected)
 
-    result = df.groupby("x", maintain_order=True).agg_list()
+    result = df.groupby("x", maintain_order=True).all()
     expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/test_groupby.py
+++ b/py-polars/tests/unit/test_groupby.py
@@ -58,7 +58,7 @@ def test_groupby() -> None:
     assert sorted(df.groupby("b").mean().rows()) == [("a", 1.5, 1.0), ("b", 4.0, 1.0)]
     assert sorted(df.groupby("b").n_unique().rows()) == [("a", 2, 2), ("b", 3, 2)]
     assert sorted(df.groupby("b").median().rows()) == [("a", 1.5, 1.0), ("b", 4.0, 1.0)]
-    assert sorted(df.groupby("b").agg_list().rows()) == [
+    assert sorted(df.groupby("b").all().rows()) == [
         ("a", [1, 2], [None, 1]),
         ("b", [3, 4, 5], [None, 1, None]),
     ]

--- a/py-polars/tests/unit/test_struct.py
+++ b/py-polars/tests/unit/test_struct.py
@@ -328,7 +328,7 @@ def test_struct_list_head_tail() -> None:
     }
 
 
-def test_struct_agg_list() -> None:
+def test_struct_agg_all() -> None:
     df = pl.DataFrame(
         {
             "group": ["a", "a", "b", "b", "b"],
@@ -342,7 +342,7 @@ def test_struct_agg_list() -> None:
         }
     )
 
-    assert df.groupby("group", maintain_order=True).agg_list().to_dict(False) == {
+    assert df.groupby("group", maintain_order=True).all().to_dict(False) == {
         "group": ["a", "b"],
         "col1": [
             [{"x": 1, "y": 100}, {"x": 2, "y": 200}],


### PR DESCRIPTION
The docstring mentioned this method was deprecated, but did not raise a deprecation warning.

Now it will raise a deprecation warning using the `redirect` decorator.