### PR TITLE
fix(rust, python): avoid ambiguous time error when passing python Datetime to DataFrame constructor

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -385,7 +385,7 @@ def sequence_to_pyseries(
                         "Given time_zone is different from that of timezone aware datetimes."
                         f" Given: '{dtype_tz}', got: '{tz}'."
                     )
-                return s.dt.replace_time_zone(tz)._s
+                return s.dt.replace_time_zone("UTC").dt.convert_time_zone(tz)._s
             return s._s
 
         elif (

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -352,6 +352,20 @@ def test_datetime_consistency() -> None:
         (test_data[2], 123456000),
         (test_data[3], 999999000),
     ]
+    # Similar to above, but check for no error when crossing DST
+    test_data = [
+        datetime(2021, 11, 7, 0, 0, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 1, 0, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 1, 0, fold=1, tzinfo=ZoneInfo("US/Central")),
+        datetime(2021, 11, 7, 2, 0, tzinfo=ZoneInfo("US/Central")),
+    ]
+    ddf = pl.DataFrame({"dtm": test_data})
+    assert ddf.rows() == [
+        (test_data[0],),
+        (test_data[1],),
+        (test_data[2],),
+        (test_data[3],),
+    ]
 
 
 def test_timezone() -> None:


### PR DESCRIPTION
closes #7710 