### PR TITLE
test(python): date-time unit tests refactor

### DIFF
--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -223,7 +223,7 @@ def test_cast_time_units(
     assert dates.dt.cast_time_unit(time_unit).cast(int).to_list() == date_in_that_unit
 
 
-def test_epoch() -> None:
+def test_epoch_matches_timestamp() -> None:
     dates = pl.Series([datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
 
     for unit in DTYPE_TEMPORAL_UNITS:
@@ -255,7 +255,7 @@ def test_date_time_combine() -> None:
         }
     )
 
-    # Combine datetime/date and time
+    # Combine datetime/date with time
     df = df.select(
         [
             pl.col("dtm").dt.combine(pl.col("tm")).alias("d1"),  # datetime & time
@@ -264,22 +264,18 @@ def test_date_time_combine() -> None:
         ]
     )
 
-    # Check that the new columns have the expected values and datatypes
+    # Assert that the new columns have the expected values and datatypes
     expected_dict = {
-        "d1": [
-            datetime(
-                2022, 12, 31, 1, 2, 3, 456000
-            ),  # Time component should be overwritten by `tm`
+        "d1": [  # Time component should be overwritten by `tm` values
+            datetime(2022, 12, 31, 1, 2, 3, 456000),
             datetime(2023, 7, 5, 7, 8, 9, 101000),
         ],
-        "d2": [
+        "d2": [  # Both date and time components combined "as-is" into new datetime
             datetime(2022, 10, 10, 1, 2, 3, 456000),
             datetime(2022, 7, 5, 7, 8, 9, 101000),
         ],
-        "d3": [
-            datetime(
-                2022, 10, 10, 4, 5, 6
-            ),  # New datetime should use specified time component
+        "d3": [  # New datetime should use specified time component
+            datetime(2022, 10, 10, 4, 5, 6),
             datetime(2022, 7, 5, 4, 5, 6),
         ],
     }

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -36,27 +36,22 @@ def test_dt_strftime(series_of_dates: pl.Series) -> None:
     assert_series_equal(series_of_dates.dt.strftime("%F"), expected)
 
 
+@pytest.mark.parametrize(
+    ("unit", "expected"),
+    [
+        ("year", pl.Series("", [1997, 2024, 2052], pl.Int32)),
+        ("month", pl.Series("", [5, 10, 2], pl.UInt32)),
+        ("week", pl.Series("", [21, 40, 8], pl.UInt32)),
+        ("day", pl.Series("", [19, 4, 20], pl.UInt32)),
+        ("ordinal_day", pl.Series("", [139, 278, 51], pl.UInt32)),
+    ],
+)
 def test_dt_year_month_week_day_ordinal_day(
+    unit: str,
+    expected: pl.Series,
     series_of_dates: pl.Series,
 ) -> None:
-    assert_series_equal(
-        series_of_dates.dt.year(), pl.Series([1997, 2024, 2052], dtype=pl.Int32)
-    )
-    assert_series_equal(
-        series_of_dates.dt.month(), pl.Series([5, 10, 2], dtype=pl.UInt32)
-    )
-    assert_series_equal(
-        series_of_dates.dt.weekday(), pl.Series([1, 5, 2], dtype=pl.UInt32)
-    )
-    assert_series_equal(
-        series_of_dates.dt.week(), pl.Series([21, 40, 8], dtype=pl.UInt32)
-    )
-    assert_series_equal(
-        series_of_dates.dt.day(), pl.Series([19, 4, 20], dtype=pl.UInt32)
-    )
-    assert_series_equal(
-        series_of_dates.dt.ordinal_day(), pl.Series([139, 278, 51], dtype=pl.UInt32)
-    )
+    assert_series_equal(getattr(series_of_dates.dt, unit)(), expected)
 
 
 def test_dt_datetimes() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -206,17 +206,22 @@ def test_round(
     assert out.dt[-1] == stop
 
 
-def test_cast_time_units() -> None:
+@pytest.mark.parametrize(
+    ("time_unit", "date_in_that_unit"),
+    [
+        ("ns", [978307200000000000, 981022089000000000]),
+        ("us", [978307200000000, 981022089000000]),
+        ("ms", [978307200000, 981022089000]),
+    ],
+    ids=["nanoseconds", "microseconds", "milliseconds"],
+)
+def test_cast_time_units(
+    time_unit: Literal["ms", "us", "ns"],
+    date_in_that_unit: list[int],
+) -> None:
     dates = pl.Series([datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
-    dates_in_ns = np.array([978307200000000000, 981022089000000000])
 
-    assert dates.dt.cast_time_unit("ns").cast(int).to_list() == list(dates_in_ns)
-    assert dates.dt.cast_time_unit("us").cast(int).to_list() == list(
-        dates_in_ns // 1_000
-    )
-    assert dates.dt.cast_time_unit("ms").cast(int).to_list() == list(
-        dates_in_ns // 1_000_000
-    )
+    assert dates.dt.cast_time_unit(time_unit).cast(int).to_list() == date_in_that_unit
 
 
 def test_epoch() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -37,21 +37,22 @@ def test_dt_strftime(series_of_dates: pl.Series) -> None:
 
 
 @pytest.mark.parametrize(
-    ("unit", "expected"),
+    ("unit_attr", "expected"),
     [
-        ("year", pl.Series("", [1997, 2024, 2052], pl.Int32)),
-        ("month", pl.Series("", [5, 10, 2], pl.UInt32)),
-        ("week", pl.Series("", [21, 40, 8], pl.UInt32)),
-        ("day", pl.Series("", [19, 4, 20], pl.UInt32)),
-        ("ordinal_day", pl.Series("", [139, 278, 51], pl.UInt32)),
+        ("year", pl.Series(values=[1997, 2024, 2052], dtype=pl.Int32)),
+        ("month", pl.Series(values=[5, 10, 2], dtype=pl.UInt32)),
+        ("week", pl.Series(values=[21, 40, 8], dtype=pl.UInt32)),
+        ("day", pl.Series(values=[19, 4, 20], dtype=pl.UInt32)),
+        ("ordinal_day", pl.Series(values=[139, 278, 51], dtype=pl.UInt32)),
+        ("day_of_year", pl.Series(values=[139, 278, 51], dtype=pl.UInt32)),
     ],
 )
-def test_dt_year_month_week_day_ordinal_day(
-    unit: str,
+def test_dt_extract_year_month_week_day_ordinal_day(
+    unit_attr: str,
     expected: pl.Series,
     series_of_dates: pl.Series,
 ) -> None:
-    assert_series_equal(getattr(series_of_dates.dt, unit)(), expected)
+    assert_series_equal(getattr(series_of_dates.dt, unit_attr)(), expected)
 
 
 def test_dt_datetimes() -> None:
@@ -84,22 +85,26 @@ def test_dt_datetimes() -> None:
 
 
 @pytest.mark.parametrize(
-    ("unit", "expected"),
+    ("unit_attr", "expected"),
     [
-        ("days", [1]),
-        ("hours", [24]),
-        ("seconds", [3600 * 24]),
-        ("milliseconds", [3600 * 24 * int(1e3)]),
-        ("microseconds", [3600 * 24 * int(1e6)]),
-        ("nanoseconds", [3600 * 24 * int(1e9)]),
+        ("days", pl.Series([1])),
+        ("hours", pl.Series([24])),
+        ("minutes", pl.Series([24 * 60])),
+        ("seconds", pl.Series([3600 * 24])),
+        ("milliseconds", pl.Series([3600 * 24 * int(1e3)])),
+        ("microseconds", pl.Series([3600 * 24 * int(1e6)])),
+        ("nanoseconds", pl.Series([3600 * 24 * int(1e9)])),
     ],
 )
 def test_duration_extract_times(
-    unit: str, expected: list[int], date_2022_01_01: datetime, date_2022_01_02: datetime
+    unit_attr: str,
+    expected: pl.Series,
+    date_2022_01_01: datetime,
+    date_2022_01_02: datetime
 ) -> None:
     duration = pl.Series([date_2022_01_02]) - pl.Series([date_2022_01_01])
 
-    assert_series_equal(getattr(duration.dt, unit)(), pl.Series(expected))
+    assert_series_equal(getattr(duration.dt, unit_attr)(), expected)
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -92,7 +92,7 @@ def test_strptime_extract_times(
     ],
 )
 def test_strptime_epoch(
-    temporal_unit: Literal["d", "s", "ms"],
+    temporal_unit: TimeUnit,
     expected: pl.Series,
     series_of_str_dates: pl.Series,
 ) -> None:
@@ -101,7 +101,7 @@ def test_strptime_epoch(
     assert_series_equal(s.dt.epoch(tu=temporal_unit), expected)
 
 
-def test_strptime_fractional_seconds(series_of_str_dates: pl.Series):
+def test_strptime_fractional_seconds(series_of_str_dates: pl.Series) -> None:
     s = series_of_str_dates.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
 
     assert_series_equal(
@@ -143,7 +143,7 @@ def test_duration_extract_times(
     ids=["milliseconds", "microseconds", "nanoseconds"],
 )
 def test_truncate(
-    time_unit: Literal["ms", "us", "ns"],
+    time_unit: TimeUnit,
     every: str | timedelta,
     date_2022_01_01: datetime,
     date_2022_01_02: datetime,
@@ -179,7 +179,7 @@ def test_truncate(
     ids=["milliseconds", "microseconds", "nanoseconds"],
 )
 def test_round(
-    time_unit: Literal["ms", "us", "ns"],
+    time_unit: TimeUnit,
     every: str | timedelta,
     date_2022_01_01: datetime,
     date_2022_01_02: datetime,
@@ -215,7 +215,7 @@ def test_round(
     ids=["nanoseconds", "microseconds", "milliseconds"],
 )
 def test_cast_time_units(
-    time_unit: Literal["ms", "us", "ns"],
+    time_unit: TimeUnit,
     date_in_that_unit: list[int],
 ) -> None:
     dates = pl.Series([datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
@@ -327,7 +327,7 @@ def test_year_empty_df() -> None:
     ["ms", "us", "ns"],
     ids=["milliseconds", "microseconds", "nanoseconds"],
 )
-def test_weekday(time_unit: Literal["ms", "us", "ns"]) -> None:
+def test_weekday(time_unit: TimeUnit) -> None:
     friday = pl.Series([datetime(2023, 2, 17)])
 
     assert friday.dt.cast_time_unit(time_unit).dt.weekday()[0] == 5

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -248,18 +248,22 @@ def test_quarter() -> None:
 
 
 def test_date_offset() -> None:
-    out = pl.DataFrame(
-        {"dates": pl.date_range(datetime(2000, 1, 1), datetime(2020, 1, 1), "1y")}
-    ).with_columns(
-        [
-            pl.col("dates").dt.offset_by("1y").alias("date_plus_1y"),
-            pl.col("dates").dt.offset_by("-1y2mo").alias("date_min"),
-        ]
-    )
+    df = pl.DataFrame({"dates": pl.date_range(datetime(2000, 1, 1), datetime(2020, 1, 1), "1y")})
 
-    assert (out["date_plus_1y"].dt.day() == 1).all()
-    assert (out["date_min"].dt.day() == 1).all()
-    assert out["date_min"].to_list() == [
+    # Add two new columns to the DataFrame using the offset_by() method
+    df = df.with_columns([
+        df["dates"].dt.offset_by("1y").alias("date_plus_1y"),
+        df["dates"].dt.offset_by("-1y2mo").alias("date_min"),
+    ])
+
+    # Assert that the day of the month for all dates in the 'date_plus_1y' column is 1
+    assert (df["date_plus_1y"].dt.day() == 1).all()
+
+    # Assert that the day of the month for all dates in the 'date_min' column is 1
+    assert (df["date_min"].dt.day() == 1).all()
+
+    # Assert that the 'date_min' column contains the expected list of dates
+    expected_dates = [
         datetime(1998, 11, 1, 0, 0),
         datetime(1999, 11, 1, 0, 0),
         datetime(2000, 11, 1, 0, 0),
@@ -282,6 +286,7 @@ def test_date_offset() -> None:
         datetime(2017, 11, 1, 0, 0),
         datetime(2018, 11, 1, 0, 0),
     ]
+    assert df["date_min"].to_list() == expected_dates
 
 
 def test_year_empty_df() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -24,28 +24,39 @@ def date_2022_01_02() -> date:
     return date(2022, 1, 2)
 
 
-def test_dt_strftime() -> None:
-    s = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
-    assert s.dtype == pl.Date
-    expected = pl.Series("a", ["1997-05-19", "2024-10-04", "2052-02-20"])
-    assert_series_equal(s.dt.strftime("%F"), expected)
+@pytest.fixture()
+def series_of_dates() -> pl.Series:
+    return pl.Series([10000, 20000, 30000], dtype=pl.Date)
 
 
-def test_dt_year_month_week_day_ordinal_day() -> None:
-    s = pl.Series("a", [10000, 20000, 30000], dtype=pl.Date)
+def test_dt_strftime(series_of_dates: pl.Series) -> None:
+    expected = pl.Series(["1997-05-19", "2024-10-04", "2052-02-20"])
 
-    assert_series_equal(s.dt.year(), pl.Series("a", [1997, 2024, 2052], dtype=pl.Int32))
+    assert series_of_dates.dtype == pl.Date
+    assert_series_equal(series_of_dates.dt.strftime("%F"), expected)
 
-    assert_series_equal(s.dt.month(), pl.Series("a", [5, 10, 2], dtype=pl.UInt32))
-    assert_series_equal(s.dt.weekday(), pl.Series("a", [1, 5, 2], dtype=pl.UInt32))
-    assert_series_equal(s.dt.week(), pl.Series("a", [21, 40, 8], dtype=pl.UInt32))
-    assert_series_equal(s.dt.day(), pl.Series("a", [19, 4, 20], dtype=pl.UInt32))
+
+def test_dt_year_month_week_day_ordinal_day(
+    series_of_dates: pl.Series,
+) -> None:
     assert_series_equal(
-        s.dt.ordinal_day(), pl.Series("a", [139, 278, 51], dtype=pl.UInt32)
+        series_of_dates.dt.year(), pl.Series([1997, 2024, 2052], dtype=pl.Int32)
     )
-
-    assert s.dt.median() == date(2024, 10, 4)
-    assert s.dt.mean() == date(2024, 10, 4)
+    assert_series_equal(
+        series_of_dates.dt.month(), pl.Series([5, 10, 2], dtype=pl.UInt32)
+    )
+    assert_series_equal(
+        series_of_dates.dt.weekday(), pl.Series([1, 5, 2], dtype=pl.UInt32)
+    )
+    assert_series_equal(
+        series_of_dates.dt.week(), pl.Series([21, 40, 8], dtype=pl.UInt32)
+    )
+    assert_series_equal(
+        series_of_dates.dt.day(), pl.Series([19, 4, 20], dtype=pl.UInt32)
+    )
+    assert_series_equal(
+        series_of_dates.dt.ordinal_day(), pl.Series([139, 278, 51], dtype=pl.UInt32)
+    )
 
 
 def test_dt_datetimes() -> None:
@@ -53,31 +64,27 @@ def test_dt_datetimes() -> None:
     s = s.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
 
     # hours, minutes, seconds, milliseconds, microseconds, and nanoseconds
-    assert_series_equal(s.dt.hour(), pl.Series("", [0, 3], dtype=pl.UInt32))
-    assert_series_equal(s.dt.minute(), pl.Series("", [0, 20], dtype=pl.UInt32))
-    assert_series_equal(s.dt.second(), pl.Series("", [0, 10], dtype=pl.UInt32))
-    assert_series_equal(s.dt.millisecond(), pl.Series("", [0, 987], dtype=pl.UInt32))
-    assert_series_equal(s.dt.microsecond(), pl.Series("", [0, 987654], dtype=pl.UInt32))
-    assert_series_equal(
-        s.dt.nanosecond(), pl.Series("", [0, 987654321], dtype=pl.UInt32)
-    )
+    assert_series_equal(s.dt.hour(), pl.Series([0, 3], dtype=pl.UInt32))
+    assert_series_equal(s.dt.minute(), pl.Series([0, 20], dtype=pl.UInt32))
+    assert_series_equal(s.dt.second(), pl.Series([0, 10], dtype=pl.UInt32))
+    assert_series_equal(s.dt.millisecond(), pl.Series([0, 987], dtype=pl.UInt32))
+    assert_series_equal(s.dt.microsecond(), pl.Series([0, 987654], dtype=pl.UInt32))
+    assert_series_equal(s.dt.nanosecond(), pl.Series([0, 987654321], dtype=pl.UInt32))
 
     # epoch methods
-    assert_series_equal(
-        s.dt.epoch(tu="d"), pl.Series("", [18262, 18294], dtype=pl.Int32)
-    )
+    assert_series_equal(s.dt.epoch(tu="d"), pl.Series([18262, 18294], dtype=pl.Int32))
     assert_series_equal(
         s.dt.epoch(tu="s"),
-        pl.Series("", [1_577_836_800, 1_580_613_610], dtype=pl.Int64),
+        pl.Series([1_577_836_800, 1_580_613_610], dtype=pl.Int64),
     )
     assert_series_equal(
         s.dt.epoch(tu="ms"),
-        pl.Series("", [1_577_836_800_000, 1_580_613_610_000], dtype=pl.Int64),
+        pl.Series([1_577_836_800_000, 1_580_613_610_000], dtype=pl.Int64),
     )
     # fractional seconds
     assert_series_equal(
         s.dt.second(fractional=True),
-        pl.Series("", [0.0, 10.987654321], dtype=pl.Float64),
+        pl.Series([0.0, 10.987654321], dtype=pl.Float64),
     )
 
 
@@ -171,7 +178,7 @@ def test_round(
 
 
 def test_cast_time_units() -> None:
-    dates = pl.Series("dates", [datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
+    dates = pl.Series([datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
     dates_in_ns = np.array([978307200000000000, 981022089000000000])
 
     assert dates.dt.cast_time_unit("ns").cast(int).to_list() == list(dates_in_ns)
@@ -184,7 +191,7 @@ def test_cast_time_units() -> None:
 
 
 def test_epoch() -> None:
-    dates = pl.Series("dates", [datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
+    dates = pl.Series([datetime(2001, 1, 1), datetime(2001, 2, 1, 10, 8, 9)])
 
     for unit in DTYPE_TEMPORAL_UNITS:
         assert_series_equal(dates.dt.epoch(unit), dates.dt.timestamp(unit))

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Literal
 
-import numpy as np
 import pytest
 
 import polars as pl
@@ -256,16 +255,12 @@ def test_date_time_combine() -> None:
         }
     )
 
-    # Use the .select() method to combine datetime/date and time
+    # Combine datetime/date and time
     df = df.select(
         [
-            pl.col("dtm")
-            .dt.combine(pl.col("tm"))
-            .alias("d1"),  # Combine datetime and time
-            pl.col("dt").dt.combine(pl.col("tm")).alias("d2"),  # Combine date and time
-            pl.col("dt")
-            .dt.combine(time(4, 5, 6))
-            .alias("d3"),  # Combine date and a specified time
+            pl.col("dtm").dt.combine(pl.col("tm")).alias("d1"),  # datetime & time
+            pl.col("dt").dt.combine(pl.col("tm")).alias("d2"),  # date & time
+            pl.col("dt").dt.combine(time(4, 5, 6)).alias("d3"),  # date & specified time
         ]
     )
 
@@ -317,16 +312,12 @@ def test_date_offset() -> None:
         ]
     )
 
-    # Assert that the day of the month for all dates in the 'date_plus_1y' column is 1
+    # Assert that the day of the month for all the dates in new columns is 1
     assert (df["date_plus_1y"].dt.day() == 1).all()
-
-    # Assert that the day of the month for all dates in the 'date_min' column is 1
     assert (df["date_min"].dt.day() == 1).all()
 
     # Assert that the 'date_min' column contains the expected list of dates
-    expected_dates = [
-        datetime(year, 11, 1, 0, 0) for year in range(1998, 2019)
-    ]
+    expected_dates = [datetime(year, 11, 1, 0, 0) for year in range(1998, 2019)]
     assert df["date_min"].to_list() == expected_dates
 
 

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -14,16 +14,6 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture()
-def date_2022_01_01() -> datetime:
-    return datetime(2022, 1, 1)
-
-
-@pytest.fixture()
-def date_2022_01_02() -> datetime:
-    return datetime(2022, 1, 2)
-
-
-@pytest.fixture()
 def series_of_int_dates() -> pl.Series:
     return pl.Series([10000, 20000, 30000], dtype=pl.Date)
 
@@ -125,10 +115,8 @@ def test_strptime_fractional_seconds(series_of_str_dates: pl.Series) -> None:
 def test_duration_extract_times(
     unit_attr: str,
     expected: pl.Series,
-    date_2022_01_01: datetime,
-    date_2022_01_02: datetime,
 ) -> None:
-    duration = pl.Series([date_2022_01_02]) - pl.Series([date_2022_01_01])
+    duration = pl.Series([datetime(2022, 1, 2)]) - pl.Series([datetime(2022, 1, 1)])
 
     assert_series_equal(getattr(duration.dt, unit_attr)(), expected)
 
@@ -145,10 +133,8 @@ def test_duration_extract_times(
 def test_truncate(
     time_unit: TimeUnit,
     every: str | timedelta,
-    date_2022_01_01: datetime,
-    date_2022_01_02: datetime,
 ) -> None:
-    start, stop = date_2022_01_01, date_2022_01_02
+    start, stop = datetime(2022, 1, 1), datetime(2022, 1, 2)
     s = pl.date_range(
         start,
         stop,
@@ -181,10 +167,8 @@ def test_truncate(
 def test_round(
     time_unit: TimeUnit,
     every: str | timedelta,
-    date_2022_01_01: datetime,
-    date_2022_01_02: datetime,
 ) -> None:
-    start, stop = date_2022_01_01, date_2022_01_02
+    start, stop = datetime(2022, 1, 1), datetime(2022, 1, 2)
     s = pl.date_range(
         start,
         stop,

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -11,7 +11,7 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import TimeUnit
+    pass
 
 
 @pytest.fixture()
@@ -205,32 +205,42 @@ def test_epoch() -> None:
 
 def test_date_time_combine() -> None:
     # Define a DataFrame with columns for datetime, date, and time
-    df = pl.DataFrame({
-        "dtm": [
-            datetime(2022, 12, 31, 10, 30, 45),
-            datetime(2023, 7, 5, 23, 59, 59),
-        ],
-        "dt": [
-            date(2022, 10, 10),
-            date(2022, 7, 5),
-        ],
-        "tm": [
-            time(1, 2, 3, 456000),
-            time(7, 8, 9, 101000),
-        ],
-    })
+    df = pl.DataFrame(
+        {
+            "dtm": [
+                datetime(2022, 12, 31, 10, 30, 45),
+                datetime(2023, 7, 5, 23, 59, 59),
+            ],
+            "dt": [
+                date(2022, 10, 10),
+                date(2022, 7, 5),
+            ],
+            "tm": [
+                time(1, 2, 3, 456000),
+                time(7, 8, 9, 101000),
+            ],
+        }
+    )
 
     # Use the .select() method to combine datetime/date and time
-    df = df.select([
-        pl.col("dtm").dt.combine(pl.col("tm")).alias("d1"),  # Combine datetime and time
-        pl.col("dt").dt.combine(pl.col("tm")).alias("d2"),  # Combine date and time
-        pl.col("dt").dt.combine(time(4, 5, 6)).alias("d3"),  # Combine date and a specified time
-    ])
+    df = df.select(
+        [
+            pl.col("dtm")
+            .dt.combine(pl.col("tm"))
+            .alias("d1"),  # Combine datetime and time
+            pl.col("dt").dt.combine(pl.col("tm")).alias("d2"),  # Combine date and time
+            pl.col("dt")
+            .dt.combine(time(4, 5, 6))
+            .alias("d3"),  # Combine date and a specified time
+        ]
+    )
 
     # Check that the new columns have the expected values and datatypes
     expected_dict = {
         "d1": [
-            datetime(2022, 12, 31, 1, 2, 3, 456000),  # Time component should be overwritten by `tm`
+            datetime(
+                2022, 12, 31, 1, 2, 3, 456000
+            ),  # Time component should be overwritten by `tm`
             datetime(2023, 7, 5, 7, 8, 9, 101000),
         ],
         "d2": [
@@ -238,7 +248,9 @@ def test_date_time_combine() -> None:
             datetime(2022, 7, 5, 7, 8, 9, 101000),
         ],
         "d3": [
-            datetime(2022, 10, 10, 4, 5, 6),  # New datetime should use specified time component
+            datetime(
+                2022, 10, 10, 4, 5, 6
+            ),  # New datetime should use specified time component
             datetime(2022, 7, 5, 4, 5, 6),
         ],
     }
@@ -259,13 +271,17 @@ def test_quarter() -> None:
 
 
 def test_date_offset() -> None:
-    df = pl.DataFrame({"dates": pl.date_range(datetime(2000, 1, 1), datetime(2020, 1, 1), "1y")})
+    df = pl.DataFrame(
+        {"dates": pl.date_range(datetime(2000, 1, 1), datetime(2020, 1, 1), "1y")}
+    )
 
     # Add two new columns to the DataFrame using the offset_by() method
-    df = df.with_columns([
-        df["dates"].dt.offset_by("1y").alias("date_plus_1y"),
-        df["dates"].dt.offset_by("-1y2mo").alias("date_min"),
-    ])
+    df = df.with_columns(
+        [
+            df["dates"].dt.offset_by("1y").alias("date_plus_1y"),
+            df["dates"].dt.offset_by("-1y2mo").alias("date_min"),
+        ]
+    )
 
     # Assert that the day of the month for all dates in the 'date_plus_1y' column is 1
     assert (df["date_plus_1y"].dt.day() == 1).all()

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -11,17 +11,17 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    pass
+    from polars.internals.type_aliases import TimeUnit
 
 
 @pytest.fixture()
-def date_2022_01_01() -> date:
-    return date(2022, 1, 1)
+def date_2022_01_01() -> datetime:
+    return datetime(2022, 1, 1)
 
 
 @pytest.fixture()
-def date_2022_01_02() -> date:
-    return date(2022, 1, 2)
+def date_2022_01_02() -> datetime:
+    return datetime(2022, 1, 2)
 
 
 @pytest.fixture()
@@ -100,7 +100,7 @@ def test_dt_datetimes() -> None:
     ],
 )
 def test_duration_extract_times(
-    unit: str, expected: list[int], date_2022_01_01: date, date_2022_01_02: date
+    unit: str, expected: list[int], date_2022_01_01: datetime, date_2022_01_02: datetime
 ) -> None:
     duration = pl.Series([date_2022_01_02]) - pl.Series([date_2022_01_01])
 
@@ -119,9 +119,10 @@ def test_duration_extract_times(
 def test_truncate(
     time_unit: Literal["ms", "us", "ns"],
     every: str | timedelta,
-    start: date = date_2022_01_01,
-    stop: date = date_2022_01_02,
+    date_2022_01_01: datetime,
+    date_2022_01_02: datetime,
 ) -> None:
+    start, stop = date_2022_01_01, date_2022_01_02
     s = pl.date_range(
         start,
         stop,
@@ -154,9 +155,10 @@ def test_truncate(
 def test_round(
     time_unit: Literal["ms", "us", "ns"],
     every: str | timedelta,
-    start: date = date_2022_01_01,
-    stop: date = date_2022_01_02,
+    date_2022_01_01: datetime,
+    date_2022_01_02: datetime,
 ) -> None:
+    start, stop = date_2022_01_01, date_2022_01_02
     s = pl.date_range(
         start,
         stop,
@@ -326,8 +328,8 @@ def test_year_empty_df() -> None:
     ["ms", "us", "ns"],
     ids=["milliseconds", "microseconds", "nanoseconds"],
 )
-def test_weekday(time_unit: Literal["ms", "us", "ns"], date_2022_01_01: date) -> None:
-    friday = pl.Series([date_2022_01_01])
+def test_weekday(time_unit: Literal["ms", "us", "ns"]) -> None:
+    friday = pl.Series([datetime(2023, 2, 17)])
 
     assert friday.dt.cast_time_unit(time_unit).dt.weekday()[0] == 5
     assert friday.cast(pl.Date).dt.weekday()[0] == 5

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -279,26 +279,32 @@ def test_weekday() -> None:
 
 
 @pytest.mark.parametrize(
-    ("values", "expected"),
+    ("values", "expected_median"),
     [
-        ([datetime(1969, 12, 31), datetime(1970, 1, 2)], datetime(1970, 1, 1)),
+        ([], None),
         ([None, None], None),
+        ([date(2022, 1, 1)], date(2022, 1, 1)),
+        ([date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3)], date(2022, 1, 2)),
+        ([date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)], date(2022, 1, 2)),
     ],
-    ids=["datetime_dates", "Nones"],
+    ids=["empty", "Nones", "single", "spread_even", "spread_skewed"],
 )
-def test_median(values: list[datetime | None], expected: datetime | None) -> None:
-    result = pl.Series(values).cast(pl.Datetime).dt.median()
-    assert result == expected
+def test_median(values: list[date | None], expected_median: date | None) -> None:
+    result = pl.Series(values).cast(pl.Date).dt.median()
+    assert result == expected_median
 
 
 @pytest.mark.parametrize(
-    ("values", "expected"),
+    ("values", "expected_mean"),
     [
-        ([datetime(1969, 12, 31), datetime(1970, 1, 2)], datetime(1970, 1, 1)),
+        ([], None),
         ([None, None], None),
+        ([date(2022, 1, 1)], date(2022, 1, 1)),
+        ([date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3)], date(2022, 1, 2)),
+        ([date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)], date(2022, 10, 16)),
     ],
-    ids=["datetime_dates", "Nones"],
+    ids=["empty", "Nones", "single", "spread_even", "spread_skewed"],
 )
-def test_mean(values: list[datetime | None], expected: datetime | None) -> None:
-    result = pl.Series(values).cast(pl.Datetime).dt.mean()
-    assert result == expected
+def test_mean(values: list[date | None], expected_mean: date | None) -> None:
+    result = pl.Series(values).cast(pl.Date).dt.mean()
+    assert result == expected_mean


### PR DESCRIPTION
Refactored `test_datetime.py` to utilize more `pytest`.

Changes:

- using more of `parametrize` 
- `test_median` & `test_mean` parameters updated as suggested by @stinodego in #6960 
- fixtures added
- split `test_dt_datetimes` into three separate unit tests

Please note that the actual testing logic has been barely altered. Open to any suggestions and improvements.