### PR TITLE
docs(python): add a performance hint about use of `lru_cache` to the `apply` docstrings

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -161,7 +161,7 @@ class Config:
     @classmethod
     def set_ascii_tables(cls, active: bool = True) -> type[Config]:
         """
-        Use ASCII characters to print table outlines (set False to revert to UTF8).
+        Use ASCII characters to display table outlines (set False to revert to UTF8).
 
         Examples
         --------
@@ -193,12 +193,12 @@ class Config:
     @classmethod
     def set_fmt_str_lengths(cls, n: int) -> type[Config]:
         """
-        Set the number of characters used to print string values.
+        Set the number of characters used to display string values.
 
         Parameters
         ----------
         n : int
-            number of characters to print
+            number of characters to display
 
         """
         os.environ["POLARS_FMT_STR_LEN"] = str(n)
@@ -247,12 +247,12 @@ class Config:
     @classmethod
     def set_tbl_cols(cls, n: int) -> type[Config]:
         """
-        Set the number of columns used to print tables.
+        Set the number of columns that are visible when displaying tables.
 
         Parameters
         ----------
         n : int
-            number of columns to print. If n<0 print all the columns.
+            number of columns to display; if ``n < 0`` (eg: -1), display all columns.
 
         Examples
         --------
@@ -515,8 +515,8 @@ class Config:
         Parameters
         ----------
         n : int
-            number of rows to print; if n < 0, prints all rows (DataFrame) and
-            all elements (Series).
+            number of rows to display; if ``n < 0`` (eg: -1), display all
+            rows (DataFrame) and all elements (Series).
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4966,7 +4966,7 @@ class DataFrame:
 
         - The native expression engine runs in Rust; UDFs run in Python.
         - Use of Python UDFs forces the DataFrame to be materialized in memory.
-        - Polars-native expressions can be parallelised (UDFs cannot).
+        - Polars-native expressions can be parallelised (UDFs typically cannot).
         - Polars-native expressions can be logically optimised (UDFs cannot).
 
         Wherever possible you should strongly prefer the native expression API
@@ -4975,7 +4975,7 @@ class DataFrame:
         Parameters
         ----------
         function
-            Custom function/ lambda function.
+            Custom function or lambda.
         return_dtype
             Output type of the operation. If none given, Polars tries to infer the type.
         inference_size
@@ -4984,10 +4984,14 @@ class DataFrame:
 
         Notes
         -----
-        The frame-level ``apply`` cannot track column names (as the UDF is a black-box
-        that may arbitrarily drop, rearrange, transform, or add new columns); if you
-        want to apply a UDF such that column names are preserved, you should use the
-        expression-level ``apply`` syntax instead.
+        * The frame-level ``apply`` cannot track column names (as the UDF is a black-box
+          that may arbitrarily drop, rearrange, transform, or add new columns); if you
+          want to apply a UDF such that column names are preserved, you should use the
+          expression-level ``apply`` syntax instead.
+
+        * If your function is expensive and you don't want it to be called more than
+          once for a given input, consider applying an ``@lru_cache`` decorator to it.
+          With suitable data you may achieve order-of-magnitude speedups (or more).
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3270,10 +3270,13 @@ class Expr:
 
         Notes
         -----
-        Using ``apply`` is strongly discouraged as you will be effectively running
-        python for loops. This will be very slow.
-        Wherever possible you should strongly prefer the native expression API
-        to achieve the best performance.
+        * Using ``apply`` is strongly discouraged as you will be effectively running
+          python "for" loops. This will be very slow. Wherever possible you should
+          strongly prefer the native expression API to achieve the best performance.
+
+        * If your function is expensive and you don't want it to be called more than
+          once for a given input, consider applying an ``@lru_cache`` decorator to it.
+          With suitable data you may achieve order-of-magnitude speedups (or more).
 
         Parameters
         ----------


### PR DESCRIPTION
Ref:  #7592.

* When applicable, use of `lru_cache` can be a game-changer for UDFs. (I've taken advantage of this to get orders of magnitude speedups on occasion - let's share that knowledge ;)
* Will see about adding a slightly more detailed note into [The Book](https://pola-rs.github.io/polars-book/user-guide/dsl/custom_functions.html) too.

Ref: #7591.

* Minor improvement to `set_tbl_cols` and `set_tbl_rows` docstrings to better clarify use of `-1` to display all cols/rows, and prefer use of "display" to "print" in most cases (in Config docstring text).