### PR TITLE
fix(python): add test of median function in lazy mode

### DIFF
--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1448,6 +1448,7 @@ def test_compare_schema_between_lazy_and_eager_6904() -> None:
         pl.col("x").arg_min(),
         pl.col("x").max(),
         pl.col("x").mean(),
+        pl.col("x").median(),
         pl.col("x").min(),
         pl.col("x").nan_max(),
         pl.col("x").nan_min(),


### PR DESCRIPTION
#6814 

This PR only adds tests because the bug of `median` function reported in #6814 is already fixed  (by  maybe #6861).