### PR TITLE
fix(rust): Enable link to DateLikeNameSpace in the docs.

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -6,7 +6,7 @@ pub use cat::*;
 mod arithmetic;
 pub mod binary;
 #[cfg(feature = "temporal")]
-mod dt;
+pub mod dt;
 mod expr;
 mod from;
 pub(crate) mod function_expr;


### PR DESCRIPTION
The link to the `DateLikeNameSpace` type in the [`Expr::dt()`](https://docs.rs/polars/latest/polars/prelude/enum.Expr.html#method.dt) is disabled, this PR makes the module pub so that it is shown in the generated docs:

<img width="423" alt="Screenshot 2023-03-13 at 16 49 41" src="https://user-images.githubusercontent.com/10183380/224754863-871980f4-98e7-4e05-8bdf-3df13429952b.png">

