### PR TITLE
fix(python): minor `Excel` export improvements/fixes

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -24,6 +24,7 @@ from polars.convert import (
     from_records,
 )
 from polars.datatypes import (
+    DATETIME_DTYPES,
     DURATION_DTYPES,
     FLOAT_DTYPES,
     INTEGER_DTYPES,
@@ -223,6 +224,7 @@ __all__ = [
     "Utf8",
     "get_idx_type",
     # polars.datatypes: dtype groups
+    "DATETIME_DTYPES",
     "DURATION_DTYPES",
     "FLOAT_DTYPES",
     "INTEGER_DTYPES",

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -244,11 +244,20 @@ def _xl_setup_table_options(
     return table_style, table_options
 
 
-def _xl_unique_table_name(ws: Worksheet) -> str:
-    """Establish a unique (per-worksheet) incrementing table object name."""
-    default_name = "PolarsFrameTable"
-    n_polars_tables = sum(1 for t in ws.tables if t["name"].startswith(default_name))
-    return f"{default_name}{n_polars_tables}"
+def _xl_unique_table_name(wb: Workbook) -> str:
+    """Establish a unique (per-workbook) table object name."""
+    table_prefix = "PolarsFrameTable"
+    polars_tables: set[str] = set()
+    for ws in wb.worksheets():
+        polars_tables.update(
+            tbl["name"] for tbl in ws.tables if tbl["name"].startswith(table_prefix)
+        )
+    n = len(polars_tables)
+    table_name = f"{table_prefix}{n}"
+    while table_name in polars_tables:
+        n += 1
+        table_name = f"{table_prefix}{n}"
+    return table_name
 
 
 def _xl_column_range(

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -1946,11 +1946,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> from polars.datatypes import INTEGER_DTYPES
         >>> with pl.Config() as cfg:
         ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
         ...     ldf.select(
-        ...         is_odd=(pl.col(INTEGER_DTYPES) % 2).suffix("_is_odd"),
+        ...         is_odd=(pl.col(pl.INTEGER_DTYPES) % 2).suffix("_is_odd"),
         ...     ).collect()
         ...
         shape: (3, 1)

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -436,7 +436,7 @@ def test_list_mean() -> None:
 
 
 def test_list_min_max() -> None:
-    for dt in pl.datatypes.NUMERIC_DTYPES:
+    for dt in pl.NUMERIC_DTYPES:
         df = pl.DataFrame(
             {"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]]},
             schema={"a": pl.List(dt)},

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -8,7 +8,6 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES
 from polars.testing import assert_frame_equal
 
 
@@ -79,7 +78,7 @@ def test_read_excel_all_sheets(excel_file_path: Path) -> None:
                 },
             },
             "dtype_formats": {
-                FLOAT_DTYPES: '_(£* #,##0.00_);_(£* (#,##0.00);_(£* "-"??_);_(@_)'
+                pl.FLOAT_DTYPES: '_(£* #,##0.00_);_(£* (#,##0.00);_(£* "-"??_);_(@_)'
             },
             "column_formats": {
                 "dtm": {"font_color": "#31869c", "bg_color": "#b7dee8"},
@@ -144,7 +143,7 @@ def test_excel_sparklines() -> None:
             workbook=wb,
             worksheet="frame_data",
             table_style="Table Style Light 2",
-            dtype_formats={INTEGER_DTYPES: "#,##0_);(#,##0)"},
+            dtype_formats={pl.INTEGER_DTYPES: "#,##0_);(#,##0)"},
             sparklines={
                 "trend": ["q1", "q2", "q3", "q4"],
                 "+/-": {
@@ -155,6 +154,9 @@ def test_excel_sparklines() -> None:
             },
             hide_gridlines=True,
         )
+
+    tables = {tbl["name"] for tbl in wb.get_worksheet_by_name("frame_data").tables}
+    assert "PolarsFrameTable0" in tables
 
     xldf = pl.read_excel(file=xls, sheet_name="frame_data")  # type: ignore[call-overload]
     # ┌──────┬──────┬─────┬─────┬─────┬─────┬───────┐
@@ -174,3 +176,28 @@ def test_excel_sparklines() -> None:
 
     assert xldf.columns == ["id", "+/-", "q1", "q2", "q3", "q4", "trend"]
     assert_frame_equal(df, xldf.drop("+/-", "trend"))
+
+
+def test_excel_write_multiple_tables() -> None:
+    from xlsxwriter import Workbook
+
+    # note: also checks that empty tables don't error on write
+    df1 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
+    df2 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
+    df3 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
+    df4 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
+
+    xls = BytesIO()
+    with Workbook(xls) as wb:
+        df1.write_excel(workbook=wb, worksheet="sheet1", position="A1")
+        df2.write_excel(workbook=wb, worksheet="sheet1", position="A6")
+        df3.write_excel(workbook=wb, worksheet="sheet2", position="A1")
+        df4.write_excel(workbook=wb, worksheet="sheet3", position="A1")
+
+    table_names: set[str] = set()
+    for sheet in ("sheet1", "sheet2", "sheet3"):
+        table_names.update(
+            tbl["name"] for tbl in wb.get_worksheet_by_name(sheet).tables
+        )
+    assert table_names == {f"PolarsFrameTable{n}" for n in range(4)}
+    assert pl.read_excel(file=xls, sheet_name="sheet3").rows() == [(None, None, None)]  # type: ignore[call-overload]

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -48,7 +48,7 @@ def test_dtype_base_type() -> None:
         pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)]).base_type()
         is pl.Struct
     )
-    for dtype in datatypes.DATETIME_DTYPES:
+    for dtype in pl.DATETIME_DTYPES:
         assert dtype.base_type() is pl.Datetime
 
 


### PR DESCRIPTION
**Excel updates**:
* Ensure that exported table names are unique per _workbook_, not just per _worksheet_. \
  (ref: https://github.com/jmcnamara/XlsxWriter/issues/961) 
* Fix writing empty tables that have headers.
* Miscellaneous minor docstring updates. 
* Additional test coverage.

**Also**:
* Exposed `DATETIME_DTYPES` in the top-level namespace, along with all the other dtype groups (was accidentally missed).