### PR TITLE
fix(rust): add type annotation to avoid potential build errors

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -75,7 +75,7 @@ macro_rules! format_array {
                 .map_or(LIMIT, |n: i64| if n < 0 { $a.len() } else { n as usize });
             std::cmp::min(limit, $a.len())
         };
-        let write_fn = |v, f: &mut Formatter| {
+        let write_fn = |v, f: &mut Formatter| -> fmt::Result {
             if truncate {
                 let v = format!("{}", v);
                 let v_trunc = &v[..v


### PR DESCRIPTION
closes #7221  

havent figured out exactly why #7221 is happening but simply add a type annotation does fix it. and this change looks pretty safe imo..  