### PR TITLE
fix(python): don't lose microsecond precision in constructors when input is tz-aware datetime

### DIFF
--- a/py-polars/polars/datatypes.py
+++ b/py-polars/polars/datatypes.py
@@ -777,14 +777,18 @@ def py_type_to_arrow_type(dtype: PythonDataType) -> pa.lib.DataType:
         ) from None
 
 
-def dtype_to_arrow_type(dtype: PolarsDataType) -> pa.lib.DataType:
+def dtype_to_arrow_type(
+    dtype: PolarsDataType, tz_override: str | None = None
+) -> pa.lib.DataType:
     """Convert a Polars dtype to an Arrow dtype."""
     try:
         # special handling for mapping to tz-aware timestamp type.
         # (don't want to include every possible tz string in the lookup)
         tz = None
-        if dtype == Datetime:
+        if dtype == Datetime and tz_override is None:
             dtype, tz = Datetime(dtype.tu), dtype.tz  # type: ignore[union-attr]
+        elif dtype == Datetime:
+            dtype, tz = Datetime(dtype.tu), tz_override  # type: ignore[union-attr]
 
         arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
         if tz:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -346,6 +346,23 @@ def test_datetime_consistency() -> None:
         (test_data[3], 999999000),
     ]
 
+    # same as above, but for tz-aware
+    test_data = [
+        datetime(2000, 1, 1, 1, 1, 1, 555555, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(2514, 5, 30, 1, 53, 4, 986754, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(3099, 12, 31, 23, 59, 59, 123456, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=ZoneInfo("Asia/Kathmandu")),
+    ]
+    ddf = pl.DataFrame({"dtm": test_data}).with_columns(
+        pl.col("dtm").dt.nanosecond().alias("ns")
+    )
+    assert ddf.rows() == [
+        (test_data[0], 555555000),
+        (test_data[1], 986754000),
+        (test_data[2], 123456000),
+        (test_data[3], 999999000),
+    ]
+
 
 def test_timezone() -> None:
     ts = pa.timestamp("s")


### PR DESCRIPTION
closes #7252 