### PR TITLE
fix(rust, python): respect time zone in groupby_rolling with negative offset

### DIFF
--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -644,6 +644,7 @@ fn test_rolling_lookback() {
         &dates,
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
+        NO_TIMEZONE.copied(),
     );
     assert_eq!(dates.len(), groups.len());
     assert_eq!(groups[0], [0, 1]); // bound: 22:00 -> 24:00     time: 24:00
@@ -663,6 +664,7 @@ fn test_rolling_lookback() {
         &dates,
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
+        NO_TIMEZONE.copied(),
     );
     assert_eq!(dates.len(), groups.len());
     assert_eq!(groups[0], [0, 3]);
@@ -682,6 +684,7 @@ fn test_rolling_lookback() {
         &dates,
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
+        NO_TIMEZONE.copied(),
     );
     assert_eq!(dates.len(), groups.len());
     assert_eq!(groups[0], [0, 5]);
@@ -703,11 +706,26 @@ fn test_rolling_lookback() {
         ClosedWindow::None,
     ] {
         let offset = Duration::parse("0h");
-        let g0 =
-            groupby_values_iter_full_lookahead(period, offset, &dates, closed_window, tu, 0, None)
-                .collect::<Vec<_>>();
-        let g1 = groupby_values_iter_partial_lookbehind(period, offset, &dates, closed_window, tu)
-            .collect::<Vec<_>>();
+        let g0 = groupby_values_iter_full_lookahead(
+            period,
+            offset,
+            &dates,
+            closed_window,
+            tu,
+            NO_TIMEZONE.copied(),
+            0,
+            None,
+        )
+        .collect::<Vec<_>>();
+        let g1 = groupby_values_iter_partial_lookbehind(
+            period,
+            offset,
+            &dates,
+            closed_window,
+            tu,
+            NO_TIMEZONE.copied(),
+        )
+        .collect::<Vec<_>>();
         assert_eq!(g0, g1);
 
         let offset = Duration::parse("-2h");
@@ -721,8 +739,15 @@ fn test_rolling_lookback() {
             0,
         )
         .collect::<Vec<_>>();
-        let g1 = groupby_values_iter_partial_lookbehind(period, offset, &dates, closed_window, tu)
-            .collect::<Vec<_>>();
+        let g1 = groupby_values_iter_partial_lookbehind(
+            period,
+            offset,
+            &dates,
+            closed_window,
+            tu,
+            NO_TIMEZONE.copied(),
+        )
+        .collect::<Vec<_>>();
         assert_eq!(g0, g1);
     }
 }

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -343,6 +343,30 @@ def test_groupby_rolling_negative_offset_3914() -> None:
     ]
 
 
+@pytest.mark.parametrize("time_zone", [None, "US/Central", "+01:00"])
+def test_groupby_rolling_negative_offset_crossing_dst(time_zone: str | None) -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": pl.date_range(
+                datetime(2021, 11, 6), datetime(2021, 11, 9), "1d", time_zone=time_zone
+            ),
+            "value": [1, 4, 9, 155],
+        }
+    )
+    result = df.groupby_rolling(index_column="datetime", period="2d", offset="-1d").agg(
+        pl.col("value")
+    )
+    expected = pl.DataFrame(
+        {
+            "datetime": pl.date_range(
+                datetime(2021, 11, 6), datetime(2021, 11, 9), "1d", time_zone=time_zone
+            ),
+            "value": [[1, 4], [4, 9], [9, 155], [155]],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_groupby_signed_transmutes() -> None:
     df = pl.DataFrame({"foo": [-1, -2, -3, -4, -5], "bar": [500, 600, 700, 800, 900]})
 


### PR DESCRIPTION
closes #7663 

This addresses all the "todo respect time zone"s introduced in previous PRs, so...hopefully might spell the end of time zone issues (for now at least 😄 )