### PR TITLE
style(python): Enable `strict` for ruff `TCH` lints

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
 
-from polars.datatypes import N_INFER_DEFAULT, SchemaDefinition, SchemaDict
+from polars.datatypes import N_INFER_DEFAULT
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
@@ -12,6 +11,8 @@ from polars.internals import DataFrame, Series
 from polars.utils import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
+    from polars.datatypes import SchemaDefinition, SchemaDict
+    from polars.dependencies import numpy as np
     from polars.internals.type_aliases import Orientation
 
 

--- a/py-polars/polars/datatypes_constructor.py
+++ b/py-polars/polars/datatypes_constructor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
@@ -17,7 +17,6 @@ from polars.datatypes import (
     Int64,
     Null,
     Object,
-    PolarsDataType,
     Time,
     UInt8,
     UInt16,
@@ -36,6 +35,8 @@ try:
 except ImportError:
     _DOCUMENTING = True
 
+if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType
 
 if not _DOCUMENTING:
     _POLARS_TYPE_TO_CONSTRUCTOR: dict[

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Sequence
 import polars.internals as pli
 from polars.datatypes import (
     N_INFER_DEFAULT,
-    PolarsDataType,
-    SchemaDict,
     py_type_to_dtype,
 )
 from polars.utils import (
@@ -22,6 +20,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyBatchedCsv
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType, SchemaDict
     from polars.internals.type_aliases import CsvEncoding
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -27,9 +27,6 @@ from polars.datatypes import (
     Duration,
     Float32,
     List,
-    PolarsDataType,
-    SchemaDefinition,
-    SchemaDict,
     Struct,
     Time,
     Unknown,
@@ -68,6 +65,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyDataFrame, PySeries
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
     from polars.internals.type_aliases import Orientation
 
 if version_info >= (3, 10):

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -7,7 +7,7 @@ import os
 import random
 import typing
 from collections.abc import Sized
-from io import BytesIO, IOBase, StringIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -39,9 +39,6 @@ from polars.datatypes import (
     Int32,
     Int64,
     Object,
-    PolarsDataType,
-    SchemaDefinition,
-    SchemaDict,
     UInt8,
     UInt16,
     UInt32,
@@ -96,9 +93,11 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
     from datetime import timedelta
+    from io import IOBase
 
     from pyarrow.interchange.dataframe import _PyArrowDataFrame
 
+    from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         AvroCompression,

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import time, timedelta
+from datetime import time
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
@@ -8,6 +8,8 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils import _timedelta_to_pl_duration, deprecated_alias, redirect
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
 
 

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -18,7 +18,6 @@ from typing import (
 
 from polars import internals as pli
 from polars.datatypes import (
-    PolarsDataType,
     Struct,
     UInt32,
     is_polars_dtype,
@@ -43,6 +42,7 @@ from polars.utils import (
 if TYPE_CHECKING:
     import sys
 
+    from polars.datatypes import PolarsDataType
     from polars.internals.type_aliases import (
         ClosedInterval,
         FillNullStrategy,

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -7,14 +7,13 @@ from polars.datatypes import (
     DataType,
     Date,
     Datetime,
-    PolarsDataType,
-    PolarsTemporalType,
     Time,
     is_polars_dtype,
     py_type_to_dtype,
 )
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType, PolarsTemporalType
     from polars.internals.type_aliases import TransferEncoding
 
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Iterable, Sequence, overload
 
 from polars import internals as pli
-from polars.datatypes import Date, PolarsDataType
+from polars.datatypes import Date
 from polars.utils import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
@@ -27,7 +27,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from datetime import date
 
+    from polars.datatypes import PolarsDataType
     from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit
 
     if sys.version_info >= (3, 8):
@@ -625,6 +627,7 @@ def align_frames(
 
     Examples
     --------
+    >>> from datetime import date
     >>> df1 = pl.DataFrame(
     ...     {
     ...         "dt": [date(2022, 9, 1), date(2022, 9, 2), date(2022, 9, 3)],
@@ -646,7 +649,6 @@ def align_frames(
     ...         "y": [2.5, 2.0],
     ...     }
     ... )  # doctest: +IGNORE_RESULT
-    >>>
     >>> pl.Config.set_tbl_formatting("UTF8_FULL")  # doctest: +IGNORE_RESULT
     #
     # df1                              df2                              df3
@@ -663,7 +665,9 @@ def align_frames(
     # │ 2022-09-03 ┆ 1.0 ┆ 1.5  │_/  `>│ 2022-09-01 ┆ 3.5 ┆ 5.0  │-//-
     # └────────────┴─────┴──────┘      └────────────┴─────┴──────┘
     ...
-    >>> # align frames by the "dt" column:
+
+    Align frames by the "dt" column:
+
     >>> af1, af2, af3 = pl.align_frames(
     ...     df1, df2, df3, on="dt"
     ... )  # doctest: +IGNORE_RESULT
@@ -682,7 +686,9 @@ def align_frames(
     # │ 2022-09-03 ┆ 1.0 ┆ 1.5  │----->│ 2022-09-03 ┆ 1.0 ┆ 12.0 │----->│ 2022-09-03 ┆ 2.0  ┆ 2.5  │
     # └────────────┴─────┴──────┘      └────────────┴─────┴──────┘      └────────────┴──────┴──────┘
     ...
-    >>> # align frames by "dt", but keep only cols "x" and "y":
+
+    Align frames by "dt", but keep only cols "x" and "y":
+
     >>> af1, af2, af3 = pl.align_frames(
     ...     df1, df2, df3, on="dt", select=["x", "y"]
     ... )  # doctest: +IGNORE_RESULT
@@ -701,7 +707,9 @@ def align_frames(
     # │ 1.0 ┆ 1.5  │      │ 1.0 ┆ 12.0 │      │ 2.0  ┆ 2.5  │
     # └─────┴──────┘      └─────┴──────┘      └──────┴──────┘
     ...
-    >>> # now data is aligned, can easily calculate the row-wise dot product:
+
+    Now data is aligned, and you can easily calculate the row-wise dot product:
+
     >>> (af1 * af2 * af3).fill_null(0).select(pl.sum(pl.col("*")).alias("dot"))
     shape: (3, 1)
     ┌───────┐

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -13,8 +13,6 @@ from polars.datatypes import (
     Duration,
     Int32,
     Int64,
-    PolarsDataType,
-    SchemaDict,
     Struct,
     Time,
     UInt32,
@@ -65,6 +63,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
+    from polars.datatypes import PolarsDataType, SchemaDict
     from polars.internals.type_aliases import (
         EpochTimeUnit,
         IntoExpr,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import typing
 from datetime import date, datetime, time, timedelta
-from io import BytesIO, IOBase, StringIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -33,9 +33,6 @@ from polars.datatypes import (
     Int16,
     Int32,
     Int64,
-    PolarsDataType,
-    SchemaDefinition,
-    SchemaDict,
     Time,
     UInt8,
     UInt16,
@@ -64,9 +61,11 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from io import IOBase
 
     import pyarrow as pa
 
+    from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -31,7 +31,6 @@ from polars.datatypes import (
     Int64,
     List,
     Object,
-    PolarsDataType,
     Time,
     UInt8,
     UInt16,
@@ -94,6 +93,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
+    from polars.datatypes import PolarsDataType
     from polars.internals.series._numpy import SeriesView
     from polars.internals.type_aliases import (
         ClosedInterval,

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -6,9 +6,10 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import polars.internals as pli
-from polars.datatypes import PolarsDataType, dtype_to_ffiname
+from polars.datatypes import dtype_to_ffiname
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType
     from polars.polars import PySeries
 
     if sys.version_info >= (3, 10):

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -10,16 +10,16 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
-
 if TYPE_CHECKING:
     from polars import internals as pli
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 
 # Types that qualify as expressions (eg: for use in 'select', 'with_columns'...)

--- a/py-polars/polars/io.py
+++ b/py-polars/polars/io.py
@@ -1,7 +1,7 @@
 """Functions for reading and writing data."""
 from __future__ import annotations
 
-from io import BytesIO, IOBase, StringIO
+from io import StringIO
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -18,9 +18,8 @@ from typing import (
 import polars.internals as pli
 from polars import BatchedCsvReader
 from polars.convert import from_arrow
-from polars.datatypes import N_INFER_DEFAULT, PolarsDataType, SchemaDict, Utf8
+from polars.datatypes import N_INFER_DEFAULT, Utf8
 from polars.dependencies import _DELTALAKE_AVAILABLE, _PYARROW_AVAILABLE, deltalake
-from polars.dependencies import pyarrow as pa
 from polars.internals import DataFrame, LazyFrame, _scan_ds
 from polars.internals.io import _prepare_file_arg
 from polars.utils import (
@@ -32,7 +31,10 @@ from polars.utils import (
 
 if TYPE_CHECKING:
     import sys
+    from io import BytesIO, IOBase
 
+    from polars.datatypes import PolarsDataType, SchemaDict
+    from polars.dependencies import pyarrow as pa
     from polars.internals.type_aliases import CsvEncoding, ParallelStrategy
 
     if sys.version_info >= (3, 8):

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -6,13 +6,11 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import isfinite
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from hypothesis import settings
 from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
 from hypothesis.strategies import (
-    DrawFn,
-    SearchStrategy,
     booleans,
     composite,
     dates,
@@ -41,7 +39,6 @@ from polars.datatypes import (
     Int16,
     Int32,
     Int64,
-    PolarsDataType,
     Time,
     UInt8,
     UInt16,
@@ -53,6 +50,11 @@ from polars.datatypes import (
 )
 from polars.string_cache import StringCache
 from polars.testing.asserts import is_categorical_dtype
+
+if TYPE_CHECKING:
+    from hypothesis.strategies import DrawFn, SearchStrategy
+
+    from polars.datatypes import PolarsDataType
 
 # Default profile (eg: running locally)
 common_settings = {"print_blob": True, "deadline": None}

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -8,8 +8,8 @@ import os
 import re
 import sys
 import warnings
-from collections.abc import MappingView, Reversible, Sized
-from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from collections.abc import MappingView, Sized
+from datetime import datetime, time, timedelta, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -22,13 +22,7 @@ from typing import (
 )
 
 import polars.internals as pli
-from polars.datatypes import (
-    Date,
-    Datetime,
-    Int64,
-    PolarsDataType,
-    is_polars_dtype,
-)
+from polars.datatypes import Date, Datetime, Int64, is_polars_dtype
 from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -43,10 +37,6 @@ if sys.version_info >= (3, 9):
 elif _ZONEINFO_AVAILABLE:
     from backports.zoneinfo._zoneinfo import ZoneInfo
 
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec, TypeGuard
-else:
-    from typing_extensions import ParamSpec, TypeGuard
 
 # note: reversed views don't match as instances of MappingView
 if sys.version_info >= (3, 11):
@@ -54,9 +44,20 @@ if sys.version_info >= (3, 11):
     _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
 if TYPE_CHECKING:
+    from collections.abc import Reversible
+    from datetime import date, tzinfo
     from pathlib import Path
 
+    from polars.datatypes import PolarsDataType
     from polars.internals.type_aliases import SizeUnit, TimeUnit
+
+    if sys.version_info >= (3, 10):
+        from typing import ParamSpec, TypeGuard
+    else:
+        from typing_extensions import ParamSpec, TypeGuard
+
+    P = ParamSpec("P")
+    T = TypeVar("T")
 
 
 def _process_null_values(
@@ -401,10 +402,6 @@ def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:
 def threadpool_size() -> int:
     """Get the size of polars' thread pool."""
     return _pool_size()
-
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 
 def _rename_kwargs(

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -152,6 +152,9 @@ max-doc-length = 88
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
 
+[tool.ruff.flake8-type-checking]
+strict = true
+
 [tool.ruff.per-file-ignores]
 "polars/datatypes.py" = ["B019"]
 "tests/**/*.py" = ["D100", "D103"]

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -11,12 +11,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import (
-    DATETIME_DTYPES,
-    DTYPE_TEMPORAL_UNITS,
-    TEMPORAL_DTYPES,
-    PolarsTemporalType,
-)
+from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, TEMPORAL_DTYPES
 from polars.exceptions import ComputeError, PanicException
 from polars.testing import (
     assert_frame_equal,
@@ -25,6 +20,7 @@ from polars.testing import (
 )
 
 if TYPE_CHECKING:
+    from polars.datatypes import PolarsTemporalType
     from polars.internals.type_aliases import TimeUnit
 
 if sys.version_info >= (3, 9):

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars import DataType
 from polars.exceptions import ComputeError, NoDataError
 from polars.testing import (
     assert_frame_equal,
@@ -574,7 +573,7 @@ def test_ignore_try_parse_dates() -> None:
     ).encode()
 
     headers = ["a", "b", "c"]
-    dtypes: dict[str, type[DataType]] = {
+    dtypes: dict[str, type[pl.DataType]] = {
         k: pl.Utf8 for k in headers
     }  # Forces Utf8 type for every column
     df = pl.read_csv(csv, columns=headers, dtypes=dtypes)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -24,7 +24,6 @@ from polars.datatypes import (
     INTEGER_DTYPES,
     NUMERIC_DTYPES,
     TEMPORAL_DTYPES,
-    PolarsDataType,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -627,7 +626,7 @@ def test_map_dict() -> None:
 
 
 def test_lit_dtypes() -> None:
-    def lit_series(value: Any, dtype: PolarsDataType | None) -> pl.Series:
+    def lit_series(value: Any, dtype: pl.PolarsDataType | None) -> pl.Series:
         return pl.select(pl.lit(value, dtype=dtype)).to_series()
 
     d = datetime(2049, 10, 5, 1, 2, 3, 987654)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -12,7 +12,7 @@ import pytest
 
 import polars as pl
 from polars import lit, when
-from polars.datatypes import NUMERIC_DTYPES, PolarsDataType
+from polars.datatypes import NUMERIC_DTYPES
 from polars.testing import assert_frame_equal
 from polars.testing.asserts import assert_series_equal
 
@@ -1327,7 +1327,7 @@ def test_quadratic_behavior_4736() -> None:
 
 
 @pytest.mark.parametrize("input_dtype", [pl.Utf8, pl.Int64, pl.Float64])
-def test_from_epoch(input_dtype: PolarsDataType) -> None:
+def test_from_epoch(input_dtype: pl.PolarsDataType) -> None:
     ldf = pl.LazyFrame(
         [
             pl.Series("timestamp_d", [13285]).cast(input_dtype),

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -17,7 +17,6 @@ from polars.datatypes import (
     Float64,
     Int32,
     Int64,
-    PolarsDataType,
     Time,
     UInt32,
     UInt64,
@@ -2359,7 +2358,7 @@ def test_builtin_abs() -> None:
     ],
 )
 def test_from_epoch_expr(
-    value: int, unit: EpochTimeUnit, exp: date | datetime, exp_type: PolarsDataType
+    value: int, unit: EpochTimeUnit, exp: date | datetime, exp_type: pl.PolarsDataType
 ) -> None:
     s = pl.Series("timestamp", [value, None])
     result = pl.from_epoch(s, unit=unit)
@@ -2484,7 +2483,7 @@ def test_map_dict() -> None:
     ],
 )
 def test_upper_lower_bounds(
-    dtype: PolarsDataType, upper: int | float, lower: int | float
+    dtype: pl.PolarsDataType, upper: int | float, lower: int | float
 ) -> None:
     s = pl.Series("s", dtype=dtype)
     assert s.lower_bound().item() == lower


### PR DESCRIPTION
Enable [strict mode](https://beta.ruff.rs/docs/settings/#strict) for `TCH` lints.

This setting makes sure that all imports that are done specifically for type checking are moved to an `if TYPE_CHECKING` block.

This does not have a performance benefit over non-strict mode, but improves readability: it's now immediately clear which imports are done for type checking, and which are used for the implementation.