### PR TITLE
fix(rust,python): don't panic when writing `NullArray` values to python row tuple

### DIFF
--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -64,7 +64,7 @@ def _xl_inject_dummy_table_columns(
 
     df = df.select(
         [
-            (col if col in df_original_columns else pli.lit("").alias(col))
+            (col if col in df_original_columns else pli.lit(None).alias(col))
             for col in df_select_cols
         ]
     )

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -625,6 +625,7 @@ impl PyDataFrame {
                     PyTuple::new(
                         py,
                         self.df.get_columns().iter().map(|s| match s.dtype() {
+                            DataType::Null => py.None(),
                             DataType::Object(_) => {
                                 let obj: Option<&ObjectValue> =
                                     s.get_object(idx).map(|any| any.into());

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -59,6 +59,15 @@ def test_rows() -> None:
     rows = df.rows(named=True)
     assert rows == [{"a": 1, "b": 1}, {"a": 2, "b": 2}]
 
+    # Rows with nullarray cols
+    df = df.with_columns(c=pl.lit(None))
+    assert df.schema == {"a": pl.Int64, "b": pl.Int64, "c": pl.Null}
+    assert df.rows() == [(1, 1, None), (2, 2, None)]
+    assert df.rows(named=True) == [
+        {"a": 1, "b": 1, "c": None},
+        {"a": 2, "b": 2, "c": None},
+    ]
+
 
 def test_iter_rows() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
`NullArray` cols would panic on export into python rows; other exports (such as numpy/etc) seem fine.

```python
import polars as pl

df = pl.DataFrame(
    data = {"colx": [0,1,2,3]},
).with_columns(
    coly = pl.lit(None),
)
```

**Before**:
```python
df.rows()
# PanicException: this operation is not implemented/valid for this dtype: Null
```

**After**:
```python
df.rows()
# [(0, None), (1, None), (2, None), (3, None)]
```
