### PR TITLE
chore(rust): Replace `num` with `num-traits` + a few minor maintenance fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.27.2"
 [workspace.dependencies]
 rayon = "1.6"
 thiserror = "^1"
-num = "0.4"
+num-traits = "0.2"
 ahash = "0.8"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 # todo! remove

--- a/examples/read_csv/src/main.rs
+++ b/examples/read_csv/src/main.rs
@@ -5,7 +5,7 @@ fn main() -> PolarsResult<()> {
     let file = std::fs::File::open("/home/ritchie46/Downloads/tpch/tables_scale_100/lineitem.tbl")
         .unwrap();
     let file = Box::new(file) as Box<dyn MmapBytesReader>;
-    let df = CsvReader::new(file)
+    let _df = CsvReader::new(file)
         .with_delimiter(b'|')
         .has_header(false)
         .with_chunk_size(10)
@@ -16,7 +16,7 @@ fn main() -> PolarsResult<()> {
     Ok(())
 }
 
-fn write_other_formats(df: &mut DataFrame) -> PolarsResult<()> {
+fn _write_other_formats(df: &mut DataFrame) -> PolarsResult<()> {
     let parquet_out = "../datasets/foods1.parquet";
     if std::fs::metadata(&parquet_out).is_err() {
         let f = std::fs::File::create(&parquet_out).unwrap();

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -13,7 +13,7 @@ arrow.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 chrono-tz = { version = "0.8", optional = true }
 hashbrown.workspace = true
-num.workspace = true
+num-traits.workspace = true
 polars-error = { version = "0.27.2", path = "../polars-error" }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror.workspace = true

--- a/polars/polars-arrow/src/floats/ord.rs
+++ b/polars/polars-arrow/src/floats/ord.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use num_traits::ToPrimitive;
+
 use crate::data_types::IsFloat;
 use crate::kernels::rolling::compare_fn_nan_max;
 
@@ -33,7 +35,7 @@ impl<T: IsFloat + PartialEq> PartialEq for OrdFloat<T> {
 
 impl<T: PartialEq + IsFloat> Eq for OrdFloat<T> {}
 
-impl<T: num::ToPrimitive> num::ToPrimitive for OrdFloat<T> {
+impl<T: ToPrimitive> ToPrimitive for OrdFloat<T> {
     fn to_isize(&self) -> Option<isize> {
         self.0.to_isize()
     }

--- a/polars/polars-arrow/src/index.rs
+++ b/polars/polars-arrow/src/index.rs
@@ -2,7 +2,7 @@
 use arrow::array::UInt32Array;
 #[cfg(feature = "bigidx")]
 use arrow::array::UInt64Array;
-use num::{NumCast, Signed, Zero};
+use num_traits::{NumCast, Signed, Zero};
 
 pub trait IndexToUsize {
     /// Translate the negative index to an offset.

--- a/polars/polars-arrow/src/kernels/ewm/average.rs
+++ b/polars/polars-arrow/src/kernels/ewm/average.rs
@@ -2,7 +2,7 @@ use std::ops::{AddAssign, MulAssign};
 
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
-use num::Float;
+use num_traits::Float;
 
 use crate::trusted_len::TrustedLen;
 use crate::utils::CustomIterTools;

--- a/polars/polars-arrow/src/kernels/ewm/variance.rs
+++ b/polars/polars-arrow/src/kernels/ewm/variance.rs
@@ -2,7 +2,7 @@ use std::ops::{AddAssign, DivAssign, MulAssign};
 
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
-use num::Float;
+use num_traits::Float;
 
 use crate::trusted_len::TrustedLen;
 use crate::utils::CustomIterTools;

--- a/polars/polars-arrow/src/kernels/float.rs
+++ b/polars/polars-arrow/src/kernels/float.rs
@@ -1,7 +1,7 @@
 use arrow::array::{BooleanArray, PrimitiveArray};
 use arrow::bitmap::Bitmap;
 use arrow::types::NativeType;
-use num::Float;
+use num_traits::Float;
 
 use crate::array::default_arrays::FromData;
 use crate::prelude::*;

--- a/polars/polars-arrow/src/kernels/rolling/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/mod.rs
@@ -8,7 +8,7 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use arrow::array::PrimitiveArray;
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::NativeType;
-use num::{Bounded, Float, NumCast, One, ToPrimitive, Zero};
+use num_traits::{Bounded, Float, NumCast, One, ToPrimitive, Zero};
 use window::*;
 
 use crate::data_types::IsFloat;

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -11,7 +11,7 @@ use arrow::datatypes::DataType;
 use arrow::types::NativeType;
 pub use mean::*;
 pub use min_max::*;
-use num::{Float, NumCast};
+use num_traits::{Float, NumCast};
 pub use quantile::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use num_traits::ToPrimitive;
+
 use super::*;
 use crate::index::IdxSize;
 use crate::trusted_len::TrustedLen;
@@ -16,8 +18,8 @@ where
     T: std::iter::Sum<T>
         + NativeType
         + Copy
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Add<Output = T>
         + Sub<Output = T>
@@ -58,8 +60,8 @@ pub(crate) fn compute_quantile2<T>(
 where
     T: std::iter::Sum<T>
         + Copy
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Add<Output = T>
         + Sub<Output = T>
@@ -126,8 +128,8 @@ pub fn rolling_median<T>(
 where
     T: NativeType
         + std::iter::Sum<T>
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Add<Output = T>
         + Sub<Output = T>
@@ -159,8 +161,8 @@ pub fn rolling_quantile<T>(
 where
     T: NativeType
         + std::iter::Sum<T>
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Add<Output = T>
         + Sub<Output = T>

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -1,5 +1,5 @@
 use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
-use num::pow::Pow;
+use num_traits::pow::Pow;
 
 use super::mean::MeanWindow;
 use super::*;

--- a/polars/polars-arrow/src/kernels/rolling/nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/quantile.rs
@@ -16,8 +16,8 @@ where
     T: std::iter::Sum<T>
         + NativeType
         + Copy
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Add<Output = T>
         + Sub<Output = T>
@@ -148,8 +148,8 @@ where
         + std::iter::Sum<T>
         + Zero
         + AddAssign
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Default
         + Add<Output = T>
@@ -213,8 +213,8 @@ where
         + Zero
         + AddAssign
         + Copy
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Default
         + Add<Output = T>
@@ -249,8 +249,8 @@ where
         + Zero
         + AddAssign
         + Copy
-        + std::cmp::PartialOrd
-        + num::ToPrimitive
+        + PartialOrd
+        + ToPrimitive
         + NumCast
         + Default
         + Add<Output = T>

--- a/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/nulls/variance.rs
@@ -1,7 +1,7 @@
 use mean::MeanWindow;
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
-use num::pow::Pow;
+use num_traits::pow::Pow;
 
 use super::*;
 

--- a/polars/polars-arrow/src/kernels/take_agg.rs
+++ b/polars/polars-arrow/src/kernels/take_agg.rs
@@ -1,7 +1,7 @@
 //! kernels that combine take and aggregations.
 use arrow::array::{PrimitiveArray, Utf8Array};
 use arrow::types::NativeType;
-use num::{NumCast, ToPrimitive};
+use num_traits::{NumCast, ToPrimitive};
 
 use crate::array::PolarsArray;
 use crate::index::IdxSize;

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -161,7 +161,7 @@ comfy-table = { version = "6.1.4", optional = true, default_features = false }
 hashbrown.workspace = true
 indexmap = { version = "1", features = ["std"] }
 ndarray = { version = "0.15", optional = true, default_features = false }
-num.workspace = true
+num-traits.workspace = true
 object_store = { version = "0.5.3", default-features = false, optional = true }
 once_cell.workspace = true
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["compute"] }

--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -8,7 +8,7 @@ use arrow::compute::arithmetics::basic;
 use arrow::compute::arithmetics::decimal;
 use arrow::compute::arity_assign;
 use arrow::types::NativeType;
-use num::{Num, NumCast, ToPrimitive};
+use num_traits::{Num, NumCast, ToPrimitive};
 
 use crate::prelude::*;
 use crate::series::IsSorted;

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -6,7 +6,7 @@ use arrow::compute::comparison;
 #[cfg(feature = "dtype-binary")]
 use arrow::scalar::BinaryScalar;
 use arrow::scalar::{PrimitiveScalar, Scalar, Utf8Scalar};
-use num::{NumCast, ToPrimitive};
+use num_traits::{NumCast, ToPrimitive};
 use polars_arrow::prelude::FromData;
 
 use crate::prelude::*;

--- a/polars/polars-core/src/chunked_array/float.rs
+++ b/polars/polars-core/src/chunked_array/float.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 use polars_arrow::kernels::float::*;
 use polars_arrow::kernels::set::set_at_nulls;
 

--- a/polars/polars-core/src/chunked_array/ops/abs.rs
+++ b/polars/polars-core/src/chunked_array/ops/abs.rs
@@ -1,4 +1,4 @@
-use num::Signed;
+use num_traits::Signed;
 
 use crate::prelude::*;
 

--- a/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -8,7 +8,7 @@ use std::ops::Add;
 use arrow::compute;
 use arrow::types::simd::Simd;
 use arrow::types::NativeType;
-use num::{Float, ToPrimitive};
+use num_traits::{Float, ToPrimitive};
 use polars_arrow::kernels::rolling::{compare_fn_nan_max, compare_fn_nan_min};
 pub use quantile::*;
 pub use var::*;

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -1,8 +1,6 @@
 use std::convert::TryFrom;
 
 #[cfg(feature = "dtype-categorical")]
-use polars_arrow::is_valid::IsValid;
-#[cfg(feature = "dtype-categorical")]
 use polars_utils::sync::SyncPtr;
 
 #[cfg(feature = "object")]
@@ -130,6 +128,7 @@ impl<'a> AnyValue<'a> {
                         // so we set the array pointer with values of the dictionary array.
                         #[cfg(feature = "dtype-categorical")]
                         {
+                            use polars_arrow::is_valid::{IsValid as _};
                             if let Some(arr) = arr.as_any().downcast_ref::<DictionaryArray<u32>>() {
                                 let keys = arr.keys();
                                 let values = arr.values();

--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 use std::ops::{Add, AddAssign, Mul};
 
-use num::Bounded;
+use num_traits::Bounded;
 
 use crate::prelude::*;
 use crate::utils::CustomIterTools;

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -2,7 +2,7 @@ use std::ops::Add;
 
 use arrow::compute;
 use arrow::types::simd::Simd;
-use num::{Bounded, NumCast, One, Zero};
+use num_traits::{Bounded, NumCast, One, Zero};
 use polars_arrow::kernels::set::set_at_nulls;
 use polars_arrow::trusted_len::FromIteratorReversed;
 use polars_arrow::utils::{CustomIterTools, FromTrustedLenIterator};

--- a/polars/polars-core/src/chunked_array/ops/peaks.rs
+++ b/polars/polars-core/src/chunked_array/ops/peaks.rs
@@ -1,4 +1,4 @@
-use num::Zero;
+use num_traits::Zero;
 
 use crate::prelude::*;
 

--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -28,7 +28,8 @@ mod inner_mod {
 
     use arrow::array::{Array, PrimitiveArray};
     use arrow::bitmap::MutableBitmap;
-    use num::{Float, Zero};
+    use num_traits::pow::Pow;
+    use num_traits::{Float, Zero};
     use polars_arrow::bit_util::unset_bit_raw;
     use polars_arrow::data_types::IsFloat;
     use polars_arrow::trusted_len::PushUnchecked;
@@ -182,7 +183,7 @@ mod inner_mod {
     where
         ChunkedArray<T>: IntoSeries,
         T: PolarsFloatType,
-        T::Native: Float + IsFloat + SubAssign + num::pow::Pow<T::Native, Output = T::Native>,
+        T::Native: Float + IsFloat + SubAssign + Pow<T::Native, Output = T::Native>,
     {
         /// Apply a rolling custom function. This is pretty slow because of dynamic dispatch.
         pub fn rolling_apply_float<F>(&self, window_size: usize, mut f: F) -> PolarsResult<Self>

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -1,4 +1,4 @@
-use num::{abs, clamp};
+use num_traits::{abs, clamp};
 
 use crate::prelude::*;
 

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -11,7 +11,7 @@ use std::iter::FromIterator;
 pub(crate) use arg_sort_multiple::argsort_multiple_row_fmt;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
-use num::Float;
+use num_traits::Float;
 use polars_arrow::array::default_arrays::FromDataUtf8;
 use polars_arrow::kernels::rolling::compare_fn_nan_max;
 use polars_arrow::prelude::{FromData, ValueSize};

--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -1,4 +1,4 @@
-use num::{Float, NumCast};
+use num_traits::{Float, NumCast};
 use rand::distributions::Bernoulli;
 use rand::prelude::*;
 use rand_distr::{Distribution, Normal, Standard, StandardNormal, Uniform};

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -30,7 +30,7 @@ use arrow::types::simd::Simd;
 use arrow::types::NativeType;
 pub use dtype::*;
 pub use field::*;
-use num::{Bounded, FromPrimitive, Num, NumCast, Zero};
+use num_traits::{Bounded, FromPrimitive, Num, NumCast, Zero};
 use polars_arrow::data_types::IsFloat;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};

--- a/polars/polars-core/src/export.rs
+++ b/polars/polars-core/src/export.rs
@@ -4,7 +4,7 @@ pub use arrow;
 #[cfg(feature = "temporal")]
 pub use chrono;
 #[cfg(feature = "private")]
-pub use num;
+pub use num_traits as num;
 #[cfg(feature = "private")]
 pub use once_cell;
 #[cfg(feature = "private")]

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -20,7 +20,7 @@ use comfy_table::modifiers::*;
 use comfy_table::presets::*;
 #[cfg(any(feature = "fmt", feature = "fmt_no_tty"))]
 use comfy_table::*;
-use num::{Num, NumCast};
+use num_traits::{Num, NumCast};
 
 use crate::config::*;
 use crate::prelude::*;

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -4,7 +4,7 @@ use std::ops::Sub;
 
 use ahash::RandomState;
 use arrow::types::NativeType;
-use num::Zero;
+use num_traits::Zero;
 use rayon::prelude::*;
 
 use super::*;
@@ -158,7 +158,7 @@ fn process_group<K, T>(
     forward: bool,
 ) where
     K: Hash + PartialEq + Eq,
-    T: NativeType + Sub<Output = T> + PartialOrd + num::Zero,
+    T: NativeType + Sub<Output = T> + PartialOrd + Zero,
 {
     let (offset_slice, mut previous_join_idx) =
         *right_tbl_offsets.get(&k).unwrap_or(&(0usize, None));
@@ -179,7 +179,7 @@ fn process_group<K, T>(
             if forward {
                 previous_join_idx = None;
             }
-            if tolerance > num::zero() {
+            if tolerance > Zero::zero() {
                 if let Some(idx) = previous_join_idx {
                     debug_assert!((idx as usize) < right_asof.len());
                     let val_r = unsafe { *right_asof.get_unchecked(idx as usize) };

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -4,7 +4,7 @@ mod groups;
 use std::borrow::Cow;
 
 use asof::*;
-use num::Bounded;
+use num_traits::Bounded;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -5,7 +5,8 @@ pub use agg_list::*;
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::simd::Simd;
 use arrow::types::NativeType;
-use num::{Bounded, Num, NumCast, ToPrimitive, Zero};
+use num_traits::pow::Pow;
+use num_traits::{Bounded, Num, NumCast, ToPrimitive, Zero};
 use polars_arrow::data_types::IsFloat;
 use polars_arrow::kernels::rolling;
 use polars_arrow::kernels::rolling::no_nulls::{
@@ -829,7 +830,7 @@ where
         + VarAggSeries
         + ChunkQuantile<T::Native>
         + QuantileAggSeries,
-    T::Native: Simd + NumericNative + num::pow::Pow<T::Native, Output = T::Native>,
+    T::Native: Simd + NumericNative + Pow<T::Native, Output = T::Native>,
     <T::Native as Simd>::Simd: std::ops::Add<Output = <T::Native as Simd>::Simd>
         + arrow::compute::aggregate::Sum<T::Native>
         + arrow::compute::aggregate::SimdOrd<T::Native>,

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
 use ahash::RandomState;
-use num::NumCast;
+use num_traits::NumCast;
 use polars_arrow::prelude::QuantileInterpolOptions;
 use rayon::prelude::*;
 
@@ -901,7 +901,7 @@ pub fn fmt_groupby_column(name: &str, method: GroupByMethod) -> String {
 
 #[cfg(test)]
 mod test {
-    use num::traits::FloatConst;
+    use num_traits::FloatConst;
 
     use crate::frame::groupby::{groupby, groupby_threaded_num};
     use crate::prelude::*;

--- a/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
@@ -1,3 +1,5 @@
+use num_traits::NumCast;
+
 use super::*;
 #[cfg(feature = "chunked_ids")]
 use crate::utils::create_chunked_index_mapping;
@@ -283,7 +285,7 @@ where
 impl<T> ChunkedArray<T>
 where
     T: PolarsIntegerType + Sync,
-    T::Native: Eq + Hash + num::NumCast,
+    T::Native: Eq + Hash + NumCast,
 {
     fn hash_join_outer(&self, other: &ChunkedArray<T>) -> Vec<(Option<IdxSize>, Option<IdxSize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -8,7 +8,7 @@ use std::ops::Add;
 use ahash::AHashSet;
 use arrow::compute;
 use arrow::types::simd::Simd;
-use num::{Float, NumCast, ToPrimitive};
+use num_traits::{Float, NumCast, ToPrimitive};
 #[cfg(feature = "concat_str")]
 use polars_arrow::prelude::ValueSize;
 

--- a/polars/polars-core/src/series/arithmetic/borrowed.rs
+++ b/polars/polars-core/src/series/arithmetic/borrowed.rs
@@ -92,7 +92,7 @@ impl NumOpsDispatch for BinaryChunked {
 
 #[cfg(feature = "checked_arithmetic")]
 pub mod checked {
-    use num::{CheckedDiv, ToPrimitive, Zero};
+    use num_traits::{CheckedDiv, One, ToPrimitive, Zero};
 
     use super::*;
     use crate::utils::align_chunks_binary;
@@ -115,8 +115,7 @@ pub mod checked {
     impl<T> NumOpsDispatchChecked for ChunkedArray<T>
     where
         T: PolarsIntegerType,
-        T::Native:
-            CheckedDiv<Output = T::Native> + CheckedDiv<Output = T::Native> + num::Zero + num::One,
+        T::Native: CheckedDiv<Output = T::Native> + CheckedDiv<Output = T::Native> + Zero + One,
         ChunkedArray<T>: IntoSeries,
     {
         fn checked_div(&self, rhs: &Series) -> PolarsResult<Series> {

--- a/polars/polars-core/src/series/arithmetic/mod.rs
+++ b/polars/polars-core/src/series/arithmetic/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::ops::{self, Add, Div, Mul, Sub};
 
 pub use borrowed::*;
-use num::{Num, NumCast};
+use num_traits::{Num, NumCast};
 
 use crate::prelude::*;
 use crate::utils::{get_time_units, try_get_supertype};

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -23,7 +23,7 @@ use ahash::RandomState;
 use arrow::compute::aggregate::estimated_bytes_size;
 pub use from::*;
 pub use iterator::SeriesIter;
-use num::NumCast;
+use num_traits::NumCast;
 use rayon::prelude::*;
 pub use series_trait::{IsSorted, *};
 

--- a/polars/polars-core/src/series/ops/round.rs
+++ b/polars/polars-core/src/series/ops/round.rs
@@ -1,9 +1,11 @@
+use num_traits::pow::Pow;
+use num_traits::{clamp_max, clamp_min};
+
 use crate::prelude::*;
 
 impl Series {
     /// Round underlying floating point array to given decimal.
     pub fn round(&self, decimals: u32) -> PolarsResult<Self> {
-        use num::traits::Pow;
         if let Ok(ca) = self.f32() {
             // Note we do the computation on f64 floats to not loose precision
             // when the computation is done, we cast to f32
@@ -82,7 +84,6 @@ impl Series {
 
     /// Clamp underlying values to the `max` value.
     pub fn clip_max(mut self, max: AnyValue<'_>) -> PolarsResult<Self> {
-        use num::traits::clamp_max;
         if self.dtype().is_numeric() {
             macro_rules! apply_clip {
                 ($pl_type:ty, $ca:expr) => {{
@@ -105,8 +106,6 @@ impl Series {
 
     /// Clamp underlying values to the `min` value.
     pub fn clip_min(mut self, min: AnyValue<'_>) -> PolarsResult<Self> {
-        use num::traits::clamp_min;
-
         if self.dtype().is_numeric() {
             macro_rules! apply_clip {
                 ($pl_type:ty, $ca:expr) => {{

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
 use arrow::bitmap::Bitmap;
+use num_traits::{One, Zero};
 pub use polars_arrow::utils::{TrustMyLength, *};
 use rayon::prelude::*;
 pub use series::*;
@@ -831,20 +832,20 @@ where
 #[inline]
 pub(crate) fn index_to_chunked_index<
     I: Iterator<Item = Idx>,
-    Idx: PartialOrd + std::ops::AddAssign + std::ops::SubAssign + num::Zero + num::One,
+    Idx: PartialOrd + std::ops::AddAssign + std::ops::SubAssign + Zero + One,
 >(
     chunk_lens: I,
     index: Idx,
 ) -> (Idx, Idx) {
     let mut index_remainder = index;
-    let mut current_chunk_idx = num::Zero::zero();
+    let mut current_chunk_idx = Zero::zero();
 
     for chunk_len in chunk_lens {
         if chunk_len > index_remainder {
             break;
         } else {
             index_remainder -= chunk_len;
-            current_chunk_idx += num::One::one();
+            current_chunk_idx += One::one();
         }
     }
     (current_chunk_idx, index_remainder)

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -64,7 +64,7 @@ lexical = { version = "6", optional = true, default-features = false, features =
 lexical-core = { version = "0.8", optional = true }
 memchr = "2.5"
 memmap = { package = "memmap2", version = "0.5.2", optional = true }
-num.workspace = true
+num-traits.workspace = true
 object_store = { version = "0.5.3", default-features = false, optional = true }
 once_cell = "1"
 polars-arrow = { version = "0.27.2", path = "../polars-arrow" }

--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -1,5 +1,5 @@
 use memchr::memchr2_iter;
-use num::traits::Pow;
+use num_traits::Pow;
 use polars_core::prelude::*;
 
 use super::buffer::*;

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -1,7 +1,7 @@
 use std::hash::{Hash, Hasher};
 
 use arrow::types::NativeType;
-use num::traits::NumCast;
+use num_traits::NumCast;
 use polars_core::frame::row::AnyValueBuffer;
 use polars_core::prelude::*;
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
@@ -136,10 +136,10 @@ pub(crate) fn init_buffers(
 
 fn deserialize_number<T: NativeType + NumCast>(value: &Value) -> Option<T> {
     match value {
-        Value::Static(StaticNode::F64(f)) => num::traits::cast::<f64, T>(*f),
-        Value::Static(StaticNode::I64(i)) => num::traits::cast::<i64, T>(*i),
-        Value::Static(StaticNode::U64(u)) => num::traits::cast::<u64, T>(*u),
-        Value::Static(StaticNode::Bool(b)) => num::traits::cast::<i32, T>(*b as i32),
+        Value::Static(StaticNode::F64(f)) => num_traits::cast(*f),
+        Value::Static(StaticNode::I64(i)) => num_traits::cast(*i),
+        Value::Static(StaticNode::U64(u)) => num_traits::cast(*u),
+        Value::Static(StaticNode::Bool(b)) => num_traits::cast(*b as i32),
         _ => None,
     }
 }

--- a/polars/polars-io/src/ndjson_core/ndjson.rs
+++ b/polars/polars-io/src/ndjson_core/ndjson.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 pub use arrow::array::StructArray;
 pub use arrow::io::ndjson as arrow_ndjson;
-use num::traits::Pow;
+use num_traits::pow::Pow;
 use polars_core::prelude::*;
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_core::POOL;

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -12,7 +12,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 crossbeam-channel = "0.5"
 enum_dispatch = "0.3"
 hashbrown.workspace = true
-num.workspace = true
+num-traits.workspace = true
 polars-arrow = { version = "0.27.2", path = "../../polars-arrow", default-features = false }
 polars-core = { version = "0.27.2", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.27.2", path = "../../polars-io", default-features = false, features = ["ipc"] }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::hash::{Hash, Hasher};
 
 use hashbrown::hash_map::RawEntryMut;
-use num::NumCast;
+use num_traits::NumCast;
 use polars_core::export::ahash::RandomState;
 use polars_core::frame::row::AnyValueBuffer;
 use polars_core::prelude::*;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/primitive.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 use hashbrown::hash_map::RawEntryMut;
-use num::NumCast;
+use num_traits::NumCast;
 use polars_arrow::kernels::sort_partition::partition_to_groups_amortized;
 use polars_core::export::ahash::RandomState;
 use polars_core::frame::row::AnyValueBuffer;

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/string.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/string.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use hashbrown::hash_map::RawEntryMut;
-use num::NumCast;
+use num_traits::NumCast;
 use polars_core::export::ahash::RandomState;
 use polars_core::frame::row::AnyValueBuffer;
 use polars_core::prelude::*;

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -6,8 +6,6 @@ use std::ops::{BitAnd, BitOr};
 
 use polars_core::export::arrow::temporal_conversions::NANOSECONDS;
 use polars_core::utils::arrow::temporal_conversions::SECONDS_IN_DAY;
-#[cfg(feature = "rank")]
-use polars_core::utils::coalesce_nulls_series;
 #[cfg(feature = "dtype-struct")]
 use polars_core::utils::get_supertype;
 
@@ -179,6 +177,7 @@ pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
 ///     and thus lead to the highest rank.
 #[cfg(all(feature = "rank", feature = "propagate_nans"))]
 pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> Expr {
+    use polars_core::utils::coalesce_nulls_series;
     use polars_ops::prelude::nan_propagating_aggregate::nan_max_s;
 
     let function = move |a: Series, b: Series| {

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -327,6 +327,7 @@ pub(crate) fn insert_streaming_nodes(
                 #[cfg(not(feature = "dtype-categorical"))]
                 let string_cache = true;
 
+                #[allow(unused_variables)]
                 fn allowed_dtype(dt: &DataType, string_cache: bool) -> bool {
                     match dt {
                         #[cfg(feature = "object")]

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -14,7 +14,7 @@ arrow.workspace = true
 base64 = { version = "0.21", optional = true }
 hex = { version = "0.4", optional = true }
 jsonpath_lib = { version = "0.3.0", optional = true, git = "https://github.com/ritchie46/jsonpath", branch = "improve_compiled" }
-memchr = { vlist_count = "2", optional = true }
+memchr = { version = "2", optional = true }
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", default-features = false }
 polars-core = { version = "0.27.2", path = "../polars-core", features = ["private"], default-features = false }
 polars-utils = { version = "0.27.2", path = "../polars-utils", default-features = false }

--- a/polars/polars-ops/src/series/ops/rolling.rs
+++ b/polars/polars-ops/src/series/ops/rolling.rs
@@ -1,9 +1,10 @@
-use std::ops::SubAssign;
-
-use polars_core::export::num;
-use polars_core::export::num::{Float, FromPrimitive};
 use polars_core::prelude::*;
-use polars_core::utils::with_unstable_series;
+#[cfg(feature = "moment")]
+use {
+    polars_core::export::num::{self, Float, FromPrimitive},
+    polars_core::utils::with_unstable_series,
+    std::ops::SubAssign,
+};
 
 use crate::series::ops::SeriesSealed;
 

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -24,8 +24,6 @@ rustyline = { version = "10.0.0", optional = true }
 serde = "1"
 serde_json = { version = "1" }
 sqlparser = { version = "0.30" }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"], optional = true }
-
-[target.'cfg(not(target_os = "linux"))'.features]
-jemallocator = []

--- a/polars/polars-sql/src/table_functions.rs
+++ b/polars/polars-sql/src/table_functions.rs
@@ -47,6 +47,7 @@ impl FromStr for PolarsTableFunctions {
 }
 
 impl PolarsTableFunctions {
+    #[allow(unused_variables)]
     pub(crate) fn execute(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
         match self {
             #[cfg(feature = "csv")]
@@ -81,6 +82,7 @@ impl PolarsTableFunctions {
         Ok((path, lf))
     }
 
+    #[allow(dead_code)]
     fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<String> {
         use sqlparser::ast::{Expr as SqlExpr, Value as SqlValue};
         match arg {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.8"
+version = "0.16.9"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1247,31 +1247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,29 +1262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -1533,7 +1485,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.8.1",
  "hashbrown 0.13.2",
- "num",
+ "num-traits",
  "polars-error",
  "serde",
  "thiserror",
@@ -1553,7 +1505,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "indexmap",
  "ndarray",
- "num",
+ "num-traits",
  "once_cell",
  "polars-arrow",
  "polars-error",
@@ -1597,7 +1549,7 @@ dependencies = [
  "lexical-core",
  "memchr",
  "memmap2",
- "num",
+ "num-traits",
  "once_cell",
  "polars-arrow",
  "polars-core",
@@ -1653,7 +1605,7 @@ dependencies = [
  "crossbeam-channel",
  "enum_dispatch",
  "hashbrown 0.13.2",
- "num",
+ "num-traits",
  "polars-arrow",
  "polars-core",
  "polars-io",


### PR DESCRIPTION
- Drop `num` dependency in favor of `num-traits` (that's all that's being currently used anyway)
  - This removes four crates from the dependency tree: `num`, `num-iter`, `num-bigint`, `num-rational`
- Fix various build warnings appearing when some features are enabled/disabled
- Fix memchr version in polars-ops manifest
- Remove unneeded jemallocator dummy feature in polars-sql (also causing a build warning)
- In py-polars conversion, use pre-cached modules instead of importing them by hand on every conversion
- In py-polars conversion, query the type name of an object at most once if needed
- Update `py-polars` to `0.16.9` in `Cargo.lock` (not sure it should be bumped right away? but it comes up in git diff every time you run tests)