### PR TITLE
fix(python): handle an unusual edge-case introspecting dataclass type hints

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -73,7 +73,7 @@ if version_info >= (3, 10):
 else:
 
     def dataclass_type_hints(obj: type) -> dict[str, Any]:
-        return obj.__annotations__
+        return getattr(obj, "__annotations__", {})
 
 
 def is_namedtuple(value: Any, annotated: bool = False) -> bool:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -108,6 +108,8 @@ def test_init_dataclasses_and_namedtuple() -> None:
     from dataclasses import dataclass
     from typing import NamedTuple
 
+    from polars.internals.construction import dataclass_type_hints
+
     @dataclass
     class TradeDC:
         timestamp: datetime
@@ -169,6 +171,9 @@ def test_init_dataclasses_and_namedtuple() -> None:
             "sz": pl.UInt16,
         }
         assert df.rows() == raw_data
+
+        # cover a miscellaneous edge-case when detecting the annotations
+        assert dataclass_type_hints(obj=type(None)) == {}
 
 
 def test_init_ndarray(monkeypatch: Any) -> None:


### PR DESCRIPTION
You have to try quite hard (_and_ be on python versions below 3.10) to hit this - but we did :)
```python
AttributeError: type object '...' has no attribute '__annotations__'
```
Should return an empty dict instead of raising AttributeError (as per `typing.get_type_hints` on more recent python versions).