### PR TITLE
fix(python): detect deltalake version in show_versions

### DIFF
--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -65,9 +65,15 @@ def _get_dependency_info() -> dict[str, str]:
 def _get_dependency_version(dep_name: str) -> str:
     try:
         module = importlib.import_module(dep_name)
-        module_version = getattr(module, "__version__", "<version not detected>")
     except ImportError:
         return "<not installed>"
 
-    # all our dependencies (as of 2022-08-11) implement __version__
+    if hasattr(module, "__version__"):
+        module_version = module.__version__
+    elif sys.version_info >= (3, 8):
+        # importlib.metadata was introduced in Python 3.8
+        module_version = importlib.metadata.version(dep_name)
+    else:
+        module_version = "<version not detected>"
+
     return module_version


### PR DESCRIPTION
I noticed that we did not pick up the version of the optional deltalake dependency, as per https://github.com/delta-io/delta/issues/1339.

Solved this using importlib.metadata. This standard library function is not availble for Python 3.7, but I dont think it is worth adding the backport for that given Python 3.7 support may soon be dropped and there is no significant loss in functionality to end users.