### PR TITLE
feat(rust, python): don't rechunk before writing to csv

### DIFF
--- a/polars/polars-io/src/csv/write.rs
+++ b/polars/polars-io/src/csv/write.rs
@@ -32,7 +32,6 @@ where
     }
 
     fn finish(&mut self, df: &mut DataFrame) -> PolarsResult<()> {
-        df.as_single_chunk_par();
         let names = df.get_column_names();
         if self.header {
             write_impl::write_header(&mut self.buffer, &names, &self.options)?;


### PR DESCRIPTION
Can now write `DataFrames` that are much larger than RAM:

```python
df = pl.read_csv("my_just_fits_in_memory.csv")
pl.concat([df] * 100, rechunk=False).write_csv("out.csv")
```
