### PR TITLE
feat(python,rust): include `set_fmt_float` value in `Config` load/save state

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -35,7 +35,7 @@ pub enum FloatFmt {
 }
 static FLOAT_FMT: AtomicU8 = AtomicU8::new(FloatFmt::Mixed as u8);
 
-fn get_float_fmt() -> FloatFmt {
+pub fn get_float_fmt() -> FloatFmt {
     match FLOAT_FMT.load(Ordering::Relaxed) {
         0 => FloatFmt::Mixed,
         1 => FloatFmt::Full,

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -81,6 +81,7 @@ CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 FillNullStrategy: TypeAlias = Literal[
     "forward", "backward", "min", "max", "mean", "zero", "one"
 ]
+FloatFmt: TypeAlias = Literal["full", "mixed"]
 IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
 NullBehavior: TypeAlias = Literal["ignore", "drop"]
 NullStrategy: TypeAlias = Literal["ignore", "propagate"]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -594,6 +594,16 @@ fn set_float_fmt(fmt: &str) -> PyResult<()> {
     Ok(())
 }
 
+#[pyfunction]
+fn get_float_fmt() -> PyResult<String> {
+    use polars_core::fmt::{get_float_fmt, FloatFmt};
+    let strfmt = match get_float_fmt() {
+        FloatFmt::Full => "full",
+        FloatFmt::Mixed => "mixed",
+    };
+    Ok(strfmt.to_string())
+}
+
 #[pymodule]
 fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("ArrowError", py.get_type::<ArrowErrorException>())
@@ -692,5 +702,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_index_type)).unwrap();
     m.add_wrapped(wrap_pyfunction!(coalesce_exprs)).unwrap();
     m.add_wrapped(wrap_pyfunction!(set_float_fmt)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(get_float_fmt)).unwrap();
     Ok(())
 }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -397,7 +397,7 @@ impl PySeries {
             if val == v_trunc {
                 val
             } else {
-                format!("{v_trunc}...")
+                format!("{v_trunc}…")
             }
         } else {
             val

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -6,6 +6,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
+from polars.config import _get_float_fmt
 from polars.testing import assert_frame_equal
 
 
@@ -416,6 +417,7 @@ def test_config_load_save() -> None:
     # set some config options...
     pl.Config.set_tbl_cols(12)
     pl.Config.set_verbose(True)
+    pl.Config.set_fmt_float("full")
     assert os.environ.get("POLARS_VERBOSE") == "1"
 
     cfg = pl.Config.save()
@@ -433,6 +435,7 @@ def test_config_load_save() -> None:
     # ...and confirm the saved options were set.
     assert os.environ.get("POLARS_FMT_MAX_COLS") == "12"
     assert os.environ.get("POLARS_VERBOSE") == "1"
+    assert _get_float_fmt() == "full"
 
     # restore all default options (unsets from env)
     pl.Config.restore_defaults()
@@ -442,6 +445,7 @@ def test_config_load_save() -> None:
 
     assert os.environ.get("POLARS_FMT_MAX_COLS") is None
     assert os.environ.get("POLARS_VERBOSE") is None
+    assert _get_float_fmt() == "mixed"
 
 
 def test_config_scope() -> None:


### PR DESCRIPTION
Allow current state of the associated `Config.set_fmt_float` value to be saved; this also allows it to work properly in context-manager scope. 

(Also, declares a TypeAlias for FloatFmt and sorts some of the Config methods).

**Example:**
```python
with pl.Config() as cfg:
    cfg.set_fmt_float("full")
    print(df)

# float fmt reset to "mixed" (original state) on scope-exit
```