### PR TITLE
perf(python): Improve performance of `expr_to_lit_or_expr` for arguments of type `Expr` by ~80%

### DIFF
--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -110,7 +110,9 @@ def expr_to_lit_or_expr(
     Expr
 
     """
-    if isinstance(expr, str) and not str_to_lit:
+    if isinstance(expr, Expr):
+        pass
+    elif isinstance(expr, str) and not str_to_lit:
         expr = pli.col(expr)
     elif (
         isinstance(expr, (int, float, str, pli.Series, datetime, date, time, timedelta))
@@ -123,7 +125,7 @@ def expr_to_lit_or_expr(
         structify = False
     elif isinstance(expr, (pli.WhenThen, pli.WhenThenThen)):
         expr = expr.otherwise(None)  # implicitly add the null branch.
-    elif not isinstance(expr, Expr):
+    else:
         raise TypeError(
             f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with"
             " pl.lit or pl.col"


### PR DESCRIPTION
`expr_to_lit_or_expr` is used extensively throughout the codebase. When providing arguments of type `Expr` in an attempt to improve performance, the current implementation can do better IMO.

Benchmark

```
python3 -m timeit -s "import polars; expr = polars.col('test')" "polars.internals.expr_to_lit_or_expr(expr)"
```

0.16.6: `351 nsec per loop`
After PR: `74.1 nsec per loop`