### PR TITLE
feat(python): support setting multiple conditional formats on the same `Excel` table column/range

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -113,7 +113,7 @@ if TYPE_CHECKING:
         SchemaDefinition,
         SchemaDict,
     )
-    from polars.internals.io_excel import ColumnTotalsDict, ConditionalFormatDict
+    from polars.internals.io_excel import ColumnTotalsDefinition, ConditionalFormatDict
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         AvroCompression,
@@ -2407,7 +2407,7 @@ class DataFrame:
         column_formats: dict[str | tuple[str, ...], str] | None = None,
         dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
         conditional_formats: ConditionalFormatDict | None = None,
-        column_totals: ColumnTotalsDict | None = None,
+        column_totals: ColumnTotalsDefinition | None = None,
         column_widths: dict[str | tuple[str, ...], int] | None = None,
         sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
         float_precision: int = 3,

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -7,6 +7,8 @@ from typing import (
     Any,
     Iterable,
     Sequence,
+    TypeAlias,
+    Union,
 )
 
 import polars.internals as pli
@@ -37,6 +39,18 @@ _XL_DEFAULT_DTYPE_FORMATS_: dict[PolarsDataType, str] = {
 for tp in INTEGER_DTYPES:
     _XL_DEFAULT_DTYPE_FORMATS_[tp] = _XL_DEFAULT_INTEGER_FORMAT_
 
+ColumnTotalsDict: TypeAlias = Union[
+    # dict of colname(s) to str, a sequence of str, or a boolean
+    dict[Union[str, tuple[str, ...]], str],
+    Sequence[str],
+    bool,
+]
+ConditionalFormatDict: TypeAlias = dict[
+    # dict of colname(s) to str, dict, or sequence of str/dict
+    Union[str, tuple[str, ...]],
+    Union[str, Union[dict[str, Any], Sequence[Union[str, dict[str, Any]]]]],
+]
+
 
 def _unpack_multi_column_dict(
     d: dict[str | Sequence[str], str] | Any
@@ -49,6 +63,39 @@ def _unpack_multi_column_dict(
         for k in (key,) if isinstance(key, str) else key:
             unpacked[k] = value
     return unpacked
+
+
+def _xl_apply_conditional_formats(
+    df: pli.DataFrame,
+    workbook: Workbook,
+    worksheet: Worksheet,
+    conditional_formats: ConditionalFormatDict,
+    table_start: tuple[int, int],
+    has_header: bool,
+) -> None:
+    """Take all conditional formatting options and apply them to the table/range."""
+    for cols, formats in conditional_formats.items():
+        if not isinstance(cols, str) and len(cols) == 1:
+            cols = cols[0]
+        if isinstance(formats, (str, dict)):
+            formats = [formats]
+        for fmt in formats:
+            if not isinstance(fmt, dict):
+                fmt = {"type": fmt}
+            if isinstance(cols, str):
+                col = cols
+            else:
+                col = cols[0]
+                fmt["multi_range"] = _xl_column_multi_range(
+                    df, table_start, cols, has_header
+                )
+            col_range = _xl_column_range(df, table_start, col, has_header)
+            if "format" in fmt:
+                f = fmt["format"]
+                fmt["format"] = workbook.add_format(
+                    {"num_format": f} if isinstance(f, str) else f
+                )
+            worksheet.conditional_format(*col_range, fmt)
 
 
 def _xl_column_range(
@@ -161,8 +208,8 @@ def _xl_inject_sparklines(
 def _xl_setup_table_columns(
     df: pli.DataFrame,
     wb: Workbook,
-    column_totals: dict[str | Sequence[str], str] | Sequence[str] | bool | None = None,
-    column_formats: dict[str | Sequence[str], str] | None = None,
+    column_totals: ColumnTotalsDict | None = None,
+    column_formats: dict[str | tuple[str, ...], str] | None = None,
     dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
     sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
     float_precision: int = 3,

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Iterable,
     Sequence,
-    TypeAlias,
+    Tuple,
     Union,
 )
 
@@ -23,10 +24,17 @@ from polars.datatypes import (
 from polars.exceptions import DuplicateError
 
 if TYPE_CHECKING:
+    import sys
+
     from xlsxwriter import Workbook
     from xlsxwriter.worksheet import Worksheet
 
     from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 
 _XL_DEFAULT_FLOAT_FORMAT_ = "#,##0.{zeros};[Red]-#,##0.{zeros}"
@@ -39,16 +47,17 @@ _XL_DEFAULT_DTYPE_FORMATS_: dict[PolarsDataType, str] = {
 for tp in INTEGER_DTYPES:
     _XL_DEFAULT_DTYPE_FORMATS_[tp] = _XL_DEFAULT_INTEGER_FORMAT_
 
-ColumnTotalsDict: TypeAlias = Union[
+
+ColumnTotalsDefinition: TypeAlias = Union[
     # dict of colname(s) to str, a sequence of str, or a boolean
-    dict[Union[str, tuple[str, ...]], str],
+    Dict[Union[str, Tuple[str, ...]], str],
     Sequence[str],
     bool,
 ]
-ConditionalFormatDict: TypeAlias = dict[
+ConditionalFormatDict: TypeAlias = Dict[
     # dict of colname(s) to str, dict, or sequence of str/dict
-    Union[str, tuple[str, ...]],
-    Union[str, Union[dict[str, Any], Sequence[Union[str, dict[str, Any]]]]],
+    Union[str, Tuple[str, ...]],
+    Union[str, Union[Dict[str, Any], Sequence[Union[str, Dict[str, Any]]]]],
 ]
 
 
@@ -208,7 +217,7 @@ def _xl_inject_sparklines(
 def _xl_setup_table_columns(
     df: pli.DataFrame,
     wb: Workbook,
-    column_totals: ColumnTotalsDict | None = None,
+    column_totals: ColumnTotalsDefinition | None = None,
     column_formats: dict[str | tuple[str, ...], str] | None = None,
     dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
     sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,


### PR DESCRIPTION
A follow-on from #7379, which allowed one format to be applied to multiple columns...

...can now apply multiple conditional formats to the same column/range; just supply them as a list.

## Also

* Extends parameterised tests to cover additional Excel export variations.
* Further improves typing and the help/docstring.

## Example

Building on the [previous](https://github.com/pola-rs/polars/pull/7379) demo...

```python
df = pl.DataFrame(
    {
        "jan": range(0,12,1),
        "feb": range(0,24,2),
        "mar": range(0,36,3),
        "apr": range(0,48,4),
        "may": range(0,60,5),
        "jun": range(0,72,6),
        "jul": range(0,84,7),
        "aug": range(0,96,8),
        "sep": range(0,108,9),
        "oct": range(0,120,10),
        "nov": range(0,132,11),
        "dec": range(0,144,12),
    }
)
```
...apply _multiple_ formats to the same column-range:
```python
cols = tuple( df.columns )

df.write_excel(
    conditional_formats = {
        cols: [
            {"type":"3_color_scale"},
            {"type":"unique", "format":{"font_color":"#ffffff"}},
            {"type":"cell", "criteria":"between", "minimum":30, "maximum":55, "format":{"bold":True}},
        ],
    },
    column_widths = {cols: 45},
)
```
* Apply three-colour scale as a heatmap.
* Highlight values that only occur once in white.
* Bold formatting for values falling within a specific range.

<img width="615" alt="xl_multiple_conditional_formats" src="https://user-images.githubusercontent.com/2613171/223654615-d432d6f4-3fc1-4f31-ab18-1a631b79bbbe.png">