### PR TITLE
fix(python): keep series name in arithmetic

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -540,7 +540,7 @@ class Series:
             isinstance(other, (float, date, datetime, timedelta, str))
             and not self.is_float()
         ):
-            _s = sequence_to_pyseries("", [other])
+            _s = sequence_to_pyseries(self.name, [other])
             if "rhs" in op_ffi:
                 return wrap_s(getattr(_s, op_s)(self._s))
             else:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2573,17 +2573,17 @@ def test_cut() -> None:
 
 def test_symmetry_for_max_in_names() -> None:
     # int
-    a = pl.Series('a', [1])
+    a = pl.Series("a", [1])
     assert (a - a.max()).name == (a.max() - a).name == a.name
     # float
-    a = pl.Series('a', [1.])
+    a = pl.Series("a", [1.0])
     assert (a - a.max()).name == (a.max() - a).name == a.name
     # duration
-    a = pl.Series('a', [1], dtype=pl.Duration('ns'))
+    a = pl.Series("a", [1], dtype=pl.Duration("ns"))
     assert (a - a.max()).name == (a.max() - a).name == a.name
     # datetime
-    a = pl.Series('a', [1], dtype=pl.Datetime('ns'))
+    a = pl.Series("a", [1], dtype=pl.Datetime("ns"))
     assert (a - a.max()).name == (a.max() - a).name == a.name
     # time
-    a = pl.Series('a', [1], dtype=pl.Time('ns'))
+    a = pl.Series("a", [1], dtype=pl.Time("ns"))
     assert (a - a.max()).name == (a.max() - a).name == a.name

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2569,3 +2569,21 @@ def test_cut() -> None:
         (3.0, inf, "(1.0, inf]"),
         (4.0, inf, "(1.0, inf]"),
     ]
+
+
+def test_symmetry_for_max_in_names() -> None:
+    # int
+    a = pl.Series('a', [1])
+    assert (a - a.max()).name == (a.max() - a).name == a.name
+    # float
+    a = pl.Series('a', [1.])
+    assert (a - a.max()).name == (a.max() - a).name == a.name
+    # duration
+    a = pl.Series('a', [1], dtype=pl.Duration('ns'))
+    assert (a - a.max()).name == (a.max() - a).name == a.name
+    # datetime
+    a = pl.Series('a', [1], dtype=pl.Datetime('ns'))
+    assert (a - a.max()).name == (a.max() - a).name == a.name
+    # time
+    a = pl.Series('a', [1], dtype=pl.Time('ns'))
+    assert (a - a.max()).name == (a.max() - a).name == a.name


### PR DESCRIPTION
#fixes #7491
This pull request makes sure that applying the name of the series is kept if a series is added/subtracted/etc. to a scalar.