### PR TITLE
fix(python): Conversion of negative timedelta to polars duration

### DIFF
--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -83,9 +83,22 @@ def _timedelta_to_pl_duration(td: timedelta | str | None) -> str | None:
     if td is None or isinstance(td, str):
         return td
     else:
-        d = td.days and f"{td.days}d" or ""
-        s = td.seconds and f"{td.seconds}s" or ""
-        us = td.microseconds and f"{td.microseconds}us" or ""
+        if td.days >= 0:
+            d = td.days and f"{td.days}d" or ""
+            s = td.seconds and f"{td.seconds}s" or ""
+            us = td.microseconds and f"{td.microseconds}us" or ""
+        else:
+            if not td.seconds and not td.microseconds:
+                d = td.days and f"{td.days}d" or ""
+                s = ""
+                us = ""
+            else:
+                corrected_d = td.days + 1
+                d = corrected_d and f"{corrected_d}d" or "-"
+                corrected_seconds = 24 * 3600 - (td.seconds + (td.microseconds > 0))
+                s = corrected_seconds and f"{corrected_seconds}s" or ""
+                us = td.microseconds and f"{10**6 - td.microseconds}us" or ""
+
         return f"{d}{s}{us}"
 
 

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -11,6 +11,7 @@ from polars.utils import (
     _date_to_pl_date,
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
+    _timedelta_to_pl_duration,
     _timedelta_to_pl_timedelta,
     deprecate_nonkeyword_arguments,
     parse_version,
@@ -61,6 +62,26 @@ def test_timedelta_to_pl_timedelta() -> None:
     assert out == 86_400_000
     out = _timedelta_to_pl_timedelta(timedelta(days=1), tu=None)
     assert out == 86_400_000_000
+
+
+@pytest.mark.parametrize(
+    ("td", "expected"),
+    [
+        (timedelta(days=1), "1d"),
+        (timedelta(days=-1), "-1d"),
+        (timedelta(seconds=1), "1s"),
+        (timedelta(seconds=-1), "-1s"),
+        (timedelta(microseconds=1), "1us"),
+        (timedelta(microseconds=-1), "-1us"),
+        (timedelta(days=1, seconds=1), "1d1s"),
+        (timedelta(days=-1, seconds=-1), "-1d1s"),
+        (timedelta(days=1, microseconds=1), "1d1us"),
+        (timedelta(days=-1, microseconds=-1), "-1d1us"),
+    ],
+)
+def test_timedelta_to_pl_duration(td: timedelta, expected: str) -> None:
+    out = _timedelta_to_pl_duration(td)
+    assert out == expected
 
 
 def test_estimated_size() -> None:


### PR DESCRIPTION
https://github.com/pola-rs/polars/issues/6477

The root cause of the bug in the `upsample` function was the conversion of negative timedelta to polar duration by the function `_timedelta_to_pl_duration`

A timedelta of -1 second (represented by the timedelta object as `datetime.timedelta(days=-1, seconds=86399)` was then incorrectly converted as `"-1d86399s"` instead of `"-1s"`

This PR handled this by handling the timedelta representation when days < 0

