### PR TITLE
fix(rust, python): parse single-digit months and dates when code would have gone down fastpath

### DIFF
--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -297,6 +297,20 @@ def test_full_month_name() -> None:
     assert s[0] == datetime(2022, 12, 1)
 
 
+@pytest.mark.parametrize(
+    ("datatype", "expected"),
+    [
+        (pl.Datetime, datetime(2022, 1, 1)),
+        (pl.Date, date(2022, 1, 1)),
+    ],
+)
+def test_single_digit_month(
+    datatype: PolarsTemporalType, expected: datetime | date
+) -> None:
+    s = pl.Series(["2022-1-1"]).str.strptime(datatype, "%Y-%m-%d")
+    assert s[0] == expected
+
+
 def test_invalid_date_parsing_4898() -> None:
     assert pl.Series(["2022-09-18", "2022-09-50"]).str.strptime(
         pl.Date, "%Y-%m-%d", strict=False


### PR DESCRIPTION
closes #7390

This is a very small change, but the diff is making it look much larger than it really is because of a change in the indentation level

If reviewing, I'd suggest setting "ignore whitespace" option by appending "?w=1" to the URL, i.e.: https://github.com/pola-rs/polars/pull/7391/files?w=1