### PR TITLE
fix(rust, python): cached node critical section

### DIFF
--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1"
 ahash.workspace = true
 bitflags.workspace = true
 glob = "0.3"
+once_cell = "1"
 polars-arrow = { version = "0.28.0", path = "../polars-arrow" }
 polars-core = { version = "0.28.0", path = "../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.28.0", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "ahash",
  "bitflags",
  "glob",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-io",

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1335,6 +1335,64 @@ def test_lazy_cache_hit(monkeypatch: Any, capfd: Any) -> None:
     assert "CACHE HIT" in out
 
 
+def test_lazy_cache_parallel() -> None:
+    df_evaluated = 0
+
+    def map_df(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_evaluated
+        df_evaluated += 1
+        return df
+
+    df = pl.LazyFrame({"a": [1]}).map(map_df).cache()
+
+    df = pl.concat(
+        [
+            df.select(pl.col("a") + 1),
+            df.select(pl.col("a") + 2),
+            df.select(pl.col("a") + 3),
+        ],
+        parallel=True,
+    )
+
+    assert df_evaluated == 0
+
+    df.collect()
+    assert df_evaluated == 1
+
+
+def test_lazy_cache_nested_parallel() -> None:
+    df_inner_evaluated = 0
+    df_outer_evaluated = 0
+
+    def map_df_inner(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_inner_evaluated
+        df_inner_evaluated += 1
+        return df
+
+    def map_df_outer(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_outer_evaluated
+        df_outer_evaluated += 1
+        return df
+
+    df_inner = pl.LazyFrame({"a": [1]}).map(map_df_inner).cache()
+    df_outer = df_inner.select(pl.col("a") + 1).map(map_df_outer).cache()
+
+    df = pl.concat(
+        [
+            df_outer.select(pl.col("a") + 2),
+            df_outer.select(pl.col("a") + 3),
+        ],
+        parallel=True,
+    )
+
+    assert df_inner_evaluated == 0
+    assert df_outer_evaluated == 0
+
+    df.collect()
+    assert df_inner_evaluated == 1
+    assert df_outer_evaluated == 1
+
+
 def test_quadratic_behavior_4736() -> None:
     # no assert; if this function does not stall our tests it has passed!
     ldf = pl.LazyFrame(schema=list(ascii_letters))


### PR DESCRIPTION
Cached nodes have a race condition when evaluated in parallel.

The way it's working on `master` is that:

1. Cache node is visited
2. `df_cache` mutex is obtained
3. `df_cache` is missing cache id
4. `df_cache` mutex is unlocked
5. cached node is evalutated
6. `df_cache` mutex is obtained
7. `df_cache` cache id set to value
8. `df_cache` mutex is unlocked

The race condition is if two threads start these steps at the same time, both will reach step 5 and start evaluating the node because `self.input.execute(state)` itself is outside of the critical section of the mutex. Both threads will then set the cache id multiple times. A lock really needs to be held for the entire critical section of checking the cache state, generating the cached value, and setting the value.