### PR TITLE
fix(rust, python): raise error on ambiguous filter predicates

### DIFF
--- a/polars/tests/it/lazy/predicate_queries.rs
+++ b/polars/tests/it/lazy/predicate_queries.rs
@@ -44,32 +44,6 @@ fn filter_true_lit() -> PolarsResult<()> {
     Ok(())
 }
 
-#[test]
-fn test_combine_columns_in_filter() -> PolarsResult<()> {
-    let df = df![
-        "a" => [1, 2, 3],
-        "b" => [None, Some("a"), Some("b")]
-    ]?;
-
-    let out = df
-        .lazy()
-        .filter(
-            cols(vec!["a".to_string(), "b".to_string()])
-                .cast(DataType::Utf8)
-                .gt(lit("2")),
-        )
-        .collect()?;
-
-    let expected = df![
-        "a" => [3],
-        "b" => ["b"],
-    ]?;
-
-    // "b" > "2" == true
-    assert!(out.frame_equal(&expected));
-    Ok(())
-}
-
 fn create_n_filters(col_name: &str, num_filters: usize) -> Vec<Expr> {
     (0..num_filters)
         .into_iter()

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -448,3 +448,12 @@ def test_file_path_truncate_err() -> None:
         match=r"\.\.\.42jfdksl32jfdksl22jfdksl12jfdksl02jfdksl91jfdksl81jfdksl71jfdksl61jfdksl51jfdksl41jfdksl",
     ):
         pl.read_csv(content)
+
+
+def test_ambiguous_filter_err() -> None:
+    df = pl.DataFrame({"a": [None, "2", "3"], "b": [None, None, "z"]})
+    with pytest.raises(
+        pl.ComputeError,
+        match=r"The predicate passed to 'filter' expanded to multiple expressions",
+    ):
+        df.filter(pl.col(["a", "b"]).is_null())


### PR DESCRIPTION
People tend to trip over expression expansion. Make it clear in the error message that the expressions are expanded.

```python
df = pl.DataFrame({"a": [None, "2", "3"], "b": [None, None, "z"]})
df.filter(pl.col(['a','b']).is_null())
```

```python
ComputeError: The predicate passed to 'filter' expanded to multiple expressions: 

	col("a").is_null(),
	col("b").is_null(),

This is ambiguous. Try to combine the predicates with the 'all' or `any' expression.

> Error originated just after operation: '  DF ["a", "b"]; PROJECT */2 COLUMNS; SELECTION: "None"
'
This operation could not be added to the plan.
```

closes #6808
closes #7254