### PR TITLE
docs(rust): add more docstrings to `Expr`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -278,10 +278,10 @@ impl AsRef<Expr> for AggExpr {
     }
 }
 
-// TODO: is there any way to link to `polars_lazy::dsl` here? It's not a dependency (and can't be — circular dependency)
-// of polars-plan so I don't see any way to get a link to it in here.
+// TODO: is there any way to link to `polars_lazy::dsl` here? It's not a dependency of polars-plan (and can't be —
+// circular dependency) so I don't see any way to get a link to it in here.
 /// An abstract representation of a DataFrame column or an operation to perform on one. Queries consist of multiple
-/// expressions. When using the polars lazy API, don't use this type or its variants directly; instead, use the
+/// expressions. When using the polars lazy API, don't construct an `Expr` directly; instead, create one using the
 /// functions in the `polars_lazy::dsl` module. See that module's docs for more info.
 #[derive(Clone, PartialEq)]
 #[must_use]

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -278,11 +278,9 @@ impl AsRef<Expr> for AggExpr {
     }
 }
 
-// TODO: is there any way to link to `polars_lazy::dsl` here? It's not a dependency of polars-plan (and can't be —
-// circular dependency) so I don't see any way to get a link to it in here.
-/// An abstract representation of a DataFrame column or an operation to perform on one. Queries consist of multiple
-/// expressions. When using the polars lazy API, don't construct an `Expr` directly; instead, create one using the
-/// functions in the `polars_lazy::dsl` module. See that module's docs for more info.
+/// Expressions that can be used in various contexts. Queries consist of multiple expressions. When using the polars
+/// lazy API, don't construct an `Expr` directly; instead, create one using the functions in the `polars_lazy::dsl`
+/// module. See that module's docs for more info.
 #[derive(Clone, PartialEq)]
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -278,7 +278,11 @@ impl AsRef<Expr> for AggExpr {
     }
 }
 
-/// Queries consists of multiple expressions.
+// TODO: is there any way to link to `polars_lazy::dsl` here? It's not a dependency (and can't be — circular dependency)
+// of polars-plan so I don't see any way to get a link to it in here.
+/// An abstract representation of a DataFrame column or an operation to perform on one. Queries consist of multiple
+/// expressions. When using the polars lazy API, don't use this type or its variants directly; instead, use the
+/// functions in the `polars_lazy::dsl` module. See that module's docs for more info.
 #[derive(Clone, PartialEq)]
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -739,7 +739,7 @@ macro_rules! prepare_binary_function {
 
 /// Apply a closure on the two columns that are evaluated from `Expr` a and `Expr` b.
 ///
-/// The closure takes two arguments, each a `Series`. `output_type` must be the element type of the resulting `Series`.
+/// The closure takes two arguments, each a `Series`. `output_type` must be the output dtype of the resulting `Series`.
 pub fn map_binary<F: 'static>(a: Expr, b: Expr, f: F, output_type: GetOutput) -> Expr
 where
     F: Fn(Series, Series) -> PolarsResult<Option<Series>> + Send + Sync,

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -448,6 +448,7 @@ pub struct DatetimeArgs {
     pub microsecond: Option<Expr>,
 }
 
+/// Construct a column of `Datetime` from the provided args.
 #[cfg(feature = "temporal")]
 pub fn datetime(args: DatetimeArgs) -> Expr {
     use polars_core::export::chrono::NaiveDate;
@@ -563,6 +564,7 @@ pub struct DurationArgs {
     pub weeks: Option<Expr>,
 }
 
+/// Construct a column of `Duration` from the provided args.
 #[cfg(feature = "temporal")]
 pub fn duration(args: DurationArgs) -> Expr {
     let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
@@ -737,7 +739,7 @@ macro_rules! prepare_binary_function {
 
 /// Apply a closure on the two columns that are evaluated from `Expr` a and `Expr` b.
 ///
-/// The closure takes two arguments, each a `Series`.
+/// The closure takes two arguments, each a `Series`. `output_type` must be the element type of the resulting `Series`.
 pub fn map_binary<F: 'static>(a: Expr, b: Expr, f: F, output_type: GetOutput) -> Expr
 where
     F: Fn(Series, Series) -> PolarsResult<Option<Series>> + Send + Sync,

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1,4 +1,4 @@
-//! Domain specific language for the Lazy api.
+//! Domain specific language for the Lazy API.
 #[cfg(feature = "dtype-categorical")]
 pub mod cat;
 #[cfg(feature = "dtype-categorical")]

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -45,6 +45,7 @@ use crate::utils::has_expr;
 #[cfg(feature = "is_in")]
 use crate::utils::has_root_literal_expr;
 
+/// Compute `op(l, r)` (or equivalently `l op r`). `l` and `r` must have types compatible with the Operator.
 pub fn binary_expr(l: Expr, op: Operator, r: Expr) -> Expr {
     Expr::BinaryExpr {
         left: Box::new(l),

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -21,7 +21,8 @@ impl StringNameSpace {
         )
     }
 
-    /// Check if a string value contains a Regex substring.
+    /// Check if this column of strings contains a Regex. If `strict` is `true`, then it is an error if any `pat` is
+    /// an invalid regex, whereas if `strict` is `false`, an invalid regex will simply evaluate to `false`.
     #[cfg(feature = "regex")]
     pub fn contains(self, pat: Expr, strict: bool) -> Expr {
         self.0.map_many_private(
@@ -52,7 +53,7 @@ impl StringNameSpace {
         )
     }
 
-    /// Extract a regex pattern from the a string value.
+    /// Extract a regex pattern from the a string value. If `group_index` is out of bounds, null is returned.
     pub fn extract(self, pat: &str, group_index: usize) -> Expr {
         let pat = pat.to_string();
         self.0
@@ -98,6 +99,7 @@ impl StringNameSpace {
         self.0.map_private(StringFunction::CountMatch(pat).into())
     }
 
+    /// Construct a `Datetime` column by parsing this string column as datetimes, using the provided `options`.
     #[cfg(feature = "temporal")]
     pub fn strptime(self, options: StrpTimeOptions) -> Expr {
         self.0.map_private(StringFunction::Strptime(options).into())

--- a/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
@@ -289,7 +289,13 @@ impl Literal for Series {
     }
 }
 
-/// Create a Literal Expression from `L`
+/// Create a Literal Expression from `L`. A literal expression behaves like a column that contains a single distinct
+/// value.
+///
+/// The column is automatically of the "correct" length to make the operations work. Often this is determined by the
+/// length of the `LazyFrame` it is being used with. For instance, `lazy_df.with_column(lit(5).alias("five"))` creates a
+/// new column named "five" that is the length of the Dataframe (at the time `collect` is called), where every value in
+/// the column is `5`.
 pub fn lit<L: Literal>(t: L) -> Expr {
     t.lit()
 }

--- a/polars/polars-lazy/src/dsl/mod.rs
+++ b/polars/polars-lazy/src/dsl/mod.rs
@@ -1,4 +1,33 @@
-//! Domain specific language for the Lazy api.
+//! Domain specific language for the Lazy API. This DSL revolves around the [`Expr`] type, which represents an abstract
+//! operaton on a DataFrame, such as mapping over a column, filtering, groupby, or aggregation.
+//! In general, functions on [`LazyFrame`](crate::frame::LazyFrame)s consume the LazyFrame and produce a new LazyFrame representing
+//! the result of applying the function and passed expressions to the consumed LazyFrame.
+//! At runtime, when [`LazyFrame::collect`](crate::frame::LazyFrame::collect) is called, the expressions that comprise
+//! the LazyFrame's logical plan are materialized on the actual underlying Series.
+//! For instance, `let expr = col("x").pow(lit(2)).alias("x2");` would produce an expression representing the abstract
+//! operation of squaring the column `"x"` and naming the resulting column `"x2"`, and to apply this operation to a
+//! LazyFrame, you'd use `let lazy_df = lazy_df.with_column(expr);`.
+//! (Of course, a column named `"x"` must either exist in the original DataFrame or be produced by one of the preceding
+//! operations on the LazyFrame.)
+//!
+//! There are many, many free functions that this module exports that produce an [`Expr`] from scratch; [`col`] and
+//! [`lit`] are two examples.
+//! Expressions also have several methods, such as [`pow`](`Expr::pow`) and [`alias`](`Expr::alias`), that consume them
+//! and produce a new expression.
+//!
+//! Several expressions are only available when the necessary feature is enabled.
+//! Examples of features that unlock specialized expression include `string`, `temporal`, and `dtype-categorical`.
+//! These specialized expressions provide implementations of functions that you'd otherwise have to implement by hand.
+//!
+//! Because of how abstract and flexible the [`Expr`] type is, care must be take to ensure you only attempt to perform
+//! sensible operations with them.
+//! For instance, as mentioned above, you have to make sure any columns you reference already exist in the LazyFrame.
+//! Furthermore, there is nothing stopping you from calling, for example, [`any`](`Expr::any`) with an expression
+//! that will yield an `f64` column (instead of `bool`), or `col("string") - col("f64")`, which would attempt
+//! to subtract an `f64` Series from a `string` Series.
+//! These kinds of invalid operations will only yield an error at runtime, when
+//! [`collect`](crate::frame::LazyFrame::collect) is called on the LazyFrame.
+
 #[cfg(any(feature = "cumulative_eval", feature = "list_eval"))]
 mod eval;
 pub mod functions;


### PR DESCRIPTION
Biggest addition was a big intro about what exactly Expr is, in `polars/polars-lazy/src/dsl/mod.rs`