### PR TITLE
feat(python): Make polars not copy data when importing from arrow

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -140,7 +140,7 @@ def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySe
         elif array.num_chunks == 0:
             pys = PySeries.from_arrow(name, pa.array([], array.type))
         else:
-            pys = PySeries.from_arrow(name, array.combine_chunks())
+            pys = PySeries.from_arrow(name, array.chunks[0])
 
         if rechunk:
             pys.rechunk(in_place=True)

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -908,7 +908,10 @@ def test_nested_schema_construction() -> None:
     }
 
 
-def test_array_to_pyseries_with_one_chunk_does_not_copy_data():
+def test_array_to_pyseries_with_one_chunk_does_not_copy_data() -> None:
     original_array = pa.chunked_array([[1, 2, 3]], type=pa.int64())
     pyseries = pl.internals.construction.arrow_to_pyseries("", original_array)
-    assert pyseries.get_chunks()[0]._get_ptr() == original_array.chunks[0].buffers()[1].address
+    assert (
+        pyseries.get_chunks()[0]._get_ptr()
+        == original_array.chunks[0].buffers()[1].address
+    )

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -906,3 +906,9 @@ def test_nested_schema_construction() -> None:
     assert df.to_dict(False) == {
         "node_groups": [[{"nodes": [{"name": "a", "time": 0}]}], [{"nodes": []}]]
     }
+
+
+def test_array_to_pyseries_with_one_chunk_does_not_copy_data():
+    original_array = pa.chunked_array([[1, 2, 3]], type=pa.int64())
+    pyseries = pl.internals.construction.arrow_to_pyseries("", original_array)
+    assert pyseries.get_chunks()[0]._get_ptr() == original_array.chunks[0].buffers()[1].address


### PR DESCRIPTION
Closes #7007

Seems like when importing an Arrow array with one chunk, Polars is making a copy of the data by unnecessarily using `combine_chunks()`, when it should use the chunk directly and not copy data.

I didn't fine any test for the `array_to_pyseries` to write my test checking that memory is not being copied in the same file, so I used `test_constructors.py` which seemed the most appropriate. Let me know if it should live elsewhere.