### PR TITLE
feat(rust, python): add `qcut`

### DIFF
--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -31,6 +31,7 @@ Manipulation/selection
     Series.item
     Series.limit
     Series.new_from_index
+    Series.qcut
     Series.rechunk
     Series.rename
     Series.reshape

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1515,7 +1515,7 @@ class Series:
 
         Examples
         --------
-        >>> pl.Series("a", range(-5, 3))
+        >>> a = pl.Series("a", range(-5, 3))
         >>> a.qcut([0.0, 0.25, 0.75])
         shape: (8, 3)
         ┌──────┬─────────────┬───────────────┐

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2610,6 +2610,13 @@ def test_cut_maintain_order() -> None:
     )
 
 
+def test_qcut() -> None:
+    assert (
+        str(pl.Series("a", range(-5, 3)).qcut([0.0, 0.25, 0.75]).to_dict(False))
+        == "{'a': [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0], 'break_point': [-5.0, -3.25, 0.25, 0.25, 0.25, 0.25, inf, inf], 'category': ['(-inf, -5.0]', '(-5.0, -3.25]', '(-3.25, 0.25]', '(-3.25, 0.25]', '(-3.25, 0.25]', '(-3.25, 0.25]', '(0.25, inf]', '(0.25, inf]']}"
+    )
+
+
 def test_symmetry_for_max_in_names() -> None:
     # int
     a = pl.Series("a", [1])


### PR DESCRIPTION
closes #3000

Would there be much benefit exposing this to expressions that return a `struct`?  Any idea @alexander-beedie @MarcoGorelli ?