### PR TITLE
fix(rust, python): fix projection pushdown on join with unused join key

### DIFF
--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -348,6 +348,10 @@ pub fn aexpr_to_leaf_names(node: Node, arena: &Arena<AExpr>) -> Vec<Arc<str>> {
     aexpr_to_leaf_names_iter(node, arena).collect()
 }
 
+pub fn aexpr_to_leaf_name(node: Node, arena: &Arena<AExpr>) -> Arc<str> {
+    aexpr_to_leaf_names_iter(node, arena).next().unwrap()
+}
+
 /// check if a selection/projection can be done on the downwards schema
 pub(crate) fn check_input_node(
     node: Node,

--- a/polars/tests/it/lazy/projection_queries.rs
+++ b/polars/tests/it/lazy/projection_queries.rs
@@ -171,3 +171,27 @@ fn test_unnest_pushdown() -> PolarsResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_join_duplicate_7314() -> PolarsResult<()> {
+    let df_a: DataFrame = df![
+        "a" => [1, 2, 2],
+        "b" => [4, 5, 6],
+        "c" => [1, 1, 1],
+    ]?;
+
+    let df_b: DataFrame = df![
+        "a" => [1, 2, 2],
+        "b" => [4, 5, 6],
+        "d" => [1, 1, 1],
+    ]?;
+
+    let out = df_a
+        .lazy()
+        .inner_join(df_b.lazy(), col("a"), col("b"))
+        .select([col("a"), col("c") * col("d")])
+        .collect()?;
+
+    assert_eq!(out.get_column_names(), &["a", "c"]);
+    Ok(())
+}


### PR DESCRIPTION
fixes #7314