### PR TITLE
feat(python, rust): add negativ step to pl.arange

### DIFF
--- a/polars/polars-arrow/src/trusted_len/mod.rs
+++ b/polars/polars-arrow/src/trusted_len/mod.rs
@@ -6,6 +6,7 @@ use std::iter::Scan;
 use std::slice::Iter;
 
 use arrow::bitmap::utils::{BitmapIter, ZipValidity, ZipValidityIter};
+use num::iter::RangeStep;
 pub use push_unchecked::*;
 pub use rev::FromIteratorReversed;
 
@@ -76,6 +77,10 @@ unsafe impl<T, I: TrustedLen + Iterator<Item = T>, V: TrustedLen + Iterator<Item
 }
 unsafe impl TrustedLen for BitmapIter<'_> {}
 unsafe impl<A: TrustedLen> TrustedLen for std::iter::StepBy<A> {}
+unsafe impl<A> TrustedLen for RangeStep<A> where
+    A: std::clone::Clone + std::cmp::PartialOrd + num::CheckedAdd
+{
+}
 
 unsafe impl<I, St, F, B> TrustedLen for Scan<I, St, F>
 where

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -12,6 +12,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 ahash.workspace = true
 futures = { version = "0.3.25", optional = true }
 once_cell.workspace = true
+num = { workspace = true, optional = true }
 polars-arrow = { version = "0.27.2", path = "../../polars-arrow" }
 polars-core = { version = "0.27.2", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.27.2", path = "../../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
@@ -74,7 +75,7 @@ cross_join = ["polars-core/cross_join"]
 asof_join = ["polars-core/asof_join", "polars-time", "polars-ops/asof_join"]
 dot_product = ["polars-core/dot_product"]
 concat_str = ["polars-core/concat_str"]
-arange = []
+arange = ["num"]
 mode = ["polars-core/mode"]
 cum_agg = ["polars-core/cum_agg"]
 interpolate = ["polars-ops/interpolate"]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1614,6 +1614,7 @@ name = "polars-plan"
 version = "0.27.2"
 dependencies = [
  "ahash",
+ "num",
  "once_cell",
  "polars-arrow",
  "polars-core",

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -142,7 +142,7 @@ fn cumreduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-fn arange(low: PyExpr, high: PyExpr, step: usize) -> PyExpr {
+fn arange(low: PyExpr, high: PyExpr, step: i64) -> PyExpr {
     polars_rs::lazy::dsl::arange(low.inner, high.inner, step).into()
 }
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -273,6 +273,20 @@ def test_arange() -> None:
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (0, 4),
+        (4, 0),
+    ],
+)
+@pytest.mark.parametrize("step", [1, 2, -1, -2])
+def test_arange_with_step(low: int, high: int, step: int) -> None:
+    result = pl.arange(low, high, step, eager=True)
+    expected = pl.Series(np.arange(low, high, step))
+    assert_series_equal(result, expected, check_names=False)
+
+
 def test_arg_unique() -> None:
     ldf = pl.LazyFrame({"a": [4, 1, 4]})
     col_a_unique = ldf.select(pl.col("a").arg_unique()).collect()["a"]


### PR DESCRIPTION
From #3617

`pl.arange` function did not accept negativ step.
The num crate already implement it, so I mostly adapted the code to use it.


