### PR TITLE
feat(python): More ergonomic args for `min/max`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -445,38 +445,36 @@ def var(column: str | Series, ddof: int = 1) -> Expr | float | None:
 
 
 @overload
-def max(exprs: Series) -> Expr:
+def max(exprs: Series) -> PythonLiteral | None:  # type: ignore[misc]
     ...
 
 
 @overload
-def max(
-    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
-) -> PythonLiteral | None:
+def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
 @deprecated_alias(column="exprs")
 def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | Any:
     """
-    Get the maximum value. Can be used horizontally or vertically.
+    Get the maximum value.
+
+    If a single column is passed, get the maximum value of that column (vertical).
+    If multiple columns are passed, get the maximum value of each row (horizontal).
 
     Parameters
     ----------
     exprs
-        Column(s) to be used in aggregation. Will lead to different behavior based on
-        the input:
-        - Union[str, Series] -> aggregate the maximum value of that column.
-        - List[Expr] -> aggregate the maximum value horizontally.
+        Column(s) to use in the aggregation. Accepts expression input. Strings are
+        parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
-        ...
+        Additional columns to use in the aggregation, specified as positional arguments.
 
     Examples
     --------
+    Get the maximum value by columns with a string column name.
+
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
-
-    Get the maximum value by columns with a string column name
-
     >>> df.select(pl.max("a"))
     shape: (1, 1)
     ┌─────┐
@@ -487,7 +485,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     │ 8   │
     └─────┘
 
-    Get the maximum value by row with a list of columns/expressions
+    Get the maximum value by row with a list of columns/expressions.
 
     >>> df.select(pl.max(["a", "b"]))
     shape: (3, 1)
@@ -556,16 +554,16 @@ def min(
     """
     Get the minimum value.
 
+    If a single column is passed, get the minimum value of that column (vertical).
+    If multiple columns are passed, get the minimum value of each row (horizontal).
+
     Parameters
     ----------
     exprs
-        Column(s) to be used in aggregation. Will lead to different behavior based on
-        the input:
-
-        - Union[str, Series] -> aggregate the sum value of that column.
-        - List[Expr] -> aggregate the min value horizontally.
+        Column(s) to use in the aggregation. Accepts expression input. Strings are
+        parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
-        ...
+        Additional columns to use in the aggregation, specified as positional arguments.
 
     Examples
     --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1278,7 +1278,7 @@ class Series:
         """
         return self._s.min()
 
-    def max(self) -> int | float | date | datetime | timedelta | time | str | None:
+    def max(self) -> PythonLiteral | None:
         """
         Get the maximum value in this Series.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1190,7 +1190,7 @@ class Series:
         └────────────┴───────┘
 
         """
-        stats: dict[str, float | None | int | str | date | datetime | timedelta | time]
+        stats: dict[str, PythonLiteral | None]
 
         if self.len() == 0:
             raise ValueError("Series must contain at least one value")
@@ -1265,7 +1265,7 @@ class Series:
         """Reduce this Series to the product value."""
         return self.to_frame().select(F.col(self.name).product()).to_series()[0]
 
-    def min(self) -> int | float | date | datetime | timedelta | time | str | None:
+    def min(self) -> PythonLiteral | None:
         """
         Get the minimal value in this Series.
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1084,7 +1084,7 @@ def test_lazy_functions() -> None:
     assert np.isclose(pl.max(df["b"]), expected)
     expected = 1
     assert np.isclose(out.to_series(3), expected)
-    assert np.isclose(pl.min(df["b"]), expected)
+    assert np.isclose(pl.min(df["b"]), expected)  # type: ignore[arg-type]
     expected = 6
     assert np.isclose(out.to_series(4), expected)
     assert np.isclose(pl.sum(df["b"]), expected)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1081,7 +1081,7 @@ def test_lazy_functions() -> None:
     assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
     expected = 3
     assert np.isclose(out.to_series(2), expected)
-    assert np.isclose(pl.max(df["b"]), expected)
+    assert np.isclose(pl.max(df["b"]), expected)  # type: ignore[arg-type]
     expected = 1
     assert np.isclose(out.to_series(3), expected)
     assert np.isclose(pl.min(df["b"]), expected)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -329,3 +329,17 @@ def test_repeat() -> None:
     s = pl.select(pl.repeat(0, 0)).to_series()
     assert s.dtype == pl.Int32
     assert s.len() == 0
+
+
+def test_min() -> None:
+    s = pl.Series([1, 2, 3])
+    assert pl.min(s) == 1
+
+    df = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
+    assert df.select(pl.min("a")).item() == 1
+
+    result = df.select(pl.min(["a", "b"]))
+    assert_frame_equal(result, pl.DataFrame({"min": [1, 2]}))
+
+    result = df.select(pl.min("a", 3))
+    assert_frame_equal(result, pl.DataFrame({"min": [1, 3]}))

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -343,3 +343,17 @@ def test_min() -> None:
 
     result = df.select(pl.min("a", 3))
     assert_frame_equal(result, pl.DataFrame({"min": [1, 3]}))
+
+
+def test_max() -> None:
+    s = pl.Series([1, 2, 3])
+    assert pl.max(s) == 3
+
+    df = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
+    assert df.select(pl.max("a")).item() == 4
+
+    result = df.select(pl.max(["a", "b"]))
+    assert_frame_equal(result, pl.DataFrame({"max": [3, 4]}))
+
+    result = df.select(pl.max("a", 3))
+    assert_frame_equal(result, pl.DataFrame({"max": [3, 4]}))


### PR DESCRIPTION
Partially addresses #6451

Just continuing the crusade to get all these checked off :)

Changes:
* Improve argument parsing for `min/max` functions and allow `*args` syntax.

Not sure I really like that `pl.max(Series)` results in a literal rather than an expression. But that's the current behaviour, so this PR respects that behaviour.