### PR TITLE
doc: Add DOI link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href="https://www.npmjs.com/package/nodejs-polars">
     <img src="https://img.shields.io/npm/v/nodejs-polars.svg" alt="NPM Latest Release"/>
   </a>
+  <a href="https://doi.org/10.5281/zenodo.7697217">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.7697217.svg" alt="DOI Latest Release"/>
+  </a>
 </div>
 
 <p align="center">


### PR DESCRIPTION
Add DOI link, which will automatically point to the latest tagged release. Each tagged release gets its own DOI link automatically with the already setup github-zenodo integration.