### PR TITLE
perf(rust, python): don't pack integer keys in determining `~8-18%` group tuples.

### DIFF
--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -866,13 +866,6 @@ pub(crate) fn index_to_chunked_index2(chunks: &[ArrayRef], index: usize) -> (usi
     (current_chunk_idx, index_remainder)
 }
 
-/// # SAFETY
-/// `dst` must be valid for `dst.len()` elements, and `src` and `dst` may not overlap.
-#[inline]
-pub(crate) unsafe fn copy_from_slice_unchecked<T>(src: &[T], dst: &mut [T]) {
-    std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), dst.len());
-}
-
 #[cfg(feature = "chunked_ids")]
 pub(crate) fn create_chunked_index_mapping(chunks: &[ArrayRef], len: usize) -> Vec<ChunkId> {
     let mut vals = Vec::with_capacity(len);

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -216,10 +216,8 @@ where
                     .zip(&mut hashes[offset..])
                     .zip(arr.values().as_slice())
                     .for_each(|((valid, h), l)| {
-                        *h = _boost_hash_combine(
-                            [null_h, random_state.hash_single(l)][valid as usize],
-                            *h,
-                        )
+                        let l = l._fx_hash(k);
+                        *h = _boost_hash_combine([null_h, l][valid as usize], *h)
                     });
             }
         }


### PR DESCRIPTION
Benchmarking some old assumptions.

Cleanes up code and is faster.