### PR TITLE
refactor(python): Rename `read_x` functions arg `file` to `source`

### DIFF
--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -31,7 +31,7 @@ def _deser_and_exec(  # noqa: D417
 
 
 def _scan_pyarrow_dataset_impl(
-    ds: pa.dataset.dataset,
+    ds: pa.dataset.Dataset,
     with_columns: list[str] | None,
     predicate: str | None,
     n_rows: int | None,
@@ -58,9 +58,8 @@ def _scan_pyarrow_dataset_impl(
     _filter = None
     if predicate:
         # imports are used by inline python evaluated by `eval`
-
         from polars.datatypes import Date, Datetime, Duration  # noqa: F401
-        from polars.utils import (
+        from polars.utils.convert import (
             _to_python_datetime,  # noqa: F401
             _to_python_time,  # noqa: F401
             _to_python_timedelta,  # noqa: F401
@@ -86,7 +85,7 @@ def _scan_pyarrow_dataset_impl(
 
 
 def _scan_pyarrow_dataset(
-    ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True
+    ds: pa.dataset.Dataset, allow_pyarrow_filter: bool = True
 ) -> pli.LazyFrame:
     """
     Pickle the partially applied function `_scan_pyarrow_dataset_impl`.

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class BatchedCsvReader:
     def __init__(
         self,
-        file: str | Path,
+        source: str | Path,
         has_header: bool = True,
         columns: Sequence[int] | Sequence[str] | None = None,
         sep: str = ",",
@@ -54,8 +54,8 @@ class BatchedCsvReader:
         new_columns: list[str] | None = None,
     ):
         path: str | None
-        if isinstance(file, (str, Path)):
-            path = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            path = normalise_filepath(source)
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None

--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -672,7 +672,7 @@ class DataFrame:
     @classmethod
     def _read_csv(
         cls,
-        file: str | Path | BinaryIO | bytes,
+        source: str | Path | BinaryIO | bytes,
         has_header: bool = True,
         columns: Sequence[int] | Sequence[str] | None = None,
         sep: str = ",",
@@ -710,14 +710,14 @@ class DataFrame:
         self = cls.__new__(cls)
 
         path: str | None
-        if isinstance(file, (str, Path)):
-            path = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            path = normalise_filepath(source)
         else:
             path = None
-            if isinstance(file, BytesIO):
-                file = file.getvalue()
-            if isinstance(file, StringIO):
-                file = file.getvalue().encode()
+            if isinstance(source, BytesIO):
+                source = source.getvalue()
+            if isinstance(source, StringIO):
+                source = source.getvalue().encode()
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None
@@ -735,7 +735,7 @@ class DataFrame:
 
         if isinstance(columns, str):
             columns = [columns]
-        if isinstance(file, str) and "*" in file:
+        if isinstance(source, str) and "*" in source:
             dtypes_dict = None
             if dtype_list is not None:
                 dtypes_dict = {name: dt for (name, dt) in dtype_list}
@@ -747,7 +747,7 @@ class DataFrame:
             from polars import scan_csv
 
             scan = scan_csv(
-                file,
+                source,
                 has_header=has_header,
                 sep=sep,
                 comment_char=comment_char,
@@ -779,7 +779,7 @@ class DataFrame:
         projection, columns = handle_projection_columns(columns)
 
         self._df = PyDataFrame.read_csv(
-            file,
+            source,
             infer_schema_length,
             batch_size,
             has_header,
@@ -811,7 +811,7 @@ class DataFrame:
     @classmethod
     def _read_parquet(
         cls,
-        file: str | Path | BinaryIO,
+        source: str | Path | BinaryIO,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
         parallel: ParallelStrategy = "auto",
@@ -831,16 +831,16 @@ class DataFrame:
         polars.io.read_parquet
 
         """
-        if isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
         if isinstance(columns, str):
             columns = [columns]
 
-        if isinstance(file, str) and "*" in file and pli._is_local_file(file):
+        if isinstance(source, str) and "*" in source and pli._is_local_file(source):
             from polars import scan_parquet
 
             scan = scan_parquet(
-                file,
+                source,
                 n_rows=n_rows,
                 rechunk=True,
                 parallel=parallel,
@@ -862,7 +862,7 @@ class DataFrame:
         projection, columns = handle_projection_columns(columns)
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_parquet(
-            file,
+            source,
             columns,
             projection,
             n_rows,
@@ -877,7 +877,7 @@ class DataFrame:
     @classmethod
     def _read_avro(
         cls,
-        file: str | Path | BinaryIO,
+        source: str | Path | BinaryIO,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
     ) -> Self:
@@ -886,7 +886,7 @@ class DataFrame:
 
         Parameters
         ----------
-        file
+        source
             Path to a file or a file-like object.
         columns
             Columns.
@@ -898,17 +898,17 @@ class DataFrame:
         DataFrame
 
         """
-        if isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
         projection, columns = handle_projection_columns(columns)
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_avro(file, columns, projection, n_rows)
+        self._df = PyDataFrame.read_avro(source, columns, projection, n_rows)
         return self
 
     @classmethod
     def _read_ipc(
         cls,
-        file: str | Path | BinaryIO,
+        source: str | Path | BinaryIO,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
         row_count_name: str | None = None,
@@ -923,7 +923,7 @@ class DataFrame:
 
         Parameters
         ----------
-        file
+        source
             Path to a file or a file-like object.
         columns
             Columns to select. Accepts a list of column indices (starting at zero) or a
@@ -944,16 +944,16 @@ class DataFrame:
         DataFrame
 
         """
-        if isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
         if isinstance(columns, str):
             columns = [columns]
 
-        if isinstance(file, str) and "*" in file and pli._is_local_file(file):
+        if isinstance(source, str) and "*" in source and pli._is_local_file(source):
             from polars import scan_ipc
 
             scan = scan_ipc(
-                file,
+                source,
                 n_rows=n_rows,
                 rechunk=rechunk,
                 row_count_name=row_count_name,
@@ -974,7 +974,7 @@ class DataFrame:
         projection, columns = handle_projection_columns(columns)
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_ipc(
-            file,
+            source,
             columns,
             projection,
             n_rows,
@@ -984,7 +984,7 @@ class DataFrame:
         return self
 
     @classmethod
-    def _read_json(cls, file: str | Path | IOBase) -> Self:
+    def _read_json(cls, source: str | Path | IOBase) -> Self:
         """
         Read into a DataFrame from a JSON file.
 
@@ -995,17 +995,17 @@ class DataFrame:
         polars.io.read_json
 
         """
-        if isinstance(file, StringIO):
-            file = BytesIO(file.getvalue().encode())
-        elif isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, StringIO):
+            source = BytesIO(source.getvalue().encode())
+        elif isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
 
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_json(file, False)
+        self._df = PyDataFrame.read_json(source, False)
         return self
 
     @classmethod
-    def _read_ndjson(cls, file: str | Path | IOBase) -> Self:
+    def _read_ndjson(cls, source: str | Path | IOBase) -> Self:
         """
         Read into a DataFrame from a newline delimited JSON file.
 
@@ -1016,13 +1016,13 @@ class DataFrame:
         polars.io.read_ndjson
 
         """
-        if isinstance(file, StringIO):
-            file = BytesIO(file.getvalue().encode())
-        elif isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, StringIO):
+            source = BytesIO(source.getvalue().encode())
+        elif isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
 
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_ndjson(file)
+        self._df = PyDataFrame.read_ndjson(source)
         return self
 
     @property
@@ -3971,9 +3971,9 @@ class DataFrame:
         func
             Callable; will receive the frame as the first parameter,
             followed by any given args/kwargs.
-        args
+        *args
             Arguments to pass to the UDF.
-        kwargs
+        **kwargs
             Keyword arguments to pass to the UDF.
 
         Notes

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -745,9 +745,9 @@ class Expr:
         function
             Callable; will receive the expression as the first parameter,
             followed by any given args/kwargs.
-        args
+        *args
             Arguments to pass to the UDF.
-        kwargs
+        **kwargs
             Keyword arguments to pass to the UDF.
 
         Examples

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -16,6 +16,7 @@ from typing import (
 
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
+from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath
 
 with suppress(ImportError):
@@ -192,13 +193,14 @@ def _prepare_file_arg(
     return managed_file(file)
 
 
-def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
+@deprecated_alias(file="source")
+def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
     """
-    Get a schema of the IPC file without reading data.
+    Get the schema of an IPC file without reading data.
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
 
     Returns
@@ -206,21 +208,22 @@ def read_ipc_schema(file: str | BinaryIO | Path | bytes) -> dict[str, PolarsData
     Dictionary mapping column names to datatypes
 
     """
-    if isinstance(file, (str, Path)):
-        file = normalise_filepath(file)
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
 
-    return _ipc_schema(file)
+    return _ipc_schema(source)
 
 
+@deprecated_alias(file="source")
 def read_parquet_schema(
-    file: str | BinaryIO | Path | bytes,
+    source: str | BinaryIO | Path | bytes,
 ) -> dict[str, PolarsDataType]:
     """
-    Get a schema of the Parquet file without reading data.
+    Get the schema of a Parquet file without reading data.
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
 
     Returns
@@ -228,10 +231,10 @@ def read_parquet_schema(
     Dictionary mapping column names to datatypes
 
     """
-    if isinstance(file, (str, Path)):
-        file = normalise_filepath(file)
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
 
-    return _parquet_schema(file)
+    return _parquet_schema(source)
 
 
 def _is_local_file(file: str) -> bool:

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -296,7 +296,7 @@ class LazyFrame:
     @classmethod
     def _scan_csv(
         cls,
-        file: str,
+        source: str,
         has_header: bool = True,
         sep: str = ",",
         comment_char: str | None = None,
@@ -338,7 +338,7 @@ class LazyFrame:
 
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_csv(
-            file,
+            source,
             sep,
             has_header,
             ignore_errors,
@@ -412,7 +412,7 @@ class LazyFrame:
     @classmethod
     def _scan_ipc(
         cls,
-        file: str | Path,
+        source: str | Path,
         n_rows: int | None = None,
         cache: bool = True,
         rechunk: bool = True,
@@ -431,12 +431,12 @@ class LazyFrame:
         polars.io.scan_ipc
 
         """
-        if isinstance(file, (str, Path)):
-            file = normalise_filepath(file)
+        if isinstance(source, (str, Path)):
+            source = normalise_filepath(source)
 
         # try fsspec scanner
-        if not pli._is_local_file(file):
-            scan = pli._scan_ipc_fsspec(file, storage_options)
+        if not pli._is_local_file(source):
+            scan = pli._scan_ipc_fsspec(source, storage_options)
             if n_rows:
                 scan = scan.head(n_rows)
             if row_count_name is not None:
@@ -445,7 +445,7 @@ class LazyFrame:
 
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ipc(
-            file,
+            source,
             n_rows,
             cache,
             rechunk,
@@ -457,7 +457,7 @@ class LazyFrame:
     @classmethod
     def _scan_ndjson(
         cls,
-        file: str,
+        source: str,
         infer_schema_length: int | None = None,
         batch_size: int | None = None,
         n_rows: int | None = None,
@@ -478,7 +478,7 @@ class LazyFrame:
         """
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ndjson(
-            file,
+            source,
             infer_schema_length,
             batch_size,
             n_rows,
@@ -748,9 +748,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         func
             Callable; will receive the frame as the first parameter,
             followed by any given args/kwargs.
-        args
+        *args
             Arguments to pass to the UDF.
-        kwargs
+        **kwargs
             Keyword arguments to pass to the UDF.
 
         Examples

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -365,7 +365,7 @@ class LazyFrame:
     @classmethod
     def _scan_parquet(
         cls,
-        file: str,
+        source: str,
         n_rows: int | None = None,
         cache: bool = True,
         parallel: ParallelStrategy = "auto",
@@ -387,8 +387,8 @@ class LazyFrame:
 
         """
         # try fsspec scanner
-        if not pli._is_local_file(file):
-            scan = pli._scan_parquet_fsspec(file, storage_options)
+        if not pli._is_local_file(source):
+            scan = pli._scan_parquet_fsspec(source, storage_options)
             if n_rows:
                 scan = scan.head(n_rows)
             if row_count_name is not None:
@@ -397,7 +397,7 @@ class LazyFrame:
 
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_parquet(
-            file,
+            source,
             n_rows,
             cache,
             parallel,

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -2993,18 +2993,9 @@ class Series:
 
         If you want a zero-copy view and know what you are doing, use `.view()`.
 
-        Examples
-        --------
-        >>> s = pl.Series("a", [1, 2, 3])
-        >>> arr = s.to_numpy()
-        >>> arr  # doctest: +IGNORE_RESULT
-        array([1, 2, 3], dtype=int64)
-        >>> type(arr)
-        <class 'numpy.ndarray'>
-
         Parameters
         ----------
-        args
+        *args
             args will be sent to pyarrow.Array.to_numpy.
         zero_copy_only
             If True, an exception will be raised if the conversion to a numpy
@@ -3017,8 +3008,15 @@ class Series:
             it is writable.
         use_pyarrow
             Use pyarrow for the conversion to numpy.
-        kwargs
-            kwargs will be sent to pyarrow.Array.to_numpy
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1, 2, 3])
+        >>> arr = s.to_numpy()
+        >>> arr  # doctest: +IGNORE_RESULT
+        array([1, 2, 3], dtype=int64)
+        >>> type(arr)
+        <class 'numpy.ndarray'>
 
         """
 

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from polars.internals import DataFrame
-from polars.utils.decorators import deprecate_nonkeyword_arguments
-from polars.utils.various import normalise_filepath
+from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from io import BytesIO
+    from pathlib import Path
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(file="source")
 def read_avro(
-    file: str | Path | BytesIO | BinaryIO,
+    source: str | Path | BytesIO | BinaryIO,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
 ) -> DataFrame:
@@ -22,7 +22,7 @@ def read_avro(
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
     columns
         Columns to select. Accepts a list of column indices (starting at zero) or a list
@@ -35,7 +35,4 @@ def read_avro(
     DataFrame
 
     """
-    if isinstance(file, (str, Path)):
-        file = normalise_filepath(file)
-
-    return DataFrame._read_avro(file, n_rows=n_rows, columns=columns)
+    return DataFrame._read_avro(source, n_rows=n_rows, columns=columns)

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from polars.convert import from_arrow
 from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
-from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from polars.dependencies import pyarrow as pa
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(table_uri="source")
 def read_delta(
-    table_uri: str,
+    source: str,
     version: int | None = None,
     columns: list[str] | None = None,
     storage_options: dict[str, Any] | None = None,
@@ -27,7 +28,7 @@ def read_delta(
 
     Parameters
     ----------
-    table_uri
+    source
         Path or URI to the root of the Delta lake table.
 
         Note: For Local filesystem, absolute and relative paths are supported. But
@@ -131,7 +132,7 @@ def read_delta(
     if pyarrow_options is None:
         pyarrow_options = {}
 
-    _, resolved_uri, _ = _resolve_delta_lake_uri(table_uri)
+    _, resolved_uri, _ = _resolve_delta_lake_uri(source)
 
     dl_tbl = _get_delta_lake_table(
         table_path=resolved_uri,
@@ -144,8 +145,9 @@ def read_delta(
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(table_uri="source")
 def scan_delta(
-    table_uri: str,
+    source: str,
     version: int | None = None,
     raw_filesystem: pa.fs.FileSystem | None = None,
     storage_options: dict[str, Any] | None = None,
@@ -157,7 +159,7 @@ def scan_delta(
 
     Parameters
     ----------
-    table_uri
+    source
         Path or URI to the root of the Delta lake table.
 
         Note: For Local filesystem, absolute and relative paths are supported. But
@@ -303,7 +305,7 @@ def scan_delta(
     import pyarrow.fs as pa_fs
 
     # Resolve relative paths if not an object storage
-    scheme, resolved_uri, normalized_path = _resolve_delta_lake_uri(table_uri)
+    scheme, resolved_uri, normalized_path = _resolve_delta_lake_uri(source)
 
     # Storage Backend
     if raw_filesystem is None:
@@ -368,7 +370,7 @@ def _get_delta_lake_table(
         delta_table_options = {}
 
     dl_tbl = deltalake.DeltaTable(
-        table_uri=table_path,
+        table_path,
         version=version,
         storage_options=storage_options,
         **delta_table_options,

--- a/py-polars/polars/io/ipc.py
+++ b/py-polars/polars/io/ipc.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.internals import DataFrame, LazyFrame
 from polars.internals.io import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(file="source")
 def read_ipc(
-    file: str | BinaryIO | BytesIO | Path | bytes,
+    source: str | BinaryIO | BytesIO | Path | bytes,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
     use_pyarrow: bool = False,
@@ -29,7 +30,7 @@ def read_ipc(
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
         If ``fsspec`` is installed, it will be used to open remote files.
     columns
@@ -73,7 +74,7 @@ def read_ipc(
         )
 
     storage_options = storage_options or {}
-    with _prepare_file_arg(file, use_pyarrow=use_pyarrow, **storage_options) as data:
+    with _prepare_file_arg(source, use_pyarrow=use_pyarrow, **storage_options) as data:
         if use_pyarrow:
             if not _PYARROW_AVAILABLE:
                 raise ImportError(
@@ -104,8 +105,9 @@ def read_ipc(
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(file="source")
 def scan_ipc(
-    file: str | Path,
+    source: str | Path,
     n_rows: int | None = None,
     cache: bool = True,
     rechunk: bool = True,
@@ -122,7 +124,7 @@ def scan_ipc(
 
     Parameters
     ----------
-    file
+    source
         Path to a IPC file.
     n_rows
         Stop reading from IPC file after reading ``n_rows``.
@@ -146,7 +148,7 @@ def scan_ipc(
 
     """
     return LazyFrame._scan_ipc(
-        file=file,
+        source,
         n_rows=n_rows,
         cache=cache,
         rechunk=rechunk,

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars.internals import DataFrame
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from io import IOBase
     from pathlib import Path
 
 
-def read_json(file: str | Path | IOBase) -> DataFrame:
+@deprecated_alias(file="source")
+def read_json(source: str | Path | IOBase) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
 
     See Also
@@ -23,4 +25,4 @@ def read_json(file: str | Path | IOBase) -> DataFrame:
     read_ndjson
 
     """
-    return DataFrame._read_json(file)
+    return DataFrame._read_json(source)

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -5,29 +5,31 @@ from typing import TYPE_CHECKING
 
 from polars.datatypes import N_INFER_DEFAULT
 from polars.internals import DataFrame, LazyFrame
-from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
     from io import IOBase
 
 
-def read_ndjson(file: str | Path | IOBase) -> DataFrame:
+@deprecated_alias(file="source")
+def read_ndjson(source: str | Path | IOBase) -> DataFrame:
     """
     Read into a DataFrame from a newline delimited JSON file.
 
     Parameters
     ----------
-    file
+    source
         Path to a file or a file-like object.
 
     """
-    return DataFrame._read_ndjson(file)
+    return DataFrame._read_ndjson(source)
 
 
 @deprecate_nonkeyword_arguments()
+@deprecated_alias(file="source")
 def scan_ndjson(
-    file: str | Path,
+    source: str | Path,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,
     n_rows: int | None = None,
@@ -44,7 +46,7 @@ def scan_ndjson(
 
     Parameters
     ----------
-    file
+    source
         Path to a file.
     infer_schema_length
         Infer the schema from the first ``infer_schema_length`` rows.
@@ -63,11 +65,11 @@ def scan_ndjson(
         Offset to start the row_count column (only use if the name is set)
 
     """
-    if isinstance(file, (str, Path)):
-        file = normalise_filepath(file)
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
 
     return LazyFrame._scan_ndjson(
-        file=file,
+        source,
         infer_schema_length=infer_schema_length,
         batch_size=batch_size,
         n_rows=n_rows,

--- a/py-polars/polars/io/parquet.py
+++ b/py-polars/polars/io/parquet.py
@@ -7,80 +7,13 @@ from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.internals import DataFrame, LazyFrame
 from polars.internals.io import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
     from io import BytesIO
 
     from polars.internals.type_aliases import ParallelStrategy
-
-
-@deprecate_nonkeyword_arguments()
-def scan_parquet(
-    file: str | Path,
-    n_rows: int | None = None,
-    cache: bool = True,
-    parallel: ParallelStrategy = "auto",
-    rechunk: bool = True,
-    row_count_name: str | None = None,
-    row_count_offset: int = 0,
-    storage_options: dict[str, Any] | None = None,
-    low_memory: bool = False,
-    *,
-    use_statistics: bool = True,
-) -> LazyFrame:
-    """
-    Lazily read from a parquet file or multiple files via glob patterns.
-
-    This allows the query optimizer to push down predicates and projections to the scan
-    level, thereby potentially reducing memory overhead.
-
-    Parameters
-    ----------
-    file
-        Path to a file.
-    n_rows
-        Stop reading from parquet file after reading ``n_rows``.
-    cache
-        Cache the result after reading.
-    parallel : {'auto', 'columns', 'row_groups', 'none'}
-        This determines the direction of parallelism. 'auto' will try to determine the
-        optimal direction.
-    rechunk
-        In case of reading multiple files via a glob pattern rechunk the final DataFrame
-        into contiguous memory chunks.
-    row_count_name
-        If not None, this will insert a row count column with give name into the
-        DataFrame
-    row_count_offset
-        Offset to start the row_count column (only use if the name is set)
-    storage_options
-        Extra options that make sense for ``fsspec.open()`` or a
-        particular storage connection.
-        e.g. host, port, username, password, etc.
-    low_memory
-        Reduce memory pressure at the expense of performance.
-    use_statistics
-        Use statistics in the parquet to determine if pages
-        can be skipped from reading.
-
-    """
-    if isinstance(file, (str, Path)):
-        file = normalise_filepath(file)
-
-    return LazyFrame._scan_parquet(
-        file=file,
-        n_rows=n_rows,
-        cache=cache,
-        parallel=parallel,
-        rechunk=rechunk,
-        row_count_name=row_count_name,
-        row_count_offset=row_count_offset,
-        storage_options=storage_options,
-        low_memory=low_memory,
-        use_statistics=use_statistics,
-    )
 
 
 @deprecate_nonkeyword_arguments()
@@ -195,3 +128,71 @@ def read_parquet(
             use_statistics=use_statistics,
             rechunk=rechunk,
         )
+
+
+@deprecate_nonkeyword_arguments()
+@deprecated_alias(file="source")
+def scan_parquet(
+    source: str | Path,
+    n_rows: int | None = None,
+    cache: bool = True,
+    parallel: ParallelStrategy = "auto",
+    rechunk: bool = True,
+    row_count_name: str | None = None,
+    row_count_offset: int = 0,
+    storage_options: dict[str, Any] | None = None,
+    low_memory: bool = False,
+    *,
+    use_statistics: bool = True,
+) -> LazyFrame:
+    """
+    Lazily read from a parquet file or multiple files via glob patterns.
+
+    This allows the query optimizer to push down predicates and projections to the scan
+    level, thereby potentially reducing memory overhead.
+
+    Parameters
+    ----------
+    source
+        Path to a file.
+    n_rows
+        Stop reading from parquet file after reading ``n_rows``.
+    cache
+        Cache the result after reading.
+    parallel : {'auto', 'columns', 'row_groups', 'none'}
+        This determines the direction of parallelism. 'auto' will try to determine the
+        optimal direction.
+    rechunk
+        In case of reading multiple files via a glob pattern rechunk the final DataFrame
+        into contiguous memory chunks.
+    row_count_name
+        If not None, this will insert a row count column with give name into the
+        DataFrame
+    row_count_offset
+        Offset to start the row_count column (only use if the name is set)
+    storage_options
+        Extra options that make sense for ``fsspec.open()`` or a
+        particular storage connection.
+        e.g. host, port, username, password, etc.
+    low_memory
+        Reduce memory pressure at the expense of performance.
+    use_statistics
+        Use statistics in the parquet to determine if pages
+        can be skipped from reading.
+
+    """
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
+
+    return LazyFrame._scan_parquet(
+        source,
+        n_rows=n_rows,
+        cache=cache,
+        parallel=parallel,
+        rechunk=rechunk,
+        row_count_name=row_count_name,
+        row_count_offset=row_count_offset,
+        storage_options=storage_options,
+        low_memory=low_memory,
+        use_statistics=use_statistics,
+    )

--- a/py-polars/polars/io/pyarrow_dataset.py
+++ b/py-polars/polars/io/pyarrow_dataset.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 def scan_pyarrow_dataset(
-    source: pa.dataset.dataset, *, allow_pyarrow_filter: bool = True
+    source: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True
 ) -> LazyFrame:
     """
     Scan a pyarrow dataset.
@@ -57,7 +57,7 @@ def scan_pyarrow_dataset(
 
 
 @deprecate_nonkeyword_arguments()
-def scan_ds(ds: pa.dataset.dataset, allow_pyarrow_filter: bool = True) -> LazyFrame:
+def scan_ds(ds: pa.dataset.Dataset, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.
 

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -142,7 +142,7 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
 
     # ...and read it back again:
     xldf = pl.read_excel(  # type: ignore[call-overload]
-        file=xls,
+        xls,
         sheet_name="data",
         read_csv_options=header_opts,
     )[:3].with_columns(pl.col("dtm").str.strptime(pl.Date, fmt_strptime))
@@ -197,7 +197,7 @@ def test_excel_sparklines() -> None:
     tables = {tbl["name"] for tbl in wb.get_worksheet_by_name("frame_data").tables}
     assert "PolarsFrameTable0" in tables
 
-    xldf = pl.read_excel(file=xls, sheet_name="frame_data")  # type: ignore[call-overload]
+    xldf = pl.read_excel(xls, sheet_name="frame_data")  # type: ignore[call-overload]
     # ┌──────┬──────┬─────┬─────┬─────┬─────┬───────┐
     # │ id   ┆ +/-  ┆ q1  ┆ q2  ┆ q3  ┆ q4  ┆ trend │
     # │ ---  ┆ ---  ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---   │
@@ -239,4 +239,4 @@ def test_excel_write_multiple_tables() -> None:
             tbl["name"] for tbl in wb.get_worksheet_by_name(sheet).tables
         )
     assert table_names == {f"PolarsFrameTable{n}" for n in range(4)}
-    assert pl.read_excel(file=xls, sheet_name="sheet3").rows() == [(None, None, None)]  # type: ignore[call-overload]
+    assert pl.read_excel(xls, sheet_name="sheet3").rows() == [(None, None, None)]  # type: ignore[call-overload]


### PR DESCRIPTION
As briefly discussed in #7067

Changes:
* Rename the first argument for all `read` functions to `source` instead of `file`. Main rationale: _"it leaves room for new features like reading from bytes or the web."_