### PR TITLE
feat(sql): add "read_csv" table function

### DIFF
--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -5,13 +5,14 @@ use polars_lazy::prelude::*;
 use polars_plan::prelude::*;
 use polars_plan::utils::expressions_to_schema;
 use sqlparser::ast::{
-    Expr as SqlExpr, JoinOperator, OrderByExpr, Select, SelectItem, SetExpr, Statement,
-    TableFactor, TableWithJoins, Value as SQLValue,
+    Expr as SqlExpr, FunctionArg, JoinOperator, ObjectName, OrderByExpr, Query, Select, SelectItem,
+    SetExpr, Statement, TableAlias, TableFactor, TableWithJoins, Value as SQLValue,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
 use crate::sql_expr::{parse_sql_expr, process_join_constraint};
+use crate::table_functions::PolarsTableFunctions;
 
 thread_local! {pub(crate) static TABLES: RefCell<Vec<String>> = RefCell::new(vec![])}
 
@@ -41,69 +42,84 @@ impl SQLContext {
         TABLES.with(|cell| cell.borrow_mut().push(name.to_owned()));
         self.table_map.insert(name.to_owned(), lf);
     }
+}
 
-    fn get_relation_name<'a>(&self, relation: &'a TableFactor) -> PolarsResult<&'a str> {
-        let tbl_name = match relation {
-            TableFactor::Table { name, alias, .. } => {
-                let tbl_name = name.0.get(0).unwrap().value.as_str();
+impl SQLContext {
+    pub fn execute(&mut self, query: &str) -> PolarsResult<LazyFrame> {
+        let ast = Parser::parse_sql(&GenericDialect::default(), query)
+            .map_err(|e| PolarsError::ComputeError(format!("{:?}", e).into()))?;
+        if ast.len() != 1 {
+            return Err(PolarsError::ComputeError(
+                "One and only one statement at a time please".into(),
+            ));
+        }
 
-                if self.table_map.contains_key(tbl_name) {
-                    if let Some(_) = alias {
-                        return Err(PolarsError::ComputeError(
-                            format!("Table aliases are not supported.").into(),
-                        ));
-                    };
-
-                    tbl_name
-                } else {
-                    return Err(PolarsError::ComputeError(
-                        format!("Table name {tbl_name} was not found").into(),
-                    ));
-                }
-            }
-            // Support bare table, optional with alias for now
-            _ => return Err(PolarsError::ComputeError("Not implemented".into())),
-        };
-        Ok(tbl_name)
+        let ast = ast.get(0).unwrap();
+        return self.execute_statement(ast);
     }
 
-    fn get_table(&self, name: &str) -> PolarsResult<LazyFrame> {
-        self.table_map.get(name).cloned().ok_or_else(|| {
-            PolarsError::ComputeError(
-                format!("Table '{}' was not registered in the SQLContext", name).into(),
-            )
+    pub fn execute_statement(&mut self, stmt: &Statement) -> PolarsResult<LazyFrame> {
+        let ast = stmt;
+        Ok(match ast {
+            Statement::Query(query) => self.execute_query(query)?,
+            stmt @ Statement::CreateTable { .. } => self.execute_create_table(stmt)?,
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    format!("Statement type {:?} is not supported", ast).into(),
+                ))
+            }
         })
     }
 
-    fn execute_select(&self, select_stmt: &Select) -> PolarsResult<LazyFrame> {
-        // Determine involved dataframe
-        // Implicit join require some more work in query parsers, Explicit join are preferred for now.
-        let sql_tbl: &TableWithJoins = select_stmt
-            .from
-            .get(0)
-            .ok_or_else(|| PolarsError::ComputeError("No table name provided in query".into()))?;
+    pub fn execute_query(&mut self, query: &Query) -> PolarsResult<LazyFrame> {
+        let mut lf = match &query.body.as_ref() {
+            SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    "INSERT, UPDATE is not supported for polars".into(),
+                ))
+            }
+        };
+        if !query.order_by.is_empty() {
+            lf = self.process_order_by(lf, &query.order_by)?;
+        }
+        match &query.limit {
+            Some(SqlExpr::Value(SQLValue::Number(nrow, _))) => {
+                let nrow = nrow.parse().map_err(|err| {
+                    PolarsError::ComputeError(format!("Conversion Error: {:?}", err).into())
+                })?;
+                Ok(lf.limit(nrow))
+            }
+            None => Ok(lf),
+            _ => {
+                return Err(PolarsError::ComputeError(
+                    "Only support number argument to LIMIT clause".into(),
+                ))
+            }
+        }
+    }
 
-        let tbl_name = self.get_relation_name(&sql_tbl.relation)?;
-        let mut lf = self.get_table(tbl_name)?;
+    /// execute the 'FROM' part of the query
+    fn execute_from_statement(&mut self, tbl_expr: &TableWithJoins) -> PolarsResult<LazyFrame> {
+        let (tbl_name, mut lf) = self.get_table(&tbl_expr.relation)?;
 
-        if !sql_tbl.joins.is_empty() {
-            for tbl in &sql_tbl.joins {
-                let join_tbl_name = self.get_relation_name(&tbl.relation)?;
-                let join_tbl = self.get_table(join_tbl_name)?;
+        if !tbl_expr.joins.is_empty() {
+            for tbl in &tbl_expr.joins {
+                let (join_tbl_name, join_tbl) = self.get_table(&tbl.relation)?;
                 match &tbl.join_operator {
                     JoinOperator::Inner(constraint) => {
                         let (left_on, right_on) =
-                            process_join_constraint(&constraint, tbl_name, join_tbl_name)?;
+                            process_join_constraint(&constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.inner_join(join_tbl, left_on, right_on)
                     }
                     JoinOperator::LeftOuter(constraint) => {
                         let (left_on, right_on) =
-                            process_join_constraint(&constraint, tbl_name, join_tbl_name)?;
+                            process_join_constraint(&constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.left_join(join_tbl, left_on, right_on)
                     }
                     JoinOperator::FullOuter(constraint) => {
                         let (left_on, right_on) =
-                            process_join_constraint(&constraint, tbl_name, join_tbl_name)?;
+                            process_join_constraint(&constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.outer_join(join_tbl, left_on, right_on)
                     }
                     JoinOperator::CrossJoin => lf = lf.cross_join(join_tbl),
@@ -118,7 +134,21 @@ impl SQLContext {
                     }
                 }
             }
-        }
+        };
+
+        Ok(lf)
+    }
+
+    /// execute the 'SELECT' part of the query
+    fn execute_select(&mut self, select_stmt: &Select) -> PolarsResult<LazyFrame> {
+        // Determine involved dataframe
+        // Implicit join require some more work in query parsers, Explicit join are preferred for now.
+        let sql_tbl: &TableWithJoins = select_stmt
+            .from
+            .get(0)
+            .ok_or_else(|| PolarsError::ComputeError("No table name provided in query".into()))?;
+
+        let lf = self.execute_from_statement(sql_tbl)?;
 
         let mut contains_wildcard = false;
 
@@ -180,60 +210,89 @@ impl SQLContext {
         }
     }
 
-    // Executes the given statement against the SQLContext
-    pub fn execute_statement(&self, stmt: &Statement) -> PolarsResult<LazyFrame> {
-        let ast = stmt;
-        Ok(match ast {
-            Statement::Query(query) => {
-                let mut lf = match &query.body.as_ref() {
-                    SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
-                    _ => {
-                        return Err(PolarsError::ComputeError(
-                            "INSERT, UPDATE is not supported for polars".into(),
-                        ))
-                    }
-                };
-                if !query.order_by.is_empty() {
-                    lf = self.process_order_by(lf, &query.order_by)?;
-                }
-                match &query.limit {
-                    Some(SqlExpr::Value(SQLValue::Number(nrow, _))) => {
-                        let nrow = nrow.parse().map_err(|err| {
-                            PolarsError::ComputeError(format!("Conversion Error: {:?}", err).into())
-                        })?;
-                        lf.limit(nrow)
-                    }
-                    None => lf,
-                    _ => {
-                        return Err(PolarsError::ComputeError(
-                            "Only support number argument to LIMIT clause".into(),
-                        ))
-                    }
-                }
-            }
-            _ => {
+    fn execute_create_table(&mut self, stmt: &Statement) -> PolarsResult<LazyFrame> {
+        if let Statement::CreateTable {
+            if_not_exists,
+            name,
+            query,
+            ..
+        } = stmt
+        {
+            let tbl_name = name.0.get(0).unwrap().value.as_str();
+            // CREATE TABLE IF NOT EXISTS
+            if *if_not_exists && self.table_map.contains_key(tbl_name) {
                 return Err(PolarsError::ComputeError(
-                    format!("Statement type {:?} is not supported", ast).into(),
-                ))
+                    format!("relation {tbl_name} already exists").into(),
+                ));
+                // CREATE OR REPLACE TABLE
             }
-        })
-    }
+            if let Some(query) = query {
+                let lf = self.execute_query(query)?;
+                self.register(tbl_name, lf);
+                let out = df! {
+                    "Response" => ["Create Table"]
+                }
+                .unwrap()
+                .lazy();
 
-    // Executes the given SQL query against the SQLContext.
-    pub fn execute(&self, query: &str) -> PolarsResult<LazyFrame> {
-        let ast = Parser::parse_sql(&GenericDialect::default(), query)
-            .map_err(|e| PolarsError::ComputeError(format!("{:?}", e).into()))?;
-        if ast.len() != 1 {
-            return Err(PolarsError::ComputeError(
-                "One and only one statement at a time please".into(),
-            ));
+                return Ok(out);
+            } else {
+                return Err(PolarsError::ComputeError(
+                    format!("Only CREATE TABLE AS SELECT is supported").into(),
+                ));
+            }
+        } else {
+            unreachable!()
         }
-
-        let ast = ast.get(0).unwrap();
-        return self.execute_statement(ast);
     }
 
-    fn process_order_by(&self, lf: LazyFrame, ob: &[OrderByExpr]) -> PolarsResult<LazyFrame> {
+    fn get_table(&mut self, relation: &TableFactor) -> PolarsResult<(String, LazyFrame)> {
+        match relation {
+            TableFactor::Table {
+                name, alias, args, ..
+            } => {
+                if let Some(args) = args {
+                    return self.execute_tbl_function(name, alias, args);
+                }
+                let tbl_name = name.0.get(0).unwrap().value.as_str();
+
+                if self.table_map.contains_key(tbl_name) {
+                    let lf = self.table_map.get(tbl_name).cloned().ok_or_else(|| {
+                        PolarsError::ComputeError(
+                            format!("Table '{}' was not registered in the SQLContext", name).into(),
+                        )
+                    })?;
+                    Ok((tbl_name.to_string(), lf))
+                } else {
+                    return Err(PolarsError::ComputeError(
+                        format!("relation {tbl_name} was not found").into(),
+                    ));
+                }
+            }
+            // Support bare table, optional with alias for now
+            _ => return Err(PolarsError::ComputeError("Not implemented".into())),
+        }
+    }
+
+    fn execute_tbl_function(
+        &mut self,
+        name: &ObjectName,
+        alias: &Option<TableAlias>,
+        args: &[FunctionArg],
+    ) -> PolarsResult<(String, LazyFrame)> {
+        let tbl_fn = name.0.get(0).unwrap().value.as_str();
+
+        let read_fn = tbl_fn.parse::<PolarsTableFunctions>()?;
+        let (tbl_name, lf) = read_fn.execute(args)?;
+        let tbl_name = alias
+            .as_ref()
+            .map(|a| a.name.value.clone())
+            .unwrap_or_else(|| tbl_name);
+        self.register(&tbl_name, lf.clone());
+        Ok((tbl_name, lf))
+    }
+
+    fn process_order_by(&mut self, lf: LazyFrame, ob: &[OrderByExpr]) -> PolarsResult<LazyFrame> {
         let mut by = Vec::with_capacity(ob.len());
         let mut reverse = Vec::with_capacity(ob.len());
 
@@ -256,7 +315,7 @@ impl SQLContext {
     }
 
     fn process_groupby(
-        &self,
+        &mut self,
         lf: LazyFrame,
         contains_wildcard: bool,
         groupby_keys: &[Expr],

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -162,6 +162,7 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
         })
     }
 }
+
 impl SqlFunctionVisitor<'_> {
     pub(crate) fn visit_function(&self) -> PolarsResult<Expr> {
         let function = self.0;
@@ -335,7 +336,7 @@ fn extract_args(sql_function: &SQLFunction) -> Vec<&FunctionArgExpr> {
         .collect()
 }
 
-trait FromSqlExpr {
+pub(crate) trait FromSqlExpr {
     fn from_sql_expr(expr: &SqlExpr) -> Result<Self, PolarsError>
     where
         Self: Sized;

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -1,6 +1,7 @@
 mod context;
 mod functions;
 mod sql_expr;
+mod table_functions;
 pub use context::SQLContext;
 
 #[cfg(test)]
@@ -441,5 +442,71 @@ mod test {
             .collect()
             .unwrap();
         assert!(df_sql.frame_equal(&df_pl));
+    }
+
+    #[test]
+    fn create_table() {
+        let df = create_sample_df().unwrap();
+        let mut context = SQLContext::try_new().unwrap();
+        context.register("df", df.clone().lazy());
+        let sql = r#"
+            CREATE TABLE df2 AS
+            SELECT a
+            FROM df"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let create_tbl_res = df! {
+            "Response" => ["Create Table"]
+        }
+        .unwrap();
+        assert!(df_sql.frame_equal(&create_tbl_res));
+        let df_2 = context
+            .execute(r#"SELECT a FROM df2"#)
+            .unwrap()
+            .collect()
+            .unwrap();
+        let expected = df.lazy().select(&[col("a")]).collect().unwrap();
+
+        println!("{df_sql}");
+        assert!(df_2.frame_equal(&expected));
+    }
+
+    #[test]
+    #[cfg(feature = "csv")]
+    fn read_csv_tbl_func() {
+        let mut context = SQLContext::try_new().unwrap();
+        let sql = r#"
+            CREATE TABLE foods1 AS
+            SELECT *
+            FROM read_csv('../../examples/datasets/foods1.csv', sep=>',')"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let create_tbl_res = df! {
+            "Response" => ["Create Table"]
+        }
+        .unwrap();
+        assert!(df_sql.frame_equal(&create_tbl_res));
+        let df_2 = context
+            .execute(r#"SELECT * FROM foods1"#)
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(df_2.height(), 27);
+        assert_eq!(df_2.width(), 4);
+    }
+    #[test]
+    #[cfg(feature = "csv")]
+    fn read_csv_tbl_func_inline() {
+        let mut context = SQLContext::try_new().unwrap();
+        let sql = r#"
+            SELECT foods1.category
+            FROM read_csv('../../examples/datasets/foods1.csv') as foods1"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+
+        let expected = LazyCsvReader::new("../../examples/datasets/foods1.csv")
+            .finish()
+            .unwrap()
+            .select(&[col("category")])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&expected));
     }
 }

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -509,4 +509,21 @@ mod test {
             .unwrap();
         assert!(df_sql.frame_equal(&expected));
     }
+    #[test]
+    #[cfg(feature = "csv")]
+    fn read_csv_tbl_func_inline_2() {
+        let mut context = SQLContext::try_new().unwrap();
+        let sql = r#"
+            SELECT category
+            FROM read_csv('../../examples/datasets/foods1.csv')"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+
+        let expected = LazyCsvReader::new("../../examples/datasets/foods1.csv")
+            .finish()
+            .unwrap()
+            .select(&[col("category")])
+            .collect()
+            .unwrap();
+        assert!(df_sql.frame_equal(&expected));
+    }
 }

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -477,7 +477,7 @@ mod test {
         let sql = r#"
             CREATE TABLE foods1 AS
             SELECT *
-            FROM read_csv('../../examples/datasets/foods1.csv', sep=>',')"#;
+            FROM read_csv('../../examples/datasets/foods1.csv')"#;
         let df_sql = context.execute(sql).unwrap().collect().unwrap();
         let create_tbl_res = df! {
             "Response" => ["Create Table"]

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -9,7 +9,7 @@ use sqlparser::ast::{
 use crate::context::TABLES;
 use crate::functions::SqlFunctionVisitor;
 
-fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
+pub(crate) fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
     Ok(match data_type {
         SQLDataType::Char(_)
         | SQLDataType::Varchar(_)

--- a/polars/polars-sql/src/table_functions.rs
+++ b/polars/polars-sql/src/table_functions.rs
@@ -1,0 +1,69 @@
+use std::str::FromStr;
+
+use polars_core::prelude::{PolarsError, PolarsResult};
+#[cfg(feature = "csv")]
+use polars_lazy::prelude::LazyCsvReader;
+use polars_lazy::prelude::LazyFrame;
+use sqlparser::ast::{FunctionArg, FunctionArgExpr};
+
+/// Table functions that are supported by Polars
+pub(crate) enum PolarsTableFunctions {
+    /// SQL 'read_csv' function
+    #[cfg(feature = "csv")]
+    ReadCsv,
+    /// SQL 'read_parquet' function
+    #[cfg(feature = "parquet")]
+    ReadParquet,
+}
+
+impl FromStr for PolarsTableFunctions {
+    type Err = PolarsError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            #[cfg(feature = "csv")]
+            "read_csv" => Ok(PolarsTableFunctions::ReadCsv),
+            #[cfg(feature = "parquet")]
+            "read_parquet" => Ok(PolarsTableFunctions::ReadParquet),
+            _ => Err(PolarsError::ComputeError(
+                format!("'{}' is not a supported table function", s).into(),
+            )),
+        }
+    }
+}
+
+impl PolarsTableFunctions {
+    pub(crate) fn execute(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
+        match self {
+            #[cfg(feature = "csv")]
+            PolarsTableFunctions::ReadCsv => self.read_csv(args),
+            #[cfg(feature = "parquet")]
+            PolarsTableFunctions::ReadParquet => self.read_parquet(args),
+            _ => unreachable!(),
+        }
+    }
+
+    #[cfg(feature = "csv")]
+    fn read_csv(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
+        use polars_lazy::frame::LazyFileListReader;
+        let path = self.get_file_path_from_arg(&args[0])?;
+        let lf = LazyCsvReader::new(&path).finish()?;
+        Ok((path, lf))
+    }
+    #[cfg(feature = "parquet")]
+    fn read_parquet(&self, _: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
+        todo!()
+    }
+
+    fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<String> {
+        use sqlparser::ast::{Expr as SqlExpr, Value as SqlValue};
+        match arg {
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(
+                SqlValue::SingleQuotedString(s),
+            ))) => Ok(s.to_string()),
+            _ => Err(PolarsError::ComputeError(
+                format!("Only a single quoted string is accepted as the first parameter. Instead received: {}", arg).into(),
+            )),
+        }
+    }
+}

--- a/py-polars/src/sql.rs
+++ b/py-polars/src/sql.rs
@@ -29,7 +29,7 @@ impl PySQLContext {
         self.context.register(name, lf.ldf)
     }
 
-    pub fn execute(&self, query: &str) -> PyResult<PyLazyFrame> {
+    pub fn execute(&mut self, query: &str) -> PyResult<PyLazyFrame> {
         Ok(self
             .context
             .execute(query)


### PR DESCRIPTION
## Description
_Inspired by duckdb & spark sql implementations._ 

This adds a table function to read from CSV files without having to do the postgres way of `create table -> copy into -> select from` 

While this does diverge from the built in postgres functions, this feels like a much more intuitive way to interact with files in polars sql.


Also adds the ability to create additional tables from existing tables through sql.

## `read_csv` Example
```sql
> SELECT category FROM read_csv('datasets/foods1.csv');

-- you can alias too!
> SELECT foods.* FROM read_csv('datasets/foods1.csv') as foods;

-- or even create a table from the selection
> CREATE TABLE foods1 AS SELECT * FROM read_csv('datasets/foods1.csv');
> SELECT * FROM foods1
```
## `CREATE TABLE` Example

```rust
// existing functionality to register a DF within the sql context
let df = create_sample_df().unwrap();
let mut context = SQLContext::try_new().unwrap();
context.register("df", df.clone().lazy());
```
```sql
CREATE TABLE df_sum as SELECT sum(a), sum(b) from df
```


Todo
- support optional csv arguments (separator, schema, ...)

## Additional notes.
small refactor to `context.rs` to break down the larger functions into more manageable chunks. 