### PR TITLE
ci: Deploy docs only on release

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -2,8 +2,8 @@ name: Deploy documentation
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '**'
 
 jobs:
   main:


### PR DESCRIPTION
Related to #6373

This is a temporary band-aid to make sure users do not see unreleased changes in the API reference.

While it's nice for us to be able to view the latest API reference for the master branch, I think it's more important that users see the correct information there when they are using the latest version.

We should probably pick up that issue with some priority.