### PR TITLE
feat(python): add a `base_type` method to `DataType`

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -132,6 +132,9 @@ class DataTypeClass(type):
     def _string_repr(cls) -> str:
         return dtype_str_repr(cls)
 
+    def base_type(cls) -> PolarsDataType:
+        return cls
+
 
 class DataType(metaclass=DataTypeClass):
     """Base class for all Polars data types."""
@@ -150,7 +153,7 @@ class DataType(metaclass=DataTypeClass):
         return dtype_str_repr(self)
 
     @classmethod
-    def base_type(cls) -> type:
+    def base_type(cls) -> PolarsDataType:
         """
         Return this DataType's fundamental/root type class.
 

--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -149,6 +149,22 @@ class DataType(metaclass=DataTypeClass):
     def _string_repr(self) -> str:
         return dtype_str_repr(self)
 
+    @classmethod
+    def base_type(cls) -> type:
+        """
+        Return this DataType's fundamental/root type class.
+
+        Examples
+        --------
+        >>> pl.Datetime("ns").base_type()
+        Datetime
+        >>> pl.List(pl.Int32).base_type()
+        List
+        >>> pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)]).base_type()
+        Struct
+        """
+        return cls
+
 
 class NumericType(DataType):
     """Base class for numeric data types."""

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -49,7 +49,7 @@ def test_dtype_base_type() -> None:
         is pl.Struct
     )
     for dtype in datatypes.DATETIME_DTYPES:
-        assert dtype.base_type() is pl.Datetime  # type: ignore[union-attr]
+        assert dtype.base_type() is pl.Datetime
 
 
 def test_get_idx_type() -> None:

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -41,8 +41,19 @@ def test_dtype_temporal_units() -> None:
         assert inferred_dtype.tu == "us"  # type: ignore[union-attr]
 
 
+def test_dtype_base_type() -> None:
+    assert pl.Date.base_type() is pl.Date
+    assert pl.List(pl.Int32).base_type() is pl.List
+    assert (
+        pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)]).base_type()
+        is pl.Struct
+    )
+    for dtype in datatypes.DATETIME_DTYPES:
+        assert dtype.base_type() is pl.Datetime  # type: ignore[union-attr]
+
+
 def test_get_idx_type() -> None:
-    assert datatypes.get_idx_type() == datatypes.UInt32
+    assert datatypes.get_idx_type() == pl.UInt32
 
 
 def test_dtypes_picklable() -> None:


### PR DESCRIPTION
Allows for simplified/uniform identification of the root dtype when you have a mix of nested/compound dtypes, instances, base classes, etc.

* Can be called cleanly on _both_ class (uninstantiated) or instance (instantiated) dtypes.
* On uninstantiated/basic dtypes the `base_type()` is simply the same as the type.

## Examples
```python
import polars as pl

tp = pl.Int32
tp.base_type()
# Int32

tp = pl.Datetime("ns")
tp.base_type()
# Datetime

tp = pl.List(pl.Int32)
tp.base_type()
# List

tp = pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)])
tp.base_type()
# Struct
```
