### PR TITLE
fix(python): fix `DataFrame` table rendering issue in some Jupyter environments

### DIFF
--- a/py-polars/polars/internals/dataframe/_html.py
+++ b/py-polars/polars/internals/dataframe/_html.py
@@ -124,7 +124,11 @@ class HTMLFormatter:
 
     def render(self) -> list[str]:
         with Tag(
-            self.elements, "table", {"border": "1", "class": "dataframe pl-dataframe"}
+            # be careful changing the CSS class ref here...
+            # ref: https://github.com/pola-rs/polars/issues/7443
+            self.elements,
+            "table",
+            {"border": "1", "class": "dataframe"},
         ):
             self.write_header()
             self.write_body()
@@ -142,7 +146,7 @@ class NotebookFormatter(HTMLFormatter):
     def write_style(self) -> None:
         style = """\
             <style>
-            .pl-dataframe > thead > tr > th {
+            .dataframe > thead > tr > th {
               text-align: right;
             }
             </style>

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -1755,7 +1755,7 @@ class DataFrame:
             max_rows = self.shape[0]
 
         from_series = kwargs.get("from_series", False)
-        return "\n".join(
+        return "".join(
             NotebookFormatter(
                 self,
                 max_cols=max_cols,


### PR DESCRIPTION
Closes #7443.

* Removing the (effectively unused) `pl-dataframe` CSS class fixes blank rendering of dataframe-styled Jupyter tables (reproduced locally in PyCharm, but possibly a more generic issue according to the original bug report).
* Also, the additional linebreaks created in `_repr_html_` (when joining `NotebookFormatter` output) aren't needed and can create some odd whitespace-related element noise (observed in PyCharm-hosted Jupyter; likely renderer-specific). 

Fixed both issues.

## Before

 * _`pl-dataframe` issue; table does not render ("0 rows, -1 cols")._

   ![pl_jupyter_01](https://user-images.githubusercontent.com/2613171/224024800-04d325fb-e4f5-4b7e-ac88-45b9110bab00.png)

*  _Extraneous line-break issue: whitespace noise around element values._

   ![pl_jupyter_02](https://user-images.githubusercontent.com/2613171/224024867-684ccfdd-ad0f-4863-85fc-eef181f7eb38.png)

## After

* _Table renders, no element-level noise._

  ![pl_jupyter_03](https://user-images.githubusercontent.com/2613171/224025186-90b56a4d-f993-471c-9e09-da004515ca4c.png)

