### PR TITLE
feat(python): support sqlalchemy/pandas backed `write_database`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -2837,7 +2837,12 @@ class DataFrame:
                 raise ModuleNotFoundError(
                     f"Writing with engine 'sqlalchemy' requires Pandas 1.5.x or higher, found Pandas {pd.__version__}."
                 )
-            from sqlalchemy import create_engine
+            try:
+                from sqlalchemy import create_engine
+            except ImportError as err:
+                raise ImportError(
+                    "'sqlalchemy' not found. Install polars with 'pip install polars[sqlalchemy]'."
+                ) from err
 
             engine = create_engine(connection_uri)
 

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -92,8 +92,8 @@ SearchSortedSide: TypeAlias = Literal["any", "left", "right"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
 CorrelationMethod: TypeAlias = Literal["pearson", "spearman"]
 DbReadEngine: TypeAlias = Literal["adbc", "connectorx"]
-DbWriteEngine: TypeAlias = Literal["adbc"]
-DbWriteMode: TypeAlias = Literal["create", "append"]
+DbWriteEngine: TypeAlias = Literal["sqlalchemy", "adbc"]
+DbWriteMode: TypeAlias = Literal["replace", "append", "fail"]
 
 # type signature for allowed frame init
 FrameInitTypes: TypeAlias = "Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series] | Sequence[Any] | np.ndarray[Any, Any] | pa.Table | pd.DataFrame | pli.Series"

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -52,8 +52,9 @@ xlsx2csv = ["xlsx2csv >= 0.8.0"]
 deltalake = ["deltalake >= 0.6.2"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 matplotlib = ["matplotlib"]
+sqlalchemy = ["sqlalchemy"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib]",
+  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,sqlalchemy]",
 ]
 
 [tool.mypy]
@@ -83,6 +84,7 @@ module = [
   "xlsxwriter.utility",
   "xlsxwriter.worksheet",
   "zoneinfo",
+  "sqlalchemy",
 ]
 ignore_missing_imports = true
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -52,7 +52,7 @@ xlsx2csv = ["xlsx2csv >= 0.8.0"]
 deltalake = ["deltalake >= 0.6.2"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 matplotlib = ["matplotlib"]
-sqlalchemy = ["sqlalchemy"]
+sqlalchemy = ["sqlalchemy", "pandas"]
 all = [
   "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,sqlalchemy]",
 ]

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -170,7 +170,7 @@ def test_write_database(
         sample_df.write_database(
             table_name="test_data",
             connection_uri=f"sqlite:///{test_db}",
-            mode="create",
+            if_exists="replace",
             engine=engine,
         )
 
@@ -178,7 +178,7 @@ def test_write_database(
             sample_df.write_database(
                 table_name="test_data",
                 connection_uri=f"sqlite:///{test_db}",
-                mode="append",
+                if_exists="append",
                 engine=engine,
             )
             sample_df = pl.concat([sample_df, sample_df])


### PR DESCRIPTION
Now that we can convert to pandas zero-copy, we can piggy back on their sqlalchemy backed `pl.DataFrame.to_sql`. 

This is a utility many users need, so I think it is worth it depending on pandas/sqlalchemy for this.