### PR TITLE
feat(python): optimise `Excel` export when all data in a multi-column conditional format is contiguous

### DIFF
--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -56,23 +56,21 @@ def test_read_excel_all_sheets(excel_file_path: Path) -> None:
         {
             "position": (0, 0),
             "table_style": {
-                "style": "Table Style Medium 25",
+                "style": "Table Style Medium 23",
                 "first_column": True,
             },
-            "conditional_formats": {
-                # string: will unpack to {"type": "data_bar"}
-                "val": "data_bar"
-            },
+            "conditional_formats": {"val": "data_bar"},
             "column_formats": {"val": "#,##0.000;[White]-#,##0.000"},
             "column_widths": {"val": 100},
+            "column_totals": True,
         },
         # heavily customised formatting/definition
         {
             "position": "A1",
             "table_name": "PolarsFrameData",
-            "table_style": "Table Style Light 11",
+            "table_style": "Table Style Light 9",
             "conditional_formats": {
-                # dict format
+                # single dict format
                 "str": {
                     "type": "duplicate",
                     "format": {"bg_color": "#ff0000", "font_color": "#ffffff"},
@@ -191,6 +189,8 @@ def test_excel_sparklines() -> None:
             },
             column_widths={("q1", "q2", "q3", "q4"): 40},
             hide_gridlines=True,
+            row_height=35,
+            sheet_zoom=125,
         )
 
     tables = {tbl["name"] for tbl in wb.get_worksheet_by_name("frame_data").tables}


### PR DESCRIPTION
**Optimisation**:
* Emit `multi_range` for conditional formats _only_ when columns are discontinuous; otherwise, can apply to a single "A1:D10"-style range definition. This is significant for formats that reference a really [large number of columns](https://github.com/pola-rs/polars/pull/7411#issuecomment-1460060181).

**Also**:
* Added `row_height` support.
* Added `sheet_zoom` support.
* Allow `column_widths` as integer (broadcasts value to all table cols).

(I'm deep in the Excel rabbit hole now; will come up for air in a few more commits... 😅)