### PR TITLE
feat(python): disallow converting key values to null in map_dict due …

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -4993,6 +4993,7 @@ class Series:
             Dictionary containing the before/after values to map.
         default
             Value to use when the remapping dict does not contain the lookup value.
+            Use ``pl.first()``, to keep the original value.
 
         Examples
         --------
@@ -5015,7 +5016,19 @@ class Series:
             "Netherlands"
         ]
 
-        ...or keep the original value:
+        ...or keep the original value, by making use of ``pl.first()``:
+
+        >>> s.map_dict(country_lookup, default=pl.first()).rename("country_name")
+        shape: (4,)
+        Series: 'country_name' [str]
+        [
+            "Türkiye"
+            "???"
+            "Japan"
+            "Netherlands"
+        ]
+
+        ...or keep the original value, by assigning the input series:
 
         >>> s.map_dict(country_lookup, default=s).rename("country_name")
         shape: (4,)

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2461,6 +2461,13 @@ def test_map_dict() -> None:
         pl.Series("s", ["-1", "two", None, "four", "-5"]),
     )
 
+    remap_int = {1: 11, 2: 22, 3: 33, 4: 44, 5: 55}
+
+    assert_series_equal(
+        s.map_dict(remap_int, default=pl.first()),
+        pl.Series("s", [-1, 22, None, 44, -5]),
+    )
+
 
 @pytest.mark.parametrize(
     ("dtype", "lower", "upper"),


### PR DESCRIPTION
…to input dtype

Improve map_dict functionality:
  - Add `default=pl.first()` in docstring for easy preservation of original column values.
  - Remove experimental tag.
  - Add `_remap_key_series` helper function to ensure that none of the remapping dict keys are lost if they are not in the same dtype as the column in which the values will be replaced. Before key values could be implicitly converted to null values. The series construction now also uses `strict=True` to ensure numeric overflow checking.