### PR TITLE
perf(rust, python): csv-file use fast-float for csv float parsing

### DIFF
--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -19,7 +19,7 @@ ipc_streaming = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrow avro parsing
 avro = ["arrow/io_avro", "arrow/io_avro_compression"]
 # ipc = []
-csv-file = ["memmap", "lexical", "polars-core/rows", "lexical-core"]
+csv-file = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng"]
 dtype-categorical = ["polars-core/dtype-categorical"]
@@ -56,9 +56,10 @@ bytes = "1.3.0"
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 chrono-tz = { version = "0.8.1", optional = true }
 dirs = "4.0"
+fast-float = { version = "0.2.0", optional = true }
 flate2 = { version = "1", optional = true, default-features = false }
 futures = { version = "0.3.25", optional = true }
-lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-floats", "parse-integers"] }
+lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-integers"] }
 lexical-core = { version = "0.8", optional = true }
 memchr.workspace = true
 memmap = { package = "memmap2", version = "0.5.2", optional = true }

--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -19,13 +19,13 @@ pub(crate) trait PrimitiveParser: PolarsNumericType {
 impl PrimitiveParser for Float32Type {
     #[inline]
     fn parse(bytes: &[u8]) -> Option<f32> {
-        lexical::parse(bytes).ok()
+        fast_float::parse(bytes).ok()
     }
 }
 impl PrimitiveParser for Float64Type {
     #[inline]
     fn parse(bytes: &[u8]) -> Option<f64> {
-        lexical::parse(bytes).ok()
+        fast_float::parse(bytes).ok()
     }
 }
 


### PR DESCRIPTION
@aldanor thanks for your work! :)

Did some benchmarking and saw that most of our time in `parse_lines` on the yellowtrip taxi dataset went into float parsing.

Here are 3 perf stat runs with `master (lexical)` 

```

[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck                                                                                                                                   (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck':

          4.854,19 msec task-clock                #    1,000 CPUs utilized          
               110      context-switches          #   22,661 /sec                   
                 7      cpu-migrations            #    1,442 /sec                   
           202.979      page-faults               #   41,815 K/sec                  
    20.206.125.663      cycles                    #    4,163 GHz                    
    59.582.581.461      instructions              #    2,95  insn per cycle         
    10.304.298.249      branches                  #    2,123 G/sec                  
        99.022.176      branch-misses             #    0,96% of all branches        

       4,854599261 seconds time elapsed

       4,635337000 seconds user
       0,220158000 seconds sys


[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck                                                                                                                                   (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck':

          5.146,11 msec task-clock                #    1,000 CPUs utilized          
               114      context-switches          #   22,153 /sec                   
                10      cpu-migrations            #    1,943 /sec                   
           206.699      page-faults               #   40,166 K/sec                  
    20.252.618.547      cycles                    #    3,936 GHz                    
    59.599.111.190      instructions              #    2,94  insn per cycle         
    10.307.254.007      branches                  #    2,003 G/sec                  
        99.260.468      branch-misses             #    0,96% of all branches        

       5,146475544 seconds time elapsed

       4,899406000 seconds user
       0,248172000 seconds sys


[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck                                                                                                                                   (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck':

          5.144,27 msec task-clock                #    1,000 CPUs utilized          
               105      context-switches          #   20,411 /sec                   
                 7      cpu-migrations            #    1,361 /sec                   
           206.697      page-faults               #   40,180 K/sec                  
    20.264.431.280      cycles                    #    3,939 GHz                    
    59.598.563.374      instructions              #    2,94  insn per cycle         
    10.307.155.856      branches                  #    2,004 G/sec                  
        99.245.292      branch-misses             #    0,96% of all branches        

       5,144858949 seconds time elapsed

       4,929492000 seconds user
       0,216065000 seconds sys
```

And 3 with `fast-float`.

```
[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck_fast_flaot                                                                                                                        (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck_fast_flaot':

          4.540,48 msec task-clock                #    1,000 CPUs utilized          
                97      context-switches          #   21,363 /sec                   
                11      cpu-migrations            #    2,423 /sec                   
           200.608      page-faults               #   44,182 K/sec                  
    17.986.017.214      cycles                    #    3,961 GHz                    
    51.074.028.265      instructions              #    2,84  insn per cycle         
     9.167.403.685      branches                  #    2,019 G/sec                  
        91.813.616      branch-misses             #    1,00% of all branches        

       4,541358968 seconds time elapsed

       4,273771000 seconds user
       0,268111000 seconds sys


[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck_fast_flaot                                                                                                                        (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck_fast_flaot':

          4.353,24 msec task-clock                #    1,000 CPUs utilized          
               111      context-switches          #   25,498 /sec                   
                11      cpu-migrations            #    2,527 /sec                   
           206.697      page-faults               #   47,481 K/sec                  
    18.034.938.819      cycles                    #    4,143 GHz                    
    51.099.205.181      instructions              #    2,83  insn per cycle         
     9.171.790.267      branches                  #    2,107 G/sec                  
        92.472.174      branch-misses             #    1,01% of all branches        

       4,353339979 seconds time elapsed

       4,134504000 seconds user
       0,220133000 seconds sys


[]  ritchie46 /home/ritchie46/code/memcheck$ perf stat ./target/release/memcheck_fast_flaot                                                                                                                        (base) 
[src/main.rs:29] cont = 9291890

 Performance counter stats for './target/release/memcheck_fast_flaot':

          4.613,72 msec task-clock                #    1,000 CPUs utilized          
               103      context-switches          #   22,325 /sec                   
                10      cpu-migrations            #    2,167 /sec                   
           202.982      page-faults               #   43,995 K/sec                  
    17.984.162.759      cycles                    #    3,898 GHz                    
    51.084.140.218      instructions              #    2,84  insn per cycle         
     9.169.170.380      branches                  #    1,987 G/sec                  
        91.637.102      branch-misses             #    1,00% of all branches        

       4,613801846 seconds time elapsed

       4,362770000 seconds user
       0,252160000 seconds sys

```