### PR TITLE
test(python): Add test for for groupby referencing the same column twice

### DIFF
--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -587,3 +587,21 @@ def test_groupby_dynamic_elementwise_following_mean_agg_6904() -> None:
             }
         ),
     )
+
+
+def test_groupby_multiple_column_reference() -> None:
+    # Issue #7181
+    df = pl.DataFrame(
+        {
+            "gr": ["a", "b", "a", "b", "a", "b"],
+            "val": [1, 20, 100, 2000, 10000, 200000],
+        }
+    )
+    res = df.groupby("gr").agg(
+        pl.col("val") + pl.col("val").shift().fill_null(0),
+    )
+
+    assert res.sort("gr").to_dict(False) == {
+        "gr": ["a", "b"],
+        "val": [[1, 101, 10100], [20, 2020, 202000]],
+    }


### PR DESCRIPTION
Issue #7181

Add test for resolved issues 7181

The groupby result where simply wrong in this case, seemingly related to multiple reference of the same column.

Maybe related to the fact that at the mentionned version (0.16.8), the order of a groupby was not deterministic, as in this example

```python
import polars as pl
pl.version()
# '0.16.8'
df = pl.DataFrame(
    {
        "gr": ["b", "a", "a", "b"],
    }
 )

df.groupby("gr").count()
# shape: (2, 2)
# ┌─────┬───────┐
# │ gr  ┆ count │
# │ --- ┆ ---   │
# │ str ┆ u32   │
# ╞═════╪═══════╡
# │ a   ┆ 2     │
# │ b   ┆ 2     │
# └─────┴───────┘

df.groupby("gr").count()
# shape: (2, 2)
# ┌─────┬───────┐
# │ gr  ┆ count │
# │ --- ┆ ---   │
# │ str ┆ u32   │
# ╞═════╪═══════╡
# │ b   ┆ 2     │
# │ a   ┆ 2     │
# └─────┴───────┘
```

I did not see a test for asserting that groupby return in the order of the first seen value, as seems the case in current version. Do we want to ensure this behavior or do we not guarantee order in the return of the groupby?
