### PR TITLE
docs(python): restore docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ For contributing to the user guide, please refer to the [contributing guide](htt
 
 ### API reference
 
-Polars has separate API references for [Rust](https://pola-rs.github.io/polars/polars/index.html), [Python](https://pola-rs.github.io/polars/py-polars/reference/index.html), and [Node.js](https://pola-rs.github.io/nodejs-polars/index.html).
+Polars has separate API references for [Rust](https://pola-rs.github.io/polars/polars/html/index.html), [Python](https://pola-rs.github.io/polars/py-polars/reference/index.html), and [Node.js](https://pola-rs.github.io/nodejs-polars/index.html).
 These are generated directly from the codebase, so in order to contribute, you will have to follow the steps outlined in [this section](#contributing-to-the-codebase) above.
 
 #### Rust

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
   <b>Documentation</b>:
-  <a href="https://pola-rs.github.io/polars/py-polars/reference/index.html">Python</a>
+  <a href="https://pola-rs.github.io/polars/py-polars/reference/html/index.html">Python</a>
   -
   <a href="https://pola-rs.github.io/polars/polars/index.html">Rust</a>
   -

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://www.pola.rs/"
-Documentation = "https://pola-rs.github.io/polars/py-polars/reference/index.html"
+Documentation = "https://pola-rs.github.io/polars/py-polars/reference/html/index.html"
 Repository = "https://github.com/pola-rs/polars"
 Changelog = "https://github.com/pola-rs/polars/releases"
 


### PR DESCRIPTION
@stinodego I restored the links. I think we really should keep that link intact. We refer tot that link from multiple websites and google has that in cache. Do we need to change the CI for that? 