### PR TITLE
refactor(python): Rename `scan_ds` to `scan_pyarrow_dataset`

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -84,7 +84,7 @@ Connect to pyarrow datasets.
 .. autosummary::
    :toctree: api/
 
-   scan_ds
+   scan_pyarrow_dataset
 
 
 BatchedCsvReader

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -161,6 +161,7 @@ from polars.io import (
     scan_ipc,
     scan_ndjson,
     scan_parquet,
+    scan_pyarrow_dataset,
 )
 from polars.show_versions import show_versions
 from polars.string_cache import StringCache, toggle_string_cache, using_string_cache
@@ -236,6 +237,7 @@ __all__ = [
     "scan_ipc",
     "scan_ndjson",
     "scan_parquet",
+    "scan_pyarrow_dataset",
     # polars.stringcache
     "StringCache",
     "toggle_string_cache",

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -7,9 +7,9 @@ they all import from each other via this __init__ file using
 """
 from polars.internals.anonymous_scan import (
     _deser_and_exec,
-    _scan_ds,
     _scan_ipc_fsspec,
     _scan_parquet_fsspec,
+    _scan_pyarrow_dataset,
 )
 from polars.internals.batched import BatchedCsvReader
 from polars.internals.dataframe import DataFrame, wrap_df
@@ -87,7 +87,7 @@ __all__ = [
     "_deser_and_exec",
     "_is_local_file",
     "_prepare_file_arg",
-    "_scan_ds",
+    "_scan_pyarrow_dataset",
     "_scan_ipc_fsspec",
     "_scan_parquet_fsspec",
     "_update_columns",

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -30,7 +30,7 @@ def _deser_and_exec(  # noqa: D417
     return func(with_columns, *args)
 
 
-def _scan_ds_impl(
+def _scan_pyarrow_dataset_impl(
     ds: pa.dataset.dataset, with_columns: list[str] | None, predicate: str | None
 ) -> pli.DataFrame:
     """
@@ -58,11 +58,11 @@ def _scan_ds_impl(
     )
 
 
-def _scan_ds(
+def _scan_pyarrow_dataset(
     ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True
 ) -> pli.LazyFrame:
     """
-    Pickle the partially applied function `_scan_ds_impl`.
+    Pickle the partially applied function `_scan_pyarrow_dataset_impl`.
 
     The bytes are then sent to the polars logical plan. It can be deserialized once
     executed and ran.
@@ -77,7 +77,7 @@ def _scan_ds(
         different than polars does.
 
     """
-    func = partial(_scan_ds_impl, ds)
+    func = partial(_scan_pyarrow_dataset_impl, ds)
     func_serialized = pickle.dumps(func)
     return pli.LazyFrame._scan_python_function(
         ds.schema, func_serialized, allow_pyarrow_filter

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -9,7 +9,7 @@ from polars.io.ipc import read_ipc, scan_ipc
 from polars.io.json import read_json
 from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, scan_parquet
-from polars.io.pyarrow_dataset import scan_ds
+from polars.io.pyarrow_dataset import scan_ds, scan_pyarrow_dataset
 
 __all__ = [
     "read_avro",
@@ -29,4 +29,5 @@ __all__ = [
     "scan_ipc",
     "scan_ndjson",
     "scan_parquet",
+    "scan_pyarrow_dataset",
 ]

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -4,12 +4,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from polars.internals import DataFrame
-from polars.utils import normalise_filepath
+from polars.utils import deprecate_nonkeyword_arguments, normalise_filepath
 
 if TYPE_CHECKING:
     from io import BytesIO
 
 
+@deprecate_nonkeyword_arguments()
 def read_avro(
     file: str | Path | BytesIO | BinaryIO,
     columns: list[int] | list[str] | None = None,

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from polars.convert import from_arrow
 from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
-from polars.io.pyarrow_dataset import scan_ds
+from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.utils import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
@@ -323,7 +323,7 @@ def scan_delta(
 
     # Must provide filesystem as DeltaStorageHandler is not serializable.
     pa_ds = dl_tbl.to_pyarrow_dataset(filesystem=filesystem, **pyarrow_options)
-    return scan_ds(pa_ds)
+    return scan_pyarrow_dataset(pa_ds)
 
 
 def _resolve_delta_lake_uri(table_uri: str) -> tuple[str, str, str]:

--- a/py-polars/polars/io/pyarrow_dataset.py
+++ b/py-polars/polars/io/pyarrow_dataset.py
@@ -1,13 +1,59 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
-from polars.internals import _scan_ds
+from polars.internals import _scan_pyarrow_dataset
 from polars.utils import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
     from polars.dependencies import pyarrow as pa
     from polars.internals import LazyFrame
+
+
+def scan_pyarrow_dataset(
+    source: pa.dataset.dataset, *, allow_pyarrow_filter: bool = True
+) -> LazyFrame:
+    """
+    Scan a pyarrow dataset.
+
+    This can be useful to connect to cloud or partitioned datasets.
+
+    Parameters
+    ----------
+    source
+        Pyarrow dataset to scan.
+    allow_pyarrow_filter
+        Allow predicates to be pushed down to pyarrow. This can lead to different
+        results if comparisons are done with null values as pyarrow handles this
+        different than polars does.
+
+    Warnings
+    --------
+    This API is experimental and may change without it being considered a breaking
+    change.
+
+    Examples
+    --------
+    >>> import pyarrow.dataset as ds
+    >>> dset = ds.dataset("s3://my-partitioned-folder/", format="ipc")  # doctest: +SKIP
+    >>> (
+    ...     pl.scan_pyarrow_dataset(dset)
+    ...     .filter("bools")
+    ...     .select(["bools", "floats", "date"])
+    ...     .collect()
+    ... )  # doctest: +SKIP
+    shape: (1, 3)
+    ┌───────┬────────┬────────────┐
+    │ bools ┆ floats ┆ date       │
+    │ ---   ┆ ---    ┆ ---        │
+    │ bool  ┆ f64    ┆ date       │
+    ╞═══════╪════════╪════════════╡
+    │ true  ┆ 2.0    ┆ 1970-05-04 │
+    └───────┴────────┴────────────┘
+
+    """
+    return _scan_pyarrow_dataset(source, allow_pyarrow_filter=allow_pyarrow_filter)
 
 
 @deprecate_nonkeyword_arguments()
@@ -51,4 +97,10 @@ def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFr
     └───────┴────────┴────────────┘
 
     """
-    return _scan_ds(ds, allow_pyarrow_filter)
+    warnings.warn(
+        "`scan_ds` has been renamed; this"
+        " redirect is temporary, please use `scan_pyarrow_dataset` instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return scan_pyarrow_dataset(ds, allow_pyarrow_filter=allow_pyarrow_filter)

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -17,7 +17,7 @@ def helper_dataset_test(file_path: Path, query) -> None:
     dset = ds.dataset(file_path, format="ipc")
 
     expected = query(pl.scan_ipc(file_path))
-    out = query(pl.scan_ds(dset))
+    out = query(pl.scan_pyarrow_dataset(dset))
     assert_frame_equal(out, expected)
 
 


### PR DESCRIPTION
As discussed in #7315

Changes:
* Rename `scan_ds` to `scan_pyarrow_dataset`
  * I kept the old function (with deprecation warning). It's experimental, so we could also just break it, but this doesn't really hurt...
* Renamed the `ds` argument to `source`.
  * I also considered `dataset` - but `source` will be in line with the other read/scan functions. Either is fine with me, let me know if you have a different preference.