### PR TITLE
chore(python): Run `pytest-xdist` with worksteal

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -61,7 +61,7 @@ jobs:
           maturin develop
 
       - name: Run tests and report coverage
-        run: pytest --cov -n auto -m "not benchmark"
+        run: pytest --cov -n auto --dist worksteal -m "not benchmark"
 
       - name: Run doctests
         run: python tests/docs/run_doctest.py
@@ -125,7 +125,7 @@ jobs:
           pip install target/wheels/polars-*.whl
 
       - name: Run tests
-        run: pytest -n auto -m "not benchmark"
+        run: pytest -n auto --dist worksteal -m "not benchmark"
 
       - name: Check import without optional dependencies
         run: |

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -43,7 +43,7 @@ pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
 test: venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest -n auto
+	$(VENV_BIN)/pytest -n auto --dist worksteal
 
 .PHONY: doctest
 doctest: venv build  ## Run doctests
@@ -51,12 +51,12 @@ doctest: venv build  ## Run doctests
 
 .PHONY: test-all
 test-all: venv build  ## Run all tests
-	$(VENV_BIN)/pytest -n auto -m "slow or not slow"
+	$(VENV_BIN)/pytest -n auto --dist worksteal -m "slow or not slow"
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: coverage
 coverage: venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov -n auto -m "not benchmark"
+	$(VENV_BIN)/pytest --cov -n auto --dist worksteal -m "not benchmark"
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts


### PR DESCRIPTION
Changes:
* Use the new `worksteal` feature for `pytest-xdist`.

It doesn't really impact the runtime for regular `make test`, but really improves runtime when also running slower tests:

* Before: `pytest --cov -n auto -m "not benchmark"` -> ~32s
* After: `pytest --cov -n auto --dist worksteal -m "not benchmark"` -> 15-20s