### PR TITLE
fix(rust, python): raise error on invalid categorical cast

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -281,6 +281,10 @@ impl ChunkCast for ListChunked {
                             )
                         })
                     }
+                    #[cfg(feature = "dtype-categorical")]
+                    (dt, Categorical(None)) => {
+                        polars_bail!(ComputeError: "cannot cast list inner type: '{:?}' to Categorical", dt)
+                    }
                     _ if phys_child.is_primitive() => {
                         let mut ca = if child_type.to_physical() != self.inner_dtype().to_physical()
                         {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -483,7 +483,7 @@ def test_err_on_time_datetime_cast() -> None:
 
 
 def test_invalid_inner_type_cast_list() -> None:
-    s = pl.Series([[-1, 1]]).cast(pl.List(pl.Categorical))
+    s = pl.Series([[-1, 1]])
     with pytest.raises(
         pl.ComputeError, match=r"cannot cast list inner type: 'Int64' to Categorical"
     ):

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -480,3 +480,11 @@ def test_err_on_time_datetime_cast() -> None:
     s = pl.Series([time(10, 0, 0), time(11, 30, 59)])
     with pytest.raises(pl.ComputeError, match=r"cannot cast `Time` to `Datetime`"):
         s.cast(pl.Datetime)
+
+
+def test_invalid_inner_type_cast_list() -> None:
+    s = pl.Series([[-1, 1]]).cast(pl.List(pl.Categorical))
+    with pytest.raises(
+        pl.ComputeError, match=r"cannot cast list inner type: 'Int64' to Categorical"
+    ):
+        s.cast(pl.List(pl.Categorical))


### PR DESCRIPTION
fixes #7656