### PR TITLE
fix(python): raise error if output of 'apply' cannot be determined

### DIFF
--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -829,9 +829,12 @@ impl PySeries {
         let series = &self.series;
 
         if skip_nulls && (series.null_count() == series.len()) {
+            if let Some(output_type) = output_type {
+                return Ok(Series::full_null(series.name(), series.len(), &output_type.0).into());
+            }
             let msg = "The output type of 'apply' function cannot determined.\n\
             The function was never called because 'skip_nulls=True' and all values are null.\n\
-            Consider setting 'skip_nulls=False'";
+            Consider setting 'skip_nulls=False' or setting the 'return_dtype'.";
             raise_err!(msg, ComputeError)
         }
 

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -62,8 +62,14 @@ def test_empty_sort() -> None:
         ],
         orient="row",
     )
-    df_filtered = df.filter(pl.col("blob").apply(lambda blob: blob["name"] == "baz"))
-    df_filtered.sort(pl.col("blob").apply(lambda blob: blob["sort_key"]))
+    df_filtered = df.filter(
+        pl.col("blob").apply(
+            lambda blob: blob["name"] == "baz", return_dtype=pl.Boolean
+        )
+    )
+    df_filtered.sort(
+        pl.col("blob").apply(lambda blob: blob["sort_key"], return_dtype=pl.Int64)
+    )
 
 
 def test_object_to_dicts() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3390,7 +3390,13 @@ def test_format_empty_df() -> None:
 def test_deadlocks_3409() -> None:
     assert (
         pl.DataFrame({"col1": [[1, 2, 3]]})
-        .with_columns([pl.col("col1").arr.eval(pl.element().apply(lambda x: x))])
+        .with_columns(
+            [
+                pl.col("col1").arr.eval(
+                    pl.element().apply(lambda x: x, return_dtype=pl.Int64)
+                )
+            ]
+        )
         .to_dict(False)
     ) == {"col1": [[1, 2, 3]]}
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -466,3 +466,12 @@ def test_with_column_duplicates() -> None:
         match=r"The name: 'same' passed to `LazyFrame.with_columns` is duplicate",
     ):
         assert df.with_columns([pl.all().alias("same")]).columns == ["a", "b", "same"]
+
+
+def test_skipp_nulls_err() -> None:
+    df = pl.DataFrame({"foo": [None, None]})
+
+    with pytest.raises(
+        pl.ComputeError, match=r"The output type of 'apply' function cannot determined"
+    ):
+        df.with_columns(pl.col("foo").apply(lambda x: x, skip_nulls=True))

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -317,6 +317,10 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     q = pl.DataFrame({"a": [1, 2]}).lazy()
 
-    (q.select(pl.col("a").apply(lambda x: x * 2)).collect(streaming=True))
+    (
+        q.select(pl.col("a").apply(lambda x: x * 2, return_dtype=pl.Int64)).collect(
+            streaming=True
+        )
+    )
     (_, err) = capfd.readouterr()
     assert "df -> projection -> ordered_sink" in err


### PR DESCRIPTION
`apply` argument `skip_nulls` default to `True` for performance reasons. If all values in a column are `null` the function will never be called and we cannot determine output type. Now we will inform the users of that.


```python
def my_function(x) -> str:
    if x:
        return "null"
    return "not-null"

df = pl.DataFrame({
   "foo": [None, None]
})


df.with_columns([
        pl.col('foo').apply(lambda x: x)
])
```

```python
ComputeError: ComputeError: The output type of 'apply' function cannot determined.
The function was never called because 'skip_nulls=True' and all values are null.
Consider setting 'skip_nulls=False' or setting the 'return_dtype'.
```

fixes #7281