### PR TITLE
chore(rust): Use `eprintln!` instead of `eprint!`

### DIFF
--- a/polars/polars-io/src/ipc/ipc_file.rs
+++ b/polars/polars-io/src/ipc/ipc_file.rs
@@ -81,7 +81,7 @@ fn check_mmap_err(err: PolarsError) -> PolarsResult<()> {
     if let PolarsError::ArrowError(ref e) = err {
         if let arrow::error::Error::NotYetImplemented(s) = e.as_ref() {
             if s == "mmap can only be done on uncompressed IPC files" {
-                eprint!(
+                eprintln!(
                     "Could not mmap compressed IPC file, defaulting to normal read. \
                     Toggle off 'memory_map' to silence this warning."
                 );

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -259,7 +259,7 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
     else if py_f.getattr("read").is_ok() {
         // we can still get a file name, inform the user of possibly wrong API usage.
         if py_f.getattr("name").is_ok() {
-            eprint!("Polars found a filename. \
+            eprintln!("Polars found a filename. \
             Ensure you pass a path to the file instead of a python file object when possible for best \
             performance.")
         }


### PR DESCRIPTION
The current state broke nushell's formatting
