### PR TITLE
feat(python, rust): clearer error message when replace_time_zone encounters ambiguous or non-existent datetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = "1.3"
 once_cell = "1"
 memchr = "2"
 smartstring = { version = "1" }
+multiversion = "0.7"
 
 [workspace.dependencies.arrow]
 package = "arrow2"
@@ -41,7 +42,7 @@ package = "arrow2"
 git = "https://github.com/ritchie46/arrow2"
 # rev = "f258a3e06ac408aebe7a7a497694729dc65a5e46"
 # path = "../arrow2"
-branch = "polars_2023-03-21"
+branch = "polars_2023-03-22"
 version = "0.16"
 default-features = false
 features = [

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -13,6 +13,7 @@ arrow.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 chrono-tz = { version = "0.8", optional = true }
 hashbrown.workspace = true
+multiversion.workspace = true
 num-traits.workspace = true
 polars-error = { version = "0.27.2", path = "../polars-error" }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -27,3 +28,4 @@ bigidx = []
 performant = []
 like = ["arrow/compute_like"]
 timezones = ["chrono-tz", "chrono"]
+simd = []

--- a/polars/polars-arrow/src/data_types.rs
+++ b/polars/polars-arrow/src/data_types.rs
@@ -52,10 +52,12 @@ mod private {
 macro_rules! impl_is_float {
     ($tp:ty) => {
         unsafe impl IsFloat for $tp {
+            #[inline]
             fn is_float() -> bool {
                 true
             }
 
+            #[inline]
             fn is_nan(&self) -> bool {
                 <$tp>::is_nan(*self)
             }

--- a/polars/polars-arrow/src/kernels/agg_mean.rs
+++ b/polars/polars-arrow/src/kernels/agg_mean.rs
@@ -1,0 +1,135 @@
+use std::simd::{Mask, Simd, SimdElement, SimdFloat, StdFloat, ToBitMask};
+
+use arrow::array::{Array, PrimitiveArray};
+use arrow::bitmap::utils::{BitChunkIterExact, BitChunksExact};
+use arrow::bitmap::Bitmap;
+use arrow::datatypes::PhysicalType::Primitive;
+use arrow::types::NativeType;
+use multiversion::multiversion;
+use num_traits::ToPrimitive;
+
+use crate::data_types::IsFloat;
+use crate::utils::with_match_primitive_type;
+
+#[multiversion(targets = "simd")]
+fn nonnull_sum_as_f64<T>(values: &[T]) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive,
+{
+    // we choose 8 as that the maximum size of f64x8 -> 512bit wide
+    const LANES: usize = 8;
+    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, LANES>>() };
+
+    let mut reduced: Simd<f64, LANES> = Simd::splat(0.0);
+    for chunk in simd_vals {
+        reduced += chunk.cast::<f64>();
+    }
+
+    unsafe {
+        reduced.reduce_sum()
+            + head
+                .iter()
+                .map(|v| v.to_f64().unwrap_unchecked())
+                .sum::<f64>()
+            + tail
+                .iter()
+                .map(|v| v.to_f64().unwrap_unchecked())
+                .sum::<f64>()
+    }
+}
+
+#[multiversion(targets = "simd")]
+fn null_sum_as_f64_impl<T, I>(values: &[T], mut validity_masks: I) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + IsFloat,
+    I: BitChunkIterExact<u8>,
+{
+    const LANES: usize = 8;
+    let mut chunks = values.chunks_exact(LANES);
+    let min_one = Simd::<f64, LANES>::splat(-1.0);
+    let min_one_i64 = Simd::<i64, LANES>::splat(-1);
+
+    let sum = chunks.by_ref().zip(validity_masks.by_ref()).fold(
+        Simd::<f64, LANES>::splat(0.0),
+        |acc, (chunk, validity_chunk)| {
+            // safety: exact size chunks
+            let chunk: [T; LANES] = unsafe { chunk.try_into().unwrap_unchecked() };
+            let chunk = Simd::from(chunk).cast::<f64>();
+
+            // construct [bools]
+            let mask = Mask::<i8, LANES>::from_bitmask(validity_chunk);
+            // let's say we have mask
+            //      [true, false, true, true]
+            // a cast to int gives:
+            //      [-1, 0, -1, -1]
+            // multiply by -1
+            //     [1, 0, 1, 1]
+            // and then use that as mask to multiply
+            // the chunk.
+
+            if T::is_float() {
+                // there can be NaNs masked out by validity
+                // so our strategy if multiplying by zero doesn't work on floats
+                // we transmute to i64 and multiply by 1s and 0s. This works as the multiply
+                // by 1 doesn't change the bits and the multiply by 0 gives 0 which has the same
+                // bit repr in f64 and i64
+                unsafe {
+                    let chunk_i64 =
+                        std::mem::transmute::<Simd<f64, LANES>, Simd<i64, LANES>>(chunk);
+                    let mask_mul = mask.to_int().cast::<i64>() * min_one_i64;
+
+                    // mask out and transmute back
+                    std::mem::transmute::<_, Simd<f64, LANES>>(chunk_i64 * mask_mul) + acc
+                }
+            } else {
+                // cast true to -1 and false to 0 so we multiply with -1 to get a branchless mask
+                let mask_mul = mask.to_int().cast::<f64>() * min_one;
+                // eg. null values are multiplied with 0
+                // and valid value with 1
+                chunk.mul_add(mask_mul, acc)
+            }
+        },
+    );
+    let mut sum = sum.reduce_sum();
+
+    for (v, valid) in chunks
+        .remainder()
+        .iter()
+        .zip(validity_masks.remainder_iter())
+    {
+        unsafe {
+            sum += (valid as u8 as f64) * v.to_f64().unwrap_unchecked();
+        }
+    }
+    sum
+}
+
+fn null_sum_as_f64<T>(values: &[T], bitmap: &Bitmap) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + IsFloat,
+{
+    let (slice, offset, length) = bitmap.as_slice();
+    if offset == 0 {
+        let validity_masks = BitChunksExact::<u8>::new(slice, length);
+        null_sum_as_f64_impl(values, validity_masks)
+    } else {
+        let validity_masks = bitmap.chunks::<u8>();
+        null_sum_as_f64_impl(values, validity_masks)
+    }
+}
+
+pub fn sum_as_f64(values: &dyn Array) -> f64 {
+    if let Primitive(primitive) = values.data_type().to_physical_type() {
+        with_match_primitive_type!(primitive, |$T| {
+            let arr: &PrimitiveArray<$T> = values.as_any().downcast_ref().unwrap();
+            if arr.null_count() == 0 {
+                nonnull_sum_as_f64(arr.values())
+            } else {
+                let validity = arr.validity().unwrap();
+                null_sum_as_f64(arr.values().as_slice(), validity)
+            }
+        })
+    } else {
+        unreachable!()
+    }
+}

--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -2,6 +2,8 @@ use std::iter::Enumerate;
 
 use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitChunks;
+#[cfg(feature = "simd")]
+pub mod agg_mean;
 pub mod concatenate;
 pub mod ewm;
 pub mod float;
@@ -17,6 +19,7 @@ pub mod string;
 pub mod take_agg;
 #[cfg(feature = "timezones")]
 mod time;
+
 #[cfg(feature = "timezones")]
 pub use time::replace_timezone;
 

--- a/polars/polars-arrow/src/kernels/time.rs
+++ b/polars/polars-arrow/src/kernels/time.rs
@@ -1,61 +1,79 @@
 use arrow::array::PrimitiveArray;
-use arrow::compute::arity::unary;
+use arrow::compute::arity::try_unary;
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
+use arrow::error::{Error as ArrowError, Result};
 use arrow::temporal_conversions::{
     parse_offset, timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 #[cfg(feature = "timezones")]
-use chrono::{NaiveDateTime, TimeZone};
+use chrono::{LocalResult, NaiveDateTime, TimeZone};
 use polars_error::polars_bail;
 
 use crate::error::PolarsResult;
 use crate::prelude::ArrayRef;
 
 #[cfg(feature = "timezones")]
-fn convert_to_naive_local<T1: TimeZone, T2: TimeZone>(
+fn convert_to_naive_local<T1: TimeZone + std::fmt::Debug + std::fmt::Display, T2: TimeZone>(
     from_tz: &T1,
     to_tz: &T2,
     ndt: NaiveDateTime,
-) -> NaiveDateTime {
-    from_tz
-        .from_local_datetime(&ndt)
-        .unwrap()
-        .with_timezone(to_tz)
-        .naive_local()
+) -> Result<NaiveDateTime> {
+    match from_tz.from_local_datetime(&ndt) {
+        LocalResult::Single(dt) => Ok(dt.with_timezone(to_tz).naive_local()),
+        LocalResult::Ambiguous(_, _) => Err(ArrowError::InvalidArgumentError(
+            format!("datetime '{}' is ambiguous in time zone '{}'. Ambiguous datetimes are not yet supported", ndt, from_tz),
+        )),
+        LocalResult::None => Err(ArrowError::InvalidArgumentError(
+            format!(
+                "datetime '{}' is non-existent in time zone '{}'. Non-existent datetimes are not yet supported",
+                ndt, from_tz
+            )
+            ,
+        )),
+    }
 }
 
 #[cfg(feature = "timezones")]
-fn convert_to_timestamp<T1: TimeZone, T2: TimeZone>(
+fn convert_to_timestamp<T1: TimeZone + std::fmt::Debug + std::fmt::Display, T2: TimeZone>(
     from_tz: T1,
     to_tz: T2,
     arr: &PrimitiveArray<i64>,
     tu: TimeUnit,
-) -> ArrayRef {
+) -> PolarsResult<ArrayRef> {
     match tu {
-        TimeUnit::Millisecond => Box::new(unary(
-            arr,
-            |value| {
-                let ndt = timestamp_ms_to_datetime(value);
-                convert_to_naive_local(&from_tz, &to_tz, ndt).timestamp_millis()
-            },
-            ArrowDataType::Int64,
-        )),
-        TimeUnit::Microsecond => Box::new(unary(
-            arr,
-            |value| {
-                let ndt = timestamp_us_to_datetime(value);
-                convert_to_naive_local(&from_tz, &to_tz, ndt).timestamp_micros()
-            },
-            ArrowDataType::Int64,
-        )),
-        TimeUnit::Nanosecond => Box::new(unary(
-            arr,
-            |value| {
-                let ndt = timestamp_ns_to_datetime(value);
-                convert_to_naive_local(&from_tz, &to_tz, ndt).timestamp_nanos()
-            },
-            ArrowDataType::Int64,
-        )),
+        TimeUnit::Millisecond => {
+            let data = try_unary(
+                arr,
+                |value| {
+                    let ndt = timestamp_ms_to_datetime(value);
+                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt)?.timestamp_millis())
+                },
+                ArrowDataType::Int64,
+            )?;
+            Ok(Box::new(data))
+        }
+        TimeUnit::Microsecond => {
+            let data = try_unary(
+                arr,
+                |value| {
+                    let ndt = timestamp_us_to_datetime(value);
+                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt)?.timestamp_micros())
+                },
+                ArrowDataType::Int64,
+            )?;
+            Ok(Box::new(data))
+        }
+        TimeUnit::Nanosecond => {
+            let data = try_unary(
+                arr,
+                |value| {
+                    let ndt = timestamp_ns_to_datetime(value);
+                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt)?.timestamp_nanos())
+                },
+                ArrowDataType::Int64,
+            )?;
+            Ok(Box::new(data))
+        }
         _ => unreachable!(),
     }
 }
@@ -69,17 +87,17 @@ pub fn replace_timezone(
 ) -> PolarsResult<ArrayRef> {
     Ok(match from.parse::<chrono_tz::Tz>() {
         Ok(from_tz) => match to.parse::<chrono_tz::Tz>() {
-            Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu),
+            Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu)?,
             Err(_) => match parse_offset(&to) {
-                Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu),
+                Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu)?,
                 Err(_) => polars_bail!(ComputeError: "unable to parse time zone: {}", to),
             },
         },
         Err(_) => match parse_offset(&from) {
             Ok(from_tz) => match to.parse::<chrono_tz::Tz>() {
-                Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu),
+                Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu)?,
                 Err(_) => match parse_offset(&to) {
-                    Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu),
+                    Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu)?,
                     Err(_) => polars_bail!(ComputeError: "unable to parse time zone: {}", to),
                 },
             },

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -13,25 +13,6 @@ pub mod is_valid;
 pub mod kernels;
 pub mod prelude;
 pub mod slice;
+pub mod time_zone;
 pub mod trusted_len;
 pub mod utils;
-
-#[cfg(not(feature = "timezones"))]
-pub trait PolarsTimeZone:
-    std::fmt::Debug + std::fmt::Display + std::marker::Sync + std::marker::Send
-{
-}
-
-#[cfg(feature = "timezones")]
-use chrono::FixedOffset;
-#[cfg(feature = "timezones")]
-use chrono_tz::Tz;
-#[cfg(feature = "timezones")]
-pub trait PolarsTimeZone:
-    chrono::TimeZone + std::fmt::Debug + std::fmt::Display + std::marker::Sync + std::marker::Send
-{
-}
-#[cfg(feature = "timezones")]
-impl PolarsTimeZone for FixedOffset {}
-#[cfg(feature = "timezones")]
-impl PolarsTimeZone for Tz {}

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -15,3 +15,23 @@ pub mod prelude;
 pub mod slice;
 pub mod trusted_len;
 pub mod utils;
+
+#[cfg(not(feature = "timezones"))]
+pub trait PolarsTimeZone:
+    std::fmt::Debug + std::fmt::Display + std::marker::Sync + std::marker::Send
+{
+}
+
+#[cfg(feature = "timezones")]
+use chrono::FixedOffset;
+#[cfg(feature = "timezones")]
+use chrono_tz::Tz;
+#[cfg(feature = "timezones")]
+pub trait PolarsTimeZone:
+    chrono::TimeZone + std::fmt::Debug + std::fmt::Display + std::marker::Sync + std::marker::Send
+{
+}
+#[cfg(feature = "timezones")]
+impl PolarsTimeZone for FixedOffset {}
+#[cfg(feature = "timezones")]
+impl PolarsTimeZone for Tz {}

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 pub mod array;
 pub mod bit_util;
 mod bitmap;

--- a/polars/polars-arrow/src/time_zone.rs
+++ b/polars/polars-arrow/src/time_zone.rs
@@ -1,0 +1,23 @@
+use std::fmt::{Debug, Display};
+#[cfg(not(feature = "timezones"))]
+pub trait PolarsTimeZone: Debug + Display + Sync + Send + Clone {}
+
+// a dummy type that implements required subtraits
+#[cfg(not(feature = "timezones"))]
+impl PolarsTimeZone for u8 {}
+#[cfg(not(feature = "timezones"))]
+pub const NO_TIMEZONE: Option<&u8> = None;
+
+#[cfg(feature = "timezones")]
+use chrono::FixedOffset;
+#[cfg(feature = "timezones")]
+use chrono_tz::Tz;
+#[cfg(feature = "timezones")]
+pub trait PolarsTimeZone: chrono::TimeZone + Debug + Display + Sync + Send + Clone {}
+#[cfg(feature = "timezones")]
+impl PolarsTimeZone for FixedOffset {}
+#[cfg(feature = "timezones")]
+impl PolarsTimeZone for Tz {}
+
+#[cfg(feature = "timezones")]
+pub const NO_TIMEZONE: Option<&FixedOffset> = None;

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -169,21 +169,20 @@ macro_rules! with_match_primitive_type {(
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use arrow::datatypes::PrimitiveType::*;
-    use arrow::types::{days_ms, months_days_ns};
     match $key_type {
         Int8 => __with_ty__! { i8 },
         Int16 => __with_ty__! { i16 },
         Int32 => __with_ty__! { i32 },
         Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        DaysMs => __with_ty__! { days_ms },
-        MonthDayNano => __with_ty__! { months_days_ns },
         UInt8 => __with_ty__! { u8 },
         UInt16 => __with_ty__! { u16 },
         UInt32 => __with_ty__! { u32 },
         UInt64 => __with_ty__! { u64 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        Int128 |
+        DaysMs |
+        MonthDayNano |
         Float16 | Int256 => unimplemented!(),
     }
 })}

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Core of the Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-simd = ["arrow/simd"]
+simd = ["arrow/simd", "polars-arrow/simd"]
 nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "polars-arrow/nightly"]
 avx512 = []
 docs = []

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 extern crate core;
 
 #[macro_use]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -3,7 +3,7 @@ use arrow::temporal_conversions::parse_offset;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 #[cfg(feature = "date_offset")]
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 #[cfg(feature = "date_offset")]
 use polars_time::prelude::*;
 

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::parse_offset;
-#[cfg(feature = "date_offset")]
-use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
+#[cfg(feature = "date_offset")]
+use polars_arrow::PolarsTimeZone;
 #[cfg(feature = "date_offset")]
 use polars_time::prelude::*;
 
@@ -25,7 +25,7 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
                 me.datetime().unwrap().clone()
             };
 
-            fn adder<T: TimeZoneTrait>(
+            fn adder<T: PolarsTimeZone>(
                 tu: TimeUnit,
             ) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
                 match tu {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/anonymous_scan.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 
 use polars_core::prelude::*;
@@ -5,6 +6,7 @@ use polars_core::prelude::*;
 pub use super::options::AnonymousScanOptions;
 
 pub trait AnonymousScan: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
     /// Creates a dataframe from the supplied function & scan options.
     fn scan(&self, scan_opts: AnonymousScanOptions) -> PolarsResult<DataFrame>;
 
@@ -37,6 +39,10 @@ impl<F> AnonymousScan for F
 where
     F: Fn(AnonymousScanOptions) -> PolarsResult<DataFrame> + Send + Sync,
 {
+    fn as_any(&self) -> &dyn Any {
+        unimplemented!()
+    }
+
     fn scan(&self, scan_opts: AnonymousScanOptions) -> PolarsResult<DataFrame> {
         self(scan_opts)
     }

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
@@ -4,6 +4,9 @@ use super::*;
 use crate::prelude::{AnonymousScan, AnonymousScanOptions, LazyJsonLineReader};
 
 impl AnonymousScan for LazyJsonLineReader {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
     fn scan(&self, scan_opts: AnonymousScanOptions) -> PolarsResult<DataFrame> {
         let schema = scan_opts.output_schema.unwrap_or(scan_opts.schema);
         JsonLineReader::from_path(&self.path)?

--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -31,7 +31,7 @@ dtype-duration = ["polars-core/dtype-duration", "polars-core/temporal"]
 rolling_window = ["polars-core/rolling_window", "dtype-duration"]
 private = []
 fmt = ["polars-core/fmt"]
-timezones = ["chrono-tz", "dtype-datetime", "polars-core/timezones"]
+timezones = ["chrono-tz", "dtype-datetime", "polars-core/timezones", "polars-arrow/timezones"]
 
 test = ["dtype-date", "dtype-datetime", "polars-core/fmt"]
 

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::parse_offset;
-use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 use polars_arrow::utils::CustomIterTools;
+use polars_arrow::PolarsTimeZone;
 use polars_core::export::rayon::prelude::*;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
@@ -457,7 +457,7 @@ impl Wrap<&DataFrame> {
         by: Vec<Series>,
         options: &RollingGroupOptions,
         tu: TimeUnit,
-        tz: Option<impl TimeZoneTrait + std::marker::Sync + std::marker::Send>,
+        tz: Option<impl PolarsTimeZone>,
         time_type: &DataType,
     ) -> PolarsResult<(Series, Vec<Series>, GroupsProxy)> {
         let mut dt = dt.rechunk();

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -2,8 +2,8 @@
 use arrow::temporal_conversions::parse_offset;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_arrow::utils::CustomIterTools;
-use polars_arrow::PolarsTimeZone;
 use polars_core::export::rayon::prelude::*;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;

--- a/polars/polars-time/src/lib.rs
+++ b/polars/polars-time/src/lib.rs
@@ -10,7 +10,6 @@ mod upsample;
 mod utils;
 mod windows;
 
-use chrono::FixedOffset;
 pub use date_range::*;
 #[cfg(any(feature = "dtype-date", feature = "dtype-datetime"))]
 pub use groupby::dynamic::*;
@@ -21,4 +20,3 @@ pub use windows::calendar::date_range as date_range_vec;
 pub use windows::duration::Duration;
 pub use windows::groupby::ClosedWindow;
 pub use windows::window::Window;
-pub const NO_TIMEZONE: Option<&FixedOffset> = None;

--- a/polars/polars-time/src/prelude.rs
+++ b/polars/polars-time/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use date_range::*;
+pub use polars_arrow::time_zone::NO_TIMEZONE;
 
 pub use crate::chunkedarray::*;
 pub use crate::series::{SeriesOpsTime, TemporalMethods};

--- a/polars/polars-time/src/round.rs
+++ b/polars/polars-time/src/round.rs
@@ -1,5 +1,5 @@
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;

--- a/polars/polars-time/src/round.rs
+++ b/polars/polars-time/src/round.rs
@@ -1,5 +1,5 @@
-use chrono::TimeZone as TimeZoneTrait;
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
+use polars_arrow::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;
@@ -9,7 +9,7 @@ pub trait PolarsRound {
         &self,
         every: Duration,
         offset: Duration,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self>
     where
         Self: Sized;
@@ -21,7 +21,7 @@ impl PolarsRound for DatetimeChunked {
         &self,
         every: Duration,
         offset: Duration,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self> {
         let w = Window::new(every, every, offset);
 
@@ -42,7 +42,7 @@ impl PolarsRound for DateChunked {
         &self,
         every: Duration,
         offset: Duration,
-        _tz: Option<&impl TimeZoneTrait>,
+        _tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self> {
         let w = Window::new(every, every, offset);
         Ok(self

--- a/polars/polars-time/src/truncate.rs
+++ b/polars/polars-time/src/truncate.rs
@@ -1,6 +1,6 @@
-use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "dtype-date")]
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
+use polars_arrow::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;
@@ -10,7 +10,7 @@ pub trait PolarsTruncate {
         &self,
         every: Duration,
         offset: Duration,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self>
     where
         Self: Sized;
@@ -22,7 +22,7 @@ impl PolarsTruncate for DatetimeChunked {
         &self,
         every: Duration,
         offset: Duration,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self> {
         let w = Window::new(every, every, offset);
 
@@ -44,7 +44,7 @@ impl PolarsTruncate for DateChunked {
         &self,
         every: Duration,
         offset: Duration,
-        _tz: Option<&impl TimeZoneTrait>,
+        _tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Self> {
         let w = Window::new(every, every, offset);
         Ok(self

--- a/polars/polars-time/src/truncate.rs
+++ b/polars/polars-time/src/truncate.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "dtype-date")]
 use polars_arrow::export::arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;

--- a/polars/polars-time/src/utils.rs
+++ b/polars/polars-time/src/utils.rs
@@ -3,35 +3,41 @@ use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 #[cfg(feature = "timezones")]
-use chrono::{LocalResult, NaiveDateTime, TimeZone as TimeZoneTrait};
+use chrono::{LocalResult, NaiveDateTime};
+#[cfg(feature = "timezones")]
+use polars_arrow::PolarsTimeZone;
 #[cfg(feature = "timezones")]
 use polars_core::prelude::{polars_bail, PolarsResult, TimeUnit};
 
 #[cfg(feature = "timezones")]
 pub(crate) fn localize_datetime(
     ndt: NaiveDateTime,
-    tz: &impl TimeZoneTrait,
+    tz: &impl PolarsTimeZone,
 ) -> PolarsResult<NaiveDateTime> {
     // e.g. '2021-01-01 03:00' -> '2021-01-01 03:00CDT'
     match tz.from_local_datetime(&ndt) {
         LocalResult::Single(tz) => Ok(tz.naive_utc()),
         LocalResult::Ambiguous(_, _) => {
-            polars_bail!(ComputeError: "ambiguous timestamps are not (yet) supported")
+            polars_bail!(
+                ComputeError: format!("datetime '{}' is ambiguous in time zone '{}'. Ambiguous datetimes are not yet supported", ndt, tz)
+            )
         }
         LocalResult::None => {
-            polars_bail!(ComputeError: "non-existent timestamps are not (yet) supported")
+            polars_bail!(
+                ComputeError: format!("datetime '{}' is non-existent in time zone '{}'. Non-existent datetimes are not yet supported", ndt, tz)
+            )
         }
     }
 }
 
 #[cfg(feature = "timezones")]
-pub(crate) fn unlocalize_datetime(ndt: NaiveDateTime, tz: &impl TimeZoneTrait) -> NaiveDateTime {
+pub(crate) fn unlocalize_datetime(ndt: NaiveDateTime, tz: &impl PolarsTimeZone) -> NaiveDateTime {
     // e.g. '2021-01-01 03:00CDT' -> '2021-01-01 03:00'
     tz.from_utc_datetime(&ndt).naive_local()
 }
 
 #[cfg(feature = "timezones")]
-pub(crate) fn localize_timestamp<T: TimeZoneTrait>(
+pub(crate) fn localize_timestamp<T: PolarsTimeZone>(
     timestamp: i64,
     tu: TimeUnit,
     tz: T,
@@ -50,7 +56,7 @@ pub(crate) fn localize_timestamp<T: TimeZoneTrait>(
 }
 
 #[cfg(feature = "timezones")]
-pub(crate) fn unlocalize_timestamp<T: TimeZoneTrait>(timestamp: i64, tu: TimeUnit, tz: T) -> i64 {
+pub(crate) fn unlocalize_timestamp<T: PolarsTimeZone>(timestamp: i64, tu: TimeUnit, tz: T) -> i64 {
     match tu {
         TimeUnit::Nanoseconds => {
             unlocalize_datetime(timestamp_ns_to_datetime(timestamp), &tz).timestamp_nanos()

--- a/polars/polars-time/src/utils.rs
+++ b/polars/polars-time/src/utils.rs
@@ -5,7 +5,7 @@ use arrow::temporal_conversions::{
 #[cfg(feature = "timezones")]
 use chrono::{LocalResult, NaiveDateTime};
 #[cfg(feature = "timezones")]
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 #[cfg(feature = "timezones")]
 use polars_core::prelude::{polars_bail, PolarsResult, TimeUnit};
 

--- a/polars/polars-time/src/windows/calendar.rs
+++ b/polars/polars-time/src/windows/calendar.rs
@@ -1,4 +1,4 @@
-use chrono::TimeZone as TimeZoneTrait;
+use polars_arrow::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;
@@ -41,7 +41,7 @@ pub fn date_range(
     every: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<&impl TimeZoneTrait>,
+    tz: Option<&impl PolarsTimeZone>,
 ) -> PolarsResult<Vec<i64>> {
     let size = match tu {
         TimeUnit::Nanoseconds => ((stop - start) / every.duration_ns() + 1) as usize,

--- a/polars/polars-time/src/windows/calendar.rs
+++ b/polars/polars-time/src/windows/calendar.rs
@@ -1,4 +1,4 @@
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_core::prelude::*;
 
 use crate::prelude::*;

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -5,7 +5,7 @@ use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Weekday};
 use polars_arrow::export::arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime, MILLISECONDS,
 };
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_core::export::arrow::temporal_conversions::MICROSECONDS;
 use polars_core::prelude::{
     datetime_to_timestamp_ms, datetime_to_timestamp_ns, datetime_to_timestamp_us, polars_bail,

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -672,7 +672,7 @@ mod test {
 
     #[test]
     fn test_add_ns() {
-        use crate::NO_TIMEZONE;
+        use polars_arrow::time_zone::NO_TIMEZONE;
         let t = 1;
         let seven_days = Duration::parse("7d");
         let one_week = Duration::parse("1w");

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -1,12 +1,11 @@
 use std::cmp::Ordering;
 use std::ops::Mul;
 
-use chrono::{
-    Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeZone as TimeZoneTrait, Timelike, Weekday,
-};
+use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Weekday};
 use polars_arrow::export::arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime, MILLISECONDS,
 };
+use polars_arrow::PolarsTimeZone;
 use polars_core::export::arrow::temporal_conversions::MICROSECONDS;
 use polars_core::prelude::{
     datetime_to_timestamp_ms, datetime_to_timestamp_ns, datetime_to_timestamp_us, polars_bail,
@@ -330,7 +329,7 @@ impl Duration {
     pub fn truncate_impl<F, G, J>(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
         nsecs_to_unit: F,
         timestamp_to_datetime: G,
         datetime_to_timestamp: J,
@@ -442,7 +441,7 @@ impl Duration {
 
     // Truncate the given ns timestamp by the window boundary.
     #[inline]
-    pub fn truncate_ns(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_ns(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -454,7 +453,7 @@ impl Duration {
 
     // Truncate the given ns timestamp by the window boundary.
     #[inline]
-    pub fn truncate_us(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_us(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -466,7 +465,7 @@ impl Duration {
 
     // Truncate the given ms timestamp by the window boundary.
     #[inline]
-    pub fn truncate_ms(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_ms(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -479,7 +478,7 @@ impl Duration {
     fn add_impl_month_week_or_day<F, G, J>(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
         nsecs_to_unit: F,
         timestamp_to_datetime: G,
         datetime_to_timestamp: J,
@@ -579,7 +578,7 @@ impl Duration {
         Ok(new_t)
     }
 
-    pub fn add_ns(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn add_ns(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let d = self;
         let new_t = self.add_impl_month_week_or_day(
             t,
@@ -592,7 +591,7 @@ impl Duration {
         Ok(new_t? + nsecs)
     }
 
-    pub fn add_us(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn add_us(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let d = self;
         let new_t = self.add_impl_month_week_or_day(
             t,
@@ -605,7 +604,7 @@ impl Duration {
         Ok(new_t? + nsecs / 1_000)
     }
 
-    pub fn add_ms(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn add_ms(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let d = self;
         let new_t = self.add_impl_month_week_or_day(
             t,

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -4,9 +4,9 @@ use std::cmp::Ordering;
 use arrow::temporal_conversions::parse_offset;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_arrow::trusted_len::TrustedLen;
 use polars_arrow::utils::CustomIterTools;
-use polars_arrow::PolarsTimeZone;
 use polars_core::export::rayon::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::_split_offsets;

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -2,11 +2,11 @@ use std::cmp::Ordering;
 
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::parse_offset;
-use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 use polars_arrow::trusted_len::TrustedLen;
 use polars_arrow::utils::CustomIterTools;
+use polars_arrow::PolarsTimeZone;
 use polars_core::export::rayon::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::_split_offsets;
@@ -42,7 +42,7 @@ impl Default for StartBy {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn update_groups_and_bounds<T: TimeZoneTrait>(
+fn update_groups_and_bounds<T: PolarsTimeZone>(
     bounds_iter: BoundsIter<'_, T>,
     mut start_offset: usize,
     time: &[i64],
@@ -243,12 +243,12 @@ pub(crate) fn groupby_values_iter_full_lookbehind<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a>,
+    tz: Option<impl PolarsTimeZone + 'a>,
     start_offset: usize,
 ) -> impl Iterator<Item = (IdxSize, IdxSize)> + TrustedLen + 'a {
     debug_assert!(offset.duration_ns() >= period.duration_ns());
     debug_assert!(offset.negative);
-    fn add<T: TimeZoneTrait>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
+    fn add<T: PolarsTimeZone>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
         match tu {
             TimeUnit::Nanoseconds => Duration::add_ns,
             TimeUnit::Microseconds => Duration::add_us,
@@ -307,9 +307,9 @@ pub(crate) fn groupby_values_iter_window_behind_t<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a>,
+    tz: Option<impl PolarsTimeZone + 'a>,
 ) -> impl Iterator<Item = (IdxSize, IdxSize)> + TrustedLen + 'a {
-    fn add<T: TimeZoneTrait>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
+    fn add<T: PolarsTimeZone>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
         match tu {
             TimeUnit::Nanoseconds => Duration::add_ns,
             TimeUnit::Microseconds => Duration::add_us,
@@ -364,9 +364,9 @@ pub(crate) fn groupby_values_iter_partial_lookbehind<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a>,
+    tz: Option<impl PolarsTimeZone + 'a>,
 ) -> impl Iterator<Item = (IdxSize, IdxSize)> + TrustedLen + 'a {
-    fn add<T: TimeZoneTrait>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
+    fn add<T: PolarsTimeZone>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
         match tu {
             TimeUnit::Nanoseconds => Duration::add_ns,
             TimeUnit::Microseconds => Duration::add_us,
@@ -409,14 +409,14 @@ pub(crate) fn groupby_values_iter_full_lookahead<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a>,
+    tz: Option<impl PolarsTimeZone + 'a>,
     start_offset: usize,
     upper_bound: Option<usize>,
 ) -> impl Iterator<Item = (IdxSize, IdxSize)> + TrustedLen + 'a {
     let upper_bound = upper_bound.unwrap_or(time.len());
     debug_assert!(!offset.negative);
 
-    fn add<T: TimeZoneTrait>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
+    fn add<T: PolarsTimeZone>(tu: TimeUnit) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
         match tu {
             TimeUnit::Nanoseconds => Duration::add_ns,
             TimeUnit::Microseconds => Duration::add_us,
@@ -464,7 +464,7 @@ pub(crate) fn groupby_values_iter<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a>,
+    tz: Option<impl PolarsTimeZone + 'a>,
 ) -> Box<dyn TrustedLen<Item = (IdxSize, IdxSize)> + 'a> {
     partially_check_sorted(time);
     // we have a (partial) lookbehind window
@@ -507,7 +507,7 @@ pub fn groupby_values<'a>(
     time: &'a [i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<impl TimeZoneTrait + 'a + std::marker::Sync + std::marker::Send>,
+    tz: Option<impl PolarsTimeZone + 'a>,
 ) -> GroupsSlice {
     partially_check_sorted(time);
     let thread_offsets = _split_offsets(time.len(), POOL.current_num_threads());

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDateTime;
 #[cfg(feature = "timezones")]
 use now::DateTimeNow;
 use polars_arrow::export::arrow::temporal_conversions::*;
-use polars_arrow::PolarsTimeZone;
+use polars_arrow::time_zone::PolarsTimeZone;
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::{timeunit_scale, SECONDS_IN_DAY};
 

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "timezones")]
 use chrono::NaiveDateTime;
-use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "timezones")]
 use now::DateTimeNow;
 use polars_arrow::export::arrow::temporal_conversions::*;
+use polars_arrow::PolarsTimeZone;
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::{timeunit_scale, SECONDS_IN_DAY};
 
@@ -30,7 +30,7 @@ impl Window {
     }
 
     /// Truncate the given ns timestamp by the window boundary.
-    pub fn truncate_ns(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_ns(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = self.every.truncate_ns(t, tz)?;
         self.offset.add_ns(t, tz)
     }
@@ -38,13 +38,13 @@ impl Window {
     pub fn truncate_no_offset_ns(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<i64> {
         self.every.truncate_ns(t, tz)
     }
 
     /// Truncate the given us timestamp by the window boundary.
-    pub fn truncate_us(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_us(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = self.every.truncate_us(t, tz)?;
         self.offset.add_us(t, tz)
     }
@@ -52,12 +52,12 @@ impl Window {
     pub fn truncate_no_offset_us(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<i64> {
         self.every.truncate_us(t, tz)
     }
 
-    pub fn truncate_ms(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn truncate_ms(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = self.every.truncate_ms(t, tz)?;
         self.offset.add_ms(t, tz)
     }
@@ -66,26 +66,26 @@ impl Window {
     pub fn truncate_no_offset_ms(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<i64> {
         self.every.truncate_ms(t, tz)
     }
 
     /// Round the given ns timestamp by the window boundary.
-    pub fn round_ns(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn round_ns(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns() / 2_i64;
         self.truncate_ns(t, tz)
     }
 
     /// Round the given us timestamp by the window boundary.
-    pub fn round_us(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn round_us(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns()
             / (2 * timeunit_scale(ArrowTimeUnit::Nanosecond, ArrowTimeUnit::Microsecond) as i64);
         self.truncate_us(t, tz)
     }
 
     /// Round the given ms timestamp by the window boundary.
-    pub fn round_ms(&self, t: i64, tz: Option<&impl TimeZoneTrait>) -> PolarsResult<i64> {
+    pub fn round_ms(&self, t: i64, tz: Option<&impl PolarsTimeZone>) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns()
             / (2 * timeunit_scale(ArrowTimeUnit::Nanosecond, ArrowTimeUnit::Millisecond) as i64);
         self.truncate_ms(t, tz)
@@ -107,7 +107,7 @@ impl Window {
     pub fn get_earliest_bounds_ns(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Bounds> {
         let start = if !self.every.months_only()
             && self.every.duration_ns() > NANOSECONDS * SECONDS_IN_DAY
@@ -126,7 +126,7 @@ impl Window {
     pub fn get_earliest_bounds_us(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Bounds> {
         let start = if !self.every.months_only()
             && self.every.duration_us() > MICROSECONDS * SECONDS_IN_DAY
@@ -142,7 +142,7 @@ impl Window {
     pub fn get_earliest_bounds_ms(
         &self,
         t: i64,
-        tz: Option<&impl TimeZoneTrait>,
+        tz: Option<&impl PolarsTimeZone>,
     ) -> PolarsResult<Bounds> {
         let start = if !self.every.months_only()
             && self.every.duration_ms() > MILLISECONDS * SECONDS_IN_DAY
@@ -172,7 +172,7 @@ impl Window {
             + self.period.duration_ms() / self.every.duration_ms()) as usize
     }
 
-    pub fn get_overlapping_bounds_iter<'a, T: TimeZoneTrait>(
+    pub fn get_overlapping_bounds_iter<'a, T: PolarsTimeZone>(
         &self,
         boundary: Bounds,
         tu: TimeUnit,
@@ -183,7 +183,7 @@ impl Window {
     }
 }
 
-pub struct BoundsIter<'a, T: TimeZoneTrait> {
+pub struct BoundsIter<'a, T: PolarsTimeZone> {
     window: Window,
     // wrapping boundary
     boundary: Bounds,
@@ -192,7 +192,7 @@ pub struct BoundsIter<'a, T: TimeZoneTrait> {
     tu: TimeUnit,
     tz: Option<&'a T>,
 }
-impl<'a, T: TimeZoneTrait> BoundsIter<'a, T> {
+impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
     fn new(
         window: Window,
         boundary: Bounds,
@@ -287,7 +287,7 @@ impl<'a, T: TimeZoneTrait> BoundsIter<'a, T> {
     }
 }
 
-impl<'a, T: TimeZoneTrait> Iterator for BoundsIter<'a, T> {
+impl<'a, T: PolarsTimeZone> Iterator for BoundsIter<'a, T> {
     type Item = Bounds;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.16.0"
-source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-21#a49a36e313abe15237027b1d830e6345b49a8bbe"
+source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-22#dd53a883e9091edeed670789207edda14f5a0f5f"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -86,7 +86,7 @@ dependencies = [
  "base64",
  "bytemuck",
  "chrono",
- "chrono-tz 0.6.3",
+ "chrono-tz",
  "dyn-clone",
  "either",
  "ethnum",
@@ -108,7 +108,7 @@ dependencies = [
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
- "zstd",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
@@ -309,35 +309,13 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
-dependencies = [
- "chrono",
- "chrono-tz-build 0.0.3",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.1.0",
+ "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -1207,22 +1185,24 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
+checksum = "e6a87eede2251ca235e5573086d01d2ab6b59dfaea54c2be10f9320980f7e8f7"
 dependencies = [
  "multiversion-macros",
+ "target-features",
 ]
 
 [[package]]
 name = "multiversion-macros"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
+checksum = "1af1abf82261d780d114014eff4b555e47d823f3b84f893c4388572b40e089fb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "target-features",
 ]
 
 [[package]]
@@ -1389,7 +1369,7 @@ dependencies = [
  "seq-macro",
  "snap",
  "streaming-decompression",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -1443,7 +1423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -1493,8 +1472,9 @@ version = "0.27.2"
 dependencies = [
  "arrow2",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "hashbrown 0.13.2",
+ "multiversion",
  "num-traits",
  "polars-error",
  "serde",
@@ -1509,7 +1489,7 @@ dependencies = [
  "arrow2",
  "bitflags",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "comfy-table",
  "hashbrown 0.13.2",
  "indexmap",
@@ -1551,7 +1531,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "dirs",
  "fast-float",
  "flate2",
@@ -1639,7 +1619,7 @@ dependencies = [
  "ahash",
  "arrow2",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "once_cell",
  "polars-arrow",
  "polars-core",
@@ -1683,7 +1663,7 @@ dependencies = [
  "arrow2",
  "atoi",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "now",
  "once_cell",
  "polars-arrow",
@@ -2208,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-features"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24840de800c1707d75c800893dbd727a5e1501ce921944e602f0698167491e36"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,15 +2275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "uncased"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -2580,7 +2557,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe 6.0.4+zstd.1.5.4",
 ]
 
 [[package]]
@@ -2588,6 +2574,16 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.4+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2124,6 +2124,22 @@ class Expr:
         │ b     ┆ [2, 4]    │
         └───────┴───────────┘
 
+        Take a single row from each group where a column attains its minimal value
+        within that group.
+
+        >>> df.groupby("group").agg(
+        ...     pl.all().sort_by("value2").first()
+        ... )  # doctest: +IGNORE_RESULT
+        shape: (2, 3)
+        ┌───────┬────────┬────────┐
+        │ group ┆ value1 ┆ value2 |
+        │ ---   ┆ ---    ┆ ---    │
+        │ str   ┆ i64    ┆ i64    |
+        ╞═══════╪════════╪════════╡
+        │ a     ┆ 3      ┆ 7      |
+        │ b     ┆ 2      ┆ 5      |
+        └───────┴────────┴────────┘
+
         """
         if isinstance(descending, bool):
             descending = [descending]

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2116,7 +2116,8 @@ def test_tzaware_date_range_with_fixed_offset() -> None:
 
 def test_date_range_with_unsupported_datetimes() -> None:
     with pytest.raises(
-        ComputeError, match=r"ambiguous timestamps are not \(yet\) supported"
+        ComputeError,
+        match=r"datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
     ):
         pl.date_range(
             datetime(2021, 11, 7, 1),
@@ -2125,7 +2126,8 @@ def test_date_range_with_unsupported_datetimes() -> None:
             time_zone="US/Central",
         )
     with pytest.raises(
-        ComputeError, match=r"non-existent timestamps are not \(yet\) supported"
+        ComputeError,
+        match=r"datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Vienna'",
     ):
         pl.date_range(
             datetime(2021, 3, 28, 2, 30),

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ArrowError, ComputeError
 from polars.testing import assert_series_equal
 
 if sys.version_info >= (3, 9):
@@ -322,6 +322,19 @@ def test_replace_timezone_invalid_timezone() -> None:
     )
     with pytest.raises(ComputeError, match=r"unable to parse time zone: foo"):
         ts.dt.replace_time_zone("foo")
+
+
+def test_replace_time_zone_ambiguous_or_non_existent() -> None:
+    with pytest.raises(
+        ArrowError,
+        match="datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
+    ):
+        pl.Series(["2021-11-07 01:00"]).str.strptime(pl.Datetime("us", "US/Central"))
+    with pytest.raises(
+        ArrowError,
+        match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
+    ):
+        pl.Series(["2021-03-28 02:30"]).str.strptime(pl.Datetime("us", "Europe/Warsaw"))
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -124,3 +124,23 @@ def test_quantile_vs_numpy() -> None:
                 assert np.isclose(
                     pl.Series(a).quantile(q, interpolation="linear"), np_result
                 )
+
+
+@typing.no_type_check
+def test_mean_overflow() -> None:
+    assert np.isclose(
+        pl.Series([9_223_372_036_854_775_800, 100]).mean(), 4.611686018427388e18
+    )
+
+
+def test_mean_null_simd() -> None:
+    for dtype in [int, float]:
+        df = (
+            pl.Series(np.random.randint(0, 100, 1000))
+            .cast(dtype)
+            .to_frame("a")
+            .select(pl.when(pl.col("a") > 40).then(pl.col("a")))
+        )
+
+    s = df["a"]
+    assert s.mean() == s.to_pandas().mean()


### PR DESCRIPTION
This came up on discord

On master (shows neither the offending datetime, nor the offending time zone):
```python
In [91]: pl.Series(['2021-03-28 02:00']).str.strptime(pl.Datetime).dt.replace_time_zone('Europe/Warsaw')
thread '<unnamed>' panicked at 'No such local time', /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.23/src/offset/mod.rs:186:34
---------------------------------------------------------------------------

PanicException: No such local time
```

Here:
```python
In [1]: pl.Series(['2021-03-28 02:00']).str.strptime(pl.Datetime).dt.replace_time_zone('Europe/Warsaw')
---------------------------------------------------------------------------

ArrowErrorException: InvalidArgumentError("datetime '2021-03-28 02:00:00' is non-existent in time zone 'Europe/Warsaw'. Non-existent datetimes are not yet supported")
```

note: I've removed irrelevant parts of the traceback here for readability