### PR TITLE
perf(rust, python): improve single argument elementwise expression pe…

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -186,9 +186,7 @@ impl<'a> AggregationContext<'a> {
     pub(crate) fn is_aggregated(&self) -> bool {
         !self.is_not_aggregated()
     }
-    pub(crate) fn is_aggregated_flat(&self) -> bool {
-        matches!(self.state, AggState::AggregatedFlat(_))
-    }
+
     pub(crate) fn is_literal(&self) -> bool {
         matches!(self.state, AggState::Literal(_))
     }


### PR DESCRIPTION
…rformance in groupby context

This greatly simplifies the expressions by not exploding anymore to do elementwise operations in the groupby context. This explode could also lead to a full realloc (if it could not fast explode), and often lead to a recomputation of the groups.

When the groups overlapped (e.g. in groupby dynamic), the explode could lead to an explosion of memory usage. So all in all, small change, but a lot of benefit.