### PR TITLE
fix(python): fix type hint of 'when->then->otherwise'

### DIFF
--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -27,13 +27,7 @@ class WhenThenThen:
 
     def then(
         self,
-        expr: (
-            PolarsExprType
-            | PythonLiteral
-            | pli.Series
-            | Iterable[PolarsExprType | PythonLiteral | pli.Series]
-            | None
-        ),
+        expr: (PolarsExprType | PythonLiteral | pli.Series | None),
     ) -> WhenThenThen:
         """
         Values to return in case of the predicate being `True`.
@@ -49,13 +43,7 @@ class WhenThenThen:
 
     def otherwise(
         self,
-        expr: (
-            PolarsExprType
-            | PythonLiteral
-            | pli.Series
-            | Iterable[PolarsExprType | PythonLiteral | pli.Series]
-            | None
-        ),
+        expr: (PolarsExprType | PythonLiteral | pli.Series | None),
     ) -> pli.Expr:
         """
         Values to return in case of the predicate being `False`.


### PR DESCRIPTION
partially adresses #7031. We should accept iterables here.