### PR TITLE
feat(python): include `add` operator-equivalent expression

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -244,6 +244,10 @@ class Expr:
         return self.__ne__(other)
 
     # math / binary
+    def add(self, other: Any) -> Self:
+        """Method equivalent of operator expression ``expr + other``."""
+        return self.__add__(other)
+
     def floordiv(self, other: Any) -> Self:
         """Method equivalent of operator expression ``expr // other``."""
         return self.__floordiv__(other)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -791,6 +791,8 @@ def test_operators_vs_expressions() -> None:
             h=pl.col(c1) != pl.col(c2),
             i=pl.col(c1) - pl.col(c2),
             j=pl.col(c1) / pl.col(c2),
+            k=pl.col(c1) * pl.col(c2),
+            l=pl.col(c1) + pl.col(c2),
         )
         df_expr = df.select(
             a=pl.col(c1).eq(pl.col(c2)),
@@ -803,6 +805,8 @@ def test_operators_vs_expressions() -> None:
             h=pl.col(c1).ne(pl.col(c2)),
             i=pl.col(c1).sub(pl.col(c2)),
             j=pl.col(c1).truediv(pl.col(c2)),
+            k=pl.col(c1).mul(pl.col(c2)),
+            l=pl.col(c1).add(pl.col(c2)),
         )
         assert_frame_equal(df_op, df_expr)
 


### PR DESCRIPTION
Add support for `+` → `add`.

(Unintentionally missed in previous commit: #7660).

```python
df.select(
    x = pl.col(c1) + pl.col(c2),
    y = pl.col(c1).add(pl.col(c2)),
)
```