### PR TITLE
chore(python): let read_csv take Sequence as columns, remove several `type: ignore`

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -5,7 +5,10 @@ import html
 import os
 from textwrap import dedent
 from types import TracebackType
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from polars.internals import DataFrame
 
 
 class Tag:
@@ -43,7 +46,7 @@ class Tag:
 class HTMLFormatter:
     def __init__(
         self,
-        df: DataFrame,  # type: ignore[name-defined] # noqa: F821
+        df: DataFrame,
         max_cols: int = 75,
         max_rows: int = 40,
         from_series: bool = False,
@@ -75,7 +78,7 @@ class HTMLFormatter:
 
     def write_header(self) -> None:
         """Write the header of an HTML table."""
-        shape = self.df.shape
+        shape: tuple[int, ...] = self.df.shape
         if self.series:
             shape = shape[:1]
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
@@ -52,7 +52,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 1, 0, 0)
 
         """
-        return cast("date | datetime | timedelta | None", pli.wrap_s(self._s).min())
+        return pli.wrap_s(self._s).min()  # type: ignore[return-value]
 
     def max(self) -> date | datetime | timedelta | None:
         """
@@ -74,7 +74,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 3, 0, 0)
 
         """
-        return cast("date | datetime | timedelta | None", pli.wrap_s(self._s).max())
+        return pli.wrap_s(self._s).max()  # type: ignore[return-value]
 
     def median(self) -> date | datetime | timedelta | None:
         """

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -52,7 +52,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 1, 0, 0)
 
         """
-        return cast(date | datetime | timedelta, pli.wrap_s(self._s).min())
+        return cast("date | datetime | timedelta", pli.wrap_s(self._s).min())
 
     def max(self) -> date | datetime | timedelta:
         """
@@ -74,7 +74,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 3, 0, 0)
 
         """
-        return cast(date | datetime | timedelta, pli.wrap_s(self._s).max())
+        return cast("date | datetime | timedelta", pli.wrap_s(self._s).max())
 
     def median(self) -> date | datetime | timedelta | None:
         """

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
@@ -52,8 +52,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 1, 0, 0)
 
         """
-        # we can ignore types because we are certain we get a logical type
-        return pli.wrap_s(self._s).min()  # type: ignore[return-value]
+        return cast(date | datetime | timedelta, pli.wrap_s(self._s).min())
 
     def max(self) -> date | datetime | timedelta:
         """
@@ -75,7 +74,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 3, 0, 0)
 
         """
-        return pli.wrap_s(self._s).max()  # type: ignore[return-value]
+        return cast(date | datetime | timedelta, pli.wrap_s(self._s).max())
 
     def median(self) -> date | datetime | timedelta | None:
         """

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -32,7 +32,7 @@ class DateTimeNameSpace:
         s = pli.wrap_s(self._s)
         return s[item]
 
-    def min(self) -> date | datetime | timedelta:
+    def min(self) -> date | datetime | timedelta | None:
         """
         Return minimum as python DateTime.
 
@@ -52,9 +52,9 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 1, 0, 0)
 
         """
-        return cast("date | datetime | timedelta", pli.wrap_s(self._s).min())
+        return cast("date | datetime | timedelta | None", pli.wrap_s(self._s).min())
 
-    def max(self) -> date | datetime | timedelta:
+    def max(self) -> date | datetime | timedelta | None:
         """
         Return maximum as python DateTime.
 
@@ -74,7 +74,7 @@ class DateTimeNameSpace:
         datetime.datetime(2001, 1, 3, 0, 0)
 
         """
-        return cast("date | datetime | timedelta", pli.wrap_s(self._s).max())
+        return cast("date | datetime | timedelta | None", pli.wrap_s(self._s).max())
 
     def median(self) -> date | datetime | timedelta | None:
         """

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -10,6 +10,7 @@ from typing import (
     BinaryIO,
     Callable,
     Mapping,
+    Sequence,
     TextIO,
     cast,
     overload,
@@ -58,7 +59,7 @@ def _check_arg_is_1byte(
 def read_csv(
     file: str | TextIO | BytesIO | Path | BinaryIO | bytes,
     has_header: bool = True,
-    columns: list[int] | list[str] | None = None,
+    columns: Sequence[int] | Sequence[str] | None = None,
     new_columns: list[str] | None = None,
     sep: str = ",",
     comment_char: str | None = None,
@@ -230,7 +231,7 @@ def read_csv(
         and not low_memory
         and null_values is None
     ):
-        include_columns = None
+        include_columns: Sequence[str] | None = None
 
         if columns:
             if not has_header:
@@ -1235,7 +1236,7 @@ def _read_excel_sheet(
     parser: Any,
     sheet_id: int | None,
     sheet_name: str | None,
-    read_csv_options: dict[str, Any] | None,
+    read_csv_options: dict[str, Any],
 ) -> DataFrame:
     csv_buffer = StringIO()
 
@@ -1246,7 +1247,7 @@ def _read_excel_sheet(
     csv_buffer.seek(0)
 
     # Parse CSV output.
-    return read_csv(csv_buffer, **read_csv_options)  # type: ignore[arg-type]
+    return read_csv(csv_buffer, **read_csv_options)
 
 
 def _get_delta_lake_table(
@@ -1660,7 +1661,7 @@ def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFr
 def read_csv_batched(
     file: str | Path,
     has_header: bool = True,
-    columns: list[int] | list[str] | None = None,
+    columns: Sequence[int] | Sequence[str] | None = None,
     new_columns: list[str] | None = None,
     sep: str = ",",
     comment_char: str | None = None,

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -18,7 +18,6 @@ from typing import (
     Iterable,
     Sequence,
     TypeVar,
-    cast,
     overload,
 )
 
@@ -331,7 +330,7 @@ def _parse_fixed_tz_offset(offset: str) -> tzinfo:
     except ValueError:
         raise ValueError(f"Offset: {offset} not understood.") from None
 
-    return cast(tzinfo, dt_offset.tzinfo)
+    return dt_offset.tzinfo  # type: ignore[return-value]
 
 
 def _localize(dt: datetime, tz: str) -> datetime:


### PR DESCRIPTION
`read_csv` can take a sequence for `columns`, just like other IO functions
```python
In [77]: pl.read_csv(io.StringIO('a,b\n1,2\n'), columns=('a',))
Out[77]:
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 1   │
└─────┘
```

Making the typing a bit laxer, and removing a few `type: ignore` along the way
