### PR TITLE
perf(rust, python): speedup `replace_literal_all` of single byte replacements `~15x`. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ smartstring = { version = "1" }
 
 [workspace.dependencies.arrow]
 package = "arrow2"
-git = "https://github.com/jorgecarleitao/arrow2"
-# git = "https://github.com/ritchie46/arrow2"
-rev = "f258a3e06ac408aebe7a7a497694729dc65a5e46"
+# git = "https://github.com/jorgecarleitao/arrow2"
+git = "https://github.com/ritchie46/arrow2"
+# rev = "f258a3e06ac408aebe7a7a497694729dc65a5e46"
 # path = "../arrow2"
-# branch = "polars_2023-03-01"
+branch = "polars_2023-03-15"
 version = "0.16"
 default-features = false
 features = [

--- a/polars/polars-ops/src/chunked_array/strings/mod.rs
+++ b/polars/polars-ops/src/chunked_array/strings/mod.rs
@@ -2,6 +2,8 @@
 mod json_path;
 #[cfg(feature = "strings")]
 mod namespace;
+#[cfg(feature = "strings")]
+mod replace;
 
 #[cfg(feature = "extract_jsonpath")]
 pub use json_path::*;

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -241,15 +241,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// Replace the leftmost literal (sub)string with another string
     fn replace_literal<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
         let ca = self.as_utf8();
-        // for single bytes we can replace on the whole values buffer
-        if pat.len() == 1 && val.len() == 1 {
-            let pat = pat.as_bytes()[0];
-            let val = val.as_bytes()[0];
-            return Ok(
-                ca.apply_kernel(&|arr| Box::new(replace::replace_lit_single_char(arr, pat, val)))
-            );
-        }
-
         // amortize allocation
         let mut buf = String::new();
 
@@ -288,6 +279,16 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
 
     /// Replace all matching literal (sub)strings with another string
     fn replace_literal_all<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
+        let ca = self.as_utf8();
+        // for single bytes we can replace on the whole values buffer
+        if pat.len() == 1 && val.len() == 1 {
+            let pat = pat.as_bytes()[0];
+            let val = val.as_bytes()[0];
+            return Ok(
+                ca.apply_kernel(&|arr| Box::new(replace::replace_lit_single_char(arr, pat, val)))
+            );
+        }
+
         // amortize allocation
         let mut buf = String::new();
 
@@ -315,7 +316,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
             }
         };
 
-        let ca = self.as_utf8();
         Ok(ca.apply_mut(f))
     }
 

--- a/polars/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/namespace.rs
@@ -240,6 +240,16 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
 
     /// Replace the leftmost literal (sub)string with another string
     fn replace_literal<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
+        let ca = self.as_utf8();
+        // for single bytes we can replace on the whole values buffer
+        if pat.len() == 1 && val.len() == 1 {
+            let pat = pat.as_bytes()[0];
+            let val = val.as_bytes()[0];
+            return Ok(
+                ca.apply_kernel(&|arr| Box::new(replace::replace_lit_single_char(arr, pat, val)))
+            );
+        }
+
         // amortize allocation
         let mut buf = String::new();
 
@@ -266,7 +276,6 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
                 s
             }
         };
-        let ca = self.as_utf8();
         Ok(ca.apply_mut(f))
     }
 

--- a/polars/polars-ops/src/chunked_array/strings/replace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/replace.rs
@@ -6,7 +6,7 @@ pub(super) fn replace_lit_single_char(arr: &Utf8Array<i64>, pat: u8, val: u8) ->
     let mut offsets = arr.offsets().clone();
     let validity = arr.validity().cloned();
     let start = offsets[0] as usize;
-    let end = (offsets[offsets.len() - 1] + 1) as usize;
+    let end = (offsets[offsets.len() - 1]) as usize;
 
     let mut values = values.as_slice()[start..end].to_vec();
     for byte in values.iter_mut() {

--- a/polars/polars-ops/src/chunked_array/strings/replace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/replace.rs
@@ -1,0 +1,15 @@
+use arrow::array::Utf8Array;
+
+pub(super) fn replace_lit_single_char(arr: &Utf8Array<i64>, pat: u8, val: u8) -> Utf8Array<i64> {
+    let values = arr.values();
+    let offsets = arr.offsets().clone();
+    let validity = arr.validity().cloned();
+
+    let mut values = values.as_slice().to_vec();
+    for byte in values.iter_mut() {
+        if *byte == pat {
+            *byte = val;
+        }
+    }
+    unsafe { Utf8Array::new_unchecked(arr.data_type().clone(), offsets, values.into(), validity) }
+}

--- a/polars/polars-ops/src/chunked_array/strings/replace.rs
+++ b/polars/polars-ops/src/chunked_array/strings/replace.rs
@@ -1,15 +1,23 @@
 use arrow::array::Utf8Array;
+use arrow::offset::OffsetsBuffer;
 
 pub(super) fn replace_lit_single_char(arr: &Utf8Array<i64>, pat: u8, val: u8) -> Utf8Array<i64> {
     let values = arr.values();
-    let offsets = arr.offsets().clone();
+    let mut offsets = arr.offsets().clone();
     let validity = arr.validity().cloned();
+    let start = offsets[0] as usize;
+    let end = (offsets[offsets.len() - 1] + 1) as usize;
 
-    let mut values = values.as_slice().to_vec();
+    let mut values = values.as_slice()[start..end].to_vec();
     for byte in values.iter_mut() {
         if *byte == pat {
             *byte = val;
         }
+    }
+    if start != 0 {
+        let start = start as i64;
+        let offsets_buf: Vec<i64> = offsets.iter().map(|o| *o - start).collect();
+        offsets = unsafe { OffsetsBuffer::new_unchecked(offsets_buf.into()) };
     }
     unsafe { Utf8Array::new_unchecked(arr.data_type().clone(), offsets, values.into(), validity) }
 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.16.0"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=f258a3e06ac408aebe7a7a497694729dc65a5e46#f258a3e06ac408aebe7a7a497694729dc65a5e46"
+source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-15#adf4571d52a38a86719182d3953b34ac5a7b0bb9"
 dependencies = [
  "ahash",
  "arrow-format",


### PR DESCRIPTION
Will follow up with a refactor that makes sure we default to `replace` all. This will be much faster for the single byte case and I assume this is the intent of most users who are replacing.