### PR TITLE
Replace "Blazingly Fast" with "Blazing Fast"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@
   <a href="https://discord.gg/4UfP5cfBE7">Discord</a>
 </p>
 
-## Polars: Blazingly fast DataFrames in Rust, Python & Node.js
+## Polars: Blazing fast DataFrames in Rust, Python & Node.js
 
-Polars is a blazingly fast DataFrames library implemented in Rust using
+Polars is a blazing fast DataFrames library implemented in Rust using
 [Apache Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html) as the memory model.
 
 - Lazy | eager execution
@@ -98,7 +98,7 @@ shape: (5, 8)
 
 ## Performance 🚀🚀
 
-### Blazingly fast
+### Blazing fast
 
 Polars is very fast. In fact, it is one of the best performing solutions available.
 See the results in [h2oai's db-benchmark](https://h2oai.github.io/db-benchmark/).


### PR DESCRIPTION
Blazingly Fast is bad grammar. If you were doing something very fast, you could say you were doing it blazingly fast (if you wanted), but if you're describing something that is very fast, it's blazing fast, not blazingly fast. The latter is wrong, and sounds dumb.