### PR TITLE
perf(rust, python): [csv] SIMD accelerate SplitFields `-40%`

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -12,7 +12,7 @@ description = "DataFrame Library based on Apache Arrow"
 [features]
 sql = ["polars-sql"]
 rows = ["polars-core/rows"]
-simd = ["polars-core/simd"]
+simd = ["polars-core/simd", "polars-io/simd"]
 avx512 = ["polars-core/avx512"]
 nightly = ["polars-core/nightly", "polars-ops/nightly", "simd"]
 docs = ["polars-core/docs"]

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -19,7 +19,7 @@ ipc_streaming = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrow avro parsing
 avro = ["arrow/io_avro", "arrow/io_avro_compression"]
 # ipc = []
-csv-file = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float"]
+csv-file = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float", "simdutf8"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng"]
 dtype-categorical = ["polars-core/dtype-categorical"]
@@ -47,6 +47,7 @@ partition = ["polars-core/partition_by"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
 # don't use this
 private = ["polars-time/private"]
+simd = []
 
 [dependencies]
 ahash.workspace = true
@@ -75,7 +76,7 @@ regex = "1.6"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
 simd-json = { version = "0.7.0", optional = true, features = ["allow-non-simd", "known-key"] }
-simdutf8 = "0.1"
+simdutf8 = { version = "0.1", optional = true }
 tokio = { version = "1.22.0", features = ["net"], optional = true }
 url = { version = "2.3.1", optional = true }
 

--- a/polars/polars-io/src/csv/mod.rs
+++ b/polars/polars-io/src/csv/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod parser;
 pub mod read_impl;
 
 mod read;
+pub(super) mod splitfields;
 #[cfg(not(feature = "private"))]
 pub(crate) mod utils;
 #[cfg(feature = "private")]

--- a/polars/polars-io/src/csv/splitfields.rs
+++ b/polars/polars-io/src/csv/splitfields.rs
@@ -1,0 +1,324 @@
+#[cfg(not(feature = "simd"))]
+mod inner {
+    /// An adapted version of std::iter::Split.
+    /// This exists solely because we cannot split the lines naively as
+    pub(crate) struct SplitFields<'a> {
+        v: &'a [u8],
+        delimiter: u8,
+        finished: bool,
+        quote_char: u8,
+        quoting: bool,
+        eol_char: u8,
+    }
+
+    impl<'a> SplitFields<'a> {
+        pub(crate) fn new(
+            slice: &'a [u8],
+            delimiter: u8,
+            quote_char: Option<u8>,
+            eol_char: u8,
+        ) -> Self {
+            Self {
+                v: slice,
+                delimiter,
+                finished: false,
+                quote_char: quote_char.unwrap_or(b'"'),
+                quoting: quote_char.is_some(),
+                eol_char,
+            }
+        }
+
+        unsafe fn finish_eol(
+            &mut self,
+            need_escaping: bool,
+            idx: usize,
+        ) -> Option<(&'a [u8], bool)> {
+            self.finished = true;
+            debug_assert!(idx <= self.v.len());
+            Some((self.v.get_unchecked(..idx), need_escaping))
+        }
+
+        fn finish(&mut self, need_escaping: bool) -> Option<(&'a [u8], bool)> {
+            self.finished = true;
+            Some((self.v, need_escaping))
+        }
+
+        fn eof_oel(&self, current_ch: u8) -> bool {
+            current_ch == self.delimiter || current_ch == self.eol_char
+        }
+    }
+
+    impl<'a> Iterator for SplitFields<'a> {
+        // the bool is used to indicate that it requires escaping
+        type Item = (&'a [u8], bool);
+
+        #[inline]
+        fn next(&mut self) -> Option<(&'a [u8], bool)> {
+            if self.v.is_empty() || self.finished {
+                return None;
+            }
+
+            let mut needs_escaping = false;
+            // There can be strings with delimiters:
+            // "Street, City",
+
+            // Safety:
+            // we have checked bounds
+            let pos = if self.quoting && unsafe { *self.v.get_unchecked(0) } == self.quote_char {
+                needs_escaping = true;
+                // There can be pair of double-quotes within string.
+                // Each of the embedded double-quote characters must be represented
+                // by a pair of double-quote characters:
+                // e.g. 1997,Ford,E350,"Super, ""luxurious"" truck",20020
+
+                // denotes if we are in a string field, started with a quote
+                let mut in_field = false;
+
+                let mut idx = 0u32;
+                let mut current_idx = 0u32;
+                // micro optimizations
+                #[allow(clippy::explicit_counter_loop)]
+                for &c in self.v.iter() {
+                    if c == self.quote_char {
+                        // toggle between string field enclosure
+                        //      if we encounter a starting '"' -> in_field = true;
+                        //      if we encounter a closing '"' -> in_field = false;
+                        in_field = !in_field;
+                    }
+
+                    if !in_field && self.eof_oel(c) {
+                        if c == self.eol_char {
+                            // safety
+                            // we are in bounds
+                            return unsafe {
+                                self.finish_eol(needs_escaping, current_idx as usize)
+                            };
+                        }
+                        idx = current_idx;
+                        break;
+                    }
+                    current_idx += 1;
+                }
+
+                if idx == 0 {
+                    return self.finish(needs_escaping);
+                }
+
+                idx as usize
+            } else {
+                match self.v.iter().position(|&c| self.eof_oel(c)) {
+                    None => return self.finish(needs_escaping),
+                    Some(idx) => unsafe {
+                        // Safety:
+                        // idx was just found
+                        if *self.v.get_unchecked(idx) == self.eol_char {
+                            return self.finish_eol(needs_escaping, idx);
+                        } else {
+                            idx
+                        }
+                    },
+                }
+            };
+
+            unsafe {
+                debug_assert!(pos <= self.v.len());
+                // safety
+                // we are in bounds
+                let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
+                self.v = self.v.get_unchecked(pos + 1..);
+                ret
+            }
+        }
+    }
+}
+
+#[cfg(feature = "simd")]
+mod inner {
+    use std::ops::BitOr;
+    use std::simd::*;
+
+    const SIMD_SIZE: usize = 16;
+    type SimdVec = u8x16;
+
+    #[inline]
+    unsafe fn simple_argmax(arr: &[bool; SIMD_SIZE]) -> usize {
+        let mut high_index = 0usize;
+        for (i, item) in arr.iter().enumerate() {
+            if *item {
+                high_index = i;
+                break;
+            }
+        }
+        high_index
+    }
+
+    /// An adapted version of std::iter::Split.
+    /// This exists solely because we cannot split the lines naively as
+    pub(crate) struct SplitFields<'a> {
+        pub v: &'a [u8],
+        delimiter: u8,
+        pub finished: bool,
+        quote_char: u8,
+        quoting: bool,
+        eol_char: u8,
+        simd_delimiter: SimdVec,
+        simd_eol_char: SimdVec,
+    }
+
+    impl<'a> SplitFields<'a> {
+        pub(crate) fn new(
+            slice: &'a [u8],
+            delimiter: u8,
+            quote_char: Option<u8>,
+            eol_char: u8,
+        ) -> Self {
+            let simd_delimiter = SimdVec::splat(delimiter);
+            let simd_eol_char = SimdVec::splat(eol_char);
+
+            Self {
+                v: slice,
+                delimiter,
+                finished: false,
+                quote_char: quote_char.unwrap_or(b'"'),
+                quoting: quote_char.is_some(),
+                eol_char,
+                simd_delimiter,
+                simd_eol_char,
+            }
+        }
+
+        unsafe fn finish_eol(
+            &mut self,
+            need_escaping: bool,
+            idx: usize,
+        ) -> Option<(&'a [u8], bool)> {
+            self.finished = true;
+            debug_assert!(idx <= self.v.len());
+            Some((self.v.get_unchecked(..idx), need_escaping))
+        }
+
+        fn finish(&mut self, need_escaping: bool) -> Option<(&'a [u8], bool)> {
+            self.finished = true;
+            Some((self.v, need_escaping))
+        }
+
+        fn eof_oel(&self, current_ch: u8) -> bool {
+            current_ch == self.delimiter || current_ch == self.eol_char
+        }
+    }
+
+    impl<'a> Iterator for SplitFields<'a> {
+        // the bool is used to indicate that it requires escaping
+        type Item = (&'a [u8], bool);
+
+        #[inline]
+        fn next(&mut self) -> Option<(&'a [u8], bool)> {
+            if self.v.is_empty() || self.finished {
+                return None;
+            }
+
+            let mut needs_escaping = false;
+            // There can be strings with delimiters:
+            // "Street, City",
+
+            // Safety:
+            // we have checked bounds
+            let pos = if self.quoting && unsafe { *self.v.get_unchecked(0) } == self.quote_char {
+                needs_escaping = true;
+                // There can be pair of double-quotes within string.
+                // Each of the embedded double-quote characters must be represented
+                // by a pair of double-quote characters:
+                // e.g. 1997,Ford,E350,"Super, ""luxurious"" truck",20020
+
+                // denotes if we are in a string field, started with a quote
+                let mut in_field = false;
+
+                let mut idx = 0u32;
+                let mut current_idx = 0u32;
+                // micro optimizations
+                #[allow(clippy::explicit_counter_loop)]
+                for &c in self.v.iter() {
+                    if c == self.quote_char {
+                        // toggle between string field enclosure
+                        //      if we encounter a starting '"' -> in_field = true;
+                        //      if we encounter a closing '"' -> in_field = false;
+                        in_field = !in_field;
+                    }
+
+                    if !in_field && self.eof_oel(c) {
+                        if c == self.eol_char {
+                            // safety
+                            // we are in bounds
+                            return unsafe {
+                                self.finish_eol(needs_escaping, current_idx as usize)
+                            };
+                        }
+                        idx = current_idx;
+                        break;
+                    }
+                    current_idx += 1;
+                }
+
+                if idx == 0 {
+                    return self.finish(needs_escaping);
+                }
+
+                idx as usize
+            } else {
+                let mut total_idx = 0;
+
+                loop {
+                    if self.v.len() >= SIMD_SIZE {
+                        unsafe {
+                            let lane: [u8; SIMD_SIZE] = self
+                                .v
+                                .get_unchecked(total_idx..total_idx + 16)
+                                .try_into()
+                                .unwrap_unchecked();
+                            let simd_bytes = SimdVec::from(lane);
+                            let has_eol_char = simd_bytes.simd_eq(self.simd_eol_char);
+                            let has_delimiter = simd_bytes.simd_eq(self.simd_delimiter);
+                            let has_any = has_delimiter.bitor(has_eol_char);
+                            if has_any.any() {
+                                let has_any = std::mem::transmute::<
+                                    Mask<_, SIMD_SIZE>,
+                                    [bool; SIMD_SIZE],
+                                >(has_any);
+                                total_idx += simple_argmax(&has_any);
+                                break;
+                            } else {
+                                total_idx += SIMD_SIZE;
+                            }
+                        }
+                    } else {
+                        match self.v.iter().position(|&c| self.eof_oel(c)) {
+                            None => return self.finish(needs_escaping),
+                            Some(idx) => {
+                                total_idx += idx;
+                                break;
+                            }
+                        }
+                    }
+                }
+                unsafe {
+                    if *self.v.get_unchecked(total_idx) == self.eol_char {
+                        return self.finish_eol(needs_escaping, total_idx);
+                    } else {
+                        total_idx
+                    }
+                }
+            };
+
+            unsafe {
+                debug_assert!(pos <= self.v.len());
+                // safety
+                // we are in bounds
+                let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
+                self.v = self.v.get_unchecked(pos + 1..);
+                ret
+            }
+        }
+    }
+}
+
+pub(crate) use inner::SplitFields;

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -13,7 +13,8 @@ use regex::{Regex, RegexBuilder};
 
 #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
 use crate::csv::parser::next_line_position_naive;
-use crate::csv::parser::{next_line_position, skip_bom, skip_line_ending, SplitFields, SplitLines};
+use crate::csv::parser::{next_line_position, skip_bom, skip_line_ending, SplitLines};
+use crate::csv::splitfields::SplitFields;
 use crate::csv::CsvEncoding;
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 use crate::prelude::NullValues;

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 
 #[cfg(feature = "avro")]
 pub mod avro;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -570,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1540,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.8.1",
  "dirs",
+ "fast-float",
  "flate2",
  "lexical",
  "lexical-core",


### PR DESCRIPTION
Made the `SplitFields` iterator ~40% faster by utilizing SIMD. Tested different registers widths, but 128bits was most performant.

`SplitFields` takes approximately 15/20% of runtime of CPU bound work during csv parsing. 