### PR TITLE
doc: Add strings filter example. (#7474)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "examples/read_csv",
   "examples/read_parquet",
   "examples/read_parquet_cloud",
+  "examples/string_filter",
   "examples/python_rust_compiled_function",
 ]
 

--- a/examples/string_filter/Cargo.toml
+++ b/examples/string_filter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "string_filter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+polars = { path = "../../polars", features = ["strings", "lazy"] }

--- a/examples/string_filter/src/main.rs
+++ b/examples/string_filter/src/main.rs
@@ -1,14 +1,13 @@
 use polars::lazy::prelude::*;
 use polars::prelude::*;
 
-fn main() {
+fn main() -> PolarsResult<()> {
     let a = Series::new("a", [1, 2, 3, 4]);
     let b = Series::new("b", ["one", "two", "three", "four"]);
-    let df = DataFrame::new(vec![a, b])
-        .unwrap()
+    let df = DataFrame::new(vec![a, b])?
         .lazy()
         .filter(col("b").str().starts_with(lit("t")))
-        .collect()
-        .unwrap();
+        .collect()?;
     println!("{df:?}");
+    Ok(())
 }

--- a/examples/string_filter/src/main.rs
+++ b/examples/string_filter/src/main.rs
@@ -1,0 +1,14 @@
+use polars::lazy::prelude::*;
+use polars::prelude::*;
+
+fn main() {
+    let a = Series::new("a", [1, 2, 3, 4]);
+    let b = Series::new("b", ["one", "two", "three", "four"]);
+    let df = DataFrame::new(vec![a, b])
+        .unwrap()
+        .lazy()
+        .filter(col("b").str().starts_with(lit("t")))
+        .collect()
+        .unwrap();
+    println!("{df:?}");
+}


### PR DESCRIPTION
This simple example will help users to quickly understand how to translate Python examples (e.g., showing a `.str` attribute) to Rust specifics (e.g., use the `lazy` and `strings` features and instead use the `.str()` *method*).