### PR TITLE
refactor(python,rust): Rename Decimal `prec` to `precision`

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/any_value.rs
+++ b/polars/polars-core/src/chunked_array/ops/any_value.rs
@@ -104,7 +104,7 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
             AnyValue::Time(v)
         }
         #[cfg(feature = "dtype-decimal")]
-        DataType::Decimal(prec, scale) => {
+        DataType::Decimal(precision, scale) => {
             let arr = &*(arr as *const dyn Array as *const Int128Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Decimal(v, scale.unwrap_or_else(|| unreachable!()))

--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -18,7 +18,7 @@ pub enum DataType {
     #[cfg(feature = "dtype-decimal")]
     /// Fixed point decimal type optional precision and non-negative scale.
     /// This is backed by a signed 128-bit integer which allows for up to 38 significant digits.
-    Decimal(Option<usize>, Option<usize>), // prec/scale; scale being None means "infer"
+    Decimal(Option<usize>, Option<usize>), // precision/scale; scale being None means "infer"
     /// String data
     Utf8,
     Binary,
@@ -207,9 +207,9 @@ impl DataType {
             Float32 => ArrowDataType::Float32,
             Float64 => ArrowDataType::Float64,
             #[cfg(feature = "dtype-decimal")]
-            // note: what else can we do here other than setting prec to 38?..
-            Decimal(prec, scale) => ArrowDataType::Decimal(
-                (*prec).unwrap_or(38),
+            // note: what else can we do here other than setting precision to 38?..
+            Decimal(precision, scale) => ArrowDataType::Decimal(
+                (*precision).unwrap_or(38),
                 scale.unwrap_or(0), // and what else can we do here?
             ),
             Utf8 => ArrowDataType::LargeUtf8,
@@ -265,11 +265,13 @@ impl Display for DataType {
             DataType::Float32 => "f32",
             DataType::Float64 => "f64",
             #[cfg(feature = "dtype-decimal")]
-            DataType::Decimal(prec, scale) => {
-                return match (prec, scale) {
+            DataType::Decimal(precision, scale) => {
+                return match (precision, scale) {
                     (_, None) => f.write_str("decimal[?]"), // shouldn't happen
                     (None, Some(scale)) => f.write_str(&format!("decimal[{scale}]")),
-                    (Some(prec), Some(scale)) => f.write_str(&format!("decimal[.{prec},{scale}]")),
+                    (Some(precision), Some(scale)) => {
+                        f.write_str(&format!("decimal[.{precision},{scale}]"))
+                    }
                 };
             }
             DataType::Utf8 => "str",

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -63,9 +63,9 @@ impl Series {
                 .into_datetime(*tu, tz.clone())
                 .into_series(),
             #[cfg(feature = "dtype-decimal")]
-            Decimal(prec, scale) => Int128Chunked::from_chunks(name, chunks)
+            Decimal(precision, scale) => Int128Chunked::from_chunks(name, chunks)
                 .into_decimal_unchecked(
-                    *prec,
+                    *precision,
                     scale.unwrap_or_else(|| unreachable!("scale should be set")),
                 )
                 .into_series(),
@@ -342,12 +342,12 @@ impl Series {
                 Ok(BinaryChunked::from_chunks(name, chunks).into_series())
             }
             #[cfg(feature = "dtype-decimal")]
-            ArrowDataType::Decimal(prec, scale) => {
+            ArrowDataType::Decimal(precision, scale) => {
                 #[cfg(feature = "python")]
                 {
                     if std::env::var("POLARS_ACTIVATE_DECIMAL").is_ok() {
                         Ok(Int128Chunked::from_chunks(name, chunks)
-                            .into_decimal_unchecked(Some(*prec), *scale)
+                            .into_decimal_unchecked(Some(*precision), *scale)
                             .into_series())
                     } else {
                         if verbose() {
@@ -365,12 +365,13 @@ impl Series {
 
                 #[cfg(not(feature = "python"))]
                 {
-                    let (prec, scale) = (Some(*prec), *scale);
+                    let (precision, scale) = (Some(*precision), *scale);
                     let chunks =
-                        cast_chunks(&chunks, &DataType::Decimal(prec, Some(scale)), false).unwrap();
+                        cast_chunks(&chunks, &DataType::Decimal(precision, Some(scale)), false)
+                            .unwrap();
                     // or DecimalChunked?
                     Ok(Int128Chunked::from_chunks(name, chunks)
-                        .into_decimal_unchecked(prec, scale)
+                        .into_decimal_unchecked(precision, scale)
                         .into_series())
                 }
             }

--- a/polars/polars-core/src/series/ops/null.rs
+++ b/polars/polars-core/src/series/ops/null.rs
@@ -26,9 +26,9 @@ impl Series {
                 .into_time()
                 .into_series(),
             #[cfg(feature = "dtype-decimal")]
-            DataType::Decimal(prec, scale) => Int128Chunked::full_null(name, size)
+            DataType::Decimal(precision, scale) => Int128Chunked::full_null(name, size)
                 .into_decimal_unchecked(
-                    *prec,
+                    *precision,
                     scale.unwrap_or_else(|| unreachable!("scale should be set")),
                 )
                 .into_series(),

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -145,27 +145,29 @@ class Decimal(FractionalType):
     NOTE: this is an experimental work-in-progress feature and may not work as expected.
     """
 
-    prec: int | None
+    precision: int | None
     scale: int
 
-    def __init__(self, prec: int | None, scale: int):
-        self.prec = prec
+    def __init__(self, precision: int | None, scale: int):
+        self.precision = precision
         self.scale = scale
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(prec={self.prec}, scale={self.scale})"
+        return (
+            f"{self.__class__.__name__}(precision={self.precision}, scale={self.scale})"
+        )
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is DataTypeClass and issubclass(other, Decimal):
             return True
         elif isinstance(other, Decimal):
-            return self.prec == other.prec and self.scale == other.scale
+            return self.precision == other.precision and self.scale == other.scale
         else:
             return False
 
     def __hash__(self) -> int:
-        return hash((Decimal, self.prec, self.scale))
+        return hash((Decimal, self.precision, self.scale))
 
 
 class Boolean(DataType):


### PR DESCRIPTION
In Rust, the method was already called `precision`. Now the Python object uses the same name. Also updated some related variable names across the Rust code.