### PR TITLE
fix(rust, python): no panic on empty cross join

### DIFF
--- a/polars/polars-core/src/chunked_array/random.rs
+++ b/polars/polars-core/src/chunked_array/random.rs
@@ -70,7 +70,7 @@ impl Series {
             ));
         }
         if n == 0 {
-            return Ok(self.slice(0, 0));
+            return Ok(self.clear());
         }
         let len = self.len();
 

--- a/polars/polars-core/src/frame/cross_join.rs
+++ b/polars/polars-core/src/frame/cross_join.rs
@@ -52,6 +52,9 @@ impl DataFrame {
             return Err(PolarsError::ComputeError("Cross joins would produce more rows than fits into 2^32.\n\
             Consider comping with polars-big-idx feature, or set 'streaming'.".into()))
         };
+        if n_rows_left == 0 || n_rows_right == 0 {
+            return Ok((self.clear(), other.clear()));
+        }
 
         // the left side has the Nth row combined with every row from right.
         // So let's say we have the following no. of rows

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -354,7 +354,7 @@ mod test {
     fn test_explode_df_empty_list() -> PolarsResult<()> {
         let s0 = Series::new("a", &[1, 2, 3]);
         let s1 = Series::new("b", &[1, 1, 1]);
-        let list = Series::new("foo", &[s0, s1.clone(), s1.slice(0, 0)]);
+        let list = Series::new("foo", &[s0, s1.clone(), s1.clear()]);
         let s0 = Series::new("B", [1, 2, 3]);
         let s1 = Series::new("C", [1, 1, 1]);
         let df = DataFrame::new(vec![list, s0.clone(), s1.clone()])?;
@@ -368,7 +368,7 @@ mod test {
 
         assert!(out.frame_equal_missing(&expected));
 
-        let list = Series::new("foo", &[s0.clone(), s1.slice(0, 0), s1.clone()]);
+        let list = Series::new("foo", &[s0.clone(), s1.clear(), s1.clone()]);
         let df = DataFrame::new(vec![list, s0.clone(), s1.clone()])?;
         let out = df.explode(["foo"])?;
         let expected = df![

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1142,7 +1142,7 @@ impl DataFrame {
             }
             // special case for literals
             else if height == 0 && series.len() == 1 {
-                let s = series.slice(0, 0);
+                let s = series.clear();
                 df.add_column_by_search(s)?;
                 Ok(df)
             } else {
@@ -1219,7 +1219,7 @@ impl DataFrame {
         }
         // special case for literals
         else if height == 0 && series.len() == 1 {
-            let s = series.slice(0, 0);
+            let s = series.clear();
             self.add_column_by_schema(s, schema)?;
             Ok(self)
         } else {
@@ -2277,6 +2277,11 @@ impl DataFrame {
             .iter()
             .map(|s| s.slice(offset, length))
             .collect::<Vec<_>>();
+        DataFrame::new_no_checks(col)
+    }
+
+    pub fn clear(&self) -> Self {
+        let col = self.columns.iter().map(|s| s.clear()).collect::<Vec<_>>();
         DataFrame::new_no_checks(col)
     }
 
@@ -3669,7 +3674,7 @@ mod test {
         )?;
 
         // has got columns, but no rows
-        let mut df = base.slice(0, 0);
+        let mut df = base.clear();
         let out = df.with_column(Series::new("c", [1]))?;
         assert_eq!(out.shape(), (0, 3));
         assert!(out.iter().all(|s| s.len() == 0));

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -158,6 +158,10 @@ impl Series {
         Series::full_null(name, 0, dtype)
     }
 
+    pub fn clear(&self) -> Series {
+        Series::new_empty(self.name(), self.dtype())
+    }
+
     #[doc(hidden)]
     #[cfg(feature = "private")]
     pub fn _get_inner_mut(&mut self) -> &mut dyn SeriesTrait {

--- a/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/projection.rs
@@ -59,7 +59,7 @@ impl Operator for ProjectionOperator {
 
         if has_empty {
             for s in &mut projected {
-                *s = s.slice(0, 0);
+                *s = s.clear();
             }
         } else if has_literals {
             let height = projected.iter().map(|s| s.len()).max().unwrap();

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -86,7 +86,7 @@ fn run_partitions(
 
                             if agg.len() == 1 {
                                 Ok(match groups.len()  {
-                                    0 => agg.slice(0, 0),
+                                    0 => agg.clear(),
                                     len => agg.new_from_index(0, len)
                                 })
                             } else {

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -4875,6 +4875,9 @@ class DataFrame:
         └──────┴──────┴──────┘
 
         """
+        # faster path
+        if n == 0:
+            return self._from_pydf(self._df.clear())
         if n > 0 or len(self) > 0:
             return self.__class__(
                 {

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -3319,6 +3319,8 @@ class Series:
         ]
 
         """
+        if n == 0:
+            return wrap_s(self._s.clear())
         s = (
             self.__class__(name=self.name, values=[], dtype=self.dtype)
             if len(self) > 0

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1355,4 +1355,8 @@ impl PyDataFrame {
         let df = self.df.unnest(names).map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }
+
+    pub fn clear(&self) -> Self {
+        self.df.clear().into()
+    }
 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -309,7 +309,7 @@ fn concat_df(dfs: &PyAny, py: Python) -> PyResult<PyDataFrame> {
     let first = iter.next().unwrap()?;
 
     let first_rdf = get_df(first)?;
-    let identity_df = first_rdf.slice(0, 0);
+    let identity_df = first_rdf.clear();
 
     let mut rdfs: Vec<PolarsResult<DataFrame>> = vec![Ok(first_rdf)];
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1164,6 +1164,10 @@ impl PySeries {
         };
         self.series.is_sorted(options)
     }
+
+    pub fn clear(&self) -> Self {
+        self.series.clear().into()
+    }
 }
 
 macro_rules! impl_set_with_mask {

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -15,3 +15,10 @@ def test_top_k_empty() -> None:
     df = pl.DataFrame({"test": []})
 
     assert_frame_equal(df.select([pl.col("test").top_k(2)]), df)
+
+
+def test_empty_cross_join() -> None:
+    a = pl.LazyFrame(schema={"a": pl.Int32})
+    b = pl.LazyFrame(schema={"b": pl.Int32})
+
+    assert (a.join(b, how="cross").collect()).schema == {"a": pl.Int32, "b": pl.Int32}


### PR DESCRIPTION
Also implements `clear` natively. This will be slightly faster as we loop in rust, but most importantly we replaced `slice(0, 0)` usages with `clear` freeing up memory.