### PR TITLE
feat(rust): Add support for small dtypes for LazyCsvReader

### DIFF
--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -397,6 +397,15 @@ pub fn infer_file_schema(
                 fields.push(Field::new(name, dtype.clone()));
                 continue;
             }
+
+            // column might have been renamed
+            // execute only if schema is complete
+            if schema_overwrite.len() == header_length {
+                if let Some((name, dtype)) = schema_overwrite.get_index(i) {
+                    fields.push(Field::new(name, dtype.clone()));
+                    continue;
+                }
+            }
         }
 
         // determine data type based on possible types

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -132,21 +132,6 @@ binary_encoding = ["polars-plan/binary_encoding"]
 # no guarantees whatsoever
 private = ["polars-plan/private"]
 
-# all opt-in datatypes
-dtype-full = [
-  "dtype-date",
-  "dtype-datetime",
-  "dtype-duration",
-  "dtype-time",
-  "dtype-i8",
-  "dtype-i16",
-  "dtype-i128",
-  "dtype-u8",
-  "dtype-u16",
-  "dtype-categorical",
-  "dtype-struct",
-]
-
 bigidx = ["polars-plan/bigidx"]
 
 panic_on_schema = ["polars-plan/panic_on_schema"]

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -132,6 +132,21 @@ binary_encoding = ["polars-plan/binary_encoding"]
 # no guarantees whatsoever
 private = ["polars-plan/private"]
 
+# all opt-in datatypes
+dtype-full = [
+  "dtype-date",
+  "dtype-datetime",
+  "dtype-duration",
+  "dtype-time",
+  "dtype-i8",
+  "dtype-i16",
+  "dtype-i128",
+  "dtype-u8",
+  "dtype-u16",
+  "dtype-categorical",
+  "dtype-struct",
+]
+
 bigidx = ["polars-plan/bigidx"]
 
 panic_on_schema = ["polars-plan/panic_on_schema"]

--- a/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -28,7 +28,7 @@ impl CsvExec {
         CsvReader::from_path(&self.path)
             .unwrap()
             .has_header(self.options.has_header)
-            .with_schema(self.schema.clone())
+            .with_dtypes(Some(self.schema.clone()))
             .with_delimiter(self.options.delimiter)
             .with_ignore_errors(self.options.ignore_errors)
             .with_skip_rows(self.options.skip_rows)

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -439,18 +439,13 @@ fn scan_small_dtypes() -> PolarsResult<()> {
         let df = LazyCsvReader::new(FOODS_CSV)
             .has_header(true)
             .with_dtype_overwrite(Some(&Schema::from(
-                vec![
-                    Field::new("sugars_g", dt.clone()),
-                ]
-                .into_iter())))
+                vec![Field::new("sugars_g", dt.clone())].into_iter(),
+            )))
             .finish()?
             .select(&[col("sugars_g")])
             .collect()?;
 
-        assert_eq!(
-            df.dtypes(),
-            &[dt]
-        );
+        assert_eq!(df.dtypes(), &[dt]);
     }
     Ok(())
 }

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -425,3 +425,32 @@ fn scan_anonymous_fn() -> PolarsResult<()> {
     assert_eq!(df.shape(), (5, 4));
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "dtype-full")]
+fn scan_small_dtypes() -> PolarsResult<()> {
+    let small_dt = vec![
+        DataType::Int8,
+        DataType::UInt8,
+        DataType::Int16,
+        DataType::UInt16,
+    ];
+    for dt in small_dt {
+        let df = LazyCsvReader::new(FOODS_CSV)
+            .has_header(true)
+            .with_dtype_overwrite(Some(&Schema::from(
+                vec![
+                    Field::new("sugars_g", dt.clone()),
+                ]
+                .into_iter())))
+            .finish()?
+            .select(&[col("sugars_g")])
+            .collect()?;
+
+        assert_eq!(
+            df.dtypes(),
+            &[dt]
+        );
+    }
+    Ok(())
+}

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -81,6 +81,7 @@ def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
         "sugars_g_foo",
     ]
 
+
 @pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
 @pytest.mark.parametrize("dtype", [pl.Int8, pl.UInt8, pl.Int16, pl.UInt16])
 def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
@@ -99,6 +100,7 @@ def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
         "fats_g_foo",
         "sugars_g_foo",
     ]
+
 
 def test_lazy_n_rows(foods_file_path: Path) -> None:
     df = (

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -81,6 +81,24 @@ def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
         "sugars_g_foo",
     ]
 
+@pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
+@pytest.mark.parametrize("dtype", [pl.Int8, pl.UInt8, pl.Int16, pl.UInt16])
+def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
+    io_files_path: Path, file_name: str, dtype: pl.DataType
+) -> None:
+    file_path = io_files_path / file_name
+    df = pl.scan_csv(
+        file_path,
+        dtypes={"calories_foo": pl.Utf8, "sugars_g_foo": dtype},
+        with_column_names=lambda names: [f"{a}_foo" for a in names],
+    ).collect()
+    assert df.dtypes == [pl.Utf8, pl.Utf8, pl.Float64, dtype]
+    assert df.columns == [
+        "category_foo",
+        "calories_foo",
+        "fats_g_foo",
+        "sugars_g_foo",
+    ]
 
 def test_lazy_n_rows(foods_file_path: Path) -> None:
     df = (


### PR DESCRIPTION
Uses `CsvReader::with_dypes` rather than `CsvReader::with_schema` to make use of the `to_cast` routine to accept small datatypes (`UInt8`, `Int8`, `UInt16`, `Int16`)