### PR TITLE
docs(python): Add sort_by example taking one row per group

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2124,6 +2124,22 @@ class Expr:
         │ b     ┆ [2, 4]    │
         └───────┴───────────┘
 
+        Take a single row from each group where a column attains its minimal value
+        within that group.
+
+        >>> df.groupby("group").agg(
+        ...     pl.all().sort_by("value2").first()
+        ... )  # doctest: +IGNORE_RESULT
+        shape: (2, 3)
+        ┌───────┬────────┬────────┐
+        │ group ┆ value1 ┆ value2 |
+        │ ---   ┆ ---    ┆ ---    │
+        │ str   ┆ i64    ┆ i64    |
+        ╞═══════╪════════╪════════╡
+        │ a     ┆ 3      ┆ 7      |
+        │ b     ┆ 2      ┆ 5      |
+        └───────┴────────┴────────┘
+
         """
         if isinstance(descending, bool):
             descending = [descending]


### PR DESCRIPTION
This PR adds an example to the `Expr.sort_by` docstring that shows how to take one row per group in a groupby where the minimum value of a column within that group is attained. I think this is probably a common use case and is worth highlighting since I had to search a little bit for how to achieve this. It's a natural extension of the use of `sort_by` from the previous example, so I think it fits nicely. Thanks for the great library btw :)