### PR TITLE
build(rust,python): bump rust toolchain channel

### DIFF
--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -29,7 +29,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: nightly-2023-03-10
+          rust-toolchain: nightly-2023-03-18
           maturin-version: '0.14.10'
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -54,7 +54,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           JEMALLOC_SYS_WITH_LG_PAGE: 16
         with:
-          rust-toolchain: nightly-2023-03-10
+          rust-toolchain: nightly-2023-03-18
           target: aarch64-unknown-linux-gnu
           maturin-version: '0.14.10'
           command: publish
@@ -85,7 +85,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: nightly-2023-03-10
+          rust-toolchain: nightly-2023-03-18
           maturin-version: '0.14.10'
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -112,7 +112,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
         with:
-          rust-toolchain: nightly-2023-03-10
+          rust-toolchain: nightly-2023-03-18
           maturin-version: '0.14.10'
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -141,7 +141,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
         with:
-          rust-toolchain: nightly-2023-03-10
+          rust-toolchain: nightly-2023-03-18
           maturin-version: '0.14.10'
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-03-10"
+channel = "nightly-2023-03-18"


### PR DESCRIPTION
# Motivation

Using `cargo` with the current toolchain results in the following error on Apple Silicon:

```
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the 'nightly-2023-03-10-aarch64-apple-darwin' toolchain
```