### PR TITLE
feat(python): allow import of dtype groups from the top-level to improve discovery

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -24,6 +24,11 @@ from polars.convert import (
     from_records,
 )
 from polars.datatypes import (
+    DURATION_DTYPES,
+    FLOAT_DTYPES,
+    INTEGER_DTYPES,
+    NUMERIC_DTYPES,
+    TEMPORAL_DTYPES,
     Binary,
     Boolean,
     Categorical,
@@ -217,6 +222,12 @@ __all__ = [
     "Unknown",
     "Utf8",
     "get_idx_type",
+    # polars.datatypes: dtype groups
+    "DURATION_DTYPES",
+    "FLOAT_DTYPES",
+    "INTEGER_DTYPES",
+    "NUMERIC_DTYPES",
+    "TEMPORAL_DTYPES",
     # polars.io
     "read_avro",
     "read_csv",


### PR DESCRIPTION
Make dtype groups (such as `NUMERIC_DTYPES`, `INTEGER_DTYPES`, etc) available at the same level as the individual dtypes.

**Before**:
```python
from polars.datatypes import TEMPORAL_DTYPES
import polars as pl
pl.col( TEMPORAL_DTYPES )
```
**Before**:
```python
import polars as pl
pl.col( pl.TEMPORAL_DTYPES )
```