### PR TITLE
fix(python): improve error message if unavailable lazy module is queried for `__version__` attribute

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -80,13 +80,15 @@ class _LazyModule(ModuleType):
             # import the module and return the requested attribute
             module = self._import()
             return getattr(module, attr)
-        else:
-            # user has not installed the proxied module
-            if re.match(r"^__\w+__$", attr):
-                # allow some minimal introspection on private module
-                # attrs to avoid unnecessary error-handling elsewhere
-                return None
 
+        # user has not installed the proxied/lazy module
+        elif attr == "__name__":
+            return self._module_name
+        elif re.match(r"^__\w+__$", attr) and attr != "__version__":
+            # allow some minimal introspection on private module
+            # attrs to avoid unnecessary error-handling elsewhere
+            return None
+        else:
             # all other attribute access raises a helpful exception
             pfx = self._mod_pfx.get(self._module_name, "")
             raise ModuleNotFoundError(


### PR DESCRIPTION
Closes #7676.

Ensures that we raise the correct error when asking for the `__version__` attribute of unavailable lazy modules (eg: not installed in the host env/venv); now we'll get the expected `ModuleNotFound`, instead of some likely variant of `TypeError` (currently the version of an unavailable module is reported as `None`).

Relevant as we now check `__version__` in one or two places, so we'll benefit from raising the right error when the module isn't available; much more informative for the caller.