### PR TITLE
test(python): Fix `read/write_database` tests

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -35,7 +35,7 @@ Parquet
    read_parquet_schema
    DataFrame.write_parquet
 
-DataBase
+Database
 ~~~~~~~~
 .. autosummary::
    :toctree: api/

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -13,7 +13,7 @@ backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv
 XlsxWriter
-adbc_driver_sqlite
+adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 connectorx==0.3.2a2; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
 
 # Tooling

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -13,6 +13,8 @@ backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv
 XlsxWriter
+connectorx==0.3.2a2  # Latest full release is broken - unpin when 0.3.2 released
+adbc_driver_sqlite
 
 # Tooling
 hypothesis==6.68.2

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -13,8 +13,8 @@ backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv
 XlsxWriter
-connectorx==0.3.2a2  # Latest full release is broken - unpin when 0.3.2 released
 adbc_driver_sqlite
+connectorx==0.3.2a2; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
 
 # Tooling
 hypothesis==6.68.2

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from contextlib import suppress
 from datetime import date
 from typing import TYPE_CHECKING
@@ -88,28 +89,23 @@ def test_read_database(
     expected_dtypes: dict[str, pl.DataType],
     expected_dates: list[date | str],
 ) -> None:
-    import tempfile
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        test_db = os.path.join(tmpdir_name, "test.db")
+        create_temp_sqlite_db(test_db)
 
-    with suppress(ImportError):
-        import connectorx  # noqa: F401
+        df = pl.read_database(
+            connection_uri=f"sqlite:///{test_db}",
+            query="SELECT * FROM test_data",
+            engine=engine,
+        )
 
-        with tempfile.TemporaryDirectory() as tmpdir_name:
-            test_db = os.path.join(tmpdir_name, "test.db")
-            create_temp_sqlite_db(test_db)
-
-            df = pl.read_database(
-                connection_uri=f"sqlite:///{test_db}",
-                sql="SELECT * FROM test_data",
-                engine=engine,
-            )
-
-            assert df.schema == expected_dtypes
-            assert df.shape == (2, 4)
-            assert df["date"].to_list() == expected_dates
+        assert df.schema == expected_dtypes
+        assert df.shape == (2, 4)
+        assert df["date"].to_list() == expected_dates
 
 
 @pytest.mark.parametrize(
-    ("engine", "sql", "database", "err"),
+    ("engine", "query", "database", "err"),
     [
         pytest.param(
             "not_engine",
@@ -135,10 +131,8 @@ def test_read_database(
     ],
 )
 def test_read_database_exceptions(
-    engine: DbReadEngine, sql: str, database: str, err: str
+    engine: DbReadEngine, query: str, database: str, err: str
 ) -> None:
-    import tempfile
-
     with tempfile.TemporaryDirectory() as tmpdir_name:
         test_db = os.path.join(tmpdir_name, "test.db")
         create_temp_sqlite_db(test_db)
@@ -146,7 +140,7 @@ def test_read_database_exceptions(
         with pytest.raises(ValueError, match=err):
             pl.read_database(
                 connection_uri=f"{database}:///{test_db}",
-                sql=sql,
+                query=query,
                 engine=engine,
             )
 
@@ -162,8 +156,6 @@ def test_read_database_exceptions(
 def test_write_database(
     engine: DbWriteEngine, mode: DbWriteMode, sample_df: pl.DataFrame
 ) -> None:
-    import tempfile
-
     with suppress(ImportError), tempfile.TemporaryDirectory() as tmpdir_name:
         test_db = os.path.join(tmpdir_name, "test.db")
 
@@ -183,7 +175,10 @@ def test_write_database(
             )
             sample_df = pl.concat([sample_df, sample_df])
 
-        assert_frame_equal(
-            sample_df,
-            pl.read_database("SELECT * FROM test_data", f"sqlite:///{test_db}"),
-        )
+        result = pl.read_database("SELECT * FROM test_data", f"sqlite:///{test_db}")
+
+    # TODO: Fix this bug! Floats shouldn't be rounded
+    sample_df = sample_df.with_columns(pl.col("value").ceil())
+
+    sample_df = sample_df.with_columns(pl.col("date").cast(pl.Utf8))
+    assert_frame_equal(sample_df, result)

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from contextlib import suppress
 from datetime import date
@@ -71,6 +72,10 @@ def create_temp_sqlite_db(test_db: str) -> None:
                 "date": pl.Date,
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 8),
+                reason="connectorx not available on Python 3.7",
+            ),
         ),
         pytest.param(
             "adbc",


### PR DESCRIPTION
Changes:
* Rename `sql` argument to `query` for `read_database`. This is more intuitive - and it's in line with how `connectorx` does the naming. Make some args keyword-only. This is not breaking as this function has not been released yet.
* Tests for `read_database` weren't being run! Due to the packages not being available and a sneaky `suppress(ImportError)`. Tests shouldn't silently pass just because the environment isn't set up correctly...
  * `connectorx` only supports Python `>=3.8`
  * `adbc_driver_sqlite` only supports Python `>=3.9`, and doesn't support Windows on Python 3.11.
  * Packages have been added to the `dev` requirements and are conditionally skipped for Python 3.7 / Windows tests.

After fixing the tests, I encountered a strange bug where apparently `write_database` rounds floats? Check out the `# TODO` comment in the test... out of scope for this PR, but should definitely be fixed.