### PR TITLE
fix(python): remove pyarrow from construction and dispatch to rust

### DIFF
--- a/polars/polars-core/src/datatypes/field.rs
+++ b/polars/polars-core/src/datatypes/field.rs
@@ -150,6 +150,8 @@ impl From<&ArrowDataType> for DataType {
                     panic!("activate the 'object' feature to be able to load POLARS_EXTENSION_TYPE")
                 }
             }
+            #[cfg(feature = "dtype-decimal")]
+            ArrowDataType::Decimal(precision, scale) => DataType::Decimal(Some(*precision), Some(*scale)),
             dt => panic!("Arrow datatype {dt:?} not supported by Polars. You probably need to activate that data-type feature."),
         }
     }

--- a/polars/polars-core/src/frame/row.rs
+++ b/polars/polars-core/src/frame/row.rs
@@ -493,7 +493,9 @@ impl<'a> AnyValueBuffer<'a> {
             Float32(b) => b.finish().into_series(),
             Float64(b) => b.finish().into_series(),
             Utf8(b) => b.finish().into_series(),
-            All(dtype, vals) => Series::from_any_values_and_dtype("", &vals, &dtype).unwrap(),
+            All(dtype, vals) => {
+                Series::from_any_values_and_dtype("", &vals, &dtype, false).unwrap()
+            }
         }
     }
 

--- a/polars/polars-core/src/serde/mod.rs
+++ b/polars/polars-core/src/serde/mod.rs
@@ -178,7 +178,8 @@ mod test {
         let row_3 = AnyValue::Null;
 
         let s =
-            Series::from_any_values_and_dtype("item", &vec![row_1, row_2, row_3], &dtype).unwrap();
+            Series::from_any_values_and_dtype("item", &vec![row_1, row_2, row_3], &dtype, false)
+                .unwrap();
         let df = DataFrame::new(vec![s]).unwrap();
 
         let df_str = serde_json::to_string(&df).unwrap();

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1028,7 +1028,7 @@ mod test {
     fn new_series_from_empty_structs() {
         let dtype = DataType::Struct(vec![]);
         let empties = vec![AnyValue::StructOwned(Box::new((vec![], vec![]))); 3];
-        let s = Series::from_any_values_and_dtype("", &empties, &dtype).unwrap();
+        let s = Series::from_any_values_and_dtype("", &empties, &dtype, false).unwrap();
         assert_eq!(s.len(), 3);
     }
     #[test]

--- a/polars/polars-core/src/series/ops/extend.rs
+++ b/polars/polars-core/src/series/ops/extend.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 impl Series {
     /// Extend with a constant value.
     pub fn extend_constant(&self, value: AnyValue, n: usize) -> PolarsResult<Self> {
-        let s = Series::from_any_values("", &[value]).unwrap();
+        let s = Series::from_any_values("", &[value], false).unwrap();
         let s = s.cast(self.dtype())?;
         let to_append = s.new_from_index(0, n);
 

--- a/polars/polars-io/src/ndjson_core/buffer.rs
+++ b/polars/polars-io/src/ndjson_core/buffer.rs
@@ -178,7 +178,7 @@ fn deserialize_all<'a>(json: &Value, dtype: &DataType) -> PolarsResult<AnyValue<
                 .iter()
                 .map(|val| deserialize_all(val, inner_dtype))
                 .collect::<PolarsResult<_>>()?;
-            let s = Series::from_any_values_and_dtype("", &vals, inner_dtype)?;
+            let s = Series::from_any_values_and_dtype("", &vals, inner_dtype, false)?;
             AnyValue::List(s)
         }
         #[cfg(feature = "dtype-struct")]

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -160,7 +160,7 @@ impl Sink for SortSink {
             let lock = self.io_thread.lock().unwrap();
             let io_thread = lock.as_ref().unwrap();
 
-            let dist = Series::from_any_values("", &self.dist_sample).unwrap();
+            let dist = Series::from_any_values("", &self.dist_sample, false).unwrap();
             let dist = dist.sort_with(SortOptions {
                 descending: self.sort_args.descending[0],
                 nulls_last: self.sort_args.nulls_last,

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -225,10 +225,14 @@ impl From<Series> for PySeries {
 )]
 impl PySeries {
     #[staticmethod]
-    pub fn new_from_anyvalues(name: &str, val: Vec<Wrap<AnyValue<'_>>>) -> PyResult<PySeries> {
+    pub fn new_from_anyvalues(
+        name: &str,
+        val: Vec<Wrap<AnyValue<'_>>>,
+        strict: bool,
+    ) -> PyResult<PySeries> {
         let avs = slice_extract_wrapped(&val);
         // from anyvalues is fallible
-        let s = Series::from_any_values(name, avs).map_err(PyPolarsErr::from)?;
+        let s = Series::from_any_values(name, avs, strict).map_err(PyPolarsErr::from)?;
         Ok(s.into())
     }
 
@@ -275,13 +279,14 @@ impl PySeries {
     pub fn new_decimal(
         name: &str,
         val: Vec<Wrap<AnyValue<'_>>>,
-        _strict: bool,
+        strict: bool,
     ) -> PyResult<PySeries> {
         // TODO: do we have to respect 'strict' here? it's possible if we want to
         let avs = slice_extract_wrapped(&val);
         // create a fake dtype with a placeholder "none" scale, to be inferred later
         let dtype = DataType::Decimal(None, None);
-        let s = Series::from_any_values_and_dtype(name, avs, &dtype).map_err(PyPolarsErr::from)?;
+        let s = Series::from_any_values_and_dtype(name, avs, &dtype, strict)
+            .map_err(PyPolarsErr::from)?;
         Ok(s.into())
     }
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -437,6 +437,8 @@ def test_list_mean() -> None:
 
 def test_list_min_max() -> None:
     for dt in pl.NUMERIC_DTYPES:
+        if dt == pl.Decimal:
+            continue
         df = pl.DataFrame(
             {"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]]},
             schema={"a": pl.List(dt)},

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -32,9 +32,9 @@ def test_init_dict() -> None:
         assert df.shape == (0, 2)
         assert df.schema == {"a": pl.Date, "b": pl.Utf8}
 
-    # List of empty list/tuple
-    df = pl.DataFrame({"a": [[]], "b": [()]})
-    expected = {"a": pl.List(pl.Float64), "b": pl.List(pl.Float64)}
+    # List of empty list
+    df = pl.DataFrame({"a": [[]], "b": [[]]})
+    expected = {"a": pl.List(pl.Int32), "b": pl.List(pl.Int32)}
     assert df.schema == expected
     assert df.rows() == [([], [])]
 
@@ -938,3 +938,9 @@ def test_init_with_explicit_binary_schema() -> None:
     s = pl.Series("a", [b"hello", b"world"], dtype=pl.Binary)
     assert s.dtype == pl.Binary
     assert s.to_list() == [b"hello", b"world"]
+
+
+def test_nested_categorical() -> None:
+    s = pl.Series([["a"]], dtype=pl.List(pl.Categorical))
+    assert s.to_list() == [["a"]]
+    assert s.dtype == pl.List(pl.Categorical)


### PR DESCRIPTION
fixes #7528

This removes really awkward code branches that were hard to follow and tried to band-aid downstream behavior.

Now all nested construction goes via `AnyValue`s and can accept a `strict` argument. This `strict` will by fully implemented in a later PR. The parameter controls if a value that does not adhere to the dtype raises an error or leads to inserting a `null` sentinel.