### PR TITLE
docs(python): Remove duplicate column from Expr.sort example

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1825,7 +1825,6 @@ class Expr:
         ...     {
         ...         "group": ["one", "one", "one", "two", "two", "two"],
         ...         "value": [1, 98, 2, 3, 99, 4],
-        ...         "value": [1, 98, 2, 3, 99, 4],
         ...     }
         ... )
         >>> df.groupby("group").agg(pl.col("value").sort())  # doctest: +IGNORE_RESULT


### PR DESCRIPTION
A very minor documentation change - I noticed this duplication in one of the examples in the API reference for `polars.Expr.sort`.