### PR TITLE
fix(python): fix negative indexing for `head`/`tail`

### DIFF
--- a/py-polars/polars/internals/dataframe/frame.py
+++ b/py-polars/polars/internals/dataframe/frame.py
@@ -3733,46 +3733,15 @@ class DataFrame:
             length = self.height - offset + length
         return self._from_pydf(self._df.slice(offset, length))
 
-    def limit(self, n: int = 5) -> Self:
+    def head(self, n: int = 5) -> Self:
         """
         Get the first `n` rows.
 
-        Alias for :func:`DataFrame.head`.
-
         Parameters
         ----------
         n
-            Number of rows to return.
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {"foo": [1, 2, 3, 4, 5, 6], "bar": ["a", "b", "c", "d", "e", "f"]}
-        ... )
-        >>> df.limit(4)
-        shape: (4, 2)
-        ┌─────┬─────┐
-        │ foo ┆ bar │
-        │ --- ┆ --- │
-        │ i64 ┆ str │
-        ╞═════╪═════╡
-        │ 1   ┆ a   │
-        │ 2   ┆ b   │
-        │ 3   ┆ c   │
-        │ 4   ┆ d   │
-        └─────┴─────┘
-
-        """
-        return self.head(n)
-
-    def head(self, n: int = 5) -> Self:
-        """
-        Get the first `n` rows (if negative, returns all rows except the last `n`).
-
-        Parameters
-        ----------
-        n
-            Number of rows to return.
+            Number of rows to return. If a negative value is passed, return all rows
+            except the last ``abs(n)``.
 
         See Also
         --------
@@ -3799,7 +3768,7 @@ class DataFrame:
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        Negative values of ``head`` return all rows _except_ the last abs(n).
+        Pass a negative value to get all rows `except` the last ``abs(n)``.
 
         >>> df.head(-3)
         shape: (2, 3)
@@ -3811,19 +3780,21 @@ class DataFrame:
         │ 1   ┆ 6   ┆ a   │
         │ 2   ┆ 7   ┆ b   │
         └─────┴─────┴─────┘
+
         """
         if n < 0:
-            n = len(self) + n
+            n = max(0, self.height + n)
         return self._from_pydf(self._df.head(n))
 
     def tail(self, n: int = 5) -> Self:
         """
-        Get the last `n` rows (if negative, returns all rows except the first `n`).
+        Get the last `n` rows.
 
         Parameters
         ----------
         n
-            Number of rows to return.
+            Number of rows to return. If a negative value is passed, return all rows
+            except the first ``abs(n)``.
 
         See Also
         --------
@@ -3850,7 +3821,7 @@ class DataFrame:
         │ 5   ┆ 10  ┆ e   │
         └─────┴─────┴─────┘
 
-        Negative values of ``tail`` return all rows _except_ the first abs(n).
+        Pass a negative value to get all rows `except` the first ``abs(n)``.
 
         >>> df.tail(-3)
         shape: (2, 3)
@@ -3862,10 +3833,30 @@ class DataFrame:
         │ 4   ┆ 9   ┆ d   │
         │ 5   ┆ 10  ┆ e   │
         └─────┴─────┴─────┘
+
         """
         if n < 0:
-            n = len(self) + n
+            n = max(0, self.height + n)
         return self._from_pydf(self._df.tail(n))
+
+    def limit(self, n: int = 5) -> Self:
+        """
+        Get the first `n` rows.
+
+        Alias for :func:`DataFrame.head`.
+
+        Parameters
+        ----------
+        n
+            Number of rows to return. If a negative value is passed, return all rows
+            except the last ``abs(n)``.
+
+        See Also
+        --------
+        head
+
+        """
+        return self.head(n)
 
     def drop_nulls(self, subset: str | Sequence[str] | None = None) -> Self:
         """

--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1812,31 +1812,6 @@ class Series:
 
         """
 
-    def limit(self, n: int = 10) -> Series:
-        """
-        Get the first `n` rows.
-
-        Alias for :func:`Series.head`.
-
-        Parameters
-        ----------
-        n
-            Number of rows to return.
-
-        Examples
-        --------
-        >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.head(2)
-        shape: (2,)
-        Series: 'a' [i64]
-        [
-                1
-                2
-        ]
-
-        """
-        return self.to_frame().select(pli.col(self.name).limit(n)).to_series()
-
     def slice(self, offset: int, length: int | None = None) -> Series:
         """
         Get a slice of this Series.
@@ -1952,17 +1927,33 @@ class Series:
 
     def head(self, n: int = 10) -> Series:
         """
-        Get the first `n` rows.
+        Get the first `n` elements.
 
         Parameters
         ----------
         n
-            Number of rows to return.
+            Number of elements to return. If a negative value is passed, return all
+            elements except the last ``abs(n)``.
+
+        See Also
+        --------
+        tail, slice
 
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.head(2)
+        >>> s = pl.Series("a", [1, 2, 3, 4, 5])
+        >>> s.head(3)
+        shape: (3,)
+        Series: 'a' [i64]
+        [
+                1
+                2
+                3
+        ]
+
+        Pass a negative value to get all rows `except` the last ``abs(n)``.
+
+        >>> s.head(-3)
         shape: (2,)
         Series: 'a' [i64]
         [
@@ -1971,30 +1962,69 @@ class Series:
         ]
 
         """
+        if n < 0:
+            n = max(0, self.len() + n)
         return self.to_frame().select(pli.col(self.name).head(n)).to_series()
 
     def tail(self, n: int = 10) -> Series:
         """
-        Get the last `n` rows.
+        Get the last `n` elements.
 
         Parameters
         ----------
         n
-            Number of rows to return.
+            Number of elements to return. If a negative value is passed, return all
+            elements except the first ``abs(n)``.
+
+        See Also
+        --------
+        head, slice
 
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.tail(2)
+        >>> s = pl.Series("a", [1, 2, 3, 4, 5])
+        >>> s.tail(3)
+        shape: (3,)
+        Series: 'a' [i64]
+        [
+                3
+                4
+                5
+        ]
+
+        Pass a negative value to get all rows `except` the first ``abs(n)``.
+
+        >>> s.tail(-3)
         shape: (2,)
         Series: 'a' [i64]
         [
-                2
-                3
+                4
+                5
         ]
 
         """
+        if n < 0:
+            n = max(0, self.len() + n)
         return self.to_frame().select(pli.col(self.name).tail(n)).to_series()
+
+    def limit(self, n: int = 10) -> Series:
+        """
+        Get the first `n` elements.
+
+        Alias for :func:`Series.head`.
+
+        Parameters
+        ----------
+        n
+            Number of elements to return. If a negative value is passed, return all
+            elements except the last ``abs(n)``.
+
+        See Also
+        --------
+        head
+
+        """
+        return self.head(n)
 
     def take_every(self, n: int) -> Series:
         """

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -577,6 +577,11 @@ def test_head_tail_limit() -> None:
     assert df.tail(-8).rows() == [(8, 8), (9, 9)]
     assert len(df.tail(-6)) == 4
 
+    # negative values out of bounds
+    assert len(df.head(-12)) == 0
+    assert len(df.limit(-12)) == 0
+    assert len(df.tail(-12)) == 0
+
 
 def test_pipe() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6, None, 8]})

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -429,6 +429,30 @@ def test_various() -> None:
     assert not a.is_numeric()
 
 
+def test_series_head_tail_limit() -> None:
+    s = pl.Series(range(10))
+
+    assert_series_equal(s.head(5), pl.Series(range(5)))
+    assert_series_equal(s.limit(5), s.head(5))
+    assert_series_equal(s.tail(5), pl.Series(range(5, 10)))
+
+    # check if it doesn't fail when out of bounds
+    assert s.head(100).len() == 10
+    assert s.limit(100).len() == 10
+    assert s.tail(100).len() == 10
+
+    # negative values
+    assert_series_equal(s.head(-7), pl.Series(range(3)))
+    assert s.head(-2).len() == 8
+    assert_series_equal(s.tail(-8), pl.Series(range(8, 10)))
+    assert s.head(-6).len() == 4
+
+    # negative values out of bounds
+    assert s.head(-12).len() == 0
+    assert s.limit(-12).len() == 0
+    assert s.tail(-12).len() == 0
+
+
 def test_filter_ops() -> None:
     a = pl.Series("a", range(20))
     assert a.filter(a > 1).len() == 18


### PR DESCRIPTION
Closes #7550

Changes:
* Handle out of bounds negative input by setting it to 0 (returns empty dataframe)
* Add support for negative inputs to Series head/tail/limit
* Clean up some docstrings / add tests