### PR TITLE
feat(rust): enhancements to slice pushdowns for anonymous scan

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 
 use polars_core::prelude::*;
@@ -5,6 +6,9 @@ use polars_core::prelude::*;
 pub use super::options::AnonymousScanOptions;
 
 pub trait AnonymousScan: Send + Sync {
+    fn as_any(&self) -> &dyn Any {
+        unimplemented!()
+    }
     /// Creates a dataframe from the supplied function & scan options.
     fn scan(&self, scan_opts: AnonymousScanOptions) -> PolarsResult<DataFrame>;
 

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -99,8 +99,27 @@ impl SlicePushDown {
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<ALogicalPlan> {
         use ALogicalPlan::*;
-
         match (lp, state) {
+            (AnonymousScan {
+                function,
+                file_info,
+                output_schema,
+                predicate,
+                mut options,
+            },
+                Some(state)) if function.allows_slice_pushdown() && function.allows_predicate_pushdown() => {
+
+                options.n_rows = Some(state.len as usize);
+                options.skip_rows = Some(state.offset as usize);
+                    let lp = AnonymousScan {
+                        function,
+                        file_info,
+                        output_schema,
+                        predicate,
+                        options,
+                    };
+                    Ok(lp)
+            },
             (AnonymousScan {
                 function,
                 file_info,


### PR DESCRIPTION
2 separate things are added in this PR, but both of them make improvements to the AnonymousScan trait. 

1. add an `as_any` to allow downcasting of the AnonymousScan. I'm working on a custom physical plan builder for a specific use case & need to cast anonymous scan back to the original type, so to avoid some unsafe transmute shenanigans `as_any` is needed.

2. if the source supports both slice & predicate pushdowns, we can push down the entire slice node during optimization. 

