### PR TITLE
perf(rust, python): runtime SIMD target detection for `min/max/sum` and impl SIMD `mean` `~2-5x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = "1.3"
 once_cell = "1"
 memchr = "2"
 smartstring = { version = "1" }
+multiversion = "0.7"
 
 [workspace.dependencies.arrow]
 package = "arrow2"
@@ -41,7 +42,7 @@ package = "arrow2"
 git = "https://github.com/ritchie46/arrow2"
 # rev = "f258a3e06ac408aebe7a7a497694729dc65a5e46"
 # path = "../arrow2"
-branch = "polars_2023-03-21"
+branch = "polars_2023-03-22"
 version = "0.16"
 default-features = false
 features = [

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -13,6 +13,7 @@ arrow.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 chrono-tz = { version = "0.8", optional = true }
 hashbrown.workspace = true
+multiversion.workspace = true
 num-traits.workspace = true
 polars-error = { version = "0.27.2", path = "../polars-error" }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -27,3 +28,4 @@ bigidx = []
 performant = []
 like = ["arrow/compute_like"]
 timezones = ["chrono-tz", "chrono"]
+simd = []

--- a/polars/polars-arrow/src/data_types.rs
+++ b/polars/polars-arrow/src/data_types.rs
@@ -52,10 +52,12 @@ mod private {
 macro_rules! impl_is_float {
     ($tp:ty) => {
         unsafe impl IsFloat for $tp {
+            #[inline]
             fn is_float() -> bool {
                 true
             }
 
+            #[inline]
             fn is_nan(&self) -> bool {
                 <$tp>::is_nan(*self)
             }

--- a/polars/polars-arrow/src/kernels/agg_mean.rs
+++ b/polars/polars-arrow/src/kernels/agg_mean.rs
@@ -1,11 +1,14 @@
-use std::simd::{Simd, SimdElement, SimdFloat};
+use std::simd::{Mask, Simd, SimdElement, SimdFloat, StdFloat, ToBitMask};
 
 use arrow::array::{Array, PrimitiveArray};
+use arrow::bitmap::utils::{BitChunkIterExact, BitChunksExact};
+use arrow::bitmap::Bitmap;
 use arrow::datatypes::PhysicalType::Primitive;
 use arrow::types::NativeType;
 use multiversion::multiversion;
 use num_traits::ToPrimitive;
 
+use crate::data_types::IsFloat;
 use crate::utils::with_match_primitive_type;
 
 #[multiversion(targets = "simd")]
@@ -14,9 +17,10 @@ where
     T: NativeType + SimdElement + ToPrimitive,
 {
     // we choose 8 as that the maximum size of f64x8 -> 512bit wide
-    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, 64>>() };
+    const LANES: usize = 8;
+    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, LANES>>() };
 
-    let mut reduced: Simd<f64, 64> = Simd::splat(0.0);
+    let mut reduced: Simd<f64, LANES> = Simd::splat(0.0);
     for chunk in simd_vals {
         reduced += chunk.cast::<f64>();
     }
@@ -34,12 +38,96 @@ where
     }
 }
 
-pub fn no_null_sum_as_f64(values: &dyn Array) -> f64 {
-    debug_assert_eq!(values.null_count(), 0);
+#[multiversion(targets = "simd")]
+fn null_sum_as_f64_impl<T, I>(values: &[T], mut validity_masks: I) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + IsFloat,
+    I: BitChunkIterExact<u8>,
+{
+    const LANES: usize = 8;
+    let mut chunks = values.chunks_exact(LANES);
+    let min_one = Simd::<f64, LANES>::splat(-1.0);
+    let min_one_i64 = Simd::<i64, LANES>::splat(-1);
+
+    let sum = chunks.by_ref().zip(validity_masks.by_ref()).fold(
+        Simd::<f64, LANES>::splat(0.0),
+        |acc, (chunk, validity_chunk)| {
+            // safety: exact size chunks
+            let chunk: [T; LANES] = unsafe { chunk.try_into().unwrap_unchecked() };
+            let chunk = Simd::from(chunk).cast::<f64>();
+
+            // construct [bools]
+            let mask = Mask::<i8, LANES>::from_bitmask(validity_chunk);
+            // let's say we have mask
+            //      [true, false, true, true]
+            // a cast to int gives:
+            //      [-1, 0, -1, -1]
+            // multiply by -1
+            //     [1, 0, 1, 1]
+            // and then use that as mask to multiply
+            // the chunk.
+
+            if T::is_float() {
+                // there can be NaNs masked out by validity
+                // so our strategy if multiplying by zero doesn't work on floats
+                // we transmute to i64 and multiply by 1s and 0s. This works as the multiply
+                // by 1 doesn't change the bits and the multiply by 0 gives 0 which has the same
+                // bit repr in f64 and i64
+                unsafe {
+                    let chunk_i64 =
+                        std::mem::transmute::<Simd<f64, LANES>, Simd<i64, LANES>>(chunk);
+                    let mask_mul = mask.to_int().cast::<i64>() * min_one_i64;
+
+                    // mask out and transmute back
+                    std::mem::transmute::<_, Simd<f64, LANES>>(chunk_i64 * mask_mul) + acc
+                }
+            } else {
+                // cast true to -1 and false to 0 so we multiply with -1 to get a branchless mask
+                let mask_mul = mask.to_int().cast::<f64>() * min_one;
+                // eg. null values are multiplied with 0
+                // and valid value with 1
+                chunk.mul_add(mask_mul, acc)
+            }
+        },
+    );
+    let mut sum = sum.reduce_sum();
+
+    for (v, valid) in chunks
+        .remainder()
+        .iter()
+        .zip(validity_masks.remainder_iter())
+    {
+        unsafe {
+            sum += (valid as u8 as f64) * v.to_f64().unwrap_unchecked();
+        }
+    }
+    sum
+}
+
+fn null_sum_as_f64<T>(values: &[T], bitmap: &Bitmap) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + IsFloat,
+{
+    let (slice, offset, length) = bitmap.as_slice();
+    if offset == 0 {
+        let validity_masks = BitChunksExact::<u8>::new(slice, length);
+        null_sum_as_f64_impl(values, validity_masks)
+    } else {
+        let validity_masks = bitmap.chunks::<u8>();
+        null_sum_as_f64_impl(values, validity_masks)
+    }
+}
+
+pub fn sum_as_f64(values: &dyn Array) -> f64 {
     if let Primitive(primitive) = values.data_type().to_physical_type() {
         with_match_primitive_type!(primitive, |$T| {
             let arr: &PrimitiveArray<$T> = values.as_any().downcast_ref().unwrap();
-            nonnull_sum_as_f64(arr.values())
+            if arr.null_count() == 0 {
+                nonnull_sum_as_f64(arr.values())
+            } else {
+                let validity = arr.validity().unwrap();
+                null_sum_as_f64(arr.values().as_slice(), validity)
+            }
         })
     } else {
         unreachable!()

--- a/polars/polars-arrow/src/kernels/agg_mean.rs
+++ b/polars/polars-arrow/src/kernels/agg_mean.rs
@@ -11,19 +11,27 @@ use crate::utils::with_match_primitive_type;
 #[multiversion(targets = "simd")]
 fn nonnull_sum_as_f64<T>(values: &[T]) -> f64
 where
-    T: NativeType + SimdElement + ToPrimitive + std::iter::Sum<T>,
+    T: NativeType + SimdElement + ToPrimitive,
 {
     // we choose 8 as that the maximum size of f64x8 -> 512bit wide
-    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, 8>>() };
+    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, 64>>() };
 
-    let mut reduced: Simd<f64, 8> = Simd::splat(0.0);
+    let mut reduced: Simd<f64, 64> = Simd::splat(0.0);
     for chunk in simd_vals {
         reduced += chunk.cast::<f64>();
     }
 
-    reduced.reduce_sum()
-        + head.iter().copied().sum::<T>().to_f64().unwrap()
-        + tail.iter().copied().sum::<T>().to_f64().unwrap()
+    unsafe {
+        reduced.reduce_sum()
+            + head
+                .iter()
+                .map(|v| v.to_f64().unwrap_unchecked())
+                .sum::<f64>()
+            + tail
+                .iter()
+                .map(|v| v.to_f64().unwrap_unchecked())
+                .sum::<f64>()
+    }
 }
 
 pub fn no_null_sum_as_f64(values: &dyn Array) -> f64 {

--- a/polars/polars-arrow/src/kernels/agg_mean.rs
+++ b/polars/polars-arrow/src/kernels/agg_mean.rs
@@ -1,0 +1,46 @@
+use std::simd::{Simd, SimdElement, SimdFloat};
+
+use arrow::array::{Array, PrimitiveArray};
+use arrow::datatypes::PhysicalType::Primitive;
+use arrow::types::NativeType;
+use multiversion::multiversion;
+use num_traits::ToPrimitive;
+
+use crate::utils::with_match_primitive_type;
+
+#[multiversion(targets = "simd")]
+fn nonnull_mean<T>(values: &[T]) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + std::iter::Sum<T>,
+{
+    // we choose 8 as that the maximum size of f64x8 -> 512bit wide
+    let (head, simd_vals, tail) = unsafe { values.align_to::<Simd<T, 8>>() };
+
+    let mut reduced: Simd<f64, 8> = Simd::splat(0.0);
+    for chunk in simd_vals {
+        reduced += chunk.cast::<f64>();
+    }
+
+    (reduced.reduce_sum()
+        + head.iter().copied().sum::<T>().to_f64().unwrap()
+        + tail.iter().copied().sum::<T>().to_f64().unwrap())
+        / values.len() as f64
+}
+
+pub fn primitive_no_null_sum_as_f64<T>(array: &PrimitiveArray<T>) -> f64
+where
+    T: NativeType + SimdElement + ToPrimitive + std::iter::Sum<T>,
+{
+    assert_eq!(array.null_count(), 0);
+    nonnull_mean(array.values())
+}
+pub fn no_null_sum_as_f64(values: &dyn Array) -> f64 {
+    if let Primitive(primitive) = values.data_type().to_physical_type() {
+        with_match_primitive_type!(primitive, |$T| {
+            let arr: &PrimitiveArray<$T> = values.as_any().downcast_ref().unwrap();
+            nonnull_mean(arr.values())
+        })
+    } else {
+        unreachable!()
+    }
+}

--- a/polars/polars-arrow/src/kernels/agg_mean.rs
+++ b/polars/polars-arrow/src/kernels/agg_mean.rs
@@ -27,6 +27,7 @@ where
 }
 
 pub fn no_null_sum_as_f64(values: &dyn Array) -> f64 {
+    debug_assert_eq!(values.null_count(), 0);
     if let Primitive(primitive) = values.data_type().to_physical_type() {
         with_match_primitive_type!(primitive, |$T| {
             let arr: &PrimitiveArray<$T> = values.as_any().downcast_ref().unwrap();

--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -2,6 +2,8 @@ use std::iter::Enumerate;
 
 use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitChunks;
+#[cfg(feature = "simd")]
+pub mod agg_mean;
 pub mod concatenate;
 pub mod ewm;
 pub mod float;
@@ -17,6 +19,7 @@ pub mod string;
 pub mod take_agg;
 #[cfg(feature = "timezones")]
 mod time;
+
 #[cfg(feature = "timezones")]
 pub use time::replace_timezone;
 

--- a/polars/polars-arrow/src/lib.rs
+++ b/polars/polars-arrow/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 pub mod array;
 pub mod bit_util;
 mod bitmap;

--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -169,21 +169,20 @@ macro_rules! with_match_primitive_type {(
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use arrow::datatypes::PrimitiveType::*;
-    use arrow::types::{days_ms, months_days_ns};
     match $key_type {
         Int8 => __with_ty__! { i8 },
         Int16 => __with_ty__! { i16 },
         Int32 => __with_ty__! { i32 },
         Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        DaysMs => __with_ty__! { days_ms },
-        MonthDayNano => __with_ty__! { months_days_ns },
         UInt8 => __with_ty__! { u8 },
         UInt16 => __with_ty__! { u16 },
         UInt32 => __with_ty__! { u32 },
         UInt64 => __with_ty__! { u64 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        Int128 |
+        DaysMs |
+        MonthDayNano |
         Float16 | Int256 => unimplemented!(),
     }
 })}

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Core of the Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-simd = ["arrow/simd"]
+simd = ["arrow/simd", "polars-arrow/simd"]
 nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "polars-arrow/nightly"]
 avx512 = []
 docs = []

--- a/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -173,6 +173,7 @@ where
                 let null_count = self.null_count();
                 let len = self.len();
                 match null_count {
+                    nc if nc == len => None,
                     #[cfg(feature = "simd")]
                     0 => {
                         // TODO: investigate if we need a stable mean
@@ -185,7 +186,6 @@ where
                         }
                         Some(sum / len)
                     }
-                    nc if nc == len => None,
                     _ => {
                         let mut acc = 0.0;
                         let len = (len - null_count) as f64;

--- a/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -175,17 +175,17 @@ where
                 match null_count {
                     nc if nc == len => None,
                     #[cfg(feature = "simd")]
-                    0 => {
+                    _ => {
                         // TODO: investigate if we need a stable mean
                         // because of SIMD memory locations and associativity.
                         // similar to sum
-                        let len = self.len() as f64;
                         let mut sum = 0.0;
                         for arr in self.downcast_iter() {
-                            sum += polars_arrow::kernels::agg_mean::no_null_sum_as_f64(arr);
+                            sum += polars_arrow::kernels::agg_mean::sum_as_f64(arr);
                         }
-                        Some(sum / len)
+                        Some(sum / (len - null_count) as f64)
                     }
+                    #[cfg(not(feature = "simd"))]
                     _ => {
                         let mut acc = 0.0;
                         let len = (len - null_count) as f64;

--- a/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -172,34 +172,47 @@ where
             _ => {
                 let null_count = self.null_count();
                 let len = self.len();
-                if null_count == len {
-                    None
-                } else {
-                    let mut acc = 0.0;
-                    let len = (len - null_count) as f64;
+                match null_count {
+                    #[cfg(feature = "simd")]
+                    0 => {
+                        // TODO: investigate if we need a stable mean
+                        // because of SIMD memory locations and associativity.
+                        // similar to sum
+                        let len = self.len() as f64;
+                        let mut sum = 0.0;
+                        for arr in self.downcast_iter() {
+                            sum += polars_arrow::kernels::agg_mean::no_null_sum_as_f64(arr);
+                        }
+                        Some(sum / len)
+                    }
+                    nc if nc == len => None,
+                    _ => {
+                        let mut acc = 0.0;
+                        let len = (len - null_count) as f64;
 
-                    for arr in self.downcast_iter() {
-                        if arr.null_count() > 0 {
-                            for v in arr.into_iter().flatten() {
-                                // safety
-                                // all these types can be coerced to f64
-                                unsafe {
-                                    let val = v.to_f64().unwrap_unchecked();
-                                    acc += val
+                        for arr in self.downcast_iter() {
+                            if arr.null_count() > 0 {
+                                for v in arr.into_iter().flatten() {
+                                    // safety
+                                    // all these types can be coerced to f64
+                                    unsafe {
+                                        let val = v.to_f64().unwrap_unchecked();
+                                        acc += val
+                                    }
                                 }
-                            }
-                        } else {
-                            for v in arr.values().as_slice() {
-                                // safety
-                                // all these types can be coerced to f64
-                                unsafe {
-                                    let val = v.to_f64().unwrap_unchecked();
-                                    acc += val
+                            } else {
+                                for v in arr.values().as_slice() {
+                                    // safety
+                                    // all these types can be coerced to f64
+                                    unsafe {
+                                        let val = v.to_f64().unwrap_unchecked();
+                                        acc += val
+                                    }
                                 }
                             }
                         }
+                        Some(acc / len)
                     }
-                    Some(acc / len)
                 }
             }
         }

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 extern crate core;
 
 #[macro_use]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.16.0"
-source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-21#a49a36e313abe15237027b1d830e6345b49a8bbe"
+source = "git+https://github.com/ritchie46/arrow2?branch=polars_2023-03-22#dd53a883e9091edeed670789207edda14f5a0f5f"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -86,7 +86,7 @@ dependencies = [
  "base64",
  "bytemuck",
  "chrono",
- "chrono-tz 0.6.3",
+ "chrono-tz",
  "dyn-clone",
  "either",
  "ethnum",
@@ -108,7 +108,7 @@ dependencies = [
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
- "zstd",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
@@ -309,35 +309,13 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
-dependencies = [
- "chrono",
- "chrono-tz-build 0.0.3",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.1.0",
+ "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -1207,22 +1185,24 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
+checksum = "e6a87eede2251ca235e5573086d01d2ab6b59dfaea54c2be10f9320980f7e8f7"
 dependencies = [
  "multiversion-macros",
+ "target-features",
 ]
 
 [[package]]
 name = "multiversion-macros"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
+checksum = "1af1abf82261d780d114014eff4b555e47d823f3b84f893c4388572b40e089fb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "target-features",
 ]
 
 [[package]]
@@ -1389,7 +1369,7 @@ dependencies = [
  "seq-macro",
  "snap",
  "streaming-decompression",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -1443,7 +1423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -1493,8 +1472,9 @@ version = "0.27.2"
 dependencies = [
  "arrow2",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "hashbrown 0.13.2",
+ "multiversion",
  "num-traits",
  "polars-error",
  "serde",
@@ -1509,7 +1489,7 @@ dependencies = [
  "arrow2",
  "bitflags",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "comfy-table",
  "hashbrown 0.13.2",
  "indexmap",
@@ -1551,7 +1531,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "dirs",
  "fast-float",
  "flate2",
@@ -1639,7 +1619,7 @@ dependencies = [
  "ahash",
  "arrow2",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "once_cell",
  "polars-arrow",
  "polars-core",
@@ -1683,7 +1663,7 @@ dependencies = [
  "arrow2",
  "atoi",
  "chrono",
- "chrono-tz 0.8.1",
+ "chrono-tz",
  "now",
  "once_cell",
  "polars-arrow",
@@ -2208,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-features"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24840de800c1707d75c800893dbd727a5e1501ce921944e602f0698167491e36"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,15 +2275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "uncased"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -2580,7 +2557,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe 6.0.4+zstd.1.5.4",
 ]
 
 [[package]]
@@ -2588,6 +2574,16 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.4+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -131,3 +131,16 @@ def test_mean_overflow() -> None:
     assert np.isclose(
         pl.Series([9_223_372_036_854_775_800, 100]).mean(), 4.611686018427388e18
     )
+
+
+def test_mean_null_simd() -> None:
+    for dtype in [int, float]:
+        df = (
+            pl.Series(np.random.randint(0, 100, 1000))
+            .cast(dtype)
+            .to_frame("a")
+            .select(pl.when(pl.col("a") > 40).then(pl.col("a")))
+        )
+
+    s = df["a"]
+    assert s.mean() == s.to_pandas().mean()

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -124,3 +124,10 @@ def test_quantile_vs_numpy() -> None:
                 assert np.isclose(
                     pl.Series(a).quantile(q, interpolation="linear"), np_result
                 )
+
+
+@typing.no_type_check
+def test_mean_overflow() -> None:
+    assert np.isclose(
+        pl.Series([9_223_372_036_854_775_800, 100]).mean(), 4.611686018427388e18
+    )


### PR DESCRIPTION
Added runtime target cpu detection for SIMD accelerated min/max and sum kernels upstream in arrow2. This can double the perf as we compile the binary only for avx -> 128 bit registers. Whereas that specific function now also is compiled for avx2 -> 256 bit registers and at runtime dispatched.

Also implemented SIMD for `mean` aggregation. And added runtime dispatch. 

closes #7693

We are slightly slower than pyarrow here, because we are careful not to overflow:

![image](https://user-images.githubusercontent.com/3023000/226931488-bf977cf2-c919-42c2-87a9-2625ae740940.png)
