### PR TITLE
test(python): ensure that `DataFrame` and `LazyFrame` init params don't diverge

### DIFF
--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from functools import reduce
+from inspect import signature
 from operator import add
 from string import ascii_letters
 from typing import TYPE_CHECKING, Any, cast
@@ -17,6 +18,13 @@ from polars.testing.asserts import assert_series_equal
 
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
+
+
+def test_init_signature_match() -> None:
+    # eager/lazy init signatures are expected to match; if this test fails, it
+    # means a parameter was added to one but not the other, and that should be
+    # fixed (or an explicit exemption should be made here, with an explanation)
+    assert signature(pl.DataFrame.__init__) == signature(pl.LazyFrame.__init__)
 
 
 def test_lazy() -> None:


### PR DESCRIPTION
Following https://github.com/pola-rs/polars/pull/7122, the two `__init__` signatures are expected to match; this test explicitly validates that, to prevent any inadvertent drift in the future.

> `DataFrame(*params).lazy()` => `pl.LazyFrame(*params)`