### PR TITLE
perf(python): extend ultrafast constant-value frame init to temporal types (over 1,000x speedup)

### DIFF
--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -653,7 +653,7 @@ def _expand_dict_scalars(
                     )
 
                 elif val is None or isinstance(  # type: ignore[redundant-expr]
-                    val, (int, float, str, bool)
+                    val, (int, float, str, bool, date, datetime, time, timedelta)
                 ):
                     updated_data[name] = pli.Series(
                         name=name, values=[val], dtype=dtype

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -380,6 +380,50 @@ def test_from_dict_with_scalars() -> None:
         "z": pl.UInt8,
     }
 
+    # a bit of everything
+    mixed_dtype_data: dict[str, Any] = {
+        "a": 0,
+        "b": 8,
+        "c": 9.5,
+        "d": None,
+        "e": True,
+        "f": False,
+        "g": time(0, 1, 2),
+        "h": date(2023, 3, 14),
+        "i": timedelta(seconds=3601),
+        "j": datetime(2111, 11, 11, 11, 11, 11, 11),
+        "k": "「趣味でヒーローをやっている者だ」",
+    }
+    # note: deliberately set this value large; if all dtypes are
+    # on the fast-path it'll only take ~0.03secs. if it becomes
+    # even remotely noticeable that will indicate a regression.
+    n_range = 1_000_000
+    index_and_data: dict[str, Any] = {"idx": range(n_range)}
+    index_and_data.update(mixed_dtype_data.items())
+    df8 = pl.DataFrame(
+        data=index_and_data,
+        schema={
+            "idx": pl.Int32,
+            "a": pl.UInt16,
+            "b": pl.UInt32,
+            "c": pl.Float64,
+            "d": pl.Float32,
+            "e": pl.Boolean,
+            "f": pl.Boolean,
+            "g": pl.Time,
+            "h": pl.Date,
+            "i": pl.Duration,
+            "j": pl.Datetime,
+            "k": pl.Utf8,
+        },
+    )
+    dfx = df8.select(pl.exclude("idx"))
+
+    assert len(df8) == n_range
+    assert dfx[:5].rows() == dfx[5:10].rows()
+    assert dfx[-10:-5].rows() == dfx[-5:].rows()
+    assert dfx.row(n_range // 2, named=True) == mixed_dtype_data
+
 
 def test_dataframe_membership_operator() -> None:
     # cf. issue #4032


### PR DESCRIPTION
Extends #6034 and #6111 with support for fast expansion of temporal constants, since `extend_constant` gained support for these types (datetime/date/time/timedelta) a few versions back. Trivial update, but absolutely colossal speedup:

## Example
```python
from codetiming import Timer
from datetime import date
import polars as pl

with Timer():
    df = pl.DataFrame({
        "idx": range(5_000_000), 
        "dt1": date(2002,1,2), 
        "dt2": date(2007,2,3), 
        "dt3": date(2012,3,4),
        "dt4": date(2017,4,5),
        "dt5": date(2022,5,6),
    })

# shape: (5000000, 6)
# ┌─────────┬────────────┬────────────┬────────────┬────────────┬────────────┐
# │ idx     ┆ dt1        ┆ dt2        ┆ dt3        ┆ dt4        ┆ dt5        │
# │ ---     ┆ ---        ┆ ---        ┆ ---        ┆ ---        ┆ ---        │
# │ i64     ┆ date       ┆ date       ┆ date       ┆ date       ┆ date       │
# ╞═════════╪════════════╪════════════╪════════════╪════════════╪════════════╡
# │ 0       ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 1       ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 2       ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 3       ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ ...     ┆ ...        ┆ ...        ┆ ...        ┆ ...        ┆ ...        │
# │ 4999996 ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 4999997 ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 4999998 ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# │ 4999999 ┆ 2002-01-02 ┆ 2007-02-03 ┆ 2012-03-04 ┆ 2017-04-05 ┆ 2022-05-06 │
# └─────────┴────────────┴────────────┴────────────┴────────────┴────────────┘
```

**Before**: 
`Elapsed time: 32.3975 seconds`

**After**: 
`Elapsed time: 0.0190 seconds`

**Speedup**: 
`1705x times faster`