### PR TITLE
fix(python): fix reversed non-existant file error msg  (#7657)

### DIFF
--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -191,7 +191,7 @@ pub enum EitherRustPythonFile {
 
 fn no_such_file_err(file_path: &str) -> PyResult<()> {
     let msg = if file_path.len() > 88 {
-        let file_path: String = file_path.chars().rev().take(88).collect();
+        let file_path: &str = &file_path[file_path.len() - 88..];
         format!("No such file or directory: ...{file_path}",)
     } else {
         format!("No such file or directory: {file_path}",)

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -191,7 +191,7 @@ pub enum EitherRustPythonFile {
 
 fn no_such_file_err(file_path: &str) -> PyResult<()> {
     let msg = if file_path.len() > 88 {
-        let file_path: &str = &file_path[file_path.len() - 88..];
+        let file_path: String = file_path.chars().skip(file_path.len() - 88).collect();
         format!("No such file or directory: ...{file_path}",)
     } else {
         format!("No such file or directory: {file_path}",)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -444,7 +444,7 @@ def test_file_path_truncate_err() -> None:
     content = "lskdfj".join(str(i) for i in range(25))
     with pytest.raises(
         FileNotFoundError,
-        match=r"\.\.\.42jfdksl32jfdksl22jfdksl12jfdksl02jfdksl91jfdksl81jfdksl71jfdksl61jfdksl51jfdksl41jfdksl",
+        match=r"\.\.\.lskdfj14lskdfj15lskdfj16lskdfj17lskdfj18lskdfj19lskdfj20lskdfj21lskdfj22lskdfj23lskdfj24",
     ):
         pl.read_csv(content)
 


### PR DESCRIPTION
Fixes #7657 

Note: Changed the `file_path` type from `String` to `&str`. Might also be solvable by iters. Thank you @Smebbs for your help!