### PR TITLE
docs(python): fix docstring in set_tbl_cols()

### DIFF
--- a/py-polars/polars/cfg.py
+++ b/py-polars/polars/cfg.py
@@ -268,7 +268,7 @@ class Config:
         └─────┴─────┴─────┴─────┴─────┴─────┘
 
         >>> with pl.Config() as cfg:
-        ...     pl.cfg.Config.set_tbl_cols(10)  # doctest: +IGNORE_RESULT
+        ...     cfg.set_tbl_cols(10)  # doctest: +IGNORE_RESULT
         ...     df
         ...
         shape: (1, 100)


### PR DESCRIPTION
### About docstring of `set_tbl_cols()`:
Fixed a call to use `cfg` in the with block since it was not being used.

<details>
  <summary>Results of Examples</summary>

~~~py
>>> import polars as pl
>>> df = pl.DataFrame({str(i): [i] for i in range(100)})
>>> df
shape: (1, 100)
┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
│ 0   ┆ 1   ┆ 2   ┆ 3   ┆ ... ┆ 96  ┆ 97  ┆ 98  ┆ 99  │
│ --- ┆ --- ┆ --- ┆ --- ┆     ┆ --- ┆ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 ┆ i64 ┆     ┆ i64 ┆ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╡
│ 0   ┆ 1   ┆ 2   ┆ 3   ┆ ... ┆ 96  ┆ 97  ┆ 98  ┆ 99  │
└─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
>>> with pl.Config() as cfg:
...     cfg.set_tbl_cols(10)  # doctest: +IGNORE_RESULT
...     df
... 
<class 'polars.cfg.Config'>
shape: (1, 100)
┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
│ 0   ┆ 1   ┆ 2   ┆ 3   ┆ 4   ┆ ... ┆ 95  ┆ 96  ┆ 97  ┆ 98  ┆ 99  │
│ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆     ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 ┆ i64 ┆ i64 ┆     ┆ i64 ┆ i64 ┆ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╡
│ 0   ┆ 1   ┆ 2   ┆ 3   ┆ 4   ┆ ... ┆ 95  ┆ 96  ┆ 97  ┆ 98  ┆ 99  │
└─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
~~~

</detail>