### PR TITLE
feat(python): Make groupby agg shortcuts available in lazy

### DIFF
--- a/py-polars/docs/source/reference/lazyframe/groupby.rst
+++ b/py-polars/docs/source/reference/lazyframe/groupby.rst
@@ -10,6 +10,17 @@ This namespace comes available by calling `LazyFrame.groupby(..)`.
    :toctree: api/
 
     LazyGroupBy.agg
+    LazyGroupBy.all
     LazyGroupBy.apply
+    LazyGroupBy.count
+    LazyGroupBy.first
     LazyGroupBy.head
+    LazyGroupBy.last
+    LazyGroupBy.max
+    LazyGroupBy.mean
+    LazyGroupBy.median
+    LazyGroupBy.min
+    LazyGroupBy.n_unique
+    LazyGroupBy.quantile
+    LazyGroupBy.sum
     LazyGroupBy.tail


### PR DESCRIPTION
Changes:
* Alphabetize the aggregate shortcuts in the `GroupBy` utility class
* Fix return types
* Make shortcuts available in `LazyGroupBy`