### PR TITLE
fix(rust, python): make cast unknown a no-op

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -228,6 +228,10 @@ impl Series {
 
     /// Cast `[Series]` to another `[DataType]`
     pub fn cast(&self, dtype: &DataType) -> PolarsResult<Self> {
+        // best leave as is.
+        if matches!(dtype, DataType::Unknown) {
+            return Ok(self.clone());
+        }
         match self.0.cast(dtype) {
             Ok(out) => Ok(out),
             Err(err) => {

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -581,6 +581,13 @@ def test_map_dict() -> None:
             "remapped": ["France", "Not specified", "ES", "Germany"],
         }
 
+    # 7132
+    df = pl.DataFrame({"text": ["abc"]})
+    mapper = {"abc": "123"}
+    assert df.select(pl.col("text").map_dict(mapper).str.replace_all("1", "-")).to_dict(
+        False
+    ) == {"text": ["-23"]}
+
 
 def test_lit_dtypes() -> None:
     def lit_series(value: Any, dtype: PolarsDataType | None) -> pl.Series:


### PR DESCRIPTION
fixes #7132