### PR TITLE
fix(python): fix boolean `Series` init with integer 1/0 values

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6466,6 +6466,11 @@ class Expr:
                     dtype=input_dtype,
                     strict=True,
                 )
+                if input_dtype != remap_key_s.dtype:
+                    raise ValueError(
+                        f"Remapping keys could not be converted to {input_dtype}: found {remap_key_s.dtype}"
+                    )
+
             except TypeError as exc:
                 raise ValueError(
                     f"Remapping keys could not be converted to {input_dtype}: {str(exc)}"

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -628,7 +628,9 @@ def test_upcast_primitive_and_strings() -> None:
     assert pl.Series([1, 1.0, "1.0"]).dtype == pl.Utf8
     assert pl.Series([True, 1]).dtype == pl.Int64
     assert pl.Series([True, 1.0]).dtype == pl.Float64
-    assert pl.Series([True, "1.0"]).dtype == pl.Utf8
+    assert pl.Series([True, 1], dtype=pl.Boolean).dtype == pl.Boolean
+    assert pl.Series([False, 1.0], dtype=pl.Boolean).dtype == pl.Boolean
+    assert pl.Series([False, "1.0"]).dtype == pl.Utf8
     assert pl.from_dict({"a": [1, 2.1, 3], "b": [4, 5, 6.4]}).dtypes == [
         pl.Float64,
         pl.Float64,

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2600,6 +2600,7 @@ def test_symmetry_for_max_in_names() -> None:
     # datetime
     a = pl.Series("a", [1], dtype=pl.Datetime("ns"))
     assert (a - a.max()).name == (a.max() - a).name == a.name
-    # time
-    a = pl.Series("a", [1], dtype=pl.Time("ns"))
-    assert (a - a.max()).name == (a.max() - a).name == a.name
+
+    # TODO: time arithmetic support?
+    # a = pl.Series("a", [1], dtype=pl.Time)
+    # assert (a - a.max()).name == (a.max() - a).name == a.name


### PR DESCRIPTION
Closes #7615.

We already had the necessary fallback logic, but one of the branches in `sequence_to_pyseries` didn't invoke it; factored out the fallback logic so we get consistent results across both branches.

(Also; this fix uncovered a bogus Time arithmetic/symmetry test, which I've commented-out for now; the test only passed because the dtype was actually ignored - indeed, we don't even _have_ a `Time('ns')` dtype... ;)