### PR TITLE
feat(rust, python): support nulls_last for multi-column sort

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -742,6 +742,14 @@ pub(crate) fn convert_sort_column_multi_sort(
     Ok(out)
 }
 
+pub(super) fn broadcast_descending(n_cols: usize, descending: &mut Vec<bool>) {
+    if n_cols > descending.len() && descending.len() == 1 {
+        while n_cols != descending.len() {
+            descending.push(descending[0]);
+        }
+    }
+}
+
 #[cfg(feature = "sort_multiple")]
 pub(crate) fn prepare_arg_sort(
     columns: Vec<Series>,
@@ -757,11 +765,7 @@ pub(crate) fn prepare_arg_sort(
     let first = columns.remove(0);
 
     // broadcast ordering
-    if n_cols > descending.len() && descending.len() == 1 {
-        while n_cols != descending.len() {
-            descending.push(descending[0]);
-        }
-    }
+    broadcast_descending(n_cols, &mut descending);
     Ok((first, columns, descending))
 }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1841,8 +1841,8 @@ impl DataFrame {
             _ => {
                 #[cfg(feature = "sort_multiple")]
                 {
-                    if std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
-                        argsort_multiple_row_fmt(&by_column, &descending, nulls_last, parallel)?
+                    if nulls_last || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
+                        argsort_multiple_row_fmt(&by_column, descending, nulls_last, parallel)?
                     } else {
                         let (first, by_column, descending) =
                             prepare_arg_sort(by_column, descending)?;
@@ -2451,7 +2451,7 @@ impl DataFrame {
     ///
     /// let df2: DataFrame = df1.describe(None)?;
     /// assert_eq!(df2.shape(), (9, 4));
-    /// dbg!(df2);
+    /// println!("{}", df2);
     /// # Ok::<(), PolarsError>(())
     /// ```
     ///

--- a/polars/polars-row/src/lib.rs
+++ b/polars/polars-row/src/lib.rs
@@ -266,7 +266,7 @@
 //! [COBS]: https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing
 //! [byte stuffing]: https://en.wikipedia.org/wiki/High-Level_Data_Link_Control#Asynchronous_framing
 
-mod encode;
+pub mod encode;
 mod encodings;
 mod row;
 mod sort_field;
@@ -276,4 +276,5 @@ use arrow::array::*;
 pub type ArrayRef = Box<dyn Array>;
 
 pub use encode::convert_columns;
+pub use row::RowsEncoded;
 pub use sort_field::SortField;

--- a/polars/polars-row/src/row.rs
+++ b/polars/polars-row/src/row.rs
@@ -24,6 +24,13 @@ impl RowsEncoded {
             buf: &self.buf,
         }
     }
+
+    #[cfg(test)]
+    pub fn get(&self, i: usize) -> &[u8] {
+        let start = self.offsets[i];
+        let end = self.offsets[i + 1];
+        &self.buf[start..end]
+    }
 }
 
 pub struct RowsEncodedIter<'a> {

--- a/polars/polars-row/src/sort_field.rs
+++ b/polars/polars-row/src/sort_field.rs
@@ -3,6 +3,7 @@ use encodings::fixed::FixedLengthEncoding;
 
 use super::*;
 
+#[derive(Clone)]
 pub struct SortField {
     /// Whether to sort in descending order
     pub descending: bool,

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1082,12 +1082,6 @@ naive plan: (run LazyFrame.describe_optimized_plan() to see the optimized plan)
         if more_by:
             by.extend(pli.selection_to_pyexpr_list(more_by))
 
-        # TODO: Do this check on the Rust side
-        if nulls_last and len(by) > 1:
-            raise ValueError(
-                "`nulls_last=True` only works when sorting by a single column"
-            )
-
         if isinstance(descending, bool):
             descending = [descending]
         return self._from_pyldf(self._ldf.sort_by_exprs(by, descending, nulls_last))

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -68,7 +68,7 @@ class WhenThen:
     def __init__(self, pywhenthen: Any):
         self._pywhenthen = pywhenthen
 
-    def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
+    def when(self, predicate: pli.Expr | bool | pli.Series) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
@@ -131,7 +131,7 @@ class When:
         return WhenThen(pywhenthen)
 
 
-def when(expr: pli.Expr | bool) -> When:
+def when(expr: pli.Expr | bool | pli.Series) -> When:
     """
     Start a "when, then, otherwise" expression.
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import random
+import string
 from datetime import datetime
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -446,9 +449,6 @@ def test_sort_args() -> None:
     result = df.sort("a", nulls_last=True)
     assert_frame_equal(result, df)
 
-    with pytest.raises(ValueError):
-        df.sort("a", "b", nulls_last=True)
-
 
 def test_sort_type_coersion_6892() -> None:
     df = pl.DataFrame({"a": [2, 1], "b": [2, 3]})
@@ -456,3 +456,33 @@ def test_sort_type_coersion_6892() -> None:
         "a": [1, 2],
         "b": [3, 2],
     }
+
+
+@pytest.mark.slow()
+def test_sort_row_fmt() -> None:
+    # we sort nulls_last as this will always dispatch
+    # to row_fmt and is the default in pandas
+
+    n = 1000
+    strs = pl.Series("strs", random.choices(string.ascii_lowercase, k=n))
+    strs = pl.select(
+        pl.when(strs == "a")
+        .then("")
+        .when(strs == "b")
+        .then(None)
+        .otherwise(strs)
+        .alias("strs")
+    ).to_series()
+
+    vals = pl.Series("vals", np.random.rand(n))
+
+    df = pl.DataFrame([vals, strs])
+    df_pd = df.to_pandas()
+
+    for descending in [True, False]:
+        pl.testing.assert_frame_equal(
+            df.sort(["strs", "vals"], nulls_last=True, descending=descending),
+            pl.from_pandas(
+                df_pd.sort_values(["strs", "vals"], ascending=not descending)
+            ),
+        )

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1935,12 +1935,7 @@ def test_trigonometric(f: str) -> None:
     expected = (
         pl.Series("a", getattr(np, f)(s.to_numpy()))
         .to_frame()
-        .with_columns(
-            pl.when(s.is_null())  # type: ignore[arg-type]
-            .then(None)
-            .otherwise(pl.col("a"))
-            .alias("a")
-        )
+        .with_columns(pl.when(s.is_null()).then(None).otherwise(pl.col("a")).alias("a"))
         .to_series()
     )
     result = getattr(s, f)()


### PR DESCRIPTION
This completes the `row_fmt` to what we need for sorting. Currently this enables multi-column sort where `nulls_last` is respected. This should also respect lexical ordering of categorical columns.