### PR TITLE
refactor(python): Add `TYPE_CHECKING` lints

### DIFF
--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 import html
 import os
 from textwrap import dedent
-from types import TracebackType
 from typing import TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from polars.internals import DataFrame
 
 

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import sys
-from types import TracebackType
+from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import set_float_fmt as _set_float_fmt
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
+if TYPE_CHECKING:
+    import sys
+    from types import TracebackType
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 # note: register all Config-specific environment variable names here; need to constrain
 # which 'POLARS_' environment variables are recognised, as there are other lower-level

--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
 from types import TracebackType
 
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import set_float_fmt as _set_float_fmt
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
-
-try:
-    from polars.polars import set_float_fmt as _set_float_fmt
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 
 # note: register all Config-specific environment variable names here; need to constrain

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -33,10 +33,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import get_idx_type as _get_idx_type
 
 if sys.version_info >= (3, 8):
-    from typing import Literal, get_args
+    from typing import get_args
 else:
-    from typing_extensions import Literal
-
     # pass-through (only impact is that under 3.7 we'll end-up doing
     # standard inference for dataclass fields with an option/union)
     def get_args(tp: Any) -> Any:
@@ -46,17 +44,24 @@ else:
 OptionType = type(Optional[type])
 if sys.version_info >= (3, 10):
     from types import NoneType, UnionType
-    from typing import TypeAlias
 else:
-    from typing_extensions import TypeAlias
-
     # infer equivalent class
     NoneType = type(None)
     UnionType = type(Union[int, float])
 
+
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit
 
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 # number of rows to scan by default when inferring datatypes
 N_INFER_DEFAULT = 100

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import functools
 import re
@@ -27,14 +28,9 @@ from typing import List as ListType
 from polars.dependencies import numpy as np
 from polars.dependencies import pyarrow as pa
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr
     from polars.polars import get_idx_type as _get_idx_type
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
-
 
 if sys.version_info >= (3, 8):
     from typing import Literal, get_args
@@ -57,7 +53,6 @@ else:
     # infer equivalent class
     NoneType = type(None)
     UnionType = type(Union[int, float])
-
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import TimeUnit

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -28,6 +28,7 @@ from polars.datatypes import (
 )
 from polars.dependencies import numpy as np
 
+# Module not available when building docs
 try:
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import polars as pl
 from polars import internals as pli
-from polars.dependencies import pyarrow as pa
+from polars.dependencies import pyarrow as pa  # noqa: TCH001
 
 
 def _deser_and_exec(  # noqa: D417

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Sequence
 
@@ -18,12 +19,8 @@ from polars.utils import (
     normalise_filepath,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyBatchedCsv
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 
 class BatchedCsvReader:

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import polars.internals as pli
 from polars.datatypes import (
@@ -11,7 +11,6 @@ from polars.datatypes import (
     SchemaDict,
     py_type_to_dtype,
 )
-from polars.internals.type_aliases import CsvEncoding
 from polars.utils import (
     _prepare_row_count_args,
     _process_null_values,
@@ -21,6 +20,9 @@ from polars.utils import (
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyBatchedCsv
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import CsvEncoding
 
 
 class BatchedCsvReader:

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from contextlib import suppress
 from dataclasses import astuple, is_dataclass
 from datetime import date, datetime, time, timedelta
@@ -62,6 +63,12 @@ from polars.utils import (
     threadpool_size,
 )
 
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame, PySeries
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import Orientation
+
 if version_info >= (3, 10):
 
     def dataclass_type_hints(obj: type) -> dict[str, Any]:
@@ -71,18 +78,6 @@ else:
 
     def dataclass_type_hints(obj: type) -> dict[str, Any]:
         return obj.__annotations__
-
-
-try:
-    from polars.polars import PyDataFrame, PySeries
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
-
-
-if TYPE_CHECKING:
-    from polars.internals.type_aliases import Orientation
 
 
 def is_namedtuple(value: Any, annotated: bool = False) -> bool:

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1,6 +1,7 @@
 """Module containing logic related to eager DataFrames."""
 from __future__ import annotations
 
+import contextlib
 import math
 import os
 import random
@@ -90,12 +91,8 @@ from polars.utils import (
     scale_bytes,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -6929,8 +6926,8 @@ class DataFrame:
         one row is returned; more than one row raises ``TooManyRowsReturned``, and
         zero rows will raise ``NoRowsReturned`` (both inherit from ``RowsException``).
 
-        Warning
-        -------
+        Warnings
+        --------
         You should NEVER use this method to iterate over a DataFrame; if you absolutely
         require row-iteration you should strongly prefer ``iter_rows()`` instead.
 

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -5,10 +5,8 @@ import contextlib
 import math
 import os
 import random
-import sys
 import typing
 from collections.abc import Sized
-from datetime import timedelta
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
@@ -94,22 +92,11 @@ from polars.utils import (
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-if sys.version_info >= (3, 10):
-    from typing import Concatenate, ParamSpec, TypeAlias
-else:
-    from typing_extensions import Concatenate, ParamSpec, TypeAlias
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if TYPE_CHECKING:
+    import sys
+    from datetime import timedelta
+
     from pyarrow.interchange.dataframe import _PyArrowDataFrame
 
     from polars.internals.type_aliases import (
@@ -133,6 +120,21 @@ if TYPE_CHECKING:
         UniqueKeepStrategy,
         UnstackDirection,
     )
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+    if sys.version_info >= (3, 10):
+        from typing import Concatenate, ParamSpec, TypeAlias
+    else:
+        from typing_extensions import Concatenate, ParamSpec, TypeAlias
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
     # these aliases are used to annotate DataFrame.__getitem__()
     # MultiRowSelector indexes into the vertical axis and

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -14,6 +13,8 @@ import polars.internals as pli
 from polars.utils import _timedelta_to_pl_duration, deprecated_alias, redirect
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from polars.internals.type_aliases import (
         ClosedInterval,
         IntoExpr,

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import contextlib
 import math
 import os
 import random
-import sys
 import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable, NoReturn, Sequence, cast
@@ -27,7 +25,6 @@ from polars.internals.expr.list import ExprListNameSpace
 from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
-from polars.internals.type_aliases import PythonLiteral
 from polars.utils import (
     _timedelta_to_pl_duration,
     deprecate_nonkeyword_arguments,
@@ -35,25 +32,26 @@ from polars.utils import (
     sphinx_accessor,
 )
 
-with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import PyExpr
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 if TYPE_CHECKING:
+    import sys
+
     from polars.internals.type_aliases import (
         ClosedInterval,
         FillNullStrategy,
         InterpolationMethod,
         IntoExpr,
         NullBehavior,
+        PythonLiteral,
         RankMethod,
         RollingInterpolationMethod,
         SearchSortedSide,
     )
+    from polars.polars import PyExpr
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import math
 import os
 import random
@@ -34,12 +35,13 @@ from polars.utils import (
     sphinx_accessor,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyExpr
 
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import (
@@ -54,11 +56,6 @@ if TYPE_CHECKING:
     )
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 
 def selection_to_pyexpr_list(

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import copy
-from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars.internals as pli
 from polars.utils import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
+    from datetime import date, datetime, time
+
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
 
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import sys
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Iterable, Sequence, overload
@@ -13,13 +14,7 @@ from polars.utils import (
     deprecated_alias,
 )
 
-if sys.version_info >= (3, 10):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
-
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import concat_df as _concat_df
     from polars.polars import concat_lf as _concat_lf
     from polars.polars import concat_series as _concat_series
@@ -29,9 +24,10 @@ try:
     from polars.polars import py_diag_concat_lf as _diag_concat_lf
     from polars.polars import py_hor_concat_df as _hor_concat_df
 
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
+if sys.version_info >= (3, 10):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import sys
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Iterable, Sequence, overload
 
@@ -24,13 +23,16 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import py_diag_concat_lf as _diag_concat_lf
     from polars.polars import py_hor_concat_df as _hor_concat_df
 
-if sys.version_info >= (3, 10):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
+    import sys
+
     from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 
 def get_dummies(

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -4,10 +4,16 @@ import glob
 from contextlib import contextmanager, suppress
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any, BinaryIO, ContextManager, Iterator, TextIO, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    BinaryIO,
+    ContextManager,
+    Iterator,
+    TextIO,
+    overload,
+)
 
-import polars.internals as pli
-from polars.datatypes import PolarsDataType
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
 from polars.utils import normalise_filepath
@@ -15,6 +21,10 @@ from polars.utils import normalise_filepath
 with suppress(ImportError):
     from polars.polars import ipc_schema as _ipc_schema
     from polars.polars import parquet_schema as _parquet_schema
+
+if TYPE_CHECKING:
+    import polars.internals as pli
+    from polars.datatypes import PolarsDataType
 
 
 def _check_empty(b: BytesIO, context: str, read_position: int | None = None) -> BytesIO:

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import sys
 import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
@@ -61,18 +60,21 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
     from polars.polars import sum_exprs as _sum_exprs
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if TYPE_CHECKING:
+    import sys
+
     from polars.internals.type_aliases import (
         EpochTimeUnit,
         IntoExpr,
         RollingInterpolationMethod,
         TimeUnit,
     )
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 
 def col(

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import sys
 import warnings
 from datetime import date, datetime, time, timedelta
@@ -30,7 +31,7 @@ from polars.utils import (
     deprecated_alias,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import arange as pyarange
     from polars.polars import arg_sort_by as py_arg_sort_by
     from polars.polars import arg_where as py_arg_where
@@ -59,10 +60,6 @@ try:
     from polars.polars import repeat as _repeat
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
     from polars.polars import sum_exprs as _sum_exprs
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 import sys
@@ -59,12 +60,8 @@ from polars.utils import (
     redirect,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyLazyFrame
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import os
 import subprocess
-import sys
 import typing
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, IOBase, StringIO
@@ -44,11 +43,9 @@ from polars.datatypes import (
     Utf8,
     py_type_to_dtype,
 )
-from polars.dependencies import pyarrow as pa
 from polars.internals import selection_to_pyexpr_list
 from polars.internals.lazyframe.groupby import LazyGroupBy
 from polars.internals.slice import LazyPolarsSlice
-from polars.internals.type_aliases import PythonLiteral
 from polars.utils import (
     _in_notebook,
     _prepare_row_count_args,
@@ -63,17 +60,11 @@ from polars.utils import (
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyLazyFrame
 
-if sys.version_info >= (3, 10):
-    from typing import Concatenate, ParamSpec
-else:
-    from typing_extensions import Concatenate, ParamSpec
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if TYPE_CHECKING:
+    import sys
+
+    from polars.dependencies import pyarrow as pa
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -83,10 +74,21 @@ if TYPE_CHECKING:
         JoinStrategy,
         ParallelStrategy,
         PolarsExprType,
+        PythonLiteral,
         RollingInterpolationMethod,
         StartBy,
         UniqueKeepStrategy,
     )
+
+    if sys.version_info >= (3, 10):
+        from typing import Concatenate, ParamSpec
+    else:
+        from typing_extensions import Concatenate, ParamSpec
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
     T = TypeVar("T")
     P = ParamSpec("P")

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 
 import polars.internals as pli
-from polars.datatypes import SchemaDict
 from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
 from polars.utils import deprecated_alias
 
 if TYPE_CHECKING:
+    from polars.datatypes import SchemaDict
     from polars.internals.type_aliases import IntoExpr, RollingInterpolationMethod
     from polars.polars import PyLazyGroupBy
 

--- a/py-polars/polars/internals/series/_numpy.py
+++ b/py-polars/polars/internals/series/_numpy.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import ctypes
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from polars import internals as pli
+if TYPE_CHECKING:
+    from polars import internals as pli
 
 
 # https://numpy.org/doc/stable/user/basics.subclassing.html#slightly-more-realistic-example-attribute-added-to-existing-array

--- a/py-polars/polars/internals/series/binary.py
+++ b/py-polars/polars/internals/series/binary.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    import polars.internals as pli
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/series/categorical.py
+++ b/py-polars/polars/internals/series/categorical.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    import polars.internals as pli
     from polars.internals.type_aliases import CategoricalOrdering
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
@@ -8,6 +7,8 @@ from polars.internals.series.utils import expr_dispatch
 from polars.utils import _to_python_datetime, deprecated_alias, redirect
 
 if TYPE_CHECKING:
+    from datetime import date, datetime, time, timedelta
+
     from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars.internals as pli
@@ -8,6 +7,8 @@ from polars.internals.series.utils import expr_dispatch
 from polars.utils import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
+    from datetime import date, datetime, time
+
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import math
 import os
-import sys
 import typing
 from datetime import date, datetime, time, timedelta
 from typing import (
@@ -90,12 +89,10 @@ from polars.utils import (
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PySeries
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if TYPE_CHECKING:
+    import sys
+
     from polars.internals.series._numpy import SeriesView
     from polars.internals.type_aliases import (
         ClosedInterval,
@@ -110,6 +107,11 @@ if TYPE_CHECKING:
         SizeUnit,
         TimeUnit,
     )
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
 

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import math
 import os
 import sys
@@ -86,13 +87,13 @@ from polars.utils import (
     sphinx_accessor,
 )
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PySeries
 
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
-
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if TYPE_CHECKING:
     from polars.internals.series._numpy import SeriesView
@@ -111,13 +112,6 @@ if TYPE_CHECKING:
     )
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
-
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 
 ArrayLike = Union[
     Sequence[Any],

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import PolarsDataType, PolarsTemporalType
 from polars.internals.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType, PolarsTemporalType
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/sql/context.py
+++ b/py-polars/polars/internals/sql/context.py
@@ -1,11 +1,9 @@
+import contextlib
+
 import polars.internals as pli
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 
 class SQLContext:

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-
-from polars import internals as pli
+from typing import TYPE_CHECKING, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -16,7 +15,8 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-from typing import Union
+if TYPE_CHECKING:
+    from polars import internals as pli
 
 # Types that qualify as expressions (eg: for use in 'select', 'with_columns'...)
 PolarsExprType: TypeAlias = "pli.Expr | pli.WhenThen | pli.WhenThenThen"

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import contextlib
 import typing
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 from polars import internals as pli
-from polars.internals.type_aliases import PolarsExprType, PythonLiteral
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import when as pywhen
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import PolarsExprType, PythonLiteral
 
 
 class WhenThenThen:

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import typing
 from typing import Any, Iterable
 
-try:
-    from polars.polars import when as pywhen
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
-
 from polars import internals as pli
 from polars.internals.type_aliases import PolarsExprType, PythonLiteral
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import when as pywhen
 
 
 class WhenThenThen:

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,7 +1,6 @@
 """Functions for reading and writing data."""
 from __future__ import annotations
 
-import sys
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import (
@@ -16,15 +15,8 @@ from typing import (
     overload,
 )
 
-from polars import BatchedCsvReader
-from polars.utils import deprecated_alias
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 import polars.internals as pli
+from polars import BatchedCsvReader
 from polars.convert import from_arrow
 from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, SchemaDict, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake
@@ -33,12 +25,20 @@ from polars.internals import DataFrame, LazyFrame, _scan_ds
 from polars.internals.io import _prepare_file_arg
 from polars.utils import (
     deprecate_nonkeyword_arguments,
+    deprecated_alias,
     handle_projection_columns,
     normalise_filepath,
 )
 
 if TYPE_CHECKING:
+    import sys
+
     from polars.internals.type_aliases import CsvEncoding, ParallelStrategy
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 
 def _check_arg_is_1byte(

--- a/py-polars/polars/show_versions.py
+++ b/py-polars/polars/show_versions.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import platform
 import sys
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import get_idx_type as _get_idx_type
     from polars.polars import version
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 
 def show_versions() -> None:

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 from types import TracebackType
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import toggle_string_cache as _toggle_string_cache
     from polars.polars import using_string_cache as _using_string_cache
-
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 
 class StringCache:

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import contextlib
-from types import TracebackType
+from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import toggle_string_cache as _toggle_string_cache
     from polars.polars import using_string_cache as _using_string_cache
+
+if TYPE_CHECKING:
+    from types import TracebackType
 
 
 class StringCache:

--- a/py-polars/polars/testing/_private.py
+++ b/py-polars/polars/testing/_private.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import polars.internals as pli
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars.internals as pli
 
 
 def _to_rust_syntax(df: pli.DataFrame) -> str:

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -10,7 +10,6 @@ import sys
 import warnings
 from collections.abc import MappingView, Reversible, Sized
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -55,6 +54,8 @@ if sys.version_info >= (3, 11):
     _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from polars.internals.type_aliases import SizeUnit, TimeUnit
 
 

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,6 +1,7 @@
 """Utility functions."""
 from __future__ import annotations
 
+import contextlib
 import functools
 import inspect
 import os
@@ -31,13 +32,10 @@ from polars.datatypes import (
 )
 from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
-try:
+with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyExpr
     from polars.polars import pool_size as _pool_size
 
-    _DOCUMENTING = False
-except ImportError:
-    _DOCUMENTING = True
 
 # This code block is due to a typing issue with backports.zoneinfo package:
 # https://github.com/pganssle/zoneinfo/issues/125

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -109,6 +109,7 @@ select = [
   "D", # flake8-docstrings
   "I", # isort
   "SIM", # flake8-simplify
+  "TCH", # flake8-type-checking
   "TID", # flake8-tidy-imports
   "Q", # flake8-quotes
   "UP", # pyupgrade

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -35,10 +35,12 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import ModuleType
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 import polars
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 def doctest_teardown(d: doctest.DocTest) -> None:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -8,6 +8,7 @@ import textwrap
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -15,13 +16,15 @@ import pytest
 import polars as pl
 from polars import DataType
 from polars.exceptions import ComputeError, NoDataError
-from polars.internals.type_aliases import TimeUnit
 from polars.testing import (
     assert_frame_equal,
     assert_frame_equal_local_categoricals,
     assert_series_equal,
 )
 from polars.utils import normalise_filepath
+
+if TYPE_CHECKING:
+    from polars.internals.type_aliases import TimeUnit
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003
 
 import pyarrow.fs
 import pytest

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003
 
 import pytest
 

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003
 
 import pytest
 

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
-from polars.datatypes import PolarsTemporalType
 from polars.exceptions import ComputeError
-from polars.internals.type_aliases import TimeUnit
 from polars.testing import assert_series_equal
 
 if sys.version_info >= (3, 9):
@@ -22,6 +21,10 @@ else:
     # Import from submodule due to typing issue with backports.zoneinfo package:
     # https://github.com/pganssle/zoneinfo/issues/125
     from backports.zoneinfo._zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from polars.datatypes import PolarsTemporalType
+    from polars.internals.type_aliases import TimeUnit
 
 
 def test_str_strptime() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -4,17 +4,19 @@ from datetime import date, datetime, time
 from functools import reduce
 from operator import add
 from string import ascii_letters
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pytest
-from _pytest.capture import CaptureFixture
 
 import polars as pl
 from polars import col, lit, when
 from polars.datatypes import NUMERIC_DTYPES, PolarsDataType
 from polars.testing import assert_frame_equal
 from polars.testing.asserts import assert_series_equal
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
 
 
 def test_lazy() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -24,11 +24,10 @@ from polars.datatypes import (
 )
 from polars.exceptions import ShapeError
 from polars.internals.construction import iterable_to_pyseries
-from polars.internals.type_aliases import EpochTimeUnit
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import TimeUnit
+    from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
 
 
 def test_cum_agg() -> None:


### PR DESCRIPTION
Enable the [TCH lints](https://beta.ruff.rs/docs/rules/#flake8-type-checking-tch), which detects imports that are only used during type checking, and tells you to move them into an `if TYPE_CHECKING` block.

This has a slight performance benefit, but is also nice for readability, to easily discern which imports are used for type hints and which are actually used in the code logic.

I also removed the `_DOCUMENTING = True` flags as they weren't being used - used `contextlib.suppress(ImportError)` instead.