### PR TITLE
docs(python): Remove redundant `schema` keyword description from `pl.…

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -324,10 +324,6 @@ def from_arrow(
         Data representing an Arrow Table or Array.
     rechunk : bool, default True
         Make sure that all data is in contiguous memory.
-    schema : Sequence of str, dict, default None
-        Column labels to use for resulting DataFrame. Must match data dimensions.
-        If not specified, existing Array table columns are used, with missing names
-        named as `column_0`, `column_1`, etc.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 


### PR DESCRIPTION
…from_arrow`

Seems like this block of lines was overlooked when deprecating `columns` keyword in favor of `schema`.