### PR TITLE
refactor(python): Avoid `pli` in type hints (part 1)

### DIFF
--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -9,13 +9,14 @@ from typing import (
     TypeVar,
 )
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias, redirect
 
 if TYPE_CHECKING:
     from datetime import timedelta
 
+    from polars.dataframe import DataFrame
     from polars.internals.type_aliases import (
         ClosedInterval,
         IntoExpr,
@@ -236,7 +237,7 @@ class GroupBy(Generic[DF]):
         return self.df.__class__._from_pydf(df._df)
 
     @deprecated_alias(f="function")
-    def apply(self, function: Callable[[pli.DataFrame], pli.DataFrame]) -> DF:
+    def apply(self, function: Callable[[DataFrame], DataFrame]) -> DF:
         """
         Apply a custom/user-defined function (UDF) over the groups as a sub-DataFrame.
 

--- a/py-polars/polars/expr/binary.py
+++ b/py-polars/polars/expr/binary.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 
 if TYPE_CHECKING:
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import TransferEncoding
 
 
@@ -13,10 +14,10 @@ class ExprBinaryNameSpace:
 
     _accessor = "bin"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def contains(self, lit: bytes) -> pli.Expr:
+    def contains(self, lit: bytes) -> Expr:
         """
         Check if binaries in Series contain a binary substring.
 
@@ -32,7 +33,7 @@ class ExprBinaryNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.binary_contains(lit))
 
-    def ends_with(self, sub: bytes) -> pli.Expr:
+    def ends_with(self, sub: bytes) -> Expr:
         """
         Check if string values end with a binary substring.
 
@@ -44,7 +45,7 @@ class ExprBinaryNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.binary_ends_with(sub))
 
-    def starts_with(self, sub: bytes) -> pli.Expr:
+    def starts_with(self, sub: bytes) -> Expr:
         """
         Check if values start with a binary substring.
 
@@ -56,7 +57,7 @@ class ExprBinaryNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.binary_starts_with(sub))
 
-    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> pli.Expr:
+    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> Expr:
         """
         Decode a value using the provided encoding.
 
@@ -78,7 +79,7 @@ class ExprBinaryNameSpace:
                 f"encoding must be one of {{'hex', 'base64'}}, got {encoding}"
             )
 
-    def encode(self, encoding: TransferEncoding) -> pli.Expr:
+    def encode(self, encoding: TransferEncoding) -> Expr:
         """
         Encode a value using the provided encoding.
 

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import CategoricalOrdering

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from polars import internals as pli
 
 if TYPE_CHECKING:
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import CategoricalOrdering
 
 
@@ -13,10 +14,10 @@ class ExprCatNameSpace:
 
     _accessor = "cat"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def set_ordering(self, ordering: CategoricalOrdering) -> pli.Expr:
+    def set_ordering(self, ordering: CategoricalOrdering) -> Expr:
         """
         Determine how this categorical series should be sorted.
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -11,6 +11,7 @@ from polars.utils.decorators import deprecated_alias, redirect
 if TYPE_CHECKING:
     from datetime import timedelta
 
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
 
 
@@ -26,14 +27,14 @@ class ExprDateTimeNameSpace:
 
     _accessor = "dt"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
     def truncate(
         self,
         every: str | timedelta,
         offset: str | timedelta | None = None,
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Divide the date/datetime range into buckets.
 
@@ -147,7 +148,7 @@ class ExprDateTimeNameSpace:
         self,
         every: str | timedelta,
         offset: str | timedelta | None = None,
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Divide the date/datetime range into buckets.
 
@@ -263,7 +264,7 @@ class ExprDateTimeNameSpace:
             )
         )
 
-    def combine(self, tm: time | pli.Expr, tu: TimeUnit = "us") -> pli.Expr:
+    def combine(self, tm: time | Expr, tu: TimeUnit = "us") -> Expr:
         """
         Create a naive Datetime from an existing Date/Datetime expression and a Time.
 
@@ -324,7 +325,7 @@ class ExprDateTimeNameSpace:
         tm = pli.expr_to_lit_or_expr(tm)
         return pli.wrap_expr(self._pyexpr.dt_combine(tm._pyexpr, tu))
 
-    def strftime(self, fmt: str) -> pli.Expr:
+    def strftime(self, fmt: str) -> Expr:
         """
         Format Date/Datetime with a formatting rule.
 
@@ -363,7 +364,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.strftime(fmt))
 
-    def year(self) -> pli.Expr:
+    def year(self) -> Expr:
         """
         Extract year from underlying Date representation.
 
@@ -409,7 +410,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.year())
 
-    def iso_year(self) -> pli.Expr:
+    def iso_year(self) -> Expr:
         """
         Extract ISO year from underlying Date representation.
 
@@ -454,7 +455,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.iso_year())
 
-    def quarter(self) -> pli.Expr:
+    def quarter(self) -> Expr:
         """
         Extract quarter from underlying Date representation.
 
@@ -498,7 +499,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.quarter())
 
-    def month(self) -> pli.Expr:
+    def month(self) -> Expr:
         """
         Extract month from underlying Date representation.
 
@@ -543,7 +544,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.month())
 
-    def week(self) -> pli.Expr:
+    def week(self) -> Expr:
         """
         Extract the week from the underlying Date representation.
 
@@ -588,7 +589,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.week())
 
-    def weekday(self) -> pli.Expr:
+    def weekday(self) -> Expr:
         """
         Extract the week day from the underlying Date representation.
 
@@ -638,7 +639,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.weekday())
 
-    def day(self) -> pli.Expr:
+    def day(self) -> Expr:
         """
         Extract day from underlying Date representation.
 
@@ -689,7 +690,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.day())
 
-    def ordinal_day(self) -> pli.Expr:
+    def ordinal_day(self) -> Expr:
         """
         Extract ordinal day from underlying Date representation.
 
@@ -740,7 +741,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.ordinal_day())
 
-    def hour(self) -> pli.Expr:
+    def hour(self) -> Expr:
         """
         Extract hour from underlying DateTime representation.
 
@@ -784,7 +785,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.hour())
 
-    def minute(self) -> pli.Expr:
+    def minute(self) -> Expr:
         """
         Extract minutes from underlying DateTime representation.
 
@@ -830,7 +831,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.minute())
 
-    def second(self, fractional: bool = False) -> pli.Expr:
+    def second(self, fractional: bool = False) -> Expr:
         """
         Extract seconds from underlying DateTime representation.
 
@@ -928,7 +929,7 @@ class ExprDateTimeNameSpace:
             else sec
         )
 
-    def millisecond(self) -> pli.Expr:
+    def millisecond(self) -> Expr:
         """
         Extract milliseconds from underlying DateTime representation.
 
@@ -941,7 +942,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.millisecond())
 
-    def microsecond(self) -> pli.Expr:
+    def microsecond(self) -> Expr:
         """
         Extract microseconds from underlying DateTime representation.
 
@@ -987,7 +988,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.microsecond())
 
-    def nanosecond(self) -> pli.Expr:
+    def nanosecond(self) -> Expr:
         """
         Extract nanoseconds from underlying DateTime representation.
 
@@ -1000,7 +1001,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.nanosecond())
 
-    def epoch(self, tu: EpochTimeUnit = "us") -> pli.Expr:
+    def epoch(self, tu: EpochTimeUnit = "us") -> Expr:
         """
         Get the time passed since the Unix EPOCH in the give time unit.
 
@@ -1045,7 +1046,7 @@ class ExprDateTimeNameSpace:
                 f"tu must be one of {{'ns', 'us', 'ms', 's', 'd'}}, got {tu}"
             )
 
-    def timestamp(self, tu: TimeUnit = "us") -> pli.Expr:
+    def timestamp(self, tu: TimeUnit = "us") -> Expr:
         """
         Return a timestamp in the given time unit.
 
@@ -1081,7 +1082,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.timestamp(tu))
 
-    def with_time_unit(self, tu: TimeUnit) -> pli.Expr:
+    def with_time_unit(self, tu: TimeUnit) -> Expr:
         """
         Set time unit of a Series of dtype Datetime or Duration.
 
@@ -1123,7 +1124,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.dt_with_time_unit(tu))
 
-    def cast_time_unit(self, tu: TimeUnit) -> pli.Expr:
+    def cast_time_unit(self, tu: TimeUnit) -> Expr:
         """
         Cast the underlying data to another time unit. This may lose precision.
 
@@ -1164,7 +1165,7 @@ class ExprDateTimeNameSpace:
         return pli.wrap_expr(self._pyexpr.dt_cast_time_unit(tu))
 
     @deprecated_alias(tz="time_zone")
-    def convert_time_zone(self, time_zone: str) -> pli.Expr:
+    def convert_time_zone(self, time_zone: str) -> Expr:
         """
         Convert to given time zone for a Series of type Datetime.
 
@@ -1208,7 +1209,7 @@ class ExprDateTimeNameSpace:
         return pli.wrap_expr(self._pyexpr.dt_convert_time_zone(time_zone))
 
     @deprecated_alias(tz="time_zone")
-    def replace_time_zone(self, time_zone: str | None) -> pli.Expr:
+    def replace_time_zone(self, time_zone: str | None) -> Expr:
         """
         Replace time zone for a Series of type Datetime.
 
@@ -1257,7 +1258,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.dt_replace_time_zone(time_zone))
 
-    def days(self) -> pli.Expr:
+    def days(self) -> Expr:
         """
         Extract the days from a Duration type.
 
@@ -1295,7 +1296,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_days())
 
-    def hours(self) -> pli.Expr:
+    def hours(self) -> Expr:
         """
         Extract the hours from a Duration type.
 
@@ -1334,7 +1335,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_hours())
 
-    def minutes(self) -> pli.Expr:
+    def minutes(self) -> Expr:
         """
         Extract the minutes from a Duration type.
 
@@ -1373,7 +1374,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_minutes())
 
-    def seconds(self) -> pli.Expr:
+    def seconds(self) -> Expr:
         """
         Extract the seconds from a Duration type.
 
@@ -1413,7 +1414,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_seconds())
 
-    def milliseconds(self) -> pli.Expr:
+    def milliseconds(self) -> Expr:
         """
         Extract the milliseconds from a Duration type.
 
@@ -1457,7 +1458,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_milliseconds())
 
-    def microseconds(self) -> pli.Expr:
+    def microseconds(self) -> Expr:
         """
         Extract the microseconds from a Duration type.
 
@@ -1501,7 +1502,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_microseconds())
 
-    def nanoseconds(self) -> pli.Expr:
+    def nanoseconds(self) -> Expr:
         """
         Extract the nanoseconds from a Duration type.
 
@@ -1545,7 +1546,7 @@ class ExprDateTimeNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.duration_nanoseconds())
 
-    def offset_by(self, by: str) -> pli.Expr:
+    def offset_by(self, by: str) -> Expr:
         """
         Offset this date by a relative time offset.
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import time
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias, redirect

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -9,6 +9,7 @@ from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_a
 if TYPE_CHECKING:
     from datetime import date, datetime, time
 
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
 
 
@@ -17,10 +18,10 @@ class ExprListNameSpace:
 
     _accessor = "arr"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def lengths(self) -> pli.Expr:
+    def lengths(self) -> Expr:
         """
         Get the length of the arrays as UInt32.
 
@@ -41,7 +42,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.arr_lengths())
 
-    def sum(self) -> pli.Expr:
+    def sum(self) -> Expr:
         """
         Sum all the lists in the array.
 
@@ -62,7 +63,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_sum())
 
-    def max(self) -> pli.Expr:
+    def max(self) -> Expr:
         """
         Compute the max value of the lists in the array.
 
@@ -83,7 +84,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_max())
 
-    def min(self) -> pli.Expr:
+    def min(self) -> Expr:
         """
         Compute the min value of the lists in the array.
 
@@ -104,7 +105,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_min())
 
-    def mean(self) -> pli.Expr:
+    def mean(self) -> Expr:
         """
         Compute the mean value of the lists in the array.
 
@@ -127,7 +128,7 @@ class ExprListNameSpace:
 
     @deprecate_nonkeyword_arguments()
     @deprecated_alias(reverse="descending")
-    def sort(self, descending: bool = False) -> pli.Expr:
+    def sort(self, descending: bool = False) -> Expr:
         """
         Sort the arrays in this column.
 
@@ -167,7 +168,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_sort(descending))
 
-    def reverse(self) -> pli.Expr:
+    def reverse(self) -> Expr:
         """
         Reverse the arrays in the list.
 
@@ -192,7 +193,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_reverse())
 
-    def unique(self) -> pli.Expr:
+    def unique(self) -> Expr:
         """
         Get the unique/distinct values in the list.
 
@@ -217,8 +218,8 @@ class ExprListNameSpace:
         return pli.wrap_expr(self._pyexpr.lst_unique())
 
     def concat(
-        self, other: list[pli.Expr | str] | pli.Expr | str | pli.Series | list[Any]
-    ) -> pli.Expr:
+        self, other: list[Expr | str] | Expr | str | pli.Series | list[Any]
+    ) -> Expr:
         """
         Concat the arrays in a Series dtype List in linear time.
 
@@ -252,13 +253,13 @@ class ExprListNameSpace:
         ):
             return self.concat(pli.Series([other]))
 
-        other_list: list[pli.Expr | str | pli.Series]
+        other_list: list[Expr | str | pli.Series]
         other_list = [other] if not isinstance(other, list) else copy.copy(other)  # type: ignore[arg-type]
 
         other_list.insert(0, pli.wrap_expr(self._pyexpr))
         return pli.concat_list(other_list)
 
-    def get(self, index: int | pli.Expr | str) -> pli.Expr:
+    def get(self, index: int | Expr | str) -> Expr:
         """
         Get the value by index in the sublists.
 
@@ -292,9 +293,9 @@ class ExprListNameSpace:
 
     def take(
         self,
-        index: pli.Expr | pli.Series | list[int] | list[list[int]],
+        index: Expr | pli.Series | list[int] | list[list[int]],
         null_on_oob: bool = False,
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Take sublists by multiple indices.
 
@@ -317,10 +318,10 @@ class ExprListNameSpace:
         index = pli.expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
         return pli.wrap_expr(self._pyexpr.lst_take(index, null_on_oob))
 
-    def __getitem__(self, item: int) -> pli.Expr:
+    def __getitem__(self, item: int) -> Expr:
         return self.get(item)
 
-    def first(self) -> pli.Expr:
+    def first(self) -> Expr:
         """
         Get the first value of the sublists.
 
@@ -342,7 +343,7 @@ class ExprListNameSpace:
         """
         return self.get(0)
 
-    def last(self) -> pli.Expr:
+    def last(self) -> Expr:
         """
         Get the last value of the sublists.
 
@@ -365,8 +366,8 @@ class ExprListNameSpace:
         return self.get(-1)
 
     def contains(
-        self, item: float | str | bool | int | date | datetime | time | pli.Expr
-    ) -> pli.Expr:
+        self, item: float | str | bool | int | date | datetime | time | Expr
+    ) -> Expr:
         """
         Check if sublists contain the given item.
 
@@ -399,7 +400,7 @@ class ExprListNameSpace:
             self._pyexpr.arr_contains(pli.expr_to_lit_or_expr(item)._pyexpr)
         )
 
-    def join(self, separator: str) -> pli.Expr:
+    def join(self, separator: str) -> Expr:
         """
         Join all string items in a sublist and place a separator between them.
 
@@ -431,7 +432,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_join(separator))
 
-    def arg_min(self) -> pli.Expr:
+    def arg_min(self) -> Expr:
         """
         Retrieve the index of the minimal value in every sublist.
 
@@ -460,7 +461,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_arg_min())
 
-    def arg_max(self) -> pli.Expr:
+    def arg_max(self) -> Expr:
         """
         Retrieve the index of the maximum value in every sublist.
 
@@ -489,7 +490,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_arg_max())
 
-    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> pli.Expr:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Expr:
         """
         Calculate the n-th discrete difference of every sublist.
 
@@ -539,7 +540,7 @@ class ExprListNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.lst_diff(n, null_behavior))
 
-    def shift(self, periods: int = 1) -> pli.Expr:
+    def shift(self, periods: int = 1) -> Expr:
         """
         Shift values by the given period.
 
@@ -563,8 +564,8 @@ class ExprListNameSpace:
         return pli.wrap_expr(self._pyexpr.lst_shift(periods))
 
     def slice(
-        self, offset: int | str | pli.Expr, length: int | str | pli.Expr | None = None
-    ) -> pli.Expr:
+        self, offset: int | str | Expr, length: int | str | Expr | None = None
+    ) -> Expr:
         """
         Slice every sublist.
 
@@ -592,7 +593,7 @@ class ExprListNameSpace:
         length = pli.expr_to_lit_or_expr(length, str_to_lit=False)._pyexpr
         return pli.wrap_expr(self._pyexpr.lst_slice(offset, length))
 
-    def head(self, n: int | str | pli.Expr = 5) -> pli.Expr:
+    def head(self, n: int | str | Expr = 5) -> Expr:
         """
         Slice the first `n` values of every sublist.
 
@@ -615,7 +616,7 @@ class ExprListNameSpace:
         """
         return self.slice(0, n)
 
-    def tail(self, n: int | str | pli.Expr = 5) -> pli.Expr:
+    def tail(self, n: int | str | Expr = 5) -> Expr:
         """
         Slice the last `n` values of every sublist.
 
@@ -639,7 +640,7 @@ class ExprListNameSpace:
         offset = -pli.expr_to_lit_or_expr(n, str_to_lit=False)
         return self.slice(offset, n)
 
-    def explode(self) -> pli.Expr:
+    def explode(self) -> Expr:
         """
         Returns a column with a separate row for every list element.
 
@@ -673,8 +674,8 @@ class ExprListNameSpace:
         return pli.wrap_expr(self._pyexpr.explode())
 
     def count_match(
-        self, element: float | str | bool | int | date | datetime | time | pli.Expr
-    ) -> pli.Expr:
+        self, element: float | str | bool | int | date | datetime | time | Expr
+    ) -> Expr:
         """
         Count how often the value produced by ``element`` occurs.
 
@@ -710,7 +711,7 @@ class ExprListNameSpace:
         n_field_strategy: ToStructStrategy = "first_non_null",
         name_generator: Callable[[int], str] | None = None,
         upper_bound: int = 0,
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Convert the series of type ``List`` to a series of type ``Struct``.
 
@@ -758,7 +759,7 @@ class ExprListNameSpace:
             self._pyexpr.lst_to_struct(n_field_strategy, name_generator, upper_bound)
         )
 
-    def eval(self, expr: pli.Expr, parallel: bool = False) -> pli.Expr:
+    def eval(self, expr: Expr, parallel: bool = False) -> Expr:
         """
         Run any polars expression against the lists' elements.
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Callable
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from polars import internals as pli
+
+if TYPE_CHECKING:
+    from polars.expr.expr import Expr
 
 
 class ExprMetaNameSpace:
@@ -8,16 +13,16 @@ class ExprMetaNameSpace:
 
     _accessor = "meta"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def __eq__(self, other: ExprMetaNameSpace | pli.Expr) -> bool:  # type: ignore[override]
+    def __eq__(self, other: ExprMetaNameSpace | Expr) -> bool:  # type: ignore[override]
         return self._pyexpr.meta_eq(other._pyexpr)
 
-    def __ne__(self, other: ExprMetaNameSpace | pli.Expr) -> bool:  # type: ignore[override]
+    def __ne__(self, other: ExprMetaNameSpace | Expr) -> bool:  # type: ignore[override]
         return not self == other
 
-    def pop(self) -> list[pli.Expr]:
+    def pop(self) -> list[Expr]:
         """
         Pop the latest expression and return the input(s) of the popped expression.
 
@@ -45,7 +50,7 @@ class ExprMetaNameSpace:
         """
         return self._pyexpr.meta_output_name()
 
-    def undo_aliases(self) -> pli.Expr:
+    def undo_aliases(self) -> Expr:
         """Undo any renaming operation like ``alias`` or ``keep_name``."""
         return pli.wrap_expr(self._pyexpr.meta_undo_aliases())
 

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import polars.internals as pli
+from polars import internals as pli
 
 
 class ExprMetaNameSpace:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -14,6 +14,7 @@ from polars.datatypes import (
 
 if TYPE_CHECKING:
     from polars.datatypes import PolarsDataType, PolarsTemporalType
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import TransferEncoding
 
 
@@ -22,7 +23,7 @@ class ExprStringNameSpace:
 
     _accessor = "str"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
     def strptime(
@@ -34,7 +35,7 @@ class ExprStringNameSpace:
         cache: bool = True,
         tz_aware: bool = False,
         utc: bool = False,
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Parse a Utf8 expression to a Date/Datetime/Time type.
 
@@ -136,7 +137,7 @@ class ExprStringNameSpace:
         else:  # pragma: no cover
             raise ValueError("dtype should be of type {Date, Datetime, Time}")
 
-    def lengths(self) -> pli.Expr:
+    def lengths(self) -> Expr:
         """
         Get length of the strings as UInt32 (as number of bytes).
 
@@ -169,7 +170,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_lengths())
 
-    def n_chars(self) -> pli.Expr:
+    def n_chars(self) -> Expr:
         """
         Get length of the strings as UInt32 (as number of chars).
 
@@ -202,7 +203,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_n_chars())
 
-    def concat(self, delimiter: str = "-") -> pli.Expr:
+    def concat(self, delimiter: str = "-") -> Expr:
         """
         Vertically concat the values in the Series to a single string value.
 
@@ -231,7 +232,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_concat(delimiter))
 
-    def to_uppercase(self) -> pli.Expr:
+    def to_uppercase(self) -> Expr:
         """
         Transform to uppercase variant.
 
@@ -252,7 +253,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_to_uppercase())
 
-    def to_lowercase(self) -> pli.Expr:
+    def to_lowercase(self) -> Expr:
         """
         Transform to lowercase variant.
 
@@ -273,7 +274,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_to_lowercase())
 
-    def strip(self, matches: str | None = None) -> pli.Expr:
+    def strip(self, matches: str | None = None) -> Expr:
         r"""
         Remove leading and trailing characters.
 
@@ -315,7 +316,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_strip(matches))
 
-    def lstrip(self, matches: str | None = None) -> pli.Expr:
+    def lstrip(self, matches: str | None = None) -> Expr:
         r"""
         Remove leading characters.
 
@@ -357,7 +358,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_lstrip(matches))
 
-    def rstrip(self, matches: str | None = None) -> pli.Expr:
+    def rstrip(self, matches: str | None = None) -> Expr:
         r"""
         Remove trailing characters.
 
@@ -399,7 +400,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_rstrip(matches))
 
-    def zfill(self, alignment: int) -> pli.Expr:
+    def zfill(self, alignment: int) -> Expr:
         """
         Fills the string with zeroes.
 
@@ -443,7 +444,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_zfill(alignment))
 
-    def ljust(self, width: int, fillchar: str = " ") -> pli.Expr:
+    def ljust(self, width: int, fillchar: str = " ") -> Expr:
         """
         Return the string left justified in a string of length ``width``.
 
@@ -477,7 +478,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_ljust(width, fillchar))
 
-    def rjust(self, width: int, fillchar: str = " ") -> pli.Expr:
+    def rjust(self, width: int, fillchar: str = " ") -> Expr:
         """
         Return the string right justified in a string of length ``width``.
 
@@ -512,8 +513,8 @@ class ExprStringNameSpace:
         return pli.wrap_expr(self._pyexpr.str_rjust(width, fillchar))
 
     def contains(
-        self, pattern: str | pli.Expr, literal: bool = False, strict: bool = True
-    ) -> pli.Expr:
+        self, pattern: str | Expr, literal: bool = False, strict: bool = True
+    ) -> Expr:
         """
         Check if string contains a substring that matches a regex.
 
@@ -558,7 +559,7 @@ class ExprStringNameSpace:
         pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
-    def ends_with(self, sub: str | pli.Expr) -> pli.Expr:
+    def ends_with(self, sub: str | Expr) -> Expr:
         """
         Check if string values end with a substring.
 
@@ -605,7 +606,7 @@ class ExprStringNameSpace:
         sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_ends_with(sub))
 
-    def starts_with(self, sub: str | pli.Expr) -> pli.Expr:
+    def starts_with(self, sub: str | Expr) -> Expr:
         """
         Check if string values start with a substring.
 
@@ -652,7 +653,7 @@ class ExprStringNameSpace:
         sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_starts_with(sub))
 
-    def json_extract(self, dtype: PolarsDataType | None = None) -> pli.Expr:
+    def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
         """
         Parse string values as JSON.
 
@@ -692,7 +693,7 @@ class ExprStringNameSpace:
             dtype = py_type_to_dtype(dtype)
         return pli.wrap_expr(self._pyexpr.str_json_extract(dtype))
 
-    def json_path_match(self, json_path: str) -> pli.Expr:
+    def json_path_match(self, json_path: str) -> Expr:
         """
         Extract the first match of json string with provided JSONPath expression.
 
@@ -734,7 +735,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_json_path_match(json_path))
 
-    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> pli.Expr:
+    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> Expr:
         """
         Decode a value using the provided encoding.
 
@@ -756,7 +757,7 @@ class ExprStringNameSpace:
                 f"encoding must be one of {{'hex', 'base64'}}, got {encoding}"
             )
 
-    def encode(self, encoding: TransferEncoding) -> pli.Expr:
+    def encode(self, encoding: TransferEncoding) -> Expr:
         """
         Encode a value using the provided encoding.
 
@@ -794,7 +795,7 @@ class ExprStringNameSpace:
                 f"encoding must be one of {{'hex', 'base64'}}, got {encoding}"
             )
 
-    def extract(self, pattern: str, group_index: int = 1) -> pli.Expr:
+    def extract(self, pattern: str, group_index: int = 1) -> Expr:
         r"""
         Extract the target capture group from provided patterns.
 
@@ -841,7 +842,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_extract(pattern, group_index))
 
-    def extract_all(self, pattern: str | pli.Expr) -> pli.Expr:
+    def extract_all(self, pattern: str | Expr) -> Expr:
         r"""
         Extracts all matches for the given regex pattern.
 
@@ -880,7 +881,7 @@ class ExprStringNameSpace:
         pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)
         return pli.wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
 
-    def count_match(self, pattern: str) -> pli.Expr:
+    def count_match(self, pattern: str) -> Expr:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -914,7 +915,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.count_match(pattern))
 
-    def split(self, by: str, inclusive: bool = False) -> pli.Expr:
+    def split(self, by: str, inclusive: bool = False) -> Expr:
         """
         Split the string by a substring.
 
@@ -949,7 +950,7 @@ class ExprStringNameSpace:
             return pli.wrap_expr(self._pyexpr.str_split_inclusive(by))
         return pli.wrap_expr(self._pyexpr.str_split(by))
 
-    def split_exact(self, by: str, n: int, inclusive: bool = False) -> pli.Expr:
+    def split_exact(self, by: str, n: int, inclusive: bool = False) -> Expr:
         """
         Split the string by a substring using ``n`` splits.
 
@@ -1019,7 +1020,7 @@ class ExprStringNameSpace:
             return pli.wrap_expr(self._pyexpr.str_split_exact_inclusive(by, n))
         return pli.wrap_expr(self._pyexpr.str_split_exact(by, n))
 
-    def splitn(self, by: str, n: int) -> pli.Expr:
+    def splitn(self, by: str, n: int) -> Expr:
         """
         Split the string by a substring, restricted to returning at most ``n`` items.
 
@@ -1082,12 +1083,12 @@ class ExprStringNameSpace:
 
     def replace(
         self,
-        pattern: str | pli.Expr,
-        value: str | pli.Expr,
+        pattern: str | Expr,
+        value: str | Expr,
         literal: bool = False,
         *,
         n: int = 1,
-    ) -> pli.Expr:
+    ) -> Expr:
         r"""
         Replace first matching regex/literal substring with a new string value.
 
@@ -1130,8 +1131,8 @@ class ExprStringNameSpace:
         )
 
     def replace_all(
-        self, pattern: str | pli.Expr, value: str | pli.Expr, literal: bool = False
-    ) -> pli.Expr:
+        self, pattern: str | Expr, value: str | Expr, literal: bool = False
+    ) -> Expr:
         """
         Replace all matching regex/literal substrings with a new string value.
 
@@ -1169,7 +1170,7 @@ class ExprStringNameSpace:
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )
 
-    def slice(self, offset: int, length: int | None = None) -> pli.Expr:
+    def slice(self, offset: int, length: int | None = None) -> Expr:
         """
         Create subslices of the string values of a Utf8 Series.
 
@@ -1224,7 +1225,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.str_slice(offset, length))
 
-    def explode(self) -> pli.Expr:
+    def explode(self) -> Expr:
         """
         Returns a column with a separate row for every string character.
 
@@ -1253,7 +1254,7 @@ class ExprStringNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.explode())
 
-    def parse_int(self, radix: int = 2, strict: bool = True) -> pli.Expr:
+    def parse_int(self, radix: int = 2, strict: bool = True) -> Expr:
         """
         Parse integers with base radix from strings.
 

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import (
     DataType,
     Date,

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from polars import internals as pli
+
+if TYPE_CHECKING:
+    from polars.expr.expr import Expr
 
 
 class ExprStructNameSpace:
@@ -10,10 +13,10 @@ class ExprStructNameSpace:
 
     _accessor = "struct"
 
-    def __init__(self, expr: pli.Expr):
+    def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def __getitem__(self, item: str | int) -> pli.Expr:
+    def __getitem__(self, item: str | int) -> Expr:
         if isinstance(item, str):
             return self.field(item)
         elif isinstance(item, int):
@@ -23,7 +26,7 @@ class ExprStructNameSpace:
                 f"expected type 'int | str', got {type(item).__name__} ({item!r})"
             )
 
-    def field(self, name: str) -> pli.Expr:
+    def field(self, name: str) -> Expr:
         """
         Retrieve a ``Struct`` field as a new Series.
 
@@ -83,7 +86,7 @@ class ExprStructNameSpace:
         """
         return pli.wrap_expr(self._pyexpr.struct_field_by_name(name))
 
-    def rename_fields(self, names: Sequence[str]) -> pli.Expr:
+    def rename_fields(self, names: Sequence[str]) -> Expr:
         """
         Rename the fields of the struct.
 

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-import polars.internals as pli
+from polars import internals as pli
 
 
 class ExprStructNameSpace:

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -3,7 +3,8 @@ Core Polars functionality.
 
 The modules within `polars.internals` are interdependent. To prevent cyclical imports,
 they all import from each other via this __init__ file using
-`import polars.internals as pli`. The imports below are being shared across this module.
+`from polars import internals as pli`. The imports below are being shared across this
+module.
 """
 from polars.dataframe import DataFrame, wrap_df
 from polars.expr import (

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import pickle
 from functools import partial
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import polars as pl
 from polars import internals as pli
 from polars.dependencies import pyarrow as pa  # noqa: TCH001
 
+if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
+    from polars.lazyframe.frame import LazyFrame
+
 
 def _deser_and_exec(  # noqa: D417
     buf: bytes, with_columns: list[str] | None, *args: Any
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Deserialize and execute the given function for the projected columns.
 
@@ -35,7 +39,7 @@ def _scan_pyarrow_dataset_impl(
     with_columns: list[str] | None,
     predicate: str | None,
     n_rows: int | None,
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
@@ -79,7 +83,7 @@ def _scan_pyarrow_dataset_impl(
 
 def _scan_pyarrow_dataset(
     ds: pa.dataset.Dataset, allow_pyarrow_filter: bool = True
-) -> pli.LazyFrame:
+) -> LazyFrame:
     """
     Pickle the partially applied function `_scan_pyarrow_dataset_impl`.
 
@@ -105,7 +109,7 @@ def _scan_pyarrow_dataset(
 
 def _scan_ipc_impl(  # noqa: D417
     uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
@@ -125,7 +129,7 @@ def _scan_ipc_impl(  # noqa: D417
 def _scan_ipc_fsspec(
     file: str,
     storage_options: dict[str, object] | None = None,
-) -> pli.LazyFrame:
+) -> LazyFrame:
     func = partial(_scan_ipc_impl, file, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 
@@ -138,7 +142,7 @@ def _scan_ipc_fsspec(
 
 def _scan_parquet_impl(  # noqa: D417
     uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
@@ -158,7 +162,7 @@ def _scan_parquet_impl(  # noqa: D417
 def _scan_parquet_fsspec(
     file: str,
     storage_options: dict[str, object] | None = None,
-) -> pli.LazyFrame:
+) -> LazyFrame:
     func = partial(_scan_parquet_impl, file, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -20,6 +20,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyBatchedCsv
 
 if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import PolarsDataType, SchemaDict
     from polars.internals.type_aliases import CsvEncoding
 
@@ -101,7 +102,7 @@ class BatchedCsvReader:
         )
         self.new_columns = new_columns
 
-    def next_batches(self, n: int) -> list[pli.DataFrame] | None:
+    def next_batches(self, n: int) -> list[DataFrame] | None:
         """
         Read ``n`` batches from the reader.
 

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -4,7 +4,7 @@ import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import (
     N_INFER_DEFAULT,
     py_type_to_dtype,

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -25,8 +25,12 @@ if TYPE_CHECKING:
     import sys
     from datetime import date
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import PolarsDataType
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit
+    from polars.lazyframe.frame import LazyFrame
+    from polars.series.series import Series
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -35,11 +39,11 @@ if TYPE_CHECKING:
 
 
 def get_dummies(
-    df: pli.DataFrame,
+    df: DataFrame,
     *,
     columns: str | Sequence[str] | None = None,
     separator: str = "_",
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Convert categorical variables into dummy/indicator variables.
 
@@ -87,56 +91,53 @@ def get_dummies(
 
 @overload
 def concat(
-    items: Iterable[pli.DataFrame],
+    items: Iterable[DataFrame],
     rechunk: bool = True,
     how: ConcatMethod = "vertical",
     parallel: bool = True,
-) -> pli.DataFrame:
+) -> DataFrame:
     ...
 
 
 @overload
 def concat(
-    items: Iterable[pli.Series],
+    items: Iterable[Series],
     rechunk: bool = True,
     how: ConcatMethod = "vertical",
     parallel: bool = True,
-) -> pli.Series:
+) -> Series:
     ...
 
 
 @overload
 def concat(
-    items: Iterable[pli.LazyFrame],
+    items: Iterable[LazyFrame],
     rechunk: bool = True,
     how: ConcatMethod = "vertical",
     parallel: bool = True,
-) -> pli.LazyFrame:
+) -> LazyFrame:
     ...
 
 
 @overload
 def concat(
-    items: Iterable[pli.Expr],
+    items: Iterable[Expr],
     rechunk: bool = True,
     how: ConcatMethod = "vertical",
     parallel: bool = True,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
 @deprecate_nonkeyword_arguments()
 def concat(
     items: (
-        Iterable[pli.DataFrame]
-        | Iterable[pli.Series]
-        | Iterable[pli.LazyFrame]
-        | Iterable[pli.Expr]
+        Iterable[DataFrame] | Iterable[Series] | Iterable[LazyFrame] | Iterable[Expr]
     ),
     rechunk: bool = True,
     how: ConcatMethod = "vertical",
     parallel: bool = True,
-) -> pli.DataFrame | pli.Series | pli.LazyFrame | pli.Expr:
+) -> DataFrame | Series | LazyFrame | Expr:
     """
     Aggregate multiple Dataframes/Series to a single DataFrame/Series.
 
@@ -239,7 +240,7 @@ def concat(
     if not len(elems) > 0:
         raise ValueError("cannot concat empty list")
 
-    out: pli.Series | pli.DataFrame | pli.LazyFrame | pli.Expr
+    out: Series | DataFrame | LazyFrame | Expr
     first = elems[0]
     if isinstance(first, pli.DataFrame):
         if how == "vertical":
@@ -290,8 +291,8 @@ def _interval_granularity(interval: str) -> str:
 
 @overload
 def date_range(
-    low: pli.Expr,
-    high: date | datetime | pli.Expr | str,
+    low: Expr,
+    high: date | datetime | Expr | str,
     interval: str | timedelta = ...,
     *,
     lazy: Literal[False] = ...,
@@ -299,14 +300,14 @@ def date_range(
     name: str | None = ...,
     time_unit: TimeUnit | None = ...,
     time_zone: str | None = ...,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
 @overload
 def date_range(
-    low: date | datetime | pli.Expr | str,
-    high: pli.Expr,
+    low: date | datetime | Expr | str,
+    high: Expr,
     interval: str | timedelta = ...,
     *,
     lazy: Literal[False] = ...,
@@ -314,7 +315,7 @@ def date_range(
     name: str | None = ...,
     time_unit: TimeUnit | None = ...,
     time_zone: str | None = ...,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
@@ -329,14 +330,14 @@ def date_range(
     name: str | None = ...,
     time_unit: TimeUnit | None = ...,
     time_zone: str | None = ...,
-) -> pli.Series:
+) -> Series:
     ...
 
 
 @overload
 def date_range(
-    low: date | datetime | pli.Expr | str,
-    high: date | datetime | pli.Expr | str,
+    low: date | datetime | Expr | str,
+    high: date | datetime | Expr | str,
     interval: str | timedelta = ...,
     *,
     lazy: Literal[True],
@@ -344,13 +345,13 @@ def date_range(
     name: str | None = None,
     time_unit: TimeUnit | None = ...,
     time_zone: str | None = ...,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
 def date_range(
-    low: date | datetime | pli.Expr | str,
-    high: date | datetime | pli.Expr | str,
+    low: date | datetime | Expr | str,
+    high: date | datetime | Expr | str,
     interval: str | timedelta = "1d",
     *,
     lazy: bool = False,
@@ -358,7 +359,7 @@ def date_range(
     name: str | None = None,
     time_unit: TimeUnit | None = None,
     time_zone: str | None = None,
-) -> pli.Series | pli.Expr:
+) -> Series | Expr:
     """
     Create a range of type `Datetime` (or `Date`).
 
@@ -503,12 +504,12 @@ def date_range(
 
 
 def cut(
-    s: pli.Series,
+    s: Series,
     bins: list[float],
     labels: list[str] | None = None,
     break_point_label: str = "break_point",
     category_label: str = "category",
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Bin values into discrete values.
 
@@ -570,31 +571,31 @@ def cut(
 
 @overload
 def align_frames(
-    *frames: pli.DataFrame,
-    on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
-    select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+    *frames: DataFrame,
+    on: str | Expr | Sequence[str] | Sequence[Expr] | Sequence[str | Expr],
+    select: str | Expr | Sequence[str | Expr] | None = None,
     descending: bool | Sequence[bool] = False,
-) -> list[pli.DataFrame]:
+) -> list[DataFrame]:
     ...
 
 
 @overload
 def align_frames(
-    *frames: pli.LazyFrame,
-    on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
-    select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+    *frames: LazyFrame,
+    on: str | Expr | Sequence[str] | Sequence[Expr] | Sequence[str | Expr],
+    select: str | Expr | Sequence[str | Expr] | None = None,
     descending: bool | Sequence[bool] = False,
-) -> list[pli.LazyFrame]:
+) -> list[LazyFrame]:
     ...
 
 
 @deprecated_alias(reverse="descending")
 def align_frames(
-    *frames: pli.DataFrame | pli.LazyFrame,
-    on: str | pli.Expr | Sequence[str] | Sequence[pli.Expr] | Sequence[str | pli.Expr],
-    select: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+    *frames: DataFrame | LazyFrame,
+    on: str | Expr | Sequence[str] | Sequence[Expr] | Sequence[str | Expr],
+    select: str | Expr | Sequence[str | Expr] | None = None,
     descending: bool | Sequence[bool] = False,
-) -> list[pli.DataFrame] | list[pli.LazyFrame]:
+) -> list[DataFrame] | list[LazyFrame]:
     r"""
     Align a sequence of frames using the unique values from one or more columns as a key.
 
@@ -753,7 +754,7 @@ def align_frames(
     return [df.collect() for df in aligned_frames] if eager else aligned_frames
 
 
-def ones(n: int, dtype: PolarsDataType | None = None) -> pli.Series:
+def ones(n: int, dtype: PolarsDataType | None = None) -> Series:
     """
     Return a new Series of given length and type, filled with ones.
 
@@ -789,7 +790,7 @@ def ones(n: int, dtype: PolarsDataType | None = None) -> pli.Series:
     return s.new_from_index(0, n)
 
 
-def zeros(n: int, dtype: PolarsDataType | None = None) -> pli.Series:
+def zeros(n: int, dtype: PolarsDataType | None = None) -> Series:
     """
     Return a new Series of given length and type, filled with zeros.
 

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -24,7 +24,7 @@ with suppress(ImportError):
     from polars.polars import parquet_schema as _parquet_schema
 
 if TYPE_CHECKING:
-    from polars import internals as pli
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import PolarsDataType
 
 
@@ -245,7 +245,7 @@ def _is_local_file(file: str) -> bool:
         return False
 
 
-def _update_columns(df: pli.DataFrame, new_columns: list[str]) -> pli.DataFrame:
+def _update_columns(df: DataFrame, new_columns: list[str]) -> DataFrame:
     if df.width > len(new_columns):
         cols = df.columns
         for i, name in enumerate(new_columns):

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -24,7 +24,7 @@ with suppress(ImportError):
     from polars.polars import parquet_schema as _parquet_schema
 
 if TYPE_CHECKING:
-    import polars.internals as pli
+    from polars import internals as pli
     from polars.datatypes import PolarsDataType
 
 

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from xlsxwriter import Workbook
     from xlsxwriter.worksheet import Worksheet
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
 
     if sys.version_info >= (3, 10):
@@ -67,7 +68,7 @@ ConditionalFormatDict: TypeAlias = Dict[
 ]
 
 
-def _adjacent_cols(df: pli.DataFrame, cols: Iterable[str]) -> bool:
+def _adjacent_cols(df: DataFrame, cols: Iterable[str]) -> bool:
     """Indicate if the given columns are all adjacent to one another."""
     idxs = sorted(df.find_idx_by_name(col) for col in cols)
     return idxs == sorted(range(min(idxs), max(idxs) + 1))
@@ -89,7 +90,7 @@ def _unpack_multi_column_dict(
 
 
 def _xl_apply_conditional_formats(
-    df: pli.DataFrame,
+    df: DataFrame,
     workbook: Workbook,
     worksheet: Worksheet,
     conditional_formats: ConditionalFormatDict,
@@ -131,7 +132,7 @@ def _xl_apply_conditional_formats(
 
 @overload
 def _xl_column_range(  # type: ignore[misc]
-    df: pli.DataFrame,
+    df: DataFrame,
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     has_header: bool,
@@ -142,7 +143,7 @@ def _xl_column_range(  # type: ignore[misc]
 
 @overload
 def _xl_column_range(
-    df: pli.DataFrame,
+    df: DataFrame,
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     has_header: bool,
@@ -152,7 +153,7 @@ def _xl_column_range(
 
 
 def _xl_column_range(
-    df: pli.DataFrame,
+    df: DataFrame,
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     has_header: bool,
@@ -174,7 +175,7 @@ def _xl_column_range(
 
 
 def _xl_column_multi_range(
-    df: pli.DataFrame,
+    df: DataFrame,
     table_start: tuple[int, int],
     cols: Iterable[str],
     has_header: bool,
@@ -189,8 +190,8 @@ def _xl_column_multi_range(
 
 
 def _xl_inject_dummy_table_columns(
-    df: pli.DataFrame, options: dict[str, Sequence[str] | dict[str, Any]]
-) -> pli.DataFrame:
+    df: DataFrame, options: dict[str, Sequence[str] | dict[str, Any]]
+) -> DataFrame:
     """Insert dummy frame columns in order to create empty/named table columns."""
     df_original_columns = set(df.columns)
     df_select_cols = df.columns.copy()
@@ -224,7 +225,7 @@ def _xl_inject_dummy_table_columns(
 
 def _xl_inject_sparklines(
     ws: Worksheet,
-    df: pli.DataFrame,
+    df: DataFrame,
     table_start: tuple[int, int],
     col: str,
     has_header: bool,
@@ -275,14 +276,14 @@ def _xl_rowcols_to_range(*row_col_pairs: int) -> list[str]:
 
 
 def _xl_setup_table_columns(
-    df: pli.DataFrame,
+    df: DataFrame,
     wb: Workbook,
     column_totals: ColumnTotalsDefinition | None = None,
     column_formats: dict[str | tuple[str, ...], str] | None = None,
     dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
     sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
     float_precision: int = 3,
-) -> tuple[list[dict[str, Any]], pli.DataFrame]:
+) -> tuple[list[dict[str, Any]], DataFrame]:
     """Setup and unify all column-related formatting/defaults."""
     column_totals = _unpack_multi_column_dict(column_totals)  # type: ignore[assignment]
     column_formats = _unpack_multi_column_dict(column_formats)  # type: ignore[assignment]

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -13,7 +13,7 @@ from typing import (
     overload,
 )
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import (
     FLOAT_DTYPES,
     INTEGER_DTYPES,

--- a/py-polars/polars/io/csv.py
+++ b/py-polars/polars/io/csv.py
@@ -12,7 +12,7 @@ from typing import (
     cast,
 )
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.convert import from_arrow
 from polars.datatypes import N_INFER_DEFAULT, Utf8
 from polars.internals import DataFrame, LazyFrame

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -7,7 +7,7 @@ from polars.convert import from_arrow
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
-    import polars.internals as pli
+    from polars import internals as pli
     from polars.internals.type_aliases import DbReadEngine
 
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -68,7 +68,9 @@ if TYPE_CHECKING:
 
     import pyarrow as pa
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -85,6 +87,7 @@ if TYPE_CHECKING:
         StartBy,
         UniqueKeepStrategy,
     )
+    from polars.series.series import Series
 
     if sys.version_info >= (3, 10):
         from typing import Concatenate, ParamSpec
@@ -1103,7 +1106,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         """
 
-        def inspect(s: pli.DataFrame) -> pli.DataFrame:
+        def inspect(s: DataFrame) -> DataFrame:
             print(fmt.format(s))
             return s
 
@@ -1225,7 +1228,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         truncate_nodes: int = 0,
         figsize: tuple[int, int] = (18, 8),
         streaming: bool = False,
-    ) -> tuple[pli.DataFrame, pli.DataFrame]:
+    ) -> tuple[DataFrame, DataFrame]:
         """
         Profile a LazyFrame.
 
@@ -1365,7 +1368,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
         streaming: bool = False,
-    ) -> pli.DataFrame:
+    ) -> DataFrame:
         """
         Collect into a DataFrame.
 
@@ -1453,7 +1456,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         simplify_expression: bool = True,
         no_optimization: bool = False,
         slice_pushdown: bool = True,
-    ) -> pli.DataFrame:
+    ) -> DataFrame:
         """
         Persists a LazyFrame at the provided path.
 
@@ -1549,7 +1552,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         simplify_expression: bool = True,
         no_optimization: bool = False,
         slice_pushdown: bool = True,
-    ) -> pli.DataFrame:
+    ) -> DataFrame:
         """
         Persists a LazyFrame at the provided path.
 
@@ -1620,7 +1623,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         slice_pushdown: bool = True,
         common_subplan_elimination: bool = True,
         streaming: bool = False,
-    ) -> pli.DataFrame:
+    ) -> DataFrame:
         """
         Collect a small number of rows for debugging purposes.
 
@@ -1796,7 +1799,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.clone())
 
-    def filter(self, predicate: pli.Expr | str | pli.Series | list[bool]) -> Self:
+    def filter(self, predicate: Expr | str | Series | list[bool]) -> Self:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
@@ -2510,9 +2513,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def join_asof(
         self,
         other: LazyFrame,
-        left_on: str | None | pli.Expr = None,
-        right_on: str | None | pli.Expr = None,
-        on: str | None | pli.Expr = None,
+        left_on: str | None | Expr = None,
+        right_on: str | None | Expr = None,
+        on: str | None | Expr = None,
         by_left: str | Sequence[str] | None = None,
         by_right: str | Sequence[str] | None = None,
         by: str | Sequence[str] | None = None,
@@ -2692,9 +2695,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def join(
         self,
         other: LazyFrame,
-        left_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-        right_on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
-        on: str | pli.Expr | Sequence[str | pli.Expr] | None = None,
+        left_on: str | Expr | Sequence[str | Expr] | None = None,
+        right_on: str | Expr | Sequence[str | Expr] | None = None,
+        on: str | Expr | Sequence[str | Expr] | None = None,
         how: JoinStrategy = "inner",
         suffix: str = "_right",
         allow_parallel: bool = True,
@@ -2838,12 +2841,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             str
             | PolarsExprType
             | PythonLiteral
-            | pli.Series
-            | Iterable[str | PolarsExprType | PythonLiteral | pli.Series | None]
+            | Series
+            | Iterable[str | PolarsExprType | PythonLiteral | Series | None]
             | None
         ) = None,
-        *more_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
-        **named_exprs: str | PolarsExprType | PythonLiteral | pli.Series | None,
+        *more_exprs: str | PolarsExprType | PythonLiteral | Series | None,
+        **named_exprs: str | PolarsExprType | PythonLiteral | Series | None,
     ) -> Self:
         """
         Add columns to this DataFrame.
@@ -3249,7 +3252,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def shift_and_fill(
         self,
         periods: int,
-        fill_value: pli.Expr | int | str | float,
+        fill_value: Expr | int | str | float,
     ) -> Self:
         """
         Shift the values by a given period and fill the resulting null values.
@@ -3726,7 +3729,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self.select(pli.all().fill_null(value, strategy, limit))
 
-    def fill_nan(self, fill_value: int | float | pli.Expr | None) -> Self:
+    def fill_nan(self, fill_value: int | float | Expr | None) -> Self:
         """
         Fill floating point NaN values.
 
@@ -3961,7 +3964,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def quantile(
         self,
-        quantile: float | pli.Expr,
+        quantile: float | Expr,
         interpolation: RollingInterpolationMethod = "nearest",
     ) -> Self:
         """
@@ -3998,8 +4001,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def explode(
         self,
-        columns: str | Sequence[str] | pli.Expr | Sequence[pli.Expr],
-        *more_columns: str | pli.Expr,
+        columns: str | Sequence[str] | Expr | Sequence[Expr],
+        *more_columns: str | Expr,
     ) -> Self:
         """
         Explode the dataframe to long format by exploding the given columns.
@@ -4278,7 +4281,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @deprecate_nonkeyword_arguments()
     def map(
         self,
-        function: Callable[[pli.DataFrame], pli.DataFrame],
+        function: Callable[[DataFrame], DataFrame],
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         slice_pushdown: bool = True,

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
 from polars.utils.decorators import deprecated_alias
 

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    import polars.internals as pli
+    from polars import internals as pli
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
 

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    import polars.internals as pli
+    from polars import internals as pli
     from polars.internals.type_aliases import CategoricalOrdering
     from polars.polars import PySeries
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.series.utils import expr_dispatch
 from polars.utils.convert import _to_python_datetime
 from polars.utils.decorators import deprecated_alias, redirect

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.series.utils import expr_dispatch
 from polars.utils.decorators import deprecate_nonkeyword_arguments
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Sequence
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.series.utils import expr_dispatch
 from polars.utils.decorators import redirect
 from polars.utils.various import sphinx_accessor

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -5,7 +5,7 @@ import sys
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import dtype_to_ffiname
 
 if TYPE_CHECKING:

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -1,6 +1,6 @@
 import contextlib
 
-import polars.internals as pli
+from polars import internals as pli
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -26,7 +26,7 @@ from hypothesis.strategies import (
 )
 from hypothesis.strategies._internal.utils import defines_strategy
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import (
     Boolean,
     Categorical,

--- a/py-polars/polars/testing/_private.py
+++ b/py-polars/polars/testing/_private.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import polars.internals as pli
+    from polars import internals as pli
 
 
 def _to_rust_syntax(df: pli.DataFrame) -> str:

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from typing import Any
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import (
     Boolean,
     Categorical,

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import MappingView, Sized
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
 
-import polars.internals as pli
+from polars import internals as pli
 from polars.datatypes import Int64, is_polars_dtype
 
 with contextlib.suppress(ImportError):  # Module not available when building docs


### PR DESCRIPTION
By using `TYPE_CHECKING` blocks, we can directly import the classes for our type hints. No issues with circular imports. This makes the type hints more readable.

This turned out to be a lot of work searching/replacing 😅 so I'm breaking it up into two parts.