### PR TITLE
fix(rust, python): improve concat_list with empty list error message

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -301,10 +301,16 @@ pub fn format_str<E: AsRef<[Expr]>>(format: &str, args: E) -> PolarsResult<Expr>
 }
 
 /// Concat lists entries.
-pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> Expr {
-    let s = s.as_ref().iter().map(|e| e.clone().into()).collect();
+pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult<Expr> {
+    let s: Vec<_> = s.as_ref().iter().map(|e| e.clone().into()).collect();
 
-    Expr::Function {
+    if s.is_empty() {
+        return Err(PolarsError::ComputeError(
+            "concat_list needs one or more expressions".into(),
+        ));
+    }
+
+    Ok(Expr::Function {
         input: s,
         function: FunctionExpr::ListExpr(ListFunction::Concat),
         options: FunctionOptions {
@@ -313,7 +319,7 @@ pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> Expr {
             fmt_str: "concat_list",
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Create list entries that are range arrays

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -241,9 +241,10 @@ fn concat_str(s: Vec<dsl::PyExpr>, separator: &str) -> dsl::PyExpr {
 }
 
 #[pyfunction]
-fn concat_lst(s: Vec<dsl::PyExpr>) -> dsl::PyExpr {
+fn concat_lst(s: Vec<dsl::PyExpr>) -> PyResult<dsl::PyExpr> {
     let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-    polars_rs::lazy::dsl::concat_lst(s).into()
+    let expr = polars_rs::lazy::dsl::concat_lst(s).map_err(PyPolarsErr::from)?;
+    Ok(expr.into())
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, time
 
 import pandas as pd
+import pytest
 
 import polars as pl
 
@@ -358,6 +359,11 @@ def test_concat_list_in_agg_6397() -> None:
         "group": [1, 2, 3],
         "result": [[["a"]], [["b", "c"]], [["d"]]],
     }
+
+
+def test_concat_list_empty_raises() -> None:
+    with pytest.raises(pl.ComputeError):
+        pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.concat_list([]))
 
 
 def test_flat_aggregation_to_list_conversion_6918() -> None:


### PR DESCRIPTION
Currently calling `pl.concat_list` with an empty list panics in Rust. It seems like the expected behavior should just be to return an empty list series.

```python
pl.concat_list([])
# PanicException: index out of bounds: the len is 0 but the index is 0
```

My current fix is rather high level and only fixes it at the Python API surface. It might be better if this could somehow be patched at a lower level. But because `pl.concat_list` is implemented on top of a lower `lhs.concat([])` interface, a ton of stuff just breaks expecting there to be a _lhs_. I think I maybe out of my depth there.

Related #7235