### PR TITLE
fix(rust): compile issues in "polars-core" with default features

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -244,7 +244,6 @@ docs-selection = [
   "ipc_streaming",
   "dtype-full",
   "is_in",
-  "sort_multiple",
   "rows",
   "docs",
   "strings",

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -17,7 +17,7 @@ docs = []
 temporal = ["regex", "chrono", "polars-error/regex"]
 random = ["rand", "rand_distr"]
 default = ["docs", "temporal", "private"]
-lazy = ["sort_multiple"]
+lazy = []
 
 # ~40% faster collect, needed until trustedlength iter stabilizes
 # more fast paths, slower compilation
@@ -78,7 +78,6 @@ semi_anti_join = []
 chunked_ids = []
 describe = []
 timezones = ["chrono-tz", "arrow/chrono-tz", "polars-arrow/timezones"]
-
 dynamic_groupby = ["dtype-datetime", "dtype-date"]
 
 # opt-in datatypes for Series
@@ -105,7 +104,6 @@ serde-lazy = ["serde", "polars-arrow/serde", "indexmap/serde", "smartstring/serd
 docs-selection = [
   "ndarray",
   "is_in",
-  "sort_multiple",
   "rows",
   "docs",
   "strings",

--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -119,7 +119,7 @@ impl CategoricalChunked {
     }
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    #[cfg(feature = "sort_multiple")]
+
     pub(crate) fn arg_sort_multiple(
         &self,
         other: &[Series],
@@ -184,7 +184,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "sort_multiple")]
+
     fn test_cat_lexical_sort_multiple() -> PolarsResult<()> {
         let init = &["c", "b", "a", "a"];
 

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -1,5 +1,5 @@
 mod arg_sort;
-#[cfg(feature = "sort_multiple")]
+
 pub mod arg_sort_multiple;
 #[cfg(feature = "dtype-categorical")]
 mod categorical;
@@ -9,7 +9,6 @@ use std::cmp::Ordering;
 use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 
-#[cfg(feature = "sort_multiple")]
 pub(crate) use arg_sort_multiple::argsort_multiple_row_fmt;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
@@ -22,7 +21,6 @@ use rayon::prelude::*;
 pub use slice::*;
 
 use crate::prelude::compare_inner::PartialOrdInner;
-#[cfg(feature = "sort_multiple")]
 use crate::prelude::sort::arg_sort_multiple::{arg_sort_multiple_impl, args_validate};
 use crate::prelude::*;
 use crate::series::IsSorted;
@@ -287,7 +285,6 @@ where
     }
 }
 
-#[cfg(feature = "sort_multiple")]
 fn arg_sort_multiple_numeric<T: PolarsNumericType>(
     ca: &ChunkedArray<T>,
     other: &[Series],
@@ -327,7 +324,6 @@ where
         arg_sort_numeric(self, options)
     }
 
-    #[cfg(feature = "sort_multiple")]
     /// # Panics
     ///
     /// This function is very opinionated.
@@ -353,7 +349,6 @@ impl ChunkSort<Float32Type> for Float32Chunked {
         arg_sort_numeric(self, options)
     }
 
-    #[cfg(feature = "sort_multiple")]
     /// # Panics
     ///
     /// This function is very opinionated.
@@ -379,7 +374,6 @@ impl ChunkSort<Float64Type> for Float64Chunked {
         arg_sort_numeric(self, options)
     }
 
-    #[cfg(feature = "sort_multiple")]
     /// # Panics
     ///
     /// This function is very opinionated.
@@ -515,7 +509,6 @@ impl ChunkSort<Utf8Type> for Utf8Chunked {
         self.as_binary().arg_sort(options)
     }
 
-    #[cfg(feature = "sort_multiple")]
     /// # Panics
     ///
     /// This function is very opinionated. On the implementation of `ChunkedArray<T>` for numeric types,
@@ -641,7 +634,6 @@ impl ChunkSort<BinaryType> for BinaryChunked {
         )
     }
 
-    #[cfg(feature = "sort_multiple")]
     /// # Panics
     ///
     /// This function is very opinionated. On the implementation of `ChunkedArray<T>` for numeric types,
@@ -705,7 +697,6 @@ impl ChunkSort<BooleanType> for BooleanChunked {
     }
 }
 
-#[cfg(feature = "sort_multiple")]
 pub(crate) fn convert_sort_column_multi_sort(
     s: &Series,
     row_ordering: bool,
@@ -743,7 +734,6 @@ pub fn _broadcast_descending(n_cols: usize, descending: &mut Vec<bool>) {
     }
 }
 
-#[cfg(feature = "sort_multiple")]
 pub(crate) fn prepare_arg_sort(
     columns: Vec<Series>,
     mut descending: Vec<bool>,
@@ -854,7 +844,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "sort_multiple")]
     #[cfg_attr(miri, ignore)]
     fn test_arg_sort_multiple() -> PolarsResult<()> {
         let a = Int32Chunked::new("a", &[1, 2, 1, 1, 3, 4, 3, 3]);

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -35,10 +35,7 @@ use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
 
 use crate::frame::groupby::GroupsIndicator;
-#[cfg(feature = "sort_multiple")]
-use crate::prelude::sort::argsort_multiple_row_fmt;
-#[cfg(feature = "sort_multiple")]
-use crate::prelude::sort::prepare_arg_sort;
+use crate::prelude::sort::{argsort_multiple_row_fmt, prepare_arg_sort};
 use crate::series::IsSorted;
 #[cfg(feature = "row_hash")]
 use crate::vector_hasher::df_rows_to_hashes_threaded;
@@ -1837,19 +1834,11 @@ impl DataFrame {
                 s.arg_sort(options)
             }
             _ => {
-                #[cfg(feature = "sort_multiple")]
-                {
-                    if nulls_last || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
-                        argsort_multiple_row_fmt(&by_column, descending, nulls_last, parallel)?
-                    } else {
-                        let (first, by_column, descending) =
-                            prepare_arg_sort(by_column, descending)?;
-                        first.arg_sort_multiple(&by_column, &descending)?
-                    }
-                }
-                #[cfg(not(feature = "sort_multiple"))]
-                {
-                    panic!("activate `sort_multiple` feature gate to enable this functionality");
+                if nulls_last || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
+                    argsort_multiple_row_fmt(&by_column, descending, nulls_last, parallel)?
+                } else {
+                    let (first, by_column, descending) = prepare_arg_sort(by_column, descending)?;
+                    first.arg_sort_multiple(&by_column, &descending)?
                 }
             }
         };

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -12,7 +12,6 @@ use num_traits::{Float, NumCast, ToPrimitive};
 #[cfg(feature = "concat_str")]
 use polars_arrow::prelude::ValueSize;
 
-#[cfg(feature = "sort_multiple")]
 use crate::chunked_array::ops::sort::prepare_arg_sort;
 use crate::prelude::*;
 use crate::utils::coalesce_nulls;
@@ -94,7 +93,6 @@ where
     Some(cov_f(a, b)? / (a.std(ddof)? * b.std(ddof)?))
 }
 
-#[cfg(feature = "sort_multiple")]
 /// Find the indexes that would sort these series in order of appearance.
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -88,7 +88,6 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    #[cfg(feature = "sort_multiple")]
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -99,7 +99,6 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    #[cfg(feature = "sort_multiple")]
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -143,7 +143,6 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.logical().group_tuples(multithreaded, sorted)
     }
 
-    #[cfg(feature = "sort_multiple")]
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -154,7 +154,7 @@ macro_rules! impl_dyn_series {
             fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
                 self.0.group_tuples(multithreaded, sorted)
             }
-            #[cfg(feature = "sort_multiple")]
+
             fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
                 self.0.deref().arg_sort_multiple(by, descending)
             }

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -162,7 +162,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
         self.0.group_tuples(multithreaded, sorted)
     }
-    #[cfg(feature = "sort_multiple")]
+
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.deref().arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -190,7 +190,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
         self.0.group_tuples(multithreaded, sorted)
     }
-    #[cfg(feature = "sort_multiple")]
+
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.deref().arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -138,7 +138,6 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            #[cfg(feature = "sort_multiple")]
             fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
                 self.0.arg_sort_multiple(by, descending)
             }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -201,7 +201,6 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            #[cfg(feature = "sort_multiple")]
             fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
                 self.0.arg_sort_multiple(by, descending)
             }

--- a/polars/polars-core/src/series/implementations/null.rs
+++ b/polars/polars-core/src/series/implementations/null.rs
@@ -49,6 +49,7 @@ impl PrivateSeries for NullChunked {
         &DataType::Null
     }
 
+    #[cfg(feature = "zip_with")]
     fn zip_with_same_type(&self, _mask: &BooleanChunked, _other: &Series) -> PolarsResult<Series> {
         Ok(self.clone().into_series())
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -96,7 +96,6 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    #[cfg(feature = "sort_multiple")]
     fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, descending)
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -160,12 +160,15 @@ pub(crate) mod private {
         fn group_tuples(&self, _multithreaded: bool, _sorted: bool) -> PolarsResult<GroupsProxy> {
             invalid_operation_panic!(group_tuples, self)
         }
+        #[cfg(feature = "zip_with")]
         fn zip_with_same_type(
             &self,
             _mask: &BooleanChunked,
             _other: &Series,
-        ) -> PolarsResult<Series>;
-        #[cfg(feature = "sort_multiple")]
+        ) -> PolarsResult<Series> {
+            invalid_operation_panic!(zip_with_same_type, self)
+        }
+
         fn arg_sort_multiple(&self, _by: &[Series], _descending: &[bool]) -> PolarsResult<IdxCa> {
             polars_bail!(opq = arg_sort_multiple, self._dtype());
         }


### PR DESCRIPTION
`polars-core` would not compile independently without both `zip_with` and `sort_multiple` features enables. 

running these commands would result in compile issues.
```sh
> cd polars/polars-core
> cargo build
```

however this would work. 
```sh
> cargo build --features zip_with,sort_multiple
```

the `zip_with` was just missing a few `#[cfg(feature = "zip_with")]` statements.

However, the `sort_multiple` seems to be a core feature after the changes in  #7678. Since it is now a core part of the `sort` impl, it made sense to remove the feature flag all together. 