### PR TITLE
feat(rust, python): clearer error message when creating duration string without integer

### DIFF
--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -107,7 +107,9 @@ impl Duration {
         let mut unit = String::with_capacity(2);
         while let Some((i, mut ch)) = iter.next() {
             if !ch.is_ascii_digit() {
-                let n = duration[start..i].parse::<i64>().unwrap();
+                let n = duration[start..i]
+                    .parse::<i64>()
+                    .expect("expected an integer in the duration string");
 
                 loop {
                     if ch.is_ascii_alphabetic() {


### PR DESCRIPTION
The current error message is a bit unclear:
```python
In [83]: pl.date_range(datetime(2021, 1, 1), datetime(2021, 1, 3), interval='d')
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Empty }', /home/runner/work/polars/polars/polars/polars-time/src/windows/duration.rs:110:59
---------------------------------------------------------------------------
PanicException                            Traceback (most recent call last)
Cell In [83], line 1
----> 1 pl.date_range(datetime(2021, 1, 1), datetime(2021, 1, 3), interval='d')

File ~/tmp/.venv/lib/python3.8/site-packages/polars/functions/eager.py:498, in date_range(low, high, interval, lazy, closed, name, time_unit, time_zone)
    495 start = _datetime_to_pl_timestamp(low, tu)
    496 stop = _datetime_to_pl_timestamp(high, tu)
    497 dt_range = pli.wrap_s(
--> 498     _py_date_range(start, stop, interval, closed, name, tu, time_zone)
    499 )
    500 if (
    501     low_is_date
    502     and high_is_date
    503     and not _interval_granularity(interval).endswith(("h", "m", "s"))
    504 ):
    505     dt_range = dt_range.cast(Date)

PanicException: called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Empty }
```