### PR TITLE
fix(rust, python): fix ooc sort. the fast path was invalid

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -71,7 +71,7 @@ pub(super) fn sort_ooc(
         })
         .collect::<std::io::Result<Vec<_>>>()?;
 
-    let source = SortSource::new(files, idx, descending, slice, partitions);
+    let source = SortSource::new(files, idx, descending, slice);
     Ok(FinalizedSink::Source(Box::new(source)))
 }
 


### PR DESCRIPTION
fixes #7568