### PR TITLE
fix(python): if given, respect dtype time zone when instantiating pl.lit value

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -346,7 +346,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
         DataType::Datetime(tu, tz) => {
             if tz.is_some() && tz_aware {
                 return Err(PolarsError::ComputeError(
-                    "Cannot use strptime with both 'tz_aware=True' and tz-aware Datetime.".into(),
+                    "Cannot use strptime with both 'tz_aware=True' and tz-aware Datetime. Please drop time zone from the dtype.".into(),
                 ));
             }
             if options.exact {

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1153,9 +1153,19 @@ def lit(
 
     if isinstance(value, datetime):
         tu = "us" if dtype is None else getattr(dtype, "tu", "us")
+        tz = (
+            value.tzinfo
+            if getattr(dtype, "tz", None) is None
+            else getattr(dtype, "tz", None)
+        )
+        if value.tzinfo is not None and getattr(dtype, "tz", None) is not None:
+            raise TypeError(
+                "Cannot cast tz-aware value to tz-aware dtype. "
+                "Please drop the time zone from the dtype."
+            )
         e = lit(_datetime_to_pl_timestamp(value, tu)).cast(Datetime(tu))
-        if value.tzinfo is not None:
-            return e.dt.replace_time_zone(str(value.tzinfo))
+        if tz is not None:
+            return e.dt.replace_time_zone(str(tz))
         else:
             return e
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import random
+import sys
 import typing
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
-from zoneinfo import ZoneInfo
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+else:
+    # Import from submodule due to typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -526,12 +526,12 @@ def test_map_dict() -> None:
 
 
 def test_lit_dtypes() -> None:
-    def lit_series(value: Any, dtype: PolarsDataType) -> pl.Series:
+    def lit_series(value: Any, dtype: PolarsDataType | None) -> pl.Series:
         return pl.select(pl.lit(value, dtype=dtype)).to_series()
 
     d = datetime(2049, 10, 5, 1, 2, 3, 987654)
     d_ms = datetime(2049, 10, 5, 1, 2, 3, 987000)
-    d_aware = datetime(2049, 10, 5, 1, 2, 3, 987654, tzinfo=ZoneInfo("Asia/Kathmandu"))
+    d_tz = datetime(2049, 10, 5, 1, 2, 3, 987654, tzinfo=ZoneInfo("Asia/Kathmandu"))
 
     td = timedelta(days=942, hours=6, microseconds=123456)
     td_ms = timedelta(days=942, seconds=21600, microseconds=123000)
@@ -542,7 +542,9 @@ def test_lit_dtypes() -> None:
             "dtm_us": lit_series(d, pl.Datetime("us")),
             "dtm_ns": lit_series(d, pl.Datetime("ns")),
             "dtm_aware_0": lit_series(d, pl.Datetime("us", "Asia/Kathmandu")),
-            "dtm_aware_1": lit_series(d_aware, pl.Datetime("us")),
+            "dtm_aware_1": lit_series(d_tz, pl.Datetime("us")),
+            "dtm_aware_2": lit_series(d_tz, None),
+            "dtm_aware_3": lit_series(d, pl.Datetime(None, "Asia/Kathmandu")),
             "dur_ms": lit_series(td, pl.Duration("ms")),
             "dur_us": lit_series(td, pl.Duration("us")),
             "dur_ns": lit_series(td, pl.Duration("ns")),
@@ -557,6 +559,8 @@ def test_lit_dtypes() -> None:
         pl.Datetime("ns"),
         pl.Datetime("us", "Asia/Kathmandu"),
         pl.Datetime("us", "Asia/Kathmandu"),
+        pl.Datetime("us", "Asia/Kathmandu"),
+        pl.Datetime("us", "Asia/Kathmandu"),
         pl.Duration("ms"),
         pl.Duration("us"),
         pl.Duration("ns"),
@@ -564,7 +568,7 @@ def test_lit_dtypes() -> None:
         pl.UInt16,
         pl.Int16,
     ]
-    assert df.row(0) == (d_ms, d, d, d_aware, d_aware, td_ms, td, td, 0, 0, 0)
+    assert df.row(0) == (d_ms, d, d, d_tz, d_tz, d_tz, d_tz, td_ms, td, td, 0, 0, 0)
 
 
 def test_incompatible_lit_dtype() -> None:


### PR DESCRIPTION
closes #6992 