### PR TITLE
perf(rust, python): use inlined strings for field and schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hashbrown = { version = "0.13.1", features = ["rayon", "ahash"] }
 bitflags = "1.3"
 once_cell = "1"
 memchr = "2"
+smartstring = { version = "1" }
 
 [workspace.dependencies.arrow]
 package = "arrow2"

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -100,7 +100,7 @@ parquet = ["arrow/io_parquet"]
 bigidx = ["polars-arrow/bigidx"]
 python = []
 
-serde-lazy = ["serde", "polars-arrow/serde", "indexmap/serde"]
+serde-lazy = ["serde", "polars-arrow/serde", "indexmap/serde", "smartstring/serde"]
 
 docs-selection = [
   "ndarray",
@@ -174,7 +174,7 @@ regex = { version = "1.6", optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-smartstring = { version = "1" }
+smartstring.workspace = true
 thiserror.workspace = true
 url = { version = "2.3.1", optional = true }
 xxhash-rust.workspace = true

--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -2,6 +2,8 @@ mod from;
 
 use std::collections::BTreeMap;
 
+use smartstring::alias::String as SmartString;
+
 use super::*;
 use crate::datatypes::*;
 use crate::utils::index_to_chunked_index2;
@@ -163,7 +165,7 @@ impl StructChunked {
         &self.field
     }
 
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &SmartString {
         self.field.name()
     }
 
@@ -176,7 +178,7 @@ impl StructChunked {
     }
 
     pub fn rename(&mut self, name: &str) {
-        self.field.set_name(name.to_string())
+        self.field.set_name(name.into())
     }
 
     pub(crate) fn try_apply_fields<F>(&self, func: F) -> PolarsResult<Self>

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 
+#[cfg(feature = "sort_multiple")]
 pub(crate) use arg_sort_multiple::argsort_multiple_row_fmt;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;

--- a/polars/polars-core/src/datatypes/field.rs
+++ b/polars/polars-core/src/datatypes/field.rs
@@ -1,3 +1,5 @@
+use smartstring::alias::String as SmartString;
+
 use super::*;
 
 /// Characterizes the name and the [`DataType`] of a column.
@@ -7,7 +9,7 @@ use super::*;
     derive(Serialize, Deserialize)
 )]
 pub struct Field {
-    pub name: String,
+    pub name: SmartString,
     pub dtype: DataType,
 }
 
@@ -25,12 +27,12 @@ impl Field {
     #[inline]
     pub fn new(name: &str, dtype: DataType) -> Self {
         Field {
-            name: name.to_string(),
+            name: name.into(),
             dtype,
         }
     }
 
-    pub fn from_owned(name: String, dtype: DataType) -> Self {
+    pub fn from_owned(name: SmartString, dtype: DataType) -> Self {
         Field { name, dtype }
     }
 
@@ -45,7 +47,7 @@ impl Field {
     /// assert_eq!(f.name(), "Year");
     /// ```
     #[inline]
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &SmartString {
         &self.name
     }
 
@@ -86,11 +88,11 @@ impl Field {
     /// ```rust
     /// # use polars_core::prelude::*;
     /// let mut f = Field::new("Atomic number", DataType::UInt32);
-    /// f.set_name("Proton".to_owned());
+    /// f.set_name("Proton".into());
     ///
     /// assert_eq!(f, Field::new("Proton", DataType::UInt32));
     /// ```
-    pub fn set_name(&mut self, name: String) {
+    pub fn set_name(&mut self, name: SmartString) {
         self.name = name;
     }
 
@@ -106,7 +108,7 @@ impl Field {
     /// assert_eq!(f.to_arrow(), af);
     /// ```
     pub fn to_arrow(&self) -> ArrowField {
-        ArrowField::new(&self.name, self.dtype.to_arrow(), true)
+        ArrowField::new(self.name.as_str(), self.dtype.to_arrow(), true)
     }
 }
 

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -6,6 +6,7 @@ use ahash::RandomState;
 use arrow::types::NativeType;
 use num_traits::Zero;
 use rayon::prelude::*;
+use smartstring::alias::String as SmartString;
 
 use super::*;
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
@@ -634,8 +635,8 @@ impl DataFrame {
         other: &DataFrame,
         left_on: &str,
         right_on: &str,
-        left_by: Vec<String>,
-        right_by: Vec<String>,
+        left_by: Vec<SmartString>,
+        right_by: Vec<SmartString>,
         strategy: AsofStrategy,
         tolerance: Option<AnyValue<'static>>,
         suffix: Option<&str>,
@@ -727,14 +728,8 @@ impl DataFrame {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let left_by = left_by
-            .into_iter()
-            .map(|s| s.as_ref().to_string())
-            .collect();
-        let right_by = right_by
-            .into_iter()
-            .map(|s| s.as_ref().to_string())
-            .collect();
+        let left_by = left_by.into_iter().map(|s| s.as_ref().into()).collect();
+        let right_by = right_by.into_iter().map(|s| s.as_ref().into()).collect();
         self._join_asof_by(
             other, left_on, right_on, left_by, right_by, strategy, tolerance, None, None,
         )

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -1,12 +1,12 @@
 mod asof;
 mod groups;
-
 use std::borrow::Cow;
 
 use asof::*;
 use num_traits::Bounded;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 
 use crate::prelude::*;
 use crate::utils::slice_slice;
@@ -22,9 +22,9 @@ pub struct AsOfOptions {
     /// - "2h15m"
     /// - "1d6h"
     /// etc
-    pub tolerance_str: Option<String>,
-    pub left_by: Option<Vec<String>>,
-    pub right_by: Option<Vec<String>>,
+    pub tolerance_str: Option<SmartString>,
+    pub left_by: Option<Vec<SmartString>>,
+    pub right_by: Option<Vec<SmartString>>,
 }
 
 fn check_asof_columns(a: &Series, b: &Series) -> PolarsResult<()> {

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -2,6 +2,7 @@ use arrow::offset::OffsetsBuffer;
 use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 
 use crate::chunked_array::ops::explode::offsets_to_indexes;
 use crate::prelude::*;
@@ -22,10 +23,10 @@ fn get_exploded(series: &Series) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
 #[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MeltArgs {
-    pub id_vars: Vec<String>,
-    pub value_vars: Vec<String>,
-    pub variable_name: Option<String>,
-    pub value_name: Option<String>,
+    pub id_vars: Vec<SmartString>,
+    pub value_vars: Vec<SmartString>,
+    pub variable_name: Option<SmartString>,
+    pub value_name: Option<SmartString>,
 }
 
 impl DataFrame {
@@ -209,8 +210,8 @@ impl DataFrame {
     /// ```
     pub fn melt<I, J>(&self, id_vars: I, value_vars: J) -> PolarsResult<Self>
     where
-        I: IntoVec<String>,
-        J: IntoVec<String>,
+        I: IntoVec<SmartString>,
+        J: IntoVec<SmartString>,
     {
         let id_vars = id_vars.into_vec();
         let value_vars = value_vars.into_vec();
@@ -242,7 +243,7 @@ impl DataFrame {
                     if id_vars_set.contains(s.name()) {
                         None
                     } else {
-                        Some(s.name().to_string())
+                        Some(s.name().into())
                     }
                 })
                 .collect();

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -3,13 +3,14 @@ use std::fmt::{Debug, Formatter};
 use indexmap::IndexMap;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 
 use crate::prelude::*;
 
 #[derive(Eq, Clone, Default)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct Schema {
-    inner: PlIndexMap<String, DataType>,
+    inner: PlIndexMap<SmartString, DataType>,
 }
 
 // IndexMap does not care about order.
@@ -90,7 +91,7 @@ impl Schema {
         self.inner.is_empty()
     }
 
-    pub fn rename(&mut self, old: &str, new: String) -> Option<()> {
+    pub fn rename(&mut self, old: &str, new: SmartString) -> Option<()> {
         // we first append the new name
         // and then remove the old name
         // this works because the removed slot is swapped with the last value in the indexmap
@@ -100,7 +101,7 @@ impl Schema {
         Some(())
     }
 
-    pub fn insert_index(&self, index: usize, name: String, dtype: DataType) -> Option<Self> {
+    pub fn insert_index(&self, index: usize, name: SmartString, dtype: DataType) -> Option<Self> {
         // 0 and self.len() 0 is allowed
         if index > self.len() {
             return None;
@@ -125,7 +126,7 @@ impl Schema {
             .ok_or_else(|| PolarsError::SchemaFieldNotFound(name.to_string().into()))
     }
 
-    pub fn try_get_full(&self, name: &str) -> PolarsResult<(usize, &String, &DataType)> {
+    pub fn try_get_full(&self, name: &str) -> PolarsResult<(usize, &SmartString, &DataType)> {
         self.inner
             .get_full(name)
             .ok_or_else(|| PolarsError::SchemaFieldNotFound(name.to_string().into()))
@@ -135,7 +136,7 @@ impl Schema {
         self.inner.remove(name)
     }
 
-    pub fn get_full(&self, name: &str) -> Option<(usize, &String, &DataType)> {
+    pub fn get_full(&self, name: &str) -> Option<(usize, &SmartString, &DataType)> {
         self.inner.get_full(name)
     }
 
@@ -152,7 +153,7 @@ impl Schema {
             .map(|dtype| Field::new(name, dtype.clone()))
     }
 
-    pub fn get_index(&self, index: usize) -> Option<(&String, &DataType)> {
+    pub fn get_index(&self, index: usize) -> Option<(&SmartString, &DataType)> {
         self.inner.get_index(index)
     }
 
@@ -160,7 +161,7 @@ impl Schema {
         self.get(name).is_some()
     }
 
-    pub fn get_index_mut(&mut self, index: usize) -> Option<(&mut String, &mut DataType)> {
+    pub fn get_index_mut(&mut self, index: usize) -> Option<(&mut SmartString, &mut DataType)> {
         self.inner.get_index_mut(index)
     }
 
@@ -184,7 +185,7 @@ impl Schema {
     /// inserted, last in order, and `None` is returned.
     ///
     /// Computes in **O(1)** time (amortized average).
-    pub fn with_column(&mut self, name: String, dtype: DataType) -> Option<DataType> {
+    pub fn with_column(&mut self, name: SmartString, dtype: DataType) -> Option<DataType> {
         self.inner.insert(name, dtype)
     }
 
@@ -196,7 +197,7 @@ impl Schema {
         let fields: Vec<_> = self
             .inner
             .iter()
-            .map(|(name, dtype)| ArrowField::new(name, dtype.to_arrow(), true))
+            .map(|(name, dtype)| ArrowField::new(name.as_str(), dtype.to_arrow(), true))
             .collect();
         ArrowSchema::from(fields)
     }
@@ -211,10 +212,10 @@ impl Schema {
         self.inner.iter().map(|(_name, dtype)| dtype)
     }
 
-    pub fn iter_names(&self) -> impl Iterator<Item = &String> + '_ + ExactSizeIterator {
+    pub fn iter_names(&self) -> impl Iterator<Item = &SmartString> + '_ + ExactSizeIterator {
         self.inner.iter().map(|(name, _dtype)| name)
     }
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &DataType)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (&SmartString, &DataType)> + '_ {
         self.inner.iter()
     }
 }
@@ -222,8 +223,8 @@ impl Schema {
 pub type SchemaRef = Arc<Schema>;
 
 impl IntoIterator for Schema {
-    type Item = (String, DataType);
-    type IntoIter = <PlIndexMap<String, DataType> as IntoIterator>::IntoIter;
+    type Item = (SmartString, DataType);
+    type IntoIter = <PlIndexMap<SmartString, DataType> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -9,6 +9,7 @@ use num_traits::{One, Zero};
 pub use polars_arrow::utils::{TrustMyLength, *};
 use rayon::prelude::*;
 pub use series::*;
+use smartstring::alias::String as SmartString;
 pub use supertype::*;
 pub use {arrow, rayon};
 
@@ -821,6 +822,16 @@ where
 {
     fn into_vec(self) -> Vec<String> {
         self.into_iter().map(|s| s.as_ref().to_string()).collect()
+    }
+}
+
+impl<I, S> IntoVec<SmartString> for I
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    fn into_vec(self) -> Vec<SmartString> {
+        self.into_iter().map(|s| s.as_ref().into()).collect()
     }
 }
 

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -128,7 +128,7 @@ pub(crate) fn init_buffers(
         .iter()
         .map(|(name, dtype)| {
             let av_buf = (dtype, capacity).into();
-            let key = KnownKey::from(name);
+            let key = KnownKey::from(name.as_str());
             Ok((BufferKey(key), Buffer(name, av_buf)))
         })
         .collect()

--- a/polars/polars-io/src/parquet/predicates.rs
+++ b/polars/polars-io/src/parquet/predicates.rs
@@ -127,7 +127,7 @@ pub(crate) fn collect_statistics(
             // we select a single row group and collect only those stats
             Some(rg) => deserialize(fld, &md[rg..rg + 1])?,
         };
-        schema.with_column(fld.name.to_string(), (&fld.data_type).into());
+        schema.with_column((&fld.name).into(), (&fld.data_type).into());
         stats.push(ColumnStats(st, Field::from(fld)));
     }
 

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -26,6 +26,7 @@ polars-time = { version = "0.27.2", path = "../polars-time", optional = true }
 polars-utils = { version = "0.27.2", path = "../polars-utils" }
 pyo3 = { version = "0.18", optional = true }
 rayon.workspace = true
+smartstring.workspace = true
 
 [features]
 nightly = ["polars-core/nightly", "polars-pipe/nightly"]

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -22,6 +22,7 @@ pyo3 = { version = "0.18", optional = true }
 rayon.workspace = true
 regex = { version = "1.6", optional = true }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+smartstring.workspace = true
 
 [features]
 # debuging utility

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -1,6 +1,7 @@
 use polars_arrow::array::ValueSize;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array};
+use polars_utils::format_smartstring;
 
 use super::function_expr::StringFunction;
 use super::*;
@@ -217,7 +218,9 @@ impl StringNameSpace {
                 function,
                 GetOutput::from_type(DataType::Struct(
                     (0..n + 1)
-                        .map(|i| Field::from_owned(format!("field_{i}"), DataType::Utf8))
+                        .map(|i| {
+                            Field::from_owned(format_smartstring!("field_{i}"), DataType::Utf8)
+                        })
                         .collect(),
                 )),
             )
@@ -269,7 +272,9 @@ impl StringNameSpace {
                 function,
                 GetOutput::from_type(DataType::Struct(
                     (0..n + 1)
-                        .map(|i| Field::from_owned(format!("field_{i}"), DataType::Utf8))
+                        .map(|i| {
+                            Field::from_owned(format_smartstring!("field_{i}"), DataType::Utf8)
+                        })
                         .collect(),
                 )),
             )
@@ -321,7 +326,9 @@ impl StringNameSpace {
                 function,
                 GetOutput::from_type(DataType::Struct(
                     (0..n)
-                        .map(|i| Field::from_owned(format!("field_{i}"), DataType::Utf8))
+                        .map(|i| {
+                            Field::from_owned(format_smartstring!("field_{i}"), DataType::Utf8)
+                        })
                         .collect(),
                 )),
             )

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -374,7 +374,7 @@ impl LogicalPlanBuilder {
             let field = e
                 .to_field_amortized(&schema, Context::Default, &mut arena)
                 .unwrap();
-            new_schema.with_column(field.name().to_string(), field.data_type().clone());
+            new_schema.with_column(field.name().clone(), field.data_type().clone());
             arena.clear();
         }
 
@@ -610,7 +610,7 @@ impl LogicalPlanBuilder {
                 if let Expr::Column(name) = e {
                     if let Some(DataType::List(inner)) = schema.get(name) {
                         let inner = *inner.clone();
-                        schema.with_column(name.to_string(), inner);
+                        schema.with_column(name.as_ref().into(), inner);
                     }
 
                     (**name).to_owned()
@@ -739,12 +739,12 @@ pub(crate) fn det_melt_schema(args: &MeltArgs, input_schema: &Schema) -> SchemaR
         .variable_name
         .as_ref()
         .cloned()
-        .unwrap_or_else(|| "variable".to_string());
+        .unwrap_or_else(|| "variable".into());
     let value_name = args
         .value_name
         .as_ref()
         .cloned()
-        .unwrap_or_else(|| "value".to_string());
+        .unwrap_or_else(|| "value".into());
 
     new_schema.with_column(variable_name, DataType::Utf8);
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/drop.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/drop.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn drop_impl(mut df: DataFrame, names: &[String]) -> PolarsResult<DataFrame> {
+pub(super) fn drop_impl(mut df: DataFrame, names: &[SmartString]) -> PolarsResult<DataFrame> {
     for name in names {
         // ignore names that are not in there
         // they might already be removed by projection pushdown
@@ -14,7 +14,7 @@ pub(super) fn drop_impl(mut df: DataFrame, names: &[String]) -> PolarsResult<Dat
 
 pub(super) fn drop_schema<'a>(
     input_schema: &'a SchemaRef,
-    names: &[String],
+    names: &[SmartString],
 ) -> PolarsResult<Cow<'a, SchemaRef>> {
     let to_drop = PlHashSet::from_iter(names);
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
@@ -2,7 +2,6 @@ mod drop;
 #[cfg(feature = "merge_sorted")]
 mod merge_sorted;
 mod rename;
-
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
@@ -12,6 +11,7 @@ use polars_core::prelude::*;
 use polars_core::IUseStringCache;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 
 #[cfg(feature = "merge_sorted")]
 use crate::logical_plan::functions::merge_sorted::merge_sorted;
@@ -59,13 +59,13 @@ pub enum FunctionNode {
         column: Arc<str>,
     },
     Rename {
-        existing: Arc<Vec<String>>,
-        new: Arc<Vec<String>>,
+        existing: Arc<Vec<SmartString>>,
+        new: Arc<Vec<SmartString>>,
         // A column name gets swapped with an existing column
         swapping: bool,
     },
     Drop {
-        names: Arc<Vec<String>>,
+        names: Arc<Vec<SmartString>>,
     },
 }
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/rename.rs
@@ -2,8 +2,8 @@ use super::*;
 
 pub(super) fn rename_impl(
     mut df: DataFrame,
-    existing: &[String],
-    new: &[String],
+    existing: &[SmartString],
+    new: &[SmartString],
 ) -> PolarsResult<DataFrame> {
     let positions = existing
         .iter()
@@ -24,8 +24,8 @@ pub(super) fn rename_impl(
 
 pub(super) fn rename_schema<'a>(
     input_schema: &'a SchemaRef,
-    existing: &[String],
-    new: &[String],
+    existing: &[SmartString],
+    new: &[SmartString],
 ) -> PolarsResult<Cow<'a, SchemaRef>> {
     let mut new_schema = (**input_schema).clone();
     for (old, new) in existing.iter().zip(new.iter()) {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/rename.rs
@@ -1,3 +1,5 @@
+use smartstring::alias::String as SmartString;
+
 use super::*;
 use crate::prelude::optimizer::predicate_pushdown::keys::{key_has_name, predicate_to_key};
 
@@ -21,8 +23,8 @@ fn remove_any_key_referencing_renamed(
 pub(super) fn process_rename(
     acc_predicates: &mut PlHashMap<Arc<str>, Node>,
     expr_arena: &mut Arena<AExpr>,
-    existing: &[String],
-    new: &[String],
+    existing: &[SmartString],
+    new: &[SmartString],
 ) -> PolarsResult<Vec<Node>> {
     let mut local_predicates = vec![];
     for (existing, new) in existing.iter().zip(new.iter()) {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use smartstring::alias::String as SmartString;
+
 use super::*;
 
 fn iter_and_update_nodes(
@@ -25,8 +27,8 @@ pub(super) fn process_rename(
     acc_projections: &mut [Node],
     projected_names: &mut PlHashSet<Arc<str>>,
     expr_arena: &mut Arena<AExpr>,
-    existing: &[String],
-    new: &[String],
+    existing: &[SmartString],
+    new: &[SmartString],
     swapping: bool,
 ) -> PolarsResult<()> {
     let mut processed = BTreeSet::new();

--- a/polars/polars-lazy/polars-plan/src/logical_plan/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/schema.rs
@@ -1,4 +1,5 @@
 use polars_core::prelude::*;
+use polars_utils::format_smartstring;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -197,7 +198,7 @@ pub(crate) fn det_join_schema(
 
             for (name, dtype) in schema_left.iter() {
                 names.insert(name.as_str());
-                new_schema.with_column(name.to_string(), dtype.clone());
+                new_schema.with_column(name.clone(), dtype.clone());
             }
 
             // make sure that expression are assigned to the schema
@@ -224,7 +225,8 @@ pub(crate) fn det_join_schema(
                         if schema_left.contains(&field_right.name) {
                             use polars_core::frame::hash_join::_join_suffix_name;
                             new_schema.with_column(
-                                _join_suffix_name(&field_right.name, options.suffix.as_ref()),
+                                _join_suffix_name(&field_right.name, options.suffix.as_ref())
+                                    .into(),
                                 field_right.dtype,
                             );
                         } else {
@@ -257,10 +259,10 @@ pub(crate) fn det_join_schema(
                             }
                         }
 
-                        let new_name = format!("{}{}", name, options.suffix.as_ref());
+                        let new_name = format_smartstring!("{}{}", name, options.suffix.as_ref());
                         new_schema.with_column(new_name, dtype.clone());
                     } else {
-                        new_schema.with_column(name.to_string(), dtype.clone());
+                        new_schema.with_column(name.clone(), dtype.clone());
                     }
                 }
             }

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -3,6 +3,7 @@ use std::iter::FlatMap;
 use std::sync::Arc;
 
 use polars_core::prelude::*;
+use smartstring::alias::String as SmartString;
 
 use crate::logical_plan::iterator::ArenaExprIter;
 use crate::logical_plan::Context;
@@ -10,7 +11,7 @@ use crate::prelude::names::COUNT;
 use crate::prelude::*;
 
 /// Utility to write comma delimited
-pub fn column_delimited(mut s: String, items: &[String]) -> String {
+pub fn column_delimited(mut s: String, items: &[SmartString]) -> String {
     s.push('(');
     for c in items {
         s.push_str(c);

--- a/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -61,9 +61,9 @@ impl Executor for CsvExec {
         };
 
         let profile_name = if state.has_node_timer() {
-            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            let mut ids = vec![self.path.to_string_lossy().into()];
             if self.predicate.is_some() {
-                ids.push("predicate".to_string())
+                ids.push("predicate".into())
             }
             let name = column_delimited("csv".to_string(), &ids);
             Cow::Owned(name)

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -38,9 +38,9 @@ impl Executor for IpcExec {
         };
 
         let profile_name = if state.has_node_timer() {
-            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            let mut ids = vec![self.path.to_string_lossy().into()];
             if self.predicate.is_some() {
-                ids.push("predicate".to_string())
+                ids.push("predicate".into())
             }
             let name = column_delimited("ipc".to_string(), &ids);
             Cow::Owned(name)

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -60,9 +60,9 @@ impl Executor for ParquetExec {
         };
 
         let profile_name = if state.has_node_timer() {
-            let mut ids = vec![self.path.to_string_lossy().to_string()];
+            let mut ids = vec![self.path.to_string_lossy().into()];
             if self.predicate.is_some() {
-                ids.push("predicate".to_string())
+                ids.push("predicate".into())
             }
             let name = column_delimited("parquet".to_string(), &ids);
             Cow::Owned(name)

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -12,6 +12,7 @@ use polars_core::series::IsSorted;
 use polars_core::utils::_split_offsets;
 use polars_core::utils::arrow::bitmap::MutableBitmap;
 use polars_core::{downcast_as_macro_arg_physical, POOL};
+use polars_utils::format_smartstring;
 use polars_utils::sort::perfect_sort;
 use polars_utils::sync::SyncPtr;
 use rayon::prelude::*;
@@ -180,7 +181,7 @@ impl WindowExpr {
                 let first = group.first();
                 let group = groupby_columns
                     .iter()
-                    .map(|s| format!("{}", s.get(first as usize).unwrap()))
+                    .map(|s| format_smartstring!("{}", s.get(first as usize).unwrap()))
                     .collect::<Vec<_>>();
                 let err_msg = format!(
                     "{}\n> Group: ",

--- a/polars/polars-lazy/src/tests/queries.rs
+++ b/polars/polars-lazy/src/tests/queries.rs
@@ -50,8 +50,8 @@ fn test_lazy_melt() {
     let df = get_df();
 
     let args = MeltArgs {
-        id_vars: vec!["petal.width".to_string(), "petal.length".to_string()],
-        value_vars: vec!["sepal.length".to_string(), "sepal.width".to_string()],
+        id_vars: vec!["petal.width".into(), "petal.length".into()],
+        value_vars: vec!["sepal.length".into(), "sepal.width".into()],
         variable_name: None,
         value_name: None,
     };

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -20,6 +20,7 @@ polars-core = { version = "0.27.2", path = "../polars-core", features = ["privat
 polars-utils = { version = "0.27.2", path = "../polars-utils", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+smartstring.workspace = true
 
 [features]
 nightly = ["polars-utils/nightly"]

--- a/polars/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/polars/polars-ops/src/chunked_array/list/to_struct.rs
@@ -1,4 +1,6 @@
 use polars_core::export::rayon::prelude::*;
+use polars_utils::format_smartstring;
+use smartstring::alias::String as SmartString;
 
 use super::*;
 
@@ -45,10 +47,10 @@ fn det_n_fields(ca: &ListChunked, n_fields: ListToStructWidthStrategy) -> usize 
     }
 }
 
-pub type NameGenerator = Arc<dyn Fn(usize) -> String + Send + Sync>;
+pub type NameGenerator = Arc<dyn Fn(usize) -> SmartString + Send + Sync>;
 
-pub fn _default_struct_name_gen(idx: usize) -> String {
-    format!("field_{idx}")
+pub fn _default_struct_name_gen(idx: usize) -> SmartString {
+    format_smartstring!("field_{idx}")
 }
 
 pub trait ToStruct: AsList {

--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -20,6 +20,7 @@ polars-ops = { version = "0.27.2", path = "../polars-ops" }
 polars-utils = { version = "0.27.2", path = "../polars-utils" }
 regex = "1.7.1"
 serde = { version = "1", features = ["derive"], optional = true }
+smartstring.workspace = true
 
 [features]
 dtype-date = ["polars-core/dtype-date", "polars-core/temporal"]

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -5,6 +5,7 @@ use polars_core::prelude::*;
 use polars_core::POOL;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 
 use crate::prelude::*;
 
@@ -15,7 +16,7 @@ struct Wrap<T>(pub T);
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DynamicGroupOptions {
     /// Time or index column
-    pub index_column: String,
+    pub index_column: SmartString,
     /// start a window at this interval
     pub every: Duration,
     /// window duration
@@ -33,7 +34,7 @@ pub struct DynamicGroupOptions {
 impl Default for DynamicGroupOptions {
     fn default() -> Self {
         Self {
-            index_column: "".to_string(),
+            index_column: "".into(),
             every: Duration::new(1),
             period: Duration::new(1),
             offset: Duration::new(1),
@@ -49,7 +50,7 @@ impl Default for DynamicGroupOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RollingGroupOptions {
     /// Time or index column
-    pub index_column: String,
+    pub index_column: SmartString,
     /// window duration
     pub period: Duration,
     pub offset: Duration,

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -11,6 +11,7 @@ description = "private utils for the polars dataframe library"
 [dependencies]
 once_cell.workspace = true
 rayon.workspace = true
+smartstring.workspace = true
 sysinfo = { version = "0.28", default-features = false, optional = true }
 
 [features]

--- a/polars/polars-utils/src/fmt.rs
+++ b/polars/polars-utils/src/fmt.rs
@@ -1,0 +1,11 @@
+#[macro_export]
+macro_rules! format_smartstring {
+    ($($arg:tt)*) => {{
+        use smartstring::alias::String as SmartString;
+        use std::fmt::Write;
+
+        let mut string = SmartString::new();
+        write!(string, $($arg)*).unwrap();
+        string
+    }}
+}

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -24,6 +24,7 @@ pub type IdxSize = u32;
 #[cfg(feature = "bigidx")]
 pub type IdxSize = u64;
 
+pub mod fmt;
 pub mod iter;
 pub mod macros;
 #[cfg(target_family = "wasm")]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "polars-utils",
  "pyo3",
  "rayon",
+ "smartstring",
 ]
 
 [[package]]
@@ -1596,6 +1597,7 @@ dependencies = [
  "polars-utils",
  "serde",
  "serde_json",
+ "smartstring",
 ]
 
 [[package]]
@@ -1633,6 +1635,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "smartstring",
 ]
 
 [[package]]
@@ -1672,6 +1675,7 @@ dependencies = [
  "polars-utils",
  "regex",
  "serde",
+ "smartstring",
 ]
 
 [[package]]
@@ -1680,6 +1684,7 @@ version = "0.27.2"
 dependencies = [
  "once_cell",
  "rayon",
+ "smartstring",
  "sysinfo",
 ]
 
@@ -1717,6 +1722,7 @@ dependencies = [
  "pyo3",
  "pyo3-built",
  "serde_json",
+ "smartstring",
  "thiserror",
 ]
 
@@ -2071,6 +2077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -26,6 +26,7 @@ polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-f
 pyo3 = { version = "0.18.0", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.4", optional = true }
 serde_json = { version = "1", optional = true }
+smartstring = "1"
 thiserror = "^1.0"
 
 # features are only there to enable building a slim binary for the benchmark in CI

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -20,6 +20,7 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyList, PySequence};
 use pyo3::{PyAny, PyResult};
+use smartstring::alias::String as SmartString;
 
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
@@ -173,7 +174,7 @@ fn struct_dict<'a>(
 ) -> PyObject {
     let dict = PyDict::new(py);
     for (fld, val) in flds.iter().zip(vals) {
-        dict.set_item(fld.name(), Wrap(val)).unwrap()
+        dict.set_item(fld.name().as_str(), Wrap(val)).unwrap()
     }
     dict.into_py(py)
 }
@@ -297,7 +298,7 @@ impl ToPyObject for Wrap<DataType> {
             DataType::Struct(fields) => {
                 let field_class = pl.getattr("Field").unwrap();
                 let iter = fields.iter().map(|fld| {
-                    let name = fld.name().clone();
+                    let name = fld.name().as_str();
                     let dtype = Wrap(fld.data_type().clone()).to_object(py);
                     field_class.call1((name, dtype)).unwrap()
                 });
@@ -1169,4 +1170,12 @@ pub(crate) fn parse_parquet_compression(
         }
     };
     Ok(parsed)
+}
+
+pub(crate) fn strings_to_smartstrings<I, S>(container: I) -> Vec<SmartString>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    container.into_iter().map(|s| s.as_ref().into()).collect()
 }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -31,7 +31,7 @@ use crate::conversion::{ObjectValue, Wrap};
 use crate::error::PyPolarsErr;
 use crate::file::{get_either_file, get_file_like, get_mmap_bytes_reader, EitherRustPythonFile};
 use crate::lazy::dataframe::PyLazyFrame;
-use crate::prelude::dicts_to_rows;
+use crate::prelude::{dicts_to_rows, strings_to_smartstrings};
 use crate::series::{to_pyseries_collection, to_series_collection, PySeries};
 use crate::{arrow_interop, py_modules, PyExpr};
 
@@ -1093,16 +1093,16 @@ impl PyDataFrame {
 
     pub fn melt(
         &self,
-        id_vars: Vec<String>,
-        value_vars: Vec<String>,
-        value_name: Option<String>,
-        variable_name: Option<String>,
+        id_vars: Vec<&str>,
+        value_vars: Vec<&str>,
+        value_name: Option<&str>,
+        variable_name: Option<&str>,
     ) -> PyResult<Self> {
         let args = MeltArgs {
-            id_vars,
-            value_vars,
-            value_name,
-            variable_name,
+            id_vars: strings_to_smartstrings(id_vars),
+            value_vars: strings_to_smartstrings(value_vars),
+            value_name: value_name.map(|s| s.into()),
+            variable_name: variable_name.map(|s| s.into()),
         };
 
         let df = self.df.melt2(args).map_err(PyPolarsErr::from)?;

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -8,6 +8,7 @@ use pyo3::class::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
+use smartstring::alias::String as SmartString;
 
 use super::apply::*;
 use crate::conversion::{parse_fill_null_strategy, Wrap};
@@ -1605,7 +1606,8 @@ impl PyExpr {
             Arc::new(move |idx: usize| {
                 Python::with_gil(|py| {
                     let out = lambda.call1(py, (idx,)).unwrap();
-                    out.extract::<String>(py).unwrap()
+                    let out: SmartString = out.extract::<&str>(py).unwrap().into();
+                    out
                 })
             }) as NameGenerator
         });


### PR DESCRIPTION
Column names up to 23 bytes are now inlined via `smartstring`. 