### PR TITLE
feat(python, rust, sql): additional read functions

### DIFF
--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -127,6 +127,8 @@ serde = [
   "polars-ops/serde",
 ]
 
+binary_encoding=["polars-plan/binary_encoding", "dtype-binary"]
+
 # no guarantees whatsoever
 private = ["polars-plan/private"]
 

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -127,7 +127,7 @@ serde = [
   "polars-ops/serde",
 ]
 
-binary_encoding=["polars-plan/binary_encoding", "dtype-binary"]
+binary_encoding = ["polars-plan/binary_encoding", "dtype-binary"]
 
 # no guarantees whatsoever
 private = ["polars-plan/private"]

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -61,7 +61,7 @@ list_count = ["polars-ops/list_count"]
 trigonometry = []
 sign = []
 timezones = ["polars-time/timezones", "polars-core/timezones", "regex"]
-
+binary_encoding = ["polars-ops/binary_encoding", "dtype-binary"]
 true_div = []
 
 # operations

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -7,11 +7,12 @@ use base64::Engine as _;
 use polars_arrow::export::arrow::compute::substring::substring;
 use polars_arrow::export::arrow::{self};
 use polars_arrow::kernels::string::*;
+#[cfg(feature = "string_from_radix")]
 use polars_core::export::num::Num;
 use polars_core::export::regex::{escape, NoExpand, Regex};
 
 use super::*;
-#[cfg(feature = "string_encoding")]
+#[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
 
 fn f_regex_extract<'a>(reg: &Regex, input: &'a str, group_index: usize) -> Option<Cow<'a, str>> {

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -19,7 +19,7 @@ atty = { version = "0.2", optional = true }
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["like"] }
 polars-core = { version = "0.27.2", path = "../polars-core", features = [] }
 polars-lazy = { version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"] }
-polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile"] }
+polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile", "binary_encoding"] }
 rustyline = { version = "10.0.0", optional = true }
 serde = "1"
 serde_json = { version = "1" }

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-description = "Lazy query engine for the Polars DataFrame library"
+name = "polars-sql"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
-name = "polars-sql"
 repository = "https://github.com/pola-rs/polars"
-version = "0.2.3"
+description = "Lazy query engine for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -15,17 +15,17 @@ ipc = ["polars-lazy/ipc"]
 parquet = ["polars-lazy/parquet", "polars-lazy/dtype-binary"]
 
 [dependencies]
-atty = {version = "0.2", optional = true}
-polars-arrow = {version = "0.27.2", path = "../polars-arrow", features = ["like"]}
-polars-core = {version = "0.27.2", path = "../polars-core", features = []}
-polars-lazy = {version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"]}
-polars-plan = {version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile"]}
-rustyline = {version = "10.0.0", optional = true}
+atty = { version = "0.2", optional = true }
+polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["like"] }
+polars-core = { version = "0.27.2", path = "../polars-core", features = [] }
+polars-lazy = { version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"] }
+polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile"] }
+rustyline = { version = "10.0.0", optional = true }
 serde = "1"
-serde_json = {version = "1"}
-sqlparser = {version = "0.30"}
+serde_json = { version = "1" }
+sqlparser = { version = "0.30" }
 [target.'cfg(target_os = "linux")'.dependencies]
-jemallocator = {version = "0.5", features = ["disable_initial_exec_tls"], optional = true}
+jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"], optional = true }
 
 [target.'cfg(not(target_os = "linux"))'.features]
 jemallocator = []

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-name = "polars-sql"
-version = "0.2.3"
+description = "Lazy query engine for the Polars DataFrame library"
 edition = "2021"
 license = "MIT"
+name = "polars-sql"
 repository = "https://github.com/pola-rs/polars"
-description = "Lazy query engine for the Polars DataFrame library"
+version = "0.2.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = []
 cli = ["csv", "polars-lazy/fmt", "atty", "rustyline", "jemallocator"]
 csv = ["polars-lazy/csv-file"]
-parquet = ["polars-lazy/parquet", "polars-lazy/dtype-binary"]
+default = []
 ipc = ["polars-lazy/ipc"]
+parquet = ["polars-lazy/parquet", "polars-lazy/dtype-binary"]
 
 [dependencies]
-atty = { version = "0.2", optional = true }
-polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["like"] }
-polars-core = { version = "0.27.2", path = "../polars-core", features = [] }
-polars-lazy = { version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"] }
-polars-plan = { version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile", "binary_encoding"] }
-rustyline = { version = "10.0.0", optional = true }
+atty = {version = "0.2", optional = true}
+polars-arrow = {version = "0.27.2", path = "../polars-arrow", features = ["like"]}
+polars-core = {version = "0.27.2", path = "../polars-core", features = []}
+polars-lazy = {version = "0.27.2", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in"]}
+polars-plan = {version = "0.27.2", path = "../polars-lazy/polars-plan", features = ["compile"]}
+rustyline = {version = "10.0.0", optional = true}
 serde = "1"
-serde_json = { version = "1" }
-sqlparser = { version = "0.30" }
+serde_json = {version = "1"}
+sqlparser = {version = "0.30"}
 [target.'cfg(target_os = "linux")'.dependencies]
-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"], optional = true }
+jemallocator = {version = "0.5", features = ["disable_initial_exec_tls"], optional = true}
 
 [target.'cfg(not(target_os = "linux"))'.features]
 jemallocator = []

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -15,88 +15,212 @@ pub(crate) enum PolarsSqlFunctions {
     // Math functions
     // ----
     /// SQL 'abs' function
+    /// ```sql
+    /// SELECT ABS(column_1) from df;
+    /// ```
     Abs,
     /// SQL 'acos' function
+    /// ```sql
+    /// SELECT ACOS(column_1) from df;
+    /// ```
     Acos,
     /// SQL 'asin' function
+    /// ```sql
+    /// SELECT ASIN(column_1) from df;
+    /// ```
     Asin,
     /// SQL 'atan' function
+    /// ```sql
+    /// SELECT ATAN(column_1) from df;
+    /// ```
     Atan,
     /// SQL 'ceil' function
+    /// ```sql
+    /// SELECT CEIL(column_1) from df;
+    /// ```
     Ceil,
     /// SQL 'exp' function
+    /// ```sql
+    /// SELECT EXP(column_1) from df;
+    /// ```
     Exp,
     /// SQL 'floor' function
+    /// ```sql
+    /// SELECT FLOOR(column_1) from df;
+    /// ```
     Floor,
     /// SQL 'ln' function
+    /// ```sql
+    /// SELECT LN(column_1) from df;
+    /// ```
     Ln,
     /// SQL 'log2' function
+    /// ```sql
+    /// SELECT LOG2(column_1) from df;
+    /// ```
     Log2,
     /// SQL 'log10' function
+    /// ```sql
+    /// SELECT LOG10(column_1) from df;
+    /// ```
     Log10,
     /// SQL 'log' function
+    /// ```sql
+    /// SELECT LOG(column_1, 10) from df;
+    /// ```
     Log,
-
     /// SQL 'pow' function
+    /// ```sql
+    /// SELECT POW(column_1, 2) from df;
+    /// ```
     Pow,
     // ----
     // String functions
     // ----
     /// SQL 'lower' function
+    /// ```sql
+    /// SELECT LOWER(column_1) from df;
+    /// ```
     Lower,
     /// SQL 'upper' function
+    /// ```sql
+    /// SELECT UPPER(column_1) from df;
+    /// ```
     Upper,
     /// SQL 'ltrim' function
+    /// ```sql
+    /// SELECT LTRIM(column_1) from df;
+    /// ```
     LTrim,
     /// SQL 'rtrim' function
+    /// ```sql
+    /// SELECT RTRIM(column_1) from df;
+    /// ```
     RTrim,
     /// SQL 'starts_with' function
+    /// ```sql
+    /// SELECT STARTS_WITH(column_1, 'a') from df;
+    /// SELECT column_2 from df WHERE STARTS_WITH(column_1, 'a');
+    /// ```
     StartsWith,
     /// SQL 'ends_with' function
+    /// ```sql
+    /// SELECT ENDS_WITH(column_1, 'a') from df;
+    /// SELECT column_2 from df WHERE ENDS_WITH(column_1, 'a');
+    /// ```
     EndsWith,
     // ----
     // Aggregate functions
     // ----
     /// SQL 'count' function
+    /// ```sql
+    /// SELECT COUNT(column_1) from df;
+    /// SELECT COUNT(*) from df;
+    /// SELECT COUNT(DISTINCT column_1) from df;
+    /// SELECT COUNT(DISTINCT *) from df;
+    /// ```
     Count,
     /// SQL 'sum' function
+    /// ```sql
+    /// SELECT SUM(column_1) from df;
+    /// ```
     Sum,
     /// SQL 'min' function
+    /// ```sql
+    /// SELECT MIN(column_1) from df;
+    /// ```
     Min,
     /// SQL 'max' function
+    /// ```sql
+    /// SELECT MAX(column_1) from df;
+    /// ```
     Max,
     /// SQL 'avg' function
+    /// ```sql
+    /// SELECT AVG(column_1) from df;
+    /// ```
     Avg,
     /// SQL 'stddev' function
+    /// ```sql
+    /// SELECT STDDEV(column_1) from df;
+    /// ```
     StdDev,
     /// SQL 'variance' function
+    /// ```sql
+    /// SELECT VARIANCE(column_1) from df;
+    /// ```
     Variance,
     /// SQL 'first' function
+    /// ```sql
+    /// SELECT FIRST(column_1) from df;
+    /// ```
     First,
     /// SQL 'last' function
+    /// ```sql
+    /// SELECT LAST(column_1) from df;
+    /// ```
     Last,
     // ----
     // Array functions
     // ----
     /// SQL 'array_length' function
+    /// ```sql
+    /// SELECT ARRAY_LENGTH(column_1) from df;
+    /// ```
     ArrayLength,
     /// SQL 'array_lower' function
+    /// Returns the minimum value in an array; equivalent to `array_min`
+    /// ```sql
+    /// SELECT ARRAY_LOWER(column_1) from df;
+    /// ```
     ArrayMin,
     /// SQL 'array_upper' function
+    /// Returns the maximum value in an array; equivalent to `array_max`
+    /// ```sql
+    /// SELECT ARRAY_UPPER(column_1) from df;
+    /// ```
     ArrayMax,
     /// SQL 'array_sum' function
+    /// Returns the sum of all values in an array
+    /// ```sql
+    /// SELECT ARRAY_SUM(column_1) from df;
+    /// ```
     ArraySum,
     /// SQL 'array_mean' function
+    /// Returns the mean of all values in an array
+    /// ```sql
+    /// SELECT ARRAY_MEAN(column_1) from df;
+    /// ```
     ArrayMean,
     /// SQL 'array_reverse' function
+    /// Returns the array with the elements in reverse order
+    /// ```sql
+    /// SELECT ARRAY_REVERSE(column_1) from df;
+    /// ```
     ArrayReverse,
     /// SQL 'array_unique' function
+    /// Returns the array with the unique elements
+    /// ```sql
+    /// SELECT ARRAY_UNIQUE(column_1) from df;
+    /// ```
     ArrayUnique,
     /// SQL 'unnest' function
+    /// unnest/explods an array column into multiple rows
+    /// ```sql
+    /// SELECT unnest(column_1) from df;
+    /// ```
     Explode,
     /// SQL 'array_get' function
+    /// Returns the value at the given index in the array
+    /// ```sql
+    /// SELECT ARRAY_GET(column_1, 1) from df;
+    /// ```
     ArrayGet,
     /// SQL 'array_contains' function
+    /// Returns true if the array contains the value
+    /// ```sql
+    /// SELECT ARRAY_CONTAINS(column_1, 'foo') from df;
+    /// ```
     ArrayContains,
 }
 

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -526,4 +526,49 @@ mod test {
             .unwrap();
         assert!(df_sql.frame_equal(&expected));
     }
+
+    #[test]
+    #[cfg(feature = "parquet")]
+    fn read_parquet_tbl() {
+        let mut context = SQLContext::try_new().unwrap();
+        let sql = r#"
+            CREATE TABLE foods1 AS
+            SELECT *
+            FROM read_parquet('../../examples/datasets/foods1.parquet')"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let create_tbl_res = df! {
+            "Response" => ["Create Table"]
+        }
+        .unwrap();
+        assert!(df_sql.frame_equal(&create_tbl_res));
+        let df_2 = context
+            .execute(r#"SELECT * FROM foods1"#)
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(df_2.height(), 27);
+        assert_eq!(df_2.width(), 4);
+    }
+    #[test]
+    #[cfg(feature = "ipc")]
+    fn read_ipc_tbl() {
+        let mut context = SQLContext::try_new().unwrap();
+        let sql = r#"
+            CREATE TABLE foods1 AS
+            SELECT *
+            FROM read_ipc('../../examples/datasets/foods1.ipc')"#;
+        let df_sql = context.execute(sql).unwrap().collect().unwrap();
+        let create_tbl_res = df! {
+            "Response" => ["Create Table"]
+        }
+        .unwrap();
+        assert!(df_sql.frame_equal(&create_tbl_res));
+        let df_2 = context
+            .execute(r#"SELECT * FROM foods1"#)
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(df_2.height(), 27);
+        assert_eq!(df_2.width(), 4);
+    }
 }

--- a/polars/polars-sql/src/table_functions.rs
+++ b/polars/polars-sql/src/table_functions.rs
@@ -9,11 +9,23 @@ use sqlparser::ast::{FunctionArg, FunctionArgExpr};
 /// Table functions that are supported by Polars
 pub(crate) enum PolarsTableFunctions {
     /// SQL 'read_csv' function
+    /// ```sql
+    /// SELECT * FROM read_csv('path/to/file.csv')
+    /// ```
     #[cfg(feature = "csv")]
     ReadCsv,
     /// SQL 'read_parquet' function
+    /// ```sql
+    /// SELECT * FROM read_parquet('path/to/file.parquet')
+    /// ```
     #[cfg(feature = "parquet")]
     ReadParquet,
+    /// SQL 'read_ipc' function
+    /// ```sql
+    /// SELECT * FROM read_ipc('path/to/file.ipc')
+    /// ```
+    #[cfg(feature = "ipc")]
+    ReadIpc,
 }
 
 impl FromStr for PolarsTableFunctions {
@@ -25,6 +37,8 @@ impl FromStr for PolarsTableFunctions {
             "read_csv" => Ok(PolarsTableFunctions::ReadCsv),
             #[cfg(feature = "parquet")]
             "read_parquet" => Ok(PolarsTableFunctions::ReadParquet),
+            #[cfg(feature = "ipc")]
+            "read_ipc" => Ok(PolarsTableFunctions::ReadIpc),
             _ => Err(PolarsError::ComputeError(
                 format!("'{}' is not a supported table function", s).into(),
             )),
@@ -39,6 +53,8 @@ impl PolarsTableFunctions {
             PolarsTableFunctions::ReadCsv => self.read_csv(args),
             #[cfg(feature = "parquet")]
             PolarsTableFunctions::ReadParquet => self.read_parquet(args),
+            #[cfg(feature = "ipc")]
+            PolarsTableFunctions::ReadIpc => self.read_ipc(args),
             _ => unreachable!(),
         }
     }
@@ -50,9 +66,19 @@ impl PolarsTableFunctions {
         let lf = LazyCsvReader::new(&path).finish()?;
         Ok((path, lf))
     }
+
     #[cfg(feature = "parquet")]
-    fn read_parquet(&self, _: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
-        todo!()
+    fn read_parquet(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
+        let path = self.get_file_path_from_arg(&args[0])?;
+        let lf = LazyFrame::scan_parquet(&path, Default::default())?;
+        Ok((path, lf))
+    }
+
+    #[cfg(feature = "ipc")]
+    fn read_ipc(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
+        let path = self.get_file_path_from_arg(&args[0])?;
+        let lf = LazyFrame::scan_ipc(&path, Default::default())?;
+        Ok((path, lf))
     }
 
     fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<String> {


### PR DESCRIPTION
### Table functions
adds 2 new table functions
- `read_parquet`
- `read_ipc`

### Docs
adds some docstrings with simple examples

### Feature flagging
There were some issues with binary-encoding not being properly feature flagged when running tests, so just updated some of the feature flags. 