### PR TITLE
feat(python): More ergonomic `drop` args

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4711,7 +4711,7 @@ class DataFrame:
         self._df.extend(other._df)
         return self
 
-    def drop(self, columns: str | Sequence[str]) -> Self:
+    def drop(self, columns: str | Sequence[str], *more_columns: str) -> Self:
         """
         Remove columns from the dataframe.
 
@@ -4719,9 +4719,13 @@ class DataFrame:
         ----------
         columns
             Name of the column(s) that should be removed from the dataframe.
+        *more_columns
+            Additional columns to drop, specified as positional arguments.
 
         Examples
         --------
+        Drop a single column by passing the name of that column.
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
@@ -4741,19 +4745,51 @@ class DataFrame:
         │ 3   ┆ 8.0 │
         └─────┴─────┘
 
+        Drop multiple columns by passing a list of column names.
+
+        >>> df.drop(["bar", "ham"])
+        shape: (3, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        │ 2   │
+        │ 3   │
+        └─────┘
+
+        Or use positional arguments to drop multiple columns in the same way.
+
+        >>> df.drop("foo", "bar")
+        shape: (3, 1)
+        ┌─────┐
+        │ ham │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ a   │
+        │ b   │
+        │ c   │
+        └─────┘
+
         """
         return self._from_pydf(
-            self.lazy().drop(columns).collect(no_optimization=True)._df
+            self.lazy().drop(columns, *more_columns).collect(no_optimization=True)._df
         )
 
     def drop_in_place(self, name: str) -> pli.Series:
         """
-        Drop in place.
+        Drop a single column in-place and return the dropped column.
 
         Parameters
         ----------
         name
-            Column to drop.
+            Name of the column to drop.
+
+        Returns
+        -------
+        The dropped column.
 
         Examples
         --------

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2759,7 +2759,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
-    def drop(self, columns: str | Sequence[str]) -> Self:
+    def drop(self, columns: str | Sequence[str], *more_columns: str) -> Self:
         """
         Remove columns from the dataframe.
 
@@ -2767,17 +2767,21 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ----------
         columns
             Name of the column(s) that should be removed from the dataframe.
+        *more_columns
+            Additional columns to drop, specified as positional arguments.
 
         Examples
         --------
-        >>> df = pl.DataFrame(
+        Drop a single column by passing the name of that column.
+
+        >>> ldf = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
         ...         "bar": [6.0, 7.0, 8.0],
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... ).lazy()
-        >>> df.drop("ham").collect()
+        >>> ldf.drop("ham").collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │
@@ -2789,10 +2793,41 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         │ 3   ┆ 8.0 │
         └─────┴─────┘
 
+        Drop multiple columns by passing a list of column names.
+
+        >>> ldf.drop(["bar", "ham"]).collect()
+        shape: (3, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        │ 2   │
+        │ 3   │
+        └─────┘
+
+        Or use positional arguments to drop multiple columns in the same way.
+
+        >>> ldf.drop("foo", "bar").collect()
+        shape: (3, 1)
+        ┌─────┐
+        │ ham │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ a   │
+        │ b   │
+        │ c   │
+        └─────┘
+
         """
         if isinstance(columns, str):
             columns = [columns]
-        return self._from_pyldf(self._ldf.drop_columns(columns))
+        if more_columns:
+            columns = list(columns)
+            columns.extend(more_columns)
+        return self._from_pyldf(self._ldf.drop(columns))
 
     def rename(self, mapping: dict[str, str]) -> Self:
         """

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -904,9 +904,9 @@ impl PyLazyFrame {
         ldf.map(function, opt, udf_schema, None).into()
     }
 
-    pub fn drop_columns(&self, cols: Vec<String>) -> Self {
+    pub fn drop(&self, columns: Vec<String>) -> Self {
         let ldf = self.ldf.clone();
-        ldf.drop_columns(cols).into()
+        ldf.drop_columns(columns).into()
     }
 
     pub fn clone(&self) -> PyLazyFrame {

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -720,8 +720,12 @@ def test_custom_groupby() -> None:
 
 def test_multiple_columns_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
+    # List input
     out = df.drop(["a", "b"])
     assert out.columns == ["c"]
+    # Positional input
+    out = df.drop("b", "c")
+    assert out.columns == ["a"]
 
 
 def test_concat() -> None:


### PR DESCRIPTION
Partially addresses #6451

Changes:
* Allow positional input for `drop`, and update docstring examples/tests
* Also updated the function signature of the Rust binding, as it did not match the Python argument, which led to a suboptimal error messages.