### PR TITLE
feat(python): tweak default Date and Time format strings for `Excel` export

### DIFF
--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -30,8 +30,8 @@ _XL_DEFAULT_FLOAT_FORMAT_ = "#,##0.{zeros};[Red]-#,##0.{zeros}"
 _XL_DEFAULT_INTEGER_FORMAT_ = "#,##0;[Red]-#,##0"
 _XL_DEFAULT_DTYPE_FORMATS_: dict[PolarsDataType, str] = {
     Datetime: "yyyy-mm-dd hh:mm:ss",
-    Date: "yyyy-mm-dd",
-    Time: "hh:mm:ss",
+    Date: "yyyy-mm-dd;@",
+    Time: "hh:mm:ss;@",
 }
 for tp in INTEGER_DTYPES:
     _XL_DEFAULT_DTYPE_FORMATS_[tp] = _XL_DEFAULT_INTEGER_FORMAT_


### PR DESCRIPTION
As per https://github.com/jmcnamara/XlsxWriter/issues/961#issuecomment-1456173948, this tweak allows the given types to be better-detected as `Date` and `Time` by Excel's format picker; minor quality of life improvement ;)

* Before (`yyyy-mm-dd`), would appear under "Custom".
* Now (`yyyy-mm-dd;@`) appears as "Date":

<img width="728" alt="xl_format_picker" src="https://user-images.githubusercontent.com/2613171/223229818-dac37558-9b9c-4165-8cd7-731ae8bf97c8.png">
