### PR TITLE
feat(sql): additional sql functions

### DIFF
--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -18,7 +18,7 @@ ipc = ["polars-lazy/ipc"]
 atty = { version = "0.2", optional = true }
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["like"] }
 polars-core = { version = "0.27.2", path = "../polars-core", features = [] }
-polars-lazy = { version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join"] }
+polars-lazy = { version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"] }
 polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile"] }
 rustyline = { version = "10.0.0", optional = true }
 serde = "1"

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -23,8 +23,7 @@ polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", feature
 rustyline = { version = "10.0.0", optional = true }
 serde = "1"
 serde_json = { version = "1" }
-sqlparser = { version = "0.19" }
-
+sqlparser = { version = "0.30" }
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"], optional = true }
 

--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -141,7 +141,7 @@ impl SQLContext {
                         let expr = parse_sql_expr(expr)?;
                         expr.alias(&alias.value)
                     }
-                    SelectItem::QualifiedWildcard(_) | SelectItem::Wildcard => {
+                    SelectItem::QualifiedWildcard { .. } | SelectItem::Wildcard { .. } => {
                         contains_wildcard = true;
                         col("*")
                     }

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -1,0 +1,398 @@
+use polars_core::prelude::{PolarsError, PolarsResult};
+use polars_lazy::dsl::{lit, Expr};
+use sqlparser::ast::{
+    Expr as SqlExpr, Function as SQLFunction, FunctionArg, FunctionArgExpr, JoinConstraint,
+    Value as SqlValue,
+};
+
+use crate::sql_expr::{apply_window_spec, parse_sql_expr};
+
+/// Convert a SQL function to a Polars Expr
+pub(crate) enum SQLFunctionExpr<'a> {
+    // ----
+    // Math functions
+    // ----
+    /// SQL 'abs' function
+    Abs(&'a SQLFunction),
+    /// SQL 'acos' function
+    Acos(&'a SQLFunction),
+    /// SQL 'asin' function
+    Asin(&'a SQLFunction),
+    /// SQL 'atan' function
+    Atan(&'a SQLFunction),
+    /// SQL 'ceil' function
+    Ceil(&'a SQLFunction),
+    /// SQL 'exp' function
+    Exp(&'a SQLFunction),
+    /// SQL 'floor' function
+    Floor(&'a SQLFunction),
+    /// SQL 'ln' function
+    Ln(&'a SQLFunction),
+    /// SQL 'log2' function
+    Log2(&'a SQLFunction),
+    /// SQL 'log10' function
+    Log10(&'a SQLFunction),
+    /// SQL 'log' function
+    Log(&'a SQLFunction),
+
+    /// SQL 'pow' function
+    Pow(&'a SQLFunction),
+    // ----
+    // String functions
+    // ----
+    /// SQL 'lower' function
+    Lower(&'a SQLFunction),
+    /// SQL 'upper' function
+    Upper(&'a SQLFunction),
+    /// SQL 'ltrim' function
+    LTrim(&'a SQLFunction),
+    /// SQL 'rtrim' function
+    RTrim(&'a SQLFunction),
+    /// SQL 'starts_with' function
+    StartsWith(&'a SQLFunction),
+    /// SQL 'ends_with' function
+    EndsWith(&'a SQLFunction),
+    // ----
+    // Aggregate functions
+    // ----
+    /// SQL 'count' function
+    Count(CountExpr<'a>),
+    /// SQL 'sum' function
+    Sum(&'a SQLFunction),
+    /// SQL 'min' function
+    Min(&'a SQLFunction),
+    /// SQL 'max' function
+    Max(&'a SQLFunction),
+    /// SQL 'avg' function
+    Avg(&'a SQLFunction),
+    /// SQL 'stddev' function
+    StdDev(&'a SQLFunction),
+    /// SQL 'variance' function
+    Variance(&'a SQLFunction),
+    /// SQL 'first' function
+    First(&'a SQLFunction),
+    /// SQL 'last' function
+    Last(&'a SQLFunction),
+    // ----
+    // Array functions
+    // ----
+    /// SQL 'array_length' function
+    ArrayLength(&'a SQLFunction),
+    /// SQL 'array_min' function
+    ArrayMin(&'a SQLFunction),
+    /// SQL 'array_max' function
+    ArrayMax(&'a SQLFunction),
+    /// SQL 'array_sum' function
+    ArraySum(&'a SQLFunction),
+    /// SQL 'array_mean' function
+    ArrayMean(&'a SQLFunction),
+    /// SQL 'array_reverse' function
+    ArrayReverse(&'a SQLFunction),
+    /// SQL 'array_unique' function
+    ArrayUnique(&'a SQLFunction),
+    /// SQL 'explode' function
+    Explode(&'a SQLFunction),
+    /// SQL 'slice' function
+    Slice(&'a SQLFunction),
+    /// SQL 'array_get' function
+    ArrayGet(&'a SQLFunction),
+    /// SQL 'array_contains' function
+    ArrayContains(&'a SQLFunction),
+}
+
+impl<'a> From<&'a SQLFunction> for SQLFunctionExpr<'a> {
+    fn from(function: &'a SQLFunction) -> Self {
+        let function_name = function.name.0[0].value.to_lowercase();
+        match function_name.as_str() {
+            // ----
+            // Math functions
+            // ----
+            "abs" => Self::Abs(function),
+            "acos" => Self::Acos(function),
+            "asin" => Self::Asin(function),
+            "atan" => Self::Atan(function),
+            "ceil" | "ceiling" => Self::Ceil(function),
+            "exp" => Self::Exp(function),
+            "floor" => Self::Floor(function),
+            "ln" => Self::Ln(function),
+            "log2" => Self::Log2(function),
+            "log10" => Self::Log10(function),
+            "log" => Self::Log(function),
+            "pow" => Self::Pow(function),
+            // ----
+            // String functions
+            // ----
+            "lower" => Self::Lower(function),
+            "upper" => Self::Upper(function),
+            "ltrim" => Self::LTrim(function),
+            "rtrim" => Self::RTrim(function),
+            "starts_with" => Self::StartsWith(function),
+            "ends_with" => Self::EndsWith(function),
+            // ----
+            // Aggregate functions
+            // ----
+            "count" => Self::Count(CountExpr(function)),
+            "sum" => Self::Sum(function),
+            "min" => Self::Min(function),
+            "max" => Self::Max(function),
+            "avg" => Self::Avg(function),
+            "stddev" | "stddev_samp" => Self::StdDev(function),
+            "variance" | "var_samp" => Self::Variance(function),
+            "first" => Self::First(function),
+            "last" => Self::Last(function),
+            // ----
+            // Array functions
+            // ----
+            "array_length" => Self::ArrayLength(function),
+            "array_min" => Self::ArrayMin(function),
+            "array_max" => Self::ArrayMax(function),
+            "array_sum" => Self::ArraySum(function),
+            "array_mean" => Self::ArrayMean(function),
+            "array_reverse" => Self::ArrayReverse(function),
+            "array_unique" => Self::ArrayUnique(function),
+            "explode" => Self::Explode(function),
+            "slice" => Self::Slice(function),
+            "array_get" => Self::ArrayGet(function),
+            "array_contains" => Self::ArrayContains(function),
+            other => unimplemented!("{other}"),
+        }
+    }
+}
+
+impl TryFrom<SQLFunctionExpr<'_>> for Expr {
+    type Error = PolarsError;
+    fn try_from(function_expr: SQLFunctionExpr) -> Result<Self, Self::Error> {
+        use SQLFunctionExpr::*;
+        match function_expr {
+            // ----
+            // Math functions
+            // ----
+            Abs(function) => unary(function, Expr::abs),
+            Acos(function) => unary(function, Expr::arccos),
+            Asin(function) => unary(function, Expr::arcsin),
+            Atan(function) => unary(function, Expr::arctan),
+            Ceil(function) => unary(function, Expr::ceil),
+            Exp(function) => unary(function, Expr::exp),
+            Floor(function) => unary(function, Expr::floor),
+            Ln(function) => unary(function, |e| e.log(std::f64::consts::E)),
+            Log2(function) => unary(function, |e| e.log(2.0)),
+            Log10(function) => unary(function, |e| e.log(10.0)),
+            Log(function) => binary(function, Expr::log),
+            Pow(function) => binary(function, |e: Expr, p: Expr| e.pow(p)),
+            // ----
+            // String functions
+            // ----
+            Lower(function) => unary(function, |e| e.str().to_lowercase()),
+            Upper(function) => unary(function, |e| e.str().to_uppercase()),
+            LTrim(function) => match function.args.len() {
+                1 => unary(function, |e| e.str().lstrip(None)),
+                2 => binary(function, |e, s| e.str().lstrip(Some(s))),
+                _ => panic!(
+                    "Invalid number of arguments for LTrim: {}",
+                    function.args.len()
+                ),
+            },
+            RTrim(function) => match function.args.len() {
+                1 => unary(function, |e| e.str().rstrip(None)),
+                2 => binary(function, |e, s| e.str().rstrip(Some(s))),
+                _ => panic!(
+                    "Invalid number of arguments for RTrim: {}",
+                    function.args.len()
+                ),
+            },
+            StartsWith(function) => binary(function, |e, s| e.str().starts_with(s)),
+            EndsWith(function) => binary(function, |e, s| e.str().ends_with(s)),
+
+            // ----
+            // Aggregate functions
+            // ----
+            Count(count_expr) => count_expr.try_into(),
+            Sum(function) => unary(function, Expr::sum),
+            Min(function) => unary(function, Expr::min),
+            Max(function) => unary(function, Expr::max),
+            Avg(function) => unary(function, Expr::mean),
+            StdDev(function) => unary(function, |e| e.std(1)),
+            Variance(function) => unary(function, |e| e.var(1)),
+            First(function) => unary(function, Expr::first),
+            Last(function) => unary(function, Expr::last),
+            // ----
+            // Array functions
+            // ----
+            ArrayLength(function) => unary(function, |e| e.arr().lengths()),
+            ArrayMin(function) => unary(function, |e| e.arr().min()),
+            ArrayMax(function) => unary(function, |e| e.arr().max()),
+            ArraySum(function) => unary(function, |e| e.arr().sum()),
+            ArrayMean(function) => unary(function, |e| e.arr().mean()),
+            ArrayReverse(function) => unary(function, |e| e.arr().reverse()),
+            ArrayUnique(function) => unary(function, |e| e.arr().unique()),
+            Explode(function) => unary(function, |e| e.explode()),
+            Slice(function) => trinary(function, |e, s: Expr, l: Expr| e.slice(s, l)),
+            ArrayGet(function) => binary(function, |e, i| e.arr().get(i)),
+            ArrayContains(function) => binary(function, |e, i: Expr| e.arr().contains(i)),
+        }
+    }
+}
+
+fn unary<'a>(function: &'a SQLFunction, f: impl Fn(Expr) -> Expr) -> Result<Expr, PolarsError> {
+    let args = extract_args(function);
+    if let FunctionArgExpr::Expr(sql_expr) = args[0] {
+        let expr = apply_window_spec(parse_sql_expr(sql_expr)?, &function.over)?;
+        Ok(f(expr))
+    } else {
+        not_supported_error(function.name.0[0].value.as_str(), &args)
+    }
+}
+
+fn binary<'a, T: FromSqlExpr>(
+    function: &'a SQLFunction,
+    f: impl Fn(Expr, T) -> Expr,
+) -> Result<Expr, PolarsError> {
+    let args = extract_args(function);
+
+    if let FunctionArgExpr::Expr(sql_expr) = args[0] {
+        let expr1 = apply_window_spec(parse_sql_expr(sql_expr)?, &function.over)?;
+        if let FunctionArgExpr::Expr(sql_expr) = args[1] {
+            let expr2 = T::from_sql_expr(sql_expr)?;
+            Ok(f(expr1, expr2))
+        } else {
+            not_supported_error(function.name.0[0].value.as_str(), &args)
+        }
+    } else {
+        not_supported_error(function.name.0[0].value.as_str(), &args)
+    }
+}
+
+fn trinary<'a, Arg1: FromSqlExpr, Arg2: FromSqlExpr>(
+    function: &'a SQLFunction,
+    f: impl Fn(Expr, Arg1, Arg2) -> Expr,
+) -> Result<Expr, PolarsError> {
+    let args = extract_args(function);
+
+    if let [FunctionArgExpr::Expr(sql_expr1), FunctionArgExpr::Expr(sql_expr2), FunctionArgExpr::Expr(sql_expr3)] =
+        &args[..]
+    {
+        let expr1 = apply_window_spec(parse_sql_expr(sql_expr1)?, &function.over)?;
+        let arg1 = Arg1::from_sql_expr(sql_expr2)?;
+        let arg2 = Arg2::from_sql_expr(sql_expr3)?;
+        Ok(f(expr1, arg1, arg2))
+    } else {
+        not_supported_error(function.name.0[0].value.as_str(), &args)
+    }
+}
+
+// CountExpr is extracted because it has many special cases
+pub(crate) struct CountExpr<'a>(&'a SQLFunction);
+
+impl TryFrom<CountExpr<'_>> for Expr {
+    type Error = PolarsError;
+    fn try_from(count_expr: CountExpr) -> Result<Self, Self::Error> {
+        let args = extract_args(count_expr.0);
+        Ok(match (args.len(), count_expr.0.distinct) {
+            // count()
+            (0, false) => lit(1i32).count(),
+            // count(distinct)
+            (0, true) => return not_supported_error("count", &args),
+            (1, false) => match args[0] {
+                // count(col)
+                FunctionArgExpr::Expr(sql_expr) => {
+                    let expr = apply_window_spec(parse_sql_expr(sql_expr)?, &count_expr.0.over)?;
+                    expr.count()
+                }
+                // count(*)
+                FunctionArgExpr::Wildcard => lit(1i32).count(),
+                // count(tbl.*) is not supported
+                _ => return not_supported_error("count", &args),
+            },
+            (1, true) => {
+                // count(distinct col)
+                if let FunctionArgExpr::Expr(sql_expr) = args[0] {
+                    let expr = apply_window_spec(parse_sql_expr(sql_expr)?, &count_expr.0.over)?;
+                    expr.n_unique()
+                } else {
+                    // count(distinct *) or count(distinct tbl.*) is not supported
+                    return not_supported_error("count", &args);
+                }
+            }
+            _ => return not_supported_error("count", &args),
+        })
+    }
+}
+
+fn not_supported_error(
+    function_name: &str,
+    args: &Vec<&sqlparser::ast::FunctionArgExpr>,
+) -> PolarsResult<Expr> {
+    Err(PolarsError::ComputeError(
+        format!(
+            "Function {:?} with args {:?} was not supported in polars-sql yet!",
+            function_name, args
+        )
+        .into(),
+    ))
+}
+
+fn extract_args(sql_function: &SQLFunction) -> Vec<&FunctionArgExpr> {
+    sql_function
+        .args
+        .iter()
+        .map(|arg| match arg {
+            FunctionArg::Named { arg, .. } => arg,
+            FunctionArg::Unnamed(arg) => arg,
+        })
+        .collect()
+}
+
+trait FromSqlExpr {
+    fn from_sql_expr(expr: &SqlExpr) -> Result<Self, PolarsError>
+    where
+        Self: Sized;
+}
+
+impl FromSqlExpr for f64 {
+    fn from_sql_expr(expr: &SqlExpr) -> Result<Self, PolarsError>
+    where
+        Self: Sized,
+    {
+        match expr {
+            SqlExpr::Value(v) => match v {
+                SqlValue::Number(s, _) => s.parse::<f64>().map_err(|_| {
+                    PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
+                }),
+                _ => Err(PolarsError::ComputeError(
+                    format!("Can't parse literal {:?}", v).into(),
+                )),
+            },
+            _ => Err(PolarsError::ComputeError(
+                format!("Can't parse literal {:?}", expr).into(),
+            )),
+        }
+    }
+}
+
+impl FromSqlExpr for String {
+    fn from_sql_expr(expr: &SqlExpr) -> Result<Self, PolarsError>
+    where
+        Self: Sized,
+    {
+        match expr {
+            SqlExpr::Value(v) => match v {
+                SqlValue::SingleQuotedString(s) => Ok(s.clone()),
+                _ => Err(PolarsError::ComputeError(
+                    format!("Can't parse literal {:?}", v).into(),
+                )),
+            },
+            _ => Err(PolarsError::ComputeError(
+                format!("Can't parse literal {:?}", expr).into(),
+            )),
+        }
+    }
+}
+
+impl FromSqlExpr for Expr {
+    fn from_sql_expr(expr: &SqlExpr) -> Result<Self, PolarsError>
+    where
+        Self: Sized,
+    {
+        parse_sql_expr(expr)
+    }
+}

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -1,6 +1,6 @@
 mod context;
+mod functions;
 mod sql_expr;
-
 pub use context::SQLContext;
 
 #[cfg(test)]
@@ -84,5 +84,362 @@ mod test {
             .collect()?;
         assert_eq!(df_sql, df_pl);
         Ok(())
+    }
+
+    #[test]
+    fn test_cast_exprs() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                cast(a as FLOAT) as floats, 
+                cast(a as INT) as ints, 
+                cast(a as BIGINT) as bigints, 
+                cast(a as STRING) as strings
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                col("a").cast(DataType::Float32).alias("floats"),
+                col("a").cast(DataType::Int32).alias("ints"),
+                col("a").cast(DataType::Int64).alias("bigints"),
+                col("a").cast(DataType::Utf8).alias("strings"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&df_pl));
+    }
+
+    #[test]
+    fn test_literal_exprs() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                1 as int_lit, 
+                1.0 as float_lit, 
+                'foo' as string_lit,
+                true as bool_lit,
+                null as null_lit
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                lit(1i64).alias("int_lit"),
+                lit(1.0).alias("float_lit"),
+                lit("foo").alias("string_lit"),
+                lit(true).alias("bool_lit"),
+                lit(NULL).alias("null_lit"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal_missing(&df_pl));
+    }
+    #[test]
+    fn test_prefixed_column_names() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                df.a as a, 
+                df.b as b
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[col("a").alias("a"), col("b").alias("b")])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&df_pl));
+    }
+
+    #[test]
+    fn test_prefixed_column_names_2() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                "df"."a" as a, 
+                "df"."b" as b
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[col("a").alias("a"), col("b").alias("b")])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&df_pl));
+    }
+    #[test]
+    fn test_binary_functions() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                a, 
+                b, 
+                a + b as add, 
+                a - b as sub, 
+                a * b as mul, 
+                a / b as div, 
+                a % b as rem,
+                a <> b as neq,
+                a = b as eq,
+                a > b as gt,
+                a < b as lt,
+                a >= b as gte,
+                a <= b as lte,
+                a and b as and,
+                a or b as or,
+                a xor b as xor,
+                a || b as concat
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df.lazy().select(&[
+            col("a"),
+            col("b"),
+            (col("a") + col("b")).alias("add"),
+            (col("a") - col("b")).alias("sub"),
+            (col("a") * col("b")).alias("mul"),
+            (col("a") / col("b")).alias("div"),
+            (col("a") % col("b")).alias("rem"),
+            col("a").eq(col("b")).not().alias("neq"),
+            col("a").eq(col("b")).alias("eq"),
+            col("a").gt(col("b")).alias("gt"),
+            col("a").lt(col("b")).alias("lt"),
+            col("a").gt_eq(col("b")).alias("gte"),
+            col("a").lt_eq(col("b")).alias("lte"),
+            col("a").and(col("b")).alias("and"),
+            col("a").or(col("b")).alias("or"),
+            col("a").xor(col("b")).alias("xor"),
+            (col("a").cast(DataType::Utf8) + col("b").cast(DataType::Utf8)).alias("concat"),
+        ]);
+        let df_pl = df_pl.collect().unwrap();
+        assert_eq!(df_sql, df_pl);
+    }
+
+    #[test]
+    fn test_null_exprs() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                a, 
+                b,
+                a is null as isnull_a, 
+                b is null as isnull_b, 
+                a is not null as isnotnull_a,
+                b is not null as isnotnull_b 
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                col("a"),
+                col("b"),
+                col("a").is_null().alias("isnull_a"),
+                col("b").is_null().alias("isnull_b"),
+                col("a").is_not_null().alias("isnotnull_a"),
+                col("b").is_not_null().alias("isnotnull_b"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&df_pl));
+    }
+
+    #[test]
+    fn test_null_exprs_in_where() {
+        let df = df! {
+            "a" => &[Some(1), None, Some(3)],
+            "b" => &[Some(1), Some(2), None]
+        }
+        .unwrap();
+
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                a, 
+                b
+            FROM df
+            WHERE a is null and b is not null"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .filter(col("a").is_null().and(col("b").is_not_null()))
+            .collect()
+            .unwrap();
+
+        assert!(df_sql.frame_equal_missing(&df_pl));
+    }
+
+    #[test]
+    fn test_math_functions() {
+        let df = df! {
+            "a" => &[1.0]
+        }
+        .unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                a, 
+                abs(a) as abs_a,
+                exp(a) as exp_a,
+                floor(a) as floor_a,
+                ln(a) as ln_a,
+                acos(a) as acos_a,
+                asin(a) as asin_a,
+                atan(a) as atan_a,
+                log(a, 10) as log_a,
+                log2(a) as log2_a,
+                log10(a) as log10_a
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                col("a"),
+                col("a").abs().alias("abs_a"),
+                col("a").exp().alias("exp_a"),
+                col("a").floor().alias("floor_a"),
+                col("a").log(std::f64::consts::E).alias("ln_a"),
+                col("a").arccos().alias("acos_a"),
+                col("a").arcsin().alias("asin_a"),
+                col("a").arctan().alias("atan_a"),
+                col("a").log(10.0).alias("log_a"),
+                col("a").log(2.0).alias("log2_a"),
+                col("a").log(10.0).alias("log10_a"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal_missing(&df_pl));
+    }
+    #[test]
+    fn test_string_functions() {
+        let df = df! {
+            "a" => &["foo", "xxxbarxxx", "---bazyyy"]
+        }
+        .unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                a, 
+                lower('LITERAL') as lower_literal,
+                lower(a) as lower_a,
+                lower("a") as lower_a2,
+                lower(df.a) as lower_a_df,
+                lower("df".a) as lower_a_df2,
+                lower("df"."a") as lower_a_df3,
+                upper(a) as upper_a,
+                upper(df.a) as upper_a_df,
+                upper("df".a) as upper_a_df2,
+                upper("df"."a") as upper_a_df3,
+                trim(both 'x' from a) as trim_a,
+                trim(leading 'x' from a) as trim_a_leading,
+                trim(trailing 'x' from a) as trim_a_trailing,
+                ltrim(a) as ltrim_a,
+                rtrim(a) as rtrim_a,
+                ltrim(a, '-') as ltrim_a_dash,
+                rtrim(a, '-') as rtrim_a_dash,
+                ltrim(a, 'xyz') as ltrim_a_xyz,
+                rtrim(a, 'xyz') as rtrim_a_xyz
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                col("a"),
+                lit("LITERAL").str().to_lowercase().alias("lower_literal"),
+                col("a").str().to_lowercase().alias("lower_a"),
+                col("a").str().to_lowercase().alias("lower_a2"),
+                col("a").str().to_lowercase().alias("lower_a_df"),
+                col("a").str().to_lowercase().alias("lower_a_df2"),
+                col("a").str().to_lowercase().alias("lower_a_df3"),
+                col("a").str().to_uppercase().alias("upper_a"),
+                col("a").str().to_uppercase().alias("upper_a_df"),
+                col("a").str().to_uppercase().alias("upper_a_df2"),
+                col("a").str().to_uppercase().alias("upper_a_df3"),
+                col("a").str().strip(Some("x".into())).alias("trim_a"),
+                col("a")
+                    .str()
+                    .lstrip(Some("x".into()))
+                    .alias("trim_a_leading"),
+                col("a")
+                    .str()
+                    .rstrip(Some("x".into()))
+                    .alias("trim_a_trailing"),
+                col("a").str().lstrip(None).alias("ltrim_a"),
+                col("a").str().rstrip(None).alias("rtrim_a"),
+                col("a")
+                    .str()
+                    .lstrip(Some("-".into()))
+                    .alias("ltrim_a_dash"),
+                col("a")
+                    .str()
+                    .rstrip(Some("-".into()))
+                    .alias("rtrim_a_dash"),
+                col("a")
+                    .str()
+                    .lstrip(Some("xyz".into()))
+                    .alias("ltrim_a_xyz"),
+                col("a")
+                    .str()
+                    .rstrip(Some("xyz".into()))
+                    .alias("rtrim_a_xyz"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal_missing(&df_pl));
+    }
+    #[test]
+    fn test_agg_functions() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            SELECT 
+                sum(a) as sum_a,
+                first(a) as first_a,
+                last(a) as last_a,
+                avg(a) as avg_a,
+                max(a) as max_a,
+                min(a) as min_a,
+                atan(a) as atan_a,
+                stddev(a) as stddev_a,
+                variance(a) as variance_a,
+                count(a) as count_a,
+                count(distinct a) as count_distinct_a,
+                count(*) as count_all
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let df_pl = df
+            .lazy()
+            .select(&[
+                col("a").sum().alias("sum_a"),
+                col("a").first().alias("first_a"),
+                col("a").last().alias("last_a"),
+                col("a").mean().alias("avg_a"),
+                col("a").max().alias("max_a"),
+                col("a").min().alias("min_a"),
+                col("a").arctan().alias("atan_a"),
+                col("a").std(1).alias("stddev_a"),
+                col("a").var(1).alias("variance_a"),
+                col("a").count().alias("count_a"),
+                col("a").n_unique().alias("count_distinct_a"),
+                lit(1i32).count().alias("count_all"),
+            ])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&df_pl));
     }
 }

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -3,11 +3,11 @@ use polars_lazy::dsl::Expr;
 use polars_lazy::prelude::*;
 use sqlparser::ast::{
     BinaryOperator as SQLBinaryOperator, BinaryOperator, DataType as SQLDataType, Expr as SqlExpr,
-    Function as SQLFunction, JoinConstraint, TrimWhereField, Value as SqlValue, WindowSpec,
+    Function as SQLFunction, JoinConstraint, TrimWhereField, Value as SqlValue,
 };
 
 use crate::context::TABLES;
-use crate::functions::SQLFunctionExpr;
+use crate::functions::SqlFunctionVisitor;
 
 fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
     Ok(match data_type {
@@ -28,13 +28,12 @@ fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
         SQLDataType::UnsignedInt(_) => DataType::UInt32,
         SQLDataType::BigInt(_) => DataType::Int64,
         SQLDataType::UnsignedBigInt(_) => DataType::UInt64,
-
         SQLDataType::Boolean => DataType::Boolean,
         SQLDataType::Date => DataType::Date,
-        SQLDataType::Time => DataType::Time,
-        SQLDataType::Timestamp => DataType::Datetime(TimeUnit::Milliseconds, None),
+        SQLDataType::Time { .. } => DataType::Time,
+        SQLDataType::Timestamp { .. } => DataType::Datetime(TimeUnit::Milliseconds, None),
         SQLDataType::Interval => DataType::Duration(TimeUnit::Milliseconds),
-        SQLDataType::Array(inner_type) => {
+        SQLDataType::Array(Some(inner_type)) => {
             DataType::List(Box::new(map_sql_polars_datatype(inner_type)?))
         }
         _ => {
@@ -49,70 +48,220 @@ fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
     })
 }
 
-fn cast_(expr: Expr, data_type: &SQLDataType) -> PolarsResult<Expr> {
-    let polars_type = map_sql_polars_datatype(data_type)?;
-    Ok(expr.cast(polars_type))
-}
+/// Recursively walks a SQL Expr to create a polars Expr
+pub(crate) struct SqlExprVisitor {}
 
-fn binary_op_(left: Expr, right: Expr, op: &SQLBinaryOperator) -> PolarsResult<Expr> {
-    Ok(match op {
-        SQLBinaryOperator::Plus => left + right,
-        SQLBinaryOperator::Minus => left - right,
-        SQLBinaryOperator::Multiply => left * right,
-        SQLBinaryOperator::Divide => left / right,
-        SQLBinaryOperator::Modulo => left % right,
-        SQLBinaryOperator::StringConcat => left.cast(DataType::Utf8) + right.cast(DataType::Utf8),
-        SQLBinaryOperator::Gt => left.gt(right),
-        SQLBinaryOperator::Lt => left.lt(right),
-        SQLBinaryOperator::GtEq => left.gt_eq(right),
-        SQLBinaryOperator::LtEq => left.lt_eq(right),
-        SQLBinaryOperator::Eq => left.eq(right),
-        SQLBinaryOperator::NotEq => left.eq(right).not(),
-        SQLBinaryOperator::And => left.and(right),
-        SQLBinaryOperator::Or => left.or(right),
-        SQLBinaryOperator::Xor => left.xor(right),
-        _ => {
-            return Err(PolarsError::ComputeError(
-                format!("SQL Operator {:?} was not supported in polars-sql yet!", op).into(),
-            ))
+impl SqlExprVisitor {
+    fn visit_expr(&self, expr: &SqlExpr) -> PolarsResult<Expr> {
+        match expr {
+            SqlExpr::CompoundIdentifier(idents) => self.visit_compound_identifier(idents),
+            SqlExpr::Identifier(ident) => self.visit_identifier(ident),
+            SqlExpr::BinaryOp { left, op, right } => self.visit_binary_op(left, op, right),
+            SqlExpr::Function(function) => self.visit_function(function),
+            SqlExpr::Cast { expr, data_type } => self.visit_cast(expr, data_type),
+            SqlExpr::Value(value) => self.visit_literal(value),
+            SqlExpr::IsNull(expr) => Ok(self.visit_expr(expr)?.is_null()),
+            SqlExpr::IsNotNull(expr) => Ok(self.visit_expr(expr)?.is_not_null()),
+            SqlExpr::Floor { expr, .. } => self.visit_expr(expr),
+            SqlExpr::Ceil { expr, .. } => self.visit_expr(expr),
+            SqlExpr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => self.visit_between(expr, *negated, low, high),
+            SqlExpr::Trim {
+                expr,
+                trim_where,
+                trim_what,
+            } => self.visit_trim(expr, trim_where, trim_what),
+            SqlExpr::IsFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false))),
+            SqlExpr::IsNotFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false)).not()),
+            SqlExpr::IsTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true))),
+            SqlExpr::IsNotTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true)).not()),
+            SqlExpr::AnyOp(expr) => Ok(self.visit_expr(expr)?.any()),
+            SqlExpr::AllOp(_) => Ok(self.visit_expr(expr)?.all()),
+            other => Err(PolarsError::ComputeError(
+                format!("SQL Expr {:?} was not supported in polars-sql yet!", other).into(),
+            )),
         }
-    })
-}
+    }
 
-fn literal_expr(value: &SqlValue) -> PolarsResult<Expr> {
-    Ok(match value {
-        SqlValue::Number(s, _) => {
-            // Check for existence of decimal separator dot
-            if s.contains('.') {
-                s.parse::<f64>().map(lit).map_err(|_| {
-                    PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
-                })
-            } else {
-                s.parse::<i64>().map(lit).map_err(|_| {
-                    PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
-                })
-            }?
-        }
-        SqlValue::SingleQuotedString(s) => lit(s.clone()),
-        SqlValue::NationalStringLiteral(s) => lit(s.clone()),
-        SqlValue::HexStringLiteral(s) => lit(s.clone()),
-        SqlValue::DoubleQuotedString(s) => lit(s.clone()),
-        SqlValue::Boolean(b) => lit(*b),
-        SqlValue::Null => Expr::Literal(LiteralValue::Null),
-        _ => {
+    /// Visit a compound identifier
+    ///
+    /// e.g. df.column or "df"."column"
+    fn visit_compound_identifier(&self, idents: &[sqlparser::ast::Ident]) -> PolarsResult<Expr> {
+        if idents.len() != 2 {
             return Err(PolarsError::ComputeError(
+                format!("Compound identifier: {:?} is not yet supported", idents).into(),
+            ));
+        }
+        let tbl_name = &idents[0].value;
+        let refers_main_table = TABLES.with(|cell| {
+            let tables = cell.borrow();
+            tables.len() == 1 && tables.contains(tbl_name)
+        });
+
+        if refers_main_table {
+            Ok(col(&idents[1].value))
+        } else {
+            Err(PolarsError::ComputeError(
                 format!(
-                    "Parsing SQL Value {:?} was not supported in polars-sql yet!",
-                    value
+                    "Compounded identifier: {:?} is not yet supported  if multiple tables are registered",
+                    idents
                 )
-                .into(),
+                    .into(),
             ))
         }
-    })
-}
+    }
 
-pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> PolarsResult<Expr> {
-    let err = || {
+    /// Visit a single identifier
+    ///
+    /// e.g. column
+    fn visit_identifier(&self, ident: &sqlparser::ast::Ident) -> PolarsResult<Expr> {
+        Ok(col(&ident.value))
+    }
+
+    /// Visit a binary operation
+    ///
+    /// e.g. column + 1 or column1 / column2
+    fn visit_binary_op(
+        &self,
+        left: &SqlExpr,
+        op: &BinaryOperator,
+        right: &SqlExpr,
+    ) -> PolarsResult<Expr> {
+        let left = self.visit_expr(left)?;
+        let right = self.visit_expr(right)?;
+        Ok(match op {
+            SQLBinaryOperator::Plus => left + right,
+            SQLBinaryOperator::Minus => left - right,
+            SQLBinaryOperator::Multiply => left * right,
+            SQLBinaryOperator::Divide => left / right,
+            SQLBinaryOperator::Modulo => left % right,
+            SQLBinaryOperator::StringConcat => {
+                left.cast(DataType::Utf8) + right.cast(DataType::Utf8)
+            }
+            SQLBinaryOperator::Gt => left.gt(right),
+            SQLBinaryOperator::Lt => left.lt(right),
+            SQLBinaryOperator::GtEq => left.gt_eq(right),
+            SQLBinaryOperator::LtEq => left.lt_eq(right),
+            SQLBinaryOperator::Eq => left.eq(right),
+            SQLBinaryOperator::NotEq => left.eq(right).not(),
+            SQLBinaryOperator::And => left.and(right),
+            SQLBinaryOperator::Or => left.or(right),
+            SQLBinaryOperator::Xor => left.xor(right),
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    format!("SQL Operator {:?} was not supported in polars-sql yet!", op).into(),
+                ))
+            }
+        })
+    }
+
+    /// Visit a SQL function
+    ///
+    /// e.g. SUM(column) or COUNT(*)
+    ///
+    /// See [SqlFunctionVisitor] for more details
+    fn visit_function(&self, function: &SQLFunction) -> PolarsResult<Expr> {
+        let visitor = SqlFunctionVisitor(function);
+        visitor.visit_function()
+    }
+
+    /// Visit a SQL CAST
+    ///
+    /// e.g. `CAST(column AS INT)` or `column::INT`
+    fn visit_cast(&self, expr: &SqlExpr, data_type: &SQLDataType) -> PolarsResult<Expr> {
+        let polars_type = map_sql_polars_datatype(data_type)?;
+        let expr = self.visit_expr(expr)?;
+
+        Ok(expr.cast(polars_type))
+    }
+
+    /// Visit a SQL literal
+    ///
+    /// e.g. 1, 'foo', 1.0, NULL
+    ///
+    /// See [SqlValue] and [LiteralValue] for more details
+    fn visit_literal(&self, value: &SqlValue) -> PolarsResult<Expr> {
+        Ok(match value {
+            SqlValue::Number(s, _) => {
+                // Check for existence of decimal separator dot
+                if s.contains('.') {
+                    s.parse::<f64>().map(lit).map_err(|_| {
+                        PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
+                    })
+                } else {
+                    s.parse::<i64>().map(lit).map_err(|_| {
+                        PolarsError::ComputeError(format!("Can't parse literal {:?}", s).into())
+                    })
+                }?
+            }
+            SqlValue::SingleQuotedString(s) => lit(s.clone()),
+            SqlValue::NationalStringLiteral(s) => lit(s.clone()),
+            SqlValue::HexStringLiteral(s) => lit(s.clone()),
+            SqlValue::DoubleQuotedString(s) => lit(s.clone()),
+            SqlValue::Boolean(b) => lit(*b),
+            SqlValue::Null => Expr::Literal(LiteralValue::Null),
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    format!(
+                        "Parsing SQL Value {:?} was not supported in polars-sql yet!",
+                        value
+                    )
+                    .into(),
+                ))
+            }
+        })
+    }
+    /// Visit a SQL `BETWEEN` expression
+    /// See [sqlparser::ast::Expr::Between] for more details
+    fn visit_between(
+        &self,
+        expr: &SqlExpr,
+        negated: bool,
+        low: &SqlExpr,
+        high: &SqlExpr,
+    ) -> PolarsResult<Expr> {
+        let expr = self.visit_expr(expr)?;
+        let low = self.visit_expr(low)?;
+        let high = self.visit_expr(high)?;
+
+        if negated {
+            Ok(expr.clone().lt(low).or(expr.gt(high)))
+        } else {
+            Ok(expr.clone().gt(low).and(expr.lt(high)))
+        }
+    }
+    /// Visit a SQL 'TRIM' function
+    /// See [sqlparser::ast::Expr::Trim] for more details
+    fn visit_trim(
+        &self,
+        expr: &SqlExpr,
+        trim_where: &Option<TrimWhereField>,
+        trim_what: &Option<Box<SqlExpr>>,
+    ) -> PolarsResult<Expr> {
+        let expr = self.visit_expr(expr)?;
+        let trim_what = trim_what.as_ref().map(|e| self.visit_expr(e)).transpose()?;
+        let trim_what = match trim_what {
+            Some(Expr::Literal(LiteralValue::Utf8(val))) => Some(val),
+            None => None,
+            _ => return self.err(&expr),
+        };
+
+        Ok(match (trim_where, trim_what) {
+            (None | Some(TrimWhereField::Both), None) => expr.str().strip(None),
+            (None | Some(TrimWhereField::Both), Some(val)) => expr.str().strip(Some(val)),
+            (Some(TrimWhereField::Leading), None) => expr.str().lstrip(None),
+            (Some(TrimWhereField::Leading), Some(val)) => expr.str().lstrip(Some(val)),
+            (Some(TrimWhereField::Trailing), None) => expr.str().rstrip(None),
+            (Some(TrimWhereField::Trailing), Some(val)) => expr.str().rstrip(Some(val)),
+        })
+        // todo!()
+    }
+
+    fn err(&self, expr: &Expr) -> PolarsResult<Expr> {
         Err(PolarsError::ComputeError(
             format!(
                 "Expression: {:?} was not supported in polars-sql yet. Please open a feature request.",
@@ -120,113 +269,12 @@ pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> PolarsResult<Expr> {
             )
             .into(),
         ))
-    };
-
-    Ok(match expr {
-        SqlExpr::CompoundIdentifier(idents) => {
-            if idents.len() != 2 {
-                return err();
-            }
-            let tbl_name = &idents[0].value;
-            let refers_main_table = TABLES.with(|cell| {
-                let tables = cell.borrow();
-                tables.len() == 1 && tables.contains(tbl_name)
-            });
-
-            if refers_main_table {
-                col(&idents[1].value)
-            } else {
-                return Err(PolarsError::ComputeError(
-                    format!(
-                        "Compounded identifier: {:?} is not yet supported  if multiple tables are registered",
-                        expr
-                    )
-                        .into(),
-                ));
-            }
-        }
-        SqlExpr::Identifier(e) => col(&e.value),
-        SqlExpr::BinaryOp { left, op, right } => {
-            let left = parse_sql_expr(left)?;
-            let right = parse_sql_expr(right)?;
-            binary_op_(left, right, op)?
-        }
-        SqlExpr::Function(sql_function) => parse_sql_function(sql_function)?,
-        SqlExpr::Cast { expr, data_type } => cast_(parse_sql_expr(expr)?, data_type)?,
-        SqlExpr::Nested(expr) => parse_sql_expr(expr)?,
-        SqlExpr::Value(value) => literal_expr(value)?,
-        SqlExpr::IsNull(expr) => parse_sql_expr(expr)?.is_null(),
-        SqlExpr::IsNotNull(expr) => parse_sql_expr(expr)?.is_not_null(),
-        SqlExpr::Between {
-            expr,
-            negated,
-            low,
-            high,
-        } => {
-            let expr = parse_sql_expr(expr)?;
-            let low = parse_sql_expr(low)?;
-            let high = parse_sql_expr(high)?;
-
-            if *negated {
-                expr.clone().lt(low).or(expr.gt(high))
-            } else {
-                expr.clone().gt(low).and(expr.lt(high))
-            }
-        }
-        SqlExpr::Trim {
-            expr: sql_expr,
-            trim_where,
-        } => {
-            let expr = parse_sql_expr(sql_expr)?;
-            match trim_where {
-                None => return Ok(expr.str().strip(None)),
-                Some((TrimWhereField::Both, sql_expr)) => {
-                    let lit = parse_sql_expr(sql_expr)?;
-                    if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        return Ok(expr.str().strip(Some(val)));
-                    }
-                }
-                Some((TrimWhereField::Leading, sql_expr)) => {
-                    let lit = parse_sql_expr(sql_expr)?;
-                    if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        return Ok(expr.str().lstrip(Some(val)));
-                    }
-                }
-                Some((TrimWhereField::Trailing, sql_expr)) => {
-                    let lit = parse_sql_expr(sql_expr)?;
-                    if let Expr::Literal(LiteralValue::Utf8(val)) = lit {
-                        return Ok(expr.str().rstrip(Some(val)));
-                    }
-                }
-            }
-            return err();
-        }
-        _ => return err(),
-    })
+    }
 }
 
-pub(crate) fn apply_window_spec(
-    expr: Expr,
-    window_spec: &Option<WindowSpec>,
-) -> PolarsResult<Expr> {
-    Ok(match &window_spec {
-        Some(window_spec) => {
-            // Process for simple window specification, partition by first
-            let partition_by = window_spec
-                .partition_by
-                .iter()
-                .map(parse_sql_expr)
-                .collect::<PolarsResult<Vec<_>>>()?;
-            expr.over(partition_by)
-            // Order by and Row range may not be supported at the moment
-        }
-        None => expr,
-    })
-}
-
-pub(crate) fn parse_sql_function(sql_function: &SQLFunction) -> PolarsResult<Expr> {
-    let expr: SQLFunctionExpr = sql_function.into();
-    expr.try_into()
+pub(crate) fn parse_sql_expr(expr: &SqlExpr) -> PolarsResult<Expr> {
+    let visitor = SqlExprVisitor {};
+    visitor.visit_expr(expr)
 }
 
 pub(super) fn process_join_constraint(

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -258,7 +258,6 @@ impl SqlExprVisitor {
             (Some(TrimWhereField::Trailing), None) => expr.str().rstrip(None),
             (Some(TrimWhereField::Trailing), Some(val)) => expr.str().rstrip(Some(val)),
         })
-        // todo!()
     }
 
     fn err(&self, expr: &Expr) -> PolarsResult<Expr> {


### PR DESCRIPTION
## Description
Added a bunch more sql functions, and slightly refactored the existing function parsing to make it more extensible. 

## Notes.
I wasn't sure if there was a specific engine we are trying to mimic for the functions, or if we wanted to keep it consistent with the python methods.  

For example, getting the length of a List<T> column
| engine | method|
| --| --| 
|Spark SQL | `size` |
| postgres | `array_length` |
| duckdb | `len` \| `array_length` \| `list_length`|
| py-polars| `arr.lengths` |
