### PR TITLE
chore(python): Rename args `f`/`func` to `function`

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -478,10 +478,10 @@ NUMERIC_DTYPES: frozenset[PolarsDataType] = FLOAT_DTYPES | INTEGER_DTYPES
 T = TypeVar("T")
 
 
-def cache(func: Callable[..., T]) -> T:
+def cache(function: Callable[..., T]) -> T:
     # need this to satisfy mypy issue with "@property/@cache combination"
     # See: https://github.com/python/mypy/issues/5858
-    return functools.lru_cache()(func)  # type: ignore[return-value]
+    return functools.lru_cache()(function)  # type: ignore[return-value]
 
 
 class _DataTypeMappings:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4481,10 +4481,11 @@ class DataFrame:
             ._df
         )
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "f", "return_dtype"])
+    @deprecated_alias(f="function")
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
     def apply(
         self,
-        f: Callable[[tuple[Any, ...]], Any],
+        function: Callable[[tuple[Any, ...]], Any],
         return_dtype: PolarsDataType | None = None,
         inference_size: int = 256,
     ) -> Self:
@@ -4507,7 +4508,7 @@ class DataFrame:
 
         Parameters
         ----------
-        f
+        function
             Custom function/ lambda function.
         return_dtype
             Output type of the operation. If none given, Polars tries to infer the type.
@@ -4563,7 +4564,7 @@ class DataFrame:
         >>> df.select(pl.col("foo") * 2 + pl.col("bar"))  # doctest: +IGNORE_RESULT
 
         """
-        out, is_df = self._df.apply(f, return_dtype, inference_size)
+        out, is_df = self._df.apply(function, return_dtype, inference_size)
         if is_df:
             return self._from_pydf(out)
         else:

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 import polars.internals as pli
-from polars.utils import _timedelta_to_pl_duration, redirect
+from polars.utils import _timedelta_to_pl_duration, deprecated_alias, redirect
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -233,7 +233,8 @@ class GroupBy(Generic[DF]):
         )
         return self.df.__class__._from_pydf(df._df)
 
-    def apply(self, f: Callable[[pli.DataFrame], pli.DataFrame]) -> DF:
+    @deprecated_alias(f="function")
+    def apply(self, function: Callable[[pli.DataFrame], pli.DataFrame]) -> DF:
         """
         Apply a custom/user-defined function (UDF) over the groups as a sub-DataFrame.
 
@@ -251,7 +252,7 @@ class GroupBy(Generic[DF]):
 
         Parameters
         ----------
-        f
+        function
             Custom function.
 
         Returns
@@ -320,7 +321,7 @@ class GroupBy(Generic[DF]):
             raise TypeError("Cannot call `apply` when grouping by an expression.")
 
         return self.df.__class__._from_pydf(
-            self.df._df.groupby_apply(by, f, self.maintain_order)
+            self.df._df.groupby_apply(by, function, self.maintain_order)
         )
 
     def head(self, n: int = 5) -> DF:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -28,6 +28,7 @@ from polars.utils import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
     deprecate_nonkeyword_arguments,
+    deprecated_alias,
 )
 
 try:
@@ -1418,9 +1419,10 @@ def cov(
     return pli.wrap_expr(pycov(a._pyexpr, b._pyexpr))
 
 
+@deprecated_alias(f="function")
 def map(
     exprs: Sequence[str] | Sequence[pli.Expr],
-    f: Callable[[Sequence[pli.Series]], pli.Series],
+    function: Callable[[Sequence[pli.Series]], pli.Series],
     return_dtype: PolarsDataType | None = None,
 ) -> pli.Expr:
     """
@@ -1432,7 +1434,7 @@ def map(
     ----------
     exprs
         Input Series to f
-    f
+    function
         Function to apply over the input
     return_dtype
         dtype of the output Series
@@ -1444,14 +1446,17 @@ def map(
     """
     exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(
-        _map_mul(exprs, f, return_dtype, apply_groups=False, returns_scalar=False)
+        _map_mul(
+            exprs, function, return_dtype, apply_groups=False, returns_scalar=False
+        )
     )
 
 
-@deprecate_nonkeyword_arguments(allowed_args=["exprs", "f", "return_dtype"])
+@deprecated_alias(f="function")
+@deprecate_nonkeyword_arguments(allowed_args=["exprs", "function", "return_dtype"])
 def apply(
     exprs: Sequence[str | pli.Expr],
-    f: Callable[[Sequence[pli.Series]], pli.Series | Any],
+    function: Callable[[Sequence[pli.Series]], pli.Series | Any],
     return_dtype: PolarsDataType | None = None,
     returns_scalar: bool = True,
 ) -> pli.Expr:
@@ -1470,7 +1475,7 @@ def apply(
     ----------
     exprs
         Input Series to f
-    f
+    function
         Function to apply over the input
     return_dtype
         dtype of the output Series
@@ -1485,14 +1490,19 @@ def apply(
     exprs = pli.selection_to_pyexpr_list(exprs)
     return pli.wrap_expr(
         _map_mul(
-            exprs, f, return_dtype, apply_groups=True, returns_scalar=returns_scalar
+            exprs,
+            function,
+            return_dtype,
+            apply_groups=True,
+            returns_scalar=returns_scalar,
         )
     )
 
 
+@deprecated_alias(f="function")
 def fold(
     acc: IntoExpr,
-    f: Callable[[pli.Series, pli.Series], pli.Series],
+    function: Callable[[pli.Series, pli.Series], pli.Series],
     exprs: Sequence[pli.Expr | str] | pli.Expr,
 ) -> pli.Expr:
     """
@@ -1503,7 +1513,7 @@ def fold(
     acc
         Accumulator Expression. This is the value that will be initialized when the fold
         starts. For a sum this could for instance be lit(0).
-    f
+    function
         Function to apply over the accumulator and the value.
         Fn(acc, value) -> new_value
     exprs
@@ -1521,11 +1531,12 @@ def fold(
         exprs = [exprs]
 
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pyfold(acc._pyexpr, f, exprs))
+    return pli.wrap_expr(pyfold(acc._pyexpr, function, exprs))
 
 
+@deprecated_alias(f="function")
 def reduce(
-    f: Callable[[pli.Series, pli.Series], pli.Series],
+    function: Callable[[pli.Series, pli.Series], pli.Series],
     exprs: Sequence[pli.Expr | str] | pli.Expr,
 ) -> pli.Expr:
     """
@@ -1533,7 +1544,7 @@ def reduce(
 
     Parameters
     ----------
-    f
+    function
         Function to apply over the accumulator and the value.
         Fn(acc, value) -> new_value
     exprs
@@ -1549,13 +1560,14 @@ def reduce(
         exprs = [exprs]
 
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pyreduce(f, exprs))
+    return pli.wrap_expr(pyreduce(function, exprs))
 
 
+@deprecated_alias(f="function")
 @deprecate_nonkeyword_arguments()
 def cumfold(
     acc: IntoExpr,
-    f: Callable[[pli.Series, pli.Series], pli.Series],
+    function: Callable[[pli.Series, pli.Series], pli.Series],
     exprs: Sequence[pli.Expr | str] | pli.Expr,
     include_init: bool = False,
 ) -> pli.Expr:
@@ -1569,7 +1581,7 @@ def cumfold(
     acc
         Accumulator Expression. This is the value that will be initialized when the fold
         starts. For a sum this could for instance be lit(0).
-    f
+    function
         Function to apply over the accumulator and the value.
         Fn(acc, value) -> new_value
     exprs
@@ -1589,11 +1601,12 @@ def cumfold(
         exprs = [exprs]
 
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pycumfold(acc._pyexpr, f, exprs, include_init))
+    return pli.wrap_expr(pycumfold(acc._pyexpr, function, exprs, include_init))
 
 
+@deprecated_alias(f="function")
 def cumreduce(
-    f: Callable[[pli.Series, pli.Series], pli.Series],
+    function: Callable[[pli.Series, pli.Series], pli.Series],
     exprs: Sequence[pli.Expr | str] | pli.Expr,
 ) -> pli.Expr:
     """
@@ -1603,7 +1616,7 @@ def cumreduce(
 
     Parameters
     ----------
-    f
+    function
         Function to apply over the accumulator and the value.
         Fn(acc, value) -> new_value
     exprs
@@ -1615,7 +1628,7 @@ def cumreduce(
         exprs = [exprs]
 
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(pycumreduce(f, exprs))
+    return pli.wrap_expr(pycumreduce(function, exprs))
 
 
 def any(name: str | Sequence[str] | Sequence[pli.Expr] | pli.Expr) -> pli.Expr:

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -54,6 +54,7 @@ from polars.utils import (
     _process_null_values,
     _timedelta_to_pl_duration,
     deprecate_nonkeyword_arguments,
+    deprecated_alias,
     normalise_filepath,
     redirect,
 )
@@ -3864,10 +3865,11 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
             self._ldf.melt(id_vars, value_vars, value_name, variable_name)
         )
 
+    @deprecated_alias(f="function")
     @deprecate_nonkeyword_arguments()
     def map(
         self,
-        f: Callable[[pli.DataFrame], pli.DataFrame],
+        function: Callable[[pli.DataFrame], pli.DataFrame],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         slice_pushdown: bool = True,
@@ -3883,7 +3885,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Parameters
         ----------
-        f
+        function
             Lambda/ function to apply.
         predicate_pushdown
             Allow predicate pushdown optimization to pass this node.
@@ -3937,7 +3939,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return self._from_pyldf(
             self._ldf.map(
-                f,
+                function,
                 predicate_pushdown,
                 projection_pushdown,
                 slice_pushdown,

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 import polars.internals as pli
 from polars.datatypes import SchemaDict
 from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import IntoExpr, RollingInterpolationMethod
@@ -129,8 +130,11 @@ class LazyGroupBy(Generic[LDF]):
         )
         return self._lazyframe_class._from_pyldf(self.lgb.agg(exprs))
 
+    @deprecated_alias(f="function")
     def apply(
-        self, f: Callable[[pli.DataFrame], pli.DataFrame], schema: SchemaDict | None
+        self,
+        function: Callable[[pli.DataFrame], pli.DataFrame],
+        schema: SchemaDict | None,
     ) -> LDF:
         """
         Apply a custom/user-defined function (UDF) over the groups as a new DataFrame.
@@ -149,7 +153,7 @@ class LazyGroupBy(Generic[LDF]):
 
         Parameters
         ----------
-        f
+        function
             Function to apply over each group of the `LazyFrame`.
         schema
             Schema of the output function. This has to be known statically. If the
@@ -209,7 +213,7 @@ class LazyGroupBy(Generic[LDF]):
         ... )  # doctest: +IGNORE_RESULT
 
         """
-        return self._lazyframe_class._from_pyldf(self.lgb.apply(f, schema))
+        return self._lazyframe_class._from_pyldf(self.lgb.apply(function, schema))
 
     def head(self, n: int = 5) -> LDF:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3654,10 +3654,11 @@ class Series:
 
         """
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "func", "return_dtype"])
+    @deprecated_alias(func="function")
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
     def apply(
         self,
-        func: Callable[[Any], Any],
+        function: Callable[[Any], Any],
         return_dtype: PolarsDataType | None = None,
         skip_nulls: bool = True,
     ) -> Series:
@@ -3683,7 +3684,7 @@ class Series:
 
         Parameters
         ----------
-        func
+        function
             function or lambda.
         return_dtype
             Output datatype. If none is given, the same datatype as this Series will be
@@ -3702,7 +3703,7 @@ class Series:
             pl_return_dtype = None
         else:
             pl_return_dtype = py_type_to_dtype(return_dtype)
-        return wrap_s(self._s.apply_lambda(func, pl_return_dtype, skip_nulls))
+        return wrap_s(self._s.apply_lambda(function, pl_return_dtype, skip_nulls))
 
     def shift(self, periods: int = 1) -> Series:
         """

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -427,11 +427,11 @@ def deprecated_alias(**aliases: str) -> Callable[[Callable[P, T]], Callable[P, T
         ...
     """
 
-    def deco(fn: Callable[P, T]) -> Callable[P, T]:
-        @functools.wraps(fn)
+    def deco(function: Callable[P, T]) -> Callable[P, T]:
+        @functools.wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            _rename_kwargs(fn.__name__, kwargs, aliases)
-            return fn(*args, **kwargs)
+            _rename_kwargs(function.__name__, kwargs, aliases)
+            return function(*args, **kwargs)
 
         return wrapper
 
@@ -456,8 +456,8 @@ def deprecate_nonkeyword_arguments(
         Optionally overwrite the default warning message.
     """
 
-    def decorate(fn: Callable[P, T]) -> Callable[P, T]:
-        old_sig = inspect.signature(fn)
+    def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        old_sig = inspect.signature(function)
 
         if allowed_args is not None:
             allow_args = allowed_args
@@ -485,18 +485,18 @@ def deprecate_nonkeyword_arguments(
         num_allowed_args = len(allow_args)
         if message is None:
             msg_format = (
-                f"All arguments of {fn.__qualname__}{{except_args}} will be keyword-only in the next breaking release."
+                f"All arguments of {function.__qualname__}{{except_args}} will be keyword-only in the next breaking release."
                 " Use keyword arguments to silence this warning."
             )
             msg = msg_format.format(except_args=_format_argument_list(allow_args))
         else:
             msg = message
 
-        @functools.wraps(fn)
+        @functools.wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if len(args) > num_allowed_args:
                 warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            return fn(*args, **kwargs)
+            return function(*args, **kwargs)
 
         wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
         return wrapper

--- a/py-polars/tests/unit/operations/test_apply.py
+++ b/py-polars/tests/unit/operations/test_apply.py
@@ -24,14 +24,14 @@ def test_apply_none() -> None:
         df.groupby("g", maintain_order=True).agg(
             pl.apply(
                 exprs=["a", pl.col("b") ** 4, pl.col("a") / 4],
-                f=lambda x: x[0] * x[1] + x[2].sum(),
+                function=lambda x: x[0] * x[1] + x[2].sum(),
             ).alias("multiple")
         )
     )["multiple"]
     assert out[0].to_list() == [4.75, 326.75, 82.75]
     assert out[1].to_list() == [238.75, 3418849.75, 372.75]
 
-    out_df = df.select(pl.map(exprs=["a", "b"], f=lambda s: s[0] * s[1]))
+    out_df = df.select(pl.map(exprs=["a", "b"], function=lambda s: s[0] * s[1]))
     assert out_df["a"].to_list() == (df["a"] * df["b"]).to_list()
 
     # check if we can return None
@@ -43,9 +43,9 @@ def test_apply_none() -> None:
 
     out = (
         df.groupby("g", maintain_order=True).agg(
-            pl.apply(exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], f=func).alias(
-                "multiple"
-            )
+            pl.apply(
+                exprs=["a", pl.col("b") ** 4, pl.col("a") / 4], function=func
+            ).alias("multiple")
         )
     )["multiple"]
     assert out[1] is None

--- a/py-polars/tests/unit/operations/test_folds.py
+++ b/py-polars/tests/unit/operations/test_folds.py
@@ -16,10 +16,14 @@ def test_fold() -> None:
     assert_series_equal(out["min"], pl.Series("min", [1.0, 2.0, 3.0]))
 
     out = df.select(
-        pl.fold(acc=pl.lit(0), f=lambda acc, x: acc + x, exprs=pl.all()).alias("foo")
+        pl.fold(acc=pl.lit(0), function=lambda acc, x: acc + x, exprs=pl.all()).alias(
+            "foo"
+        )
     )
     assert out["foo"].to_list() == [2, 4, 6]
-    out = df.select(pl.reduce(f=lambda acc, x: acc + x, exprs=pl.all()).alias("foo"))
+    out = df.select(
+        pl.reduce(function=lambda acc, x: acc + x, exprs=pl.all()).alias("foo")
+    )
     assert out["foo"].to_list() == [2, 4, 6]
 
 

--- a/py-polars/tests/unit/test_expr_multi_cols.py
+++ b/py-polars/tests/unit/test_expr_multi_cols.py
@@ -20,9 +20,9 @@ def test_fold_regex_expand() -> None:
         }
     )
     assert df.with_columns(
-        pl.fold(acc=pl.lit(0), f=lambda acc, x: acc + x, exprs=pl.col("^y_.*$")).alias(
-            "y_sum"
-        ),
+        pl.fold(
+            acc=pl.lit(0), function=lambda acc, x: acc + x, exprs=pl.col("^y_.*$")
+        ).alias("y_sum"),
     ).to_dict(False) == {
         "x": [0, 1, 2],
         "y_1": [1.1, 2.2, 3.3],

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -350,7 +350,9 @@ def test_regex_in_filter() -> None:
     )
 
     res = df.filter(
-        pl.fold(acc=False, f=lambda acc, s: acc | s, exprs=(pl.col("^nrs|flt*$") < 3))
+        pl.fold(
+            acc=False, function=lambda acc, s: acc | s, exprs=(pl.col("^nrs|flt*$") < 3)
+        )
     ).row(0)
     expected = (1, "foo", 1.0)
     assert res == expected

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -396,7 +396,7 @@ def test_fold_filter() -> None:
     out = df.filter(
         pl.fold(
             acc=pl.lit(True),
-            f=lambda a, b: a & b,
+            function=lambda a, b: a & b,
             exprs=[pl.col(c) > 1 for c in df.columns],
         )
     )
@@ -406,7 +406,7 @@ def test_fold_filter() -> None:
     out = df.filter(
         pl.fold(
             acc=pl.lit(True),
-            f=lambda a, b: a | b,
+            function=lambda a, b: a | b,
             exprs=[pl.col(c) > 1 for c in df.columns],
         )
     )

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -208,7 +208,7 @@ def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
         pl.DataFrame({"a": [1, 2, 3]})
         .lazy()
         .map(
-            f=lambda df: df.with_columns(pl.col("a").alias("b")),
+            function=lambda df: df.with_columns(pl.col("a").alias("b")),
             schema={"a": pl.Int64, "b": pl.Int64},
             streamable=True,
         )


### PR DESCRIPTION
There was no consensus on arguments that take function inputs: I saw `f`, `fn`, and `func`. I went with `function` to standardize all. These are not keyword-only arguments, so brevity doesn't count for much.

Note that `pipe` still has `func` as argument, as I could not find a way to deprecate it nicely (decorator doesn't work due to that function taking `*args` and `**kwargs`). So I think we'll just have to hard break that one.