### PR TITLE
perf(rust, python): implement top-k optimization

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1789,7 +1789,7 @@ impl DataFrame {
     pub fn sort_impl(
         &self,
         by_column: Vec<Series>,
-        descending: Vec<bool>,
+        mut descending: Vec<bool>,
         nulls_last: bool,
         slice: Option<(i64, usize)>,
         parallel: bool,
@@ -1799,6 +1799,10 @@ impl DataFrame {
         }
 
         if let Some((0, k)) = slice {
+            // reverse as top_k expects the largest
+            for v in descending.iter_mut() {
+                *v = !*v;
+            }
             return self.top_k_impl(k, descending, by_column, nulls_last);
         }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1799,10 +1799,6 @@ impl DataFrame {
         }
 
         if let Some((0, k)) = slice {
-            // reverse as top_k expects the largest
-            for v in descending.iter_mut() {
-                *v = !*v;
-            }
             return self.top_k_impl(k, descending, by_column, nulls_last);
         }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -26,7 +26,9 @@ pub mod groupby;
 pub mod hash_join;
 #[cfg(feature = "rows")]
 pub mod row;
+mod top_k;
 mod upstream_traits;
+
 pub use chunks::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -1795,6 +1797,11 @@ impl DataFrame {
         if self.height() == 0 {
             return Ok(self.clone());
         }
+
+        if let Some((0, k)) = slice {
+            return self.top_k_impl(k, descending, by_column, nulls_last);
+        }
+
         // a lot of indirection in both sorting and take
         let mut df = self.clone();
         let df = df.as_single_chunk_par();

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1789,7 +1789,7 @@ impl DataFrame {
     pub fn sort_impl(
         &self,
         by_column: Vec<Series>,
-        mut descending: Vec<bool>,
+        descending: Vec<bool>,
         nulls_last: bool,
         slice: Option<(i64, usize)>,
         parallel: bool,

--- a/polars/polars-core/src/frame/top_k.rs
+++ b/polars/polars-core/src/frame/top_k.rs
@@ -1,0 +1,71 @@
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use polars_error::PolarsResult;
+use polars_utils::iter::EnumerateIdxTrait;
+use polars_utils::IdxSize;
+use smartstring::alias::String as SmartString;
+
+use crate::datatypes::IdxCa;
+use crate::frame::DataFrame;
+use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded;
+use crate::prelude::*;
+use crate::utils::NoNull;
+
+#[derive(Eq, PartialOrd)]
+struct CompareRow<'a> {
+    idx: IdxSize,
+    bytes: &'a [u8],
+}
+
+impl PartialEq for CompareRow<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
+impl Ord for CompareRow<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.bytes.cmp(other.bytes)
+    }
+}
+
+impl DataFrame {
+    pub fn top_k(
+        &self,
+        k: usize,
+        descending: impl IntoVec<bool>,
+        by_column: impl IntoVec<SmartString>,
+    ) -> PolarsResult<DataFrame> {
+        let by_column = self.select_series(by_column)?;
+        let descending = descending.into_vec();
+        self.top_k_impl(k, descending, by_column, false)
+    }
+
+    pub(crate) fn top_k_impl(
+        &self,
+        k: usize,
+        descending: Vec<bool>,
+        by_column: Vec<Series>,
+        nulls_last: bool,
+    ) -> PolarsResult<DataFrame> {
+        let encoded = _get_rows_encoded(&by_column, &descending, nulls_last)?;
+        let arr = encoded.into_array();
+
+        let len = self.height();
+        let k = std::cmp::min(k, len);
+        let mut heap = BinaryHeap::with_capacity(len);
+
+        for (idx, bytes) in arr.values_iter().enumerate_idx() {
+            heap.push(CompareRow { idx, bytes })
+        }
+        let idx: NoNull<IdxCa> = (0..k)
+            .map(|_| {
+                let cmp_row = heap.pop().unwrap();
+                cmp_row.idx
+            })
+            .collect();
+
+        unsafe { Ok(self.take_unchecked(&idx.into_inner())) }
+    }
+}


### PR DESCRIPTION
This implements a `top-k` for `DataFrame` (not exposed yet).

A `df.lazy().sort().head(100)` now gets optimized into a `top_k` call instead.