### PR TITLE
perf(rust, python): use atoi in favor of lexical in strptime `-25%`

### DIFF
--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -9,9 +9,9 @@ description = "Time related code for the polars dataframe library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atoi = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8", optional = true }
-lexical = { version = "6", default-features = false, features = ["std", "parse-floats", "parse-integers"] }
 now = "0.1"
 once_cell.workspace = true
 polars-arrow = { version = "0.27.2", path = "../polars-arrow", features = ["compute", "temporal"] }


### PR DESCRIPTION
Parsing a csv with 1 column of datetimes is 25% faster by swapping the algo.