### PR TITLE
fix(rust, python): improve error message when read_csv fails

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -589,10 +589,11 @@ pub(super) fn parse_lines<'a>(
                                             "Could not parse `{}` as dtype {:?} at column {}.\n\
                                             The current offset in the file is {} bytes.\n\
                                             \n\
-                                            Consider specifying the correct dtype, increasing\n\
-                                            the number of records used to infer the schema,\n\
-                                            enabling the `ignore_errors` flag, or adding\n\
-                                            `{}` to the `null_values` list.",
+                                            You might want to try:\n\
+                                            - increasing `infer_schema_length` (e.g. `infer_schema_length=10000`),\n\
+                                            - specifying the correct dtype with the `dtypes` argument\n\
+                                            - setting `ignore_errors` to `True`,\n\
+                                            - adding `{}` to the `null_values` list.",
                                             &unparsable,
                                             buf.dtype(),
                                             idx,


### PR DESCRIPTION
This came up on Discord, when someone asked how to deal with this.

Now the error message would look like this:
```python
exceptions.ComputeError: Could not parse `1.1` as dtype Int64 at column 1.
The current offset in the file is 8 bytes.

You might want to try:
- increasing `infer_schema_length` (e.g. `infer_schema_length=10000`),
- specifying the correct dtype with the `dtypes` argument
- setting `ignore_errors` to `True`,
- adding `1.1` to the `null_values` list.
```
which they've said looks better and clearer

---

(not sure which conventional commit category error messages fall into)