### PR TITLE
refactor(python): Rename functions that clash with builtins

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -90,8 +90,6 @@ from polars.internals.functions import (
     zeros,
 )
 from polars.internals.io import read_ipc_schema, read_parquet_schema
-from polars.internals.lazy_functions import _date as date
-from polars.internals.lazy_functions import _datetime as datetime
 from polars.internals.lazy_functions import (
     all,
     any,
@@ -141,7 +139,9 @@ from polars.internals.lazy_functions import (
     tail,
     var,
 )
-from polars.internals.lazy_functions import to_list as list
+from polars.internals.lazy_functions import date_ as date
+from polars.internals.lazy_functions import datetime_ as datetime
+from polars.internals.lazy_functions import list_ as list
 from polars.internals.lazyframe import LazyFrame
 
 # TODO: remove need for wrap_s
@@ -289,8 +289,8 @@ __all__ = [
     "cumfold",
     "cumreduce",
     "cumsum",
-    "date",  # name _date, see import above
-    "datetime",  # named _datetime, see import above
+    "date",  # named date_, see import above
+    "datetime",  # named datetime_, see import above
     "duration",
     "exclude",
     "first",
@@ -300,7 +300,7 @@ __all__ = [
     "groups",
     "head",
     "last",
-    "list",  # named to_list, see import above
+    "list",  # named list_, see import above
     "lit",
     "map",
     "max",

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -354,11 +354,14 @@ def count(column: str | pli.Series | None = None) -> pli.Expr | int:
     return col(column).count()
 
 
-def to_list(name: str) -> pli.Expr:
+def list_(name: str) -> pli.Expr:
     """
     Aggregate to list.
 
-    Re-exported as `pl.list()`
+    Parameters
+    ----------
+    name
+        Name of the column that should be aggregated into a list.
 
     """
     return col(name).list()
@@ -2420,7 +2423,7 @@ def duration(
     )
 
 
-def _datetime(
+def datetime_(
     year: pli.Expr | str | int,
     month: pli.Expr | str | int,
     day: pli.Expr | str | int,
@@ -2430,7 +2433,7 @@ def _datetime(
     microsecond: pli.Expr | str | int | None = None,
 ) -> pli.Expr:
     """
-    Create polars `Datetime` from distinct time components.
+    Create a Polars literal expression of type Datetime.
 
     Parameters
     ----------
@@ -2480,13 +2483,13 @@ def _datetime(
     )
 
 
-def _date(
+def date_(
     year: pli.Expr | str | int,
     month: pli.Expr | str | int,
     day: pli.Expr | str | int,
 ) -> pli.Expr:
     """
-    Create polars Date from distinct time components.
+    Create a Polars literal expression of type Date.
 
     Parameters
     ----------
@@ -2502,7 +2505,7 @@ def _date(
     Expr of type pl.Date
 
     """
-    return _datetime(year, month, day).cast(Date).alias("date")
+    return datetime_(year, month, day).cast(Date).alias("date")
 
 
 @deprecated_alias(sep="separator")


### PR DESCRIPTION
In `lazy_functions`, we define three functions that clash with Python built-in names:
* `_datetime` (re-exported as `datetime`)
* `_date` (re-exported as `date`)
* `to_list` (re-exported as `list`)

The convention for naming stuff that clashes with built-ins is to use a _trailing underscore_. A leading underscore actually indicates private functions/variables.

So this PR makes those functions conform to the convention. This is not breaking, as the exported name is unchanged.

* `_datetime` -> `datetime_`
* `_date` -> `date_`
* `to_list` -> `list_`