### PR TITLE
fix(rust, python): don't upcast column to string in 'is_in' operation

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
@@ -347,6 +347,8 @@ impl OptimizationRule for TypeCoercionRule {
                 unpack!(early_escape(&type_left, &type_other));
 
                 let casted_expr = match (&type_left, &type_other) {
+                    // types are equal, do nothing
+                    (a, b) if a == b => return Ok(None),
                     // cast both local and global string cache
                     // note that there might not yet be a rev
                     #[cfg(feature = "dtype-categorical")]
@@ -357,6 +359,9 @@ impl OptimizationRule for TypeCoercionRule {
                             // does not matter
                             strict: false,
                         }
+                    }
+                    (dt, DataType::Utf8) => {
+                        polars_bail!(ComputeError: "cannot compare {:?} to {:?} type in 'is_in' operation", dt, type_other)
                     }
                     (DataType::List(_), _) | (_, DataType::List(_)) => return Ok(None),
                     #[cfg(feature = "dtype-struct")]
@@ -372,7 +377,7 @@ impl OptimizationRule for TypeCoercionRule {
                             strict: false,
                         }
                     }
-                    // types are equal, do nothing
+                    // do nothing
                     _ => return Ok(None),
                 };
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.12"
+version = "0.16.13"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1118,10 +1118,9 @@ def test_is_in() -> None:
         False,
     ]
     assert df.select(pl.col("b").is_in([])).to_series().to_list() == [False]
-    assert df.select(pl.col("b").is_in(["x", "x"])).to_series().to_list() == [
-        False,
-        False,
-    ]
+
+    with pytest.raises(pl.ComputeError, match=r"cannot compare"):
+        df.select(pl.col("b").is_in(["x", "x"]))
 
 
 def test_slice() -> None:


### PR DESCRIPTION
fixes #7477