### PR TITLE
fix(rust, python): expose sort expressions to stack-optimizer

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -481,12 +481,12 @@ impl ALogicalPlan {
         match self {
             Melt { .. }
             | Slice { .. }
-            | Sort { .. }
             | Explode { .. }
             | Cache { .. }
             | Distinct { .. }
             | Union { .. }
             | MapFunction { .. } => {}
+            Sort { by_column, .. } => container.extend_from_slice(by_column),
             Selection { predicate, .. } => container.push(*predicate),
             Projection { expr, .. } => container.extend_from_slice(expr),
             LocalProjection { expr, .. } => container.extend_from_slice(expr),

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -448,3 +448,11 @@ def test_sort_args() -> None:
 
     with pytest.raises(ValueError):
         df.sort("a", "b", nulls_last=True)
+
+
+def test_sort_type_coersion_6892() -> None:
+    df = pl.DataFrame({"a": [2, 1], "b": [2, 3]})
+    assert df.lazy().sort(pl.col("a") // 2).collect().to_dict(False) == {
+        "a": [1, 2],
+        "b": [3, 2],
+    }


### PR DESCRIPTION
fixes #6892