### PR TITLE
Type infer failed when building with openssl crate

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -92,7 +92,7 @@ macro_rules! format_array {
             } else {
                 write!(f, "\t{}\n", v)?;
             };
-            Ok(())
+            Ok::<(), std::fmt::Error>(())
         };
         if limit < $a.len() {
             if limit > 0 {


### PR DESCRIPTION
I met a weird compilation failure at https://github.com/feathr-ai/feathr-online/pull/15
The compiler says it cannot infer the return type. I haven't made a minimal sample to repro the error but I can try if needed.

Add an explicit type annotation as a quick workaround.