### PR TITLE
chore(python): exit non-zero on fix from ruff

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           black --check .
           blackdoc --check .
-          ruff .
+          ruff . --exit-non-zero-on-fix
 
 
   lint-rust:


### PR DESCRIPTION
In the CI of https://github.com/pola-rs/polars/actions/runs/4270474083/jobs/7434291441 , `ruff` modified a file, and the logs showed:
```
 Found 1 error (1 fixed, 0 remaining).
```
but it didn't fail CI because `ruff` exits `0` in such cases

So then, in https://github.com/pola-rs/polars/pull/7203#discussion_r1118352397, after running `make pre-commit` locally, I got an unrelated change.
Same happened in https://github.com/pola-rs/polars/pull/7213/files , which fixed it