### PR TITLE
fix(python): if given, respect dtype timeunit when instantiating `pl.lit` value

### DIFF
--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1127,9 +1127,10 @@ def lit(
 
     """
     tu: TimeUnit
+
     if isinstance(value, datetime):
         tu = "us" if dtype is None else getattr(dtype, "tu", "us")
-        e = lit(_datetime_to_pl_timestamp(value, tu)).cast(dtype or Datetime(tu))
+        e = lit(_datetime_to_pl_timestamp(value, tu)).cast(Datetime(tu))
         if value.tzinfo is not None:
             return e.dt.replace_time_zone(str(value.tzinfo))
         else:
@@ -1137,7 +1138,7 @@ def lit(
 
     elif isinstance(value, timedelta):
         tu = "us" if dtype is None else getattr(dtype, "tu", "us")
-        return lit(_timedelta_to_pl_timedelta(value, tu)).cast(dtype or Duration(tu))
+        return lit(_timedelta_to_pl_timedelta(value, tu)).cast(Duration(tu))
 
     elif isinstance(value, time):
         return lit(_time_to_pl_time(value)).cast(Time)

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1128,16 +1128,16 @@ def lit(
     """
     tu: TimeUnit
     if isinstance(value, datetime):
-        tu = "us"
-        e = lit(_datetime_to_pl_timestamp(value, tu)).cast(Datetime(tu))
+        tu = "us" if dtype is None else getattr(dtype, "tu", "us")
+        e = lit(_datetime_to_pl_timestamp(value, tu)).cast(dtype or Datetime(tu))
         if value.tzinfo is not None:
             return e.dt.replace_time_zone(str(value.tzinfo))
         else:
             return e
 
     elif isinstance(value, timedelta):
-        tu = "us"
-        return lit(_timedelta_to_pl_timedelta(value, tu)).cast(Duration(tu))
+        tu = "us" if dtype is None else getattr(dtype, "tu", "us")
+        return lit(_timedelta_to_pl_timedelta(value, tu)).cast(dtype or Duration(tu))
 
     elif isinstance(value, time):
         return lit(_time_to_pl_time(value)).cast(Time)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import random
 import typing
+from datetime import datetime
 from typing import cast
 
 import numpy as np
@@ -520,3 +521,16 @@ def test_map_dict() -> None:
         "country_code": ["FR", None, "ES", "DE"],
         "remapped": ["France", "Not specified", "2", "Germany"],
     }
+
+
+def test_lit_dtype_timeunits() -> None:
+    d = datetime(2049, 10, 5, 1, 2, 3, 456789)
+    df = pl.DataFrame(
+        {
+            "ms": pl.select(pl.lit(d, dtype=pl.Datetime("ms"))).to_series(),
+            "us": pl.select(pl.lit(d, dtype=pl.Datetime("us"))).to_series(),
+            "ns": pl.select(pl.lit(d, dtype=pl.Datetime("ns"))).to_series(),
+        }
+    )
+    assert df.dtypes == [pl.Datetime("ms"), pl.Datetime("us"), pl.Datetime("ns")]
+    assert df.row(0) == (datetime(2049, 10, 5, 1, 2, 3, 456000), d, d)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import random
 import typing
-from datetime import datetime
-from typing import cast
+from datetime import datetime, timedelta
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -16,6 +16,7 @@ from polars.datatypes import (
     INTEGER_DTYPES,
     NUMERIC_DTYPES,
     TEMPORAL_DTYPES,
+    PolarsDataType,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -523,14 +524,38 @@ def test_map_dict() -> None:
     }
 
 
-def test_lit_dtype_timeunits() -> None:
-    d = datetime(2049, 10, 5, 1, 2, 3, 456789)
+def test_lit_dtypes() -> None:
+    def lit_series(value: Any, dtype: PolarsDataType) -> pl.Series:
+        return pl.select(pl.lit(value, dtype=dtype)).to_series()
+
+    d = datetime(2049, 10, 5, 1, 2, 3, 987654)
+    d_ms = datetime(2049, 10, 5, 1, 2, 3, 987000)
+
+    td = timedelta(days=942, hours=6, microseconds=123456)
+    td_ms = timedelta(days=942, seconds=21600, microseconds=123000)
+
     df = pl.DataFrame(
         {
-            "ms": pl.select(pl.lit(d, dtype=pl.Datetime("ms"))).to_series(),
-            "us": pl.select(pl.lit(d, dtype=pl.Datetime("us"))).to_series(),
-            "ns": pl.select(pl.lit(d, dtype=pl.Datetime("ns"))).to_series(),
+            "dtm_ms": lit_series(d, pl.Datetime("ms")),
+            "dtm_us": lit_series(d, pl.Datetime("us")),
+            "dtm_ns": lit_series(d, pl.Datetime("ns")),
+            "dur_ms": lit_series(td, pl.Duration("ms")),
+            "dur_us": lit_series(td, pl.Duration("us")),
+            "dur_ns": lit_series(td, pl.Duration("ns")),
+            "f32": lit_series(0, pl.Float32),
+            "u16": lit_series(0, pl.UInt16),
+            "i16": lit_series(0, pl.Int16),
         }
     )
-    assert df.dtypes == [pl.Datetime("ms"), pl.Datetime("us"), pl.Datetime("ns")]
-    assert df.row(0) == (datetime(2049, 10, 5, 1, 2, 3, 456000), d, d)
+    assert df.dtypes == [
+        pl.Datetime("ms"),
+        pl.Datetime("us"),
+        pl.Datetime("ns"),
+        pl.Duration("ms"),
+        pl.Duration("us"),
+        pl.Duration("ns"),
+        pl.Float32,
+        pl.UInt16,
+        pl.Int16,
+    ]
+    assert df.row(0) == (d_ms, d, d, td_ms, td, td, 0, 0, 0)


### PR DESCRIPTION
Closes #6980.