### PR TITLE
fix index columns in pandas to_sql()

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2961,7 +2961,7 @@ class DataFrame:
             # this conversion to pandas as zero-copy
             # so we can utilize their sql utils for free
             self.to_pandas(use_pyarrow_extension_array=True).to_sql(
-                name=table_name, con=engine, if_exists=if_exists
+                name=table_name, con=engine, if_exists=if_exists, index=False
             )
 
         else:


### PR DESCRIPTION
<img width="947" alt="image" src="https://user-images.githubusercontent.com/15261901/225763842-976bc178-8e19-4173-969b-757a9930642f.png">
Hello, I notice that in `.write_database` with sqlalchemy throw pandas.DataFrame.to_sql, the pandas index will be inserted in the table