### PR TITLE
feat(rust, python): allow passing utc=True when parsing time-zone-naive date strings

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -51,7 +51,6 @@ from polars.dependencies import (
     _PANDAS_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
-    _check_for_pandas,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1760,6 +1760,21 @@ def test_strptime_with_invalid_tz() -> None:
         pl.Series(["2020-01-01 03:00:00+01:00"]).str.strptime(
             pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S%z", tz_aware=True
         )
+    with pytest.raises(
+        ComputeError,
+        match="Cannot use strptime with both 'utc=True' and tz-aware Datetime.",
+    ):
+        pl.Series(["2020-01-01 03:00:00"]).str.strptime(
+            pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S", utc=True
+        )
+
+
+def test_strptime_unguessable_format():
+    with pytest.raises(
+        ComputeError,
+        match="Could not find an appropriate format to parse dates, please define a fmt",
+    ):
+        pl.Series(["foobar"]).str.strptime(pl.Datetime)
 
 
 def test_convert_time_zone_invalid() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1769,7 +1769,7 @@ def test_strptime_with_invalid_tz() -> None:
         )
 
 
-def test_strptime_unguessable_format():
+def test_strptime_unguessable_format() -> None:
     with pytest.raises(
         ComputeError,
         match="Could not find an appropriate format to parse dates, please define a fmt",

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -93,14 +93,13 @@ def test_strptime_precision_with_time_unit(
 
 @pytest.mark.parametrize("fmt", ["%Y-%m-%dT%H:%M:%S", None])
 def test_utc_with_tz_naive(fmt: str | None) -> None:
-    with pytest.raises(
-        ComputeError,
-        match=(
-            r"^Cannot use 'utc=True' with tz-naive data. "
-            r"Parse the data as naive, and then use `.dt.convert_time_zone\('UTC'\)`.$"
-        ),
-    ):
-        pl.Series(["2020-01-01 00:00:00"]).str.strptime(pl.Datetime, fmt, utc=True)
+    result = (
+        pl.Series(["2020-01-01T00:00:00"])
+        .str.strptime(pl.Datetime, fmt, utc=True)
+        .item()
+    )
+    expected = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
On the way towards https://github.com/pola-rs/polars/issues/7198 (this should probably be done first)

On `master`, this errors:
```python
In [7]: pl.Series(['2020-01-01']).str.strptime(pl.Datetime, utc=True)
---------------------------------------------------------------------------
ComputeError: Cannot use 'utc=True' with tz-naive data. Parse the data as naive, and then use `.dt.convert_time_zone('UTC')`.
```

This PR allows for that:
```python
In [1]:  pl.Series(['2020-01-01']).str.strptime(pl.Datetime, utc=True)
Out[1]: 
shape: (1,)
Series: '' [datetime[μs, UTC]]
[
        2020-01-01 00:00:00 UTC
]
```