### PR TITLE
feat(python): provide option to set individual `row_heights` on Excel export

### DIFF
--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -74,14 +74,16 @@ def _adjacent_cols(df: pli.DataFrame, cols: Iterable[str]) -> bool:
 
 
 def _unpack_multi_column_dict(
-    d: dict[str | Sequence[str], str] | Any
+    d: dict[str | Sequence[str], Any] | Any
 ) -> dict[str, Any] | Any:
     """Unpack multi-col dictionary into equivalent single-col definitions."""
     if not isinstance(d, dict):
         return d
     unpacked: dict[str, Any] = {}
     for key, value in d.items():
-        for k in (key,) if isinstance(key, str) else key:
+        if isinstance(key, str) or not isinstance(key, Sequence):
+            key = (key,)
+        for k in key:
             unpacked[k] = value
     return unpacked
 

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -62,6 +62,7 @@ def test_read_excel_all_sheets(excel_file_path: Path) -> None:
             "conditional_formats": {"val": "data_bar"},
             "column_formats": {"val": "#,##0.000;[White]-#,##0.000"},
             "column_widths": {"val": 100},
+            "row_heights": {0: 35},
             "column_totals": True,
         },
         # heavily customised formatting/definition
@@ -189,7 +190,7 @@ def test_excel_sparklines() -> None:
             },
             column_widths={("q1", "q2", "q3", "q4"): 40},
             hide_gridlines=True,
-            row_height=35,
+            row_heights=35,
             sheet_zoom=125,
         )
 


### PR DESCRIPTION
Quick follow-up to [previous](https://github.com/pola-rs/polars/pull/7427) PR.

Replaces `row_height` with `row_heights`, allowing individual row heights to be customised in the exported table. Only niche use-cases (eg: setting a taller table header row, as below), but brings equivalence with `column_heights` and doesn't cost anything.

```python
import polars as pl

df = pl.DataFrame(
    {
        "id":["aaa", "bbb", "ccc", "ddd", "eee"],
        "q1":[100, 55, -20, 0, 35],
        "q2":[30, -10, 15, 60, 20],
        "q3":[-50, 0, 40, 80, 80],
        "q4":[75, 55, 25, -10, -55],
    }
)
df.write_excel(
    table_style = "Table Style Dark 7",
    column_formats = {
        ("q1","q2","q3","q4"): "[White]#,##0;[Black]-#,##0",
    },
    row_heights = {0: 40},
    sheet_zoom = 125,
)
```

![xl_custom_row_height](https://user-images.githubusercontent.com/2613171/223970676-ce04ce8e-1a82-4b80-966d-756cf7be64a7.png)
