### PR TITLE
test(python): Move `fmt` tests to `test_fmt`

### DIFF
--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -29,27 +29,6 @@ def test_categorical_round_trip() -> None:
     assert df2.dtypes == [pl.Int64, pl.Categorical]
 
 
-def test_date_list_fmt() -> None:
-    df = pl.DataFrame(
-        {
-            "mydate": ["2020-01-01", "2020-01-02", "2020-01-05", "2020-01-05"],
-            "index": [1, 2, 5, 5],
-        }
-    )
-
-    df = df.with_columns(pl.col("mydate").str.strptime(pl.Date, "%Y-%m-%d"))
-    assert (
-        str(df.groupby("index", maintain_order=True).agg(pl.col("mydate"))["mydate"])
-        == """shape: (3,)
-Series: 'mydate' [list[date]]
-[
-	[2020-01-01]
-	[2020-01-02]
-	[2020-01-05, 2020-01-05]
-]"""
-    )
-
-
 def test_from_different_chunks() -> None:
     s0 = pl.Series("a", [1, 2, 3, 4, None])
     s1 = pl.Series("b", [1, 2])

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1757,18 +1757,6 @@ def test_groupby_cat_list() -> None:
     assert out.dtype == pl.Categorical
     assert out[0] == "a"
 
-    # test if we can also correctly fmt the categorical in list
-    assert (
-        str(grouped)
-        == """shape: (3,)
-Series: 'cat_column' [list[cat]]
-[
-	["a", "b"]
-	["b", "a"]
-	["b"]
-]"""
-    )
-
 
 def test_groupby_agg_n_unique_floats() -> None:
     # tests proper dispatch

--- a/py-polars/tests/unit/test_fmt.py
+++ b/py-polars/tests/unit/test_fmt.py
@@ -127,3 +127,45 @@ def test_fmt_float_full() -> None:
         assert str(s) == fmt_float_full
 
     assert str(s) != fmt_float_full
+
+
+def test_date_list_fmt() -> None:
+    df = pl.DataFrame(
+        {
+            "mydate": ["2020-01-01", "2020-01-02", "2020-01-05", "2020-01-05"],
+            "index": [1, 2, 5, 5],
+        }
+    )
+
+    df = df.with_columns(pl.col("mydate").str.strptime(pl.Date, "%Y-%m-%d"))
+    assert (
+        str(df.groupby("index", maintain_order=True).agg(pl.col("mydate"))["mydate"])
+        == """shape: (3,)
+Series: 'mydate' [list[date]]
+[
+	[2020-01-01]
+	[2020-01-02]
+	[2020-01-05, 2020-01-05]
+]"""
+    )
+
+
+def test_fmt_series_cat_list() -> None:
+    s = pl.Series(
+        [
+            ["a", "b"],
+            ["b", "a"],
+            ["b"],
+        ],
+    ).cast(pl.List(pl.Categorical))
+
+    assert (
+        str(s)
+        == """shape: (3,)
+Series: '' [list[cat]]
+[
+	["a", "b"]
+	["b", "a"]
+	["b"]
+]"""
+    )


### PR DESCRIPTION
Just some misplaced tests.

I ran into this while trying to bump the version of `ruff`. There's some issues with the VSCode extension on the later versions, but this improvement we can already merge.