### PR TITLE
feat(python): More ergonomic `partition_by` args

### DIFF
--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1131,11 +1131,11 @@ impl PyDataFrame {
         Ok(PyDataFrame::new(df))
     }
 
-    pub fn partition_by(&self, groups: Vec<String>, stable: bool) -> PyResult<Vec<Self>> {
-        let out = if stable {
-            self.df.partition_by_stable(groups)
+    pub fn partition_by(&self, by: Vec<String>, maintain_order: bool) -> PyResult<Vec<Self>> {
+        let out = if maintain_order {
+            self.df.partition_by_stable(by)
         } else {
-            self.df.partition_by(groups)
+            self.df.partition_by(by)
         }
         .map_err(PyPolarsErr::from)?;
         // Safety:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2312,14 +2312,18 @@ def test_partition_by() -> None:
         }
     )
 
-    assert [
-        a.to_dict(False) for a in df.partition_by(["foo", "bar"], maintain_order=True)
-    ] == [
+    expected = [
         {"foo": ["A"], "N": [1], "bar": ["k"]},
         {"foo": ["A"], "N": [2], "bar": ["l"]},
         {"foo": ["B", "B"], "N": [2, 4], "bar": ["m", "m"]},
         {"foo": ["C"], "N": [2], "bar": ["l"]},
     ]
+    assert [
+        a.to_dict(False) for a in df.partition_by(["foo", "bar"], maintain_order=True)
+    ] == expected
+    assert [
+        a.to_dict(False) for a in df.partition_by("foo", "bar", maintain_order=True)
+    ] == expected
 
     assert [a.to_dict(False) for a in df.partition_by("foo", maintain_order=True)] == [
         {"foo": ["A", "A"], "N": [1, 2], "bar": ["k", "l"]},


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/6451

Changes:
* Update function signature to allow positional inputs
* Rename `groups` to `by` to match the `groupby` signature
* Update parsing logic
* Update docstring and add test