### PR TITLE
chore(python): Deprecating more non-keyword arguments

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -9,7 +9,7 @@ from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 from polars.internals import DataFrame, Series
-from polars.utils import deprecated_alias
+from polars.utils import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import Orientation
@@ -70,6 +70,7 @@ def from_dict(
     )
 
 
+@deprecate_nonkeyword_arguments(allowed_args=["dicts"])
 def from_dicts(
     dicts: Sequence[dict[str, Any]],
     infer_schema_length: int | None = N_INFER_DEFAULT,
@@ -303,6 +304,7 @@ def from_numpy(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def from_arrow(
     a: pa.Table | pa.Array | pa.ChunkedArray,
     rechunk: bool = True,
@@ -411,6 +413,7 @@ def from_pandas(
     ...
 
 
+@deprecate_nonkeyword_arguments()
 @deprecated_alias(nan_to_none="nan_to_null")
 def from_pandas(
     df: pd.DataFrame | pd.Series | pd.DatetimeIndex,
@@ -491,6 +494,7 @@ def from_pandas(
         raise ValueError(f"Expected pandas DataFrame or Series, got {type(df)}.")
 
 
+@deprecate_nonkeyword_arguments()
 def from_dataframe(df: Any, allow_copy: bool = True) -> DataFrame:
     """
     Build a Polars DataFrame from any dataframe supporting the interchange protocol.

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5021,7 +5021,7 @@ class DataFrame:
         """
         return self._from_pydf(
             self.lazy()
-            .fill_null(value, strategy, limit, matches_supertype)
+            .fill_null(value, strategy, limit, matches_supertype=matches_supertype)
             .collect(no_optimization=True)
             ._df
         )

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2090,6 +2090,7 @@ class DataFrame:
     ) -> None:
         ...
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"])
     def write_json(
         self,
         file: IOBase | str | Path | None = None,
@@ -2223,6 +2224,7 @@ class DataFrame:
     ) -> None:
         ...
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"])
     def write_csv(
         self,
         file: BytesIO | str | Path | None = None,
@@ -2537,6 +2539,7 @@ class DataFrame:
         sz = self._df.estimated_size()
         return scale_bytes(sz, unit)
 
+    @deprecate_nonkeyword_arguments()
     def transpose(
         self,
         include_header: bool = False,
@@ -2835,6 +2838,7 @@ class DataFrame:
     def glimpse(self, return_as_string: Literal[True]) -> str:
         ...
 
+    @deprecate_nonkeyword_arguments()
     def glimpse(self, return_as_string: bool = False) -> str | None:
         """
         Return a dense preview of the dataframe.
@@ -3151,6 +3155,7 @@ class DataFrame:
             ._df
         )
 
+    @deprecate_nonkeyword_arguments()
     def frame_equal(self, other: DataFrame, null_equal: bool = True) -> bool:
         """
         Check if DataFrame is equal to other.
@@ -4571,6 +4576,7 @@ class DataFrame:
         else:
             return self._from_pydf(pli.wrap_s(out).to_frame()._df)
 
+    @deprecate_nonkeyword_arguments()
     def hstack(
         self,
         columns: list[pli.Series] | DataFrame,
@@ -4617,6 +4623,7 @@ class DataFrame:
         else:
             return self._from_pydf(self._df.hstack([s._s for s in columns]))
 
+    @deprecate_nonkeyword_arguments()
     def vstack(self, df: DataFrame, in_place: bool = False) -> Self:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
@@ -4921,6 +4928,7 @@ class DataFrame:
         """
         return self[name]
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "value", "strategy", "limit"])
     def fill_null(
         self,
         value: Any | None = None,
@@ -6259,6 +6267,7 @@ class DataFrame:
     ) -> Self | pli.Series:
         ...
 
+    @deprecate_nonkeyword_arguments()
     def mean(
         self,
         axis: int = 0,
@@ -6707,6 +6716,7 @@ class DataFrame:
         """
         return self._from_pydf(self._df.null_count())
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"])
     def sample(
         self,
         n: int | None = None,
@@ -7000,6 +7010,7 @@ class DataFrame:
     def rows(self, named: Literal[True]) -> list[dict[str, Any]]:
         ...
 
+    @deprecate_nonkeyword_arguments()
     def rows(self, named: bool = False) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         """
         Returns all data in the DataFrame as a list of rows of python-native values.
@@ -7063,6 +7074,7 @@ class DataFrame:
     ) -> Iterator[dict[str, Any]]:
         ...
 
+    @deprecate_nonkeyword_arguments()
     def iter_rows(
         self, named: bool = False, buffer_size: int = 500
     ) -> Iterator[tuple[Any, ...]] | Iterator[dict[str, Any]]:
@@ -7199,6 +7211,7 @@ class DataFrame:
         for offset in range(0, self.height, n_rows):
             yield self.slice(offset, n_rows)
 
+    @deprecate_nonkeyword_arguments()
     def shrink_to_fit(self, in_place: bool = False) -> Self:
         """
         Shrink DataFrame memory usage.

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -9,6 +9,7 @@ from polars.datatypes import Categorical, Date, Float64, PolarsDataType
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
+    deprecate_nonkeyword_arguments,
     deprecated_alias,
 )
 
@@ -119,6 +120,7 @@ def concat(
     ...
 
 
+@deprecate_nonkeyword_arguments()
 def concat(
     items: (
         Iterable[pli.DataFrame]

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -22,7 +22,6 @@ from polars.datatypes import (
 )
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
-from polars.internals.type_aliases import EpochTimeUnit, PolarsExprType
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
@@ -72,8 +71,8 @@ else:
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
+        EpochTimeUnit,
         IntoExpr,
-        PythonLiteral,
         RollingInterpolationMethod,
         TimeUnit,
     )
@@ -1110,6 +1109,7 @@ def tail(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
     return col(column).tail(n)
 
 
+@deprecate_nonkeyword_arguments(allowed_args=["value", "dtype"])
 def lit(
     value: Any, dtype: PolarsDataType | None = None, allow_object: bool = False
 ) -> pli.Expr:
@@ -1307,6 +1307,7 @@ def cumsum(
     return cumfold(lit(0).cast(UInt32), lambda a, b: a + b, column).alias("cumsum")
 
 
+@deprecate_nonkeyword_arguments(allowed_args=["a", "b", "ddof"])
 def spearman_rank_corr(
     a: str | pli.Expr, b: str | pli.Expr, ddof: int = 1, propagate_nans: bool = False
 ) -> pli.Expr:
@@ -1385,10 +1386,7 @@ def pearson_corr(a: str | pli.Expr, b: str | pli.Expr, ddof: int = 1) -> pli.Exp
     return pli.wrap_expr(pypearson_corr(a._pyexpr, b._pyexpr, ddof))
 
 
-def cov(
-    a: str | pli.Expr,
-    b: str | pli.Expr,
-) -> pli.Expr:
+def cov(a: str | pli.Expr, b: str | pli.Expr) -> pli.Expr:
     """
     Compute the covariance between two columns/ expressions.
 
@@ -2264,6 +2262,7 @@ def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.
     return pli.wrap_expr(_concat_lst(exprs))
 
 
+@deprecate_nonkeyword_arguments()
 def collect_all(
     lazy_frames: Sequence[pli.LazyFrame],
     type_coercion: bool = True,
@@ -2335,16 +2334,9 @@ def collect_all(
 
 
 def select(
-    exprs: (
-        str
-        | PolarsExprType
-        | PythonLiteral
-        | pli.Series
-        | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
-        | None
-    ) = None,
-    *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
-    **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+    exprs: IntoExpr | Iterable[IntoExpr] | None = None,
+    *more_exprs: IntoExpr,
+    **named_exprs: IntoExpr,
 ) -> pli.DataFrame:
     """
     Run polars expressions without a context.

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -655,6 +655,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             return self._ldf.describe_optimized_plan()
         return self._ldf.describe_plan()
 
+    @deprecate_nonkeyword_arguments()
     def describe_optimized_plan(
         self,
         type_coercion: bool = True,
@@ -678,6 +679,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return ldf.describe_optimized_plan()
 
+    @deprecate_nonkeyword_arguments()
     def show_graph(
         self,
         optimized: bool = True,
@@ -921,6 +923,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             descending = [descending]
         return self._from_pyldf(self._ldf.sort_by_exprs(by, descending, nulls_last))
 
+    @deprecate_nonkeyword_arguments()
     def profile(
         self,
         type_coercion: bool = True,
@@ -3247,6 +3250,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """
         return self.select(pli.col("*").take_every(n))
 
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "value", "strategy", "limit"])
     def fill_null(
         self,
         value: Any | None = None,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1388,7 +1388,6 @@ class Series:
         """
         return self._s.quantile(quantile, interpolation)
 
-    @deprecate_nonkeyword_arguments()
     def to_dummies(self, separator: str = "_") -> pli.DataFrame:
         """
         Get dummy/indicator variables.

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -31,7 +31,11 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltal
 from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
 from polars.internals.io import _prepare_file_arg
-from polars.utils import handle_projection_columns, normalise_filepath
+from polars.utils import (
+    deprecate_nonkeyword_arguments,
+    handle_projection_columns,
+    normalise_filepath,
+)
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import CsvEncoding, ParallelStrategy
@@ -55,6 +59,7 @@ def _check_arg_is_1byte(
             )
 
 
+@deprecate_nonkeyword_arguments()
 @deprecated_alias(parse_dates="try_parse_dates")
 def read_csv(
     file: str | TextIO | BytesIO | Path | BinaryIO | bytes,
@@ -409,6 +414,7 @@ def read_csv(
     return df
 
 
+@deprecate_nonkeyword_arguments()
 @deprecated_alias(parse_dates="try_parse_dates")
 def scan_csv(
     file: str | Path,
@@ -588,6 +594,7 @@ def scan_csv(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def scan_ipc(
     file: str | Path,
     n_rows: int | None = None,
@@ -641,6 +648,7 @@ def scan_ipc(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def scan_parquet(
     file: str | Path,
     n_rows: int | None = None,
@@ -701,6 +709,7 @@ def scan_parquet(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def scan_ndjson(
     file: str | Path,
     infer_schema_length: int | None = N_INFER_DEFAULT,
@@ -782,6 +791,7 @@ def read_avro(
     return DataFrame._read_avro(file, n_rows=n_rows, columns=columns)
 
 
+@deprecate_nonkeyword_arguments()
 def read_ipc(
     file: str | BinaryIO | BytesIO | Path | bytes,
     columns: list[int] | list[str] | None = None,
@@ -866,6 +876,7 @@ def read_ipc(
         )
 
 
+@deprecate_nonkeyword_arguments()
 def read_parquet(
     source: str | Path | BinaryIO | BytesIO | bytes,
     columns: list[int] | list[str] | None = None,
@@ -1001,6 +1012,7 @@ def read_ndjson(file: str | Path | IOBase) -> DataFrame:
     return DataFrame._read_ndjson(file)
 
 
+@deprecate_nonkeyword_arguments()
 def read_sql(
     sql: list[str] | str,
     connection_uri: str,
@@ -1122,6 +1134,7 @@ def read_excel(
     ...
 
 
+@deprecate_nonkeyword_arguments()
 def read_excel(
     file: str | BytesIO | Path | BinaryIO | bytes,
     sheet_id: int | None = 1,
@@ -1301,6 +1314,7 @@ def _resolve_delta_lake_uri(table_uri: str) -> tuple[str, str, str]:
     return (scheme, resolved_uri, normalized_path)
 
 
+@deprecate_nonkeyword_arguments()
 def scan_delta(
     table_uri: str,
     version: int | None = None,
@@ -1483,6 +1497,7 @@ def scan_delta(
     return scan_ds(pa_ds)
 
 
+@deprecate_nonkeyword_arguments()
 def read_delta(
     table_uri: str,
     version: int | None = None,
@@ -1615,6 +1630,7 @@ def read_delta(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.
@@ -1658,6 +1674,7 @@ def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFr
     return _scan_ds(ds, allow_pyarrow_filter)
 
 
+@deprecate_nonkeyword_arguments()
 def read_csv_batched(
     file: str | Path,
     has_header: bool = True,

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -13,9 +13,10 @@ from polars.datatypes import (
     dtype_to_py_type,
 )
 from polars.exceptions import InvalidAssert, PanicException
-from polars.utils import deprecated_alias
+from polars.utils import deprecate_nonkeyword_arguments, deprecated_alias
 
 
+@deprecate_nonkeyword_arguments()
 @deprecated_alias(check_column_names="check_column_order")
 def assert_frame_equal(
     left: pli.DataFrame | pli.LazyFrame,
@@ -117,6 +118,7 @@ def assert_frame_equal(
             raise AssertionError(msg) from exc
 
 
+@deprecate_nonkeyword_arguments()
 def assert_frame_not_equal(
     left: pli.DataFrame | pli.LazyFrame,
     right: pli.DataFrame | pli.LazyFrame,
@@ -182,6 +184,7 @@ def assert_frame_not_equal(
         raise AssertionError("Expected the input frames to be unequal.")
 
 
+@deprecate_nonkeyword_arguments()
 def assert_series_equal(
     left: pli.Series,
     right: pli.Series,
@@ -240,6 +243,7 @@ def assert_series_equal(
     )
 
 
+@deprecate_nonkeyword_arguments()
 def assert_series_not_equal(
     left: pli.Series,
     right: pli.Series,


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/6993

I did everything except Series/Expr, which are a bit more involved due to the dispatch decorator.

In fact, could we just _not_ deprecate these and just break them in the next breaking release? That would save a lot of hassle. Or I could add an unsilence-able `DeprecationWarning` on the `Expr` side for the affected methods, but that would be a little annoying for the user 😕 