### PR TITLE
fix(rust, python): creating empty struct series with some unit fields

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -51,12 +51,16 @@ impl StructChunked {
         let mut max_len = first_len;
 
         let mut all_equal_len = true;
+        let mut is_empty = false;
         for s in fields {
             let s_len = s.len();
             max_len = std::cmp::max(max_len, s_len);
 
             if s_len != first_len {
                 all_equal_len = false;
+            }
+            if s_len == 0 {
+                is_empty = true;
             }
             let name = s.name();
             if !names.insert(name) {
@@ -70,7 +74,9 @@ impl StructChunked {
             let mut new_fields = Vec::with_capacity(fields.len());
             for s in fields {
                 let s_len = s.len();
-                if s_len == max_len {
+                if is_empty {
+                    new_fields.push(s.clear())
+                } else if s_len == max_len {
                     new_fields.push(s.clone())
                 } else if s_len == 1 {
                     new_fields.push(s.new_from_index(0, max_len))

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -860,3 +860,21 @@ def test_struct_applies_as_map() -> None:
     ).to_dict(False) == {
         "x": [{"x": "a", "y": "dd"}, {"x": "b", "y": "ee"}, {"x": "c", "y": "ff"}]
     }
+
+
+def test_struct_with_lit() -> None:
+    expr = pl.struct([pl.col("a"), pl.lit(1).alias("b")])
+
+    assert (
+        pl.DataFrame({"a": pl.Series([], dtype=pl.Int64)}).select(expr).to_dict(False)
+    ) == {"a": []}
+
+    assert (
+        pl.DataFrame({"a": pl.Series([1], dtype=pl.Int64)}).select(expr).to_dict(False)
+    ) == {"a": [{"a": 1, "b": 1}]}
+
+    assert (
+        pl.DataFrame({"a": pl.Series([1, 2], dtype=pl.Int64)})
+        .select(expr)
+        .to_dict(False)
+    ) == {"a": [{"a": 1, "b": 1}, {"a": 2, "b": 1}]}


### PR DESCRIPTION
When using `pl.struct` as an expression, using a `pl.lit()` as one of the fields will crash on empty data frames. Works fine when the data frame is not empty.

```python
pl.DataFrame({"a": pl.Series([], dtype=pl.Int64)}).select(
  pl.struct([pl.col("a"), pl.lit(1).alias("b")])
)
# exceptions.ShapeError: expected all fields to have equal length
```