### PR TITLE
chore(rust): remove apply_on_tz_corrected

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -118,27 +118,6 @@ impl DatetimeChunked {
         }
     }
 
-    pub fn apply_on_tz_corrected<F>(&self, mut func: F) -> PolarsResult<DatetimeChunked>
-    where
-        F: FnMut(DatetimeChunked) -> PolarsResult<DatetimeChunked>,
-    {
-        #[allow(unused_mut)]
-        let mut ca = self.clone();
-        #[cfg(feature = "timezones")]
-        if self.time_zone().is_some() {
-            ca = self.replace_time_zone(Some("UTC"))?
-        }
-        let out = func(ca)?;
-
-        #[cfg(feature = "timezones")]
-        if let Some(tz) = self.time_zone() {
-            return out
-                .convert_time_zone("UTC".to_string())?
-                .replace_time_zone(Some(tz));
-        }
-        Ok(out)
-    }
-
     #[cfg(feature = "timezones")]
     pub fn replace_time_zone(&self, time_zone: Option<&str>) -> PolarsResult<DatetimeChunked> {
         match (self.time_zone(), time_zone) {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/datetime.rs
@@ -123,8 +123,34 @@ pub(super) fn truncate(s: &Series, every: &str, offset: &str) -> PolarsResult<Se
     let every = Duration::parse(every);
     let offset = Duration::parse(offset);
     Ok(match s.dtype() {
-        DataType::Datetime(_, _) => s.datetime().unwrap().truncate(every, offset).into_series(),
-        DataType::Date => s.date().unwrap().truncate(every, offset).into_series(),
+        DataType::Datetime(_, tz) => match tz {
+            #[cfg(feature = "timezones")]
+            Some(tz) => match tz.parse::<Tz>() {
+                Ok(tz) => s
+                    .datetime()
+                    .unwrap()
+                    .truncate(every, offset, Some(&tz))?
+                    .into_series(),
+                Err(_) => match parse_offset(tz) {
+                    Ok(tz) => s
+                        .datetime()
+                        .unwrap()
+                        .truncate(every, offset, Some(&tz))?
+                        .into_series(),
+                    Err(_) => unreachable!(),
+                },
+            },
+            _ => s
+                .datetime()
+                .unwrap()
+                .truncate(every, offset, NO_TIMEZONE)?
+                .into_series(),
+        },
+        DataType::Date => s
+            .date()
+            .unwrap()
+            .truncate(every, offset, NO_TIMEZONE)?
+            .into_series(),
         dt => polars_bail!(opq = round, got = dt, expected = "date/datetime"),
     })
 }


### PR DESCRIPTION
`apply_on_tz_corrected` isn't really necessary any more, the logic from https://github.com/pola-rs/polars/pull/7611 can be used in `truncate` too

If an [ambiguous](https://github.com/pola-rs/polars/issues/6672) argument were to be introduced, I think it'd be safer and more maintainable to have `truncate` and `round` go down the same path