### PR TITLE
feat(python): allow `scan_csv` to take a list of column names in a `new_columns` param

### DIFF
--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -50,11 +50,12 @@ def _create_namespace(
 
     def namespace(ns_class: type[NS]) -> type[NS]:
         if name in _reserved_namespaces:
-            raise AttributeError(f"Cannot override reserved namespace ({name!r})")
+            raise AttributeError(f"Cannot override reserved namespace {name!r}")
         elif hasattr(cls, name):
             warn(
                 f"Overriding existing custom namespace {name!r} (on {cls.__name__})",
                 UserWarning,
+                stacklevel=2,
             )
 
         setattr(cls, name, NameSpace(name, ns_class))

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -677,7 +677,7 @@ class DataFrame:
         quote_char: str | None = r'"',
         skip_rows: int = 0,
         dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
-        null_values: str | list[str] | dict[str, str] | None = None,
+        null_values: str | Sequence[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
         try_parse_dates: bool = False,

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -35,7 +35,7 @@ class BatchedCsvReader:
         quote_char: str | None = r'"',
         skip_rows: int = 0,
         dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
-        null_values: str | list[str] | dict[str, str] | None = None,
+        null_values: str | Sequence[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
         try_parse_dates: bool = False,
@@ -51,7 +51,7 @@ class BatchedCsvReader:
         row_count_offset: int = 0,
         sample_size: int = 1024,
         eol_char: str = "\n",
-        new_columns: list[str] | None = None,
+        new_columns: Sequence[str] | None = None,
     ):
         path: str | None
         if isinstance(source, (str, Path)):

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -10,6 +10,7 @@ from typing import (
     BinaryIO,
     ContextManager,
     Iterator,
+    Sequence,
     TextIO,
     overload,
 )
@@ -245,11 +246,11 @@ def _is_local_file(file: str) -> bool:
         return False
 
 
-def _update_columns(df: DataFrame, new_columns: list[str]) -> DataFrame:
+def _update_columns(df: DataFrame, new_columns: Sequence[str]) -> DataFrame:
     if df.width > len(new_columns):
         cols = df.columns
         for i, name in enumerate(new_columns):
             cols[i] = name
         new_columns = cols
-    df.columns = new_columns
+    df.columns = list(new_columns)
     return df

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -308,7 +308,7 @@ class LazyFrame:
         quote_char: str | None = r'"',
         skip_rows: int = 0,
         dtypes: SchemaDict | None = None,
-        null_values: str | list[str] | dict[str, str] | None = None,
+        null_values: str | Sequence[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
         cache: bool = True,

--- a/py-polars/polars/utils/polars_version.py
+++ b/py-polars/polars/utils/polars_version.py
@@ -6,7 +6,7 @@ except ImportError:
     # this is only useful for documentation
     import warnings
 
-    warnings.warn("polars binary missing!")
+    warnings.warn("polars binary missing!", stacklevel=2)
     polars_version_string = ""
 
 

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -39,8 +39,8 @@ if TYPE_CHECKING:
 
 
 def _process_null_values(
-    null_values: None | str | list[str] | dict[str, str] = None,
-) -> None | str | list[str] | list[tuple[str, str]]:
+    null_values: None | str | Sequence[str] | dict[str, str] = None,
+) -> None | str | Sequence[str] | list[tuple[str, str]]:
     if isinstance(null_values, dict):
         return list(null_values.items())
     else:

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
 black==23.1.0
 blackdoc==0.3.8
 mypy==1.1.1
-ruff==0.0.256
+ruff==0.0.257

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import PanicException
 from polars.testing import assert_frame_equal
 
 
@@ -101,6 +102,60 @@ def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
         "fats_g_foo",
         "sugars_g_foo",
     ]
+
+
+@pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
+def test_scan_csv_schema_new_columns_dtypes(
+    io_files_path: Path, file_name: str
+) -> None:
+    file_path = io_files_path / file_name
+
+    for dtype in [pl.Int8, pl.UInt8, pl.Int16, pl.UInt16]:
+        # assign 'new_columns', providing partial dtype overrides
+        df1 = pl.scan_csv(
+            file_path,
+            dtypes={"calories": pl.Utf8, "sugars": dtype},
+            new_columns=["category", "calories", "fats", "sugars"],
+        ).collect()
+        assert df1.dtypes == [pl.Utf8, pl.Utf8, pl.Float64, dtype]
+        assert df1.columns == ["category", "calories", "fats", "sugars"]
+
+        # assign 'new_columns' with 'dtypes' list
+        df2 = pl.scan_csv(
+            file_path,
+            dtypes=[pl.Utf8, pl.Utf8, pl.Float64, dtype],
+            new_columns=["category", "calories", "fats", "sugars"],
+        ).collect()
+        assert df1.rows() == df2.rows()
+
+    # rename existing columns, then lazy-select disjoint cols
+    df3 = pl.scan_csv(
+        file_path,
+        new_columns=["colw", "colx", "coly", "colz"],
+    )
+    assert df3.dtypes == [pl.Utf8, pl.Int64, pl.Float64, pl.Int64]
+    assert df3.columns == ["colw", "colx", "coly", "colz"]
+    assert (
+        df3.select(["colz", "colx"]).collect().rows()
+        == df1.select(["sugars", pl.col("calories").cast(pl.Int64)]).rows()
+    )
+
+    # expect same number of column names as there are columns in the file
+    with pytest.raises(PanicException, match="should be equal"):
+        pl.scan_csv(
+            file_path,
+            dtypes=[pl.Utf8, pl.Utf8],
+            new_columns=["category", "calories"],
+        ).collect()
+
+    # cannot set both 'new_columns' and 'with_column_names'
+    with pytest.raises(ValueError, match="mutually.exclusive"):
+        pl.scan_csv(
+            file_path,
+            dtypes=[pl.Utf8, pl.Utf8],
+            new_columns=["category", "calories", "fats", "sugars"],
+            with_column_names=lambda cols: [col.capitalize() for col in cols],
+        ).collect()
 
 
 def test_lazy_n_rows(foods_file_path: Path) -> None:


### PR DESCRIPTION
Closes: #7483.

Provides an easier way to assign column names to a headerless CSV file when using `scan_csv`, by automatically wrapping a sequence of names as a callable (as expected by the lower-level code), using the same "new_columns" parameter name found in `read_csv`.

**Before:**
```python
df = pl.scan_csv( 
    path_to_headerless_csv, 
    with_column_names = lambda cols: ["colx","coly","colz"],
)
```
**After:**
```python
df = pl.scan_csv( 
    path_to_headerless_csv, 
    new_columns = ["colx","coly","colz"],
)
```