### PR TITLE
refactor(python): Reduce number of polars.internals imports

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -10,7 +10,7 @@ from polars.dependencies import html
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from polars.internals import DataFrame
+    from polars.dataframe import DataFrame
 
 
 class Tag:

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, BinaryIO
 
 from polars import internals as pli
 from polars.convert import from_arrow
-from polars.dataframe import DataFrame
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _prepare_file_arg
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO
 
 from polars import internals as pli
 from polars.convert import from_arrow
+from polars.dataframe import DataFrame
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _prepare_file_arg
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars import internals as pli
+from polars.lazyframe import wrap_ldf
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext
@@ -51,7 +51,7 @@ class SQLContext:
             A SQL query
 
         """
-        return pli.wrap_ldf(self._ctxt.execute(query))
+        return wrap_ldf(self._ctxt.execute(query))
 
     def query(self, query: str) -> DataFrame:
         return self.execute(query).collect()

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -26,7 +26,7 @@ from hypothesis.strategies import (
 )
 from hypothesis.strategies._internal.utils import defines_strategy
 
-from polars import internals as pli
+from polars.dataframe import DataFrame
 from polars.datatypes import (
     Boolean,
     Categorical,
@@ -48,17 +48,15 @@ from polars.datatypes import (
     is_polars_dtype,
     py_type_to_dtype,
 )
+from polars.series.series import Series
 from polars.string_cache import StringCache
 from polars.testing.asserts import is_categorical_dtype
 
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn, SearchStrategy
 
-    from polars.dataframe.frame import DataFrame
-    from polars.lazyframe.frame import LazyFrame
-    from polars.series.series import Series
+    from polars.lazyframe import LazyFrame
     from polars.type_aliases import OneOrMoreDataTypes, PolarsDataType
-
 
 # Default profile (eg: running locally)
 common_settings = {"print_blob": True, "deadline": None}
@@ -440,7 +438,7 @@ def series(
                         series_values[idx] = None
 
             # init series with strategy-generated data
-            s = pli.Series(
+            s = Series(
                 name=series_name,
                 dtype=series_dtype,
                 values=series_values,
@@ -614,7 +612,7 @@ def dataframes(
             frame_columns = [
                 c.name if (c.dtype is None) else (c.name, c.dtype) for c in coldefs
             ]
-            df = pli.DataFrame(
+            df = DataFrame(
                 data={
                     c.name: draw(
                         series(

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from polars import functions as F
 from polars import internals as pli
@@ -14,12 +14,9 @@ from polars.datatypes import (
     dtype_to_py_type,
 )
 from polars.exceptions import ComputeError, InvalidAssert
+from polars.lazyframe import LazyFrame
+from polars.series import Series
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
-
-if TYPE_CHECKING:
-    from polars.dataframe.frame import DataFrame
-    from polars.lazyframe.frame import LazyFrame
-    from polars.series.series import Series
 
 
 @deprecate_nonkeyword_arguments()
@@ -71,10 +68,10 @@ def assert_frame_equal(
     >>> assert_frame_equal(df1, df2)  # doctest: +SKIP
     AssertionError: Values for column 'a' are different.
     """
-    if isinstance(left, pli.LazyFrame) and isinstance(right, pli.LazyFrame):
+    if isinstance(left, LazyFrame) and isinstance(right, LazyFrame):
         left, right = left.collect(), right.collect()
         obj = "LazyFrames"
-    elif isinstance(left, pli.DataFrame) and isinstance(right, pli.DataFrame):
+    elif isinstance(left, DataFrame) and isinstance(right, DataFrame):
         obj = "DataFrames"
     else:
         raise_assert_detail("Inputs", "Unexpected input types", type(left), type(right))
@@ -233,8 +230,8 @@ def assert_series_equal(
 
     """
     if not (
-        isinstance(left, pli.Series)  # type: ignore[redundant-expr]
-        and isinstance(right, pli.Series)
+        isinstance(left, Series)  # type: ignore[redundant-expr]
+        and isinstance(right, Series)
     ):
         raise_assert_detail("Inputs", "Unexpected input types", type(left), type(right))
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -4,7 +4,7 @@ import textwrap
 from typing import Any
 
 from polars import functions as F
-from polars import internals as pli
+from polars.dataframe import DataFrame
 from polars.datatypes import (
     Boolean,
     Categorical,

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import re
 import sys
@@ -10,12 +9,9 @@ from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
 from polars import functions as F
 from polars import internals as pli
 from polars.datatypes import Int64, is_polars_dtype
-
-with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import PyExpr
+from polars.functions.lazy import arange
 
 if TYPE_CHECKING:
-    from polars.expr.expr import Expr
     from polars.series.series import Series
 
 
@@ -74,16 +70,6 @@ def is_dtype_sequence(val: object) -> TypeGuard[Sequence[PolarsDataType]]:
 def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
     return isinstance(val, Sequence) and _is_iterable_of(val, int)
-
-
-def is_expr_sequence(val: object) -> TypeGuard[Sequence[Expr]]:
-    """Check whether the given object is a sequence of Exprs."""
-    return isinstance(val, Sequence) and _is_iterable_of(val, pli.Expr)
-
-
-def is_pyexpr_sequence(val: object) -> TypeGuard[Sequence[PyExpr]]:
-    """Check whether the given object is a sequence of PyExprs."""
-    return isinstance(val, Sequence) and _is_iterable_of(val, PyExpr)
 
 
 def is_str_sequence(

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -7,9 +7,7 @@ from collections.abc import MappingView, Sized
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
 
 from polars import functions as F
-from polars import internals as pli
 from polars.datatypes import Int64, is_polars_dtype
-from polars.functions.lazy import arange
 
 if TYPE_CHECKING:
     from polars.series.series import Series


### PR DESCRIPTION
In most cases, we just need the type annotation, in TYPE_CHECKING blocks you can just import. And in other cases, the import actually works. Only did this for modules that are outside the DataFrame/Series/Expr objects, such as testing and utils.