### PR TITLE
refactor(rust)!: some ergonomic updates to the lazyframe apis

### DIFF
--- a/examples/read_parquet/src/main.rs
+++ b/examples/read_parquet/src/main.rs
@@ -1,7 +1,7 @@
 use polars::prelude::*;
 
 fn main() -> PolarsResult<()> {
-    let df = LazyFrame::scan_parquet("../datasets/foods1.parquet", ScanArgsParquet::default())?
+    let df = LazyFrame::scan_parquet("../datasets/foods1.parquet", ParquetOptions::default())?
         .select([
             // select all columns
             all(),

--- a/examples/read_parquet_cloud/src/main.rs
+++ b/examples/read_parquet_cloud/src/main.rs
@@ -10,13 +10,15 @@ fn main() -> PolarsResult<()> {
     let cred = Credentials::default().unwrap();
 
     // Propagate the credentials and other cloud options.
-    let mut args = ScanArgsParquet::default();
+    let mut args = ParquetOptions::default();
+
     let cloud_options = cloud::CloudOptions::default().with_aws([
         (Key::AccessKeyId, &cred.access_key.unwrap()),
         (Key::SecretAccessKey, &cred.secret_key.unwrap()),
         (Key::Region, &"us-west-2".into()),
     ]);
     args.cloud_options = Some(cloud_options);
+
     let df = LazyFrame::scan_parquet(TEST_S3, args)?
         .with_streaming(true)
         .select([

--- a/polars/polars-core/src/cloud.rs
+++ b/polars/polars-core/src/cloud.rs
@@ -31,9 +31,24 @@ use crate::error::{PolarsError, PolarsResult};
 #[allow(dead_code)]
 type Configs<T> = Vec<(T, String)>;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
-/// Options to conect to various cloud providers.
+/// Options to connect to various cloud providers.
+/// 
+/// # Example
+/// 
+/// ```rust
+/// use awscreds::Credentials;
+/// use polars::prelude::cloud::AmazonS3ConfigKey as Key;
+/// use polars::prelude::cloud::CloudOptions;
+/// 
+/// let cred = Credentials::default().unwrap();
+/// let cloud_options = CloudOptions::default().with_aws([
+///   (Key::AccessKeyId, &cred.access_key.unwrap()),
+///   (Key::SecretAccessKey, &cred.secret_key.unwrap()),
+///   (Key::Region, &"us-west-2".into()),
+/// ]);
+/// ```
 pub struct CloudOptions {
     #[cfg(feature = "aws")]
     aws: Option<Configs<AmazonS3ConfigKey>>,

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/parquet.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/parquet.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use polars_core::cloud::CloudOptions;
 use polars_core::error::PolarsResult;
 use polars_core::schema::*;
 use polars_core::POOL;
@@ -25,7 +24,6 @@ impl ParquetSource {
     pub(crate) fn new(
         path: PathBuf,
         options: ParquetOptions,
-        cloud_options: Option<CloudOptions>,
         schema: &Schema,
         verbose: bool,
     ) -> PolarsResult<Self> {
@@ -54,7 +52,7 @@ impl ParquetSource {
             #[cfg(feature = "async")]
             {
                 let uri = path.to_string_lossy();
-                ParquetAsyncReader::from_uri(&uri, cloud_options.as_ref())?
+                ParquetAsyncReader::from_uri(&uri, options.cloud_options.as_ref())?
                     .with_n_rows(options.n_rows)
                     .with_row_count(options.row_count)
                     .with_projection(projection)

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -85,7 +85,6 @@ where
             path,
             file_info,
             options,
-            cloud_options,
             predicate,
             output_schema,
             ..
@@ -97,13 +96,7 @@ where
                 let op = Box::new(op) as Box<dyn Operator>;
                 operator_objects.push(op)
             }
-            let src = sources::ParquetSource::new(
-                path,
-                options,
-                cloud_options,
-                &file_info.schema,
-                verbose,
-            )?;
+            let src = sources::ParquetSource::new(path, options, &file_info.schema, verbose)?;
             Ok(Box::new(src) as Box<dyn Source>)
         }
         _ => todo!(),

--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[cfg(feature = "parquet")]
-use polars_core::cloud::CloudOptions;
 use polars_core::prelude::*;
 use polars_utils::arena::{Arena, Node};
 
@@ -69,7 +67,6 @@ pub enum ALogicalPlan {
         output_schema: Option<SchemaRef>,
         predicate: Option<Node>,
         options: ParquetOptions,
-        cloud_options: Option<CloudOptions>,
     },
     DataFrameScan {
         df: Arc<DataFrame>,
@@ -385,7 +382,6 @@ impl ALogicalPlan {
                 output_schema,
                 predicate,
                 options,
-                cloud_options,
                 ..
             } => {
                 let mut new_predicate = None;
@@ -399,7 +395,6 @@ impl ALogicalPlan {
                     output_schema: output_schema.clone(),
                     predicate: new_predicate,
                     options: options.clone(),
-                    cloud_options: cloud_options.clone(),
                 }
             }
             #[cfg(feature = "csv-file")]

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -234,14 +234,12 @@ pub fn to_alp(
             file_info,
             predicate,
             options,
-            cloud_options,
         } => ALogicalPlan::ParquetScan {
             path,
             file_info,
             output_schema: None,
             predicate: predicate.map(|expr| to_aexpr(expr, expr_arena)),
             options,
-            cloud_options,
         },
         LogicalPlan::DataFrameScan {
             df,
@@ -717,13 +715,11 @@ impl ALogicalPlan {
                 output_schema: _,
                 predicate,
                 options,
-                cloud_options,
             } => LogicalPlan::ParquetScan {
                 path,
                 file_info,
                 predicate: predicate.map(|n| node_to_expr(n, expr_arena)),
                 options,
-                cloud_options,
             },
             ALogicalPlan::DataFrameScan {
                 df,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -4,8 +4,6 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "parquet")]
-use polars_core::cloud::CloudOptions;
 use polars_core::prelude::*;
 
 use crate::logical_plan::LogicalPlan::DataFrameScan;
@@ -152,7 +150,6 @@ pub enum LogicalPlan {
         file_info: FileInfo,
         predicate: Option<Expr>,
         options: ParquetOptions,
-        cloud_options: Option<CloudOptions>,
     },
     #[cfg(feature = "ipc")]
     IpcScan {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -280,7 +280,6 @@ impl FileCacher {
                     output_schema,
                     predicate,
                     mut options,
-                    cloud_options,
                 } => {
                     let predicate_expr = predicate.map(|node| node_to_expr(node, expr_arena));
                     let finger_print = FileFingerPrint {
@@ -306,7 +305,6 @@ impl FileCacher {
                         output_schema,
                         predicate,
                         options: options.clone(),
-                        cloud_options,
                     };
                     let lp = self.finish_rewrite(
                         lp,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -267,7 +267,6 @@ impl PredicatePushDown {
                 output_schema,
                 predicate,
                 options,
-                cloud_options,
             } => {
                 let local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
 
@@ -279,7 +278,6 @@ impl PredicatePushDown {
                     output_schema,
                     predicate,
                     options,
-                    cloud_options,
                 };
                 Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
             }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -449,7 +449,6 @@ impl ProjectionPushDown {
                 file_info,
                 predicate,
                 mut options,
-                cloud_options,
                 ..
             } => {
                 let with_columns = get_scan_columns(&mut acc_projections, expr_arena);
@@ -471,7 +470,6 @@ impl ProjectionPushDown {
                     output_schema,
                     predicate,
                     options,
-                    cloud_options,
                 };
                 Ok(lp)
             }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -145,7 +145,6 @@ impl SlicePushDown {
                 output_schema,
                 predicate,
                 mut options,
-                cloud_options,
 
             },
                 // TODO! we currently skip slice pushdown if there is a predicate.
@@ -158,7 +157,6 @@ impl SlicePushDown {
                     output_schema,
                     predicate,
                     options,
-                    cloud_options,
                 };
 
                 Ok(lp)

--- a/polars/polars-lazy/polars-plan/src/prelude.rs
+++ b/polars/polars-lazy/polars-plan/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use options::*;
 pub(crate) use polars_ops::prelude::*;
 #[cfg(feature = "rolling_window")]
 pub(crate) use polars_time::chunkedarray::{RollingOptions, RollingOptionsImpl};

--- a/polars/polars-lazy/src/frame/anonymous_scan.rs
+++ b/polars/polars-lazy/src/frame/anonymous_scan.rs
@@ -25,6 +25,7 @@ impl Default for ScanArgsAnonymous {
         }
     }
 }
+
 impl LazyFrame {
     pub fn anonymous_scan(
         function: Arc<dyn AnonymousScan>,

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
@@ -8,11 +8,10 @@ impl AnonymousScan for LazyJsonLineReader {
         let schema = scan_opts.output_schema.unwrap_or(scan_opts.schema);
         JsonLineReader::from_path(&self.path)?
             .with_schema(&schema)
-            .with_rechunk(self.rechunk)
-            .with_chunk_size(self.batch_size)
-            .low_memory(self.low_memory)
+            .with_rechunk(self.options.rechunk)
+            .with_chunk_size(self.options.batch_size)
+            .low_memory(self.options.low_memory)
             .with_n_rows(scan_opts.n_rows)
-            .with_chunk_size(self.batch_size)
             .finish()
     }
 

--- a/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use polars_core::cloud::CloudOptions;
-
 use super::*;
 
 #[allow(dead_code)]
@@ -10,7 +8,6 @@ pub struct ParquetExec {
     schema: SchemaRef,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     options: ParquetOptions,
-    cloud_options: Option<CloudOptions>,
 }
 
 impl ParquetExec {
@@ -19,14 +16,12 @@ impl ParquetExec {
         schema: SchemaRef,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         options: ParquetOptions,
-        cloud_options: Option<CloudOptions>,
     ) -> Self {
         ParquetExec {
             path,
             schema,
             predicate,
             options,
-            cloud_options,
         }
     }
 

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -218,7 +218,6 @@ pub fn create_physical_plan(
             output_schema,
             predicate,
             options,
-            cloud_options,
         } => {
             let predicate = predicate
                 .map(|pred| {
@@ -231,7 +230,6 @@ pub fn create_physical_plan(
                 file_info.schema,
                 predicate,
                 options,
-                cloud_options,
             )))
         }
         Projection {

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -2,11 +2,13 @@ pub(crate) use polars_ops::prelude::*;
 pub use polars_plan::logical_plan::{
     AnonymousScan, AnonymousScanOptions, Literal, LiteralValue, LogicalPlan, Null, NULL,
 };
-#[cfg(feature = "ipc")]
-pub use polars_plan::prelude::IpcWriterOptions;
-#[cfg(feature = "parquet")]
-pub use polars_plan::prelude::ParquetWriteOptions;
+#[cfg(feature = "json")]
+pub use polars_plan::prelude::JsonLineOptions;
 pub(crate) use polars_plan::prelude::*;
+#[cfg(feature = "ipc")]
+pub use polars_plan::prelude::{IpcOptions, IpcWriterOptions};
+#[cfg(feature = "parquet")]
+pub use polars_plan::prelude::{ParquetOptions, ParquetWriteOptions};
 #[cfg(feature = "rolling_window")]
 pub use polars_time::{prelude::RollingOptions, Duration};
 #[cfg(feature = "dynamic_groupby")]

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -151,7 +151,7 @@ fn test_parquet_globbing() -> PolarsResult<()> {
     let glob = "../../examples/datasets/*.parquet";
     let df = LazyFrame::scan_parquet(
         glob,
-        ScanArgsParquet {
+        ParquetOptions {
             n_rows: None,
             cache: true,
             parallel: Default::default(),
@@ -175,12 +175,9 @@ fn test_ipc_globbing() -> PolarsResult<()> {
     let glob = "../../examples/datasets/*.ipc";
     let df = LazyFrame::scan_ipc(
         glob,
-        ScanArgsIpc {
-            n_rows: None,
-            cache: true,
+        IpcOptions {
             rechunk: false,
-            row_count: None,
-            memmap: true,
+            ..Default::default()
         },
     )?
     .collect()?;
@@ -244,7 +241,9 @@ fn test_ndjson_globbing() -> PolarsResult<()> {
     // for side effects
     init_files();
     let glob = "../../examples/datasets/*.ndjson";
-    let df = LazyJsonLineReader::new(glob.into()).finish()?.collect()?;
+    let df = LazyJsonLineReader::new(glob, Default::default())
+        .finish()?
+        .collect()?;
     assert_eq!(df.shape(), (54, 4));
     let cal = df.column("calories")?;
     assert_eq!(cal.get(0)?, AnyValue::Int64(45));

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -109,7 +109,7 @@ fn scan_foods_parquet(parallel: bool) -> LazyFrame {
         ParallelStrategy::None
     };
 
-    let args = ScanArgsParquet {
+    let args = ParquetOptions {
         n_rows: None,
         cache: false,
         parallel,

--- a/polars/polars-lazy/src/tests/tpch.rs
+++ b/polars/polars-lazy/src/tests/tpch.rs
@@ -9,40 +9,32 @@ const fn base_path() -> &'static str {
 
 fn region() -> LazyFrame {
     let base_path = base_path();
-    LazyFrame::scan_ipc(
-        format!("{base_path}/region.feather"),
-        ScanArgsIpc::default(),
-    )
-    .unwrap()
+    LazyFrame::scan_ipc(format!("{base_path}/region.feather"), IpcOptions::default()).unwrap()
 }
 fn nation() -> LazyFrame {
     let base_path = base_path();
-    LazyFrame::scan_ipc(
-        format!("{base_path}/nation.feather"),
-        ScanArgsIpc::default(),
-    )
-    .unwrap()
+    LazyFrame::scan_ipc(format!("{base_path}/nation.feather"), IpcOptions::default()).unwrap()
 }
 
 fn supplier() -> LazyFrame {
     let base_path = base_path();
     LazyFrame::scan_ipc(
         format!("{base_path}/supplier.feather"),
-        ScanArgsIpc::default(),
+        IpcOptions::default(),
     )
     .unwrap()
 }
 
 fn part() -> LazyFrame {
     let base_path = base_path();
-    LazyFrame::scan_ipc(format!("{base_path}/part.feather"), ScanArgsIpc::default()).unwrap()
+    LazyFrame::scan_ipc(format!("{base_path}/part.feather"), IpcOptions::default()).unwrap()
 }
 
 fn partsupp() -> LazyFrame {
     let base_path = base_path();
     LazyFrame::scan_ipc(
         format!("{base_path}/partsupp.feather"),
-        ScanArgsIpc::default(),
+        IpcOptions::default(),
     )
     .unwrap()
 }

--- a/polars/polars-sql/src/cli.rs
+++ b/polars/polars-sql/src/cli.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use polars_core::prelude::*;
-use polars_lazy::frame::LazyFrame;
 #[cfg(feature = "ipc")]
-use polars_lazy::frame::ScanArgsIpc;
+use polars_lazy::frame::IpcOptions;
+use polars_lazy::frame::LazyFrame;
 #[cfg(feature = "parquet")]
-use polars_lazy::frame::ScanArgsParquet;
+use polars_lazy::frame::ParquetOptions;
 #[cfg(feature = "csv")]
 use polars_lazy::frame::{LazyCsvReader, LazyFileListReader};
 use polars_sql::SQLContext;
@@ -87,9 +87,9 @@ fn create_dataframe_from_filename(filename: &str) -> PolarsResult<LazyFrame> {
         #[cfg(feature = "csv")]
         Some("csv") => LazyCsvReader::new(filename).finish(),
         #[cfg(feature = "parquet")]
-        Some("parquet") => LazyFrame::scan_parquet(filename, ScanArgsParquet::default()),
+        Some("parquet") => LazyFrame::scan_parquet(filename, ParquetOptions::default()),
         #[cfg(feature = "ipc")]
-        Some("ipc") => LazyFrame::scan_ipc(filename, ScanArgsIpc::default()),
+        Some("ipc") => LazyFrame::scan_ipc(filename, IpcOptions::default()),
         None => polars_bail!(
             ComputeError: "unable to infer dataframe format from filename \"{}\"; \"\
             either specify a dataframe name registered with \\rd or an absolute path to a file",


### PR DESCRIPTION
Unlike the python api, the rust lazyframe api feels very fragmented. This is an attempt at making the rust lazyframe api more closely aligned with the python api. 

## Motivation
Some of the readers take in an `Options` object, some a builder pattern, and some both. 

Additionally, many of them use a `ScanArgs<X>` object for the lazyframe, but then use a separate, but nearly identical `<X>Options` under the hood. 


## Solution

First: 
Consolidate all of the args/options  to use a single `<X>Options`, and if a slightly different one is absolutely needed within the LogicalPlan, it will be `<X>OptionsInner`.
`ParquetOptions, IpcOptions, ...`

Second, expose all of the file readers with the following signature `LazyFrame::scan_X(path, options)`

```rust
let csv_lf = LazyFrame::scan_csv(csv_path, csv_options);
let json_lf = LazyFrame::scan_ndjson(json_path, json_options);
let parquet_lf = LazyFrame::scan_parquet(parquet_path, parquet_options);
...
```

Finally, adding some much needed documentation to those methods & options objects. 


## Notes.
I still have to do the CSV one. I wanted to put this draft out there before attempting to refactor that one as it is a bit of a monster.

Additionally, I think it could make sense to deprecate the builders & move the builder over to the options object, that way there is a single concise way of building a lazyframe in rust.

for example: 
```rust 
let csv_options = CsvOptions::builder()
  .n_rows(n_rows)
  .rechunk(rechunk)
  .build();
LazyFrame::scan_csv(csv_path, csv_options);
```
Instead of 

```rust
let lf = LazyCsvReader::new(csv_path)
  .with_n_rows(n_rows)
  .with_rechunk(rechunk)
  .finish();
```