### PR TITLE
refactor(python): Avoid `pli` in type hints (part 2)

### DIFF
--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -62,7 +62,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import PolarsDataType, SchemaDict
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import (
         CorrelationMethod,
         EpochTimeUnit,
@@ -70,6 +72,8 @@ if TYPE_CHECKING:
         RollingInterpolationMethod,
         TimeUnit,
     )
+    from polars.lazyframe.frame import LazyFrame
+    from polars.series.series import Series
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -80,7 +84,7 @@ if TYPE_CHECKING:
 def col(
     name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
     *more_names: str | PolarsDataType,
-) -> pli.Expr:
+) -> Expr:
     """
     Return an expression representing column(s) in a dataframe.
 
@@ -249,7 +253,7 @@ def col(
         )
 
 
-def element() -> pli.Expr:
+def element() -> Expr:
     """
     Alias for an element being evaluated in an `eval` expression.
 
@@ -294,21 +298,21 @@ def element() -> pli.Expr:
 
 
 @overload
-def count(column: str) -> pli.Expr:
+def count(column: str) -> Expr:
     ...
 
 
 @overload
-def count(column: pli.Series) -> int:
+def count(column: Series) -> int:
     ...
 
 
 @overload
-def count(column: None = None) -> pli.Expr:
+def count(column: None = None) -> Expr:
     ...
 
 
-def count(column: str | pli.Series | None = None) -> pli.Expr | int:
+def count(column: str | Series | None = None) -> Expr | int:
     """
     Count the number of values in this column/context.
 
@@ -353,7 +357,7 @@ def count(column: str | pli.Series | None = None) -> pli.Expr | int:
     return col(column).count()
 
 
-def list_(name: str) -> pli.Expr:
+def list_(name: str) -> Expr:
     """
     Aggregate to list.
 
@@ -367,16 +371,16 @@ def list_(name: str) -> pli.Expr:
 
 
 @overload
-def std(column: str, ddof: int = 1) -> pli.Expr:
+def std(column: str, ddof: int = 1) -> Expr:
     ...
 
 
 @overload
-def std(column: pli.Series, ddof: int = 1) -> float | None:
+def std(column: Series, ddof: int = 1) -> float | None:
     ...
 
 
-def std(column: str | pli.Series, ddof: int = 1) -> pli.Expr | float | None:
+def std(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     Get the standard deviation.
 
@@ -402,16 +406,16 @@ def std(column: str | pli.Series, ddof: int = 1) -> pli.Expr | float | None:
 
 
 @overload
-def var(column: str, ddof: int = 1) -> pli.Expr:
+def var(column: str, ddof: int = 1) -> Expr:
     ...
 
 
 @overload
-def var(column: pli.Series, ddof: int = 1) -> float | None:
+def var(column: Series, ddof: int = 1) -> float | None:
     ...
 
 
-def var(column: str | pli.Series, ddof: int = 1) -> pli.Expr | float | None:
+def var(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     Get the variance.
 
@@ -437,16 +441,16 @@ def var(column: str | pli.Series, ddof: int = 1) -> pli.Expr | float | None:
 
 
 @overload
-def max(column: str | Sequence[pli.Expr | str]) -> pli.Expr:
+def max(column: str | Sequence[Expr | str]) -> Expr:
     ...
 
 
 @overload
-def max(column: pli.Series) -> int | float:
+def max(column: Series) -> int | float:
     ...
 
 
-def max(column: str | Sequence[pli.Expr | str] | pli.Series) -> pli.Expr | Any:
+def max(column: str | Sequence[Expr | str] | Series) -> Expr | Any:
     """
     Get the maximum value. Can be used horizontally or vertically.
 
@@ -523,19 +527,19 @@ def max(column: str | Sequence[pli.Expr | str] | pli.Series) -> pli.Expr | Any:
 
 @overload
 def min(
-    column: str | Sequence[pli.Expr | str | date | datetime | int | float],
-) -> pli.Expr:
+    column: str | Sequence[Expr | str | date | datetime | int | float],
+) -> Expr:
     ...
 
 
 @overload
-def min(column: pli.Series) -> int | float:
+def min(column: Series) -> int | float:
     ...
 
 
 def min(
-    column: str | Sequence[pli.Expr | str | date | datetime | int | float] | pli.Series,
-) -> pli.Expr | Any:
+    column: str | Sequence[Expr | str | date | datetime | int | float] | Series,
+) -> Expr | Any:
     """
     Get the minimum value.
 
@@ -609,18 +613,18 @@ def min(
 
 
 @overload
-def sum(column: str | Sequence[pli.Expr | str] | pli.Expr) -> pli.Expr:
+def sum(column: str | Sequence[Expr | str] | Expr) -> Expr:
     ...
 
 
 @overload
-def sum(column: pli.Series) -> int | float:
+def sum(column: Series) -> int | float:
     ...
 
 
 def sum(
-    column: str | Sequence[pli.Expr | str] | pli.Series | pli.Expr,
-) -> pli.Expr | Any:
+    column: str | Sequence[Expr | str] | Series | Expr,
+) -> Expr | Any:
     """
     Sum values in a column/Series, or horizontally across list of columns/expressions.
 
@@ -728,16 +732,16 @@ def sum(
 
 
 @overload
-def mean(column: str) -> pli.Expr:
+def mean(column: str) -> Expr:
     ...
 
 
 @overload
-def mean(column: pli.Series) -> float:
+def mean(column: Series) -> float:
     ...
 
 
-def mean(column: str | pli.Series) -> pli.Expr | float | None:
+def mean(column: str | Series) -> Expr | float | None:
     """
     Get the mean value.
 
@@ -763,16 +767,16 @@ def mean(column: str | pli.Series) -> pli.Expr | float | None:
 
 
 @overload
-def avg(column: str) -> pli.Expr:
+def avg(column: str) -> Expr:
     ...
 
 
 @overload
-def avg(column: pli.Series) -> float:
+def avg(column: Series) -> float:
     ...
 
 
-def avg(column: str | pli.Series) -> pli.Expr | float:
+def avg(column: str | Series) -> Expr | float:
     """
     Alias for mean.
 
@@ -796,16 +800,16 @@ def avg(column: str | pli.Series) -> pli.Expr | float:
 
 
 @overload
-def median(column: str) -> pli.Expr:
+def median(column: str) -> Expr:
     ...
 
 
 @overload
-def median(column: pli.Series) -> float | int:
+def median(column: Series) -> float | int:
     ...
 
 
-def median(column: str | pli.Series) -> pli.Expr | float | int | None:
+def median(column: str | Series) -> Expr | float | int | None:
     """
     Get the median value.
 
@@ -831,16 +835,16 @@ def median(column: str | pli.Series) -> pli.Expr | float | int | None:
 
 
 @overload
-def n_unique(column: str) -> pli.Expr:
+def n_unique(column: str) -> Expr:
     ...
 
 
 @overload
-def n_unique(column: pli.Series) -> int:
+def n_unique(column: Series) -> int:
     ...
 
 
-def n_unique(column: str | pli.Series) -> pli.Expr | int:
+def n_unique(column: str | Series) -> Expr | int:
     """
     Count unique values.
 
@@ -866,21 +870,21 @@ def n_unique(column: str | pli.Series) -> pli.Expr | int:
 
 
 @overload
-def first(column: str) -> pli.Expr:
+def first(column: str) -> Expr:
     ...
 
 
 @overload
-def first(column: pli.Series) -> Any:
+def first(column: Series) -> Any:
     ...
 
 
 @overload
-def first(column: None = None) -> pli.Expr:
+def first(column: None = None) -> Expr:
     ...
 
 
-def first(column: str | pli.Series | None = None) -> pli.Expr | Any:
+def first(column: str | Series | None = None) -> Expr | Any:
     """
     Get the first value.
 
@@ -931,21 +935,21 @@ def first(column: str | pli.Series | None = None) -> pli.Expr | Any:
 
 
 @overload
-def last(column: str) -> pli.Expr:
+def last(column: str) -> Expr:
     ...
 
 
 @overload
-def last(column: pli.Series) -> Any:
+def last(column: Series) -> Any:
     ...
 
 
 @overload
-def last(column: None = None) -> pli.Expr:
+def last(column: None = None) -> Expr:
     ...
 
 
-def last(column: str | pli.Series | None = None) -> pli.Expr:
+def last(column: str | Series | None = None) -> Expr:
     """
     Get the last value.
 
@@ -994,16 +998,16 @@ def last(column: str | pli.Series | None = None) -> pli.Expr:
 
 
 @overload
-def head(column: str, n: int = ...) -> pli.Expr:
+def head(column: str, n: int = ...) -> Expr:
     ...
 
 
 @overload
-def head(column: pli.Series, n: int = ...) -> pli.Series:
+def head(column: Series, n: int = ...) -> Series:
     ...
 
 
-def head(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
+def head(column: str | Series, n: int = 10) -> Expr | Series:
     """
     Get the first `n` rows.
 
@@ -1053,16 +1057,16 @@ def head(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
 
 
 @overload
-def tail(column: str, n: int = ...) -> pli.Expr:
+def tail(column: str, n: int = ...) -> Expr:
     ...
 
 
 @overload
-def tail(column: pli.Series, n: int = ...) -> pli.Series:
+def tail(column: Series, n: int = ...) -> Series:
     ...
 
 
-def tail(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
+def tail(column: str | Series, n: int = 10) -> Expr | Series:
     """
     Get the last `n` rows.
 
@@ -1114,7 +1118,7 @@ def tail(column: str | pli.Series, n: int = 10) -> pli.Expr | pli.Series:
 @deprecate_nonkeyword_arguments(allowed_args=["value", "dtype"])
 def lit(
     value: Any, dtype: PolarsDataType | None = None, allow_object: bool = False
-) -> pli.Expr:
+) -> Expr:
     """
     Return an expression representing a literal value.
 
@@ -1220,18 +1224,18 @@ def lit(
 
 
 @overload
-def cumsum(column: str | Sequence[pli.Expr | str] | pli.Expr) -> pli.Expr:
+def cumsum(column: str | Sequence[Expr | str] | Expr) -> Expr:
     ...
 
 
 @overload
-def cumsum(column: pli.Series) -> int | float:
+def cumsum(column: Series) -> int | float:
     ...
 
 
 def cumsum(
-    column: str | Sequence[pli.Expr | str] | pli.Series | pli.Expr,
-) -> pli.Expr | Any:
+    column: str | Sequence[Expr | str] | Series | Expr,
+) -> Expr | Any:
     """
     Cumulatively sum values in a column/Series, or horizontally across list of columns/expressions.
 
@@ -1311,8 +1315,8 @@ def cumsum(
 
 @deprecate_nonkeyword_arguments(allowed_args=["a", "b", "ddof"])
 def spearman_rank_corr(
-    a: str | pli.Expr, b: str | pli.Expr, ddof: int = 1, propagate_nans: bool = False
-) -> pli.Expr:
+    a: str | Expr, b: str | Expr, ddof: int = 1, propagate_nans: bool = False
+) -> Expr:
     """
     Compute the spearman rank correlation between two columns.
 
@@ -1366,7 +1370,7 @@ def spearman_rank_corr(
     )
 
 
-def pearson_corr(a: str | pli.Expr, b: str | pli.Expr, ddof: int = 1) -> pli.Expr:
+def pearson_corr(a: str | Expr, b: str | Expr, ddof: int = 1) -> Expr:
     """
     Compute the pearson's correlation between two columns.
 
@@ -1412,13 +1416,13 @@ def pearson_corr(a: str | pli.Expr, b: str | pli.Expr, ddof: int = 1) -> pli.Exp
 
 
 def corr(
-    a: str | pli.Expr,
-    b: str | pli.Expr,
+    a: str | Expr,
+    b: str | Expr,
     *,
     method: CorrelationMethod = "pearson",
     ddof: int = 1,
     propagate_nans: bool = False,
-) -> pli.Expr:
+) -> Expr:
     """
     Compute the pearson's or spearman rank correlation correlation between two columns.
 
@@ -1482,7 +1486,7 @@ def corr(
         )
 
 
-def cov(a: str | pli.Expr, b: str | pli.Expr) -> pli.Expr:
+def cov(a: str | Expr, b: str | Expr) -> Expr:
     """
     Compute the covariance between two columns/ expressions.
 
@@ -1516,10 +1520,10 @@ def cov(a: str | pli.Expr, b: str | pli.Expr) -> pli.Expr:
 
 @deprecated_alias(f="function")
 def map(
-    exprs: Sequence[str] | Sequence[pli.Expr],
-    function: Callable[[Sequence[pli.Series]], pli.Series],
+    exprs: Sequence[str] | Sequence[Expr],
+    function: Callable[[Sequence[Series]], Series],
     return_dtype: PolarsDataType | None = None,
-) -> pli.Expr:
+) -> Expr:
     """
     Map a custom function over multiple columns/expressions.
 
@@ -1580,11 +1584,11 @@ def map(
 @deprecated_alias(f="function")
 @deprecate_nonkeyword_arguments(allowed_args=["exprs", "function", "return_dtype"])
 def apply(
-    exprs: Sequence[str | pli.Expr],
-    function: Callable[[Sequence[pli.Series]], pli.Series | Any],
+    exprs: Sequence[str | Expr],
+    function: Callable[[Sequence[Series]], Series | Any],
     return_dtype: PolarsDataType | None = None,
     returns_scalar: bool = True,
-) -> pli.Expr:
+) -> Expr:
     """
     Apply a custom/user-defined function (UDF) in a GroupBy context.
 
@@ -1662,9 +1666,9 @@ def apply(
 @deprecated_alias(f="function")
 def fold(
     acc: IntoExpr,
-    function: Callable[[pli.Series, pli.Series], pli.Series],
-    exprs: Sequence[pli.Expr | str] | pli.Expr,
-) -> pli.Expr:
+    function: Callable[[Series, Series], Series],
+    exprs: Sequence[Expr | str] | Expr,
+) -> Expr:
     """
     Accumulate over multiple columns horizontally/ row wise with a left fold.
 
@@ -1770,9 +1774,9 @@ def fold(
 
 @deprecated_alias(f="function")
 def reduce(
-    function: Callable[[pli.Series, pli.Series], pli.Series],
-    exprs: Sequence[pli.Expr | str] | pli.Expr,
-) -> pli.Expr:
+    function: Callable[[Series, Series], Series],
+    exprs: Sequence[Expr | str] | Expr,
+) -> Expr:
     """
     Accumulate over multiple columns horizontally/ row wise with a left fold.
 
@@ -1837,10 +1841,10 @@ def reduce(
 @deprecate_nonkeyword_arguments()
 def cumfold(
     acc: IntoExpr,
-    function: Callable[[pli.Series, pli.Series], pli.Series],
-    exprs: Sequence[pli.Expr | str] | pli.Expr,
+    function: Callable[[Series, Series], Series],
+    exprs: Sequence[Expr | str] | Expr,
     include_init: bool = False,
-) -> pli.Expr:
+) -> Expr:
     """
     Cumulatively accumulate over multiple columns horizontally/ row wise with a left fold.
 
@@ -1913,9 +1917,9 @@ def cumfold(
 
 @deprecated_alias(f="function")
 def cumreduce(
-    function: Callable[[pli.Series, pli.Series], pli.Series],
-    exprs: Sequence[pli.Expr | str] | pli.Expr,
-) -> pli.Expr:
+    function: Callable[[Series, Series], Series],
+    exprs: Sequence[Expr | str] | Expr,
+) -> Expr:
     """
     Cumulatively accumulate over multiple columns horizontally/ row wise with a left fold.
 
@@ -1974,7 +1978,7 @@ def cumreduce(
     return pli.wrap_expr(pycumreduce(function, exprs))
 
 
-def any(name: str | Sequence[str] | Sequence[pli.Expr] | pli.Expr) -> pli.Expr:
+def any(name: str | Sequence[str] | Sequence[Expr] | Expr) -> Expr:
     """
     Evaluate columnwise or elementwise with a bitwise OR operation.
 
@@ -2024,7 +2028,7 @@ def any(name: str | Sequence[str] | Sequence[pli.Expr] | pli.Expr) -> pli.Expr:
 def exclude(
     columns: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
     *more_columns: str | PolarsDataType,
-) -> pli.Expr:
+) -> Expr:
     """
     Represent all columns except for the given columns.
 
@@ -2094,7 +2098,7 @@ def exclude(
     return col("*").exclude(columns, *more_columns)
 
 
-def all(name: str | Sequence[pli.Expr] | pli.Expr | None = None) -> pli.Expr:
+def all(name: str | Sequence[Expr] | Expr | None = None) -> Expr:
     """
     Do one of two things.
 
@@ -2134,16 +2138,16 @@ def all(name: str | Sequence[pli.Expr] | pli.Expr | None = None) -> pli.Expr:
         )
 
 
-def groups(column: str) -> pli.Expr:
+def groups(column: str) -> Expr:
     """Syntactic sugar for `pl.col("foo").agg_groups()`."""
     return col(column).agg_groups()
 
 
 def quantile(
     column: str,
-    quantile: float | pli.Expr,
+    quantile: float | Expr,
     interpolation: RollingInterpolationMethod = "nearest",
-) -> pli.Expr:
+) -> Expr:
     """
     Syntactic sugar for `pl.col("foo").quantile(..)`.
 
@@ -2162,47 +2166,47 @@ def quantile(
 
 @overload
 def arange(
-    low: int | pli.Expr | pli.Series,
-    high: int | pli.Expr | pli.Series,
+    low: int | Expr | Series,
+    high: int | Expr | Series,
     step: int = ...,
     *,
     eager: Literal[False],
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
 @overload
 def arange(
-    low: int | pli.Expr | pli.Series,
-    high: int | pli.Expr | pli.Series,
+    low: int | Expr | Series,
+    high: int | Expr | Series,
     step: int = ...,
     *,
     eager: Literal[True],
     dtype: PolarsDataType | None = ...,
-) -> pli.Series:
+) -> Series:
     ...
 
 
 @overload
 def arange(
-    low: int | pli.Expr | pli.Series,
-    high: int | pli.Expr | pli.Series,
+    low: int | Expr | Series,
+    high: int | Expr | Series,
     step: int = ...,
     *,
     eager: bool = ...,
     dtype: PolarsDataType | None = ...,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     ...
 
 
 def arange(
-    low: int | pli.Expr | pli.Series,
-    high: int | pli.Expr | pli.Series,
+    low: int | Expr | Series,
+    high: int | Expr | Series,
     step: int = 1,
     *,
     eager: bool = False,
     dtype: PolarsDataType | None = None,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     """
     Create a range expression (or Series).
 
@@ -2250,7 +2254,7 @@ def arange(
 def arg_sort_by(
     exprs: IntoExpr | Iterable[IntoExpr],
     descending: bool | Sequence[bool] = False,
-) -> pli.Expr:
+) -> Expr:
     """
     Return the row indices that would sort the columns.
 
@@ -2310,9 +2314,9 @@ def arg_sort_by(
 
 @deprecated_alias(reverse="descending")
 def argsort_by(
-    exprs: pli.Expr | str | Sequence[pli.Expr | str],
+    exprs: Expr | str | Sequence[Expr | str],
     descending: Sequence[bool] | bool = False,
-) -> pli.Expr:
+) -> Expr:
     """
     Find the indexes that would sort the columns.
 
@@ -2341,15 +2345,15 @@ def argsort_by(
 
 def duration(
     *,
-    days: pli.Expr | str | int | None = None,
-    seconds: pli.Expr | str | int | None = None,
-    nanoseconds: pli.Expr | str | int | None = None,
-    microseconds: pli.Expr | str | int | None = None,
-    milliseconds: pli.Expr | str | int | None = None,
-    minutes: pli.Expr | str | int | None = None,
-    hours: pli.Expr | str | int | None = None,
-    weeks: pli.Expr | str | int | None = None,
-) -> pli.Expr:
+    days: Expr | str | int | None = None,
+    seconds: Expr | str | int | None = None,
+    nanoseconds: Expr | str | int | None = None,
+    microseconds: Expr | str | int | None = None,
+    milliseconds: Expr | str | int | None = None,
+    minutes: Expr | str | int | None = None,
+    hours: Expr | str | int | None = None,
+    weeks: Expr | str | int | None = None,
+) -> Expr:
     """
     Create polars `Duration` from distinct time components.
 
@@ -2423,14 +2427,14 @@ def duration(
 
 
 def datetime_(
-    year: pli.Expr | str | int,
-    month: pli.Expr | str | int,
-    day: pli.Expr | str | int,
-    hour: pli.Expr | str | int | None = None,
-    minute: pli.Expr | str | int | None = None,
-    second: pli.Expr | str | int | None = None,
-    microsecond: pli.Expr | str | int | None = None,
-) -> pli.Expr:
+    year: Expr | str | int,
+    month: Expr | str | int,
+    day: Expr | str | int,
+    hour: Expr | str | int | None = None,
+    minute: Expr | str | int | None = None,
+    second: Expr | str | int | None = None,
+    microsecond: Expr | str | int | None = None,
+) -> Expr:
     """
     Create a Polars literal expression of type Datetime.
 
@@ -2483,10 +2487,10 @@ def datetime_(
 
 
 def date_(
-    year: pli.Expr | str | int,
-    month: pli.Expr | str | int,
-    day: pli.Expr | str | int,
-) -> pli.Expr:
+    year: Expr | str | int,
+    month: Expr | str | int,
+    day: Expr | str | int,
+) -> Expr:
     """
     Create a Polars literal expression of type Date.
 
@@ -2509,7 +2513,7 @@ def date_(
 
 @deprecated_alias(sep="separator")
 @deprecate_nonkeyword_arguments()
-def concat_str(exprs: IntoExpr | Iterable[IntoExpr], separator: str = "") -> pli.Expr:
+def concat_str(exprs: IntoExpr | Iterable[IntoExpr], separator: str = "") -> Expr:
     """
     Horizontally concatenate columns into a single string column.
 
@@ -2559,7 +2563,7 @@ def concat_str(exprs: IntoExpr | Iterable[IntoExpr], separator: str = "") -> pli
     return pli.wrap_expr(_concat_str(exprs, separator))
 
 
-def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
+def format(fstring: str, *args: Expr | str) -> Expr:
     """
     Format expressions as a string.
 
@@ -2613,7 +2617,7 @@ def format(fstring: str, *args: pli.Expr | str) -> pli.Expr:
     return concat_str(exprs, separator="")
 
 
-def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.Expr:
+def concat_list(exprs: Sequence[str | Expr | Series] | Expr) -> Expr:
     """
     Concat the arrays in a Series dtype List in linear time.
 
@@ -2662,7 +2666,7 @@ def concat_list(exprs: Sequence[str | pli.Expr | pli.Series] | pli.Expr) -> pli.
 
 @deprecate_nonkeyword_arguments()
 def collect_all(
-    lazy_frames: Sequence[pli.LazyFrame],
+    lazy_frames: Sequence[LazyFrame],
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
@@ -2671,7 +2675,7 @@ def collect_all(
     slice_pushdown: bool = True,
     common_subplan_elimination: bool = True,
     streaming: bool = False,
-) -> list[pli.DataFrame]:
+) -> list[DataFrame]:
     """
     Collect multiple LazyFrames at the same time.
 
@@ -2735,7 +2739,7 @@ def select(
     exprs: IntoExpr | Iterable[IntoExpr] | None = None,
     *more_exprs: IntoExpr,
     **named_exprs: IntoExpr,
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Run polars expressions without a context.
 
@@ -2781,7 +2785,7 @@ def struct(  # type: ignore[misc]
     eager: Literal[False] = ...,
     schema: SchemaDict | None = ...,
     **named_exprs: IntoExpr,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
@@ -2791,7 +2795,7 @@ def struct(
     eager: Literal[True] = ...,
     schema: SchemaDict | None = ...,
     **named_exprs: IntoExpr,
-) -> pli.Series:
+) -> Series:
     ...
 
 
@@ -2801,7 +2805,7 @@ def struct(
     eager: bool = ...,
     schema: SchemaDict | None = ...,
     **named_exprs: IntoExpr,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     ...
 
 
@@ -2811,7 +2815,7 @@ def struct(
     eager: bool = False,
     schema: SchemaDict | None = None,
     **named_exprs: IntoExpr,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     """
     Collect columns into a struct column.
 
@@ -2891,43 +2895,43 @@ def struct(
 @overload
 def repeat(
     value: float | int | str | bool | None,
-    n: pli.Expr | int,
+    n: Expr | int,
     *,
     eager: Literal[False] = ...,
     name: str | None = ...,
-) -> pli.Expr:
+) -> Expr:
     ...
 
 
 @overload
 def repeat(
     value: float | int | str | bool | None,
-    n: pli.Expr | int,
+    n: Expr | int,
     *,
     eager: Literal[True],
     name: str | None = ...,
-) -> pli.Series:
+) -> Series:
     ...
 
 
 @overload
 def repeat(
     value: float | int | str | bool | None,
-    n: pli.Expr | int,
+    n: Expr | int,
     *,
     eager: bool,
     name: str | None,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     ...
 
 
 def repeat(
     value: float | int | str | bool | None,
-    n: pli.Expr | int,
+    n: Expr | int,
     *,
     eager: bool = False,
     name: str | None = None,
-) -> pli.Expr | pli.Series:
+) -> Expr | Series:
     """
     Repeat a single value n times.
 
@@ -2963,25 +2967,21 @@ def repeat(
 
 
 @overload
-def arg_where(
-    condition: pli.Expr | pli.Series, eager: Literal[False] = ...
-) -> pli.Expr:
+def arg_where(condition: Expr | Series, eager: Literal[False] = ...) -> Expr:
     ...
 
 
 @overload
-def arg_where(condition: pli.Expr | pli.Series, eager: Literal[True]) -> pli.Series:
+def arg_where(condition: Expr | Series, eager: Literal[True]) -> Series:
     ...
 
 
 @overload
-def arg_where(condition: pli.Expr | pli.Series, eager: bool) -> pli.Expr | pli.Series:
+def arg_where(condition: Expr | Series, eager: bool) -> Expr | Series:
     ...
 
 
-def arg_where(
-    condition: pli.Expr | pli.Series, eager: bool = False
-) -> pli.Expr | pli.Series:
+def arg_where(condition: Expr | Series, eager: bool = False) -> Expr | Series:
     """
     Return indices where `condition` evaluates `True`.
 
@@ -3027,7 +3027,7 @@ def arg_where(
         return pli.wrap_expr(py_arg_where(condition._pyexpr))
 
 
-def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> pli.Expr:
+def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     """
     Folds the columns from left to right, keeping the first non-null value.
 
@@ -3081,20 +3081,18 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> pli
 
 
 @overload
-def from_epoch(column: str | pli.Expr, unit: EpochTimeUnit = ...) -> pli.Expr:
+def from_epoch(column: str | Expr, unit: EpochTimeUnit = ...) -> Expr:
     ...
 
 
 @overload
-def from_epoch(
-    column: pli.Series | Sequence[int], unit: EpochTimeUnit = ...
-) -> pli.Series:
+def from_epoch(column: Series | Sequence[int], unit: EpochTimeUnit = ...) -> Series:
     ...
 
 
 def from_epoch(
-    column: str | pli.Expr | pli.Series | Sequence[int], unit: EpochTimeUnit = "s"
-) -> pli.Expr | pli.Series:
+    column: str | Expr | Series | Sequence[int], unit: EpochTimeUnit = "s"
+) -> Expr | Series:
     """
     Utility function that parses an epoch timestamp (or Unix time) to Polars Date(time).
 

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -11,10 +11,12 @@ else:
     from typing_extensions import Literal
 
 if TYPE_CHECKING:
-    from polars import internals as pli
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
+    from polars.expr.expr import Expr
+    from polars.internals.whenthen import WhenThen, WhenThenThen
+    from polars.series.series import Series
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -23,14 +25,14 @@ if TYPE_CHECKING:
 
 
 # Types that qualify as expressions (eg: for use in 'select', 'with_columns'...)
-PolarsExprType: TypeAlias = "pli.Expr | pli.WhenThen | pli.WhenThenThen"
+PolarsExprType: TypeAlias = "Expr | WhenThen | WhenThenThen"
 
 # literal types that are allowed in expressions (auto-converted to pl.lit)
 PythonLiteral: TypeAlias = Union[
     str, int, float, bool, date, time, datetime, timedelta, bytes, Decimal
 ]
 
-IntoExpr: TypeAlias = "PolarsExprType | PythonLiteral | pli.Series | None"
+IntoExpr: TypeAlias = "PolarsExprType | PythonLiteral | Series | None"
 ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq"]
 
 # User-facing string literal types
@@ -96,4 +98,4 @@ DbWriteEngine: TypeAlias = Literal["sqlalchemy", "adbc"]
 DbWriteMode: TypeAlias = Literal["replace", "append", "fail"]
 
 # type signature for allowed frame init
-FrameInitTypes: TypeAlias = "Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | pli.Series] | Sequence[Any] | np.ndarray[Any, Any] | pa.Table | pd.DataFrame | pli.Series"
+FrameInitTypes: TypeAlias = "Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series] | Sequence[Any] | np.ndarray[Any, Any] | pa.Table | pd.DataFrame"

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -10,7 +10,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import when as pywhen
 
 if TYPE_CHECKING:
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import PolarsExprType, PythonLiteral
+    from polars.series.series import Series
 
 
 class WhenThenThen:
@@ -19,14 +21,14 @@ class WhenThenThen:
     def __init__(self, pywhenthenthen: Any):
         self.pywhenthenthen = pywhenthenthen
 
-    def when(self, predicate: pli.Expr | bool) -> WhenThenThen:
+    def when(self, predicate: Expr | bool) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
     def then(
         self,
-        expr: (PolarsExprType | PythonLiteral | pli.Series | None),
+        expr: (PolarsExprType | PythonLiteral | Series | None),
     ) -> WhenThenThen:
         """
         Values to return in case of the predicate being `True`.
@@ -42,8 +44,8 @@ class WhenThenThen:
 
     def otherwise(
         self,
-        expr: (PolarsExprType | PythonLiteral | pli.Series | None),
-    ) -> pli.Expr:
+        expr: (PolarsExprType | PythonLiteral | Series | None),
+    ) -> Expr:
         """
         Values to return in case of the predicate being `False`.
 
@@ -57,7 +59,7 @@ class WhenThenThen:
         return pli.wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
-    def __getattr__(self, item) -> pli.Expr:
+    def __getattr__(self, item) -> Expr:
         expr = self.otherwise(None)  # noqa: F841
         return eval(f"expr.{item}")
 
@@ -68,7 +70,7 @@ class WhenThen:
     def __init__(self, pywhenthen: Any):
         self._pywhenthen = pywhenthen
 
-    def when(self, predicate: pli.Expr | bool | pli.Series) -> WhenThenThen:
+    def when(self, predicate: Expr | bool | Series) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
         predicate = pli.expr_to_lit_or_expr(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
@@ -78,11 +80,11 @@ class WhenThen:
         expr: (
             PolarsExprType
             | PythonLiteral
-            | pli.Series
-            | Iterable[PolarsExprType | PythonLiteral | pli.Series]
+            | Series
+            | Iterable[PolarsExprType | PythonLiteral | Series]
             | None
         ),
-    ) -> pli.Expr:
+    ) -> Expr:
         """
         Values to return in case of the predicate being `False`.
 
@@ -96,7 +98,7 @@ class WhenThen:
         return pli.wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
-    def __getattr__(self, item) -> pli.Expr:
+    def __getattr__(self, item) -> Expr:
         expr = self.otherwise(None)  # noqa: F841
         return eval(f"expr.{item}")
 
@@ -112,8 +114,8 @@ class When:
         expr: (
             PolarsExprType
             | PythonLiteral
-            | pli.Series
-            | Iterable[PolarsExprType | PythonLiteral | pli.Series]
+            | Series
+            | Iterable[PolarsExprType | PythonLiteral | Series]
             | None
         ),
     ) -> WhenThen:
@@ -131,7 +133,7 @@ class When:
         return WhenThen(pywhenthen)
 
 
-def when(expr: pli.Expr | bool | pli.Series) -> When:
+def when(expr: Expr | bool | Series) -> When:
     """
     Start a "when, then, otherwise" expression.
 

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -7,7 +7,7 @@ from polars.convert import from_arrow
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
-    from polars import internals as pli
+    from polars.dataframe.frame import DataFrame
     from polars.internals.type_aliases import DbReadEngine
 
 
@@ -20,7 +20,7 @@ def read_database(
     partition_num: int | None = None,
     protocol: str | None = None,
     engine: DbReadEngine = "connectorx",
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Read a SQL query into a DataFrame.
 
@@ -119,7 +119,7 @@ def read_sql(
     protocol: str | None = None,
     *,
     engine: DbReadEngine = "connectorx",
-) -> pli.DataFrame:
+) -> DataFrame:
     """
     Read a SQL query into a DataFrame.
 
@@ -213,7 +213,7 @@ def _read_sql_connectorx(
     partition_range: tuple[int, int] | None = None,
     partition_num: int | None = None,
     protocol: str | None = None,
-) -> pli.DataFrame:
+) -> DataFrame:
     try:
         import connectorx as cx
     except ImportError:
@@ -234,7 +234,7 @@ def _read_sql_connectorx(
     return from_arrow(tbl)  # type: ignore[return-value]
 
 
-def _read_sql_adbc(query: str, connection_uri: str) -> pli.DataFrame:
+def _read_sql_adbc(query: str, connection_uri: str) -> DataFrame:
     with _open_adbc_connection(connection_uri) as conn:
         cursor = conn.cursor()
         cursor.execute(query)

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -7,6 +7,7 @@ from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
 from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import SchemaDict
     from polars.internals.type_aliases import IntoExpr, RollingInterpolationMethod
     from polars.polars import PyLazyGroupBy
@@ -136,7 +137,7 @@ class LazyGroupBy(Generic[LDF]):
     @deprecated_alias(f="function")
     def apply(
         self,
-        function: Callable[[pli.DataFrame], pli.DataFrame],
+        function: Callable[[DataFrame], DataFrame],
         schema: SchemaDict | None,
     ) -> LDF:
         """

--- a/py-polars/polars/series/_numpy.py
+++ b/py-polars/polars/series/_numpy.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
-    from polars import internals as pli
+    from polars.series.series import Series
 
 
 # https://numpy.org/doc/stable/user/basics.subclassing.html#slightly-more-realistic-example-attribute-added-to-existing-array
 class SeriesView(np.ndarray):  # type: ignore[type-arg]
     def __new__(
-        cls, input_array: np.ndarray[Any, Any], owned_series: pli.Series
+        cls, input_array: np.ndarray[Any, Any], owned_series: Series
     ) -> SeriesView:
         # Input array is an already formed ndarray instance
         # We first cast to be our class type

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import internals as pli
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
+    from polars.series.series import Series
 
 
 @expr_dispatch
@@ -16,10 +16,10 @@ class BinaryNameSpace:
 
     _accessor = "bin"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def contains(self, lit: bytes) -> pli.Series:
+    def contains(self, lit: bytes) -> Series:
         """
         Check if binaries in Series contain a binary substring.
 
@@ -34,7 +34,7 @@ class BinaryNameSpace:
 
         """
 
-    def ends_with(self, sub: bytes) -> pli.Series:
+    def ends_with(self, sub: bytes) -> Series:
         """
         Check if string values end with a binary substring.
 
@@ -45,7 +45,7 @@ class BinaryNameSpace:
 
         """
 
-    def starts_with(self, sub: bytes) -> pli.Series:
+    def starts_with(self, sub: bytes) -> Series:
         """
         Check if values start with a binary substring.
 
@@ -56,7 +56,7 @@ class BinaryNameSpace:
 
         """
 
-    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> pli.Series:
+    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> Series:
         """
         Decode a value using the provided encoding.
 
@@ -70,7 +70,7 @@ class BinaryNameSpace:
 
         """
 
-    def encode(self, encoding: TransferEncoding) -> pli.Series:
+    def encode(self, encoding: TransferEncoding) -> Series:
         """
         Encode a value using the provided encoding.
 

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import internals as pli
     from polars.internals.type_aliases import CategoricalOrdering
     from polars.polars import PySeries
+    from polars.series.series import Series
 
 
 @expr_dispatch
@@ -16,10 +16,10 @@ class CatNameSpace:
 
     _accessor = "cat"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def set_ordering(self, ordering: CategoricalOrdering) -> pli.Series:
+    def set_ordering(self, ordering: CategoricalOrdering) -> Series:
         """
         Determine how this categorical series should be sorted.
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -10,8 +10,10 @@ from polars.utils.decorators import deprecated_alias, redirect
 if TYPE_CHECKING:
     from datetime import date, datetime, time, timedelta
 
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
     from polars.polars import PySeries
+    from polars.series.series import Series
 
 
 @redirect(
@@ -27,7 +29,7 @@ class DateTimeNameSpace:
 
     _accessor = "dt"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
     def __getitem__(self, item: int) -> date | datetime:
@@ -130,7 +132,7 @@ class DateTimeNameSpace:
             return _to_python_datetime(int(out), s.dtype, s.time_unit)
         return None
 
-    def strftime(self, fmt: str) -> pli.Series:
+    def strftime(self, fmt: str) -> Series:
         """
         Format Date/datetime with a formatting rule.
 
@@ -168,7 +170,7 @@ class DateTimeNameSpace:
 
         """
 
-    def year(self) -> pli.Series:
+    def year(self) -> Series:
         """
         Extract the year from the underlying date representation.
 
@@ -203,7 +205,7 @@ class DateTimeNameSpace:
 
         """
 
-    def iso_year(self) -> pli.Series:
+    def iso_year(self) -> Series:
         """
         Extract ISO year from underlying Date representation.
 
@@ -229,7 +231,7 @@ class DateTimeNameSpace:
 
         """
 
-    def quarter(self) -> pli.Series:
+    def quarter(self) -> Series:
         """
         Extract quarter from underlying Date representation.
 
@@ -268,7 +270,7 @@ class DateTimeNameSpace:
 
         """
 
-    def month(self) -> pli.Series:
+    def month(self) -> Series:
         """
         Extract the month from the underlying date representation.
 
@@ -308,7 +310,7 @@ class DateTimeNameSpace:
 
         """
 
-    def week(self) -> pli.Series:
+    def week(self) -> Series:
         """
         Extract the week from the underlying date representation.
 
@@ -348,7 +350,7 @@ class DateTimeNameSpace:
 
         """
 
-    def weekday(self) -> pli.Series:
+    def weekday(self) -> Series:
         """
         Extract the week day from the underlying date representation.
 
@@ -393,7 +395,7 @@ class DateTimeNameSpace:
 
         """
 
-    def day(self) -> pli.Series:
+    def day(self) -> Series:
         """
         Extract the day from the underlying date representation.
 
@@ -435,7 +437,7 @@ class DateTimeNameSpace:
 
         """
 
-    def ordinal_day(self) -> pli.Series:
+    def ordinal_day(self) -> Series:
         """
         Extract ordinal day from underlying date representation.
 
@@ -473,7 +475,7 @@ class DateTimeNameSpace:
 
         """
 
-    def hour(self) -> pli.Series:
+    def hour(self) -> Series:
         """
         Extract the hour from the underlying DateTime representation.
 
@@ -512,7 +514,7 @@ class DateTimeNameSpace:
 
         """
 
-    def minute(self) -> pli.Series:
+    def minute(self) -> Series:
         """
         Extract the minutes from the underlying DateTime representation.
 
@@ -549,7 +551,7 @@ class DateTimeNameSpace:
 
         """
 
-    def second(self, fractional: bool = False) -> pli.Series:
+    def second(self, fractional: bool = False) -> Series:
         """
         Extract seconds from underlying DateTime representation.
 
@@ -614,7 +616,7 @@ class DateTimeNameSpace:
 
         """
 
-    def millisecond(self) -> pli.Series:
+    def millisecond(self) -> Series:
         """
         Extract the milliseconds from the underlying DateTime representation.
 
@@ -661,7 +663,7 @@ class DateTimeNameSpace:
 
         """
 
-    def microsecond(self) -> pli.Series:
+    def microsecond(self) -> Series:
         """
         Extract the microseconds from the underlying DateTime representation.
 
@@ -708,7 +710,7 @@ class DateTimeNameSpace:
 
         """
 
-    def nanosecond(self) -> pli.Series:
+    def nanosecond(self) -> Series:
         """
         Extract the nanoseconds from the underlying DateTime representation.
 
@@ -755,7 +757,7 @@ class DateTimeNameSpace:
 
         """
 
-    def timestamp(self, tu: TimeUnit = "us") -> pli.Series:
+    def timestamp(self, tu: TimeUnit = "us") -> Series:
         """
         Return a timestamp in the given time unit.
 
@@ -797,7 +799,7 @@ class DateTimeNameSpace:
 
         """
 
-    def epoch(self, tu: EpochTimeUnit = "us") -> pli.Series:
+    def epoch(self, tu: EpochTimeUnit = "us") -> Series:
         """
         Get the time passed since the Unix EPOCH in the give time unit.
 
@@ -839,7 +841,7 @@ class DateTimeNameSpace:
 
         """
 
-    def with_time_unit(self, tu: TimeUnit) -> pli.Series:
+    def with_time_unit(self, tu: TimeUnit) -> Series:
         """
         Set time unit a Series of dtype Datetime or Duration.
 
@@ -876,7 +878,7 @@ class DateTimeNameSpace:
 
         """
 
-    def cast_time_unit(self, tu: TimeUnit) -> pli.Series:
+    def cast_time_unit(self, tu: TimeUnit) -> Series:
         """
         Cast the underlying data to another time unit. This may lose precision.
 
@@ -919,7 +921,7 @@ class DateTimeNameSpace:
         """
 
     @deprecated_alias(tz="time_zone")
-    def convert_time_zone(self, time_zone: str) -> pli.Series:
+    def convert_time_zone(self, time_zone: str) -> Series:
         """
         Convert to given time zone for a Series of type Datetime.
 
@@ -960,7 +962,7 @@ class DateTimeNameSpace:
         )
 
     @deprecated_alias(tz="time_zone")
-    def replace_time_zone(self, time_zone: str | None) -> pli.Series:
+    def replace_time_zone(self, time_zone: str | None) -> Series:
         """
         Replace time zone for a Series of type Datetime.
 
@@ -1039,7 +1041,7 @@ class DateTimeNameSpace:
             .to_series()
         )
 
-    def days(self) -> pli.Series:
+    def days(self) -> Series:
         """
         Extract the days from a Duration type.
 
@@ -1070,7 +1072,7 @@ class DateTimeNameSpace:
 
         """
 
-    def hours(self) -> pli.Series:
+    def hours(self) -> Series:
         """
         Extract the hours from a Duration type.
 
@@ -1103,7 +1105,7 @@ class DateTimeNameSpace:
 
         """
 
-    def minutes(self) -> pli.Series:
+    def minutes(self) -> Series:
         """
         Extract the minutes from a Duration type.
 
@@ -1136,7 +1138,7 @@ class DateTimeNameSpace:
 
         """
 
-    def seconds(self) -> pli.Series:
+    def seconds(self) -> Series:
         """
         Extract the seconds from a Duration type.
 
@@ -1173,7 +1175,7 @@ class DateTimeNameSpace:
 
         """
 
-    def milliseconds(self) -> pli.Series:
+    def milliseconds(self) -> Series:
         """
         Extract the milliseconds from a Duration type.
 
@@ -1206,7 +1208,7 @@ class DateTimeNameSpace:
 
         """
 
-    def microseconds(self) -> pli.Series:
+    def microseconds(self) -> Series:
         """
         Extract the microseconds from a Duration type.
 
@@ -1239,7 +1241,7 @@ class DateTimeNameSpace:
 
         """
 
-    def nanoseconds(self) -> pli.Series:
+    def nanoseconds(self) -> Series:
         """
         Extract the nanoseconds from a Duration type.
 
@@ -1272,7 +1274,7 @@ class DateTimeNameSpace:
 
         """
 
-    def offset_by(self, by: str) -> pli.Series:
+    def offset_by(self, by: str) -> Series:
         """
         Offset this date by a relative time offset.
 
@@ -1345,7 +1347,7 @@ class DateTimeNameSpace:
         self,
         every: str | timedelta,
         offset: str | timedelta | None = None,
-    ) -> pli.Series:
+    ) -> Series:
         """
         Divide the date/ datetime range into buckets.
 
@@ -1453,7 +1455,7 @@ class DateTimeNameSpace:
         self,
         every: str | timedelta,
         offset: str | timedelta | None = None,
-    ) -> pli.Series:
+    ) -> Series:
         """
         Divide the date/ datetime range into buckets.
 
@@ -1549,7 +1551,7 @@ class DateTimeNameSpace:
 
         """
 
-    def combine(self, tm: time | pli.Series, tu: TimeUnit = "us") -> pli.Expr:
+    def combine(self, tm: time | Series, tu: TimeUnit = "us") -> Expr:
         """
         Create a naive Datetime from an existing Date/Datetime expression and a Time.
 

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -9,8 +9,10 @@ from polars.utils.decorators import deprecate_nonkeyword_arguments
 if TYPE_CHECKING:
     from datetime import date, datetime, time
 
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import NullBehavior, ToStructStrategy
     from polars.polars import PySeries
+    from polars.series.series import Series
 
 
 @expr_dispatch
@@ -19,10 +21,10 @@ class ListNameSpace:
 
     _accessor = "arr"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def lengths(self) -> pli.Series:
+    def lengths(self) -> Series:
         """
         Get the length of the arrays as UInt32.
 
@@ -39,20 +41,20 @@ class ListNameSpace:
 
         """
 
-    def sum(self) -> pli.Series:
+    def sum(self) -> Series:
         """Sum all the arrays in the list."""
 
-    def max(self) -> pli.Series:
+    def max(self) -> Series:
         """Compute the max value of the arrays in the list."""
 
-    def min(self) -> pli.Series:
+    def min(self) -> Series:
         """Compute the min value of the arrays in the list."""
 
-    def mean(self) -> pli.Series:
+    def mean(self) -> Series:
         """Compute the mean value of the arrays in the list."""
 
     @deprecate_nonkeyword_arguments()
-    def sort(self, descending: bool = False) -> pli.Series:
+    def sort(self, descending: bool = False) -> Series:
         """
         Sort the arrays in this column.
 
@@ -87,13 +89,13 @@ class ListNameSpace:
             .to_series()
         )
 
-    def reverse(self) -> pli.Series:
+    def reverse(self) -> Series:
         """Reverse the arrays in the list."""
 
-    def unique(self) -> pli.Series:
+    def unique(self) -> Series:
         """Get the unique/distinct values in the list."""
 
-    def concat(self, other: list[pli.Series] | pli.Series | list[Any]) -> pli.Series:
+    def concat(self, other: list[Series] | Series | list[Any]) -> Series:
         """
         Concat the arrays in a Series dtype List in linear time.
 
@@ -104,7 +106,7 @@ class ListNameSpace:
 
         """
 
-    def get(self, index: int | pli.Series | list[int]) -> pli.Series:
+    def get(self, index: int | Series | list[int]) -> Series:
         """
         Get the value by index in the sublists.
 
@@ -120,8 +122,8 @@ class ListNameSpace:
         """
 
     def take(
-        self, index: pli.Series | list[int] | list[list[int]], null_on_oob: bool = False
-    ) -> pli.Series:
+        self, index: Series | list[int] | list[list[int]], null_on_oob: bool = False
+    ) -> Series:
         """
         Take sublists by multiple indices.
 
@@ -140,10 +142,10 @@ class ListNameSpace:
 
         """
 
-    def __getitem__(self, item: int) -> pli.Series:
+    def __getitem__(self, item: int) -> Series:
         return self.get(item)
 
-    def join(self, separator: str) -> pli.Series:
+    def join(self, separator: str) -> Series:
         """
         Join all string items in a sublist and place a separator between them.
 
@@ -171,13 +173,13 @@ class ListNameSpace:
 
         """
 
-    def first(self) -> pli.Series:
+    def first(self) -> Series:
         """Get the first value of the sublists."""
 
-    def last(self) -> pli.Series:
+    def last(self) -> Series:
         """Get the last value of the sublists."""
 
-    def contains(self, item: float | str | bool | int | date | datetime) -> pli.Series:
+    def contains(self, item: float | str | bool | int | date | datetime) -> Series:
         """
         Check if sublists contain the given item.
 
@@ -192,7 +194,7 @@ class ListNameSpace:
 
         """
 
-    def arg_min(self) -> pli.Series:
+    def arg_min(self) -> Series:
         """
         Retrieve the index of the minimal value in every sublist.
 
@@ -202,7 +204,7 @@ class ListNameSpace:
 
         """
 
-    def arg_max(self) -> pli.Series:
+    def arg_max(self) -> Series:
         """
         Retrieve the index of the maximum value in every sublist.
 
@@ -212,7 +214,7 @@ class ListNameSpace:
 
         """
 
-    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> pli.Series:
+    def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
         Calculate the n-th discrete difference of every sublist.
 
@@ -252,7 +254,7 @@ class ListNameSpace:
 
         """
 
-    def shift(self, periods: int = 1) -> pli.Series:
+    def shift(self, periods: int = 1) -> Series:
         """
         Shift values by the given period.
 
@@ -274,7 +276,7 @@ class ListNameSpace:
 
         """
 
-    def slice(self, offset: int, length: int | None = None) -> pli.Series:
+    def slice(self, offset: int, length: int | None = None) -> Series:
         """
         Slice every sublist.
 
@@ -299,7 +301,7 @@ class ListNameSpace:
 
         """
 
-    def head(self, n: int = 5) -> pli.Series:
+    def head(self, n: int = 5) -> Series:
         """
         Slice the first `n` values of every sublist.
 
@@ -321,7 +323,7 @@ class ListNameSpace:
 
         """
 
-    def tail(self, n: int = 5) -> pli.Series:
+    def tail(self, n: int = 5) -> Series:
         """
         Slice the last `n` values of every sublist.
 
@@ -343,7 +345,7 @@ class ListNameSpace:
 
         """
 
-    def explode(self) -> pli.Series:
+    def explode(self) -> Series:
         """
         Returns a column with a separate row for every list element.
 
@@ -373,8 +375,8 @@ class ListNameSpace:
         """
 
     def count_match(
-        self, element: float | str | bool | int | date | datetime | time | pli.Expr
-    ) -> pli.Expr:
+        self, element: float | str | bool | int | date | datetime | time | Expr
+    ) -> Expr:
         """
         Count how often the value produced by ``element`` occurs.
 
@@ -389,7 +391,7 @@ class ListNameSpace:
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",
         name_generator: Callable[[int], str] | None = None,
-    ) -> pli.Series:
+    ) -> Series:
         """
         Convert the series of type ``List`` to a series of type ``Struct``.
 
@@ -441,7 +443,7 @@ class ListNameSpace:
             .to_series()
         )
 
-    def eval(self, expr: pli.Expr, parallel: bool = False) -> pli.Series:
+    def eval(self, expr: Expr, parallel: bool = False) -> Series:
         """
         Run any polars expression against the lists' elements.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -97,7 +97,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import (
         ClosedInterval,
         ComparisonOperator,
@@ -555,14 +557,14 @@ class Series:
         return self._from_pyseries(f(other))
 
     @overload
-    def __add__(self, other: pli.DataFrame) -> pli.DataFrame:  # type: ignore[misc]
+    def __add__(self, other: DataFrame) -> DataFrame:  # type: ignore[misc]
         ...
 
     @overload
     def __add__(self, other: Any) -> Self:
         ...
 
-    def __add__(self, other: Any) -> Self | pli.DataFrame:
+    def __add__(self, other: Any) -> Self | DataFrame:
         if isinstance(other, str):
             other = Series("", [other])
         elif isinstance(other, pli.DataFrame):
@@ -597,14 +599,14 @@ class Series:
         return NotImplemented
 
     @overload
-    def __mul__(self, other: pli.DataFrame) -> pli.DataFrame:  # type: ignore[misc]
+    def __mul__(self, other: DataFrame) -> DataFrame:  # type: ignore[misc]
         ...
 
     @overload
     def __mul__(self, other: Any) -> Series:
         ...
 
-    def __mul__(self, other: Any) -> Series | pli.DataFrame:
+    def __mul__(self, other: Any) -> Series | DataFrame:
         if self.is_temporal():
             raise ValueError("first cast to integer before multiplying datelike dtypes")
         elif isinstance(other, pli.DataFrame):
@@ -1104,7 +1106,7 @@ class Series:
     def drop_nans(self) -> Series:
         """Drop NaN values."""
 
-    def to_frame(self, name: str | None = None) -> pli.DataFrame:
+    def to_frame(self, name: str | None = None) -> DataFrame:
         """
         Cast this Series to a DataFrame.
 
@@ -1145,7 +1147,7 @@ class Series:
             return pli.wrap_df(PyDataFrame([self.rename(name)._s]))
         return pli.wrap_df(PyDataFrame([self._s]))
 
-    def describe(self) -> pli.DataFrame:
+    def describe(self) -> DataFrame:
         """
         Quick summary statistics of a series.
 
@@ -1388,7 +1390,7 @@ class Series:
         """
         return self._s.quantile(quantile, interpolation)
 
-    def to_dummies(self, separator: str = "_") -> pli.DataFrame:
+    def to_dummies(self, separator: str = "_") -> DataFrame:
         """
         Get dummy/indicator variables.
 
@@ -1421,7 +1423,7 @@ class Series:
         labels: list[str] | None = None,
         break_point_label: str = "break_point",
         category_label: str = "category",
-    ) -> pli.DataFrame:
+    ) -> DataFrame:
         """
         Bin values into discrete values.
 
@@ -1504,7 +1506,7 @@ class Series:
         )
         return result
 
-    def value_counts(self, sort: bool = False) -> pli.DataFrame:
+    def value_counts(self, sort: bool = False) -> DataFrame:
         """
         Count the unique values in a Series.
 
@@ -1575,7 +1577,7 @@ class Series:
         return pli.select(pli.lit(self).entropy(base, normalize)).to_series()[0]
 
     def cumulative_eval(
-        self, expr: pli.Expr, min_periods: int = 1, parallel: bool = False
+        self, expr: Expr, min_periods: int = 1, parallel: bool = False
     ) -> Series:
         """
         Run an expression over a sliding window that increases `1` slot every iteration.
@@ -2290,7 +2292,7 @@ class Series:
         """
 
     def take(
-        self, indices: int | list[int] | pli.Expr | Series | np.ndarray[Any, Any]
+        self, indices: int | list[int] | Expr | Series | np.ndarray[Any, Any]
     ) -> Series:
         """
         Take values by index.
@@ -2812,8 +2814,8 @@ class Series:
 
     def is_between(
         self,
-        start: pli.Expr | datetime | date | time | int | float | str,
-        end: pli.Expr | datetime | date | time | int | float | str,
+        start: Expr | datetime | date | time | int | float | str,
+        end: Expr | datetime | date | time | int | float | str,
         closed: ClosedInterval = "both",
     ) -> Series:
         """
@@ -3374,7 +3376,7 @@ class Series:
         """
         return self._from_pyseries(self._s.clone())
 
-    def fill_nan(self, fill_value: int | float | pli.Expr | None) -> Series:
+    def fill_nan(self, fill_value: int | float | Expr | None) -> Series:
         """
         Fill floating point NaN value with a fill value.
 
@@ -3891,7 +3893,7 @@ class Series:
 
         """
 
-    def shift_and_fill(self, periods: int, fill_value: int | pli.Expr) -> Series:
+    def shift_and_fill(self, periods: int, fill_value: int | Expr) -> Series:
         """
         Shift the values by a given period and fill the resulting null values.
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -7,8 +7,10 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     from polars.datatypes import PolarsDataType, PolarsTemporalType
+    from polars.expr.expr import Expr
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
+    from polars.series.series import Series
 
 
 @expr_dispatch
@@ -17,7 +19,7 @@ class StringNameSpace:
 
     _accessor = "str"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
     def strptime(
@@ -29,7 +31,7 @@ class StringNameSpace:
         cache: bool = True,
         tz_aware: bool = False,
         utc: bool = False,
-    ) -> pli.Series:
+    ) -> Series:
         """
         Parse a Series of dtype Utf8 to a Date/Datetime Series.
 
@@ -109,7 +111,7 @@ class StringNameSpace:
 
         """
 
-    def lengths(self) -> pli.Series:
+    def lengths(self) -> Series:
         """
         Get length of the string values in the Series (as number of bytes).
 
@@ -137,7 +139,7 @@ class StringNameSpace:
 
         """
 
-    def n_chars(self) -> pli.Series:
+    def n_chars(self) -> Series:
         """
         Get length of the string values in the Series (as number of chars).
 
@@ -165,7 +167,7 @@ class StringNameSpace:
 
         """
 
-    def concat(self, delimiter: str = "-") -> pli.Series:
+    def concat(self, delimiter: str = "-") -> Series:
         """
         Vertically concat the values in the Series to a single string value.
 
@@ -186,8 +188,8 @@ class StringNameSpace:
         """
 
     def contains(
-        self, pattern: str | pli.Expr, literal: bool = False, strict: bool = True
-    ) -> pli.Series:
+        self, pattern: str | Expr, literal: bool = False, strict: bool = True
+    ) -> Series:
         """
         Check if strings in Series contain a substring that matches a regex.
 
@@ -229,7 +231,7 @@ class StringNameSpace:
 
         """
 
-    def ends_with(self, sub: str | pli.Expr) -> pli.Series:
+    def ends_with(self, sub: str | Expr) -> Series:
         """
         Check if string values end with a substring.
 
@@ -257,7 +259,7 @@ class StringNameSpace:
 
         """
 
-    def starts_with(self, sub: str | pli.Expr) -> pli.Series:
+    def starts_with(self, sub: str | Expr) -> Series:
         """
         Check if string values start with a substring.
 
@@ -285,7 +287,7 @@ class StringNameSpace:
 
         """
 
-    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> pli.Series:
+    def decode(self, encoding: TransferEncoding, *, strict: bool = True) -> Series:
         """
         Decode a value using the provided encoding.
 
@@ -299,7 +301,7 @@ class StringNameSpace:
 
         """
 
-    def encode(self, encoding: TransferEncoding) -> pli.Series:
+    def encode(self, encoding: TransferEncoding) -> Series:
         """
         Encode a value using the provided encoding.
 
@@ -326,7 +328,7 @@ class StringNameSpace:
 
         """
 
-    def json_extract(self, dtype: PolarsDataType | None = None) -> pli.Series:
+    def json_extract(self, dtype: PolarsDataType | None = None) -> Series:
         """
         Parse string values as JSON.
 
@@ -357,7 +359,7 @@ class StringNameSpace:
 
         """
 
-    def json_path_match(self, json_path: str) -> pli.Series:
+    def json_path_match(self, json_path: str) -> Series:
         """
         Extract the first match of json string with provided JSONPath expression.
 
@@ -395,7 +397,7 @@ class StringNameSpace:
 
         """
 
-    def extract(self, pattern: str, group_index: int = 1) -> pli.Series:
+    def extract(self, pattern: str, group_index: int = 1) -> Series:
         r"""
         Extract the target capture group from provided patterns.
 
@@ -437,7 +439,7 @@ class StringNameSpace:
 
         """
 
-    def extract_all(self, pattern: str | pli.Series) -> pli.Series:
+    def extract_all(self, pattern: str | Series) -> Series:
         r"""
         Extracts all matches for the given regex pattern.
 
@@ -467,7 +469,7 @@ class StringNameSpace:
 
         """
 
-    def count_match(self, pattern: str) -> pli.Series:
+    def count_match(self, pattern: str) -> Series:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -494,7 +496,7 @@ class StringNameSpace:
 
         """
 
-    def split(self, by: str, inclusive: bool = False) -> pli.Series:
+    def split(self, by: str, inclusive: bool = False) -> Series:
         """
         Split the string by a substring.
 
@@ -511,7 +513,7 @@ class StringNameSpace:
 
         """
 
-    def split_exact(self, by: str, n: int, inclusive: bool = False) -> pli.Series:
+    def split_exact(self, by: str, n: int, inclusive: bool = False) -> Series:
         """
         Split the string by a substring using ``n`` splits.
 
@@ -570,7 +572,7 @@ class StringNameSpace:
 
         """
 
-    def splitn(self, by: str, n: int) -> pli.Series:
+    def splitn(self, by: str, n: int) -> Series:
         """
         Split the string by a substring, restricted to returning at most ``n`` items.
 
@@ -631,7 +633,7 @@ class StringNameSpace:
 
     def replace(
         self, pattern: str, value: str, literal: bool = False, *, n: int = 1
-    ) -> pli.Series:
+    ) -> Series:
         r"""
         Replace first matching regex/literal substring with a new string value.
 
@@ -663,9 +665,7 @@ class StringNameSpace:
 
         """
 
-    def replace_all(
-        self, pattern: str, value: str, literal: bool = False
-    ) -> pli.Series:
+    def replace_all(self, pattern: str, value: str, literal: bool = False) -> Series:
         """
         Replace all matching regex/literal substrings with a new string value.
 
@@ -695,7 +695,7 @@ class StringNameSpace:
 
         """
 
-    def strip(self, matches: str | None = None) -> pli.Series:
+    def strip(self, matches: str | None = None) -> Series:
         r"""
         Remove leading and trailing characters.
 
@@ -730,7 +730,7 @@ class StringNameSpace:
 
         """
 
-    def lstrip(self, matches: str | None = None) -> pli.Series:
+    def lstrip(self, matches: str | None = None) -> Series:
         r"""
         Remove leading characters.
 
@@ -765,7 +765,7 @@ class StringNameSpace:
 
         """
 
-    def rstrip(self, matches: str | None = None) -> pli.Series:
+    def rstrip(self, matches: str | None = None) -> Series:
         r"""
         Remove trailing characters.
 
@@ -800,7 +800,7 @@ class StringNameSpace:
 
         """
 
-    def zfill(self, alignment: int) -> pli.Series:
+    def zfill(self, alignment: int) -> Series:
         """
         Fills the string with zeroes.
 
@@ -818,7 +818,7 @@ class StringNameSpace:
 
         """
 
-    def ljust(self, width: int, fillchar: str = " ") -> pli.Series:
+    def ljust(self, width: int, fillchar: str = " ") -> Series:
         """
         Return the string left justified in a string of length ``width``.
 
@@ -847,7 +847,7 @@ class StringNameSpace:
 
         """
 
-    def rjust(self, width: int, fillchar: str = " ") -> pli.Series:
+    def rjust(self, width: int, fillchar: str = " ") -> Series:
         """
         Return the string right justified in a string of length ``width``.
 
@@ -876,13 +876,13 @@ class StringNameSpace:
 
         """
 
-    def to_lowercase(self) -> pli.Series:
+    def to_lowercase(self) -> Series:
         """Modify the strings to their lowercase equivalent."""
 
-    def to_uppercase(self) -> pli.Series:
+    def to_uppercase(self) -> Series:
         """Modify the strings to their uppercase equivalent."""
 
-    def slice(self, offset: int, length: int | None = None) -> pli.Series:
+    def slice(self, offset: int, length: int | None = None) -> Series:
         """
         Create subslices of the string values of a Utf8 Series.
 
@@ -926,7 +926,7 @@ class StringNameSpace:
 
         """
 
-    def explode(self) -> pli.Series:
+    def explode(self) -> Series:
         """
         Returns a column with a separate row for every string character.
 
@@ -951,7 +951,7 @@ class StringNameSpace:
 
         """
 
-    def parse_int(self, radix: int = 2, strict: bool = True) -> pli.Series:
+    def parse_int(self, radix: int = 2, strict: bool = True) -> Series:
         r"""
         Parse integers with base radix from strings.
 

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -9,7 +9,9 @@ from polars.utils.decorators import redirect
 from polars.utils.various import sphinx_accessor
 
 if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
     from polars.polars import PySeries
+    from polars.series.series import Series
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
 
@@ -21,10 +23,10 @@ class StructNameSpace:
 
     _accessor = "struct"
 
-    def __init__(self, series: pli.Series):
+    def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def __getitem__(self, item: int | str) -> pli.Series:
+    def __getitem__(self, item: int | str) -> Series:
         if isinstance(item, int):
             return self.field(self.fields[item])
         elif isinstance(item, str):
@@ -42,7 +44,7 @@ class StructNameSpace:
             return []
         return self._s.struct_fields()
 
-    def field(self, name: str) -> pli.Series:
+    def field(self, name: str) -> Series:
         """
         Retrieve one of the fields of this `Struct` as a new Series.
 
@@ -53,7 +55,7 @@ class StructNameSpace:
 
         """
 
-    def rename_fields(self, names: Sequence[str]) -> pli.Series:
+    def rename_fields(self, names: Sequence[str]) -> Series:
         """
         Rename the fields of the struct.
 
@@ -64,7 +66,7 @@ class StructNameSpace:
 
         """
 
-    def unnest(self) -> pli.DataFrame:
+    def unnest(self) -> DataFrame:
         """
         Convert this struct Series to a DataFrame with a separate column for each field.
 

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -11,6 +11,7 @@ from polars.datatypes import dtype_to_ffiname
 if TYPE_CHECKING:
     from polars.datatypes import PolarsDataType
     from polars.polars import PySeries
+    from polars.series.series import Series
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
     P = ParamSpec("P")
-    SeriesMethod = Callable[..., pli.Series]
+    SeriesMethod = Callable[..., Series]
 
 
 class _EmptyBytecodeHelper:
@@ -89,7 +90,7 @@ def call_expr(func: SeriesMethod) -> SeriesMethod:
     """Dispatch Series method to an expression implementation."""
 
     @wraps(func)  # type: ignore[arg-type]
-    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> pli.Series:
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Series:
         s = pli.wrap_s(self._s)
         expr = pli.col(s.name)
         namespace = getattr(self, "_accessor", None)

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import contextlib
+from typing import TYPE_CHECKING
 
 from polars import internals as pli
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext
+
+if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
+    from polars.lazyframe.frame import LazyFrame
 
 
 class SQLContext:
@@ -20,7 +27,7 @@ class SQLContext:
     def __init__(self) -> None:
         self._ctxt = PySQLContext.new()
 
-    def register(self, name: str, lf: pli.LazyFrame) -> None:
+    def register(self, name: str, lf: LazyFrame) -> None:
         """
         Register a ``LazyFrame`` in this ``SQLContext`` under a given ``name``.
 
@@ -34,7 +41,7 @@ class SQLContext:
         """
         self._ctxt.register(name, lf._ldf)
 
-    def execute(self, query: str) -> pli.LazyFrame:
+    def execute(self, query: str) -> LazyFrame:
         """
         Parse the givens SQL query and transform that to a ``LazyFrame``.
 
@@ -46,5 +53,5 @@ class SQLContext:
         """
         return pli.wrap_ldf(self._ctxt.execute(query))
 
-    def query(self, query: str) -> pli.DataFrame:
+    def query(self, query: str) -> DataFrame:
         return self.execute(query).collect()

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -54,7 +54,10 @@ from polars.testing.asserts import is_categorical_dtype
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn, SearchStrategy
 
+    from polars.dataframe.frame import DataFrame
     from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
+    from polars.lazyframe.frame import LazyFrame
+    from polars.series.series import Series
 
 
 # Default profile (eg: running locally)
@@ -167,7 +170,7 @@ class column:
 
     name: str
     dtype: PolarsDataType | None = None
-    strategy: SearchStrategy[pli.Series | int] | None = None
+    strategy: SearchStrategy[Series | int] | None = None
     null_probability: float | None = None
     unique: bool = False
 
@@ -309,7 +312,7 @@ def series(
     chunked: bool | None = None,
     allowed_dtypes: Sequence[PolarsDataType] | None = None,
     excluded_dtypes: Sequence[PolarsDataType] | None = None,
-) -> SearchStrategy[pli.Series]:
+) -> SearchStrategy[Series]:
     """
     Strategy for producing a polars Series.
 
@@ -388,7 +391,7 @@ def series(
     null_probability = float(null_probability or 0.0)
 
     @composite
-    def draw_series(draw: DrawFn) -> pli.Series:
+    def draw_series(draw: DrawFn) -> Series:
         with StringCache():
             # create/assign series dtype and retrieve matching strategy
             series_dtype = (
@@ -468,7 +471,7 @@ def dataframes(
     allow_infinities: bool = True,
     allowed_dtypes: Sequence[PolarsDataType] | None = None,
     excluded_dtypes: Sequence[PolarsDataType] | None = None,
-) -> SearchStrategy[pli.DataFrame | pli.LazyFrame]:
+) -> SearchStrategy[DataFrame | LazyFrame]:
     """
     Provides a strategy for producing a DataFrame or LazyFrame.
 
@@ -572,7 +575,7 @@ def dataframes(
     ]
 
     @composite
-    def draw_frames(draw: DrawFn) -> pli.DataFrame | pli.LazyFrame:
+    def draw_frames(draw: DrawFn) -> DataFrame | LazyFrame:
         with StringCache():
             # if not given, create 'n' cols with random dtypes
             if cols is None or isinstance(cols, int):

--- a/py-polars/polars/testing/_private.py
+++ b/py-polars/polars/testing/_private.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from polars import internals as pli
+    from polars.dataframe.frame import DataFrame
+    from polars.series.series import Series
 
 
-def _to_rust_syntax(df: pli.DataFrame) -> str:
+def _to_rust_syntax(df: DataFrame) -> str:
     """Utility to generate the syntax that creates a polars 'DataFrame' in Rust."""
     syntax = "df![\n"
 
-    def format_s(s: pli.Series) -> str:
+    def format_s(s: Series) -> str:
         if s.null_count() == 0:
             return str(s.to_list()).replace("'", '"')
         else:

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -15,12 +15,17 @@ from polars.datatypes import (
 from polars.exceptions import ComputeError, InvalidAssert
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
+if TYPE_CHECKING:
+    from polars.dataframe.frame import DataFrame
+    from polars.lazyframe.frame import LazyFrame
+    from polars.series.series import Series
+
 
 @deprecate_nonkeyword_arguments()
 @deprecated_alias(check_column_names="check_column_order")
 def assert_frame_equal(
-    left: pli.DataFrame | pli.LazyFrame,
-    right: pli.DataFrame | pli.LazyFrame,
+    left: DataFrame | LazyFrame,
+    right: DataFrame | LazyFrame,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
@@ -120,8 +125,8 @@ def assert_frame_equal(
 
 @deprecate_nonkeyword_arguments()
 def assert_frame_not_equal(
-    left: pli.DataFrame | pli.LazyFrame,
-    right: pli.DataFrame | pli.LazyFrame,
+    left: DataFrame | LazyFrame,
+    right: DataFrame | LazyFrame,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
@@ -186,8 +191,8 @@ def assert_frame_not_equal(
 
 @deprecate_nonkeyword_arguments()
 def assert_series_equal(
-    left: pli.Series,
-    right: pli.Series,
+    left: Series,
+    right: Series,
     check_dtype: bool = True,
     check_names: bool = True,
     check_exact: bool = False,
@@ -245,8 +250,8 @@ def assert_series_equal(
 
 @deprecate_nonkeyword_arguments()
 def assert_series_not_equal(
-    left: pli.Series,
-    right: pli.Series,
+    left: Series,
+    right: Series,
     check_dtype: bool = True,
     check_names: bool = True,
     check_exact: bool = False,
@@ -303,8 +308,8 @@ def assert_series_not_equal(
 
 
 def _assert_series_inner(
-    left: pli.Series,
-    right: pli.Series,
+    left: Series,
+    right: Series,
     check_dtype: bool,
     check_exact: bool,
     nans_compare_equal: bool,
@@ -398,9 +403,7 @@ def is_categorical_dtype(data_type: Any) -> bool:
     )
 
 
-def assert_frame_equal_local_categoricals(
-    df_a: pli.DataFrame, df_b: pli.DataFrame
-) -> None:
+def assert_frame_equal_local_categoricals(df_a: DataFrame, df_b: DataFrame) -> None:
     """Assert frame equal for frames containing categoricals."""
     for (a_name, a_value), (b_name, b_value) in zip(
         df_a.schema.items(), df_b.schema.items()

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -13,6 +13,10 @@ from polars.datatypes import Int64, is_polars_dtype
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyExpr
 
+if TYPE_CHECKING:
+    from polars.expr.expr import Expr
+    from polars.series.series import Series
+
 
 # note: reversed views don't match as instances of MappingView
 if sys.version_info >= (3, 11):
@@ -72,7 +76,7 @@ def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
     return isinstance(val, Sequence) and _is_iterable_of(val, int)
 
 
-def is_expr_sequence(val: object) -> TypeGuard[Sequence[pli.Expr]]:
+def is_expr_sequence(val: object) -> TypeGuard[Sequence[Expr]]:
     """Check whether the given object is a sequence of Exprs."""
     return isinstance(val, Sequence) and _is_iterable_of(val, pli.Expr)
 
@@ -98,7 +102,7 @@ def is_str_sequence(
 
 def range_to_series(
     name: str, rng: range, dtype: PolarsDataType | None = Int64
-) -> pli.Series:
+) -> Series:
     """Fast conversion of the given range to a Series."""
     return pli.arange(
         low=rng.start,


### PR DESCRIPTION
548 out of 1172 occurrences of `pli.` eliminated :cop: