### PR TITLE
fix(rust, python): ensure literals are expanded in streaming

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
@@ -40,11 +40,28 @@ impl Operator for ProjectionOperator {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-        let projected = self
+        let mut has_literals = false;
+        let mut projected = self
             .exprs
             .iter()
-            .map(|e| e.evaluate(chunk, context.execution_state.as_any()))
+            .map(|e| {
+                let s = e.evaluate(chunk, context.execution_state.as_any())?;
+                if s.len() == 1 {
+                    has_literals = true;
+                }
+                Ok(s)
+            })
             .collect::<PolarsResult<Vec<_>>>()?;
+
+        if has_literals {
+            let height = projected.iter().map(|s| s.len()).max().unwrap();
+            for s in &mut projected {
+                let len = s.len();
+                if len == 1 && len != height {
+                    *s = s.new_from_index(0, height)
+                }
+            }
+        }
 
         let chunk = chunk.with_data(DataFrame::new_no_checks(projected));
         Ok(OperatorResult::Finished(chunk))

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -246,10 +246,12 @@ def test_ooc_sort(monkeypatch: Any) -> None:
 
 
 def test_streaming_literal_expansion() -> None:
-    df = pl.DataFrame({
-        "y": ["a", "b"],
-        "z": [1, 2],
-    })
+    df = pl.DataFrame(
+        {
+            "y": ["a", "b"],
+            "z": [1, 2],
+        }
+    )
 
     q = df.lazy().select(
         x=pl.lit("constant"),
@@ -257,6 +259,19 @@ def test_streaming_literal_expansion() -> None:
         z=pl.col("z"),
     )
 
-    assert q.collect(streaming=True).to_dict(False) == {'x': ['constant', 'constant'], 'y': ['a', 'b'], 'z': [1, 2]}
-    assert q.groupby(["x", "y"]).agg(pl.mean("z")).sort("y").collect(streaming=True).to_dict(False) == {'x': ['constant', 'constant'], 'y': ['a', 'b'], 'z': [1.0, 2.0]}
-    assert q.groupby(["x"]).agg(pl.mean("z")).collect().to_dict(False) == {'x': ['constant'], 'z': [1.5]}
+    assert q.collect(streaming=True).to_dict(False) == {
+        "x": ["constant", "constant"],
+        "y": ["a", "b"],
+        "z": [1, 2],
+    }
+    assert q.groupby(["x", "y"]).agg(pl.mean("z")).sort("y").collect(
+        streaming=True
+    ).to_dict(False) == {
+        "x": ["constant", "constant"],
+        "y": ["a", "b"],
+        "z": [1.0, 2.0],
+    }
+    assert q.groupby(["x"]).agg(pl.mean("z")).collect().to_dict(False) == {
+        "x": ["constant"],
+        "z": [1.5],
+    }

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -243,3 +243,20 @@ def test_ooc_sort(monkeypatch: Any) -> None:
         ).to_series()
 
         assert_series_equal(out, s.sort(reverse=reverse))
+
+
+def test_streaming_literal_expansion() -> None:
+    df = pl.DataFrame({
+        "y": ["a", "b"],
+        "z": [1, 2],
+    })
+
+    q = df.lazy().select(
+        x=pl.lit("constant"),
+        y=pl.col("y"),
+        z=pl.col("z"),
+    )
+
+    assert q.collect(streaming=True).to_dict(False) == {'x': ['constant', 'constant'], 'y': ['a', 'b'], 'z': [1, 2]}
+    assert q.groupby(["x", "y"]).agg(pl.mean("z")).sort("y").collect(streaming=True).to_dict(False) == {'x': ['constant', 'constant'], 'y': ['a', 'b'], 'z': [1.0, 2.0]}
+    assert q.groupby(["x"]).agg(pl.mean("z")).collect().to_dict(False) == {'x': ['constant'], 'z': [1.5]}


### PR DESCRIPTION
fixes #6945
