### PR TITLE
perf(python): optimize `sequence_to_pydf`

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -836,7 +836,7 @@ def sequence_to_pydf(
                 if schema_overrides
                 else {}
             )
-            if column_names and data and len(data[0]) != len(column_names):
+            if column_names and len(data[0]) != len(column_names):
                 raise ShapeError("The row data does not match the number of columns")
 
             for col, tp in schema_override.items():

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -4,6 +4,7 @@ import contextlib
 from contextlib import suppress
 from dataclasses import astuple, is_dataclass
 from datetime import date, datetime, time, timedelta
+from functools import singledispatch
 from itertools import islice, zip_longest
 from sys import version_info
 from typing import (
@@ -47,6 +48,7 @@ from polars.datatypes_constructor import (
 )
 from polars.dependencies import (
     _NUMPY_AVAILABLE,
+    _PANDAS_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
@@ -751,129 +753,50 @@ def sequence_to_pydf(
     infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a sequence."""
-    data_series: list[PySeries]
     if len(data) == 0:
         return dict_to_pydf({}, schema=schema, schema_overrides=schema_overrides)
 
-    first_element: Any = data[0]
+    return _sequence_to_pydf_dispatcher(
+        data[0],
+        data=data,
+        schema=schema,
+        schema_overrides=schema_overrides,
+        orient=orient,
+        infer_schema_length=infer_schema_length,
+    )
 
+
+@singledispatch
+def _sequence_to_pydf_dispatcher(
+    first_element: Any,
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
     if isinstance(first_element, Generator):
         data = [list(row) for row in data]
-        first_element = data[0]
+        return _sequence_of_sequence_to_pydf(
+            data[0],
+            data=data,
+            schema=schema,
+            schema_overrides=schema_overrides,
+            orient=orient,
+            infer_schema_length=infer_schema_length,
+        )
 
     if isinstance(first_element, pli.Series):
-        series_names = [s.name for s in data]
-        column_names, schema_overrides = _unpack_schema(
-            schema or series_names,
+        return _sequence_of_series_to_pydf(
+            first_element,
+            data=data,
+            schema=schema,
             schema_overrides=schema_overrides,
-            n_expected=len(data),
+            orient=orient,
+            infer_schema_length=infer_schema_length,
         )
-        data_series = []
-        for i, s in enumerate(data):
-            if not s.name:  # TODO: Replace by `if s.name is None` once allowed
-                s.rename(column_names[i], in_place=True)
-            new_dtype = schema_overrides.get(column_names[i])
-            if new_dtype and new_dtype != s.dtype:
-                s = s.cast(new_dtype)
-            data_series.append(s._s)
 
-    elif isinstance(first_element, dict):
-        column_names, schema_overrides = _unpack_schema(
-            schema, schema_overrides=schema_overrides
-        )
-        dicts_schema = (
-            include_unknowns(schema_overrides, column_names or list(schema_overrides))
-            if schema_overrides and column_names
-            else None
-        )
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
-
-        if column_names and set(column_names).intersection(pydf.columns()):
-            column_names = []
-        if column_names or schema_overrides:
-            pydf = _post_apply_columns(
-                pydf,
-                columns=column_names,
-                schema_overrides=schema_overrides,
-            )
-        return pydf
-
-    elif (
-        isinstance(first_element, (list, tuple, Sequence))
-        and not isinstance(first_element, str)
-    ) or (
-        _check_for_numpy(first_element)
-        and isinstance(first_element, np.ndarray)
-        and first_element.ndim == 1
-    ):
-        if is_namedtuple(first_element):
-            if schema is None:
-                schema = first_element._fields  # type: ignore[union-attr]
-                if len(first_element.__annotations__) == len(schema):
-                    schema = [
-                        (name, py_type_to_dtype(tp, raise_unmatched=False))
-                        for name, tp in first_element.__annotations__.items()
-                    ]
-            elif orient is None:
-                orient = "row"
-
-        if orient is None:
-            # note: limit type-checking to smaller data; larger values are much more
-            # likely to indicate col orientation anyway, so minimise extra checks.
-            if len(first_element) > 1000:
-                orient = "col" if schema and len(schema) == len(data) else "row"
-            elif (schema is not None and len(schema) == len(data)) or not schema:
-                # check if element types in the first 'row' resolve to a single dtype.
-                row_types = {
-                    type(value) for value in first_element if value is not None
-                }
-                if int in row_types and float in row_types:
-                    row_types.discard(int)
-                orient = "col" if len(row_types) == 1 else "row"
-            else:
-                orient = "row"
-
-        if orient == "row":
-            column_names, schema_overrides = _unpack_schema(
-                schema, schema_overrides=schema_overrides, n_expected=len(first_element)
-            )
-            schema_override = (
-                include_unknowns(schema_overrides, column_names)
-                if schema_overrides
-                else {}
-            )
-            if column_names and len(first_element) != len(column_names):
-                raise ShapeError("The row data does not match the number of columns")
-
-            for col, tp in schema_override.items():
-                if tp == Categorical:
-                    schema_override[col] = Utf8
-
-            pydf = PyDataFrame.read_rows(
-                data,
-                infer_schema_length,
-                schema_override or None,
-            )
-            if column_names or schema_overrides:
-                pydf = _post_apply_columns(
-                    pydf, column_names, schema_overrides=schema_overrides
-                )
-            return pydf
-
-        elif orient == "col" or orient is None:
-            column_names, schema_overrides = _unpack_schema(
-                schema, schema_overrides=schema_overrides, n_expected=len(data)
-            )
-            data_series = [
-                pli.Series(column_names[i], s, schema_overrides.get(column_names[i]))._s
-                for i, s in enumerate(data)
-            ]
-        else:
-            raise ValueError(
-                f"orient must be one of {{'col', 'row', None}}, got {orient} instead."
-            )
-
-    elif is_dataclass(first_element):
+    if is_dataclass(first_element):
         if schema:
             column_names, schema_overrides = _unpack_schema(
                 schema, schema_overrides=schema_overrides
@@ -905,18 +828,239 @@ def sequence_to_pydf(
             )
         return pydf
 
-    elif _check_for_pandas(first_element) and isinstance(
-        first_element, (pd.Series, pd.DatetimeIndex)
-    ):
+    return _sequence_of_single_to_pydf(
+        first_element,
+        data=data,
+        schema=schema,
+        schema_overrides=schema_overrides,
+        orient=orient,
+        infer_schema_length=infer_schema_length,
+    )
+
+
+@_sequence_to_pydf_dispatcher.register(dict)
+def _sequence_of_dict_to_pydf(
+    first_element: dict[Any, Any],
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
+    column_names, schema_overrides = _unpack_schema(
+        schema, schema_overrides=schema_overrides
+    )
+    dicts_schema = (
+        include_unknowns(schema_overrides, column_names or list(schema_overrides))
+        if schema_overrides and column_names
+        else None
+    )
+    pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
+
+    if column_names and set(column_names).intersection(pydf.columns()):
+        column_names = []
+    if column_names or schema_overrides:
+        pydf = _post_apply_columns(
+            pydf,
+            columns=column_names,
+            schema_overrides=schema_overrides,
+        )
+    return pydf
+
+
+@_sequence_to_pydf_dispatcher.register(list)
+def _sequence_of_sequence_to_pydf(
+    first_element: Sequence[Any] | np.ndarray[Any, Any],
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
+    if orient is None:
+        # note: limit type-checking to smaller data; larger values are much more
+        # likely to indicate col orientation anyway, so minimise extra checks.
+        if len(first_element) > 1000:
+            orient = "col" if schema and len(schema) == len(data) else "row"
+        elif (schema is not None and len(schema) == len(data)) or not schema:
+            # check if element types in the first 'row' resolve to a single dtype.
+            row_types = {type(value) for value in first_element if value is not None}
+            if int in row_types and float in row_types:
+                row_types.discard(int)
+            orient = "col" if len(row_types) == 1 else "row"
+        else:
+            orient = "row"
+
+    if orient == "row":
+        column_names, schema_overrides = _unpack_schema(
+            schema, schema_overrides=schema_overrides, n_expected=len(first_element)
+        )
+        schema_override = (
+            include_unknowns(schema_overrides, column_names) if schema_overrides else {}
+        )
+        if column_names and len(first_element) != len(column_names):
+            raise ShapeError("The row data does not match the number of columns")
+
+        for col, tp in schema_override.items():
+            if tp == Categorical:
+                schema_override[col] = Utf8
+
+        pydf = PyDataFrame.read_rows(
+            data,
+            infer_schema_length,
+            schema_override or None,
+        )
+        if column_names or schema_overrides:
+            pydf = _post_apply_columns(
+                pydf, column_names, schema_overrides=schema_overrides
+            )
+        return pydf
+
+    if orient == "col" or orient is None:
+        column_names, schema_overrides = _unpack_schema(
+            schema, schema_overrides=schema_overrides, n_expected=len(data)
+        )
+        data_series: list[PySeries] = [
+            pli.Series(
+                column_names[i], element, schema_overrides.get(column_names[i])
+            )._s
+            for i, element in enumerate(data)
+        ]
+        return PyDataFrame(data_series)
+
+    raise ValueError(
+        f"orient must be one of {{'col', 'row', None}}, got {orient} instead."
+    )
+
+
+@_sequence_to_pydf_dispatcher.register(tuple)
+def _sequence_of_tuple_to_pydf(
+    first_element: tuple[Any, ...],
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
+    if is_namedtuple(first_element):
         if schema is None:
-            column_names = []
+            schema = first_element._fields  # type: ignore[attr-defined]
+            if len(first_element.__annotations__) == len(schema):
+                schema = [
+                    (name, py_type_to_dtype(tp, raise_unmatched=False))
+                    for name, tp in first_element.__annotations__.items()
+                ]
+        elif orient is None:
+            orient = "row"
+
+    return _sequence_of_sequence_to_pydf(
+        first_element,
+        data=data,
+        schema=schema,
+        schema_overrides=schema_overrides,
+        orient=orient,
+        infer_schema_length=infer_schema_length,
+    )
+
+
+def _sequence_of_series_to_pydf(
+    first_element: pli.Series,
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
+    series_names = [s.name for s in data]
+    column_names, schema_overrides = _unpack_schema(
+        schema or series_names,
+        schema_overrides=schema_overrides,
+        n_expected=len(data),
+    )
+    data_series: list[PySeries] = []
+    for i, s in enumerate(data):
+        if not s.name:  # TODO: Replace by `if s.name is None` once allowed
+            s.rename(column_names[i], in_place=True)
+        new_dtype = schema_overrides.get(column_names[i])
+        if new_dtype and new_dtype != s.dtype:
+            s = s.cast(new_dtype)
+        data_series.append(s._s)
+
+    data_series = _handle_columns_arg(data_series, columns=column_names)
+    return PyDataFrame(data_series)
+
+
+@_sequence_to_pydf_dispatcher.register(str)
+def _sequence_of_single_to_pydf(
+    first_element: Any,
+    data: Sequence[Any],
+    schema: SchemaDefinition | None,
+    schema_overrides: SchemaDict | None,
+    orient: Orientation | None,
+    infer_schema_length: int | None,
+) -> PyDataFrame:
+    column_names, schema_overrides = _unpack_schema(
+        schema, schema_overrides=schema_overrides, n_expected=1
+    )
+    data_series: list[PySeries] = [
+        pli.Series(column_names[0], data, schema_overrides.get(column_names[0]))._s
+    ]
+    data_series = _handle_columns_arg(data_series, columns=column_names)
+    return PyDataFrame(data_series)
+
+
+if _NUMPY_AVAILABLE:
+
+    @_sequence_to_pydf_dispatcher.register(np.ndarray)
+    def _sequence_of_ndarray_to_pydf(
+        first_element: np.ndarray[Any, Any],
+        data: Sequence[Any],
+        schema: SchemaDefinition | None,
+        schema_overrides: SchemaDict | None,
+        orient: Orientation | None,
+        infer_schema_length: int | None,
+    ) -> PyDataFrame:
+        if first_element.ndim == 1:
+            return _sequence_of_sequence_to_pydf(
+                first_element,
+                data=data,
+                schema=schema,
+                schema_overrides=schema_overrides,
+                orient=orient,
+                infer_schema_length=infer_schema_length,
+            )
+
+        return _sequence_of_single_to_pydf(
+            first_element,
+            data=data,
+            schema=schema,
+            schema_overrides=schema_overrides,
+            orient=orient,
+            infer_schema_length=infer_schema_length,
+        )
+
+
+if _PANDAS_AVAILABLE:
+
+    @_sequence_to_pydf_dispatcher.register(pd.Series)
+    @_sequence_to_pydf_dispatcher.register(pd.DatetimeIndex)
+    def _sequence_of_pandas_to_pydf(
+        first_element: pd.Series | pd.DatetimeIndex,
+        data: Sequence[Any],
+        schema: SchemaDefinition | None,
+        schema_overrides: SchemaDict | None,
+        orient: Orientation | None,
+        infer_schema_length: int | None,
+    ) -> PyDataFrame:
+        if schema is None:
+            column_names: list[str] = []
         else:
             column_names, schema_overrides = _unpack_schema(
                 schema, schema_overrides=schema_overrides, n_expected=1
             )
 
         schema_overrides = schema_overrides or {}
-        data_series = []
+        data_series: list[PySeries] = []
         for i, s in enumerate(data):
             name = column_names[i] if column_names else s.name
             dtype = schema_overrides.get(name, None)
@@ -925,17 +1069,7 @@ def sequence_to_pydf(
                 pyseries = pyseries.cast(dtype, strict=True)
             data_series.append(pyseries)
 
-        column_names = []
-    else:
-        column_names, schema_overrides = _unpack_schema(
-            schema, schema_overrides=schema_overrides, n_expected=1
-        )
-        data_series = [
-            pli.Series(column_names[0], data, schema_overrides.get(column_names[0]))._s
-        ]
-
-    data_series = _handle_columns_arg(data_series, columns=column_names)
-    return PyDataFrame(data_series)
+        return PyDataFrame(data_series)
 
 
 def numpy_to_pydf(

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -859,10 +859,8 @@ def sequence_to_pydf(
                 schema, schema_overrides=schema_overrides, n_expected=len(data)
             )
             data_series = [
-                pli.Series(
-                    column_names[i], data[i], schema_overrides.get(column_names[i])
-                )._s
-                for i in range(len(data))
+                pli.Series(column_names[i], s, schema_overrides.get(column_names[i]))._s
+                for i, s in enumerate(data)
             ]
         else:
             raise ValueError(

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -979,7 +979,7 @@ def _sequence_of_series_to_pydf(
     )
     data_series: list[PySeries] = []
     for i, s in enumerate(data):
-        if not s.name:  # TODO: Replace by `if s.name is None` once allowed
+        if not s.name:
             s.rename(column_names[i], in_place=True)
         new_dtype = schema_overrides.get(column_names[i])
         if new_dtype and new_dtype != s.dtype:


### PR DESCRIPTION
This PR breaks up the complex, nested structure of `sequence_to_pydf` that results in high amounts of calls to `isinstance`, `issubclass`, and others.

The core innovation is the implement an internal `_sequence_to_pydf_dispatcher` function that leverages `functools.singledispatch` to dispatch on the type of the first element of data. This provides an extensible solution that avoids the inefficiencies of the original implementation.