### PR TITLE
feat(python): More ergonomic `unnest` args

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -7755,17 +7755,20 @@ class DataFrame:
         """
         return pli.wrap_s(self._df.to_struct(name))
 
-    def unnest(self, names: str | Sequence[str]) -> Self:
+    @deprecated_alias(names="columns")
+    def unnest(self, columns: str | Sequence[str], *more_columns: str) -> Self:
         """
-        Decompose a struct into its fields.
+        Decompose struct columns into separate columns for each of their fields.
 
-        The fields will be inserted into the `DataFrame` on the location of the
-        `struct` type.
+        The new columns will be inserted into the dataframe at the location of the
+        struct column.
 
         Parameters
         ----------
-        names
-           Names of the struct columns that will be decomposed by its fields
+        columns
+            Name of the struct column(s) that should be unnested.
+        *more_columns
+            Additional columns to unnest, specified as positional arguments.
 
         Examples
         --------
@@ -7778,7 +7781,7 @@ class DataFrame:
         ...         "t_d": [[1, 2], [3]],
         ...         "after": ["baz", "womp"],
         ...     }
-        ... ).select(["before", pl.struct(pl.col("^t_.$")).alias("t_struct"), "after"])
+        ... ).select("before", pl.struct(pl.col("^t_.$")).alias("t_struct"), "after")
         >>> df
         shape: (2, 3)
         ┌────────┬─────────────────────┬───────┐
@@ -7801,9 +7804,12 @@ class DataFrame:
         └────────┴─────┴─────┴──────┴───────────┴───────┘
 
         """
-        if isinstance(names, str):
-            names = [names]
-        return self._from_pydf(self._df.unnest(names))
+        if isinstance(columns, str):
+            columns = [columns]
+        if more_columns:
+            columns = list(columns)
+            columns.extend(more_columns)
+        return self._from_pydf(self._df.unnest(columns))
 
     @typing.no_type_check
     def corr(self, **kwargs: Any) -> Self:

--- a/py-polars/polars/internals/expr/struct.py
+++ b/py-polars/polars/internals/expr/struct.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 import polars.internals as pli
 
 
@@ -81,7 +83,7 @@ class ExprStructNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.struct_field_by_name(name))
 
-    def rename_fields(self, names: list[str]) -> pli.Expr:
+    def rename_fields(self, names: Sequence[str]) -> pli.Expr:
         """
         Rename the fields of the struct.
 

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
@@ -52,7 +52,7 @@ class StructNameSpace:
 
         """
 
-    def rename_fields(self, names: list[str]) -> pli.Series:
+    def rename_fields(self, names: Sequence[str]) -> pli.Series:
         """
         Rename the fields of the struct.
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1351,8 +1351,8 @@ impl PyDataFrame {
         s.into_series().into()
     }
 
-    pub fn unnest(&self, names: Vec<String>) -> PyResult<Self> {
-        let df = self.df.unnest(names).map_err(PyPolarsErr::from)?;
+    pub fn unnest(&self, columns: Vec<String>) -> PyResult<Self> {
+        let df = self.df.unnest(columns).map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -941,8 +941,8 @@ impl PyLazyFrame {
         Ok(schema_dict.to_object(py))
     }
 
-    pub fn unnest(&self, cols: Vec<String>) -> PyLazyFrame {
-        self.ldf.clone().unnest(cols).into()
+    pub fn unnest(&self, columns: Vec<String>) -> PyLazyFrame {
+        self.ldf.clone().unnest(columns).into()
     }
 
     pub fn width(&self) -> PyResult<usize> {

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -81,6 +81,19 @@ def test_struct_unnesting() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_struct_unnest_multiple() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [1.0, 2.0], "d": ["a", "b"]})
+    df_structs = df.select(s1=pl.struct(["a", "b"]), s2=pl.struct(["c", "d"]))
+
+    # List input
+    result = df_structs.unnest(["s1", "s2"])
+    assert_frame_equal(result, df)
+
+    # Positional input
+    result = df_structs.unnest("s1", "s2")
+    assert_frame_equal(result, df)
+
+
 def test_struct_function_expansion() -> None:
     df = pl.DataFrame(
         {"a": [1, 2, 3, 4], "b": ["one", "two", "three", "four"], "c": [9, 8, 7, 6]}


### PR DESCRIPTION
Partially addresses #6451

Changes:
* Add `*args` syntax to `unnest`