### PR TITLE
feat(python): support applying one conditional format to multiple columns on `Excel` export (allows for heatmaps)

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -69,6 +69,7 @@ from polars.internals.construction import (
 from polars.internals.dataframe._html import NotebookFormatter
 from polars.internals.dataframe.groupby import DynamicGroupBy, GroupBy, RollingGroupBy
 from polars.internals.io_excel import (
+    _xl_column_multi_range,
     _xl_column_range,
     _xl_inject_sparklines,
     _xl_setup_table_columns,
@@ -2405,8 +2406,11 @@ class DataFrame:
         column_widths: dict[str, int] | None = None,
         column_totals: dict[str, str] | Sequence[str] | bool | None = None,
         column_formats: dict[str, str] | None = None,
-        conditional_formats: dict[str, str | dict[str, Any]] | None = None,
         dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
+        conditional_formats: dict[
+            str | Sequence[str], str | dict[str | Sequence[str], Any]
+        ]
+        | None = None,
         sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
         float_precision: int = 3,
         has_header: bool = True,
@@ -2441,24 +2445,27 @@ class DataFrame:
             in integer pixel units.
         column_totals
             Add a total row. If True, all numeric columns will have an associated total
-            using "sum". If given a list of colnames, only those listed will have a
-            total.  For more control, pass a {colname:funcname,} dict. Valid names are:
+            using "sum". If given a list of colnames, only those will have a total.
+            For more control, pass a {colname:funcname,} dict. Valid names are:
             "average", "count_nums", "count", "max", "min", "std_dev", "sum", "var".
         column_formats
             A {colname:str,} dictionary for applying an Excel format string to the given
             columns. Formats defined here (such as "dd/mm/yyyy", "0.00%", etc) will
-            override those defined in ``dtype_formats``.
-        conditional_formats
-            A {colname:str,} or {colname:dict,} dictionary defining conditional format
-            options for the specified columns. If supplying a string typename, should be
-            one of the valid ``xlsxwriter`` types such as "3_color_scale", "data_bar",
-            etc. If supplying a dictionary you have complete flexibility to apply any
-            ``xlsxwriter``-supported options, including icon sets, formulae, etc.
+            override those defined in ``dtype_formats`` (below).
         dtype_formats
             A {dtype:str,} dictionary that sets the default Excel format for the given
             dtype. (This is overridden on a per-column basis by ``column_formats``).
             It is also valid to use dtype groups such as ``pl.FLOAT_DTYPES`` as the
             dtype/format key, to simplify setting uniform int/float formats.
+        conditional_formats
+            A {colname(s):str,} or {colname(s):dict,} dictionary defining conditional
+            format options for the specified columns. If supplying a string typename,
+            should be one of the valid ``xlsxwriter`` types such as "3_color_scale",
+            "data_bar", etc. If supplying a dictionary you can make use of any/all
+            ``xlsxwriter``-supported options, including icon sets, formulae, etc.
+            Supplying multiple columns as a tuple/key will apply a single format across
+            all columns at once - this is effective in creating a heatmap, as the
+            min/max values are determined across the entire range, not per-column.
         sparklines
             A {colname:list,} or {colname:dict,} dictionary that defines one or more
             sparklines to be written into a new column in the table. If passing a
@@ -2574,7 +2581,7 @@ class DataFrame:
         ...         column_formats={"num": "#,##0.000;[White]-#,##0.000"},
         ...         column_widths={"val": 125},
         ...         autofit=True,
-        ...     )  # doctest: +IGNORE_RESULT
+        ...     )
         ...
         ...     # add some table titles (with a custom format)
         ...     ws = wb.get_worksheet_by_name("data")
@@ -2593,7 +2600,7 @@ class DataFrame:
         Export a table containing two different types of sparklines. Use default
         options for the "trend" sparkline and customised options (and positioning)
         for the "+/-" win_loss sparkline, with non-default integer dtype formatting,
-        column totals, and hidden worksheet gridlines:
+        column totals, a subtle two-tone heatmap and hidden worksheet gridlines:
 
         >>> df = pl.DataFrame(
         ...     {
@@ -2606,6 +2613,7 @@ class DataFrame:
         ... )
         >>> df.write_excel(  # doctest: +SKIP
         ...     table_style="Table Style Light 2",
+        ...     # apply accounting format to all flavours of integer
         ...     dtype_formats={pl.INTEGER_DTYPES: "#,##0_);(#,##0)"},
         ...     sparklines={
         ...         # default options; just provide source cols
@@ -2616,6 +2624,14 @@ class DataFrame:
         ...             "insert_after": "id",
         ...             "type": "win_loss",
         ...         },
+        ...     },
+        ...     conditional_formats={
+        ...         # create a unified multi-column heatmap
+        ...         ("q1", "q2", "q3", "q4"): {
+        ...             "type": "2_color_scale",
+        ...             "min_color": "#95b3d7",
+        ...             "max_color": "#ffffff",
+        ...         }
         ...     },
         ...     column_totals=["q1", "q2", "q3", "q4"],
         ...     hide_gridlines=True,
@@ -2678,11 +2694,19 @@ class DataFrame:
                 },
             )
             # apply any conditional formats
-            for col, fmt in (conditional_formats or {}).items():
-                col_range = _xl_column_range(df, table_start, col, has_header)
-                ws.conditional_format(
-                    *col_range, fmt if isinstance(fmt, dict) else {"type": fmt}
-                )
+            for cols, fmt in (conditional_formats or {}).items():
+                if not isinstance(cols, str) and len(cols) == 1:
+                    cols = cols[0]
+                if not isinstance(fmt, dict):
+                    fmt = {"type": fmt}
+                if not isinstance(cols, str):
+                    fmt["multi_range"] = _xl_column_multi_range(
+                        df, table_start, cols, has_header
+                    )
+                    cols = cols[0]
+
+                col_range = _xl_column_range(df, table_start, cols, has_header)
+                ws.conditional_format(*col_range, fmt)
 
         # worksheet options
         if autofit and not is_empty:

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -161,6 +161,7 @@ def test_excel_sparklines() -> None:
                     "max_color": "#ffffff",
                 }
             },
+            column_widths={("q1", "q2", "q3", "q4"): 40},
             hide_gridlines=True,
         )
 

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -126,8 +126,8 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
 def test_excel_sparklines() -> None:
     from xlsxwriter import Workbook
 
-    # note that we don't (quite) expect sparkline export to round-trip
-    # as we have to inject additional empty columns to hold them...
+    # note that we don't (quite) expect sparkline export to round-trip as we
+    # inject additional empty columns to hold them (which will read as nulls).
     df = pl.DataFrame(
         {
             "id": ["aaa", "bbb", "ccc", "ddd", "eee"],
@@ -153,6 +153,13 @@ def test_excel_sparklines() -> None:
                     "insert_after": "id",
                     "type": "win_loss",
                 },
+            },
+            conditional_formats={
+                ("q1", "q2", "q3", "q4"): {
+                    "type": "2_color_scale",
+                    "min_color": "#95b3d7",
+                    "max_color": "#ffffff",
+                }
             },
             hide_gridlines=True,
         )


### PR DESCRIPTION
Allows a conditional format to be applied to multiple (potentially disjoint) columns in a single definition; this lets the format work with the min/max/etc values across the _entire_ range (rather than per-column), enabling (amongst other things) proper heatmaps....

**Update**: extended support for multi-column keys to other relevant params such as `column_widths`, `column_formats` and `column_totals` (for convenience; there is no special/additional "multi-range" meaning for these params).

## Example

Generate some test data...
```python
df = pl.DataFrame(
    {
        "jan": range(0,12,1),
        "feb": range(0,24,2),
        "mar": range(0,36,3),
        "apr": range(0,48,4),
        "may": range(0,60,5),
        "jun": range(0,72,6),
        "jul": range(0,84,7),
        "aug": range(0,96,8),
        "sep": range(0,108,9),
        "oct": range(0,120,10),
        "nov": range(0,132,11),
        "dec": range(0,144,12),
    }
)
```
...and export it to Excel with a single conditional format that applies across _all_ the frame columns:
```python
df.write_excel(
    table_style="Table Style Medium 17",
    conditional_formats={
        tuple(df.columns): "3_color_scale",
    },
    column_totals=True,
    autofit=True,
)
```
<img width="598" alt="xl_export_heatmap" src="https://user-images.githubusercontent.com/2613171/223226716-389d93c4-80a7-4bb4-ae73-382d9339cbc7.png">

**Note**: can still mix & match multi-range formats with all of the other per-column or table-level formatting directives (such as sparklines, table styling, column formats, etc):
```python
df = pl.DataFrame(
    {
        "id": ["aaa","bbb","ccc","ddd","eee"],
        "q1": [100, 55, -20, 0, 35],
        "q2": [30, -10, 15, 60, 20],
        "q3": [-50, 0, 40, 80, 80],
        "q4": [75, 55, 25, -10, -55],
    }
)
df.write_excel(
    table_style={
        "style":"Table Style Light 2",
        "banded_rows": False,
    },
    sparklines={
        "trend": {
            "columns": ("q1","q2","q3","q4"),
            "markers": True,
        }
    },
    conditional_formats={
        ("q1","q2","q3","q4"): {
            "type": "2_color_scale",
            "min_color": "#95b3d7",
            "max_color": "#ffffff",
        }
    },
    column_widths={("q1","q2","q3","q4"): 40},
    hide_gridlines=True,
)
```
<img width="330" alt="xl_sparkline_heatmap" src="https://user-images.githubusercontent.com/2613171/223336608-9927fca0-967a-4ded-992c-a611de4f4a7f.png">

