### PR TITLE
feat(python): support direct `LazyFrame` init (same params as `DataFrame`)

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
         ComparisonOperator,
         CsvEncoding,
         FillNullStrategy,
+        FrameInitTypes,
         IntoExpr,
         IpcCompression,
         JoinStrategy,
@@ -216,13 +217,13 @@ class DataFrame:
     │ 2   ┆ 4   │
     └─────┴─────┘
 
-    Notice that the dtype is automatically inferred as a polars Int64:
+    Notice that the dtypes are automatically inferred as polars Int64:
 
     >>> df.dtypes
     [Int64, Int64]
 
-    To specify the frame schema you supply the `schema` parameter with a dictionary
-    of (name,dtype) pairs...
+    To specify a more detailed/specific frame schema you can supply the `schema`
+    parameter with a dictionary of (name,dtype) pairs...
 
     >>> data = {"col1": [0, 2], "col2": [3, 7]}
     >>> df2 = pl.DataFrame(data, schema={"col1": pl.Float32, "col2": pl.Int64})
@@ -320,15 +321,7 @@ class DataFrame:
     @deprecated_alias(columns="schema")
     def __init__(
         self,
-        data: (
-            Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series]
-            | Sequence[Any]
-            | np.ndarray[Any, Any]
-            | pa.Table
-            | pd.DataFrame
-            | pli.Series
-            | None
-        ) = None,
+        data: FrameInitTypes | None = None,
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -17,6 +17,10 @@ else:
 
 if TYPE_CHECKING:
     from polars import internals as pli
+    from polars.dependencies import numpy as np
+    from polars.dependencies import pandas as pd
+    from polars.dependencies import pyarrow as pa
+
 
 # Types that qualify as expressions (eg: for use in 'select', 'with_columns'...)
 PolarsExprType: TypeAlias = "pli.Expr | pli.WhenThen | pli.WhenThenThen"
@@ -33,7 +37,6 @@ ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq
 # The following all have an equivalent Rust enum with the same name
 AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
 CategoricalOrdering: TypeAlias = Literal["physical", "lexical"]
-StartBy: TypeAlias = Literal["window", "datapoint", "monday"]
 CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 FillNullStrategy: TypeAlias = Literal[
     "forward", "backward", "min", "max", "mean", "zero", "one"
@@ -41,7 +44,6 @@ FillNullStrategy: TypeAlias = Literal[
 IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
 NullBehavior: TypeAlias = Literal["ignore", "drop"]
 NullStrategy: TypeAlias = Literal["ignore", "propagate"]
-UnstackDirection: TypeAlias = Literal["vertical", "horizontal"]
 ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]
 ParquetCompression: TypeAlias = Literal[
     "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
@@ -50,8 +52,6 @@ PivotAgg: TypeAlias = Literal[
     "first", "sum", "max", "min", "mean", "median", "last", "count"
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
-TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
-UniqueKeepStrategy: TypeAlias = Literal["first", "last", "none"]
 SizeUnit: TypeAlias = Literal[
     "b",
     "kb",
@@ -64,24 +64,31 @@ SizeUnit: TypeAlias = Literal[
     "gigabytes",
     "terabytes",
 ]
+StartBy: TypeAlias = Literal["window", "datapoint", "monday"]
+TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
+UniqueKeepStrategy: TypeAlias = Literal["first", "last", "none"]
+UnstackDirection: TypeAlias = Literal["vertical", "horizontal"]
 
 # The following have a Rust enum equivalent with a different name
 AsofJoinStrategy: TypeAlias = Literal["backward", "forward"]  # AsofStrategy
 ClosedInterval: TypeAlias = Literal["left", "right", "both", "none"]  # ClosedWindow
-RollingInterpolationMethod: TypeAlias = Literal[
-    "nearest", "higher", "lower", "midpoint", "linear"
-]  # QuantileInterpolOptions
+InterpolationMethod: TypeAlias = Literal["linear", "nearest"]
 JoinStrategy: TypeAlias = Literal[
     "inner", "left", "outer", "semi", "anti", "cross"
 ]  # JoinType
+RollingInterpolationMethod: TypeAlias = Literal[
+    "nearest", "higher", "lower", "midpoint", "linear"
+]  # QuantileInterpolOptions
 ToStructStrategy: TypeAlias = Literal[
     "first_non_null", "max_width"
 ]  # ListToStructWidthStrategy
-InterpolationMethod: TypeAlias = Literal["linear", "nearest"]
 
 # The following have no equivalent on the Rust side
 ConcatMethod = Literal["vertical", "diagonal", "horizontal"]
 EpochTimeUnit = Literal["ns", "us", "ms", "s", "d"]
 Orientation: TypeAlias = Literal["col", "row"]
-TransferEncoding: TypeAlias = Literal["hex", "base64"]
 SearchSortedSide: TypeAlias = Literal["any", "left", "right"]
+TransferEncoding: TypeAlias = Literal["hex", "base64"]
+
+# type signature for allowed frame init
+FrameInitTypes: TypeAlias = "Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series] | Sequence[Any] | np.ndarray[Any, Any] | pa.Table | pd.DataFrame | pli.Series"

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import textwrap
 import typing
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from io import BytesIO
 from operator import floordiv, truediv
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, cast
@@ -454,6 +454,39 @@ def test_take_every() -> None:
     assert_frame_equal(expected_df, df.take_every(2))
 
 
+def test_take_misc(fruits_cars: pl.DataFrame) -> None:
+    df = fruits_cars
+
+    # out of bounds error
+    with pytest.raises(pl.ComputeError):
+        (
+            df.sort("fruits").select(
+                [pl.col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]
+            )
+        )
+
+    for index in [[0, 1], pl.Series([0, 1]), np.array([0, 1])]:
+        out = df.sort("fruits").select(
+            [
+                pl.col("B")
+                .reverse()
+                .take(index)  # type: ignore[arg-type]
+                .list()
+                .over("fruits"),
+                "fruits",
+            ]
+        )
+
+        assert out[0, "B"].to_list() == [2, 3]
+        assert out[4, "B"].to_list() == [1, 4]
+
+    out = df.sort("fruits").select(
+        [pl.col("B").reverse().take(pl.lit(1)).list().over("fruits"), "fruits"]
+    )
+    assert out[0, "B"] == 3
+    assert out[4, "B"] == 4
+
+
 def test_slice() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
     expected = pl.DataFrame({"a": [2, 3], "b": ["b", "c"]})
@@ -708,14 +741,10 @@ def test_to_dummies() -> None:
 
 def test_custom_groupby() -> None:
     df = pl.DataFrame({"a": [1, 2, 1, 1], "b": ["a", "b", "c", "c"]})
-
-    out = (
-        df.lazy()
-        .groupby("b")
-        .agg([pl.col("a").apply(lambda x: x.sum(), return_dtype=pl.Int64)])
-        .collect()
+    out = df.groupby("b", maintain_order=True).agg(
+        [pl.col("a").apply(lambda x: x.sum(), return_dtype=pl.Int64)]
     )
-    assert out.shape == (3, 2)
+    assert out.rows() == [("a", 1), ("b", 2), ("c", 2)]
 
 
 def test_multiple_columns_drop() -> None:
@@ -754,6 +783,16 @@ def test_concat() -> None:
 
     with pytest.raises(ValueError):
         pl.concat([df1, df1], how="rubbish")  # type: ignore[call-overload]
+
+
+def test_concat_str() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
+
+    out = df.select([pl.concat_str(["a", "b"], sep="-")])
+    assert out["a"].to_list() == ["a-1", "b-2", "c-3"]
+
+    out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
+    assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
 
 
 def test_arg_where() -> None:
@@ -842,6 +881,32 @@ def test_df_fold() -> None:
     assert_series_equal(df_width_one.fold(lambda s1, s2: s1), df["a"])
 
 
+def test_fold_filter() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+
+    out = df.filter(
+        pl.fold(
+            acc=pl.lit(True),
+            function=lambda a, b: a & b,
+            exprs=[pl.col(c) > 1 for c in df.columns],
+        )
+    )
+
+    assert out.shape == (1, 2)
+    assert out.rows() == [(3, 2)]
+
+    out = df.filter(
+        pl.fold(
+            acc=pl.lit(True),
+            function=lambda a, b: a | b,
+            exprs=[pl.col(c) > 1 for c in df.columns],
+        )
+    )
+
+    assert out.shape == (3, 2)
+    assert out.rows() == [(1, 0), (2, 1), (3, 2)]
+
+
 def test_df_apply() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.apply(lambda x: len(x), None).to_series()
@@ -858,6 +923,78 @@ def test_column_names() -> None:
     for a in (tbl, tbl[:0]):
         df = cast(pl.DataFrame, pl.from_arrow(a))
         assert df.columns == ["a", "b"]
+
+
+def test_head_groupby() -> None:
+    commodity_prices = {
+        "commodity": [
+            "Wheat",
+            "Wheat",
+            "Wheat",
+            "Wheat",
+            "Corn",
+            "Corn",
+            "Corn",
+            "Corn",
+            "Corn",
+        ],
+        "location": [
+            "StPaul",
+            "StPaul",
+            "StPaul",
+            "Chicago",
+            "Chicago",
+            "Chicago",
+            "Chicago",
+            "Chicago",
+            "Chicago",
+        ],
+        "seller": [
+            "Bob",
+            "Charlie",
+            "Susan",
+            "Paul",
+            "Ed",
+            "Mary",
+            "Paul",
+            "Charlie",
+            "Norman",
+        ],
+        "price": [1.0, 0.7, 0.8, 0.55, 2.0, 3.0, 2.4, 1.8, 2.1],
+    }
+    df = pl.DataFrame(commodity_prices)
+
+    # this query flexes the wildcard exclusion quite a bit.
+    keys = ["commodity", "location"]
+    out = (
+        df.sort(by="price", descending=True)
+        .groupby(keys, maintain_order=True)
+        .agg([pl.col("*").exclude(keys).head(2).keep_name()])
+        .explode(pl.col("*").exclude(keys))
+    )
+
+    assert out.shape == (5, 4)
+    assert out.rows() == [
+        ("Corn", "Chicago", "Mary", 3.0),
+        ("Corn", "Chicago", "Paul", 2.4),
+        ("Wheat", "StPaul", "Bob", 1.0),
+        ("Wheat", "StPaul", "Susan", 0.8),
+        ("Wheat", "Chicago", "Paul", 0.55),
+    ]
+
+    df = pl.DataFrame(
+        {"letters": ["c", "c", "a", "c", "a", "b"], "nrs": [1, 2, 3, 4, 5, 6]}
+    )
+    out = df.groupby("letters").tail(2).sort("letters")
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 2, 4]}),
+    )
+    out = df.groupby("letters").head(2).sort("letters")
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 1, 2]}),
+    )
 
 
 def test_lazy_functions() -> None:
@@ -921,6 +1058,37 @@ def test_lazy_functions() -> None:
     assert out.rows() == [
         ({"a": "foo", "b": 3}, {"b": 1, "c": 1.0}, {"a": None, "c": 6.0})
     ]
+
+
+def test_is_null_is_not_null() -> None:
+    df = pl.DataFrame({"nrs": [1, 2, None]})
+    assert df.select(pl.col("nrs").is_null())["nrs"].to_list() == [False, False, True]
+    assert df.select(pl.col("nrs").is_not_null())["nrs"].to_list() == [
+        True,
+        True,
+        False,
+    ]
+
+
+def test_is_nan_is_not_nan() -> None:
+    df = pl.DataFrame({"nrs": np.array([1, 2, np.nan])})
+    assert df.select(pl.col("nrs").is_nan())["nrs"].to_list() == [False, False, True]
+    assert df.select(pl.col("nrs").is_not_nan())["nrs"].to_list() == [True, True, False]
+
+
+def test_is_finite_is_infinite() -> None:
+    df = pl.DataFrame({"nrs": np.array([1, 2, np.inf])})
+    assert df.select(pl.col("nrs").is_infinite())["nrs"].to_list() == [
+        False,
+        False,
+        True,
+    ]
+    assert df.select(pl.col("nrs").is_finite())["nrs"].to_list() == [True, True, False]
+
+
+def test_len() -> None:
+    df = pl.DataFrame({"nrs": [1, 2, 3]})
+    assert cast(int, df.select(pl.col("nrs").len()).item()) == 3
 
 
 def test_multiple_column_sort() -> None:
@@ -1908,6 +2076,12 @@ def test_fill_nan() -> None:
     assert df.fill_nan(2.0).dtypes == [pl.Float64, pl.Datetime]
 
 
+def test_backward_fill() -> None:
+    df = pl.DataFrame({"a": [1.0, None, 3.0]})
+    col_a_backward_fill = df.select([pl.col("a").backward_fill()])["a"]
+    assert_series_equal(col_a_backward_fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
+
+
 def test_shift_and_fill() -> None:
     df = pl.DataFrame(
         {
@@ -2242,6 +2416,87 @@ def test_first_last_expression(fruits_cars: pl.DataFrame) -> None:
     assert out.columns == ["cars"]
 
 
+def test_is_between(fruits_cars: pl.DataFrame) -> None:
+    result = fruits_cars.select(pl.col("A").is_between(2, 4)).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
+
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, False, True, False, False]))
+
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
+
+    result = fruits_cars.select(
+        pl.col("A").is_between(2, 4, closed="right")
+    ).to_series()
+    assert_series_equal(result, pl.Series("A", [False, False, True, True, False]))
+
+    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left")).to_series()
+    assert_series_equal(result, pl.Series("A", [False, True, True, False, False]))
+
+
+def test_is_between_data_types() -> None:
+    df = pl.DataFrame(
+        {
+            "flt": [1.4, 1.2, 2.5],
+            "int": [2, 3, 4],
+            "str": ["xyz", "str", "abc"],
+            "date": [date(2020, 1, 1), date(2020, 2, 2), date(2020, 3, 3)],
+            "datetime": [
+                datetime(2020, 1, 1, 0, 0, 0),
+                datetime(2020, 1, 1, 10, 0, 0),
+                datetime(2020, 1, 1, 12, 0, 0),
+            ],
+            "tm": [time(10, 30), time(0, 45), time(15, 15)],
+        }
+    )
+
+    # on purpose, for float and int, we pass in a mixture of bound data types
+    assert_series_equal(
+        df.select(pl.col("flt").is_between(1, 2.3))[:, 0],
+        pl.Series("flt", [True, True, False]),
+    )
+    assert_series_equal(
+        df.select(pl.col("int").is_between(1.5, 3))[:, 0],
+        pl.Series("int", [True, True, False]),
+    )
+    assert_series_equal(
+        df.select(pl.col("date").is_between(date(2019, 1, 1), date(2020, 2, 5)))[:, 0],
+        pl.Series("date", [True, True, False]),
+    )
+    assert_series_equal(
+        df.select(
+            pl.col("datetime").is_between(
+                datetime(2020, 1, 1, 5, 0, 0), datetime(2020, 1, 1, 11, 0, 0)
+            )
+        )[:, 0],
+        pl.Series("datetime", [False, True, False]),
+    )
+    assert_series_equal(
+        df.select(
+            pl.col("str").is_between(pl.lit("str"), pl.lit("zzz"), closed="left")
+        )[:, 0],
+        pl.Series("str", [True, True, False]),
+    )
+    assert_series_equal(
+        df.select(
+            pl.col("tm")
+            .is_between(time(0, 45), time(10, 30), closed="right")
+            .alias("tm_between")
+        )[:, 0],
+        pl.Series("tm_between", [True, False, False]),
+    )
+
+
+def test_is_in() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    assert df.select(pl.col("a").is_in([1, 2]))["a"].to_list() == [
+        True,
+        True,
+        False,
+    ]
+
+
 def test_empty_is_in() -> None:
     df_empty_isin = pl.DataFrame({"foo": ["a", "b", "c", "d"]}).filter(
         pl.col("foo").is_in([])
@@ -2431,6 +2686,64 @@ def test_fill_null_limits() -> None:
     }
 
 
+def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:
+    res = fruits_cars.select(pl.max(["A", "B"]).alias("max"))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
+
+    res = fruits_cars.select(pl.min(["A", "B"]).alias("min"))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
+
+
+def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min(["*"]))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min([pl.all()]))
+    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
+
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max(["*"]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max([pl.all()]))
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
+
+    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(
+        pl.max([pl.all(), "A", "*"])
+    )
+    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
+
+
+def test_head_tail(fruits_cars: pl.DataFrame) -> None:
+    res_expr = fruits_cars.select([pl.head("A", 2)])
+    res_series = pl.head(fruits_cars["A"], 2)
+    expected = pl.Series("A", [1, 2])
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)
+
+    res_expr = fruits_cars.select([pl.tail("A", 2)])
+    res_series = pl.tail(fruits_cars["A"], 2)
+    expected = pl.Series("A", [4, 5])
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)
+
+
+def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:
+    res_expr = fruits_cars.select(pl.col("A").lower_bound())
+    assert res_expr.item() == -9223372036854775808
+
+    res_expr = fruits_cars.select(pl.col("B").upper_bound())
+    assert res_expr.item() == 9223372036854775807
+
+    with pytest.raises(pl.ComputeError):
+        fruits_cars.select(pl.col("fruits").upper_bound())
+
+
+def test_nested_min_max() -> None:
+    df = pl.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
+    out = df.with_columns(pl.max([pl.min(["a", "b"]), pl.min(["c", "d"])]).alias("t"))
+    assert out.shape == (1, 5)
+    assert out.row(0) == (1, 2, 3, 4, 3)
+    assert out.columns == ["a", "b", "c", "d", "t"]
+
+
 def test_selection_misc() -> None:
     df = pl.DataFrame({"x": "abc"}, schema={"x": pl.Utf8})
 
@@ -2528,6 +2841,14 @@ def test_selection_regex_and_multicol() -> None:
                 {"a_max": 4, "b_max": 8, "c_max": 12, "foo_max": 16},
             ),
         ]
+
+
+def test_unique_on_sorted() -> None:
+    assert (
+        pl.DataFrame({"a": [1, 1, 3], "b": [1, 2, 3]})
+        .with_columns([pl.col("a").set_sorted()])
+        .unique(subset="a", keep="last")
+    ).to_dict(False) == {"a": [1, 3], "b": [2, 3]}
 
 
 def test_with_columns() -> None:
@@ -3033,3 +3354,225 @@ def test_format_empty_df() -> None:
     )
     assert df.shape == (0, 1)
     assert df.dtypes == [pl.Utf8]
+
+
+def test_deadlocks_3409() -> None:
+    assert (
+        pl.DataFrame({"col1": [[1, 2, 3]]})
+        .with_columns([pl.col("col1").arr.eval(pl.element().apply(lambda x: x))])
+        .to_dict(False)
+    ) == {"col1": [[1, 2, 3]]}
+
+    assert (
+        pl.DataFrame({"col1": [1, 2, 3]})
+        .with_columns([pl.col("col1").cumulative_eval(pl.element().map(lambda x: 0))])
+        .to_dict(False)
+    ) == {"col1": [0, 0, 0]}
+
+
+def test_clip() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
+    assert df.select(pl.col("a").clip(2, 4))["a"].to_list() == [2, 2, 3, 4, 4]
+    assert pl.Series([1, 2, 3, 4, 5]).clip(2, 4).to_list() == [2, 2, 3, 4, 4]
+    assert pl.Series([1, 2, 3, 4, 5]).clip_min(3).to_list() == [3, 3, 3, 4, 5]
+    assert pl.Series([1, 2, 3, 4, 5]).clip_max(3).to_list() == [1, 2, 3, 3, 3]
+
+
+def test_cum_agg() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 2]})
+    assert_series_equal(
+        df.select(pl.col("a").cumsum())["a"], pl.Series("a", [1, 3, 6, 8])
+    )
+    assert_series_equal(
+        df.select(pl.col("a").cummin())["a"], pl.Series("a", [1, 1, 1, 1])
+    )
+    assert_series_equal(
+        df.select(pl.col("a").cummax())["a"], pl.Series("a", [1, 2, 3, 3])
+    )
+    assert_series_equal(
+        df.select(pl.col("a").cumprod())["a"], pl.Series("a", [1, 2, 6, 12])
+    )
+
+
+def test_floor() -> None:
+    df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
+    col_a_floor = df.select(pl.col("a").floor())["a"]
+    assert_series_equal(col_a_floor, pl.Series("a", [1, 1, 3]).cast(pl.Float64))
+
+
+def test_floor_divide() -> None:
+    x = 10.4
+    step = 0.5
+    df = pl.DataFrame({"x": [x]})
+    assert df.with_columns(pl.col("x") // step)[0, 0] == x // step
+
+
+def test_round() -> None:
+    df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
+    col_a_rounded = df.select(pl.col("a").round(decimals=0))["a"]
+    assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
+
+
+def test_dot() -> None:
+    df = pl.DataFrame({"a": [1.8, 1.2, 3.0], "b": [3.2, 1, 2]})
+    assert cast(float, df.select(pl.col("a").dot(pl.col("b"))).item()) == 12.96
+
+
+def test_all_expr() -> None:
+    df = pl.DataFrame({"nrs": [1, 2, 3, 4, 5, None]})
+    assert_frame_equal(df.select([pl.all()]), df)
+
+
+def test_any_expr(fruits_cars: pl.DataFrame) -> None:
+    assert fruits_cars.with_columns(pl.col("A").cast(bool)).select(pl.any("A"))[0, 0]
+    assert fruits_cars.select(pl.any([pl.col("A"), pl.col("B")]))[0, 0]
+
+
+def test_rolling_apply() -> None:
+    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float64)
+    out = s.rolling_apply(function=lambda s: s.std(), window_size=3)
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 4.358898943540674
+    assert out.dtype is pl.Float64
+
+    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
+    out = s.rolling_apply(function=lambda s: s.std(), window_size=3)
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 4.358899116516113
+    assert out.dtype is pl.Float32
+
+    s = pl.Series("A", [1, 2, 9, 2, 13], dtype=pl.Int32)
+    out = s.rolling_apply(function=lambda s: s.sum(), window_size=3)
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 12
+    assert out.dtype is pl.Int32
+
+    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float64)
+    out = s.rolling_apply(
+        function=lambda s: s.std(), window_size=3, weights=[1.0, 2.0, 3.0]
+    )
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 14.224392195567912
+    assert out.dtype is pl.Float64
+
+    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
+    out = s.rolling_apply(
+        function=lambda s: s.std(), window_size=3, weights=[1.0, 2.0, 3.0]
+    )
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 14.22439193725586
+    assert out.dtype is pl.Float32
+
+    s = pl.Series("A", [1, 2, 9, None, 13], dtype=pl.Int32)
+    out = s.rolling_apply(
+        function=lambda s: s.sum(), window_size=3, weights=[1.0, 2.0, 3.0]
+    )
+    assert out[0] is None
+    assert out[1] is None
+    assert out[2] == 32.0
+    assert out.dtype is pl.Float64
+    s = pl.Series("A", [1, 2, 9, 2, 10])
+
+    # compare rolling_apply to specific rolling functions
+    s = pl.Series("A", list(range(5)), dtype=pl.Float64)
+    roll_app_sum = s.rolling_apply(
+        function=lambda s: s.sum(),
+        window_size=3,
+        weights=[1.0, 2.1, 3.2],
+        min_periods=2,
+        center=True,
+    )
+
+    roll_sum = s.rolling_sum(
+        window_size=3, weights=[1.0, 2.1, 3.2], min_periods=2, center=True
+    )
+
+    assert (roll_app_sum - roll_sum).abs().sum() < 0.0001
+
+    s = pl.Series("A", list(range(6)), dtype=pl.Float64)
+    roll_app_std = s.rolling_apply(
+        function=lambda s: s.std(),
+        window_size=4,
+        weights=[1.0, 2.0, 3.0, 0.1],
+        min_periods=3,
+        center=False,
+    )
+
+    roll_std = s.rolling_std(
+        window_size=4, weights=[1.0, 2.0, 3.0, 0.1], min_periods=3, center=False
+    )
+
+    assert (roll_app_std - roll_std).abs().sum() < 0.0001
+
+
+def test_ufunc() -> None:
+    # NOTE: unfortunately we must use cast instead of a type: ignore comment
+    #   1. CI job with Python 3.10, numpy==1.23.1 -> mypy complains about arg-type
+    #   2. so we try to resolve it with type: ignore[arg-type]
+    #   3. CI job with Python 3.7, numpy==1.21.6 -> mypy complains about
+    #       unused type: ignore comment
+    # for more information, see: https://github.com/python/mypy/issues/8823
+
+    df = pl.DataFrame([pl.Series("a", [1, 2, 3, 4], dtype=pl.UInt8)])
+    out = df.select(
+        [
+            np.power(cast(Any, pl.col("a")), 2).alias("power_uint8"),
+            np.power(cast(Any, pl.col("a")), 2.0).alias("power_float64"),
+            np.power(cast(Any, pl.col("a")), 2, dtype=np.uint16).alias("power_uint16"),
+        ]
+    )
+    expected = pl.DataFrame(
+        [
+            pl.Series("power_uint8", [1, 4, 9, 16], dtype=pl.UInt8),
+            pl.Series("power_float64", [1.0, 4.0, 9.0, 16.0], dtype=pl.Float64),
+            pl.Series("power_uint16", [1, 4, 9, 16], dtype=pl.UInt16),
+        ]
+    )
+    assert_frame_equal(out, expected)
+    assert out.dtypes == expected.dtypes
+
+
+def test_ufunc_expr_not_first() -> None:
+    """Check numpy ufunc expressions also work if expression not the first argument."""
+    df = pl.DataFrame([pl.Series("a", [1, 2, 3], dtype=pl.Float64)])
+    out = df.select(
+        [
+            np.power(2.0, cast(Any, pl.col("a"))).alias("power"),
+            (2.0 / cast(Any, pl.col("a"))).alias("divide_scalar"),
+            (np.array([2, 2, 2]) / cast(Any, pl.col("a"))).alias("divide_array"),
+        ]
+    )
+    expected = pl.DataFrame(
+        [
+            pl.Series("power", [2**1, 2**2, 2**3], dtype=pl.Float64),
+            pl.Series("divide_scalar", [2 / 1, 2 / 2, 2 / 3], dtype=pl.Float64),
+            pl.Series("divide_array", [2 / 1, 2 / 2, 2 / 3], dtype=pl.Float64),
+        ]
+    )
+    assert_frame_equal(out, expected)
+
+
+def test_window_deadlock() -> None:
+    np.random.seed(12)
+
+    df = pl.DataFrame(
+        {
+            "nrs": [1, 2, 3, None, 5],
+            "names": ["foo", "ham", "spam", "egg", None],
+            "random": np.random.rand(5),
+            "groups": ["A", "A", "B", "C", "B"],
+        }
+    )
+
+    df = df.select(
+        [
+            pl.col("*"),  # select all
+            pl.col("random").sum().over("groups").alias("sum[random]/groups"),
+            pl.col("random").list().over("names").alias("random/name"),
+        ]
+    )

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
+from datetime import date, datetime
 from functools import reduce
 from operator import add
 from string import ascii_letters
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars import col, lit, when
+from polars import lit, when
 from polars.datatypes import NUMERIC_DTYPES, PolarsDataType
 from polars.testing import assert_frame_equal
 from polars.testing.asserts import assert_series_equal
@@ -20,27 +20,20 @@ if TYPE_CHECKING:
 
 
 def test_lazy() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    _ = df.lazy().with_columns(pl.lit(1).alias("foo")).select([col("a"), col("foo")])
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    _ = ldf.with_columns(pl.lit(1).alias("foo")).select([pl.col("a"), pl.col("foo")])
 
     # test if it executes
-    _ = (
-        df.lazy()
-        .with_columns(
-            when(pl.col("a") > pl.lit(2))
-            .then(pl.lit(10))
-            .otherwise(pl.lit(1))
-            .alias("new")
-        )
-        .collect()
-    )
+    _ = ldf.with_columns(
+        when(pl.col("a") > pl.lit(2)).then(pl.lit(10)).otherwise(pl.lit(1)).alias("new")
+    ).collect()
 
     # test if pl.list is available, this is `to_list` re-exported as list
-    eager = df.groupby("a").agg(pl.list("b"))
+    eager = ldf.groupby("a").agg(pl.list("b")).collect()
     assert sorted(eager.rows()) == [(1, [[1.0]]), (2, [[2.0]]), (3, [[3.0]])]
 
     # profile lazyframe operation/plan
-    lazy = df.lazy().groupby("a").agg(pl.list("b"))
+    lazy = ldf.groupby("a").agg(pl.list("b"))
     profiling_info = lazy.profile()
     # ┌──────────────┬───────┬─────┐
     # │ node         ┆ start ┆ end │
@@ -55,7 +48,7 @@ def test_lazy() -> None:
 
 
 def test_lazyframe_membership_operator() -> None:
-    ldf = pl.DataFrame({"name": ["Jane", "John"], "age": [20, 30]}).lazy()
+    ldf = pl.LazyFrame({"name": ["Jane", "John"], "age": [20, 30]})
     assert "name" in ldf
     assert "phone" not in ldf
 
@@ -65,15 +58,16 @@ def test_lazyframe_membership_operator() -> None:
 
 
 def test_apply() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    new = df.lazy().with_columns(col("a").map(lambda s: s * 2).alias("foo")).collect()
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    new = ldf.with_columns(pl.col("a").map(lambda s: s * 2).alias("foo"))
 
-    expected = df.clone().with_columns((pl.col("a") * 2).alias("foo"))
+    expected = ldf.clone().with_columns((pl.col("a") * 2).alias("foo"))
     assert_frame_equal(new, expected)
+    assert_frame_equal(new.collect(), expected.collect())
 
 
 def test_add_eager_column() -> None:
-    ldf = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}).lazy()
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     assert ldf.width == 2
 
     out = ldf.with_columns(pl.lit(pl.Series("c", [1, 2, 3]))).collect()
@@ -82,12 +76,10 @@ def test_add_eager_column() -> None:
 
 
 def test_set_null() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    out = (
-        df.lazy()
-        .with_columns(when(col("a") > 1).then(lit(None)).otherwise(100).alias("foo"))
-        .collect()
-    )
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    out = ldf.with_columns(
+        when(pl.col("a") > 1).then(lit(None)).otherwise(100).alias("foo")
+    ).collect()
     s = out["foo"]
     assert s[0] == 100
     assert s[1] is None
@@ -95,14 +87,14 @@ def test_set_null() -> None:
 
 
 def test_take_every() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}).lazy()
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]})
     expected_df = pl.DataFrame({"a": [1, 3], "b": ["w", "y"]})
-    assert_frame_equal(expected_df, df.take_every(2).collect())
+    assert_frame_equal(expected_df, ldf.take_every(2).collect())
 
 
 def test_slice() -> None:
-    ldf = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]}).lazy()
-    expected = pl.DataFrame({"a": [3, 4], "b": ["c", "d"]}).lazy()
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]})
+    expected = pl.LazyFrame({"a": [3, 4], "b": ["c", "d"]})
     for slice_params in (
         [2, 10],  # slice > len(df)
         [2, 4],  # slice == len(df)
@@ -134,15 +126,14 @@ def test_agg() -> None:
 
 
 def test_or() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    out = df.lazy().filter((pl.col("a") == 1) | (pl.col("b") > 2)).collect()
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    out = ldf.filter((pl.col("a") == 1) | (pl.col("b") > 2)).collect()
     assert out.rows() == [(1, 1.0), (3, 3.0)]
 
 
 def test_groupby_apply() -> None:
-    df = pl.DataFrame({"a": [1, 1, 3], "b": [1.0, 2.0, 3.0]})
     ldf = (
-        df.lazy()
+        pl.LazyFrame({"a": [1, 1, 3], "b": [1.0, 2.0, 3.0]})
         .groupby("a")
         .apply(lambda df: df * 2.0, schema={"a": pl.Float64, "b": pl.Float64})
     )
@@ -153,26 +144,25 @@ def test_groupby_apply() -> None:
 
 def test_filter_str() -> None:
     # use a str instead of a column expr
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "time": ["11:11:00", "11:12:00", "11:13:00", "11:14:00"],
             "bools": [True, False, True, False],
         }
     )
-    q = df.lazy()
 
     # last row based on a filter
-    result = q.filter(pl.col("bools")).select(pl.last("*")).collect()
+    result = ldf.filter(pl.col("bools")).select(pl.last("*")).collect()
     expected = pl.DataFrame({"time": ["11:13:00"], "bools": [True]})
     assert_frame_equal(result, expected)
 
     # last row based on a filter
-    result = q.filter("bools").select(pl.last("*")).collect()
+    result = ldf.filter("bools").select(pl.last("*")).collect()
     assert_frame_equal(result, expected)
 
 
 def test_apply_custom_function() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "A": [1, 2, 3, 4, 5],
             "fruits": ["banana", "banana", "apple", "apple", "banana"],
@@ -182,9 +172,8 @@ def test_apply_custom_function() -> None:
     )
 
     # two ways to determine the length groups.
-    a = (
-        df.lazy()
-        .groupby("fruits")
+    df = (
+        ldf.groupby("fruits")
         .agg(
             [
                 pl.col("cars")
@@ -198,6 +187,7 @@ def test_apply_custom_function() -> None:
         )
         .sort("custom_1", descending=True)
     ).collect()
+
     expected = pl.DataFrame(
         {
             "fruits": ["banana", "apple"],
@@ -207,25 +197,25 @@ def test_apply_custom_function() -> None:
         }
     )
     expected = expected.with_columns(pl.col("cars_count").cast(pl.UInt32))
-    assert_frame_equal(a, expected)
+    assert_frame_equal(df, expected)
 
 
 def test_groupby() -> None:
-    df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
+    ldf = pl.LazyFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
 
     expected = pl.DataFrame({"groups": ["a", "b"], "a": [1.0, 3.5]})
 
-    out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
+    out = ldf.groupby("groups").agg(pl.mean("a")).collect()
     assert_frame_equal(out.sort(by="groups"), expected)
 
     # refer to column via pl.Expr
-    out = df.lazy().groupby(pl.col("groups")).agg(pl.mean("a")).collect()
+    out = ldf.groupby(pl.col("groups")).agg(pl.mean("a")).collect()
     assert_frame_equal(out.sort(by="groups"), expected)
 
 
 def test_shift(fruits_cars: pl.DataFrame) -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
-    out = df.select(col("a").shift(1))
+    out = df.select(pl.col("a").shift(1))
     assert_series_equal(out["a"], pl.Series("a", [None, 1, 2, 3, 4]))
 
     res = fruits_cars.lazy().shift(2).collect()
@@ -248,69 +238,68 @@ def test_shift(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_shift_and_fill() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
 
     # use exprs
-    out = df.lazy().with_columns(col("a").shift_and_fill(-2, col("b").mean())).collect()
+    out = ldf.with_columns(pl.col("a").shift_and_fill(-2, pl.col("b").mean())).collect()
     assert out["a"].null_count() == 0
 
     # use df method
-    out = df.lazy().shift_and_fill(2, col("b").std()).collect()
+    out = ldf.shift_and_fill(2, pl.col("b").std()).collect()
     assert out["a"].null_count() == 0
 
 
 def test_arange() -> None:
-    df = pl.DataFrame({"a": [1, 1, 1]}).lazy()
-    result = df.filter(pl.col("a") >= pl.arange(0, 3)).collect()
+    ldf = pl.LazyFrame({"a": [1, 1, 1]})
+    result = ldf.filter(pl.col("a") >= pl.arange(0, 3)).collect()
     expected = pl.DataFrame({"a": [1, 1]})
     assert_frame_equal(result, expected)
 
 
 def test_arg_unique() -> None:
-    df = pl.DataFrame({"a": [4, 1, 4]})
-    col_a_unique = df.select(col("a").arg_unique())["a"]
+    ldf = pl.LazyFrame({"a": [4, 1, 4]})
+    col_a_unique = ldf.select(pl.col("a").arg_unique()).collect()["a"]
     assert_series_equal(col_a_unique, pl.Series("a", [0, 1]).cast(pl.UInt32))
 
 
 def test_is_unique() -> None:
     df = pl.DataFrame({"a": [4, 1, 4]})
-    result = df.select(col("a").is_unique())["a"]
+    result = df.select(pl.col("a").is_unique())["a"]
     assert_series_equal(result, pl.Series("a", [False, True, False]))
 
 
 def test_is_first() -> None:
-    df = pl.DataFrame({"a": [4, 1, 4]})
-    result = df.select(col("a").is_first())["a"]
+    ldf = pl.LazyFrame({"a": [4, 1, 4]})
+    result = ldf.select(pl.col("a").is_first()).collect()["a"]
     assert_series_equal(result, pl.Series("a", [True, True, False]))
 
     # struct
-    df = pl.DataFrame({"a": [1, 2, 3, 2, None, 2, 1], "b": [0, 2, 3, 2, None, 2, 0]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 2, None, 2, 1], "b": [0, 2, 3, 2, None, 2, 0]})
 
-    assert df.select(pl.struct(["a", "b"]).is_first()).to_dict(False) == {
+    assert ldf.select(pl.struct(["a", "b"]).is_first()).collect().to_dict(False) == {
         "a": [True, True, True, False, True, False, False]
     }
 
 
 def test_is_duplicated() -> None:
-    df = pl.DataFrame({"a": [4, 1, 4]})
-    result = df.select(col("a").is_duplicated())["a"]
-    assert_series_equal(result, pl.Series("a", [True, False, True]))
+    ldf = pl.LazyFrame({"a": [4, 1, 4]}).select(pl.col("a").is_duplicated())
+    assert_series_equal(ldf.collect()["a"], pl.Series("a", [True, False, True]))
 
 
 def test_arg_sort() -> None:
-    df = pl.DataFrame({"a": [4, 1, 3]})
-    assert df.select(col("a").arg_sort())["a"].to_list() == [1, 2, 0]
+    ldf = pl.LazyFrame({"a": [4, 1, 3]}).select(pl.col("a").arg_sort())
+    assert ldf.collect()["a"].to_list() == [1, 2, 0]
 
 
 def test_window_function() -> None:
-    ldf = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "A": [1, 2, 3, 4, 5],
             "fruits": ["banana", "banana", "apple", "apple", "banana"],
             "B": [5, 4, 3, 2, 1],
             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
         }
-    ).lazy()
+    )
     assert ldf.width == 4
 
     q = ldf.with_columns(
@@ -329,29 +318,29 @@ def test_window_function() -> None:
 
 
 def test_when_then_flatten() -> None:
-    df = pl.DataFrame({"foo": [1, 2, 3], "bar": [3, 4, 5]})
+    ldf = pl.LazyFrame({"foo": [1, 2, 3], "bar": [3, 4, 5]})
 
-    assert df.select(
-        when(col("foo") > 1)
-        .then(col("bar"))
-        .when(col("bar") < 3)
+    assert ldf.select(
+        when(pl.col("foo") > 1)
+        .then(pl.col("bar"))
+        .when(pl.col("bar") < 3)
         .then(10)
         .otherwise(30)
-    )["bar"].to_list() == [30, 4, 5]
+    ).collect()["bar"].to_list() == [30, 4, 5]
 
 
 def test_describe_plan() -> None:
-    assert isinstance(pl.DataFrame({"a": [1]}).lazy().describe_optimized_plan(), str)
-    assert isinstance(pl.DataFrame({"a": [1]}).lazy().describe_plan(), str)
+    assert isinstance(pl.LazyFrame({"a": [1]}).describe_optimized_plan(), str)
+    assert isinstance(pl.LazyFrame({"a": [1]}).describe_plan(), str)
 
 
 def test_inspect(capsys: CaptureFixture[str]) -> None:
-    df = pl.DataFrame({"a": [1]})
-    df.lazy().inspect().collect()
+    ldf = pl.LazyFrame({"a": [1]})
+    ldf.inspect().collect()
     captured = capsys.readouterr()
     assert len(captured.out) > 0
 
-    df.select(pl.col("a").cumsum().inspect().alias("bar"))
+    ldf.select(pl.col("a").cumsum().inspect().alias("bar")).collect()
     res = capsys.readouterr()
     assert len(res.out) > 0
 
@@ -361,59 +350,43 @@ def test_fetch(fruits_cars: pl.DataFrame) -> None:
     assert_frame_equal(res, res[:2])
 
 
-def test_window_deadlock() -> None:
-    np.random.seed(12)
-
-    df = pl.DataFrame(
-        {
-            "nrs": [1, 2, 3, None, 5],
-            "names": ["foo", "ham", "spam", "egg", None],
-            "random": np.random.rand(5),
-            "groups": ["A", "A", "B", "C", "B"],
-        }
-    )
-
-    df = df.select(
-        [
-            col("*"),  # select all
-            col("random").sum().over("groups").alias("sum[random]/groups"),
-            col("random").list().over("names").alias("random/name"),
-        ]
-    )
-
-
 def test_concat_str() -> None:
-    df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
+    ldf = pl.LazyFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 
-    out = df.select([pl.concat_str(["a", "b"], sep="-")])
-    assert out["a"].to_list() == ["a-1", "b-2", "c-3"]
+    out = ldf.select([pl.concat_str(["a", "b"], sep="-")])
+    assert out.collect()["a"].to_list() == ["a-1", "b-2", "c-3"]
 
-    out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
-    assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
+    out = ldf.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
+    assert out.collect()["fmt"].to_list() == [
+        "foo_a_bar_1",
+        "foo_b_bar_2",
+        "foo_c_bar_3",
+    ]
 
 
 def test_fold_filter() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
 
-    out = df.filter(
+    out = ldf.filter(
         pl.fold(
             acc=pl.lit(True),
             function=lambda a, b: a & b,
-            exprs=[pl.col(c) > 1 for c in df.columns],
+            exprs=[pl.col(c) > 1 for c in ldf.columns],
         )
-    )
+    ).collect()
 
     assert out.shape == (1, 2)
+    assert out.rows() == [(3, 2)]
 
-    out = df.filter(
+    out = ldf.filter(
         pl.fold(
             acc=pl.lit(True),
             function=lambda a, b: a | b,
-            exprs=[pl.col(c) > 1 for c in df.columns],
+            exprs=[pl.col(c) > 1 for c in ldf.columns],
         )
-    )
+    ).collect()
 
-    assert out.shape == (3, 2)
+    assert out.rows() == [(1, 0), (2, 1), (3, 2)]
 
 
 def test_head_groupby() -> None:
@@ -453,19 +426,18 @@ def test_head_groupby() -> None:
         ],
         "price": [1.0, 0.7, 0.8, 0.55, 2.0, 3.0, 2.4, 1.8, 2.1],
     }
-    df = pl.DataFrame(commodity_prices)
+    ldf = pl.LazyFrame(commodity_prices)
 
     # this query flexes the wildcard exclusion quite a bit.
     keys = ["commodity", "location"]
     out = (
-        df.sort(by="price", descending=True)
+        ldf.sort(by="price", descending=True)
         .groupby(keys, maintain_order=True)
-        .agg([col("*").exclude(keys).head(2).keep_name()])
-        .explode(col("*").exclude(keys))
+        .agg([pl.col("*").exclude(keys).head(2).keep_name()])
+        .explode(pl.col("*").exclude(keys))
     )
 
-    assert out.shape == (5, 4)
-    assert out.rows() == [
+    assert out.collect().rows() == [
         ("Corn", "Chicago", "Mary", 3.0),
         ("Corn", "Chicago", "Paul", 2.4),
         ("Wheat", "StPaul", "Bob", 1.0),
@@ -473,136 +445,160 @@ def test_head_groupby() -> None:
         ("Wheat", "Chicago", "Paul", 0.55),
     ]
 
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {"letters": ["c", "c", "a", "c", "a", "b"], "nrs": [1, 2, 3, 4, 5, 6]}
     )
-    out = df.groupby("letters").tail(2).sort("letters")
+    out = ldf.groupby("letters").tail(2).sort("letters")
     assert_frame_equal(
-        out,
+        out.collect(),
         pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 2, 4]}),
     )
-    out = df.groupby("letters").head(2).sort("letters")
+    out = ldf.groupby("letters").head(2).sort("letters")
     assert_frame_equal(
-        out,
+        out.collect(),
         pl.DataFrame({"letters": ["a", "a", "b", "c", "c"], "nrs": [3, 5, 6, 1, 2]}),
     )
 
 
 def test_is_null_is_not_null() -> None:
-    df = pl.DataFrame({"nrs": [1, 2, None]})
-    assert df.select(col("nrs").is_null())["nrs"].to_list() == [False, False, True]
-    assert df.select(col("nrs").is_not_null())["nrs"].to_list() == [True, True, False]
+    ldf = pl.LazyFrame({"nrs": [1, 2, None]}).select(
+        pl.col("nrs").is_null().alias("is_null"),
+        pl.col("nrs").is_not_null().alias("not_null"),
+    )
+    assert ldf.collect()["is_null"].to_list() == [False, False, True]
+    assert ldf.collect()["not_null"].to_list() == [True, True, False]
 
 
 def test_is_nan_is_not_nan() -> None:
-    df = pl.DataFrame({"nrs": np.array([1, 2, np.nan])})
-    assert df.select(col("nrs").is_nan())["nrs"].to_list() == [False, False, True]
-    assert df.select(col("nrs").is_not_nan())["nrs"].to_list() == [True, True, False]
+    ldf = pl.LazyFrame({"nrs": np.array([1, 2, np.nan])}).select(
+        pl.col("nrs").is_nan().alias("is_nan"),
+        pl.col("nrs").is_not_nan().alias("not_nan"),
+    )
+    assert ldf.collect()["is_nan"].to_list() == [False, False, True]
+    assert ldf.collect()["not_nan"].to_list() == [True, True, False]
 
 
 def test_is_finite_is_infinite() -> None:
-    df = pl.DataFrame({"nrs": np.array([1, 2, np.inf])})
-    assert df.select(col("nrs").is_infinite())["nrs"].to_list() == [False, False, True]
-    assert df.select(col("nrs").is_finite())["nrs"].to_list() == [True, True, False]
+    ldf = pl.LazyFrame({"nrs": np.array([1, 2, np.inf])}).select(
+        pl.col("nrs").is_infinite().alias("is_inf"),
+        pl.col("nrs").is_finite().alias("not_inf"),
+    )
+    assert ldf.collect()["is_inf"].to_list() == [False, False, True]
+    assert ldf.collect()["not_inf"].to_list() == [True, True, False]
 
 
 def test_len() -> None:
-    df = pl.DataFrame({"nrs": [1, 2, 3]})
-    assert cast(int, df.select(col("nrs").len()).item()) == 3
+    ldf = pl.LazyFrame({"nrs": [1, 2, 3]})
+    assert cast(int, ldf.select(pl.col("nrs").len()).collect().item()) == 3
 
 
 def test_cum_agg() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 2]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 2]})
     assert_series_equal(
-        df.select(pl.col("a").cumsum())["a"], pl.Series("a", [1, 3, 6, 8])
+        ldf.select(pl.col("a").cumsum()).collect()["a"], pl.Series("a", [1, 3, 6, 8])
     )
     assert_series_equal(
-        df.select(pl.col("a").cummin())["a"], pl.Series("a", [1, 1, 1, 1])
+        ldf.select(pl.col("a").cummin()).collect()["a"], pl.Series("a", [1, 1, 1, 1])
     )
     assert_series_equal(
-        df.select(pl.col("a").cummax())["a"], pl.Series("a", [1, 2, 3, 3])
+        ldf.select(pl.col("a").cummax()).collect()["a"], pl.Series("a", [1, 2, 3, 3])
     )
     assert_series_equal(
-        df.select(pl.col("a").cumprod())["a"], pl.Series("a", [1, 2, 6, 12])
+        ldf.select(pl.col("a").cumprod()).collect()["a"], pl.Series("a", [1, 2, 6, 12])
     )
 
 
 def test_floor() -> None:
-    df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
-    col_a_floor = df.select(pl.col("a").floor())["a"]
-    assert_series_equal(col_a_floor, pl.Series("a", [1, 1, 3]).cast(pl.Float64))
+    ldf = pl.LazyFrame({"a": [1.8, 1.2, 3.0]}).select(pl.col("a").floor())
+    assert_series_equal(ldf.collect()["a"], pl.Series("a", [1, 1, 3]).cast(pl.Float64))
 
 
 def test_round() -> None:
-    df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
-    col_a_rounded = df.select(pl.col("a").round(decimals=0))["a"]
-    assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
+    ldf = pl.LazyFrame({"a": [1.8, 1.2, 3.0]}).select(pl.col("a").round(decimals=0))
+    assert_series_equal(ldf.collect()["a"], pl.Series("a", [2, 1, 3]).cast(pl.Float64))
 
 
 def test_dot() -> None:
-    df = pl.DataFrame({"a": [1.8, 1.2, 3.0], "b": [3.2, 1, 2]})
-    assert cast(float, df.select(pl.col("a").dot(pl.col("b"))).item()) == 12.96
+    ldf = pl.LazyFrame({"a": [1.8, 1.2, 3.0], "b": [3.2, 1, 2]}).select(
+        pl.col("a").dot(pl.col("b"))
+    )
+    assert cast(float, ldf.collect().item()) == 12.96
 
 
 def test_sort() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 2]})
-    assert_series_equal(
-        df.select(pl.col("a").sort())["a"], pl.Series("a", [1, 2, 2, 3])
-    )
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 2]}).select(pl.col("a").sort())
+    assert_series_equal(ldf.collect()["a"], pl.Series("a", [1, 2, 2, 3]))
 
 
 def test_all_expr() -> None:
-    df = pl.DataFrame({"nrs": [1, 2, 3, 4, 5, None]})
-    assert_frame_equal(df.select([pl.all()]), df)
+    ldf = pl.LazyFrame({"nrs": [1, 2, 3, 4, 5, None]})
+    assert_frame_equal(ldf.select([pl.all()]), ldf)
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.with_columns(pl.col("A").cast(bool)).select(pl.any("A"))[0, 0]
-    assert fruits_cars.select(pl.any([pl.col("A"), pl.col("B")]))[0, 0]
+    assert (
+        fruits_cars.lazy()
+        .with_columns(pl.col("A").cast(bool))
+        .select(pl.any("A"))
+        .collect()[0, 0]
+    ) is True
+    assert (
+        fruits_cars.lazy().select(pl.any([pl.col("A"), pl.col("B")])).collect()[0, 0]
+    ) is True
+
+
+def test_custom_groupby() -> None:
+    ldf = pl.LazyFrame({"a": [1, 2, 1, 1], "b": ["a", "b", "c", "c"]})
+    out = (
+        ldf.groupby("b", maintain_order=True)
+        .agg([pl.col("a").apply(lambda x: x.sum(), return_dtype=pl.Int64)])
+        .collect()
+    )
+    assert out.rows() == [("a", 1), ("b", 2), ("c", 2)]
 
 
 def test_lazy_columns() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "a": [1],
             "b": [1],
             "c": [1],
         }
-    ).lazy()
-    assert df.select(["a", "c"]).columns == ["a", "c"]
+    )
+    assert ldf.select(["a", "c"]).columns == ["a", "c"]
 
 
 def test_regex_selection() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "foo": [1],
             "fooey": [1],
             "foobar": [1],
             "bar": [1],
         }
-    ).lazy()
-    assert df.select([col("^foo.*$")]).columns == ["foo", "fooey", "foobar"]
+    )
+    assert ldf.select([pl.col("^foo.*$")]).columns == ["foo", "fooey", "foobar"]
 
 
 def test_exclude_selection() -> None:
-    df = pl.DataFrame({"a": [1], "b": [1], "c": [True]}).lazy()
+    ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [True]})
 
-    assert df.select([pl.exclude("a")]).columns == ["b", "c"]
-    assert df.select(pl.all().exclude(pl.Boolean)).columns == ["a", "b"]
-    assert df.select(pl.all().exclude([pl.Boolean])).columns == ["a", "b"]
-    assert df.select(pl.all().exclude(NUMERIC_DTYPES)).columns == ["c"]
+    assert ldf.select([pl.exclude("a")]).columns == ["b", "c"]
+    assert ldf.select(pl.all().exclude(pl.Boolean)).columns == ["a", "b"]
+    assert ldf.select(pl.all().exclude([pl.Boolean])).columns == ["a", "b"]
+    assert ldf.select(pl.all().exclude(NUMERIC_DTYPES)).columns == ["c"]
 
 
 def test_col_series_selection() -> None:
-    df = pl.DataFrame({"a": [1], "b": [1], "c": [1]}).lazy()
+    ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [1]})
     srs = pl.Series(["b", "c"])
 
-    assert df.select(pl.col(srs)).columns == ["b", "c"]
+    assert ldf.select(pl.col(srs)).columns == ["b", "c"]
 
 
 def test_interpolate() -> None:
     df = pl.DataFrame({"a": [1, None, 3]})
-    assert df.select(col("a").interpolate())["a"].to_list() == [1, 2, 3]
+    assert df.select(pl.col("a").interpolate())["a"].to_list() == [1, 2, 3]
     assert df["a"].interpolate().to_list() == [1, 2, 3]
     assert df.interpolate()["a"].to_list() == [1, 2, 3]
     assert df.lazy().interpolate().collect()["a"].to_list() == [1, 2, 3]
@@ -641,83 +637,90 @@ def test_fill_null() -> None:
 
 
 def test_backward_fill() -> None:
-    df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    col_a_backward_fill = df.select([pl.col("a").backward_fill()])["a"]
+    ldf = pl.LazyFrame({"a": [1.0, None, 3.0]})
+    col_a_backward_fill = ldf.select([pl.col("a").backward_fill()]).collect()["a"]
     assert_series_equal(col_a_backward_fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
 
 def test_take(fruits_cars: pl.DataFrame) -> None:
-    df = fruits_cars
+    ldf = fruits_cars.lazy()
 
     # out of bounds error
     with pytest.raises(pl.ComputeError):
         (
-            df.sort("fruits").select(
-                [col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]
+            ldf.sort("fruits")
+            .select(
+                [pl.col("B").reverse().take([1, 2]).list().over("fruits"), "fruits"]
             )
+            .collect()
         )
 
     for index in [[0, 1], pl.Series([0, 1]), np.array([0, 1])]:
-        out = df.sort("fruits").select(
-            [
-                col("B")
-                .reverse()
-                .take(index)  # type: ignore[arg-type]
-                .list()
-                .over("fruits"),
-                "fruits",
-            ]
+        out = (
+            ldf.sort("fruits")
+            .select(
+                [
+                    pl.col("B")
+                    .reverse()
+                    .take(index)  # type: ignore[arg-type]
+                    .list()
+                    .over("fruits"),
+                    "fruits",
+                ]
+            )
+            .collect()
         )
 
         assert out[0, "B"].to_list() == [2, 3]
         assert out[4, "B"].to_list() == [1, 4]
 
-    out = df.sort("fruits").select(
-        [col("B").reverse().take(pl.lit(1)).list().over("fruits"), "fruits"]
+    out = (
+        ldf.sort("fruits")
+        .select([pl.col("B").reverse().take(pl.lit(1)).list().over("fruits"), "fruits"])
+        .collect()
     )
     assert out[0, "B"] == 3
     assert out[4, "B"] == 4
 
 
 def test_select_by_col_list(fruits_cars: pl.DataFrame) -> None:
-    df = fruits_cars
-    result = df.select(col(["A", "B"]).sum())
-    expected = pl.DataFrame({"A": 15, "B": 15})
+    ldf = fruits_cars.lazy()
+    result = ldf.select(pl.col(["A", "B"]).sum())
+    expected = pl.LazyFrame({"A": 15, "B": 15})
     assert_frame_equal(result, expected)
 
 
 def test_select_args_kwargs() -> None:
-    df = pl.DataFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
+    ldf = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
 
     # Single column name
-    result = df.select("foo")
-    expected = pl.DataFrame({"foo": [1, 2]})
+    result = ldf.select("foo")
+    expected = pl.LazyFrame({"foo": [1, 2]})
     assert_frame_equal(result, expected)
 
     # Column names as list
-    result = df.select(["foo", "bar"])
-    expected = pl.DataFrame({"foo": [1, 2], "bar": [3, 4]})
+    result = ldf.select(["foo", "bar"])
+    expected = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4]})
     assert_frame_equal(result, expected)
 
     # Column names as positional arguments
-    result = df.select("foo", "bar", "ham")
-    expected = df
+    result, expected = ldf.select("foo", "bar", "ham"), ldf
     assert_frame_equal(result, expected)
 
     # Keyword arguments
-    result = df.select(oof="foo")
-    expected = pl.DataFrame({"oof": [1, 2]})
+    result = ldf.select(oof="foo")
+    expected = pl.LazyFrame({"oof": [1, 2]})
     assert_frame_equal(result, expected)
 
     # Mixed
-    result = df.select(["bar"], "foo", oof="foo")
-    expected = pl.DataFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
+    result = ldf.select(["bar"], "foo", oof="foo")
+    expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
     assert_frame_equal(result, expected)
 
 
 def test_rolling(fruits_cars: pl.DataFrame) -> None:
-    df = fruits_cars
-    out = df.select(
+    ldf = fruits_cars.lazy()
+    out = ldf.select(
         [
             pl.col("A").rolling_min(3, min_periods=1).alias("1"),
             pl.col("A").rolling_min(3).alias("1b"),
@@ -734,7 +737,7 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
     )
 
     assert_frame_equal(
-        out,
+        out.collect(),
         pl.DataFrame(
             {
                 "1": [1, 1, 1, 2, 3],
@@ -751,102 +754,20 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
         ),
     )
 
-    out_single_val_variance = df.select(
+    out_single_val_variance = ldf.select(
         [
             pl.col("A").rolling_std(3, min_periods=1).round(decimals=4).alias("std"),
             pl.col("A").rolling_var(3, min_periods=1).round(decimals=1).alias("var"),
         ]
-    )
+    ).collect()
 
     assert cast(float, out_single_val_variance[0, "std"]) == 0.0
     assert cast(float, out_single_val_variance[0, "var"]) == 0.0
 
 
-def test_rolling_apply() -> None:
-    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float64)
-    out = s.rolling_apply(function=lambda s: s.std(), window_size=3)
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 4.358898943540674
-    assert out.dtype is pl.Float64
-
-    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
-    out = s.rolling_apply(function=lambda s: s.std(), window_size=3)
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 4.358899116516113
-    assert out.dtype is pl.Float32
-
-    s = pl.Series("A", [1, 2, 9, 2, 13], dtype=pl.Int32)
-    out = s.rolling_apply(function=lambda s: s.sum(), window_size=3)
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 12
-    assert out.dtype is pl.Int32
-
-    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float64)
-    out = s.rolling_apply(
-        function=lambda s: s.std(), window_size=3, weights=[1.0, 2.0, 3.0]
-    )
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 14.224392195567912
-    assert out.dtype is pl.Float64
-
-    s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
-    out = s.rolling_apply(
-        function=lambda s: s.std(), window_size=3, weights=[1.0, 2.0, 3.0]
-    )
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 14.22439193725586
-    assert out.dtype is pl.Float32
-
-    s = pl.Series("A", [1, 2, 9, None, 13], dtype=pl.Int32)
-    out = s.rolling_apply(
-        function=lambda s: s.sum(), window_size=3, weights=[1.0, 2.0, 3.0]
-    )
-    assert out[0] is None
-    assert out[1] is None
-    assert out[2] == 32.0
-    assert out.dtype is pl.Float64
-    s = pl.Series("A", [1, 2, 9, 2, 10])
-
-    # compare rolling_apply to specific rolling functions
-    s = pl.Series("A", list(range(5)), dtype=pl.Float64)
-    roll_app_sum = s.rolling_apply(
-        function=lambda s: s.sum(),
-        window_size=3,
-        weights=[1.0, 2.1, 3.2],
-        min_periods=2,
-        center=True,
-    )
-
-    roll_sum = s.rolling_sum(
-        window_size=3, weights=[1.0, 2.1, 3.2], min_periods=2, center=True
-    )
-
-    assert (roll_app_sum - roll_sum).abs().sum() < 0.0001
-
-    s = pl.Series("A", list(range(6)), dtype=pl.Float64)
-    roll_app_std = s.rolling_apply(
-        function=lambda s: s.std(),
-        window_size=4,
-        weights=[1.0, 2.0, 3.0, 0.1],
-        min_periods=3,
-        center=False,
-    )
-
-    roll_std = s.rolling_std(
-        window_size=4, weights=[1.0, 2.0, 3.0, 0.1], min_periods=3, center=False
-    )
-
-    assert (roll_app_std - roll_std).abs().sum() < 0.0001
-
-
 def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
-    df = fruits_cars
-    out = df.select(
+    ldf = fruits_cars.lazy()
+    out = ldf.select(
         [
             "fruits",
             pl.col("B").list().over("fruits").arr.min().alias("B_by_fruits_min1"),
@@ -884,25 +805,25 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             ],
         }
     )
-    assert_frame_equal(out, expected)
+    assert_frame_equal(out.collect(), expected)
 
 
 def test_arithmetic() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3]})
 
-    out = df.select(
+    out = ldf.select(
         [
-            (col("a") % 2).alias("1"),
-            (2 % col("a")).alias("2"),
-            (1 // col("a")).alias("3"),
-            (1 * col("a")).alias("4"),
-            (1 + col("a")).alias("5"),
-            (1 - col("a")).alias("6"),
-            (col("a") // 2).alias("7"),
-            (col("a") * 2).alias("8"),
-            (col("a") + 2).alias("9"),
-            (col("a") - 2).alias("10"),
-            (-col("a")).alias("11"),
+            (pl.col("a") % 2).alias("1"),
+            (2 % pl.col("a")).alias("2"),
+            (1 // pl.col("a")).alias("3"),
+            (1 * pl.col("a")).alias("4"),
+            (1 + pl.col("a")).alias("5"),
+            (1 - pl.col("a")).alias("6"),
+            (pl.col("a") // 2).alias("7"),
+            (pl.col("a") * 2).alias("8"),
+            (pl.col("a") + 2).alias("9"),
+            (pl.col("a") - 2).alias("10"),
+            (-pl.col("a")).alias("11"),
         ]
     )
     expected = pl.DataFrame(
@@ -920,24 +841,20 @@ def test_arithmetic() -> None:
             "11": [-1, -2, -3],
         }
     )
-    assert_frame_equal(out, expected)
+    assert_frame_equal(out.collect(), expected)
 
-    # floating point floor divide
+
+def test_float_floor_divide() -> None:
     x = 10.4
     step = 0.5
-    df = pl.DataFrame({"x": [x]})
-    assert df.with_columns(pl.col("x") // step)[0, 0] == x // step
+    ldf = pl.LazyFrame({"x": [x]})
+    ldf_res = ldf.with_columns(pl.col("x") // step).collect().item()
+    assert ldf_res == x // step
 
 
-def test_ufunc() -> None:
-    # NOTE: unfortunately we must use cast instead of a type: ignore comment
-    #   1. CI job with Python 3.10, numpy==1.23.1 -> mypy complains about arg-type
-    #   2. so we try to resolve it with type: ignore[arg-type]
-    #   3. CI job with Python 3.7, numpy==1.21.6 -> mypy complains about
-    #       unused type: ignore comment
-    # for more information, see: https://github.com/python/mypy/issues/8823
-    df = pl.DataFrame([pl.Series("a", [1, 2, 3, 4], dtype=pl.UInt8)])
-    out = df.select(
+def test_lazy_ufunc() -> None:
+    ldf = pl.LazyFrame([pl.Series("a", [1, 2, 3, 4], dtype=pl.UInt8)])
+    out = ldf.select(
         [
             np.power(cast(Any, pl.col("a")), 2).alias("power_uint8"),
             np.power(cast(Any, pl.col("a")), 2.0).alias("power_float64"),
@@ -951,14 +868,13 @@ def test_ufunc() -> None:
             pl.Series("power_uint16", [1, 4, 9, 16], dtype=pl.UInt16),
         ]
     )
-    assert_frame_equal(out, expected)
-    assert out.dtypes == expected.dtypes
+    assert_frame_equal(out.collect(), expected)
 
 
-def test_ufunc_expr_not_first() -> None:
+def test_lazy_ufunc_expr_not_first() -> None:
     """Check numpy ufunc expressions also work if expression not the first argument."""
-    df = pl.DataFrame([pl.Series("a", [1, 2, 3], dtype=pl.Float64)])
-    out = df.select(
+    ldf = pl.LazyFrame([pl.Series("a", [1, 2, 3], dtype=pl.Float64)])
+    out = ldf.select(
         [
             np.power(2.0, cast(Any, pl.col("a"))).alias("power"),
             (2.0 / cast(Any, pl.col("a"))).alias("divide_scalar"),
@@ -972,60 +888,32 @@ def test_ufunc_expr_not_first() -> None:
             pl.Series("divide_array", [2 / 1, 2 / 2, 2 / 3], dtype=pl.Float64),
         ]
     )
-    assert_frame_equal(out, expected)
-
-
-def test_clip() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-    assert df.select(pl.col("a").clip(2, 4))["a"].to_list() == [2, 2, 3, 4, 4]
-    assert pl.Series([1, 2, 3, 4, 5]).clip(2, 4).to_list() == [2, 2, 3, 4, 4]
-    assert pl.Series([1, 2, 3, 4, 5]).clip_min(3).to_list() == [3, 3, 3, 4, 5]
-    assert pl.Series([1, 2, 3, 4, 5]).clip_max(3).to_list() == [1, 2, 3, 3, 3]
+    assert_frame_equal(out.collect(), expected)
 
 
 def test_argminmax() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 1, 2, 2, 2]})
-    out = df.select(
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 4, 5], "b": [1, 1, 2, 2, 2]})
+    out = ldf.select(
         [
             pl.col("a").arg_min().alias("min"),
             pl.col("a").arg_max().alias("max"),
         ]
-    )
+    ).collect()
     assert out["max"][0] == 4
     assert out["min"][0] == 0
 
-    out = df.groupby("b", maintain_order=True).agg(
-        [pl.col("a").arg_min().alias("min"), pl.col("a").arg_max().alias("max")]
+    out = (
+        ldf.groupby("b", maintain_order=True)
+        .agg([pl.col("a").arg_min().alias("min"), pl.col("a").arg_max().alias("max")])
+        .collect()
     )
     assert out["max"][0] == 1
     assert out["min"][0] == 0
 
 
-def test_expr_bool_cmp() -> None:
-    # Since expressions are lazy they should not be evaluated as
-    # bool(x), this has the nice side effect of throwing an error
-    # if someone tries to chain them via the and|or operators
-    df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
-
-    with pytest.raises(ValueError):
-        df.select([(pl.col("a") > pl.col("b")) and (pl.col("b") > pl.col("b"))])
-
-    with pytest.raises(ValueError):
-        df.select([(pl.col("a") > pl.col("b")) or (pl.col("b") > pl.col("b"))])
-
-
-def test_is_in() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    assert df.select(pl.col("a").is_in([1, 2]))["a"].to_list() == [
-        True,
-        True,
-        False,
-    ]
-
-
 def test_rename() -> None:
-    lf = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy()
-    out = lf.rename({"a": "foo", "b": "bar"}).collect()
+    ldf = pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+    out = ldf.rename({"a": "foo", "b": "bar"}).collect()
     assert out.columns == ["foo", "bar", "c"]
 
 
@@ -1035,15 +923,15 @@ def test_with_column_renamed(fruits_cars: pl.DataFrame) -> None:
 
 
 def test_with_columns_single_series() -> None:
-    df = pl.DataFrame({"a": [1, 2]})
-    result = df.lazy().with_columns(pl.Series("b", [3, 4])).collect()
+    ldf = pl.LazyFrame({"a": [1, 2]})
+    result = ldf.with_columns(pl.Series("b", [3, 4]))
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result.collect(), expected)
 
 
 def test_reverse() -> None:
-    out = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).lazy().reverse()
+    out = pl.LazyFrame({"a": [1, 2], "b": [3, 4]}).reverse()
     expected = pl.DataFrame({"a": [2, 1], "b": [4, 3]})
     assert_frame_equal(out.collect(), expected)
 
@@ -1101,7 +989,7 @@ def test_collect_all(df: pl.DataFrame, no_optimization: bool) -> None:
 
 
 def test_spearman_corr() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "era": [1, 1, 1, 2, 2, 2],
             "prediction": [2, 4, 5, 190, 1, 4],
@@ -1110,25 +998,25 @@ def test_spearman_corr() -> None:
     )
 
     out = (
-        df.groupby("era", maintain_order=True).agg(
+        ldf.groupby("era", maintain_order=True).agg(
             pl.spearman_rank_corr(pl.col("prediction"), pl.col("target")).alias("c"),
         )
-    )["c"]
+    ).collect()["c"]
     assert np.isclose(out[0], 0.5)
     assert np.isclose(out[1], -1.0)
 
     # we can also pass in column names directly
     out = (
-        df.groupby("era", maintain_order=True).agg(
+        ldf.groupby("era", maintain_order=True).agg(
             pl.spearman_rank_corr("prediction", "target").alias("c"),
         )
-    )["c"]
+    ).collect()["c"]
     assert np.isclose(out[0], 0.5)
     assert np.isclose(out[1], -1.0)
 
 
 def test_pearson_corr() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "era": [1, 1, 1, 2, 2, 2],
             "prediction": [2, 4, 5, 190, 1, 4],
@@ -1137,26 +1025,27 @@ def test_pearson_corr() -> None:
     )
 
     out = (
-        df.groupby("era", maintain_order=True).agg(
+        ldf.groupby("era", maintain_order=True).agg(
             pl.pearson_corr(pl.col("prediction"), pl.col("target")).alias("c"),
         )
-    )["c"]
+    ).collect()["c"]
     assert out.to_list() == pytest.approx([0.6546536707079772, -5.477514993831792e-1])
 
     # we can also pass in column names directly
     out = (
-        df.groupby("era", maintain_order=True).agg(
+        ldf.groupby("era", maintain_order=True).agg(
             pl.pearson_corr("prediction", "target").alias("c"),
         )
-    )["c"]
+    ).collect()["c"]
     assert out.to_list() == pytest.approx([0.6546536707079772, -5.477514993831792e-1])
 
 
 def test_cov(fruits_cars: pl.DataFrame) -> None:
-    assert cast(float, fruits_cars.select(pl.cov("A", "B")).item()) == -2.5
-    assert (
-        cast(float, fruits_cars.select(pl.cov(pl.col("A"), pl.col("B"))).item()) == -2.5
-    )
+    ldf = fruits_cars.lazy()
+    cov_a_b = pl.cov(pl.col("A"), pl.col("B"))
+    cov_ab = pl.cov("A", "B")
+    assert cast(float, ldf.select(cov_a_b).collect().item()) == -2.5
+    assert cast(float, ldf.select(cov_ab).collect().item()) == -2.5
 
 
 def test_std(fruits_cars: pl.DataFrame) -> None:
@@ -1201,99 +1090,19 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
     assert fruits_cars.select(pl.col("A").quantile(0.24, "linear"))["A"][0] == 1.96
 
 
-def test_is_between(fruits_cars: pl.DataFrame) -> None:
-    result = fruits_cars.select(pl.col("A").is_between(2, 4)).to_series()
-    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
-
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="none")).to_series()
-    assert_series_equal(result, pl.Series("A", [False, False, True, False, False]))
-
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="both")).to_series()
-    assert_series_equal(result, pl.Series("A", [False, True, True, True, False]))
-
-    result = fruits_cars.select(
-        pl.col("A").is_between(2, 4, closed="right")
-    ).to_series()
-    assert_series_equal(result, pl.Series("A", [False, False, True, True, False]))
-
-    result = fruits_cars.select(pl.col("A").is_between(2, 4, closed="left")).to_series()
-    assert_series_equal(result, pl.Series("A", [False, True, True, False, False]))
-
-
-def test_is_between_data_types() -> None:
-    df = pl.DataFrame(
-        {
-            "flt": [1.4, 1.2, 2.5],
-            "int": [2, 3, 4],
-            "str": ["xyz", "str", "abc"],
-            "date": [date(2020, 1, 1), date(2020, 2, 2), date(2020, 3, 3)],
-            "datetime": [
-                datetime(2020, 1, 1, 0, 0, 0),
-                datetime(2020, 1, 1, 10, 0, 0),
-                datetime(2020, 1, 1, 12, 0, 0),
-            ],
-            "tm": [time(10, 30), time(0, 45), time(15, 15)],
-        }
-    )
-
-    # on purpose, for float and int, we pass in a mixture of bound data types
-    assert_series_equal(
-        df.select(pl.col("flt").is_between(1, 2.3))[:, 0],
-        pl.Series("flt", [True, True, False]),
-    )
-    assert_series_equal(
-        df.select(pl.col("int").is_between(1.5, 3))[:, 0],
-        pl.Series("int", [True, True, False]),
-    )
-    assert_series_equal(
-        df.select(pl.col("date").is_between(date(2019, 1, 1), date(2020, 2, 5)))[:, 0],
-        pl.Series("date", [True, True, False]),
-    )
-    assert_series_equal(
-        df.select(
-            pl.col("datetime").is_between(
-                datetime(2020, 1, 1, 5, 0, 0), datetime(2020, 1, 1, 11, 0, 0)
-            )
-        )[:, 0],
-        pl.Series("datetime", [False, True, False]),
-    )
-    assert_series_equal(
-        df.select(
-            pl.col("str").is_between(pl.lit("str"), pl.lit("zzz"), closed="left")
-        )[:, 0],
-        pl.Series("str", [True, True, False]),
-    )
-    assert_series_equal(
-        df.select(
-            pl.col("tm")
-            .is_between(time(0, 45), time(10, 30), closed="right")
-            .alias("tm_between")
-        )[:, 0],
-        pl.Series("tm_between", [True, False, False]),
-    )
-
-
 def test_unique() -> None:
-    df = pl.DataFrame({"a": [1, 2, 2], "b": [3, 3, 3]})
+    ldf = pl.LazyFrame({"a": [1, 2, 2], "b": [3, 3, 3]})
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 3]})
-    assert_frame_equal(df.lazy().unique(maintain_order=True).collect(), expected)
+    assert_frame_equal(ldf.unique(maintain_order=True).collect(), expected)
 
-    result = df.lazy().unique(subset="b", maintain_order=True).collect()
+    result = ldf.unique(subset="b", maintain_order=True).collect()
     expected = pl.DataFrame({"a": [1], "b": [3]})
     assert_frame_equal(result, expected)
 
     s0 = pl.Series("a", [1, 2, None, 2])
     # test if the null is included
     assert s0.unique().to_list() == [None, 1, 2]
-
-
-def test_unique_on_sorted() -> None:
-    assert (
-        pl.DataFrame({"a": [1, 1, 3], "b": [1, 2, 3]})
-        .with_columns([pl.col("a").set_sorted()])
-        .unique(subset="a", keep="last")
-    ).to_dict(False) == {"a": [1, 3], "b": [2, 3]}
 
 
 def test_lazy_concat(df: pl.DataFrame) -> None:
@@ -1305,67 +1114,9 @@ def test_lazy_concat(df: pl.DataFrame) -> None:
     assert_frame_equal(out, df.vstack(df.clone()))
 
 
-def test_max_min_multiple_columns(fruits_cars: pl.DataFrame) -> None:
-    res = fruits_cars.select(pl.max(["A", "B"]).alias("max"))
-    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
-
-    res = fruits_cars.select(pl.min(["A", "B"]).alias("min"))
-    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
-
-
-def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
-    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min(["*"]))
-    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
-    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.min([pl.all()]))
-    assert_series_equal(res.to_series(0), pl.Series("min", [1, 2, 3, 2, 1]))
-
-    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max(["*"]))
-    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
-    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(pl.max([pl.all()]))
-    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
-
-    res = fruits_cars.select([pl.col(pl.datatypes.Int64)]).select(
-        pl.max([pl.all(), "A", "*"])
-    )
-    assert_series_equal(res.to_series(0), pl.Series("max", [5, 4, 3, 4, 5]))
-
-
-def test_head_tail(fruits_cars: pl.DataFrame) -> None:
-    res_expr = fruits_cars.select([pl.head("A", 2)])
-    res_series = pl.head(fruits_cars["A"], 2)
-    expected = pl.Series("A", [1, 2])
-    assert_series_equal(res_expr.to_series(0), expected)
-    assert_series_equal(res_series, expected)
-
-    res_expr = fruits_cars.select([pl.tail("A", 2)])
-    res_series = pl.tail(fruits_cars["A"], 2)
-    expected = pl.Series("A", [4, 5])
-    assert_series_equal(res_expr.to_series(0), expected)
-    assert_series_equal(res_series, expected)
-
-
-def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:
-    res_expr = fruits_cars.select(pl.col("A").lower_bound())
-    assert res_expr.item() == -9223372036854775808
-
-    res_expr = fruits_cars.select(pl.col("B").upper_bound())
-    assert res_expr.item() == 9223372036854775807
-
-    with pytest.raises(pl.ComputeError):
-        fruits_cars.select(pl.col("fruits").upper_bound())
-
-
-def test_nested_min_max() -> None:
-    df = pl.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
-    out = df.with_columns(pl.max([pl.min(["a", "b"]), pl.min(["c", "d"])]).alias("t"))
-    assert out.shape == (1, 5)
-    assert out.row(0) == (1, 2, 3, 4, 3)
-    assert out.columns == ["a", "b", "c", "d", "t"]
-
-
 def test_self_join() -> None:
     # 2720
-    df = pl.from_dict(
+    ldf = pl.from_dict(
         data={
             "employee_id": [100, 101, 102],
             "employee_name": ["James", "Alice", "Bob"],
@@ -1374,7 +1125,7 @@ def test_self_join() -> None:
     ).lazy()
 
     out = (
-        df.join(other=df, left_on="manager_id", right_on="employee_id", how="left")
+        ldf.join(other=ldf, left_on="manager_id", right_on="employee_id", how="left")
         .select(
             exprs=[
                 pl.col("employee_id"),
@@ -1403,19 +1154,20 @@ def test_preservation_of_subclasses() -> None:
     ldf = pl.DataFrame({"column_1": [1, 2, 3]}).lazy()
     ldf.__class__ = SubClassedLazyFrame
     extended_ldf = ldf.with_columns(pl.lit(1).alias("column_2"))
+
     assert isinstance(extended_ldf, pl.LazyFrame)
     assert isinstance(extended_ldf, SubClassedLazyFrame)
 
 
 def test_group_lengths() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "group": ["A", "A", "A", "B", "B", "B", "B"],
             "id": ["1", "1", "2", "3", "4", "3", "5"],
         }
     )
 
-    result = df.groupby(["group"], maintain_order=True).agg(
+    result = ldf.groupby(["group"], maintain_order=True).agg(
         [
             (pl.col("id").unique_counts() / pl.col("id").len())
             .sum()
@@ -1431,141 +1183,116 @@ def test_group_lengths() -> None:
         },
         schema_overrides={"unique_len": pl.UInt32},
     )
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result.collect(), expected)
 
 
 def test_quantile_filtered_agg() -> None:
     assert (
-        pl.DataFrame(
+        pl.LazyFrame(
             {
                 "group": [0, 0, 0, 0, 1, 1, 1, 1],
                 "value": [1, 2, 3, 4, 1, 2, 3, 4],
             }
         )
         .groupby("group")
-        .agg(pl.col("value").filter(pl.col("value") < 2).quantile(0.5))["value"]
+        .agg(pl.col("value").filter(pl.col("value") < 2).quantile(0.5))
+        .collect()["value"]
         .to_list()
     ) == [1.0, 1.0]
 
 
 def test_lazy_schema() -> None:
-    lf = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "foo": [1, 2, 3],
             "bar": [6.0, 7.0, 8.0],
             "ham": ["a", "b", "c"],
         }
-    ).lazy()
-    assert lf.schema == {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.Utf8}
+    )
+    assert ldf.schema == {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.Utf8}
 
-    lf = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "foo": [1, 2, 3],
             "bar": [6.0, 7.0, 8.0],
             "ham": ["a", "b", "c"],
         }
-    ).lazy()
-    assert lf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
+    )
+    assert ldf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
 
-    lfe = lf.clear()
-    assert lfe.schema == lf.schema
+    ldfe = ldf.clear()
+    assert ldfe.schema == ldf.schema
 
-    lfe = lf.clear(2)
-    assert lfe.schema == lf.schema
-    assert lfe.collect().rows() == [(None, None, None), (None, None, None)]
-
-
-def test_deadlocks_3409() -> None:
-    assert (
-        pl.DataFrame(
-            {
-                "col1": [[1, 2, 3]],
-            }
-        )
-        .with_columns([pl.col("col1").arr.eval(pl.element().apply(lambda x: x))])
-        .to_dict(False)
-    ) == {"col1": [[1, 2, 3]]}
-
-    assert (
-        pl.DataFrame(
-            {
-                "col1": [1, 2, 3],
-            }
-        )
-        .with_columns([pl.col("col1").cumulative_eval(pl.element().map(lambda x: 0))])
-        .to_dict(False)
-    ) == {"col1": [0, 0, 0]}
+    ldfe = ldf.clear(2)
+    assert ldfe.schema == ldf.schema
+    assert ldfe.collect().rows() == [(None, None, None), (None, None, None)]
 
 
 def test_predicate_count_vstack() -> None:
-    l1 = pl.DataFrame(
+    l1 = pl.LazyFrame(
         {
             "k": ["x", "y"],
             "v": [3, 2],
         }
-    ).lazy()
-    l2 = pl.DataFrame(
+    )
+    l2 = pl.LazyFrame(
         {
             "k": ["x", "y"],
             "v": [5, 7],
         }
-    ).lazy()
+    )
     assert pl.concat([l1, l2]).filter(pl.count().over("k") == 2).collect()[
         "v"
     ].to_list() == [3, 2, 5, 7]
 
 
 def test_lazy_method() -> None:
-    # We want to support `.lazy()` on a Lazy DataFrame as to allow more generic user
-    # code.
+    # We want to support `.lazy()` on a Lazy DataFrame to allow more generic user code.
     df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": [1, 2, 3, 4, 5, 6]})
-    lazy_df = df.lazy()
-
-    assert lazy_df.lazy() == lazy_df
+    assert_frame_equal(df.lazy(), df.lazy().lazy())
 
 
 def test_update_schema_after_projection_pd_t4157() -> None:
-    assert pl.DataFrame({"c0": [], "c1": [], "c2": []}).lazy().rename(
-        {
-            "c2": "c2_",
-        }
-    ).drop("c2_").select(pl.col("c0")).collect().columns == ["c0"]
+    ldf = pl.LazyFrame({"c0": [], "c1": [], "c2": []}).rename({"c2": "c2_"})
+    assert ldf.drop("c2_").select(pl.col("c0")).collect().columns == ["c0"]
 
 
 def test_type_coercion_unknown_4190() -> None:
     df = (
-        pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
-        .lazy()
-        .with_columns([pl.col("a") & pl.col("a").fill_null(True)])
+        pl.LazyFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).with_columns(
+            [pl.col("a") & pl.col("a").fill_null(True)]
+        )
     ).collect()
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 1), (2, 2), (3, 3)]
 
 
 def test_all_any_accept_expr() -> None:
-    df = pl.DataFrame(
+    ldf = pl.LazyFrame(
         {
             "a": [1, None, 2],
             "b": [1, 2, None],
         }
     )
-    assert df.select(
+    assert ldf.select(
         [
             pl.any(pl.all().is_null()).alias("null_in_row"),
             pl.all(pl.all().is_null()).alias("all_null_in_row"),
         ]
-    ).to_dict(False) == {
+    ).collect().to_dict(False) == {
         "null_in_row": [False, True, True],
         "all_null_in_row": [False, False, False],
     }
 
 
 def test_lazy_cache_same_key() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": ["x", "y", "z"]}).lazy()
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": ["x", "y", "z"]})
 
     # these have the same schema, but should not be used by cache as they are different
-    add_node = df.select([(pl.col("a") + pl.col("b")).alias("a"), pl.col("c")]).cache()
-    mult_node = df.select([(pl.col("a") * pl.col("b")).alias("a"), pl.col("c")]).cache()
+    add_node = ldf.select([(pl.col("a") + pl.col("b")).alias("a"), pl.col("c")]).cache()
+    mult_node = ldf.select(
+        [(pl.col("a") * pl.col("b")).alias("a"), pl.col("c")]
+    ).cache()
 
     assert mult_node.join(add_node, on="c", suffix="_mult").select(
         [(pl.col("a") - pl.col("a_mult")).alias("a"), pl.col("c")]
@@ -1575,8 +1302,8 @@ def test_lazy_cache_same_key() -> None:
 def test_lazy_cache_hit(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": ["x", "y", "z"]}).lazy()
-    add_node = df.select([(pl.col("a") + pl.col("b")).alias("a"), pl.col("c")]).cache()
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": ["x", "y", "z"]})
+    add_node = ldf.select([(pl.col("a") + pl.col("b")).alias("a"), pl.col("c")]).cache()
     assert add_node.join(add_node, on="c", suffix="_mult").select(
         [(pl.col("a") - pl.col("a_mult")).alias("a"), pl.col("c")]
     ).collect().to_dict(False) == {"a": [0, 0, 0], "c": ["x", "y", "z"]}
@@ -1587,13 +1314,13 @@ def test_lazy_cache_hit(monkeypatch: Any, capfd: Any) -> None:
 
 def test_quadratic_behavior_4736() -> None:
     # no assert; if this function does not stall our tests it has passed!
-    df = pl.DataFrame(schema=list(ascii_letters))
-    df.lazy().select(reduce(add, (pl.col(fld) for fld in df.columns)))
+    ldf = pl.LazyFrame(schema=list(ascii_letters))
+    ldf.select(reduce(add, (pl.col(fld) for fld in ldf.columns)))
 
 
 @pytest.mark.parametrize("input_dtype", [pl.Utf8, pl.Int64, pl.Float64])
 def test_from_epoch(input_dtype: PolarsDataType) -> None:
-    ldf = pl.DataFrame(
+    ldf = pl.LazyFrame(
         [
             pl.Series("timestamp_d", [13285]).cast(input_dtype),
             pl.Series("timestamp_s", [1147880044]).cast(input_dtype),
@@ -1601,7 +1328,7 @@ def test_from_epoch(input_dtype: PolarsDataType) -> None:
             pl.Series("timestamp_us", [1147880044 * 1_000_000]).cast(input_dtype),
             pl.Series("timestamp_ns", [1147880044 * 1_000_000_000]).cast(input_dtype),
         ]
-    ).lazy()
+    )
 
     exp_dt = datetime(2006, 5, 17, 15, 34, 4)
     expected = pl.DataFrame(
@@ -1631,16 +1358,9 @@ def test_from_epoch(input_dtype: PolarsDataType) -> None:
         _ = ldf.select(pl.from_epoch(ts_col, unit="s2"))  # type: ignore[call-overload]
 
 
-def test_from_epoch_seq_input() -> None:
-    seq_input = [1147880044]
-    expected = pl.Series([datetime(2006, 5, 17, 15, 34, 4)])
-    result = pl.from_epoch(seq_input)
-    assert_series_equal(result, expected)
-
-
 def test_cumagg_types() -> None:
-    lf = pl.DataFrame({"a": [1, 2], "b": [True, False], "c": [1.3, 2.4]}).lazy()
-    cumsum_lf = lf.select(
+    ldf = pl.LazyFrame({"a": [1, 2], "b": [True, False], "c": [1.3, 2.4]})
+    cumsum_lf = ldf.select(
         [pl.col("a").cumsum(), pl.col("b").cumsum(), pl.col("c").cumsum()]
     )
     assert cumsum_lf.schema["a"] == pl.Int64
@@ -1649,7 +1369,7 @@ def test_cumagg_types() -> None:
     collected_cumsum_lf = cumsum_lf.collect()
     assert collected_cumsum_lf.schema == cumsum_lf.schema
 
-    cumprod_lf = lf.select(
+    cumprod_lf = ldf.select(
         [
             pl.col("a").cast(pl.UInt64).cumprod(),
             pl.col("b").cumprod(),
@@ -1661,35 +1381,6 @@ def test_cumagg_types() -> None:
     assert cumprod_lf.schema["c"] == pl.Float64
     collected_cumprod_lf = cumprod_lf.collect()
     assert collected_cumprod_lf.schema == cumprod_lf.schema
-
-
-def test_col() -> None:
-    df = pl.DataFrame(
-        {
-            "ham": [1, 2, 3],
-            "hamburger": [11, 22, 33],
-            "foo": [3, 2, 1],
-            "bar": ["a", "b", "c"],
-        }
-    )
-
-    # Single column
-    assert df.select(pl.col("foo")).columns == ["foo"]
-    # Regex
-    assert df.select(pl.col("*")).columns == ["ham", "hamburger", "foo", "bar"]
-    assert df.select(pl.col("^ham.*$")).columns == ["ham", "hamburger"]
-    assert df.select(pl.col("*").exclude("ham")).columns == ["hamburger", "foo", "bar"]
-    # Multiple inputs
-    assert df.select(pl.col(["hamburger", "foo"])).columns == ["hamburger", "foo"]
-    assert df.select(pl.col("hamburger", "foo")).columns == ["hamburger", "foo"]
-    assert df.select(pl.col(pl.Series(["ham", "foo"]))).columns == ["ham", "foo"]
-    # Dtypes
-    assert df.select(pl.col(pl.Utf8)).columns == ["bar"]
-    assert df.select(pl.col(pl.Int64, pl.Float64)).columns == [
-        "ham",
-        "hamburger",
-        "foo",
-    ]
 
 
 def test_compare_schema_between_lazy_and_eager_6904() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2516,3 +2516,10 @@ def test_numpy_series_arithmetic() -> None:
     result_pow2 = sx**y
     expected = pl.Series([1.0, 16.0], dtype=pl.Float64)
     assert_series_equal(result_pow2, expected)  # type: ignore[arg-type]
+
+
+def test_from_epoch_seq_input() -> None:
+    seq_input = [1147880044]
+    expected = pl.Series([datetime(2006, 5, 17, 15, 34, 4)])
+    result = pl.from_epoch(seq_input)
+    assert_series_equal(result, expected)


### PR DESCRIPTION
I've been experimenting with this locally, and the improved ergonomics and clarity are really quite noticeable. Being able to jump straight into a LazyFrame from local data feels very tidy, and makes the intent extremely clear.

Updating the `test_lazy` unit tests illustrated that it can be surprisingly easy to accidentally forget the `.lazy()` (and potentially eat a performance penalty), as a large number of our own tests had done exactly that (some were simply in the wrong module, but others were definitely _supposed_ to be testing lazy frames) ;)

I've moved some of those unit tests into `test_df` and updated others as `LazyFrame` as appropriate (and in a handful of cases replicated the test across both modules, where it seemed like a reasonable idea).

## Example:
```python
import polars as pl

ldf = pl.LazyFrame( {"a": [3,4], "b": ["c","d"]} )
# <polars.LazyFrame object at 0x1018AC850>

ldf.collect()
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ str │
# ╞═════╪═════╡
# │ 3   ┆ c   │
# │ 4   ┆ d   │
# └─────┴─────┘
```