### PR TITLE
refactor(python)!: set maintain_order=False for df/lf.unique

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.17"
+version = "0.16.18"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7347,7 +7347,7 @@ class DataFrame:
         ...         "ham": ["b", "b", "b", "b"],
         ...     }
         ... )
-        >>> df.unique()
+        >>> df.unique(maintain_order=True)
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -7358,7 +7358,7 @@ class DataFrame:
         │ 2   ┆ a   ┆ b   │
         │ 3   ┆ a   ┆ b   │
         └─────┴─────┴─────┘
-        >>> df.unique(subset=["bar", "ham"])
+        >>> df.unique(subset=["bar", "ham"], maintain_order=True)
         shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -7367,7 +7367,7 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ 1   ┆ a   ┆ b   │
         └─────┴─────┴─────┘
-        >>> df.unique(keep="last")
+        >>> df.unique(keep="last", maintain_order=True)
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7303,7 +7303,7 @@ class DataFrame:
     )
     def unique(
         self,
-        maintain_order: bool = True,
+        maintain_order: bool = False,
         subset: str | Sequence[str] | None = None,
         keep: UniqueKeepStrategy = "any",
     ) -> Self:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4100,7 +4100,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     )
     def unique(
         self,
-        maintain_order: bool = True,
+        maintain_order: bool = False,
         subset: str | Sequence[str] | None = None,
         keep: UniqueKeepStrategy = "any",
     ) -> Self:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4144,7 +4144,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "ham": ["b", "b", "b", "b"],
         ...     }
         ... )
-        >>> lf.unique().collect()
+        >>> lf.unique(maintain_order=True).collect()
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -4155,7 +4155,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 2   ┆ a   ┆ b   │
         │ 3   ┆ a   ┆ b   │
         └─────┴─────┴─────┘
-        >>> lf.unique(subset=["bar", "ham"]).collect()
+        >>> lf.unique(subset=["bar", "ham"], maintain_order=True).collect()
         shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -4164,7 +4164,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ╞═════╪═════╪═════╡
         │ 1   ┆ a   ┆ b   │
         └─────┴─────┴─────┘
-        >>> lf.unique(keep="last").collect()
+        >>> lf.unique(keep="last", maintain_order=True).collect()
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1075,9 +1075,9 @@ def test_csv_categorical_categorical_merge() -> None:
     f = io.BytesIO()
     pl.DataFrame({"x": ["A"] * N + ["B"] * N}).write_csv(f)
     f.seek(0)
-    assert pl.read_csv(f, dtypes={"x": pl.Categorical}, sample_size=10).unique()[
-        "x"
-    ].to_list() == ["A", "B"]
+    assert pl.read_csv(f, dtypes={"x": pl.Categorical}, sample_size=10).unique(
+        maintain_order=True
+    )["x"].to_list() == ["A", "B"]
 
 
 @typing.no_type_check


### PR DESCRIPTION
This is in line with other operations where the extra cost is opt-in. This also ensures the default arguments are eligible for streaming.