### PR TITLE
fix(rust): floating point CSV parsing with escaping and whitespace

### DIFF
--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -79,7 +79,6 @@ where
         if bytes.is_empty() {
             self.append_null()
         } else {
-            let first_byte = bytes[0];
             let bytes = if needs_escaping {
                 &bytes[1..bytes.len() - 1]
             } else {
@@ -99,7 +98,7 @@ where
                         return self.parse_bytes(
                             bytes,
                             ignore_errors,
-                            needs_escaping && is_whitespace(first_byte), // we only need to do escaping if the first byte was not whitespace
+                            false, // escaping was already done
                             _missing_is_null,
                         );
                     }

--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -79,6 +79,7 @@ where
         if bytes.is_empty() {
             self.append_null()
         } else {
+            let first_byte = bytes[0];
             let bytes = if needs_escaping {
                 &bytes[1..bytes.len() - 1]
             } else {
@@ -98,7 +99,7 @@ where
                         return self.parse_bytes(
                             bytes,
                             ignore_errors,
-                            needs_escaping,
+                            needs_escaping && is_whitespace(first_byte), // we only need to do escaping if the first byte was not whitespace
                             _missing_is_null,
                         );
                     }

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -1078,3 +1078,15 @@ fn test_try_parse_dates_3380() -> PolarsResult<()> {
     assert_eq!(df.column("validdate")?.null_count(), 0);
     Ok(())
 }
+
+#[test]
+fn test_leading_whitespace_with_quote() -> PolarsResult<()> {
+    let csv = r#"
+"ABC","DEF",
+"24.5","  4.1"
+"#;
+    let file = Cursor::new(csv);
+    let df = CsvReader::new(file).finish()?;
+    assert_eq!(df.column("DEF")?.null_count(), 0);
+    Ok(())
+}

--- a/polars/tests/it/io/csv.rs
+++ b/polars/tests/it/io/csv.rs
@@ -1087,6 +1087,9 @@ fn test_leading_whitespace_with_quote() -> PolarsResult<()> {
 "#;
     let file = Cursor::new(csv);
     let df = CsvReader::new(file).finish()?;
-    assert_eq!(df.column("DEF")?.null_count(), 0);
+    let col_1 = df.column("ABC").unwrap();
+    let col_2 = df.column("DEF").unwrap();
+    assert_eq!(col_1.get(0)?, AnyValue::Float64(24.5));
+    assert_eq!(col_2.get(0)?, AnyValue::Float64(4.1));
     Ok(())
 }


### PR DESCRIPTION
Fixes floating point CSV parsing when there's escaping. The retry mechanism needs to take into account whether escaping was already done or not.

`"24.5"...` would result in `24.5` getting passed to the parser
`"  4.1"` would result in `  4.1` getting passed to the parser on the first try and `.1` on the second (though I'm not sure why `.1` does not parse) -- this PR changes the retry to be `4.1`

Closes https://github.com/pola-rs/polars/issues/6308