### PR TITLE
fix(rust, python): fix preservation of microseconds when converting Python datetime

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -559,7 +559,11 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                             let dt = ob.call_method("replace", (), Some(kwargs))?;
                             let localize = UTILS.getattr("_localize").unwrap();
                             let loc_tz = localize.call1((dt, "UTC"));
-                            let seconds = loc_tz.call_method0("timestamp")?;
+                            let kwargs = PyDict::new(py);
+                            kwargs.set_item("microsecond", 0)?;
+                            let seconds = loc_tz
+                                .call_method("replace", (), Some(kwargs))?
+                                .call_method0("timestamp")?;
                             let microseconds = dt.getattr("microsecond")?.extract::<i64>()?;
                             (seconds, microseconds)
                         };
@@ -572,7 +576,11 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                             kwargs.set_item("tzinfo", timezone.getattr("utc")?)?;
                             let dt = ob.call_method("replace", (), Some(kwargs))?;
 
-                            let seconds = dt.call_method0("timestamp")?;
+                            let kwargs = PyDict::new(py);
+                            kwargs.set_item("microsecond", 0)?;
+                            let seconds = dt
+                                .call_method("replace", (), Some(kwargs))?
+                                .call_method0("timestamp")?;
                             let microseconds = dt.getattr("microsecond")?.extract::<i64>()?;
                             (seconds, microseconds)
                         };

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -341,6 +341,22 @@ def test_datetime_consistency() -> None:
         (test_data[2], 123456000),
         (test_data[3], 999999000),
     ]
+    # Same as above, but for tz-aware
+    test_data = [
+        datetime(2000, 1, 1, 1, 1, 1, 555555, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(2514, 5, 30, 1, 53, 4, 986754, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(3099, 12, 31, 23, 59, 59, 123456, tzinfo=ZoneInfo("Asia/Kathmandu")),
+        datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=ZoneInfo("Asia/Kathmandu")),
+    ]
+    ddf = pl.DataFrame({"dtm": test_data}).with_columns(
+        pl.col("dtm").dt.nanosecond().alias("ns")
+    )
+    assert ddf.rows() == [
+        (test_data[0], 555555000),
+        (test_data[1], 986754000),
+        (test_data[2], 123456000),
+        (test_data[3], 999999000),
+    ]
 
 
 def test_timezone() -> None:


### PR DESCRIPTION
closes #7270 