### PR TITLE
refactor(python): Remove `_base_type` util

### DIFF
--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -45,7 +45,6 @@ from polars.datatypes.constructor import (
     py_type_to_constructor,
 )
 from polars.datatypes.convert import (
-    _base_type,
     dtype_to_arrow_type,
     dtype_to_ctype,
     dtype_to_ffiname,
@@ -115,7 +114,6 @@ __all__ = [
     "polars_type_to_constructor",
     "py_type_to_constructor",
     # convert
-    "_base_type",
     "dtype_to_arrow_type",
     "dtype_to_ctype",
     "dtype_to_ffiname",

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -49,7 +49,7 @@ def polars_type_to_constructor(
 ) -> Callable[[str, Sequence[Any], bool], PySeries]:
     """Get the right PySeries constructor for the given Polars dtype."""
     try:
-        dtype = dt._base_type(dtype)
+        dtype = dtype.base_type()
         return _POLARS_TYPE_TO_CONSTRUCTOR[dtype]
     except KeyError:  # pragma: no cover
         raise ValueError(f"Cannot construct PySeries for type {dtype}.") from None

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -261,17 +261,10 @@ class _DataTypeMappings:
 DataTypeMappings = _DataTypeMappings()
 
 
-def _base_type(dtype: PolarsDataType) -> DataTypeClass:
-    """Ensure return of the DataType base dtype/class."""
-    if isinstance(dtype, DataType):
-        return type(dtype)
-    return dtype
-
-
 def dtype_to_ctype(dtype: PolarsDataType) -> Any:
     """Convert a Polars dtype to a ctype."""
     try:
-        dtype = _base_type(dtype)
+        dtype = dtype.base_type()
         return DataTypeMappings.DTYPE_TO_CTYPE[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
@@ -282,7 +275,7 @@ def dtype_to_ctype(dtype: PolarsDataType) -> Any:
 def dtype_to_ffiname(dtype: PolarsDataType) -> str:
     """Return FFI function name associated with the given Polars dtype."""
     try:
-        dtype = _base_type(dtype)
+        dtype = dtype.base_type()
         return DataTypeMappings.DTYPE_TO_FFINAME[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
@@ -293,7 +286,7 @@ def dtype_to_ffiname(dtype: PolarsDataType) -> str:
 def dtype_to_py_type(dtype: PolarsDataType) -> PythonDataType:
     """Convert a Polars dtype to a Python dtype."""
     try:
-        dtype = _base_type(dtype)
+        dtype = dtype.base_type()
         return DataTypeMappings.DTYPE_TO_PY_TYPE[dtype]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(


### PR DESCRIPTION
DataType classes now have a method `base_type`. The separate util is no longer needed.