### PR TITLE
feat(python): More ergonomic `coalesce` args

### DIFF
--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -245,28 +245,21 @@ def test_nan_aggregations() -> None:
 def test_coalesce() -> None:
     df = pl.DataFrame(
         {
-            "a": [None, None, None, None],
-            "b": [1, 2, None, None],
-            "c": [1, None, 3, None],
-        }
-    )
-    assert df.select(pl.coalesce(["a", "b", "c", 10])).to_dict(False) == {
-        "a": [1.0, 2.0, 3.0, 10.0]
-    }
-    assert df.select(pl.coalesce(pl.col(["a", "b", "c"]))).to_dict(False) == {
-        "a": [1.0, 2.0, 3.0, None]
-    }
-    # test literal and supertype #6988
-    df = pl.DataFrame(
-        {
             "a": [1, None, None, None],
             "b": [1, 2, None, None],
             "c": [5, None, 3, None],
         }
     )
-    assert df.select(pl.coalesce(["a", "b", "c", 10])).to_dict(False) == {
-        "a": [1, 2, 3, 10]
-    }
+
+    # List inputs
+    expected = pl.Series("d", [1, 2, 3, 10]).to_frame()
+    result = df.select(pl.coalesce(["a", "b", "c", 10]).alias("d"))
+    assert_frame_equal(expected, result)
+
+    # Positional inputs
+    expected = pl.Series("d", [1.0, 2.0, 3.0, 10.0]).to_frame()
+    result = df.select(pl.coalesce(pl.col(["a", "b", "c"]), 10.0).alias("d"))
+    assert_frame_equal(result, expected)
 
 
 def test_ones_zeros() -> None:


### PR DESCRIPTION
_(Currently sort-of blocked by #6988 as the doc examples / tests I came up with do not pass)_

Partially addresses https://github.com/pola-rs/polars/issues/6451

Changes:
* Add `*args` to `coalesce` and update docstring/tests