### PR TITLE
feat(python): More ergonomic `exclude` args

### DIFF
--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -1640,34 +1640,27 @@ def any(name: str | Sequence[str] | Sequence[pli.Expr] | pli.Expr) -> pli.Expr:
 
 
 def exclude(
-    columns: (
-        str
-        | PolarsDataType
-        | Sequence[str]
-        | Sequence[PolarsDataType]
-        | set[PolarsDataType]
-        | frozenset[PolarsDataType]
-    ),
+    columns: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+    *more_columns: str | PolarsDataType,
 ) -> pli.Expr:
     """
-    Exclude certain columns from a wildcard/regex selection.
+    Represent all columns except for the given columns.
 
-    Syntactic sugar for:
-
-    >>> pl.all().exclude(columns)  # doctest: +SKIP
+    Syntactic sugar for ``pl.all().exclude(columns)``.
 
     Parameters
     ----------
     columns
-        Column(s) to exclude from selection
-        This can be:
-
-        - a column name, or multiple column names
-        - a regular expression starting with `^` and ending with `$`
-        - a dtype or multiple dtypes
+        The name or datatype of the column(s) to exclude. Accepts regular expression
+        input. Regular expressions should start with ``^`` and end with ``$``.
+    *more_columns
+        Additional names or datatypes of columns to exclude, specified as positional
+        arguments.
 
     Examples
     --------
+    Exclude by column name(s):
+
     >>> df = pl.DataFrame(
     ...     {
     ...         "aa": [1, 2, 3],
@@ -1675,20 +1668,6 @@ def exclude(
     ...         "cc": [None, 2.5, 1.5],
     ...     }
     ... )
-    >>> df
-    shape: (3, 3)
-    ┌─────┬──────┬──────┐
-    │ aa  ┆ ba   ┆ cc   │
-    │ --- ┆ ---  ┆ ---  │
-    │ i64 ┆ str  ┆ f64  │
-    ╞═════╪══════╪══════╡
-    │ 1   ┆ a    ┆ null │
-    │ 2   ┆ b    ┆ 2.5  │
-    │ 3   ┆ null ┆ 1.5  │
-    └─────┴──────┴──────┘
-
-    Exclude by column name(s):
-
     >>> df.select(pl.exclude("ba"))
     shape: (3, 2)
     ┌─────┬──────┐
@@ -1730,7 +1709,7 @@ def exclude(
     └──────┘
 
     """
-    return col("*").exclude(columns)
+    return col("*").exclude(columns, *more_columns)
 
 
 def all(name: str | Sequence[pli.Expr] | pli.Expr | None = None) -> pli.Expr:

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -16,7 +16,7 @@ use polars_core::prelude::QuantileInterpolOptions;
 use polars_core::utils::arrow::types::NativeType;
 use pyo3::basic::CompareOp;
 use pyo3::conversion::{FromPyObject, IntoPy};
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyList, PySequence};
 use pyo3::{PyAny, PyResult};
@@ -391,9 +391,9 @@ impl FromPyObject<'_> for Wrap<DataType> {
                 DataType::Struct(fields)
             }
             dt => {
-                return Err(PyValueError::new_err(format!(
-                    "A {dt} object is not a correct polars DataType.\
-                 Hint: use the class without instantiating it.",
+                return Err(PyTypeError::new_err(format!(
+                    "A {dt} object is not a correct polars DataType. \
+                    Hint: use the class without instantiating it.",
                 )))
             }
         };

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -586,3 +586,26 @@ def test_incompatible_lit_dtype() -> None:
             datetime(2020, 1, 1, tzinfo=timezone.utc),
             dtype=pl.Datetime("us", "Asia/Kathmandu"),
         )
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        (("a",), ["b", "c"]),
+        (("a", "b"), ["c"]),
+        ((["a", "b"],), ["c"]),
+        ((pl.Int64,), ["c"]),
+        ((pl.Utf8, pl.Float32), ["a", "b"]),
+        (([pl.Utf8, pl.Float32],), ["a", "b"]),
+    ],
+)
+def test_exclude(input: tuple[Any, ...], expected: list[str]) -> None:
+    df = pl.DataFrame(schema={"a": pl.Int64, "b": pl.Int64, "c": pl.Utf8})
+    assert df.select(pl.all().exclude(*input)).columns == expected
+
+
+@pytest.mark.parametrize("input", [(5,), (["a"], "b"), (pl.Int64, "a")])
+def test_exclude_invalid_input(input: tuple[Any, ...]) -> None:
+    df = pl.DataFrame(schema=["a", "b", "c"])
+    with pytest.raises(TypeError):
+        df.select(pl.all().exclude(*input))


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/6451

Changes:
* Add `*args` syntax for `exclude`
* Update parsing logic / docstring