### PR TITLE
fix(python): Initialize with `Decimal` dtype

### DIFF
--- a/py-polars/docs/source/reference/datatypes.rst
+++ b/py-polars/docs/source/reference/datatypes.rst
@@ -15,6 +15,7 @@ Numeric
     :toctree: api/
     :nosignatures:
 
+    Decimal
     Float32
     Float64
     Int16
@@ -26,7 +27,7 @@ Numeric
     UInt64
     UInt8
 
-Date / Time
+Temporal
 ~~~~~~~~~~~
 .. autosummary::
     :toctree: api/

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -31,6 +31,7 @@ if not _DOCUMENTING:
         dt.UInt16: PySeries.new_opt_u16,
         dt.UInt32: PySeries.new_opt_u32,
         dt.UInt64: PySeries.new_opt_u64,
+        dt.Decimal: PySeries.new_decimal,
         dt.Date: PySeries.new_opt_i32,
         dt.Datetime: PySeries.new_opt_i64,
         dt.Duration: PySeries.new_opt_i64,

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -69,3 +69,10 @@ def test_to_from_pydecimal_and_format() -> None:
         .split()
     )
     assert formatted == dec_strs
+
+
+def test_init_decimal_dtype() -> None:
+    _ = pl.Series("a", [D("-0.01"), D("1.2345678"), D("500")], dtype=pl.Decimal)
+    _ = pl.DataFrame(
+        {"a": [D("-0.01"), D("1.2345678"), D("500")]}, schema={"a": pl.Decimal}
+    )


### PR DESCRIPTION
I noticed the Decimal datatype was missing from the docs, and I also noticed I couldn't construct a Series when passing `dtype=pl.Decimal`.

Here's the fix :)

