### PR TITLE
refactor(python)!: Rename pipe arg `func` to `function`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4134,7 +4134,7 @@ class DataFrame:
 
     def pipe(
         self,
-        func: Callable[Concatenate[DataFrame, P], T],
+        function: Callable[Concatenate[DataFrame, P], T],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> T:
@@ -4143,7 +4143,7 @@ class DataFrame:
 
         Parameters
         ----------
-        func
+        function
             Callable; will receive the frame as the first parameter,
             followed by any given args/kwargs.
         *args
@@ -4199,7 +4199,7 @@ class DataFrame:
         └─────┴─────┘
 
         """
-        return func(self, *args, **kwargs)
+        return function(self, *args, **kwargs)
 
     def with_row_count(self, name: str = "row_nr", offset: int = 0) -> Self:
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -742,7 +742,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def pipe(
         self,
-        func: Callable[Concatenate[LazyFrame, P], T],
+        function: Callable[Concatenate[LazyFrame, P], T],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> T:
@@ -751,7 +751,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Parameters
         ----------
-        func
+        function
             Callable; will receive the frame as the first parameter,
             followed by any given args/kwargs.
         *args
@@ -811,7 +811,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        return func(self, *args, **kwargs)
+        return function(self, *args, **kwargs)
 
     def explain(
         self,


### PR DESCRIPTION
**!! THIS IS BREAKING !!**

Followup of #7032 

Creating this so I don't forget. 

There is no way to nicely deprecate the argument due to the *args and **kwargs. So I guess we'll just do a hard break in 0.17.0.