### PR TITLE
fix(python): fix dtype of diff for uint8

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -242,7 +242,7 @@ impl FunctionExpr {
                 DataType::Time => DataType::Duration(TimeUnit::Nanoseconds),
                 DataType::UInt64 | DataType::UInt32 => DataType::Int64,
                 DataType::UInt16 => DataType::Int32,
-                DataType::UInt8 => DataType::Int8,
+                DataType::UInt8 => DataType::Int16,
                 dt => dt.clone(),
             }),
             #[cfg(feature = "interpolate")]

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1726,3 +1726,10 @@ def test_compare_schema_between_lazy_and_eager_6904() -> None:
         int32_df.lazy().select(pl.col("x").pow(2)).select(pl.col(pl.Float64)).collect()
     )
     assert eager_result.shape == lazy_result.shape
+
+    int8_df = pl.DataFrame({"x": pl.Series(values=[], dtype=pl.Int8)})
+    eager_result = int8_df.select(pl.col("x").diff()).select(pl.col(pl.Int16))
+    lazy_result = (
+        int8_df.lazy().select(pl.col("x").diff()).select(pl.col(pl.Int16)).collect()
+    )
+    assert eager_result.shape == lazy_result.shape


### PR DESCRIPTION
This PR fixes the behavior of `diff` function in #6814.