### PR TITLE
refactor(python): Move `expr` parsing to utils

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -80,6 +80,7 @@ from polars.utils._construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import (
     deprecate_nonkeyword_arguments,
@@ -7236,7 +7237,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = pli.expr_to_lit_or_expr(subset[0], str_to_lit=False)
+            expr = expr_to_lit_or_expr(subset[0], str_to_lit=False)
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/expr/__init__.py
+++ b/py-polars/polars/expr/__init__.py
@@ -1,13 +1,6 @@
-from polars.expr.expr import (
-    Expr,
-    expr_to_lit_or_expr,
-    selection_to_pyexpr_list,
-    wrap_expr,
-)
+from polars.expr.expr import Expr, wrap_expr
 
 __all__ = [
     "Expr",
-    "expr_to_lit_or_expr",
-    "selection_to_pyexpr_list",
     "wrap_expr",
 ]

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from polars import functions as F
 from polars import internals as pli
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias, redirect
 
@@ -323,7 +324,7 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"Expected 'tm' to be a python time or polars expression, found {tm!r}"
             )
-        tm = pli.expr_to_lit_or_expr(tm)
+        tm = expr_to_lit_or_expr(tm)
         return pli.wrap_expr(self._pyexpr.dt_combine(tm._pyexpr, tu))
 
     def strftime(self, fmt: str) -> Expr:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from polars import functions as F
 from polars import internals as pli
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
@@ -289,7 +290,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = pli.expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
+        index = expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
         return pli.wrap_expr(self._pyexpr.lst_get(index))
 
     def take(
@@ -316,7 +317,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pli.Series(index)
-        index = pli.expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
+        index = expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
         return pli.wrap_expr(self._pyexpr.lst_take(index, null_on_oob))
 
     def __getitem__(self, item: int) -> Expr:
@@ -398,7 +399,7 @@ class ExprListNameSpace:
 
         """
         return pli.wrap_expr(
-            self._pyexpr.arr_contains(pli.expr_to_lit_or_expr(item)._pyexpr)
+            self._pyexpr.arr_contains(expr_to_lit_or_expr(item)._pyexpr)
         )
 
     def join(self, separator: str) -> Expr:
@@ -590,8 +591,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = pli.expr_to_lit_or_expr(offset, str_to_lit=False)._pyexpr
-        length = pli.expr_to_lit_or_expr(length, str_to_lit=False)._pyexpr
+        offset = expr_to_lit_or_expr(offset, str_to_lit=False)._pyexpr
+        length = expr_to_lit_or_expr(length, str_to_lit=False)._pyexpr
         return pli.wrap_expr(self._pyexpr.lst_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -638,7 +639,7 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = -pli.expr_to_lit_or_expr(n, str_to_lit=False)
+        offset = -expr_to_lit_or_expr(n, str_to_lit=False)
         return self.slice(offset, n)
 
     def explode(self) -> Expr:
@@ -704,7 +705,7 @@ class ExprListNameSpace:
 
         """
         return pli.wrap_expr(
-            self._pyexpr.lst_count_match(pli.expr_to_lit_or_expr(element)._pyexpr)
+            self._pyexpr.lst_count_match(expr_to_lit_or_expr(element)._pyexpr)
         )
 
     def to_struct(

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -11,6 +11,7 @@ from polars.datatypes import (
     is_polars_dtype,
     py_type_to_dtype,
 )
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 
 if TYPE_CHECKING:
     from polars.expr.expr import Expr
@@ -555,7 +556,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)._pyexpr
+        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
     def ends_with(self, sub: str | Expr) -> Expr:
@@ -602,7 +603,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
-        sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
+        sub = expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_ends_with(sub))
 
     def starts_with(self, sub: str | Expr) -> Expr:
@@ -649,7 +650,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        sub = pli.expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
+        sub = expr_to_lit_or_expr(sub, str_to_lit=True)._pyexpr
         return pli.wrap_expr(self._pyexpr.str_starts_with(sub))
 
     def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
@@ -877,7 +878,7 @@ class ExprStringNameSpace:
         └────────────────┘
 
         """
-        pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)
+        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
         return pli.wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
 
     def count_match(self, pattern: str) -> Expr:
@@ -1123,8 +1124,8 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)
-        value = pli.expr_to_lit_or_expr(value, str_to_lit=True)
+        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
+        value = expr_to_lit_or_expr(value, str_to_lit=True)
         return pli.wrap_expr(
             self._pyexpr.str_replace_n(pattern._pyexpr, value._pyexpr, literal, n)
         )
@@ -1163,8 +1164,8 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = pli.expr_to_lit_or_expr(pattern, str_to_lit=True)
-        value = pli.expr_to_lit_or_expr(value, str_to_lit=True)
+        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
+        value = expr_to_lit_or_expr(value, str_to_lit=True)
         return pli.wrap_expr(
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Iterable, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Date
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils.convert import (
     _datetime_to_pl_timestamp,
     _timedelta_to_pl_duration,
@@ -463,8 +464,8 @@ def date_range(
         interval = interval.replace(" ", "")
 
     if isinstance(low, (str, pli.Expr)) or isinstance(high, (str, pli.Expr)) or lazy:
-        low = pli.expr_to_lit_or_expr(low, str_to_lit=False)._pyexpr
-        high = pli.expr_to_lit_or_expr(high, str_to_lit=False)._pyexpr
+        low = expr_to_lit_or_expr(low, str_to_lit=False)._pyexpr
+        high = expr_to_lit_or_expr(high, str_to_lit=False)._pyexpr
         return pli.wrap_expr(
             _py_date_range_lazy(low, high, interval, closed, name, time_zone)
         )

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -5,6 +5,7 @@ import typing
 from typing import TYPE_CHECKING, Any, Iterable
 
 from polars import internals as pli
+from polars.utils._parse_expr_input import expr_to_lit_or_expr
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import when as pywhen
@@ -23,7 +24,7 @@ class WhenThenThen:
 
     def when(self, predicate: Expr | bool) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = pli.expr_to_lit_or_expr(predicate)
+        predicate = expr_to_lit_or_expr(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
     def then(
@@ -39,7 +40,7 @@ class WhenThenThen:
         otherwise : Values to return in case of the predicate being `False`.
 
         """
-        expr_ = pli.expr_to_lit_or_expr(expr)
+        expr_ = expr_to_lit_or_expr(expr)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
     def otherwise(
@@ -55,7 +56,7 @@ class WhenThenThen:
         then : Values to return in case of the predicate being `True`.
 
         """
-        expr = pli.expr_to_lit_or_expr(expr)
+        expr = expr_to_lit_or_expr(expr)
         return pli.wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
@@ -72,7 +73,7 @@ class WhenThen:
 
     def when(self, predicate: Expr | bool | Series) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = pli.expr_to_lit_or_expr(predicate)
+        predicate = expr_to_lit_or_expr(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
 
     def otherwise(
@@ -94,7 +95,7 @@ class WhenThen:
         then : Values to return in case of the predicate being `True`.
 
         """
-        expr = pli.expr_to_lit_or_expr(expr)
+        expr = expr_to_lit_or_expr(expr)
         return pli.wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
@@ -128,7 +129,7 @@ class When:
         otherwise : Values to return in case of the predicate being `False`.
 
         """
-        expr = pli.expr_to_lit_or_expr(expr)
+        expr = expr_to_lit_or_expr(expr)
         pywhenthen = self._pywhen.then(expr._pyexpr)
         return WhenThen(pywhenthen)
 
@@ -183,6 +184,6 @@ def when(expr: Expr | bool | Series) -> When:
     otherwise : Values to return in case of the predicate being `False`.
 
     """
-    expr = pli.expr_to_lit_or_expr(expr)
+    expr = expr_to_lit_or_expr(expr)
     pw = pywhen(expr._pyexpr)
     return When(pw)

--- a/py-polars/polars/internals.py
+++ b/py-polars/polars/internals.py
@@ -1,11 +1,7 @@
-"""
-Re-export Polars functionality to avoid cyclical imports.
+"""Re-export Polars functionality to avoid cyclical imports."""
 
-If you run into cyclical imports, export functionality in this module, then import this
-module using `from polars import internals as pli`.
-"""
 from polars.dataframe import DataFrame, wrap_df
-from polars.expr import Expr, expr_to_lit_or_expr, selection_to_pyexpr_list, wrap_expr
+from polars.expr import Expr, wrap_expr
 from polars.lazyframe import LazyFrame, wrap_ldf
 from polars.series import Series, wrap_s
 
@@ -14,8 +10,6 @@ __all__ = [
     "Expr",
     "LazyFrame",
     "Series",
-    "expr_to_lit_or_expr",
-    "selection_to_pyexpr_list",
     "wrap_df",
     "wrap_expr",
     "wrap_ldf",

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 
 from polars import functions as F
-from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
 from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING, Iterable
+
+from polars import functions as F
+from polars import internals as pli
+
+if TYPE_CHECKING:
+    from polars.expr import Expr
+    from polars.polars import PyExpr
+    from polars.type_aliases import IntoExpr
+
+
+def selection_to_pyexpr_list(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    structify: bool = False,
+) -> list[PyExpr]:
+    if exprs is None:
+        return []
+
+    if isinstance(
+        exprs, (str, pli.Expr, pli.Series, F.whenthen.WhenThen, F.whenthen.WhenThenThen)
+    ) or not isinstance(exprs, Iterable):
+        return [
+            expr_to_lit_or_expr(exprs, str_to_lit=False, structify=structify)._pyexpr,
+        ]
+
+    return [
+        expr_to_lit_or_expr(e, str_to_lit=False, structify=structify)._pyexpr
+        for e in exprs  # type: ignore[union-attr]
+    ]
+
+
+def expr_to_lit_or_expr(
+    expr: IntoExpr | Iterable[IntoExpr],
+    str_to_lit: bool = True,
+    structify: bool = False,
+    name: str | None = None,
+) -> Expr:
+    """
+    Convert args to expressions.
+
+    Parameters
+    ----------
+    expr
+        Any argument.
+    str_to_lit
+        If True string argument `"foo"` will be converted to `lit("foo")`.
+        If False it will be converted to `col("foo")`.
+    structify
+        If the final unaliased expression has multiple output names,
+        automatically convert it to struct.
+    name
+        Apply the given name as an alias to the resulting expression.
+
+    Returns
+    -------
+    Expr
+
+    """
+    if isinstance(expr, pli.Expr):
+        pass
+    elif isinstance(expr, str) and not str_to_lit:
+        expr = F.col(expr)
+    elif (
+        isinstance(expr, (int, float, str, pli.Series, datetime, date, time, timedelta))
+        or expr is None
+    ):
+        expr = F.lit(expr)
+        structify = False
+    elif isinstance(expr, list):
+        expr = F.lit(pli.Series("", [expr]))
+        structify = False
+    elif isinstance(expr, (F.whenthen.WhenThen, F.whenthen.WhenThenThen)):
+        expr = expr.otherwise(None)  # implicitly add the null branch.
+    else:
+        raise TypeError(
+            f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with"
+            " pl.lit or pl.col"
+        )
+
+    if structify:
+        unaliased_expr = expr.meta.undo_aliases()
+        if unaliased_expr.meta.has_multiple_outputs():
+            expr_name = _expr_output_name(expr)
+            expr = F.struct(expr if expr_name is None else unaliased_expr)
+            name = name or expr_name
+
+    return expr if name is None else expr.alias(name)
+
+
+def _expr_output_name(expr: Expr) -> str | None:
+    try:
+        return expr.meta.output_name()
+    except Exception:
+        return None


### PR DESCRIPTION
Changes:
* Move the two expression parsing utils to the `utils` module:
  * `selection_to_pyexpr_list`
  * `expr_to_lit_or_expr`
* These utils are no longer re-exported through the `internals` module

These should also get better names, but let's do that in a different PR.