### PR TITLE
fix(python): raise error on attempt to set invalid `Datetime` or `Duration` dtype timeunit

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -211,6 +211,11 @@ class Datetime(TemporalType):
         self.tu = time_unit or "us"
         self.tz = time_zone
 
+        if self.tu not in ("ms", "us", "ns"):
+            raise ValueError(
+                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.tu!r}"
+            )
+
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class
         if type(other) is DataTypeClass and issubclass(other, Datetime):
@@ -244,6 +249,10 @@ class Duration(TemporalType):
 
         """
         self.tu = time_unit
+        if self.tu not in ("ms", "us", "ns"):
+            raise ValueError(
+                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.tu!r}"
+            )
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -40,6 +40,12 @@ def test_dtype_temporal_units() -> None:
         assert inferred_dtype == expected_dtype
         assert inferred_dtype.tu == "us"  # type: ignore[union-attr]
 
+    with pytest.raises(ValueError, match="Invalid time_unit"):
+        pl.Datetime("?")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Invalid time_unit"):
+        pl.Duration("?")  # type: ignore[arg-type]
+
 
 def test_dtype_base_type() -> None:
     assert pl.Date.base_type() is pl.Date


### PR DESCRIPTION
Somehow we missed having validation here; I made a small typo and it accepted it, leading to errors a little later. Minor update so we catch this up-front and raise a suitable ValueError.

```python
pl.Datetime("s")
# ValueError: Invalid time_unit; expected one of {'ns','us','ms'}, got 's'
```