### PR TITLE
fix(python): transparently integrate externally-registered Excel formats

### DIFF
--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -97,6 +97,8 @@ def _xl_apply_conditional_formats(
     has_header: bool,
 ) -> None:
     """Take all conditional formatting options and apply them to the table/range."""
+    from xlsxwriter.format import Format
+
     for cols, formats in conditional_formats.items():
         if not isinstance(cols, str) and len(cols) == 1:
             cols = cols[0]
@@ -117,8 +119,12 @@ def _xl_apply_conditional_formats(
 
             if "format" in fmt:
                 f = fmt["format"]
-                fmt["format"] = workbook.add_format(
-                    {"num_format": f} if isinstance(f, str) else f
+                fmt["format"] = (
+                    f  # already registered
+                    if isinstance(f, Format)
+                    else workbook.add_format(
+                        {"num_format": f} if isinstance(f, str) else f
+                    )
                 )
             worksheet.conditional_format(col_range, fmt)
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -82,6 +82,7 @@ module = [
   "IPython.*",
   "xlsx2csv",
   "xlsxwriter",
+  "xlsxwriter.format",
   "xlsxwriter.utility",
   "xlsxwriter.worksheet",
   "zoneinfo",

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -220,7 +220,7 @@ def test_excel_sparklines() -> None:
 def test_excel_write_multiple_tables() -> None:
     from xlsxwriter import Workbook
 
-    # note: also checks that empty tables don't error on write
+    # note: checks that empty tables don't error on write
     df1 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
     df2 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
     df3 = pl.DataFrame(schema={"colx": pl.Date, "coly": pl.Utf8, "colz": pl.Float64})
@@ -231,7 +231,21 @@ def test_excel_write_multiple_tables() -> None:
         df1.write_excel(workbook=wb, worksheet="sheet1", position="A1")
         df2.write_excel(workbook=wb, worksheet="sheet1", position="A6")
         df3.write_excel(workbook=wb, worksheet="sheet2", position="A1")
-        df4.write_excel(workbook=wb, worksheet="sheet3", position="A1")
+
+        # validate integration of externally-added formats
+        fmt = wb.add_format({"bg_color": "#ffff00"})
+        df4.write_excel(
+            workbook=wb,
+            worksheet="sheet3",
+            position="A1",
+            conditional_formats={
+                "colz": {
+                    "type": "formula",
+                    "criteria": "=C2=B2",
+                    "format": fmt,
+                }
+            },
+        )
 
     table_names: set[str] = set()
     for sheet in ("sheet1", "sheet2", "sheet3"):


### PR DESCRIPTION
Closes #7509.

Small fix to ensure that we transparently integrate externally registered workbook formats. This addresses a regression, and adds some explicit code coverage to prevent any future recurrence.