### PR TITLE
fix(rust, python): respect time zone in rolling_* functions

### DIFF
--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -717,7 +717,7 @@ fn test_rolling_lookback() {
             &dates,
             closed_window,
             tu,
-            NO_TIMEZONE,
+            NO_TIMEZONE.copied(),
             0,
         )
         .collect::<Vec<_>>();

--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -711,8 +711,16 @@ fn test_rolling_lookback() {
         assert_eq!(g0, g1);
 
         let offset = Duration::parse("-2h");
-        let g0 = groupby_values_iter_full_lookbehind(period, offset, &dates, closed_window, tu, 0)
-            .collect::<Vec<_>>();
+        let g0 = groupby_values_iter_full_lookbehind(
+            period,
+            offset,
+            &dates,
+            closed_window,
+            tu,
+            NO_TIMEZONE,
+            0,
+        )
+        .collect::<Vec<_>>();
         let g1 = groupby_values_iter_partial_lookbehind(period, offset, &dates, closed_window, tu)
             .collect::<Vec<_>>();
         assert_eq!(g0, g1);


### PR DESCRIPTION
closes #7640 

one step closer towards full time zone support

example from the issue:
```python
In [1]: ts = pl.date_range(
   ...:     datetime(2021, 11, 5), datetime(2021, 11, 10), "1d", time_zone="UTC"
   ...: ).dt.replace_time_zone("US/Central")
   ...: df = pl.DataFrame(
   ...:     {"ts": ts, "tsn": ts.dt.replace_time_zone(None), "value": [1, 2, 3, 4, 5, 6]}
   ...: )
   ...: print(df.with_columns(pl.col("value").rolling_mean("1d", by="ts")))
   ...: print(df.with_columns(pl.col("value").rolling_mean("1d", by="tsn")))
shape: (6, 3)
┌──────────────────────────┬─────────────────────┬───────┐
│ ts                       ┆ tsn                 ┆ value │
│ ---                      ┆ ---                 ┆ ---   │
│ datetime[μs, US/Central] ┆ datetime[μs]        ┆ f64   │
╞══════════════════════════╪═════════════════════╪═══════╡
│ 2021-11-05 00:00:00 CDT  ┆ 2021-11-05 00:00:00 ┆ null  │
│ 2021-11-06 00:00:00 CDT  ┆ 2021-11-06 00:00:00 ┆ 1.0   │
│ 2021-11-07 00:00:00 CDT  ┆ 2021-11-07 00:00:00 ┆ 2.0   │
│ 2021-11-08 00:00:00 CST  ┆ 2021-11-08 00:00:00 ┆ 3.0   │
│ 2021-11-09 00:00:00 CST  ┆ 2021-11-09 00:00:00 ┆ 4.0   │
│ 2021-11-10 00:00:00 CST  ┆ 2021-11-10 00:00:00 ┆ 5.0   │
└──────────────────────────┴─────────────────────┴───────┘
shape: (6, 3)
┌──────────────────────────┬─────────────────────┬───────┐
│ ts                       ┆ tsn                 ┆ value │
│ ---                      ┆ ---                 ┆ ---   │
│ datetime[μs, US/Central] ┆ datetime[μs]        ┆ f64   │
╞══════════════════════════╪═════════════════════╪═══════╡
│ 2021-11-05 00:00:00 CDT  ┆ 2021-11-05 00:00:00 ┆ null  │
│ 2021-11-06 00:00:00 CDT  ┆ 2021-11-06 00:00:00 ┆ 1.0   │
│ 2021-11-07 00:00:00 CDT  ┆ 2021-11-07 00:00:00 ┆ 2.0   │
│ 2021-11-08 00:00:00 CST  ┆ 2021-11-08 00:00:00 ┆ 3.0   │
│ 2021-11-09 00:00:00 CST  ┆ 2021-11-09 00:00:00 ┆ 4.0   │
│ 2021-11-10 00:00:00 CST  ┆ 2021-11-10 00:00:00 ┆ 5.0   │
└──────────────────────────┴─────────────────────┴───────┘
```