### PR TITLE
fix(python): ensure `every` type is properly normalised (for `groupby_dynamic` and `groupby_rolling`)

### DIFF
--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -2079,7 +2079,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         """
         if offset is None:
-            offset = f"-{period}"
+            offset = f"-{_timedelta_to_pl_duration(period)}"
 
         pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
         period = _timedelta_to_pl_duration(period)
@@ -2369,7 +2369,7 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
 
         """  # noqa: W505
         if offset is None:
-            offset = f"-{every}" if period is None else "0ns"
+            offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
         if period is None:
             period = every


### PR DESCRIPTION
_(As raised/spotted in the python-polars [Discord](https://discord.com/channels/908022250106667068/911186243465904178/1079812872147841106))._

When calling into either of these group functions directly from LazyFrame, the `every` param was not normalised to string-form if `offset` and `period` were None, meaning `timedelta` inputs would cause the following exception:
```python
PanicException: expected a unit in the duration string
```
Fixed, and added some test coverage.

