### PR TITLE
feat(rust, python): show column name if read_csv errors

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -584,7 +584,7 @@ pub(super) fn parse_lines<'a>(
                                 .map_err(|_| {
                                     let bytes_offset = offset + field.as_ptr() as usize - start;
                                     let unparsable = String::from_utf8_lossy(field);
-                                    let column_name = schema.get_index((idx as usize).try_into().unwrap()).unwrap().0;
+                                    let column_name = schema.get_index(idx as usize).unwrap().0;
                                     PolarsError::ComputeError(
                                         format!(
                                             "Could not parse `{}` as dtype {:?} at column '{}' (column number {}).\n\

--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -486,8 +486,9 @@ pub(super) fn parse_lines<'a>(
     buffers: &mut [Buffer<'a>],
     ignore_errors: bool,
     n_lines: usize,
-    // length or original schema
+    // length of original schema
     schema_len: usize,
+    schema: &Schema,
 ) -> PolarsResult<usize> {
     assert!(
         !projection.is_empty(),
@@ -545,13 +546,12 @@ pub(super) fn parse_lines<'a>(
                     break;
                 }
                 Some((mut field, needs_escaping)) => {
-                    idx += 1;
                     let field_len = field.len();
 
                     // +1 is the split character that is consumed by the iterator.
                     read_sol += field_len + 1;
 
-                    if (idx - 1) == next_projected as u32 {
+                    if idx == next_projected as u32 {
                         // the iterator is finished when it encounters a `\n`
                         // this could be preceded by a '\r'
                         if field_len > 0 && field[field_len - 1] == b'\r' {
@@ -584,9 +584,10 @@ pub(super) fn parse_lines<'a>(
                                 .map_err(|_| {
                                     let bytes_offset = offset + field.as_ptr() as usize - start;
                                     let unparsable = String::from_utf8_lossy(field);
+                                    let column_name = schema.get_index((idx as usize).try_into().unwrap()).unwrap().0;
                                     PolarsError::ComputeError(
                                         format!(
-                                            "Could not parse `{}` as dtype {:?} at column {}.\n\
+                                            "Could not parse `{}` as dtype {:?} at column '{}' (column number {}).\n\
                                             The current offset in the file is {} bytes.\n\
                                             \n\
                                             You might want to try:\n\
@@ -596,7 +597,8 @@ pub(super) fn parse_lines<'a>(
                                             - adding `{}` to the `null_values` list.",
                                             &unparsable,
                                             buf.dtype(),
-                                            idx,
+                                            column_name,
+                                            idx+1,
                                             bytes_offset,
                                             &unparsable,
                                         )
@@ -624,6 +626,7 @@ pub(super) fn parse_lines<'a>(
                             }
                         }
                     }
+                    idx += 1;
                 }
             }
         }

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -758,7 +758,7 @@ fn read_chunk(
             ignore_errors,
             chunk_size,
             schema.len(),
-            &schema,
+            schema,
         )?;
     }
 

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -575,6 +575,7 @@ impl<'a> CoreReader<'a> {
                                 ignore_errors,
                                 chunk_size,
                                 self.schema.len(),
+                                &self.schema,
                             )?;
 
                             let mut local_df = DataFrame::new_no_checks(
@@ -757,6 +758,7 @@ fn read_chunk(
             ignore_errors,
             chunk_size,
             schema.len(),
+            &schema,
         )?;
     }
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1025,6 +1025,15 @@ def test_duplicated_columns() -> None:
     assert pl.read_csv(csv.encode(), new_columns=new).columns == new
 
 
+def test_error_message() -> None:
+    data = io.StringIO("target,wind,energy,miso\n" "1,2,3,4\n" "1,2,1e5,1\n")
+    with pytest.raises(
+        ComputeError,
+        match=r"Could not parse `1e5` as dtype Int64 at column 'energy' \(column number 3\)",
+    ):
+        pl.read_csv(data, infer_schema_length=1)
+
+
 def test_csv_categorical_lifetime() -> None:
     # escaped strings do some heap allocates in the builder
     # this tests of the lifetimes remains valid


### PR DESCRIPTION
Is it OK to show the column name in the read_csv error?

It's not obvious from the error message if the column number is zero-indexed or one-indexed (at least, it wasn't to me when I encountered this, and I had hundreds of columns - in particular, it's not clear how to set the `dtype` of the failing column if you don't know its name)