### PR TITLE
fix(rust, python): sort_by logical types

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.16.0"
-source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-01#db533042a0129ea9ea26eec4c481126f29b6e631"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=f258a3e06ac408aebe7a7a497694729dc65a5e46#f258a3e06ac408aebe7a7a497694729dc65a5e46"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import string
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 import numpy as np
@@ -505,3 +505,16 @@ def test_streaming_sort_multiple_columns(monkeypatch: Any, capfd: Any) -> None:
     assert "RUN STREAMING PIPELINE" in err
     assert "df -> sort_multiple" in err
     assert out.columns == ["vals", "strs"]
+
+
+def test_sort_by_logical() -> None:
+    test = pl.DataFrame(
+        {
+            "start": [date(2020, 5, 6), date(2020, 5, 13), date(2020, 5, 10)],
+            "end": [date(2020, 12, 31), date(2020, 12, 31), date(2021, 1, 1)],
+            "num": [0, 1, 2],
+        }
+    )
+    assert test.select([pl.col("num").sort_by(["start", "end"]).alias("n1")])[
+        "n1"
+    ].to_list() == [0, 2, 1]


### PR DESCRIPTION
fixes #7388