### PR TITLE
ci(rust): Use pre-installed rustup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,9 +49,7 @@ jobs:
           Rscript groupby-datagen.R 1e7 1e2 5 0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
+        run: rustup show
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup override set stable
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
+        run: rustup show
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -56,10 +54,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
-          components: rustfmt, clippy, miri
+        run: rustup component add rustfmt clippy miri
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -100,9 +95,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
+        run: rustup show
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -159,11 +159,6 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
-
       - name: Set up Rust targets
         run: rustup target add aarch64-apple-darwin
 
@@ -190,11 +185,6 @@ jobs:
   #       run: |
   #         rm py-polars/README.md
   #         cp README.md py-polars/README.md
-
-  #     - name: Set up Rust
-  #       uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: nightly-2023-03-10
 
   #     - name: Set up Rust targets
   #       run: rustup target add aarch64-apple-darwin

--- a/.github/workflows/docs-deploy-rust.yml
+++ b/.github/workflows/docs-deploy-rust.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
-          components: rust-docs
+        run: rustup component add rust-docs
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -49,10 +49,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
-          components: rustfmt, clippy
+        run: rustup component add rustfmt clippy
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -44,9 +44,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
+        run: rustup show
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -107,9 +105,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-03-10
+        run: rustup show
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The benefit is that this auto-detects the `toolchain.toml`, so we won't have to update these workflows when bumping the toolchain version. And it's one less dependency.

The version now only needs to be bumped in the `toolchain.toml` and Python release workflow.