### PR TITLE
feat(python): Proper superclass for Decimal

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -86,6 +86,10 @@ class FractionalType(NumericType):
     """Base class for fractional data types."""
 
 
+class FloatType(FractionalType):
+    """Base class for float data types."""
+
+
 class TemporalType(DataType):
     """Base class for temporal data types."""
 
@@ -126,15 +130,15 @@ class UInt64(IntegralType):
     """64-bit unsigned integer type."""
 
 
-class Float32(FractionalType):
+class Float32(FloatType):
     """32-bit floating point type."""
 
 
-class Float64(FractionalType):
+class Float64(FloatType):
     """64-bit floating point type."""
 
 
-class Decimal(DataType):
+class Decimal(FractionalType):
     """
     Decimal 128-bit type with an optional precision and non-negative scale.
 

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from polars.datatypes import (
     Date,
     Datetime,
+    Decimal,
     Duration,
     Float32,
     Float64,
@@ -55,7 +56,9 @@ INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
     ]
 )
 FLOAT_DTYPES: frozenset[PolarsDataType] = frozenset([Float32, Float64])
-NUMERIC_DTYPES: frozenset[PolarsDataType] = FLOAT_DTYPES | INTEGER_DTYPES
+NUMERIC_DTYPES: frozenset[PolarsDataType] = (
+    FLOAT_DTYPES | INTEGER_DTYPES | frozenset([Decimal])
+)
 
 # number of rows to scan by default when inferring datatypes
 N_INFER_DEFAULT = 100


### PR DESCRIPTION
Just a tiny update, setting the right superclass for `Decimal` and add a separate one for `Float` types.

Something else: should we rename Decimal's property `prec` to `precision`? I think it fits better with our naming philosphy.