### PR TITLE
fix(python): accept more types in `from_records`

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -175,7 +175,7 @@ def from_dicts(
 @deprecated_alias(columns="schema")
 def from_records(
     data: Sequence[Sequence[Any]],
-    schema: Sequence[str] | None = None,
+    schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
     orient: Orientation | None = None,


### PR DESCRIPTION
Previous type hint of `schema` argument of function `from_records` is too restrictive: `schema` is simply passed down to `DataFrame._from_records()` which correctly types `schema` argument as `SchemaDefinition`.