### PR TITLE
refactor(python): Move `read_schema` functions to top-level `io` module.

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -76,7 +76,6 @@ from polars.internals.functions import (
     ones,
     zeros,
 )
-from polars.internals.io import read_ipc_schema, read_parquet_schema
 from polars.internals.lazy_functions import (
     all,
     any,
@@ -144,9 +143,11 @@ from polars.io import (
     read_delta,
     read_excel,
     read_ipc,
+    read_ipc_schema,
     read_json,
     read_ndjson,
     read_parquet,
+    read_parquet_schema,
     read_sql,
     scan_csv,
     scan_delta,

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -24,8 +24,6 @@ from polars.internals.io import (
     _is_local_file,
     _prepare_file_arg,
     _update_columns,
-    read_ipc_schema,
-    read_parquet_schema,
 )
 from polars.internals.lazy_functions import (
     all,

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -46,6 +46,8 @@ from polars.internals.lazy_functions import (
 from polars.internals.lazyframe import LazyFrame, wrap_ldf
 from polars.internals.series import Series, wrap_s
 from polars.internals.whenthen import WhenThen, WhenThenThen, when
+from polars.io.ipc import read_ipc_schema
+from polars.io.parquet import read_parquet_schema
 
 __all__ = [
     "DataFrame",

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -7,8 +7,6 @@ from typing import Any, cast
 import polars as pl
 from polars import internals as pli
 from polars.dependencies import pyarrow as pa  # noqa: TCH001
-from polars.io.ipc import read_ipc_schema
-from polars.io.parquet import read_parquet_schema
 
 
 def _deser_and_exec(  # noqa: D417
@@ -140,7 +138,7 @@ def _scan_ipc_fsspec(
 
     storage_options = storage_options or {}
     with pli._prepare_file_arg(file, **storage_options) as data:
-        schema = read_ipc_schema(data)
+        schema = pli.read_ipc_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)
 
@@ -173,6 +171,6 @@ def _scan_parquet_fsspec(
 
     storage_options = storage_options or {}
     with pli._prepare_file_arg(file, **storage_options) as data:
-        schema = read_parquet_schema(data)
+        schema = pli.read_parquet_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 import polars as pl
 from polars import internals as pli
 from polars.dependencies import pyarrow as pa  # noqa: TCH001
+from polars.io.ipc import read_ipc_schema
+from polars.io.parquet import read_parquet_schema
 
 
 def _deser_and_exec(  # noqa: D417
@@ -138,7 +140,7 @@ def _scan_ipc_fsspec(
 
     storage_options = storage_options or {}
     with pli._prepare_file_arg(file, **storage_options) as data:
-        schema = pli.read_ipc_schema(data)
+        schema = read_ipc_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)
 
@@ -171,6 +173,6 @@ def _scan_parquet_fsspec(
 
     storage_options = storage_options or {}
     with pli._prepare_file_arg(file, **storage_options) as data:
-        schema = pli.read_parquet_schema(data)
+        schema = read_parquet_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import glob
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
@@ -16,16 +16,10 @@ from typing import (
 
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
-from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath
-
-with suppress(ImportError):
-    from polars.polars import ipc_schema as _ipc_schema
-    from polars.polars import parquet_schema as _parquet_schema
 
 if TYPE_CHECKING:
     import polars.internals as pli
-    from polars.datatypes import PolarsDataType
 
 
 def _check_empty(b: BytesIO, context: str, read_position: int | None = None) -> BytesIO:
@@ -191,50 +185,6 @@ def _prepare_file_arg(
                 )
 
     return managed_file(file)
-
-
-@deprecated_alias(file="source")
-def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
-    """
-    Get the schema of an IPC file without reading data.
-
-    Parameters
-    ----------
-    source
-        Path to a file or a file-like object.
-
-    Returns
-    -------
-    Dictionary mapping column names to datatypes
-
-    """
-    if isinstance(source, (str, Path)):
-        source = normalise_filepath(source)
-
-    return _ipc_schema(source)
-
-
-@deprecated_alias(file="source")
-def read_parquet_schema(
-    source: str | BinaryIO | Path | bytes,
-) -> dict[str, PolarsDataType]:
-    """
-    Get the schema of a Parquet file without reading data.
-
-    Parameters
-    ----------
-    source
-        Path to a file or a file-like object.
-
-    Returns
-    -------
-    Dictionary mapping column names to datatypes
-
-    """
-    if isinstance(source, (str, Path)):
-        source = normalise_filepath(source)
-
-    return _parquet_schema(source)
 
 
 def _is_local_file(file: str) -> bool:

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -5,10 +5,10 @@ from polars.io.csv import read_csv, read_csv_batched, scan_csv
 from polars.io.database import read_database, read_sql
 from polars.io.delta import read_delta, scan_delta
 from polars.io.excel import read_excel
-from polars.io.ipc import read_ipc, scan_ipc
+from polars.io.ipc import read_ipc, read_ipc_schema, scan_ipc
 from polars.io.json import read_json
 from polars.io.ndjson import read_ndjson, scan_ndjson
-from polars.io.parquet import read_parquet, scan_parquet
+from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
 from polars.io.pyarrow_dataset import scan_ds, scan_pyarrow_dataset
 
 __all__ = [
@@ -19,9 +19,11 @@ __all__ = [
     "read_delta",
     "read_excel",
     "read_ipc",
+    "read_ipc_schema",
     "read_json",
     "read_ndjson",
     "read_parquet",
+    "read_parquet_schema",
     "read_sql",
     "scan_csv",
     "scan_delta",

--- a/py-polars/polars/io/ipc.py
+++ b/py-polars/polars/io/ipc.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import contextlib
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.internals import DataFrame, LazyFrame
 from polars.internals.io import _prepare_file_arg
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.various import normalise_filepath
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import read_ipc_schema as _read_ipc_schema
 
 if TYPE_CHECKING:
     from io import BytesIO
-    from pathlib import Path
+
+    from polars.datatypes.type_aliases import PolarsDataType
 
 
 @deprecate_nonkeyword_arguments()
@@ -102,6 +109,27 @@ def read_ipc(
             rechunk=rechunk,
             memory_map=memory_map,
         )
+
+
+@deprecated_alias(file="source")
+def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
+    """
+    Get the schema of an IPC file without reading data.
+
+    Parameters
+    ----------
+    source
+        Path to a file or a file-like object.
+
+    Returns
+    -------
+    Dictionary mapping column names to datatypes
+
+    """
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
+
+    return _read_ipc_schema(source)
 
 
 @deprecate_nonkeyword_arguments()

--- a/py-polars/polars/io/parquet.py
+++ b/py-polars/polars/io/parquet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO
 
@@ -10,9 +11,13 @@ from polars.internals.io import _prepare_file_arg
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import read_parquet_schema as _read_parquet_schema
+
 if TYPE_CHECKING:
     from io import BytesIO
 
+    from polars.datatypes.type_aliases import PolarsDataType
     from polars.internals.type_aliases import ParallelStrategy
 
 
@@ -128,6 +133,29 @@ def read_parquet(
             use_statistics=use_statistics,
             rechunk=rechunk,
         )
+
+
+@deprecated_alias(file="source")
+def read_parquet_schema(
+    source: str | BinaryIO | Path | bytes,
+) -> dict[str, PolarsDataType]:
+    """
+    Get the schema of a Parquet file without reading data.
+
+    Parameters
+    ----------
+    source
+        Path to a file or a file-like object.
+
+    Returns
+    -------
+    Dictionary mapping column names to datatypes
+
+    """
+    if isinstance(source, (str, Path)):
+        source = normalise_filepath(source)
+
+    return _read_parquet_schema(source)
 
 
 @deprecate_nonkeyword_arguments()

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -420,7 +420,7 @@ fn concat_series(series: &PyAny) -> PyResult<PySeries> {
 
 #[cfg(feature = "ipc")]
 #[pyfunction]
-fn ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
+fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     use polars_core::export::arrow::io::ipc::read::read_file_metadata;
     let metadata = match get_either_file(py_f, false)? {
         EitherRustPythonFile::Rust(mut r) => {
@@ -439,7 +439,7 @@ fn ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
 
 #[cfg(feature = "parquet")]
 #[pyfunction]
-fn parquet_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
+fn read_parquet_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     use polars_core::export::arrow::io::parquet::read::{infer_schema, read_metadata};
 
     let metadata = match get_either_file(py_f, false)? {
@@ -669,9 +669,10 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(concat_lf)).unwrap();
     m.add_wrapped(wrap_pyfunction!(concat_series)).unwrap();
     #[cfg(feature = "ipc")]
-    m.add_wrapped(wrap_pyfunction!(ipc_schema)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(read_ipc_schema)).unwrap();
     #[cfg(feature = "parquet")]
-    m.add_wrapped(wrap_pyfunction!(parquet_schema)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(read_parquet_schema))
+        .unwrap();
     m.add_wrapped(wrap_pyfunction!(collect_all)).unwrap();
     m.add_wrapped(wrap_pyfunction!(spearman_rank_corr)).unwrap();
     m.add_wrapped(wrap_pyfunction!(map_mul)).unwrap();


### PR DESCRIPTION
This raises a bigger issue with the `internals` module - does code that is re-exported in the `internals` module actually need to live in that module?

See #7506 for the related issue.

Changes:
* Move `read_ipc_schema` and `read_parquet_schema` to the top-level `io` module.