### PR TITLE
perf(rust, python): improve performance for datetime parsing with %Z

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -482,7 +482,6 @@ pub trait Utf8Methods: AsUtf8 {
                         // Safety:
                         // fmt_len is correct, it was computed with this `fmt` str.
                         unsafe { self::strptime::parse(s.as_bytes(), fmt.as_bytes(), fmt_len) }
-                            .or_else(|| NaiveDateTime::parse_from_str(s, &fmt).ok())
                             .map(func)
                     };
                     if utf8_ca.null_count() == 0 {

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2166,6 +2166,15 @@ def test_tz_aware_with_timezone_directive(
     assert result == expected
 
 
+def test_local_time_zone_name() -> None:
+    ser = pl.Series(["2020-01-01 03:00ACST"]).str.strptime(
+        pl.Datetime, "%Y-%m-%d %H:%M%Z"
+    )
+    result = ser[0]
+    expected = datetime(2020, 1, 1, 3)
+    assert result == expected
+
+
 def test_tz_aware_filter_lit() -> None:
     start = datetime(1970, 1, 1)
     stop = datetime(1970, 1, 1, 7)


### PR DESCRIPTION
Currently, `'%Z'` is either ignored within `strptime::parse`, or it just causes parsing to fallback to `NaiveDateTime::parse_from_str`

I'd suggest to just exclude it from `strptime::fmt_len` and let it go directly to the chrono parser

This comes with a little [perf improvement](https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=121211658) for parsing local time zone names with `'%Z'`
```python
dates = pl.date_range(datetime(1, 1, 1), datetime(9999, 1, 1)).dt.strftime('%Y-%m-%d %H:%MUTC')

dates.str.strptime(pl.Datetime, '%Y-%m-%d %H:%M%Z')
```

Here:
- 3.02 s ± 24 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 3.02 s ± 42.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 3.01 s ± 38 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

upstream/master:
- 3.4 s ± 324 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 3.24 s ± 39.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 3.33 s ± 57.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)