### PR TITLE
feat(python): allow set and/or frozenset as input to `is_in` expressions

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -10,9 +10,12 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
+    FrozenSet,
     Iterable,
     NoReturn,
     Sequence,
+    Set,
     TypeVar,
     cast,
 )
@@ -3588,7 +3591,7 @@ class Expr:
         exponent = expr_to_lit_or_expr(exponent)
         return self._from_pyexpr(self._pyexpr.pow(exponent._pyexpr))
 
-    def is_in(self, other: Expr | Sequence[Any] | str | Series) -> Self:
+    def is_in(self, other: Expr | Collection[Any] | Series) -> Self:
         """
         Check if elements of this expression are present in the other Series.
 
@@ -3619,7 +3622,9 @@ class Expr:
         └──────────┘
 
         """
-        if isinstance(other, Sequence) and not isinstance(other, str):
+        if isinstance(other, Collection) and not isinstance(other, str):
+            if isinstance(other, (Set, FrozenSet)):
+                other = sorted(other)
             other = pli.lit(None) if len(other) == 0 else pli.lit(pli.Series(other))
         else:
             other = expr_to_lit_or_expr(other, str_to_lit=False)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Iterable,
     NoReturn,
     Sequence,
@@ -2497,7 +2498,7 @@ class Series:
 
         """
 
-    def is_in(self, other: Series | Sequence[Any]) -> Series:
+    def is_in(self, other: Series | Collection[Any]) -> Series:
         """
         Check if elements of this Series are in the other Series.
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1126,8 +1126,9 @@ def test_is_in() -> None:
     out = s.is_in([])
     assert out.to_list() == [False]  # one element?
 
-    out = s.is_in(["x", "y", "z"])
-    assert out.to_list() == [False, False, False]
+    for x_y_z in (["x", "y", "z"], {"x", "y", "z"}):
+        out = s.is_in(x_y_z)
+        assert out.to_list() == [False, False, False]
 
     df = pl.DataFrame({"a": [1.0, 2.0], "b": [1, 4], "c": ["e", "d"]})
     assert df.select(pl.col("a").is_in(pl.col("b"))).to_series().to_list() == [


### PR DESCRIPTION
Closes #7607.

Completely reasonable to accept `set` input here.

## Example
```python
 pl.col("colx").is_in({"a","b","c"})
```