### PR TITLE
refactor(rust): don't branch via error in read_csv::parse_dates

### DIFF
--- a/polars/polars-io/src/csv/read.rs
+++ b/polars/polars-io/src/csv/read.rs
@@ -616,10 +616,8 @@ fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
                         return ca.into_series();
                     }
                     s
-                },
-                _ => {
-                    s
                 }
+                _ => s,
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
This gives a lot of false positive if `POLARS_PANIC_ON_ERR` is set.