### PR TITLE
perf(python): reinstate fast module import and optimise `DataFrame` init by implementing dynamic `singledispatch` registration

### DIFF
--- a/py-polars/polars/internals/series/series.py
+++ b/py-polars/polars/internals/series/series.py
@@ -1188,7 +1188,7 @@ class Series:
         └────────────┴───────┘
 
         """
-        stats: dict[str, float | None | int | str | date | datetime | timedelta]
+        stats: dict[str, float | None | int | str | date | datetime | timedelta | time]
 
         if self.len() == 0:
             raise ValueError("Series must contain at least one value")
@@ -1263,7 +1263,7 @@ class Series:
         """Reduce this Series to the product value."""
         return self.to_frame().select(pli.col(self.name).product()).to_series()[0]
 
-    def min(self) -> int | float | date | datetime | timedelta | str | None:
+    def min(self) -> int | float | date | datetime | timedelta | time | str | None:
         """
         Get the minimal value in this Series.
 
@@ -1276,7 +1276,7 @@ class Series:
         """
         return self._s.min()
 
-    def max(self) -> int | float | date | datetime | timedelta | str | None:
+    def max(self) -> int | float | date | datetime | timedelta | time | str | None:
         """
         Get the maximum value in this Series.
 

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -9,19 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar, overload
 from polars.datatypes import Date, Datetime
 from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
-# This code block is due to a typing issue with backports.zoneinfo package:
-# https://github.com/pganssle/zoneinfo/issues/125
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    from backports.zoneinfo._zoneinfo import ZoneInfo
-
-
-# note: reversed views don't match as instances of MappingView
-if sys.version_info >= (3, 11):
-    _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
-    _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
-
 if TYPE_CHECKING:
     from collections.abc import Reversible
     from datetime import date, tzinfo
@@ -37,6 +24,29 @@ if TYPE_CHECKING:
 
     P = ParamSpec("P")
     T = TypeVar("T")
+
+    # the below shenanigans with ZoneInfo are all to handle a
+    # typing issue in py < 3.9 while preserving lazy-loading
+    if sys.version_info >= (3, 9):
+        from zoneinfo import ZoneInfo
+    elif _ZONEINFO_AVAILABLE:
+        from backports.zoneinfo._zoneinfo import ZoneInfo
+
+    def get_zoneinfo(key: str) -> ZoneInfo:
+        pass
+
+else:
+    from functools import lru_cache
+
+    @lru_cache(None)
+    def get_zoneinfo(key: str) -> ZoneInfo:
+        return zoneinfo.ZoneInfo(key)
+
+
+# note: reversed views don't match as instances of MappingView
+if sys.version_info >= (3, 11):
+    _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
+    _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
 
 @overload
@@ -175,7 +185,7 @@ def _to_python_datetime(
                     "Install polars[timezone] to handle datetimes with timezones."
                 )
 
-            utc = ZoneInfo("UTC")
+            utc = get_zoneinfo("UTC")
             if tu == "ns":
                 # nanoseconds to seconds
                 dt = datetime.fromtimestamp(0, tz=utc) + timedelta(
@@ -199,7 +209,7 @@ def _localize(dt: datetime, tz: str) -> datetime:
     # zone info installation should already be checked
     _tzinfo: ZoneInfo | tzinfo
     try:
-        _tzinfo = ZoneInfo(tz)
+        _tzinfo = get_zoneinfo(tz)
     except zoneinfo.ZoneInfoNotFoundError:
         # try fixed offset, which is not supported by ZoneInfo
         _tzinfo = _parse_fixed_tz_offset(tz)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import sys
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, cast, no_type_check
 
@@ -20,15 +19,12 @@ from polars.testing import (
 )
 
 if TYPE_CHECKING:
+    from zoneinfo import ZoneInfo
+
     from polars.datatypes import PolarsTemporalType
     from polars.internals.type_aliases import TimeUnit
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
 else:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
+    from polars.utils.convert import get_zoneinfo as ZoneInfo
 
 
 def test_fill_null() -> None:

--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+
+import pytest
+
+import polars as pl
+
+
+def _import_timings() -> bytes:
+    # assemble suitable command to get polars module import timing;
+    # run in a separate process to ensure clean timing results.
+    cmd = f'{sys.executable} -X importtime -c "import polars"'
+    return (
+        subprocess.run(cmd, shell=True, capture_output=True)
+        .stderr.replace(b"import time:", b"")
+        .replace(b" ", b"")
+        .strip()
+    )
+
+
+def _import_timings_as_frame(best_of: int) -> pl.DataFrame:
+    # create master frame as minimum of 'best_of' timings.
+    import_timings = [
+        pl.read_csv(
+            source=_import_timings(),
+            separator="|",
+            has_header=True,
+            new_columns=["own_time", "cumulative_time", "import"],
+        )
+        for _ in range(best_of)
+    ]
+    return (
+        sorted(
+            import_timings,
+            key=lambda tm: int(tm["cumulative_time"].max()),  # type: ignore[arg-type]
+        )[0]
+        .select("import", "own_time", "cumulative_time")
+        .sort(by=["cumulative_time"], descending=True)
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unreliable on Windows")
+def test_polars_import() -> None:
+    # note: take the fastest of three runs to reduce noise.
+    df_import = _import_timings_as_frame(best_of=3)
+
+    # ensure that we have not broken lazy-loading (numpy, pandas, pyarrow, etc).
+    lazy_modules = [dep for dep in pl.dependencies.__all__ if not dep.startswith("_")]
+    for mod in lazy_modules:
+        assert (
+            not df_import["import"].str.starts_with(mod).any()
+        ), f"lazy-loading regression: found {mod!r} at import time"
+
+    # ensure that we do not have an import speed regression.
+    with pl.Config() as cfg:
+        cfg.set_tbl_rows(25)
+        cfg.set_tbl_hide_dataframe_shape()
+
+        total_import_time = df_import["cumulative_time"].max()
+        assert isinstance(total_import_time, int)
+
+        if_err = f"Possible import speed regression; took {total_import_time//1_000}ms"
+        assert total_import_time < 200_000, f"{if_err}\n{df_import}"


### PR DESCRIPTION
Closes #7534.

Found a way to maintain the best of both worlds while solving the import speed regression. 

* We still take full advantage of `singledispatch` (actually, even more so than before) _without_ forcing the lazy loader to prematurely invoke the underlying modules. 

* The trick is _dynamic_ `singledispatch`; py-native types remain free to register themselves by decorating their top-level functions. Types that we want to lazy load (pandas/numpy/etc), or that might trigger circular imports (pli.Series?), are registered dynamically inside `_sequence_to_pydf_dispatcher` when _first_ identified inline.

* This approach has the added advantage of automatically creating a `singledispatch` registration point for _all_ types that get used, avoiding repetitive chains of `isinstance` filtering - once identified for the first time, subsequent DataFrame init with data of the same type will jump directly to its associated construction function. This should also slightly speed up any especially recursive/repetitive init calling patterns.

* Added a unit test that validates our total import time _and_ confirms that our lazy-loading modules aren't triggered by the initial import.

---

**Updated import profiles:** _(no more numpy/pandas/etc...)_

Work machine: `0.120 secs`

![polars import timings - work](https://user-images.githubusercontent.com/2613171/225333988-e24b5d55-10f2-4276-919a-59b3aeab7940.png)

Home machine: `0.055 secs` 🏆 

![polars import timings - home](https://user-images.githubusercontent.com/2613171/225399318-1a659d27-e82e-49bb-bd62-796f2a0ff457.png)