### PR TITLE
feat(rust, python): raise informative error if invalid datetime_format passed to write_csv

### DIFF
--- a/polars/polars-io/src/csv/write_impl.rs
+++ b/polars/polars-io/src/csv/write_impl.rs
@@ -57,7 +57,7 @@ fn write_anyvalue(
     value: AnyValue,
     options: &SerializeOptions,
     datetime_format: Option<&str>,
-) {
+) -> PolarsResult<()> {
     match value {
         AnyValue::Null => write!(f, "{}", &options.null),
         AnyValue::Int8(v) => write!(f, "{v}"),
@@ -127,7 +127,21 @@ fn write_anyvalue(
         }
         dt => panic!("DataType: {dt} not supported in writing to csv"),
     }
-    .unwrap();
+    .map_err(|err| match value {
+        AnyValue::Datetime(_, _, tz) => {
+            // If this is a datetime, then datetime_format was either set or inferred.
+            let datetime_format = datetime_format.unwrap();
+            match tz {
+                Some(_) => PolarsError::ComputeError(
+                    format!("Cannot format DateTime with format '{datetime_format}'.").into(),
+                ),
+                None => PolarsError::ComputeError(
+                    format!("Cannot format NaiveDateTime with format '{datetime_format}'.").into(),
+                ),
+            }
+        }
+        _ => PolarsError::ComputeError(format!("Error writing value {value}: {:?}", err).into()),
+    })
 }
 
 /// Options to serialize logical types to CSV
@@ -230,7 +244,7 @@ pub(crate) fn write<W: Write>(
     let mut n_rows_finished = 0;
 
     // holds the buffers that will be written
-    let mut result_buf = Vec::with_capacity(n_threads);
+    let mut result_buf: Vec<PolarsResult<Vec<u8>>> = Vec::with_capacity(n_threads);
     while n_rows_finished < len {
         let par_iter = (0..n_threads).into_par_iter().map(|thread_no| {
             let thread_offset = thread_no * chunk_size;
@@ -247,7 +261,7 @@ pub(crate) fn write<W: Write>(
 
             // don't use df.empty, won't work if there are columns.
             if df.height() == 0 {
-                return write_buffer;
+                return Ok(write_buffer);
             }
 
             let any_value_iters = cols.iter().map(|s| s.iter());
@@ -265,7 +279,7 @@ pub(crate) fn write<W: Write>(
                     };
                     match col.next() {
                         Some(value) => {
-                            write_anyvalue(&mut write_buffer, value, options, datetime_format);
+                            write_anyvalue(&mut write_buffer, value, options, datetime_format)?;
                         }
                         None => {
                             finished = true;
@@ -286,13 +300,14 @@ pub(crate) fn write<W: Write>(
             col_iters.clear();
             any_value_iter_pool.set(col_iters);
 
-            write_buffer
+            Ok(write_buffer)
         });
 
         // rayon will ensure the right order
         result_buf.par_extend(par_iter);
 
-        for mut buf in result_buf.drain(..) {
+        for buf in result_buf.drain(..) {
+            let mut buf = buf?;
             let _ = writer.write(&buf)?;
             buf.clear();
             write_buffer_pool.set(buf);

--- a/polars/polars-io/src/csv/write_impl.rs
+++ b/polars/polars-io/src/csv/write_impl.rs
@@ -125,7 +125,9 @@ fn write_anyvalue(
                 Some(fmt) => write!(f, "{}", date.format(fmt)),
             }
         }
-        dt => panic!("DataType: {dt} not supported in writing to csv"),
+        ref dt => Err(PolarsError::ComputeError(
+            format!("DataType: {dt} not supported in writing to csv").into(),
+        ))?,
     }
     .map_err(|err| match value {
         AnyValue::Datetime(_, _, tz) => {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -301,11 +301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -752,7 +749,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1228,7 +1225,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -2265,17 +2262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,12 +2370,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"


### PR DESCRIPTION
closes #7004 