### PR TITLE
fix(python): fix scan_ipc receiving storage_options

### DIFF
--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -85,7 +85,7 @@ def _scan_ds(
 
 
 def _scan_ipc_impl(  # noqa: D417
-    uri: str, with_columns: list[str] | None, *args: Any
+    uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
 ) -> pli.DataFrame:
     """
     Take the projected columns and materialize an arrow table.
@@ -100,14 +100,14 @@ def _scan_ipc_impl(  # noqa: D417
     """
     import polars as pl
 
-    return pl.read_ipc(uri, with_columns)
+    return pl.read_ipc(uri, with_columns, *args, **kwargs)
 
 
 def _scan_ipc_fsspec(
     file: str,
     storage_options: dict[str, object] | None = None,
 ) -> pli.LazyFrame:
-    func = partial(_scan_ipc_impl, file)
+    func = partial(_scan_ipc_impl, file, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 
     storage_options = storage_options or {}


### PR DESCRIPTION
Fixes `scan_ipc` passing along `storage_options` as pickled argument.

Currently `pl.scan_ipc("s3://...", storage_options={"anon":True})` receives the correct storage options when attempting to fetch the table schema. But never passes the value to the lazy pickled function call.