### PR TITLE
perf(rust, python): (csv) don't use memchr for splitfields `-~0.15%`

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -423,7 +423,7 @@ impl<'a> Iterator for SplitFields<'a> {
 
             idx as usize
         } else {
-            match memchr::memchr2(self.delimiter, self.eol_char, self.v) {
+            match self.v.iter().position(|&c| self.eof_oel(c)) {
                 None => return self.finish(needs_escaping),
                 Some(idx) => unsafe {
                     // Safety:


### PR DESCRIPTION
Low latency/ high throughput. Not worth it in fields which are relatively small.