### PR TITLE
feat(python): allow for simple creation of n-row empty frame/series via `clear`

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -6,7 +6,7 @@ Manipulation/selection
 .. autosummary::
    :toctree: api/
 
-    DataFrame.cleared
+    DataFrame.clear
     DataFrame.clone
     DataFrame.drop
     DataFrame.drop_in_place

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -6,7 +6,7 @@ Manipulation/selection
 .. autosummary::
    :toctree: api/
 
-    LazyFrame.cleared
+    LazyFrame.clear
     LazyFrame.clone
     LazyFrame.drop
     LazyFrame.drop_nulls

--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -12,7 +12,7 @@ Manipulation/selection
     Series.argsort
     Series.cast
     Series.ceil
-    Series.cleared
+    Series.clear
     Series.clip
     Series.clip_max
     Series.clip_min

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -360,7 +360,7 @@ def sequence_to_pyseries(
                     nan_to_null=nan_to_null,
                     strict=strict,
                 )
-                return s if values else pli.Series._from_pyseries(s)[:0]._s
+                return s if values else pli.Series._from_pyseries(s).head(0)._s
 
             # logs will show a panic if we infer wrong dtype and it's hard to error
             # from the rust side. to reduce the likelihood of this happening we

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4822,11 +4822,16 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.drop_in_place(name))
 
-    def cleared(self) -> Self:
+    def cleared(self, n: int = 0) -> Self:
         """
-        Create an empty copy of the current DataFrame.
+        Create an empty copy of the current DataFrame, with zero to 'n' rows.
 
         Returns a DataFrame with identical schema but no data.
+
+        Parameters
+        ----------
+        n
+            Number of (empty) rows to return in the cleared frame.
 
         See Also
         --------
@@ -4850,8 +4855,26 @@ class DataFrame:
         ╞═════╪═════╪══════╡
         └─────┴─────┴──────┘
 
+        >>> df.cleared(n=2)
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ a    ┆ b    ┆ c    │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ f64  ┆ bool │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ null ┆ null ┆ null │
+        └──────┴──────┴──────┘
+
         """
-        return self.head(0) if len(self) > 0 else self.clone()
+        if n > 0 or len(self) > 0:
+            return self.__class__(
+                {
+                    nm: pli.Series(name=nm, dtype=tp).extend_constant(None, n)
+                    for nm, tp in self.schema.items()
+                }
+            )
+        return self.clone()
 
     def clone(self) -> Self:
         """

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -156,6 +156,7 @@ def wrap_df(df: PyDataFrame) -> DataFrame:
 
 @redirect(
     {
+        "cleared": "clear",
         "iterrows": "iter_rows",
         "with_column": "with_columns",
     }
@@ -4822,7 +4823,7 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.drop_in_place(name))
 
-    def cleared(self, n: int = 0) -> Self:
+    def clear(self, n: int = 0) -> Self:
         """
         Create an empty copy of the current DataFrame, with zero to 'n' rows.
 
@@ -4846,7 +4847,7 @@ class DataFrame:
         ...         "c": [True, True, False, None],
         ...     }
         ... )
-        >>> df.cleared()
+        >>> df.clear()
         shape: (0, 3)
         ┌─────┬─────┬──────┐
         │ a   ┆ b   ┆ c    │
@@ -4855,7 +4856,7 @@ class DataFrame:
         ╞═════╪═════╪══════╡
         └─────┴─────┴──────┘
 
-        >>> df.cleared(n=2)
+        >>> df.clear(n=2)
         shape: (2, 3)
         ┌──────┬──────┬──────┐
         │ a    ┆ b    ┆ c    │
@@ -4882,7 +4883,7 @@ class DataFrame:
 
         See Also
         --------
-        cleared : Create an empty copy of the current DataFrame, with identical
+        clear : Create an empty copy of the current DataFrame, with identical
             schema but no data.
 
         Examples

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -98,7 +98,12 @@ def wrap_ldf(ldf: PyLazyFrame) -> LazyFrame:
     return LazyFrame._from_pyldf(ldf)
 
 
-@redirect({"with_column": "with_columns"})
+@redirect(
+    {
+        "cleared": "clear",
+        "with_column": "with_columns",
+    }
+)
 class LazyFrame:
     """
     Representation of a Lazy computation graph/query against a DataFrame.
@@ -1442,7 +1447,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """Cache the result once the execution of the physical plan hits this node."""
         return self._from_pyldf(self._ldf.cache())
 
-    def cleared(self, n: int = 0) -> Self:
+    def clear(self, n: int = 0) -> Self:
         """
         Create an empty copy of the current LazyFrame, with zero to 'n' rows.
 
@@ -1466,7 +1471,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ...         "c": [True, True, False, None],
         ...     }
         ... ).lazy()
-        >>> ldf.cleared().fetch()
+        >>> ldf.clear().fetch()
         shape: (0, 3)
         ┌─────┬─────┬──────┐
         │ a   ┆ b   ┆ c    │
@@ -1475,7 +1480,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ╞═════╪═════╪══════╡
         └─────┴─────┴──────┘
 
-        >>> ldf.cleared(2).fetch()
+        >>> ldf.clear(2).fetch()
         shape: (2, 3)
         ┌──────┬──────┬──────┐
         │ a    ┆ b    ┆ c    │
@@ -1487,9 +1492,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         └──────┴──────┴──────┘
 
         """
-        return self._from_pyldf(
-            pli.DataFrame(schema=self.schema).cleared(n).lazy()._ldf
-        )
+        return self._from_pyldf(pli.DataFrame(schema=self.schema).clear(n).lazy()._ldf)
 
     def clone(self) -> Self:
         """
@@ -1497,7 +1500,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         See Also
         --------
-        cleared : Create an empty copy of the current LazyFrame, with identical
+        clear : Create an empty copy of the current LazyFrame, with identical
             schema but no data.
 
         Examples

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1442,11 +1442,16 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         """Cache the result once the execution of the physical plan hits this node."""
         return self._from_pyldf(self._ldf.cache())
 
-    def cleared(self) -> Self:
+    def cleared(self, n: int = 0) -> Self:
         """
-        Create an empty copy of the current LazyFrame.
+        Create an empty copy of the current LazyFrame, with zero to 'n' rows.
 
-        The copy has an identical schema but no data.
+        Returns a copy with an identical schema but no data.
+
+        Parameters
+        ----------
+        n
+            Number of (empty) rows to return in the cleared frame.
 
         See Also
         --------
@@ -1454,14 +1459,14 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         Examples
         --------
-        >>> df = pl.DataFrame(
+        >>> ldf = pl.DataFrame(
         ...     {
         ...         "a": [None, 2, 3, 4],
         ...         "b": [0.5, None, 2.5, 13],
         ...         "c": [True, True, False, None],
         ...     }
         ... ).lazy()
-        >>> df.cleared().fetch()
+        >>> ldf.cleared().fetch()
         shape: (0, 3)
         ┌─────┬─────┬──────┐
         │ a   ┆ b   ┆ c    │
@@ -1470,8 +1475,21 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         ╞═════╪═════╪══════╡
         └─────┴─────┴──────┘
 
+        >>> ldf.cleared(2).fetch()
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ a    ┆ b    ┆ c    │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ f64  ┆ bool │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ null ┆ null ┆ null │
+        └──────┴──────┴──────┘
+
         """
-        return self._from_pyldf(pli.DataFrame(schema=self.schema).lazy()._ldf)
+        return self._from_pyldf(
+            pli.DataFrame(schema=self.schema).cleared(n).lazy()._ldf
+        )
 
     def clone(self) -> Self:
         """
@@ -3144,7 +3162,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         Parameters
         ----------
         n
-            Number of rows.
+            Number of rows to return.
 
         Examples
         --------

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -130,7 +130,12 @@ def wrap_s(s: PySeries) -> Series:
     return Series._from_pyseries(s)
 
 
-@redirect({"is_datelike": "is_temporal"})
+@redirect(
+    {
+        "cleared": "clear",
+        "is_datelike": "is_temporal",
+    }
+)
 @expr_dispatch
 class Series:
     """
@@ -3182,7 +3187,7 @@ class Series:
         self._s.set_at_idx(idx._s, value._s)
         return self
 
-    def cleared(self, n: int = 0) -> Series:
+    def clear(self, n: int = 0) -> Series:
         """
         Create an empty copy of the current Series, with zero to 'n' elements.
 
@@ -3200,13 +3205,13 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [None, True, False])
-        >>> s.cleared()
+        >>> s.clear()
         shape: (0,)
         Series: 'a' [bool]
         [
         ]
 
-        >>> s.cleared(n=2)
+        >>> s.clear(n=2)
         shape: (2,)
         Series: 'a' [bool]
         [
@@ -3228,7 +3233,7 @@ class Series:
 
         See Also
         --------
-        cleared : Create an empty copy of the current Series, with identical
+        clear : Create an empty copy of the current Series, with identical
             schema but no data.
 
         Examples

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3182,11 +3182,16 @@ class Series:
         self._s.set_at_idx(idx._s, value._s)
         return self
 
-    def cleared(self) -> Series:
+    def cleared(self, n: int = 0) -> Series:
         """
-        Create an empty copy of the current Series.
+        Create an empty copy of the current Series, with zero to 'n' elements.
 
-        The copy has identical name/dtype but no data.
+        The copy has an identical name/dtype, but no data.
+
+        Parameters
+        ----------
+        n
+            Number of (empty) elements to return in the cleared frame.
 
         See Also
         --------
@@ -3201,8 +3206,21 @@ class Series:
         [
         ]
 
+        >>> s.cleared(n=2)
+        shape: (2,)
+        Series: 'a' [bool]
+        [
+            null
+            null
+        ]
+
         """
-        return self.limit(0) if len(self) > 0 else self.clone()
+        s = (
+            self.__class__(name=self.name, values=[], dtype=self.dtype)
+            if len(self) > 0
+            else self.clone()
+        )
+        return s.extend_constant(None, n=n) if n > 0 else s
 
     def clone(self) -> Series:
         """

--- a/py-polars/polars/internals/slice.py
+++ b/py-polars/polars/internals/slice.py
@@ -81,7 +81,7 @@ class PolarsSlice:
 
         # check for fast-paths / single-operation calls
         if self.slice_length == 0:
-            return self.obj.cleared()
+            return self.obj.clear()
 
         elif self.is_unbounded and self.stride in (-1, 1):
             return self.obj.reverse() if (self.stride < 0) else self.obj.clone()
@@ -146,7 +146,7 @@ class LazyPolarsSlice:
         if (step > 0 and (s.stop is not None and start >= s.stop)) or (
             step < 0 and (s.stop is not None and s.stop >= s.start >= 0)
         ):
-            return self.obj.cleared()
+            return self.obj.clear()
 
         # ---------------------------------------
         # straight-through mappings for "reverse"

--- a/py-polars/tests/unit/io/__init__.py
+++ b/py-polars/tests/unit/io/__init__.py
@@ -1,6 +1,0 @@
-"""
-Test module containing tests for all input/output methods.
-
-Note that tests should never persistently change the state on disk - all tests use a
-temporary directory when testing write functionality.
-"""

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -93,7 +93,7 @@ def test_init_dict() -> None:
     )
     assert df.schema == {"c": pl.Int8, "d": pl.Int16}
 
-    dfe = df.cleared()
+    dfe = df.clear()
     assert df.schema == dfe.schema
     assert len(dfe) == 0
 
@@ -574,7 +574,7 @@ def test_init_only_columns() -> None:
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert df.schema["d"].inner == pl.UInt8  # type: ignore[union-attr]
 
-        dfe = df.cleared()
+        dfe = df.clear()
         assert len(dfe) == 0
         assert df.schema == dfe.schema
         assert dfe.shape == df.shape

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1734,11 +1734,11 @@ def test_cleared() -> None:
     df = pl.DataFrame(
         {"a": [1, 2], "b": [True, False]}, schema_overrides={"a": pl.UInt32}
     )
-    dfc = df.cleared()
+    dfc = df.clear()
     assert dfc.schema == df.schema
     assert dfc.rows() == []
 
-    dfc = df.cleared(3)
+    dfc = df.clear(3)
     assert dfc.schema == df.schema
     assert dfc.rows() == [(None, None), (None, None), (None, None)]
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1730,6 +1730,19 @@ def test_df_schema_unique() -> None:
         df.rename({"b": "a"})
 
 
+def test_cleared() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 2], "b": [True, False]}, schema_overrides={"a": pl.UInt32}
+    )
+    dfc = df.cleared()
+    assert dfc.schema == df.schema
+    assert dfc.rows() == []
+
+    dfc = df.cleared(3)
+    assert dfc.schema == df.schema
+    assert dfc.rows() == [(None, None), (None, None), (None, None)]
+
+
 def test_empty_projection() -> None:
     empty_df = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).select([])
     assert empty_df.rows() == []

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1467,10 +1467,10 @@ def test_lazy_schema() -> None:
     ).lazy()
     assert lf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
 
-    lfe = lf.cleared()
+    lfe = lf.clear()
     assert lfe.schema == lf.schema
 
-    lfe = lf.cleared(2)
+    lfe = lf.clear(2)
     assert lfe.schema == lf.schema
     assert lfe.collect().rows() == [(None, None, None), (None, None, None)]
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1470,6 +1470,10 @@ def test_lazy_schema() -> None:
     lfe = lf.cleared()
     assert lfe.schema == lf.schema
 
+    lfe = lf.cleared(2)
+    assert lfe.schema == lf.schema
+    assert lfe.collect().rows() == [(None, None, None), (None, None, None)]
+
 
 def test_deadlocks_3409() -> None:
     assert (

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1011,9 +1011,11 @@ def test_empty() -> None:
     )
 
     a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
-    empty_a = a.cleared()
-    assert a.dtype == empty_a.dtype
-    assert len(empty_a) == 0
+    for n in (0, 2, 5):
+        empty_a = a.cleared(n)
+        assert a.dtype == empty_a.dtype
+        assert a.name == empty_a.name
+        assert len(empty_a) == n
 
     with pytest.raises(ValueError, match="ambiguous"):
         not empty_a

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1012,7 +1012,7 @@ def test_empty() -> None:
 
     a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
     for n in (0, 2, 5):
-        empty_a = a.cleared(n)
+        empty_a = a.clear(n)
         assert a.dtype == empty_a.dtype
         assert a.name == empty_a.name
         assert len(empty_a) == n


### PR DESCRIPTION
Add new param `n` (defaulting to zero, maintaining existing behaviour) to the `.cleared()` method (now renamed/redirected as `.clear()`) for eager/lazy frames and series objects. 

Allows for trivial (and _very_ fast) creation of frames/series of the given size that have been cleared of data, with identical schema to the original. Niche, but handy in some testing scenarios ;)
```python
import polars as pl

df = pl.DataFrame(
    {
        "a": [None, 2, 3, 4],
        "b": [0.5, None, 2.5, 13],
        "c": [True, True, False, None],
    },
    schema_overrides = {"a": pl.UInt32}
)

df.clear()
# ┌─────┬─────┬──────┐
# │ a   ┆ b   ┆ c    │
# │ --- ┆ --- ┆ ---  │
# │ u32 ┆ f64 ┆ bool │
# ╞═════╪═════╪══════╡
# └─────┴─────┴──────┘

df.clear( n=4 )
# ┌──────┬──────┬──────┐
# │ a    ┆ b    ┆ c    │
# │ ---  ┆ ---  ┆ ---  │
# │ u32  ┆ f64  ┆ bool │
# ╞══════╪══════╪══════╡
# │ null ┆ null ┆ null │
# │ null ┆ null ┆ null │
# │ null ┆ null ┆ null │
# │ null ┆ null ┆ null │
# └──────┴──────┴──────┘
```