### PR TITLE
refactor(rust): remove binary feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1"
 hashbrown = { version = "0.13.1", features = ["rayon", "ahash"] }
 bitflags = "1.3"
 once_cell = "1"
+memchr = "2"
 
 [workspace.dependencies.arrow]
 package = "arrow2"

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -100,7 +100,7 @@ mode = ["polars-core/mode", "polars-lazy/mode"]
 take_opt_iter = ["polars-core/take_opt_iter"]
 extract_jsonpath = ["polars-core/strings", "polars-ops/extract_jsonpath", "polars-ops/strings"]
 string_encoding = ["polars-ops/string_encoding", "polars-core/strings"]
-binary_encoding = ["polars-ops/binary_encoding", "dtype-binary"]
+binary_encoding = ["polars-ops/binary_encoding"]
 groupby_list = ["polars-core/groupby_list"]
 lazy_regex = ["polars-lazy/regex"]
 cum_agg = ["polars-core/cum_agg", "polars-core/cum_agg"]
@@ -185,7 +185,6 @@ dtype-full = [
   "dtype-u16",
   "dtype-categorical",
   "dtype-struct",
-  "dtype-binary",
 ]
 
 # sensible minimal set of opt-in datatypes
@@ -233,12 +232,6 @@ dtype-struct = [
   "polars-lazy/dtype-struct",
   "polars-ops/dtype-struct",
   "polars-io/dtype-struct",
-]
-dtype-binary = [
-  "polars-core/dtype-binary",
-  "polars-lazy/dtype-binary",
-  "polars-ops/dtype-binary",
-  "polars-io/dtype-binary",
 ]
 
 docs-selection = [

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -93,7 +93,6 @@ dtype-u8 = []
 dtype-u16 = []
 dtype-categorical = []
 dtype-struct = []
-dtype-binary = []
 
 parquet = ["arrow/io_parquet"]
 

--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -540,7 +540,6 @@ fn concat_strings(l: &str, r: &str) -> String {
     s
 }
 
-#[cfg(feature = "dtype-binary")]
 fn concat_binary_arrs(l: &[u8], r: &[u8]) -> Vec<u8> {
     let mut v = Vec::with_capacity(l.len() + r.len());
     v.extend_from_slice(l);
@@ -610,7 +609,6 @@ impl Add<&str> for &Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl Add for &BinaryChunked {
     type Output = BinaryChunked;
 
@@ -646,7 +644,6 @@ impl Add for &BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl Add for BinaryChunked {
     type Output = BinaryChunked;
 
@@ -655,7 +652,6 @@ impl Add for BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl Add<&[u8]> for &BinaryChunked {
     type Output = BinaryChunked;
 

--- a/polars/polars-core/src/chunked_array/builder/from.rs
+++ b/polars/polars-core/src/chunked_array/builder/from.rs
@@ -45,7 +45,6 @@ impl From<(&str, Utf8Array<i64>)> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl From<(&str, BinaryArray<i64>)> for BinaryChunked {
     fn from(tpl: (&str, BinaryArray<i64>)) -> Self {
         let name = tpl.0;

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -180,7 +180,6 @@ where
 
 type LargePrimitiveBuilder<T> = MutableListArray<i64, MutablePrimitiveArray<T>>;
 type LargeListUtf8Builder = MutableListArray<i64, MutableUtf8Array<i64>>;
-#[cfg(feature = "dtype-binary")]
 type LargeListBinaryBuilder = MutableListArray<i64, MutableBinaryArray<i64>>;
 type LargeListBooleanBuilder = MutableListArray<i64, MutableBooleanArray>;
 
@@ -264,14 +263,12 @@ impl ListBuilderTrait for ListUtf8ChunkedBuilder {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 pub struct ListBinaryChunkedBuilder {
     builder: LargeListBinaryBuilder,
     field: Field,
     fast_explode: bool,
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ListBinaryChunkedBuilder {
     pub fn new(name: &str, capacity: usize, values_capacity: usize) -> Self {
         let values = MutableBinaryArray::<i64>::with_capacity(values_capacity);
@@ -317,7 +314,6 @@ impl ListBinaryChunkedBuilder {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ListBuilderTrait for ListBinaryChunkedBuilder {
     fn append_opt_series(&mut self, opt_s: Option<&Series>) {
         match opt_s {
@@ -475,7 +471,6 @@ pub fn get_list_builder(
                     Box::new(builder)
                 }};
             }
-            #[cfg(feature = "dtype-binary")]
             macro_rules! get_binary_builder {
                 () => {{
                     let builder =

--- a/polars/polars-core/src/chunked_array/builder/mod.rs
+++ b/polars/polars-core/src/chunked_array/builder/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "dtype-binary")]
 mod binary;
 mod boolean;
 mod from;
@@ -13,7 +12,6 @@ use std::sync::Arc;
 
 use arrow::array::*;
 use arrow::bitmap::Bitmap;
-#[cfg(feature = "dtype-binary")]
 pub use binary::*;
 pub use boolean::*;
 pub use list::*;
@@ -167,7 +165,6 @@ where
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<B> NewChunkedArray<BinaryType, B> for BinaryChunked
 where
     B: AsRef<[u8]>,

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -3,9 +3,7 @@ use std::ops::Not;
 use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
 use arrow::compute;
 use arrow::compute::comparison;
-#[cfg(feature = "dtype-binary")]
-use arrow::scalar::BinaryScalar;
-use arrow::scalar::{PrimitiveScalar, Scalar, Utf8Scalar};
+use arrow::scalar::{BinaryScalar, PrimitiveScalar, Scalar, Utf8Scalar};
 use num_traits::{NumCast, ToPrimitive};
 use polars_arrow::prelude::FromData;
 
@@ -609,7 +607,6 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl BinaryChunked {
     fn comparison(
         &self,
@@ -628,7 +625,6 @@ impl BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkCompare<&BinaryChunked> for BinaryChunked {
     type Item = BooleanChunked;
 
@@ -849,7 +845,6 @@ impl ChunkCompare<&str> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl BinaryChunked {
     fn binary_compare_scalar(
         &self,
@@ -861,7 +856,6 @@ impl BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkCompare<&[u8]> for BinaryChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &[u8]) -> BooleanChunked {
@@ -1012,7 +1006,6 @@ impl ChunkEqualElement for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkEqualElement for BinaryChunked {
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
         let ca_other = other.as_ref().as_ref();

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -8,7 +8,6 @@ use crate::series::iterator::SeriesIter;
 use crate::utils::CustomIterTools;
 
 type LargeStringArray = Utf8Array<i64>;
-#[cfg(feature = "dtype-binary")]
 type LargeBinaryArray = BinaryArray<i64>;
 type LargeListArray = ListArray<i64>;
 pub mod par;
@@ -211,7 +210,6 @@ impl Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> IntoIterator for &'a BinaryChunked {
     type Item = Option<&'a [u8]>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
@@ -221,14 +219,12 @@ impl<'a> IntoIterator for &'a BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 pub struct BinaryIterNoNull<'a> {
     array: &'a LargeBinaryArray,
     current: usize,
     current_end: usize,
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> BinaryIterNoNull<'a> {
     /// create a new iterator
     pub fn new(array: &'a LargeBinaryArray) -> Self {
@@ -240,7 +236,6 @@ impl<'a> BinaryIterNoNull<'a> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> Iterator for BinaryIterNoNull<'a> {
     type Item = &'a [u8];
 
@@ -262,7 +257,6 @@ impl<'a> Iterator for BinaryIterNoNull<'a> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> DoubleEndedIterator for BinaryIterNoNull<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.current_end == self.current {
@@ -274,11 +268,9 @@ impl<'a> DoubleEndedIterator for BinaryIterNoNull<'a> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 /// all arrays have known size.
 impl<'a> ExactSizeIterator for BinaryIterNoNull<'a> {}
 
-#[cfg(feature = "dtype-binary")]
 impl BinaryChunked {
     #[allow(clippy::wrong_self_convention)]
     #[doc(hidden)]

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -491,7 +491,6 @@ where
 impl AsSinglePtr for BooleanChunked {}
 impl AsSinglePtr for ListChunked {}
 impl AsSinglePtr for Utf8Chunked {}
-#[cfg(feature = "dtype-binary")]
 impl AsSinglePtr for BinaryChunked {}
 #[cfg(feature = "object")]
 impl<T: PolarsObject> AsSinglePtr for ObjectChunked<T> {}
@@ -582,7 +581,6 @@ impl ValueSize for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ValueSize for BinaryChunked {
     fn get_values_size(&self) -> usize {
         self.chunks

--- a/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -459,7 +459,6 @@ impl ChunkAggSeries for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkAggSeries for BinaryChunked {
     fn sum_as_series(&self) -> Series {
         BinaryChunked::full_null(self.name(), 1).into_series()

--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -35,7 +35,6 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
     // TODO: insert types
     match dtype {
         DataType::Utf8 => downcast_and_pack!(LargeStringArray, Utf8),
-        #[cfg(feature = "dtype-binary")]
         DataType::Binary => downcast_and_pack!(LargeBinaryArray, Binary),
         DataType::Boolean => downcast_and_pack!(BooleanArray, Boolean),
         DataType::UInt8 => downcast_and_pack!(UInt8Array, UInt8),
@@ -229,7 +228,6 @@ impl ChunkAnyValue for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkAnyValue for BinaryChunked {
     #[inline]
     unsafe fn get_any_value_unchecked(&self, index: usize) -> AnyValue {

--- a/polars/polars-core/src/chunked_array/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/ops/append.rs
@@ -44,7 +44,6 @@ impl Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 #[doc(hidden)]
 impl BinaryChunked {
     pub fn append(&mut self, other: &Self) {

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -442,7 +442,6 @@ impl<'a> ChunkApply<'a, &'a str, Cow<'a, str>> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> ChunkApply<'a, &'a [u8], Cow<'a, [u8]>> for BinaryChunked {
     fn apply_cast_numeric<F, S>(&'a self, f: F) -> ChunkedArray<S>
     where
@@ -582,7 +581,6 @@ impl ChunkApplyKernel<LargeStringArray> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkApplyKernel<LargeBinaryArray> for BinaryChunked {
     fn apply_kernel(&self, f: &dyn Fn(&LargeBinaryArray) -> ArrayRef) -> Self {
         self.apply_kernel_cast(&f)

--- a/polars/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/polars/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -138,11 +138,13 @@ where
                 .collect::<Vec<_>>();
             unsafe { UInt32Chunked::from_chunks(self.name(), chunks) }
         } else {
-            self.cast_unchecked(&DataType::UInt32)
-                .unwrap()
-                .u32()
-                .unwrap()
-                .clone()
+            unsafe {
+                self.cast_unchecked(&DataType::UInt32)
+                    .unwrap()
+                    .u32()
+                    .unwrap()
+                    .clone()
+            }
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/polars/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -4,11 +4,10 @@
 
 use std::cmp::{Ordering, PartialEq};
 
-#[cfg(feature = "dtype-binary")]
-use crate::chunked_array::ops::take::take_random::{BinaryTakeRandom, BinaryTakeRandomSingleChunk};
 use crate::chunked_array::ops::take::take_random::{
-    BoolTakeRandom, BoolTakeRandomSingleChunk, NumTakeRandomChunked, NumTakeRandomCont,
-    NumTakeRandomSingleChunk, Utf8TakeRandom, Utf8TakeRandomSingleChunk,
+    BinaryTakeRandom, BinaryTakeRandomSingleChunk, BoolTakeRandom, BoolTakeRandomSingleChunk,
+    NumTakeRandomChunked, NumTakeRandomCont, NumTakeRandomSingleChunk, Utf8TakeRandom,
+    Utf8TakeRandomSingleChunk,
 };
 #[cfg(feature = "object")]
 use crate::chunked_array::ops::take::take_random::{ObjectTakeRandom, ObjectTakeRandomSingleChunk};
@@ -71,9 +70,7 @@ macro_rules! impl_traits {
 
 impl_traits!(Utf8TakeRandom<'_>);
 impl_traits!(Utf8TakeRandomSingleChunk<'_>);
-#[cfg(feature = "dtype-binary")]
 impl_traits!(BinaryTakeRandom<'_>);
-#[cfg(feature = "dtype-binary")]
 impl_traits!(BinaryTakeRandomSingleChunk<'_>);
 impl_traits!(BoolTakeRandom<'_>);
 impl_traits!(BoolTakeRandomSingleChunk<'_>);
@@ -146,7 +143,6 @@ impl<'a> IntoPartialEqInner<'a> for &'a Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> IntoPartialEqInner<'a> for &'a BinaryChunked {
     fn into_partial_eq_inner(self) -> Box<dyn PartialEqInner + 'a> {
         match self.chunks.len() {
@@ -267,7 +263,6 @@ impl<'a> IntoPartialOrdInner<'a> for &'a Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> IntoPartialOrdInner<'a> for &'a BinaryChunked {
     fn into_partial_ord_inner(self) -> Box<dyn PartialOrdInner + 'a> {
         match self.chunks.len() {

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -131,7 +131,6 @@ impl Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 #[doc(hidden)]
 impl BinaryChunked {
     pub fn downcast_iter(&self) -> impl Iterator<Item = &BinaryArray<i64>> + DoubleEndedIterator {

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -120,7 +120,6 @@ impl Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 #[doc(hidden)]
 impl BinaryChunked {
     pub fn extend(&mut self, other: &Self) {

--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -54,18 +54,10 @@ impl Series {
         let out = match s.dtype() {
             Boolean => fill_null_bool(s.bool().unwrap(), strategy),
             Utf8 => {
-                #[cfg(feature = "dtype-binary")]
-                {
-                    let s = unsafe { s.cast_unchecked(&Binary)? };
-                    let out = s.fill_null(strategy)?;
-                    return unsafe { out.cast_unchecked(&Utf8) };
-                }
-                #[cfg(not(feature = "dtype-binary"))]
-                {
-                    panic!("activate 'dtype-binary' feature")
-                }
+                let s = unsafe { s.cast_unchecked(&Binary)? };
+                let out = s.fill_null(strategy)?;
+                return unsafe { out.cast_unchecked(&Utf8) };
             }
-            #[cfg(feature = "dtype-binary")]
             Binary => {
                 let ca = s.binary().unwrap();
                 fill_null_binary(ca, strategy).map(|ca| ca.into_series())
@@ -164,7 +156,6 @@ where
         .collect_reversed()
 }
 
-#[cfg(feature = "dtype-binary")]
 fn fill_backward_limit_binary(ca: &BinaryChunked, limit: IdxSize) -> BinaryChunked {
     let mut cnt = 0;
     let mut previous = None;
@@ -361,7 +352,6 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 fn fill_null_binary(ca: &BinaryChunked, strategy: FillNullStrategy) -> PolarsResult<BinaryChunked> {
     // nothing to fill
     if !ca.has_validity() {
@@ -433,7 +423,6 @@ impl ChunkFillNullValue<bool> for BooleanChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkFillNullValue<&[u8]> for BinaryChunked {
     fn fill_null_with_values(&self, value: &[u8]) -> PolarsResult<Self> {
         self.set(&self.is_null(), Some(value))

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -73,10 +73,8 @@ impl ChunkFilter<BooleanType> for BooleanChunked {
 
 impl ChunkFilter<Utf8Type> for Utf8Chunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<Utf8Type>> {
-        let ca = self.cast(&DataType::Binary).unwrap();
-        let out = ca.filter(filter)?;
-        let out = unsafe { out.cast_unchecked(&DataType::Utf8) }.unwrap();
-        out.utf8().cloned()
+        let out = self.as_binary().filter(filter)?;
+        unsafe { Ok(out.to_utf8()) }
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -73,27 +73,13 @@ impl ChunkFilter<BooleanType> for BooleanChunked {
 
 impl ChunkFilter<Utf8Type> for Utf8Chunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<Utf8Type>> {
-        // broadcast
-        if filter.len() == 1 {
-            return match filter.get(0) {
-                Some(true) => Ok(self.clone()),
-                _ => Ok(Utf8Chunked::full_null(self.name(), 0)),
-            };
-        }
-        check_filter_len!(self, filter);
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-
-        Ok(self.copy_with_chunks(chunks, true, true))
+        let ca = self.cast(&DataType::Binary).unwrap();
+        let out = ca.filter(filter)?;
+        let out = unsafe { out.cast_unchecked(&DataType::Utf8) }.unwrap();
+        out.utf8().cloned()
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkFilter<BinaryType> for BinaryChunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<BinaryType>> {
         // broadcast

--- a/polars/polars-core/src/chunked_array/ops/full.rs
+++ b/polars/polars-core/src/chunked_array/ops/full.rs
@@ -64,7 +64,6 @@ impl ChunkFullNull for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> ChunkFull<&'a [u8]> for BinaryChunked {
     fn full(name: &str, value: &'a [u8], length: usize) -> Self {
         let mut builder = BinaryChunkedBuilder::new(name, length, length * value.len());
@@ -78,7 +77,6 @@ impl<'a> ChunkFull<&'a [u8]> for BinaryChunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkFullNull for BinaryChunked {
     fn full_null(name: &str, length: usize) -> Self {
         let arr = new_null_array(DataType::Binary.to_arrow(), length);

--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -230,7 +230,6 @@ impl IsIn for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl IsIn for BinaryChunked {
     fn is_in(&self, other: &Series) -> PolarsResult<BooleanChunked> {
         match other.dtype() {

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -283,7 +283,11 @@ pub trait ChunkCast {
     fn cast(&self, data_type: &DataType) -> PolarsResult<Series>;
 
     /// Does not check if the cast is a valid one and may over/underflow
-    fn cast_unchecked(&self, data_type: &DataType) -> PolarsResult<Series>;
+    ///
+    /// # Safety
+    /// - This doesn't do utf8 validation checking when casting from binary
+    /// - This doesn't do categorical bound checking when casting from UInt32
+    unsafe fn cast_unchecked(&self, data_type: &DataType) -> PolarsResult<Series>;
 }
 
 /// Fastest way to do elementwise operations on a ChunkedArray<T> when the operation is cheaper than
@@ -621,7 +625,6 @@ impl ChunkExpandAtIndex<Utf8Type> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkExpandAtIndex<BinaryType> for BinaryChunked {
     fn new_from_index(&self, index: usize, length: usize) -> BinaryChunked {
         let mut out = impl_chunk_expand!(self, length, index);

--- a/polars/polars-core/src/chunked_array/ops/repeat_by.rs
+++ b/polars/polars-core/src/chunked_array/ops/repeat_by.rs
@@ -49,6 +49,7 @@ impl RepeatBy for BooleanChunked {
 }
 impl RepeatBy for Utf8Chunked {
     fn repeat_by(&self, by: &IdxCa) -> ListChunked {
+        // TODO! dispatch via binary.
         let iter = self
             .into_iter()
             .zip(by.into_iter())
@@ -67,7 +68,6 @@ impl RepeatBy for Utf8Chunked {
         }
     }
 }
-#[cfg(feature = "dtype-binary")]
 impl RepeatBy for BinaryChunked {
     fn repeat_by(&self, by: &IdxCa) -> ListChunked {
         let iter = self

--- a/polars/polars-core/src/chunked_array/ops/reverse.rs
+++ b/polars/polars-core/src/chunked_array/ops/reverse.rs
@@ -39,7 +39,6 @@ macro_rules! impl_reverse {
 
 impl_reverse!(BooleanType, BooleanChunked);
 impl_reverse!(Utf8Type, Utf8Chunked);
-#[cfg(feature = "dtype-binary")]
 impl_reverse!(BinaryType, BinaryChunked);
 impl_reverse!(ListType, ListChunked);
 

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -269,7 +269,6 @@ impl<'a> ChunkSet<'a, &'a str, String> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> ChunkSet<'a, &'a [u8], Vec<u8>> for BinaryChunked {
     fn set_at_idx<I: IntoIterator<Item = IdxSize>>(
         &'a self,

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -56,11 +56,15 @@ impl ChunkShift<BooleanType> for BooleanChunked {
 
 impl ChunkShiftFill<Utf8Type, Option<&str>> for Utf8Chunked {
     fn shift_and_fill(&self, periods: i64, fill_value: Option<&str>) -> Utf8Chunked {
-        impl_shift_fill!(self, periods, fill_value)
+        let ca = self.cast(&DataType::Binary).unwrap();
+        let ca = ca.binary().unwrap();
+        unsafe {
+            ca.shift_and_fill(periods, fill_value.map(|v| v.as_bytes()))
+                .to_utf8()
+        }
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkShiftFill<BinaryType, Option<&[u8]>> for BinaryChunked {
     fn shift_and_fill(&self, periods: i64, fill_value: Option<&[u8]>) -> BinaryChunked {
         impl_shift_fill!(self, periods, fill_value)
@@ -73,7 +77,6 @@ impl ChunkShift<Utf8Type> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkShift<BinaryType> for BinaryChunked {
     fn shift(&self, periods: i64) -> Self {
         self.shift_and_fill(periods, None)

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -56,8 +56,7 @@ impl ChunkShift<BooleanType> for BooleanChunked {
 
 impl ChunkShiftFill<Utf8Type, Option<&str>> for Utf8Chunked {
     fn shift_and_fill(&self, periods: i64, fill_value: Option<&str>) -> Utf8Chunked {
-        let ca = self.cast(&DataType::Binary).unwrap();
-        let ca = ca.binary().unwrap();
+        let ca = self.as_binary();
         unsafe {
             ca.shift_and_fill(periods, fill_value.map(|v| v.as_bytes()))
                 .to_utf8()

--- a/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -79,7 +79,7 @@ pub(crate) fn argsort_multiple_row_fmt(
     let mut fields = Vec::with_capacity(by.len());
 
     for (by, descending) in by.iter().zip(descending) {
-        let by = convert_sort_column_multi_sort(by)?;
+        let by = convert_sort_column_multi_sort(by, true)?;
         let data_type = by.dtype().to_arrow();
         let by = by.rechunk();
         cols.push(by.chunks()[0].clone());

--- a/polars/polars-core/src/chunked_array/ops/take/take_chunked.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_chunked.rs
@@ -62,37 +62,16 @@ where
 
 impl TakeChunked for Utf8Chunked {
     unsafe fn take_chunked_unchecked(&self, by: &[ChunkId], sorted: IsSorted) -> Self {
-        let arrs = self.downcast_iter().collect::<Vec<_>>();
-        let mut ca: Self = by
-            .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize)
-            })
-            .collect_trusted();
-        ca.rename(self.name());
-        ca.set_sorted_flag(sorted);
-        ca
+        self.as_binary()
+            .take_chunked_unchecked(by, sorted)
+            .to_utf8()
     }
 
     unsafe fn take_opt_chunked_unchecked(&self, by: &[Option<ChunkId>]) -> Self {
-        let arrs = self.downcast_iter().collect::<Vec<_>>();
-        let mut ca: Self = by
-            .iter()
-            .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
-                    let arr = arrs.get_unchecked(chunk_idx as usize);
-                    arr.get_unchecked(array_idx as usize)
-                })
-            })
-            .collect_trusted();
-
-        ca.rename(self.name());
-        ca
+        self.as_binary().take_opt_chunked_unchecked(by).to_utf8()
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl TakeChunked for BinaryChunked {
     unsafe fn take_chunked_unchecked(&self, by: &[ChunkId], sorted: IsSorted) -> Self {
         let arrs = self.downcast_iter().collect::<Vec<_>>();

--- a/polars/polars-core/src/chunked_array/ops/take/take_every.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_every.rs
@@ -31,17 +31,10 @@ impl ChunkTakeEvery<BooleanType> for BooleanChunked {
 
 impl ChunkTakeEvery<Utf8Type> for Utf8Chunked {
     fn take_every(&self, n: usize) -> Utf8Chunked {
-        let mut ca: Self = if !self.has_validity() {
-            self.into_no_null_iter().step_by(n).collect()
-        } else {
-            self.into_iter().step_by(n).collect()
-        };
-        ca.rename(self.name());
-        ca
+        unsafe { self.as_binary().take_every(n).to_utf8() }
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkTakeEvery<BinaryType> for BinaryChunked {
     fn take_every(&self, n: usize) -> BinaryChunked {
         let mut ca: Self = if !self.has_validity() {

--- a/polars/polars-core/src/chunked_array/ops/take/take_random.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_random.rs
@@ -234,13 +234,11 @@ impl<'a> IntoTakeRandom<'a> for &'a Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 pub struct BinaryTakeRandom<'a> {
     pub(crate) chunks: Chunks<'a, BinaryArray<i64>>,
     pub(crate) chunk_lens: Vec<IdxSize>,
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> TakeRandom for BinaryTakeRandom<'a> {
     type Item = &'a [u8];
 
@@ -255,12 +253,10 @@ impl<'a> TakeRandom for BinaryTakeRandom<'a> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 pub struct BinaryTakeRandomSingleChunk<'a> {
     pub(crate) arr: &'a BinaryArray<i64>,
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> TakeRandom for BinaryTakeRandomSingleChunk<'a> {
     type Item = &'a [u8];
 
@@ -279,7 +275,6 @@ impl<'a> TakeRandom for BinaryTakeRandomSingleChunk<'a> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> IntoTakeRandom<'a> for &'a BinaryChunked {
     type Item = &'a [u8];
     type TakeRandom = TakeRandBranch2<BinaryTakeRandomSingleChunk<'a>, BinaryTakeRandom<'a>>;

--- a/polars/polars-core/src/chunked_array/ops/take/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_single.rs
@@ -108,7 +108,6 @@ impl<'a> TakeRandom for &'a Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> TakeRandom for &'a BinaryChunked {
     type Item = &'a [u8];
 

--- a/polars/polars-core/src/chunked_array/ops/zip.rs
+++ b/polars/polars-core/src/chunked_array/ops/zip.rs
@@ -143,7 +143,6 @@ impl ChunkZip<Utf8Type> for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl ChunkZip<BinaryType> for BinaryChunked {
     fn zip_with(
         &self,

--- a/polars/polars-core/src/chunked_array/trusted_len.rs
+++ b/polars/polars-core/src/chunked_array/trusted_len.rs
@@ -202,7 +202,6 @@ where
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<Ptr> FromTrustedLenIterator<Ptr> for BinaryChunked
 where
     Ptr: PolarsAsRef<[u8]>,
@@ -213,7 +212,6 @@ where
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<Ptr> FromTrustedLenIterator<Option<Ptr>> for BinaryChunked
 where
     Ptr: AsRef<[u8]>,

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -133,7 +133,6 @@ where
 }
 
 // FromIterator for BinaryChunked variants.
-#[cfg(feature = "dtype-binary")]
 impl<Ptr> FromIterator<Option<Ptr>> for BinaryChunked
 where
     Ptr: AsRef<[u8]>,
@@ -144,19 +143,15 @@ where
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl PolarsAsRef<[u8]> for Vec<u8> {}
 
-#[cfg(feature = "dtype-binary")]
 impl PolarsAsRef<[u8]> for &[u8] {}
 
-#[cfg(feature = "dtype-binary")]
+// TODO: remove!
 impl PolarsAsRef<[u8]> for &&[u8] {}
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> PolarsAsRef<[u8]> for Cow<'a, [u8]> {}
 
-#[cfg(feature = "dtype-binary")]
 impl<Ptr> FromIterator<Ptr> for BinaryChunked
 where
     Ptr: PolarsAsRef<[u8]>,

--- a/polars/polars-core/src/datatypes/_serde.rs
+++ b/polars/polars-core/src/datatypes/_serde.rs
@@ -42,7 +42,6 @@ pub enum SerializableDataType {
     Float64,
     /// String data
     Utf8,
-    #[cfg(feature = "dtype-binary")]
     Binary,
     /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
     /// in days (32 bits).
@@ -78,7 +77,6 @@ impl From<&DataType> for SerializableDataType {
             Float32 => Self::Float32,
             Float64 => Self::Float64,
             Utf8 => Self::Utf8,
-            #[cfg(feature = "dtype-binary")]
             Binary => Self::Binary,
             Date => Self::Date,
             Datetime(tu, tz) => Self::Datetime(*tu, tz.clone()),
@@ -109,7 +107,6 @@ impl From<SerializableDataType> for DataType {
             Float32 => Self::Float32,
             Float64 => Self::Float64,
             Utf8 => Self::Utf8,
-            #[cfg(feature = "dtype-binary")]
             Binary => Self::Binary,
             Date => Self::Date,
             Datetime(tu, tz) => Self::Datetime(tu, tz),

--- a/polars/polars-core/src/datatypes/any_value.rs
+++ b/polars/polars-core/src/datatypes/any_value.rs
@@ -80,9 +80,7 @@ pub enum AnyValue<'a> {
     StructOwned(Box<(Vec<AnyValue<'a>>, Vec<Field>)>),
     /// An UTF8 encoded string type.
     Utf8Owned(smartstring::alias::String),
-    #[cfg(feature = "dtype-binary")]
     Binary(&'a [u8]),
-    #[cfg(feature = "dtype-binary")]
     BinaryOwned(Vec<u8>),
 }
 
@@ -112,9 +110,7 @@ impl Serialize for AnyValue<'_> {
             AnyValue::Utf8Owned(v) => {
                 serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v.as_str())
             }
-            #[cfg(feature = "dtype-binary")]
             AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v),
-            #[cfg(feature = "dtype-binary")]
             AnyValue::BinaryOwned(v) => {
                 serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
             }
@@ -145,7 +141,6 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
             List,
             Bool,
             Utf8Owned,
-            #[cfg(feature = "dtype-binary")]
             BinaryOwned,
         }
         const VARIANTS: &[&str] = &[
@@ -165,10 +160,7 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
             "Utf8Owned",
             "BinaryOwned",
         ];
-        #[cfg(feature = "dtype-binary")]
         const LAST: u8 = unsafe { std::mem::transmute::<_, u8>(AvField::BinaryOwned) };
-        #[cfg(not(feature = "dtype-binary"))]
-        const LAST: u8 = unsafe { std::mem::transmute::<_, u8>(AvField::Utf8Owned) };
 
         struct FieldVisitor;
 
@@ -231,7 +223,6 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                     b"List" => AvField::List,
                     b"Bool" => AvField::Bool,
                     b"Utf8Owned" | b"Utf8" => AvField::Utf8Owned,
-                    #[cfg(feature = "dtype-binary")]
                     b"BinaryOwned" | b"Binary" => AvField::BinaryOwned,
                     _ => {
                         return Err(serde::de::Error::unknown_variant(
@@ -320,7 +311,6 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                         let value: String = variant.newtype_variant()?;
                         AnyValue::Utf8Owned(value.into())
                     }
-                    #[cfg(feature = "dtype-binary")]
                     (AvField::BinaryOwned, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::BinaryOwned(value)
@@ -365,7 +355,6 @@ impl<'a> AnyValue<'a> {
             Struct(_, _, fields) => DataType::Struct(fields.to_vec()),
             #[cfg(feature = "dtype-struct")]
             StructOwned(payload) => DataType::Struct(payload.1.clone()),
-            #[cfg(feature = "dtype-binary")]
             Binary(_) => DataType::Binary,
             _ => unimplemented!(),
         }
@@ -501,9 +490,7 @@ impl<'a> Hash for AnyValue<'a> {
             Utf8Owned(v) => state.write(v.as_bytes()),
             Float32(v) => state.write_u32(v.to_bits()),
             Float64(v) => state.write_u64(v.to_bits()),
-            #[cfg(feature = "dtype-binary")]
             Binary(v) => state.write(v),
-            #[cfg(feature = "dtype-binary")]
             BinaryOwned(v) => state.write(v),
             Boolean(v) => state.write_u8(*v as u8),
             List(v) => Hash::hash(&Wrap(v.clone()), state),
@@ -583,7 +570,6 @@ impl<'a> AnyValue<'a> {
     #[inline]
     pub fn as_borrowed(&self) -> AnyValue<'_> {
         match self {
-            #[cfg(feature = "dtype-binary")]
             AnyValue::BinaryOwned(data) => AnyValue::Binary(data),
             AnyValue::Utf8Owned(data) => AnyValue::Utf8(data),
             av => av.clone(),
@@ -615,9 +601,7 @@ impl<'a> AnyValue<'a> {
             List(v) => List(v),
             Utf8(v) => Utf8Owned(v.into()),
             Utf8Owned(v) => Utf8Owned(v),
-            #[cfg(feature = "dtype-binary")]
             Binary(v) => BinaryOwned(v.to_vec()),
-            #[cfg(feature = "dtype-binary")]
             BinaryOwned(v) => BinaryOwned(v),
             #[cfg(feature = "object")]
             Object(v) => ObjectOwned(OwnedObject(v.to_boxed())),
@@ -685,7 +669,6 @@ impl PartialEq for AnyValue<'_> {
             (Datetime(l, tul, tzl), Datetime(r, tur, tzr)) => l == r && tul == tur && tzl == tzr,
             (Boolean(l), Boolean(r)) => l == r,
             (List(l), List(r)) => l == r,
-            #[cfg(feature = "dtype-binary")]
             (Binary(l), Binary(r)) => l == r,
             (Utf8(l), Utf8(r)) => l == r,
             #[cfg(feature = "object")]
@@ -725,7 +708,6 @@ impl PartialOrd for AnyValue<'_> {
             (Float32(l), Float32(r)) => l.partial_cmp(r),
             (Float64(l), Float64(r)) => l.partial_cmp(r),
             (Utf8(l), Utf8(r)) => l.partial_cmp(*r),
-            #[cfg(feature = "dtype-binary")]
             (Binary(l), Binary(r)) => l.partial_cmp(*r),
             _ => None,
         }
@@ -775,9 +757,7 @@ mod test {
             ),
             (ArrowDataType::LargeUtf8, DataType::Utf8),
             (ArrowDataType::Utf8, DataType::Utf8),
-            #[cfg(feature = "dtype-binary")]
             (ArrowDataType::LargeBinary, DataType::Binary),
-            #[cfg(feature = "dtype-binary")]
             (ArrowDataType::Binary, DataType::Binary),
             (
                 ArrowDataType::Time64(ArrowTimeUnit::Nanosecond),

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -21,7 +21,6 @@ pub enum DataType {
     Decimal128(Option<(usize, usize)>),
     /// String data
     Utf8,
-    #[cfg(feature = "dtype-binary")]
     Binary,
     /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
     /// in days (32 bits).
@@ -136,16 +135,7 @@ impl DataType {
     /// Check if datatype is a primitive type. By that we mean that
     /// it is not a container type.
     pub fn is_primitive(&self) -> bool {
-        #[cfg(feature = "dtype-binary")]
-        {
-            self.is_numeric()
-                | matches!(self, DataType::Boolean | DataType::Utf8 | DataType::Binary)
-        }
-
-        #[cfg(not(feature = "dtype-binary"))]
-        {
-            self.is_numeric() | matches!(self, DataType::Boolean | DataType::Utf8)
-        }
+        self.is_numeric() | matches!(self, DataType::Boolean | DataType::Utf8 | DataType::Binary)
     }
 
     /// Check if this [`DataType`] is a numeric type
@@ -161,7 +151,6 @@ impl DataType {
             | DataType::Boolean
             | DataType::Unknown
             | DataType::Null => false,
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => false,
             #[cfg(feature = "object")]
             DataType::Object(_) => false,
@@ -216,7 +205,6 @@ impl DataType {
             #[cfg(feature = "dtype-i128")]
             Decimal128(_) => todo!(),
             Utf8 => ArrowDataType::LargeUtf8,
-            #[cfg(feature = "dtype-binary")]
             Binary => ArrowDataType::LargeBinary,
             Date => ArrowDataType::Date32,
             Datetime(unit, tz) => ArrowDataType::Timestamp(unit.to_arrow(), tz.clone()),
@@ -271,7 +259,6 @@ impl Display for DataType {
             #[cfg(feature = "dtype-i128")]
             DataType::Decimal128(_) => "i128",
             DataType::Utf8 => "str",
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => "binary",
             DataType::Date => "date",
             DataType::Datetime(tu, tz) => {

--- a/polars/polars-core/src/datatypes/field.rs
+++ b/polars/polars-core/src/datatypes/field.rs
@@ -132,7 +132,6 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Duration(tu) => DataType::Duration(tu.into()),
             ArrowDataType::Date64 => DataType::Datetime(TimeUnit::Milliseconds, None),
             ArrowDataType::LargeUtf8 | ArrowDataType::Utf8 => DataType::Utf8,
-            #[cfg(feature = "dtype-binary")]
             ArrowDataType::LargeBinary | ArrowDataType::Binary => DataType::Binary,
             ArrowDataType::Time64(_) | ArrowDataType::Time32(_) => DataType::Time,
             #[cfg(feature = "dtype-categorical")]

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -49,7 +49,6 @@ use crate::utils::Wrap;
 
 pub struct Utf8Type {}
 
-#[cfg(feature = "dtype-binary")]
 pub struct BinaryType {}
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -98,7 +97,6 @@ impl PolarsDataType for Utf8Type {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl PolarsDataType for BinaryType {
     fn get_dtype() -> DataType {
         DataType::Binary
@@ -150,7 +148,6 @@ impl<T> PolarsSingleType for T where T: NativeType + PolarsDataType {}
 
 impl PolarsSingleType for Utf8Type {}
 
-#[cfg(feature = "dtype-binary")]
 impl PolarsSingleType for BinaryType {}
 
 pub type ListChunked = ChunkedArray<ListType>;
@@ -168,7 +165,6 @@ pub type Int128Chunked = ChunkedArray<Int128Type>;
 pub type Float32Chunked = ChunkedArray<Float32Type>;
 pub type Float64Chunked = ChunkedArray<Float64Type>;
 pub type Utf8Chunked = ChunkedArray<Utf8Type>;
-#[cfg(feature = "dtype-binary")]
 pub type BinaryChunked = ChunkedArray<BinaryType>;
 
 pub trait NumericNative:

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -172,7 +172,6 @@ impl Debug for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl Debug for BinaryChunked {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         format_array!(f, self, "binary", self.name(), "ChunkedArray")
@@ -301,7 +300,6 @@ impl Debug for Series {
             DataType::Null => {
                 writeln!(f, "nullarray")
             }
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => {
                 format_array!(f, self.binary().unwrap(), "binary", self.name(), "Series")
             }
@@ -729,7 +727,6 @@ impl Display for AnyValue<'_> {
             AnyValue::Boolean(v) => write!(f, "{}", *v),
             AnyValue::Utf8(v) => write!(f, "{}", format_args!("\"{v}\"")),
             AnyValue::Utf8Owned(v) => write!(f, "{}", format_args!("\"{v}\"")),
-            #[cfg(feature = "dtype-binary")]
             AnyValue::Binary(_) | AnyValue::BinaryOwned(_) => write!(f, "[binary data]"),
             #[cfg(feature = "dtype-date")]
             AnyValue::Date(v) => write!(f, "{}", date32_to_date(*v)),
@@ -885,7 +882,6 @@ impl FmtList for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl FmtList for BinaryChunked {
     fn fmt_list(&self) -> String {
         impl_fmt_list!(self)

--- a/polars/polars-core/src/frame/groupby/aggregations/agg_list.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/agg_list.rs
@@ -175,6 +175,7 @@ impl AggList for BooleanChunked {
 
 impl AggList for Utf8Chunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
+        // TODO: dispatch via binary
         match groups {
             GroupsProxy::Idx(groups) => {
                 let mut builder =
@@ -198,7 +199,6 @@ impl AggList for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl AggList for BinaryChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         match groups {

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -246,8 +246,7 @@ impl IntoGroupsProxy for BooleanChunked {
 impl IntoGroupsProxy for Utf8Chunked {
     #[allow(clippy::needless_lifetimes)]
     fn group_tuples<'a>(&'a self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
-        let s = self.cast(&DataType::Binary).unwrap();
-        s.group_tuples(multithreaded, sorted)
+        self.as_binary().group_tuples(multithreaded, sorted)
     }
 }
 

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -218,7 +218,7 @@ where
                 num_groups_proxy(ca, multithreaded, sorted)
             }
             _ => {
-                let ca = self.cast_unchecked(&DataType::UInt32).unwrap();
+                let ca = unsafe { self.cast_unchecked(&DataType::UInt32).unwrap() };
                 let ca = ca.u32().unwrap();
                 num_groups_proxy(ca, multithreaded, sorted)
             }
@@ -246,56 +246,11 @@ impl IntoGroupsProxy for BooleanChunked {
 impl IntoGroupsProxy for Utf8Chunked {
     #[allow(clippy::needless_lifetimes)]
     fn group_tuples<'a>(&'a self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
-        let hb = RandomState::default();
-        let null_h = get_null_hash_value(hb.clone());
-
-        let out = if multithreaded {
-            let n_partitions = _set_partition_size();
-
-            let split = _split_offsets(self.len(), n_partitions);
-
-            let str_hashes = POOL.install(|| {
-                split
-                    .into_par_iter()
-                    .map(|(offset, len)| {
-                        let ca = self.slice(offset as i64, len);
-                        ca.into_iter()
-                            .map(|opt_s| {
-                                let hash = match opt_s {
-                                    Some(s) => hb.hash_single(s),
-                                    None => null_h,
-                                };
-                                // Safety:
-                                // the underlying data is tied to self
-                                unsafe {
-                                    std::mem::transmute::<BytesHash<'_>, BytesHash<'a>>(
-                                        BytesHash::new_from_str(opt_s, hash),
-                                    )
-                                }
-                            })
-                            .collect_trusted::<Vec<_>>()
-                    })
-                    .collect::<Vec<_>>()
-            });
-            groupby_threaded_num(str_hashes, 0, n_partitions as u64, sorted)
-        } else {
-            let str_hashes = self
-                .into_iter()
-                .map(|opt_s| {
-                    let hash = match opt_s {
-                        Some(s) => hb.hash_single(s),
-                        None => null_h,
-                    };
-                    BytesHash::new_from_str(opt_s, hash)
-                })
-                .collect_trusted::<Vec<_>>();
-            groupby(str_hashes.iter(), sorted)
-        };
-        Ok(out)
+        let s = self.cast(&DataType::Binary).unwrap();
+        s.group_tuples(multithreaded, sorted)
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl IntoGroupsProxy for BinaryChunked {
     #[allow(clippy::needless_lifetimes)]
     fn group_tuples<'a>(&'a self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod multiple_keys;
-mod single_keys;
+pub(super) mod single_keys;
 mod single_keys_dispatch;
 mod single_keys_inner;
 mod single_keys_left;
@@ -22,10 +22,8 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "asof_join")]
 pub(crate) use single_keys::create_probe_table;
-use single_keys::*;
 #[cfg(feature = "asof_join")]
-pub(crate) use single_keys_dispatch::prepare_strs;
-use single_keys_inner::*;
+pub(crate) use single_keys_dispatch::prepare_bytes;
 use single_keys_left::*;
 use single_keys_outer::*;
 #[cfg(feature = "semi_anti_join")]
@@ -260,7 +258,6 @@ macro_rules! impl_zip_outer_join {
 }
 impl_zip_outer_join!(BooleanChunked);
 impl_zip_outer_join!(Utf8Chunked);
-#[cfg(feature = "dtype-binary")]
 impl_zip_outer_join!(BinaryChunked);
 
 impl ZipOuterJoinColumn for Float32Chunked {

--- a/polars/polars-core/src/frame/hash_join/single_keys_inner.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_inner.rs
@@ -1,4 +1,6 @@
+use super::single_keys::create_probe_table;
 use super::*;
+use crate::frame::hash_join::single_keys::probe_to_offsets;
 
 /// Probe the build table and add tuples to the results (inner join)
 pub(super) fn probe_inner<T, F>(

--- a/polars/polars-core/src/frame/hash_join/single_keys_left.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_left.rs
@@ -1,6 +1,8 @@
 use polars_utils::flatten;
 
+use super::single_keys::create_probe_table;
 use super::*;
+use crate::frame::hash_join::single_keys::probe_to_offsets;
 
 #[cfg(feature = "chunked_ids")]
 unsafe fn apply_mapping(idx: Vec<IdxSize>, chunk_mapping: &[ChunkId]) -> Vec<ChunkId> {

--- a/polars/polars-core/src/frame/hash_join/single_keys_semi_anti.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_semi_anti.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::frame::hash_join::single_keys::probe_to_offsets;
 
 /// Only keeps track of membership in right table
 pub(super) fn create_probe_table_semi_anti<T, IntoSlice>(keys: Vec<IntoSlice>) -> Vec<PlHashSet<T>>

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -63,7 +63,6 @@ macro_rules! impl_named_from {
 }
 
 impl_named_from!([String], Utf8Type, from_slice);
-#[cfg(feature = "dtype-binary")]
 impl_named_from!([Vec<u8>], BinaryType, from_slice);
 impl_named_from!([bool], BooleanType, from_slice);
 #[cfg(feature = "dtype-u8")]
@@ -81,7 +80,6 @@ impl_named_from!([i64], Int64Type, from_slice);
 impl_named_from!([f32], Float32Type, from_slice);
 impl_named_from!([f64], Float64Type, from_slice);
 impl_named_from!([Option<String>], Utf8Type, from_slice_options);
-#[cfg(feature = "dtype-binary")]
 impl_named_from!([Option<Vec<u8>>], BinaryType, from_slice_options);
 impl_named_from!([Option<bool>], BooleanType, from_slice_options);
 #[cfg(feature = "dtype-u8")]
@@ -229,35 +227,30 @@ impl<'a, T: AsRef<[Option<Cow<'a, str>>]>> NamedFrom<T, [Option<Cow<'a, str>>]> 
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[&'a [u8]]>> NamedFrom<T, [&'a [u8]]> for Series {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_slice(name, v.as_ref()).into_series()
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[&'a [u8]]>> NamedFrom<T, [&'a [u8]]> for BinaryChunked {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_slice(name, v.as_ref())
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Option<&'a [u8]>]>> NamedFrom<T, [Option<&'a [u8]>]> for Series {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_slice_options(name, v.as_ref()).into_series()
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Option<&'a [u8]>]>> NamedFrom<T, [Option<&'a [u8]>]> for BinaryChunked {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_slice_options(name, v.as_ref())
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Cow<'a, [u8]>]>> NamedFrom<T, [Cow<'a, [u8]>]> for Series {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_iter_values(name, v.as_ref().iter().map(|value| value.as_ref()))
@@ -265,21 +258,18 @@ impl<'a, T: AsRef<[Cow<'a, [u8]>]>> NamedFrom<T, [Cow<'a, [u8]>]> for Series {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Cow<'a, [u8]>]>> NamedFrom<T, [Cow<'a, [u8]>]> for BinaryChunked {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::from_iter_values(name, v.as_ref().iter().map(|value| value.as_ref()))
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Option<Cow<'a, [u8]>>]>> NamedFrom<T, [Option<Cow<'a, [u8]>>]> for Series {
     fn new(name: &str, v: T) -> Self {
         BinaryChunked::new(name, v).into_series()
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a, T: AsRef<[Option<Cow<'a, [u8]>>]>> NamedFrom<T, [Option<Cow<'a, [u8]>>]>
     for BinaryChunked
 {

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -9,12 +9,10 @@ pub use polars_arrow::kernels::ewm::EWMOptions;
 pub use polars_arrow::prelude::*;
 pub(crate) use polars_arrow::trusted_len::TrustedLen;
 
-#[cfg(feature = "dtype-binary")]
-pub use crate::chunked_array::builder::{BinaryChunkedBuilder, ListBinaryChunkedBuilder};
 pub use crate::chunked_array::builder::{
-    BooleanChunkedBuilder, ChunkedBuilder, ListBooleanChunkedBuilder, ListBuilderTrait,
-    ListPrimitiveChunkedBuilder, ListUtf8ChunkedBuilder, NewChunkedArray, PrimitiveChunkedBuilder,
-    Utf8ChunkedBuilder,
+    BinaryChunkedBuilder, BooleanChunkedBuilder, ChunkedBuilder, ListBinaryChunkedBuilder,
+    ListBooleanChunkedBuilder, ListBuilderTrait, ListPrimitiveChunkedBuilder,
+    ListUtf8ChunkedBuilder, NewChunkedArray, PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
 };
 pub use crate::chunked_array::iterator::PolarsIterator;
 #[cfg(feature = "dtype-categorical")]

--- a/polars/polars-core/src/serde/chunked_array.rs
+++ b/polars/polars-core/src/serde/chunked_array.rs
@@ -119,8 +119,6 @@ macro_rules! impl_serialize {
 impl_serialize!(Utf8Chunked);
 impl_serialize!(BooleanChunked);
 impl_serialize!(ListChunked);
-
-#[cfg(feature = "dtype-binary")]
 impl_serialize!(BinaryChunked);
 
 #[cfg(feature = "dtype-categorical")]

--- a/polars/polars-core/src/serde/mod.rs
+++ b/polars/polars-core/src/serde/mod.rs
@@ -50,7 +50,6 @@ impl From<&DataType> for DeDataType<'_> {
             DataType::Boolean => DeDataType::Boolean,
             DataType::Null => DeDataType::Null,
             DataType::List(_) => DeDataType::List,
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => DeDataType::Binary,
             #[cfg(feature = "object")]
             DataType::Object(s) => DeDataType::Object(s),
@@ -133,7 +132,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "dtype-binary")]
     fn test_serde_binary_series_owned_bincode() {
         let s1 = Series::new(
             "foo",

--- a/polars/polars-core/src/serde/series.rs
+++ b/polars/polars-core/src/serde/series.rs
@@ -35,7 +35,6 @@ impl Serialize for Series {
             ca.serialize(serializer)
         } else {
             match self.dtype() {
-                #[cfg(feature = "dtype-binary")]
                 DataType::Binary => {
                     let ca = self.binary().unwrap();
                     ca.serialize(serializer)
@@ -206,7 +205,6 @@ impl<'de> Deserialize<'de> for Series {
                         let values: Vec<Option<Series>> = map.next_value()?;
                         Ok(Series::new(&name, values))
                     }
-                    #[cfg(feature = "dtype-binary")]
                     DeDataType::Binary => {
                         let values: Vec<Option<Cow<[u8]>>> = map.next_value()?;
                         Ok(Series::new(&name, values))

--- a/polars/polars-core/src/series/any_value.rs
+++ b/polars/polars-core/src/series/any_value.rs
@@ -19,7 +19,6 @@ fn any_values_to_utf8(avs: &[AnyValue]) -> Utf8Chunked {
             AnyValue::Utf8(s) => builder.append_value(s),
             AnyValue::Utf8Owned(s) => builder.append_value(s),
             AnyValue::Null => builder.append_null(),
-            #[cfg(feature = "dtype-binary")]
             AnyValue::Binary(_) | AnyValue::BinaryOwned(_) => builder.append_null(),
             av => {
                 owned.clear();
@@ -31,7 +30,6 @@ fn any_values_to_utf8(avs: &[AnyValue]) -> Utf8Chunked {
     builder.finish()
 }
 
-#[cfg(feature = "dtype-binary")]
 fn any_values_to_binary(avs: &[AnyValue]) -> BinaryChunked {
     avs.iter()
         .map(|av| match av {
@@ -110,7 +108,6 @@ impl Series {
             DataType::Float32 => any_values_to_primitive::<Float32Type>(av).into_series(),
             DataType::Float64 => any_values_to_primitive::<Float64Type>(av).into_series(),
             DataType::Utf8 => any_values_to_utf8(av).into_series(),
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => any_values_to_binary(av).into_series(),
             DataType::Boolean => any_values_to_bool(av).into_series(),
             #[cfg(feature = "dtype-date")]
@@ -262,7 +259,6 @@ impl<'a> From<&AnyValue<'a>> for DataType {
             Null => DataType::Null,
             Boolean(_) => DataType::Boolean,
             Utf8(_) | Utf8Owned(_) => DataType::Utf8,
-            #[cfg(feature = "dtype-binary")]
             Binary(_) | BinaryOwned(_) => DataType::Binary,
             UInt32(_) => DataType::UInt32,
             UInt64(_) => DataType::UInt64,

--- a/polars/polars-core/src/series/arithmetic/borrowed.rs
+++ b/polars/polars-core/src/series/arithmetic/borrowed.rs
@@ -81,7 +81,6 @@ impl NumOpsDispatch for Utf8Chunked {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl NumOpsDispatch for BinaryChunked {
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
         let rhs = self.unpack_series_matching_type(rhs)?;

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -22,7 +22,6 @@ macro_rules! impl_compare {
         match lhs.dtype() {
             DataType::Boolean => lhs.bool().unwrap().$method(rhs.bool().unwrap()),
             DataType::Utf8 => lhs.utf8().unwrap().$method(rhs.utf8().unwrap()),
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => lhs.binary().unwrap().$method(rhs.binary().unwrap()),
             DataType::UInt8 => lhs.u8().unwrap().$method(rhs.u8().unwrap()),
             DataType::UInt16 => lhs.u16().unwrap().$method(rhs.u16().unwrap()),

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "dtype-binary")]
 mod binary;
 mod boolean;
 #[cfg(feature = "dtype-categorical")]
@@ -541,7 +540,6 @@ impl<T: PolarsNumericType> private::PrivateSeriesNumeric for SeriesWrap<ChunkedA
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<Utf8Chunked> {}
-#[cfg(feature = "dtype-binary")]
 impl private::PrivateSeriesNumeric for SeriesWrap<BinaryChunked> {}
 impl private::PrivateSeriesNumeric for SeriesWrap<ListChunked> {}
 impl private::PrivateSeriesNumeric for SeriesWrap<BooleanChunked> {

--- a/polars/polars-core/src/series/ops/downcast.rs
+++ b/polars/polars-core/src/series/ops/downcast.rs
@@ -159,7 +159,6 @@ impl Series {
     }
 
     /// Unpack to ChunkedArray of dtype binary
-    #[cfg(feature = "dtype-binary")]
     pub fn binary(&self) -> PolarsResult<&BinaryChunked> {
         match self.dtype() {
             DataType::Binary => unsafe {

--- a/polars/polars-core/src/series/ops/null.rs
+++ b/polars/polars-core/src/series/ops/null.rs
@@ -50,7 +50,6 @@ impl Series {
                         ChunkedArray::<Utf8Type>::full_null(name, size).into_series()
                     }};
                 }
-                #[cfg(feature = "dtype-binary")]
                 macro_rules! binary {
                     () => {{
                         ChunkedArray::<BinaryType>::full_null(name, size).into_series()

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -283,7 +283,6 @@ macro_rules! match_dtype_to_logical_apply_macro {
     ($obj:expr, $macro:ident, $macro_utf8:ident, $macro_binary:ident, $macro_bool:ident $(, $opt_args:expr)*) => {{
         match $obj {
             DataType::Utf8 => $macro_utf8!($($opt_args)*),
-            #[cfg(feature = "dtype-binary")]
             DataType::Binary => $macro_binary!($($opt_args)*),
             DataType::Boolean => $macro_bool!($($opt_args)*),
             #[cfg(feature = "dtype-u8")]

--- a/polars/polars-core/src/utils/supertype.rs
+++ b/polars/polars-core/src/utils/supertype.rs
@@ -196,10 +196,8 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             (Time, Float64) => Some(Float64),
 
             // every known type can be casted to a string except binary
-            #[cfg(feature = "dtype-binary")]
             (dt, Utf8) if dt != &DataType::Unknown && dt != &DataType::Binary => Some(Utf8),
 
-            #[cfg(not(feature = "dtype-binary"))]
             (dt, Utf8) if dt != &DataType::Unknown => Some(Utf8),
 
             (dt, Null) => Some(dt.clone()),

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -246,13 +246,11 @@ vec_hash_int!(UInt8Chunked, fx_hash_8_bit);
 
 impl VecHash for Utf8Chunked {
     fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) {
-        let ca = self.cast(&DataType::Binary).unwrap();
-        ca.vec_hash(random_state, buf).unwrap();
+        self.as_binary().vec_hash(random_state, buf)
     }
 
     fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {
-        let ca = self.cast(&DataType::Binary).unwrap();
-        ca.vec_hash_combine(random_state, hashes).unwrap();
+        self.as_binary().vec_hash_combine(random_state, hashes)
     }
 }
 

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -36,7 +36,6 @@ timezones = [
 ]
 dtype-time = ["polars-core/dtype-time", "polars-core/temporal", "polars-time/dtype-time"]
 dtype-struct = ["polars-core/dtype-struct"]
-dtype-binary = ["polars-core/dtype-binary"]
 fmt = ["polars-core/fmt"]
 lazy = []
 parquet = ["polars-core/parquet", "arrow/io_parquet", "arrow/io_parquet_compression", "memmap"]
@@ -62,7 +61,7 @@ flate2 = { version = "1", optional = true, default-features = false }
 futures = { version = "0.3.25", optional = true }
 lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-floats", "parse-integers"] }
 lexical-core = { version = "0.8", optional = true }
-memchr = "2.5"
+memchr.workspace = true
 memmap = { package = "memmap2", version = "0.5.2", optional = true }
 num-traits.workspace = true
 object_store = { version = "0.5.3", default-features = false, optional = true }

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -58,7 +58,6 @@ dtype-duration = ["polars-plan/dtype-duration", "polars-time/dtype-duration", "t
 dtype-time = ["polars-core/dtype-time", "temporal"]
 dtype-categorical = ["polars-plan/dtype-categorical", "polars-pipe/dtype-categorical"]
 dtype-struct = ["polars-plan/dtype-struct"]
-dtype-binary = ["polars-plan/dtype-binary"]
 object = ["polars-plan/object"]
 date_offset = ["polars-plan/date_offset"]
 trigonometry = ["polars-plan/trigonometry"]
@@ -127,7 +126,7 @@ serde = [
   "polars-ops/serde",
 ]
 
-binary_encoding = ["polars-plan/binary_encoding", "dtype-binary"]
+binary_encoding = ["polars-plan/binary_encoding"]
 
 # no guarantees whatsoever
 private = ["polars-plan/private"]

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -53,7 +53,6 @@ dtype-duration = ["polars-core/dtype-duration", "polars-time/dtype-duration", "t
 dtype-time = ["polars-core/dtype-time", "polars-time/dtype-time"]
 dtype-categorical = ["polars-core/dtype-categorical"]
 dtype-struct = ["polars-core/dtype-struct"]
-dtype-binary = ["polars-core/dtype-binary"]
 object = ["polars-core/object"]
 date_offset = ["polars-time"]
 list_take = ["polars-ops/list_take"]
@@ -61,7 +60,7 @@ list_count = ["polars-ops/list_count"]
 trigonometry = []
 sign = []
 timezones = ["polars-time/timezones", "polars-core/timezones", "regex"]
-binary_encoding = ["polars-ops/binary_encoding", "dtype-binary"]
+binary_encoding = ["polars-ops/binary_encoding"]
 true_div = []
 
 # operations

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "arg_where")]
 mod arg_where;
-#[cfg(feature = "dtype-binary")]
 mod binary;
 #[cfg(feature = "round_series")]
 mod clip;
@@ -40,7 +39,6 @@ use polars_core::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "dtype-binary")]
 pub(crate) use self::binary::BinaryFunction;
 #[cfg(feature = "temporal")]
 pub(super) use self::datetime::TemporalFunction;
@@ -68,7 +66,6 @@ pub enum FunctionExpr {
     SearchSorted(SearchSortedSide),
     #[cfg(feature = "strings")]
     StringExpr(StringFunction),
-    #[cfg(feature = "dtype-binary")]
     BinaryExpr(BinaryFunction),
     #[cfg(feature = "temporal")]
     TemporalExpr(TemporalFunction),
@@ -145,7 +142,6 @@ impl Display for FunctionExpr {
             SearchSorted(_) => "search_sorted",
             #[cfg(feature = "strings")]
             StringExpr(s) => return write!(f, "{s}"),
-            #[cfg(feature = "dtype-binary")]
             BinaryExpr(b) => return write!(f, "{b}"),
             #[cfg(feature = "temporal")]
             TemporalExpr(fun) => return write!(f, "{fun}"),
@@ -304,7 +300,6 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             }
             #[cfg(feature = "strings")]
             StringExpr(s) => s.into(),
-            #[cfg(feature = "dtype-binary")]
             BinaryExpr(s) => s.into(),
             #[cfg(feature = "temporal")]
             TemporalExpr(func) => func.into(),
@@ -442,7 +437,6 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: BinaryFunction) -> Self {
         use BinaryFunction::*;

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -142,7 +142,6 @@ impl FunctionExpr {
                     FromRadix { .. } => with_dtype(DataType::Int32),
                 }
             }
-            #[cfg(feature = "dtype-binary")]
             BinaryExpr(s) => {
                 use BinaryFunction::*;
                 match s {

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -4,7 +4,6 @@ pub mod cat;
 #[cfg(feature = "dtype-categorical")]
 pub use cat::*;
 mod arithmetic;
-#[cfg(feature = "dtype-binary")]
 pub mod binary;
 #[cfg(feature = "temporal")]
 mod dt;
@@ -2040,7 +2039,6 @@ impl Expr {
         string::StringNameSpace(self)
     }
 
-    #[cfg(feature = "dtype-binary")]
     pub fn binary(self) -> binary::BinaryNameSpace {
         binary::BinaryNameSpace(self)
     }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -439,7 +439,6 @@ impl Debug for LiteralValue {
             Null => write!(f, "null"),
             Boolean(b) => write!(f, "{b}"),
             Utf8(s) => write!(f, "{s}"),
-            #[cfg(feature = "dtype-binary")]
             Binary(_) => write!(f, "[binary value]"),
             #[cfg(feature = "dtype-u8")]
             UInt8(v) => write!(f, "{v}u8"),

--- a/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
@@ -15,7 +15,6 @@ pub enum LiteralValue {
     /// A UTF8 encoded string type.
     Utf8(String),
     /// A raw binary array
-    #[cfg(feature = "dtype-binary")]
     Binary(Vec<u8>),
     /// An unsigned 8-bit integer number.
     #[cfg(feature = "dtype-u8")]
@@ -105,7 +104,6 @@ impl LiteralValue {
             LiteralValue::Float32(_) => DataType::Float32,
             LiteralValue::Float64(_) => DataType::Float64,
             LiteralValue::Utf8(_) => DataType::Utf8,
-            #[cfg(feature = "dtype-binary")]
             LiteralValue::Binary(_) => DataType::Binary,
             LiteralValue::Range { data_type, .. } => data_type.clone(),
             #[cfg(all(feature = "temporal", feature = "dtype-datetime"))]
@@ -135,14 +133,12 @@ impl<'a> Literal for &'a str {
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl Literal for Vec<u8> {
     fn lit(self) -> Expr {
         Expr::Literal(LiteralValue::Binary(self))
     }
 }
 
-#[cfg(feature = "dtype-binary")]
 impl<'a> Literal for &'a [u8] {
     fn lit(self) -> Expr {
         Expr::Literal(LiteralValue::Binary(self.to_vec()))
@@ -156,7 +152,6 @@ impl TryFrom<AnyValue<'_>> for LiteralValue {
             AnyValue::Null => Ok(Self::Null),
             AnyValue::Boolean(b) => Ok(Self::Boolean(b)),
             AnyValue::Utf8(s) => Ok(Self::Utf8(s.to_string())),
-            #[cfg(feature = "dtype-binary")]
             AnyValue::Binary(b) => Ok(Self::Binary(b.to_vec())),
             #[cfg(feature = "dtype-u8")]
             AnyValue::UInt8(u) => Ok(Self::UInt8(u)),

--- a/polars/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -75,7 +75,6 @@ impl PhysicalExpr for LiteralExpr {
                 }
             },
             Utf8(v) => Utf8Chunked::full(NAME, v, 1).into_series(),
-            #[cfg(feature = "dtype-binary")]
             Binary(v) => BinaryChunked::full(NAME, v, 1).into_series(),
             #[cfg(feature = "temporal")]
             DateTime(ndt, tu) => {

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -14,7 +14,7 @@ arrow.workspace = true
 base64 = { version = "0.21", optional = true }
 hex = { version = "0.4", optional = true }
 jsonpath_lib = { version = "0.3.0", optional = true, git = "https://github.com/ritchie46/jsonpath", branch = "improve_compiled" }
-memchr = { version = "2", optional = true }
+memchr.workspace = true
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", default-features = false }
 polars-core = { version = "0.27.2", path = "../polars-core", features = ["private"], default-features = false }
 polars-utils = { version = "0.27.2", path = "../polars-utils", default-features = false }
@@ -29,7 +29,6 @@ dtype-datetime = ["polars-core/dtype-datetime", "polars-core/temporal"]
 dtype-time = ["polars-core/dtype-time", "polars-core/temporal"]
 dtype-duration = ["polars-core/dtype-duration", "polars-core/temporal"]
 dtype-struct = ["polars-core/dtype-struct", "polars-core/temporal"]
-dtype-binary = ["polars-core/dtype-binary", "polars-core/dtype-binary", "memchr"]
 dtype-u8 = ["polars-core/dtype-u8"]
 dtype-u16 = ["polars-core/dtype-u16"]
 dtype-i8 = ["polars-core/dtype-i8"]
@@ -44,7 +43,7 @@ is_first = []
 is_unique = []
 
 # extra utilities for BinaryChunked
-binary_encoding = ["base64", "hex", "dtype-binary"]
+binary_encoding = ["base64", "hex"]
 string_encoding = ["base64", "hex"]
 
 # ops

--- a/polars/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/binary/namespace.rs
@@ -67,9 +67,11 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     #[cfg(feature = "binary_encoding")]
     fn hex_encode(&self) -> Series {
         let ca = self.as_binary();
-        ca.apply(|s| hex::encode(s).into_bytes().into())
-            .cast_unchecked(&DataType::Utf8)
-            .unwrap()
+        unsafe {
+            ca.apply(|s| hex::encode(s).into_bytes().into())
+                .cast_unchecked(&DataType::Utf8)
+                .unwrap()
+        }
     }
 
     #[cfg(feature = "binary_encoding")]
@@ -95,9 +97,11 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     #[cfg(feature = "binary_encoding")]
     fn base64_encode(&self) -> Series {
         let ca = self.as_binary();
-        ca.apply(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
-            .cast_unchecked(&DataType::Utf8)
-            .unwrap()
+        unsafe {
+            ca.apply(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
+                .cast_unchecked(&DataType::Utf8)
+                .unwrap()
+        }
     }
 }
 

--- a/polars/polars-ops/src/chunked_array/interpolate.rs
+++ b/polars/polars-ops/src/chunked_array/interpolate.rs
@@ -169,7 +169,6 @@ fn interpolate_nearest(s: &Series) -> Series {
     match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_) => s.clone(),
-        #[cfg(feature = "dtype-binary")]
         DataType::Binary => s.clone(),
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => s.clone(),
@@ -193,7 +192,6 @@ fn interpolate_linear(s: &Series) -> Series {
     match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_) => s.clone(),
-        #[cfg(feature = "dtype-binary")]
         DataType::Binary => s.clone(),
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => s.clone(),

--- a/polars/polars-ops/src/chunked_array/mod.rs
+++ b/polars/polars-ops/src/chunked_array/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "dtype-binary")]
 mod binary;
 #[cfg(feature = "interpolate")]
 mod interpolate;
@@ -10,7 +9,6 @@ mod strings;
 #[cfg(feature = "top_k")]
 mod top_k;
 
-#[cfg(feature = "dtype-binary")]
 pub use binary::*;
 #[cfg(feature = "interpolate")]
 pub use interpolate::*;

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -23,15 +23,13 @@ fn f_regex_extract<'a>(reg: &Regex, input: &'a str, group_index: usize) -> Optio
 pub trait Utf8NameSpaceImpl: AsUtf8 {
     #[cfg(not(feature = "binary_encoding"))]
     fn hex_decode(&self) -> PolarsResult<Utf8Chunked> {
-        panic!("activate 'dtype-binary' feature")
+        panic!("activate 'binary_encoding' feature")
     }
 
     #[cfg(feature = "binary_encoding")]
     fn hex_decode(&self, strict: bool) -> PolarsResult<BinaryChunked> {
         let ca = self.as_utf8();
-        ca.cast_unchecked(&DataType::Binary)?
-            .binary()?
-            .hex_decode(strict)
+        ca.as_binary().hex_decode(strict)
     }
 
     #[must_use]
@@ -43,15 +41,13 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
 
     #[cfg(not(feature = "binary_encoding"))]
     fn base64_decode(&self) -> PolarsResult<Utf8Chunked> {
-        panic!("activate 'dtype-binary' feature")
+        panic!("activate 'binary_encoding' feature")
     }
 
     #[cfg(feature = "binary_encoding")]
     fn base64_decode(&self, strict: bool) -> PolarsResult<BinaryChunked> {
         let ca = self.as_utf8();
-        ca.cast_unchecked(&DataType::Binary)?
-            .binary()?
-            .base64_decode(strict)
+        ca.as_binary().base64_decode(strict)
     }
 
     #[must_use]

--- a/polars/polars-ops/src/frame/join/merge_sorted.rs
+++ b/polars/polars-ops/src/frame/join/merge_sorted.rs
@@ -50,17 +50,20 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> Series 
             merge_ca(lhs, rhs, merge_indicator).into_series()
         }
         Utf8 => {
-            let lhs = lhs.utf8().unwrap();
-            let rhs = rhs.utf8().unwrap();
-            merge_ca(lhs, rhs, merge_indicator).into_series()
+            // dispatch via binary
+            let lhs = lhs.cast(&Binary).unwrap();
+            let rhs = rhs.cast(&Binary).unwrap();
+            let lhs = lhs.binary().unwrap();
+            let rhs = rhs.binary().unwrap();
+            let out = merge_ca(lhs, rhs, merge_indicator);
+            unsafe { out.cast_unchecked(&Utf8).unwrap() }
         }
-        #[cfg(feature = "dtype-binary")]
         Binary => {
             let lhs = lhs.binary().unwrap();
             let rhs = rhs.binary().unwrap();
             merge_ca(lhs, rhs, merge_indicator).into_series()
         }
-        #[cfg(feature = "dtype-binary")]
+        #[cfg(feature = "dtype-struct")]
         Struct(_) => {
             let lhs = lhs.struct_().unwrap();
             let rhs = rhs.struct_().unwrap();

--- a/polars/polars-ops/src/series/ops/is_first.rs
+++ b/polars/polars-ops/src/series/ops/is_first.rs
@@ -28,7 +28,6 @@ where
     unsafe { BooleanChunked::from_chunks(ca.name(), chunks) }
 }
 
-#[cfg(feature = "dtype-binary")]
 fn is_first_bin(ca: &BinaryChunked) -> BooleanChunked {
     let mut unique = PlHashSet::new();
     let chunks = ca
@@ -85,12 +84,10 @@ pub fn is_first(s: &Series) -> PolarsResult<BooleanChunked> {
             let ca = s.bool().unwrap();
             is_first_boolean(ca)
         }
-        #[cfg(feature = "dtype-binary")]
         Binary => {
             let ca = s.binary().unwrap();
             is_first_bin(ca)
         }
-        #[cfg(feature = "dtype-binary")]
         Utf8 => {
             let s = s.cast(&Binary).unwrap();
             return is_first(&s);

--- a/polars/polars-ops/src/series/ops/is_unique.rs
+++ b/polars/polars-ops/src/series/ops/is_unique.rs
@@ -48,12 +48,10 @@ fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
             let ca = s.bool().unwrap();
             is_unique_ca(ca, invert)
         }
-        #[cfg(feature = "dtype-binary")]
         Binary => {
             let ca = s.binary().unwrap();
             is_unique_ca(ca, invert)
         }
-        #[cfg(feature = "dtype-binary")]
         Utf8 => {
             let s = s.cast(&Binary).unwrap();
             let ca = s.binary().unwrap();

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -12,7 +12,7 @@ cli = ["csv", "polars-lazy/fmt", "atty", "rustyline", "jemallocator"]
 csv = ["polars-lazy/csv-file"]
 default = []
 ipc = ["polars-lazy/ipc"]
-parquet = ["polars-lazy/parquet", "polars-lazy/dtype-binary"]
+parquet = ["polars-lazy/parquet"]
 
 [dependencies]
 atty = { version = "0.2", optional = true }

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -280,7 +280,6 @@
 //! | UInt16                  | dtype-u16         |
 //! | Categorical             | dtype-categorical |
 //! | Struct                  | dtype-struct      |
-//! | Binary                  | dtype-binary      |
 //!
 //!
 //! Or you can choose on of the preconfigured pre-sets.

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -92,7 +92,6 @@ all = [
   "propagate_nans",
   "polars/groupby_list",
   "sql",
-  "polars/dtype-binary",
   "binary_encoding",
   "streaming",
   "performant",


### PR DESCRIPTION
Remove `dtype-binary` feature. This makes the binary dtype default, but we can save a lot of code bloat by this as most `Utf8` related code could be dispatched via binary.

I already dispatched code I encountered during refactor, but we can probably remove more `Utf8` related code.