### PR TITLE
feat(python): Add `**named_exprs` input for `struct`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -253,13 +253,13 @@ pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
 
 #[cfg(all(feature = "concat_str", feature = "strings"))]
 /// Horizontally concat string columns in linear time
-pub fn concat_str<E: AsRef<[Expr]>>(s: E, sep: &str) -> Expr {
+pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str) -> Expr {
     let input = s.as_ref().to_vec();
-    let sep = sep.to_string();
+    let separator = separator.to_string();
 
     Expr::Function {
         input,
-        function: StringFunction::ConcatHorizontal(sep).into(),
+        function: StringFunction::ConcatHorizontal(separator).into(),
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -51,7 +51,6 @@ from polars.dependencies import (
     _PANDAS_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
-    _check_for_pandas,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -147,7 +147,7 @@ def expr_to_lit_or_expr(
         unaliased_expr = expr.meta.undo_aliases()
         if unaliased_expr.meta.has_multiple_outputs():
             expr_name = expr_output_name(expr)
-            expr = cast(Expr, pli.struct(expr if expr_name is None else unaliased_expr))
+            expr = pli.struct(expr if expr_name is None else unaliased_expr)
             name = name or expr_name
 
     return expr if name is None else expr.alias(name)

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2377,17 +2377,22 @@ def _date(
     return _datetime(year, month, day).cast(Date).alias("date")
 
 
+@deprecated_alias(sep="separator")
 @deprecate_nonkeyword_arguments()
-def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli.Expr:
+def concat_str(exprs: IntoExpr | Iterable[IntoExpr], separator: str = "") -> pli.Expr:
     """
-    Horizontally concat Utf8 Series in linear time. Non-Utf8 columns are cast to Utf8.
+    Horizontally concatenate columns into a single string column.
+
+    Operates in linear time.
 
     Parameters
     ----------
     exprs
-        Columns to concat into a Utf8 Series.
-    sep
-        String value that will be used to separate the values.
+        Columns to concatenate into a single string column. Accepts expression input.
+        Strings are parsed as column names, other non-expression inputs are parsed as
+        literals. Non-``Utf8`` columns are cast to ``Utf8``.
+    separator
+        String that will be used to separate the values of each column.
 
     Examples
     --------
@@ -2399,16 +2404,14 @@ def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli
     ...     }
     ... )
     >>> df.with_columns(
-    ...     [
-    ...         pl.concat_str(
-    ...             [
-    ...                 pl.col("a") * 2,
-    ...                 pl.col("b"),
-    ...                 pl.col("c"),
-    ...             ],
-    ...             sep=" ",
-    ...         ).alias("full_sentence"),
-    ...     ]
+    ...     pl.concat_str(
+    ...         [
+    ...             pl.col("a") * 2,
+    ...             pl.col("b"),
+    ...             pl.col("c"),
+    ...         ],
+    ...         separator=" ",
+    ...     ).alias("full_sentence"),
     ... )
     shape: (3, 4)
     ┌─────┬──────┬──────┬───────────────┐
@@ -2423,7 +2426,7 @@ def concat_str(exprs: Sequence[pli.Expr | str] | pli.Expr, sep: str = "") -> pli
 
     """
     exprs = pli.selection_to_pyexpr_list(exprs)
-    return pli.wrap_expr(_concat_str(exprs, sep))
+    return pli.wrap_expr(_concat_str(exprs, separator))
 
 
 def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
@@ -2477,7 +2480,7 @@ def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
         if len(s) > 0:
             exprs.append(lit(s))
 
-    return concat_str(exprs, sep="")
+    return concat_str(exprs, separator="")
 
 
 def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.Expr:

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -235,9 +235,9 @@ fn using_string_cache() -> bool {
 }
 
 #[pyfunction]
-fn concat_str(s: Vec<dsl::PyExpr>, sep: &str) -> dsl::PyExpr {
+fn concat_str(s: Vec<dsl::PyExpr>, separator: &str) -> dsl::PyExpr {
     let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-    polars_rs::lazy::dsl::concat_str(s, sep).into()
+    polars_rs::lazy::dsl::concat_str(s, separator).into()
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -812,3 +812,26 @@ def test_sort_structs() -> None:
         "sex": ["female", "female", "male"],
         "age": [26, 38, 22],
     }
+
+
+def test_struct_args_kwargs() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": ["a", "b"]})
+
+    # Single input
+    result = df.select(r=pl.struct((pl.col("a") + pl.col("b")).alias("p")))
+    expected = pl.DataFrame({"r": [{"p": 4}, {"p": 6}]})
+    assert_frame_equal(result, expected)
+
+    # List input
+    result = df.select(r=pl.struct([pl.col("a").alias("p"), pl.col("b").alias("q")]))
+    expected = pl.DataFrame({"r": [{"p": 1, "q": 3}, {"p": 2, "q": 4}]})
+    assert_frame_equal(result, expected)
+
+    # Positional input
+    # TODO: Enable when keyword args input is supported
+    # result = df.select(r=pl.struct(pl.col("a").alias("p"), pl.col("b").alias("q")))
+    # assert_frame_equal(result, expected)
+
+    # Keyword input
+    result = df.select(r=pl.struct(p="a", q="b"))
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -788,7 +788,7 @@ def test_concat() -> None:
 def test_concat_str() -> None:
     df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 
-    out = df.select([pl.concat_str(["a", "b"], sep="-")])
+    out = df.select([pl.concat_str(["a", "b"], separator="-")])
     assert out["a"].to_list() == ["a-1", "b-2", "c-3"]
 
     out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -353,7 +353,7 @@ def test_fetch(fruits_cars: pl.DataFrame) -> None:
 def test_concat_str() -> None:
     ldf = pl.LazyFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 
-    out = ldf.select([pl.concat_str(["a", "b"], sep="-")])
+    out = ldf.select([pl.concat_str(["a", "b"], separator="-")])
     assert out.collect()["a"].to_list() == ["a-1", "b-2", "c-3"]
 
     out = ldf.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])


### PR DESCRIPTION
Partially addresses #6451 

Three functions remain, which cannot be finalized right now since it would be a breaking change:
* `struct`
* `concat_str`
* `arg_sort_by`

 In this PR I update these three methods (parsing logic, docs, tests). I will follow up with a breaking change adding `*args` support to these three methods, which will then close #6451.

One thing I could add in this PR is `**named_exprs` input for `struct`, which was requested by a @cmdlineluser.
