### PR TITLE
feat(rust, python): dynamically change chunk_size in streaming `explo…

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/operators/function.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/operators/function.rs
@@ -1,11 +1,54 @@
+use std::collections::VecDeque;
+
 use polars_core::error::PolarsResult;
+use polars_core::utils::_split_offsets;
+use polars_core::POOL;
 use polars_plan::prelude::*;
 
+use crate::determine_chunk_size;
 use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
 
 #[derive(Clone)]
 pub struct FunctionOperator {
-    pub(crate) function: FunctionNode,
+    n_threads: usize,
+    chunk_size: usize,
+    offsets: VecDeque<(usize, usize)>,
+    function: FunctionNode,
+}
+
+impl FunctionOperator {
+    pub(crate) fn new(function: FunctionNode) -> Self {
+        FunctionOperator {
+            n_threads: POOL.current_num_threads(),
+            function,
+            chunk_size: 128,
+            offsets: VecDeque::new(),
+        }
+    }
+
+    fn execute_no_expanding(&mut self, chunk: &DataChunk) -> PolarsResult<OperatorResult> {
+        Ok(OperatorResult::Finished(
+            chunk.with_data(self.function.evaluate(chunk.data.clone())?),
+        ))
+    }
+
+    // Combine every two `(offset, len)` pairs so that we double the chunk size
+    fn combine_offsets(&mut self) {
+        self.offsets = self
+            .offsets
+            .make_contiguous()
+            .chunks(2)
+            .map(|chunk| {
+                if chunk.len() == 2 {
+                    let offset = chunk[0].0;
+                    let len = chunk[0].1 + chunk[1].1;
+                    (offset, len)
+                } else {
+                    chunk[0]
+                }
+            })
+            .collect()
+    }
 }
 
 impl Operator for FunctionOperator {
@@ -14,9 +57,50 @@ impl Operator for FunctionOperator {
         _context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-        Ok(OperatorResult::Finished(
-            chunk.with_data(self.function.evaluate(chunk.data.clone())?),
-        ))
+        if self.function.expands_rows() {
+            let input_height = chunk.data.height();
+            // ideal chunk size we want to have
+            // we cannot rely on input chunk size as that can increase due to multiple explode calls
+            // for instance.
+            let chunk_size_ambition = determine_chunk_size(input_height, self.n_threads);
+
+            if self.offsets.is_empty() {
+                let n = input_height / self.chunk_size;
+                if n > 1 {
+                    self.offsets = _split_offsets(input_height, n).into();
+                } else {
+                    return self.execute_no_expanding(chunk);
+                }
+            }
+            if let Some((offset, len)) = self.offsets.pop_front() {
+                let df = chunk.data.slice(offset as i64, len);
+                let output = self.function.evaluate(df)?;
+                if output.height() * 2 < chunk.data.height()
+                    && output.height() * 2 < chunk_size_ambition
+                {
+                    self.chunk_size *= 2;
+                    // ensure that next slice is larger
+                    self.combine_offsets();
+                }
+                // allow some increase in chunk size so that we don't toggle the chunk size
+                // every iteration
+                else if output.height() * 4 > chunk.data.height()
+                    || output.height() > chunk_size_ambition * 2
+                {
+                    self.chunk_size /= 2
+                };
+                let output = chunk.with_data(output);
+                if self.offsets.is_empty() {
+                    Ok(OperatorResult::Finished(output))
+                } else {
+                    Ok(OperatorResult::HaveMoreOutPut(output))
+                }
+            } else {
+                self.execute_no_expanding(chunk)
+            }
+        } else {
+            self.execute_no_expanding(chunk)
+        }
     }
 
     fn split(&self, _thread_no: usize) -> Box<dyn Operator> {

--- a/polars/polars-lazy/polars-pipe/src/lib.rs
+++ b/polars/polars-lazy/polars-pipe/src/lib.rs
@@ -14,6 +14,7 @@ pub use operators::SExecutionContext;
 /// scale the chunk size depending on the number of
 /// columns. With 10 columns we use a chunk size of 40_000
 #[cfg(feature = "compile")]
-pub(crate) fn chunk_size(n_cols: usize) -> usize {
-    std::cmp::max(400_000 / n_cols, 1000)
+pub(crate) fn determine_chunk_size(n_cols: usize, n_threads: usize) -> usize {
+    let thread_factor = std::cmp::max(12 / n_threads, 1);
+    std::cmp::max(400_000 / n_cols * thread_factor, 1000)
 }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/functions/mod.rs
@@ -124,6 +124,17 @@ impl FunctionNode {
         }
     }
 
+    /// Whether this function will increase the number of rows
+    pub fn expands_rows(&self) -> bool {
+        use FunctionNode::*;
+        match self {
+            #[cfg(feature = "merge_sorted")]
+            MergeSorted { .. } => true,
+            Explode { .. } | Melt { .. } => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn schema<'a>(
         &self,
         input_schema: &'a SchemaRef,


### PR DESCRIPTION
…de`/`melt`


A streaming `explode` can increase the row size by a lot. This ensures we start with a very small chunk initially e.g. `128` rows and increase the row size every subsequent call so that we maintain an output chunk size and memory usage that is stable.