### PR TITLE
fix(python): Add packaging to runtime dependencies

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -13,6 +13,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
   "typing_extensions >= 4.0.1; python_version < '3.11'",
+  "packaging; python_version >= '3.10'",
 ]
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [


### PR DESCRIPTION
On https://github.com/pola-rs/polars/blob/cec13c3a9ddf70d856a47e703e605a703721ef63/py-polars/polars/internals/dataframe/frame.py#L107 `packaging` is import but not declared as a runtime dependency. This adds the listing to `pyproject.toml`.