### PR TITLE
test(python): add test to guard against accidental reintroduction of `unit/io/__init__`

### DIFF
--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os.path
 from typing import cast
 
 import polars as pl
@@ -62,3 +63,17 @@ def test_from_different_chunks() -> None:
     out = df.to_pandas()
     assert list(out.columns) == ["a", "b"]
     assert out.shape == (5, 2)
+
+
+def test_unit_io_subdir_has_no_init() -> None:
+    # --------------------------------------------------------------------------------
+    # If this test fails it means an '__init__.py' was added to 'tests/unit/io'.
+    # See https://github.com/pola-rs/polars/pull/6889 for why this can cause issues.
+    # --------------------------------------------------------------------------------
+    # TLDR: it can mask the builtin 'io' module, causing a fatal python error.
+    # --------------------------------------------------------------------------------
+    io_dir = os.path.dirname(__file__)
+    assert io_dir.endswith("unit/io")
+    assert not os.path.exists(
+        f"{io_dir}/__init__.py"
+    ), "Found undesirable '__init__.py' in the 'unit.io' tests subdirectory"

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -73,7 +73,7 @@ def test_unit_io_subdir_has_no_init() -> None:
     # TLDR: it can mask the builtin 'io' module, causing a fatal python error.
     # --------------------------------------------------------------------------------
     io_dir = os.path.dirname(__file__)
-    assert io_dir.endswith("unit/io")
+    assert io_dir.endswith(f"unit{os.path.sep}io")
     assert not os.path.exists(
-        f"{io_dir}/__init__.py"
+        f"{io_dir}{os.path.sep}__init__.py"
     ), "Found undesirable '__init__.py' in the 'unit.io' tests subdirectory"


### PR DESCRIPTION
Much lighter solution than https://github.com/pola-rs/polars/pull/7109 (now we have removed the rogue `__init__`); this PR ensures that we don't accidentally reintroduce it, while allowing us to keep the current `io` unit test subdirectory as-is. 

Should it get triggered the test comments (and assert failure msg) combine to provide a clear explanation (and a link back to the original issue) to clarify what problem it causes (masking the builtin `io` module when debugging tests, causing a fatal python error).