### PR TITLE
fix(rust, python): allow for hourly date_range to cross DST

### DIFF
--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -9,6 +9,7 @@ description = "Time related code for the polars dataframe library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arrow.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8", optional = true }
 lexical = { version = "6", default-features = false, features = ["std", "parse-floats", "parse-integers"] }

--- a/polars/polars-time/src/date_range.rs
+++ b/polars/polars-time/src/date_range.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "timezones")]
+use arrow::temporal_conversions::{
+    parse_offset, timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
+};
+#[cfg(feature = "timezones")]
+use chrono::{DateTime, LocalResult, TimeZone as TimeZoneTrait, Utc};
 use chrono::{Datelike, NaiveDateTime};
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
@@ -7,6 +13,29 @@ use crate::prelude::*;
 pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
     // ~584 year around 1970
     !(ndt.year() > 2554 || ndt.year() < 1386)
+}
+
+#[cfg(feature = "timezones")]
+fn localize_timestamp<T: TimeZoneTrait>(timestamp: i64, tu: TimeUnit, tz: T) -> PolarsResult<i64> {
+    let ndt = match tu {
+        TimeUnit::Nanoseconds => timestamp_ns_to_datetime(timestamp),
+        TimeUnit::Microseconds => timestamp_us_to_datetime(timestamp),
+        TimeUnit::Milliseconds => timestamp_ms_to_datetime(timestamp),
+    };
+    let dt: PolarsResult<DateTime<Utc>> = match tz.from_local_datetime(&ndt) {
+        LocalResult::Single(dt) => Ok(dt.with_timezone(&Utc)),
+        LocalResult::Ambiguous(_, _) => {
+            polars_bail!(ComputeError: "ambiguous timestamps are not (yet) supported")
+        }
+        LocalResult::None => {
+            polars_bail!(ComputeError: "non-existent timestamps are not (yet) supported")
+        }
+    };
+    match tu {
+        TimeUnit::Nanoseconds => Ok(dt?.timestamp_nanos()),
+        TimeUnit::Microseconds => Ok(dt?.timestamp_micros()),
+        TimeUnit::Milliseconds => Ok(dt?.timestamp_millis()),
+    }
 }
 
 #[cfg(feature = "private")]
@@ -20,18 +49,37 @@ pub fn date_range_impl(
     tu: TimeUnit,
     _tz: Option<&TimeZone>,
 ) -> PolarsResult<DatetimeChunked> {
-    let mut out = Int64Chunked::new_vec(name, date_range_vec(start, stop, every, closed, tu))
-        .into_datetime(tu, None);
-
-    #[cfg(feature = "timezones")]
-    if let Some(tz) = _tz {
-        out = out.replace_time_zone(Some(tz))?
-    }
     let s = if start > stop {
         IsSorted::Descending
     } else {
         IsSorted::Ascending
     };
+    let (start, stop): (PolarsResult<i64>, PolarsResult<i64>) = match _tz {
+        #[cfg(feature = "timezones")]
+        Some(tz) => match tz.parse::<chrono_tz::Tz>() {
+            Ok(tz) => (
+                localize_timestamp(start, tu, tz),
+                localize_timestamp(stop, tu, tz),
+            ),
+            Err(_) => match parse_offset(tz) {
+                Ok(tz) => (
+                    localize_timestamp(start, tu, tz),
+                    localize_timestamp(stop, tu, tz),
+                ),
+                _ => polars_bail!(ComputeError: "unable to parse time zone: {}", tz),
+            },
+        },
+        _ => (Ok(start), Ok(stop)),
+    };
+    let mut out = Int64Chunked::new_vec(name, date_range_vec(start?, stop?, every, closed, tu))
+        .into_datetime(tu, None);
+
+    #[cfg(feature = "timezones")]
+    if let Some(tz) = _tz {
+        out = out
+            .replace_time_zone(Some("UTC"))?
+            .convert_time_zone(tz.to_string())?
+    }
     out.set_sorted_flag(s);
     Ok(out)
 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
 name = "polars-time"
 version = "0.27.2"
 dependencies = [
+ "arrow2",
  "chrono",
  "chrono-tz 0.8.1",
  "lexical",

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1953,6 +1953,50 @@ def test_timezone_aware_date_range() -> None:
         pl.date_range(low, high, interval=timedelta(days=5), time_zone="UTC")
 
 
+def test_tzaware_date_range_crossing_dst() -> None:
+    result = pl.date_range(
+        datetime(2021, 11, 7), datetime(2021, 11, 7, 2), "1h", time_zone="US/Central"
+    )
+    assert result.to_list() == [
+        datetime(2021, 11, 7, 0, 0, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 1, 0, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 1, 0, fold=1, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 2, 0, tzinfo=ZoneInfo("US/Central")),
+    ]
+
+
+def test_tzaware_date_range_with_fixed_offset() -> None:
+    result = pl.date_range(
+        datetime(2021, 11, 7), datetime(2021, 11, 7, 2), "1h", time_zone="+01:00"
+    )
+    assert result.to_list() == [
+        datetime(2021, 11, 7, 0, 0, tzinfo=timezone(timedelta(hours=1))),
+        datetime(2021, 11, 7, 1, 0, tzinfo=timezone(timedelta(hours=1))),
+        datetime(2021, 11, 7, 2, 0, tzinfo=timezone(timedelta(hours=1))),
+    ]
+
+
+def test_date_range_with_unsupported_datetimes() -> None:
+    with pytest.raises(
+        ComputeError, match=r"ambiguous timestamps are not \(yet\) supported"
+    ):
+        pl.date_range(
+            datetime(2021, 11, 7, 1),
+            datetime(2021, 11, 7, 2),
+            "1h",
+            time_zone="US/Central",
+        )
+    with pytest.raises(
+        ComputeError, match=r"non-existent timestamps are not \(yet\) supported"
+    ):
+        pl.date_range(
+            datetime(2021, 3, 28, 2, 30),
+            datetime(2021, 3, 28, 4),
+            "1h",
+            time_zone="Europe/Vienna",
+        )
+
+
 def test_logical_nested_take() -> None:
     frame = pl.DataFrame(
         {


### PR DESCRIPTION
closes #7418

The issue was that, by removing the time zone, constructing the date range, and then putting the time zone back, one would run into an ambiguous time zone

E.g.:
`2021-11-07 01:00:00 US/Central` -> `2021-11-07 01:00:00` -> (trying to set `US/Central again`) ambiguous time error

The resolution is to take `start` and `end`, and express them in the given time zone, and then convert from UTC to the given time zone at the end

If `start` and `end` are themselves ambiguous, then not much can be done, so they will just raise:
```python
In [6]:         pl.date_range(
   ...:             datetime(2021, 11, 7, 1),
   ...:             datetime(2021, 11, 7, 2),
   ...:             "1h",
   ...:             time_zone="US/Central",
   ...:         )
---------------------------------------------------------------------------

ComputeError: ambiguous timestamps are not (yet) supported
```

Note that pandas would also raise:
```python
In [7]:         pd.date_range(
   ...:             datetime(2021, 11, 7, 1),
   ...:             datetime(2021, 11, 7, 2),
   ...:             freq="1h",
   ...:             tz="US/Central",
   ...:         )
---------------------------------------------------------------------------
AmbiguousTimeError: Cannot infer dst time from 2021-11-07 01:00:00, try using the 'ambiguous' argument
```