### PR TITLE
feat(rust, python): use IO backed reader when `low_memory=True`.

### DIFF
--- a/examples/read_csv/src/main.rs
+++ b/examples/read_csv/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> PolarsResult<()> {
         .with_delimiter(b'|')
         .has_header(false)
         .with_chunk_size(10)
-        .batched(None)
+        .batched_mmap(None)
         .unwrap();
 
     // write_other_formats(&mut df)?;

--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -108,9 +108,6 @@ pub(crate) fn next_line_position(
             // don't count the fields
             (Some(_), None) => return Some(total_pos + pos),
             // // no new line found, check latest line (without eol) for number of fields
-            // (None, Some(expected_fields)) if { count_fields(new_input) == expected_fields } => {
-            //     return Some(total_pos + pos)
-            // }
             _ => return None,
         }
     }

--- a/polars/polars-io/src/csv/read_impl/batched_read.rs
+++ b/polars/polars-io/src/csv/read_impl/batched_read.rs
@@ -334,7 +334,7 @@ impl<'a> BatchedCsvReaderRead<'a> {
 
         let mut chunks = POOL.install(|| {
             self.file_chunks
-                .iter()
+                .par_iter()
                 .map(|(ptr, len)| {
                     let chunk = unsafe { std::slice::from_raw_parts(*ptr as *const u8, *len) };
                     let stop_at_n_bytes = chunk.len();

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -1,11 +1,12 @@
-mod batched;
+mod batched_mmap;
+mod batched_read;
 
 use std::fmt;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-pub use batched::*;
+pub use batched_mmap::*;
 use polars_arrow::array::*;
 use polars_core::config::verbose;
 use polars_core::prelude::*;

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 pub use batched_mmap::*;
+pub use batched_read::*;
 use polars_arrow::array::*;
 use polars_core::config::verbose;
 use polars_core::prelude::*;

--- a/polars/polars-io/src/mmap.rs
+++ b/polars/polars-io/src/mmap.rs
@@ -58,7 +58,7 @@ impl<T: MmapBytesReader> MmapBytesReader for &mut T {
 pub enum ReaderBytes<'a> {
     Borrowed(&'a [u8]),
     Owned(Vec<u8>),
-    Mapped(memmap::Mmap),
+    Mapped(memmap::Mmap, &'a File),
 }
 
 impl std::ops::Deref for ReaderBytes<'_> {
@@ -67,7 +67,7 @@ impl std::ops::Deref for ReaderBytes<'_> {
         match self {
             Self::Borrowed(ref_bytes) => ref_bytes,
             Self::Owned(vec) => vec,
-            Self::Mapped(mmap) => mmap,
+            Self::Mapped(mmap, _) => mmap,
         }
     }
 }
@@ -79,7 +79,7 @@ impl<'a, T: 'a + MmapBytesReader> From<&'a T> for ReaderBytes<'a> {
             None => {
                 let f = m.to_file().unwrap();
                 let mmap = unsafe { memmap::Mmap::map(f).unwrap() };
-                ReaderBytes::Mapped(mmap)
+                ReaderBytes::Mapped(mmap, f)
             }
         }
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use polars_core::POOL;
-use polars_io::csv::read_impl::BatchedCsvReader;
+use polars_io::csv::read_impl::BatchedCsvReaderMmap;
 use polars_io::csv::{CsvEncoding, CsvReader};
 use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::CsvParserOptions;
@@ -15,7 +15,7 @@ pub(crate) struct CsvSource {
     // this exist because we need to keep ownership
     schema: SchemaRef,
     reader: *mut CsvReader<'static, File>,
-    batched_reader: *mut BatchedCsvReader<'static>,
+    batched_reader: *mut BatchedCsvReaderMmap<'static>,
     n_threads: usize,
     chunk_index: IdxSize,
 }
@@ -72,9 +72,9 @@ impl CsvSource {
         let reader = Box::new(reader);
         let reader = Box::leak(reader) as *mut CsvReader<'static, File>;
 
-        let batched_reader = unsafe { Box::new((*reader).batched_borrowed()?) };
+        let batched_reader = unsafe { Box::new((*reader).batched_borrowed_mmap()?) };
 
-        let batched_reader = Box::leak(batched_reader) as *mut BatchedCsvReader;
+        let batched_reader = Box::leak(batched_reader) as *mut BatchedCsvReaderMmap;
 
         Ok(CsvSource {
             schema,

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/csv.rs
@@ -1,8 +1,9 @@
 use std::fs::File;
 use std::path::PathBuf;
 
+use polars_core::export::arrow::Either;
 use polars_core::POOL;
-use polars_io::csv::read_impl::BatchedCsvReaderMmap;
+use polars_io::csv::read_impl::{BatchedCsvReaderMmap, BatchedCsvReaderRead};
 use polars_io::csv::{CsvEncoding, CsvReader};
 use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::CsvParserOptions;
@@ -15,7 +16,7 @@ pub(crate) struct CsvSource {
     // this exist because we need to keep ownership
     schema: SchemaRef,
     reader: *mut CsvReader<'static, File>,
-    batched_reader: *mut BatchedCsvReaderMmap<'static>,
+    batched_reader: Either<*mut BatchedCsvReaderMmap<'static>, *mut BatchedCsvReaderRead<'static>>,
     n_threads: usize,
     chunk_index: IdxSize,
 }
@@ -72,9 +73,15 @@ impl CsvSource {
         let reader = Box::new(reader);
         let reader = Box::leak(reader) as *mut CsvReader<'static, File>;
 
-        let batched_reader = unsafe { Box::new((*reader).batched_borrowed_mmap()?) };
-
-        let batched_reader = Box::leak(batched_reader) as *mut BatchedCsvReaderMmap;
+        let batched_reader = if options.low_memory {
+            let batched_reader = unsafe { Box::new((*reader).batched_borrowed_read()?) };
+            let batched_reader = Box::leak(batched_reader) as *mut BatchedCsvReaderRead;
+            Either::Right(batched_reader)
+        } else {
+            let batched_reader = unsafe { Box::new((*reader).batched_borrowed_mmap()?) };
+            let batched_reader = Box::leak(batched_reader) as *mut BatchedCsvReaderMmap;
+            Either::Left(batched_reader)
+        };
 
         Ok(CsvSource {
             schema,
@@ -89,7 +96,14 @@ impl CsvSource {
 impl Drop for CsvSource {
     fn drop(&mut self) {
         unsafe {
-            let _to_drop = Box::from_raw(self.batched_reader);
+            match self.batched_reader {
+                Either::Left(ptr) => {
+                    let _to_drop = Box::from_raw(ptr);
+                }
+                Either::Right(ptr) => {
+                    let _to_drop = Box::from_raw(ptr);
+                }
+            }
             let _to_drop = Box::from_raw(self.reader);
         };
     }
@@ -100,9 +114,18 @@ unsafe impl Sync for CsvSource {}
 
 impl Source for CsvSource {
     fn get_batches(&mut self, _context: &PExecutionContext) -> PolarsResult<SourceResult> {
-        let reader = unsafe { &mut *self.batched_reader };
+        let batches = match self.batched_reader {
+            Either::Left(batched_reader) => {
+                let reader = unsafe { &mut *batched_reader };
 
-        let batches = reader.next_batches(self.n_threads)?;
+                reader.next_batches(self.n_threads)?
+            }
+            Either::Right(batched_reader) => {
+                let reader = unsafe { &mut *batched_reader };
+
+                reader.next_batches(self.n_threads)?
+            }
+        };
         Ok(match batches {
             None => SourceResult::Finished,
             Some(batches) => SourceResult::GotMoreData(

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -5,6 +5,7 @@ import io
 import sys
 import tempfile
 import textwrap
+import typing
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
@@ -1068,6 +1069,7 @@ def test_csv_categorical_categorical_merge() -> None:
     ].to_list() == ["A", "B"]
 
 
+@typing.no_type_check
 def test_batched_csv_reader(foods_file_path: Path) -> None:
     reader = pl.read_csv_batched(foods_file_path, batch_size=4)
     batches = reader.next_batches(5)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1087,6 +1087,15 @@ def test_batched_csv_reader(foods_file_path: Path) -> None:
         "sugars_g": [25, 0, 5, 11],
     }
     assert_frame_equal(pl.concat(batches), pl.read_csv(foods_file_path))
+    # the final batch of the low-memory variant is different
+    reader = pl.read_csv_batched(foods_file_path, batch_size=4, low_memory=True)
+    batches = reader.next_batches(5)
+    batches += reader.next_batches(5)
+    assert_frame_equal(pl.concat(batches), pl.read_csv(foods_file_path))
+
+    reader = pl.read_csv_batched(foods_file_path, batch_size=4, low_memory=True)
+    batches = reader.next_batches(10)
+    assert_frame_equal(pl.concat(batches), pl.read_csv(foods_file_path))
 
 
 def test_batched_csv_reader_all_batches(foods_file_path: Path) -> None:


### PR DESCRIPTION
This will not use memory map but read calls and likely fixes memory issues in #7324.

The IO calls are still blocking. Will come up with an async version later.