### PR TITLE
feat(python): remove `packaging` and/or `distutils` dependency with a minimal version parser utility

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -84,6 +84,7 @@ from polars.utils import (
     is_int_sequence,
     is_str_sequence,
     normalise_filepath,
+    parse_version,
     range_to_slice,
     redirect,
     scale_bytes,
@@ -103,11 +104,7 @@ else:
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec, TypeAlias
-
-    from packaging.version import parse as ParseVersion
 else:
-    from distutils.version import LooseVersion as ParseVersion
-
     from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -2025,7 +2022,7 @@ class DataFrame:
 
         """
         if use_pyarrow_extension_array:
-            if ParseVersion(pd.__version__) < ParseVersion("1.5"):
+            if parse_version(pd.__version__) < parse_version("1.5"):
                 raise ModuleNotFoundError(
                     f'"use_pyarrow_extension_array=True" requires Pandas 1.5.x or higher, found Pandas {pd.__version__}.'
                 )

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -13,7 +13,6 @@ license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
   "typing_extensions >= 4.0.1; python_version < '3.11'",
-  "packaging; python_version >= '3.10'",
 ]
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -13,6 +13,7 @@ from polars.utils import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
     deprecate_nonkeyword_arguments,
+    parse_version,
 )
 
 if TYPE_CHECKING:
@@ -76,6 +77,21 @@ def test_estimated_size() -> None:
 
     with pytest.raises(ValueError):
         s.estimated_size("milkshake")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("v1", "v2"),
+    [
+        ("0.16.8", "0.16.7"),
+        ("23.0.0", (3, 1000)),
+        ((23, 0, 0), "3.1000"),
+        (("0", "0", "2beta"), "0.0.1"),
+        (("2", "5", "0", "1"), (2, 5, 0)),
+    ],
+)
+def test_parse_version(v1: Any, v2: Any) -> None:
+    assert parse_version(v1) > parse_version(v2)
+    assert parse_version(v2) < parse_version(v1)
 
 
 class Foo:


### PR DESCRIPTION
ref: #6966, #6962

Remove all external dependencies for basic version parsing.
Handles everything that we're realistically likely to need (just doesn't respect any "alpha", "beta", "dev" tags).

```python
parse_version("1.5.6") > parse_version("1.5.5.9")
# True

parse_version((0, 1, 2)) > parse_version("0.1.1")
# True
```