### PR TITLE
feat(python): new utility `from_repr` function that reconstructs a DataFrame from its table repr

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -10,6 +10,7 @@ from polars.convert import (
     from_numpy,
     from_pandas,
     from_records,
+    from_repr,
 )
 from polars.dataframe import DataFrame
 from polars.datatypes import (
@@ -316,6 +317,7 @@ __all__ = [
     "from_numpy",
     "from_pandas",
     "from_records",
+    "from_repr",
     # polars.sql
     "SQLContext",
     # polars.utils

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import re
+from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
 
 from polars import internals as pli
-from polars.datatypes import N_INFER_DEFAULT
+from polars.datatypes import (
+    N_INFER_DEFAULT,
+    List,
+    Object,
+    Struct,
+)
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.various import _cast_repr_strings_with_schema
 
 if TYPE_CHECKING:
     from polars.dataframe import DataFrame
@@ -243,6 +251,115 @@ def from_records(
         orient=orient,
         infer_schema_length=infer_schema_length,
     )
+
+
+def from_repr(tbl: str) -> DataFrame:
+    """
+    Debug function that reconstructs a DataFrame from a table repr.
+
+    Parameters
+    ----------
+    tbl
+        A string containing a polars table repr; does not need to be trimmed
+        of whitespace (or leading prompts) as the table will be found/extracted
+        automatically.
+
+    Notes
+    -----
+    This function handles the default UTF8_FULL and UTF8_FULL_CONDENSED format
+    tables (with or without rounded corners). Truncated columns/rows are omitted,
+    wrapped headers are accounted for, and dtypes identified.
+
+    Currently compound types such as List and Struct are not supported,
+    (and neither is Time) though support is planned.
+
+    Examples
+    --------
+    >>> df = pl.from_repr(
+    ...     '''
+    ...     Out[3]:
+    ...     shape: (1, 5)
+    ...     ┌───────────┬────────────┬───┬───────┬────────────────────────────────┐
+    ...     │ source_ac ┆ source_cha ┆ … ┆ ident ┆ timestamp                      │
+    ...     │ tor_id    ┆ nnel_id    ┆   ┆ ---   ┆ ---                            │
+    ...     │ ---       ┆ ---        ┆   ┆ str   ┆ datetime[μs, Asia/Tokyo]       │
+    ...     │ i32       ┆ i64        ┆   ┆       ┆                                │
+    ...     ╞═══════════╪════════════╪═══╪═══════╪════════════════════════════════╡
+    ...     │ 123456780 ┆ 9876543210 ┆ … ┆ a:b:c ┆ 2023-03-25 10:56:59.663053 JST │
+    ...     │ …         ┆ …          ┆ … ┆ …     ┆ …                              │
+    ...     │ 803065983 ┆ 2055938745 ┆ … ┆ x:y:z ┆ 2023-03-25 12:38:18.050545 JST │
+    ...     └───────────┴────────────┴───┴───────┴────────────────────────────────┘
+    ... '''
+    ... )
+    >>> df
+    shape: (2, 4)
+    ┌─────────────────┬───────────────────┬───────┬────────────────────────────────┐
+    │ source_actor_id ┆ source_channel_id ┆ ident ┆ timestamp                      │
+    │ ---             ┆ ---               ┆ ---   ┆ ---                            │
+    │ i32             ┆ i64               ┆ str   ┆ datetime[μs, Asia/Tokyo]       │
+    ╞═════════════════╪═══════════════════╪═══════╪════════════════════════════════╡
+    │ 123456780       ┆ 9876543210        ┆ a:b:c ┆ 2023-03-25 10:56:59.663053 JST │
+    │ 803065983       ┆ 2055938745        ┆ x:y:z ┆ 2023-03-25 12:38:18.050545 JST │
+    └─────────────────┴───────────────────┴───────┴────────────────────────────────┘
+    >>> df.schema
+    {'source_actor_id': Int32,
+     'source_channel_id': Int64,
+     'ident': Utf8,
+     'timestamp': Datetime(time_unit='us', time_zone='Asia/Tokyo')}
+
+    """
+    from polars.datatypes.convert import dtype_short_repr_to_dtype
+
+    # pick dataframe table out of the given string
+    m = re.search(r"([┌╭].*?[┘╯])", tbl, re.DOTALL)
+    if m is None:
+        raise ValueError("Table not found in the given string")
+
+    # extract elements from table structure
+    lines = m.group().split("\n")[1:-1]
+    rows = [
+        [re.sub(r"^[\W+]*│", "", elem).strip() for elem in row]
+        for row in [re.split("[┆|]", row.rstrip("│ ")) for row in lines]
+        if len(row) > 1 or not re.search("├[╌┼]+┤", row[0])
+    ]
+
+    # determine beginning/end of the header block
+    table_body_start = 2
+    for idx, (elem, *_) in enumerate(rows):
+        if re.match(r"^\W*╞", elem):
+            table_body_start = idx
+            break
+
+    # handle headers with wrapped column names and determine headers/dtypes
+    header_block = ["".join(h).split("---") for h in zip(*rows[:table_body_start])]
+    headers, dtypes = (list(h) for h in zip_longest(*header_block))
+    body = rows[table_body_start + 1 :]
+
+    # transpose rows into columns, detect/omit truncated columns
+    coldata = list(zip(*(row for row in body if not all((e == "…") for e in row))))
+    for el in ("…", "..."):
+        if el in headers:
+            idx = headers.index(el)
+            for table_elem in (headers, dtypes):
+                table_elem.pop(idx)
+            if coldata:
+                coldata.pop(idx)
+
+    # init cols as utf8 Series, handle "null" -> None, create schema from repr dtype
+    data = [pli.Series([(None if v == "null" else v) for v in cd]) for cd in coldata]
+    schema = dict(zip(headers, (dtype_short_repr_to_dtype(d) for d in dtypes)))
+    for tp in set(schema.values()):
+        # TODO: handle basic compound types
+        if tp in (List, Struct):
+            raise NotImplementedError(
+                f"'from_repr' does not (yet) support {tp} dtype columns"
+            )
+        elif tp == Object:
+            raise ValueError("'from_repr' does not (and cannot) support Object dtype")
+
+    # construct DataFrame from string series and cast from repr to native dtype
+    df = pli.DataFrame(data=data, orient="col", schema=list(schema))
+    return _cast_repr_strings_with_schema(df, schema)
 
 
 @deprecated_alias(columns="schema")


### PR DESCRIPTION
Ref: #7732.

New productivity/utillity function `pl.from_repr`; allows us to quickly reconstruct DataFrames from their table `repr`. 

* Primarily intended as a simple time-saver for quickly dropping examples off StackOverflow (or the Discord) into the console where the original init/data wasn't posted, and getting started debugging ;)

* Handles all scalar types (inc. datetimes with timeunit/timezone, categorical, duration, etc), leading line-level comments / ellipsis / whitespace / prompt chars, wrapped table headers, empty tables, and truncated/omitted rows/cols. 

* The repr start/end is auto-detected so that you don't have to trim the input string into compliance, and the supported table formats are `UTF_FULL_CONDENSED` (our default) and `UTF8_FULL`, with/without the "rounded corners" modifier.

* Obvious limitation - it can't reconstruct what isn't there (missing cols, truncated data, etc).

* Will enhance (where possible) with basic support for nested types (List, Struct) later.

## Examples

**Empty:**
```python
df = pl.from_repr(
    """
    Empty dataframe
    ┌─────┬─────┬─────┬─────┬─────┬───────┐
    │ id  ┆ q1  ┆ q2  ┆ q3  ┆ q4  ┆ total │
    │ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---   │
    │ str ┆ i8  ┆ i16 ┆ i32 ┆ i64 ┆ f64   │
    ╞═════╪═════╪═════╪═════╪═════╪═══════╡
    └─────┴─────┴─────┴─────┴─────┴───────┘
    """
)

df.rows()
# []

df.schema
# {
#     "id": pl.Utf8,
#     "q1": pl.Int8,
#     "q2": pl.Int16,
#     "q3": pl.Int32,
#     "q4": pl.Int64,
#     "total": pl.Float64,
# }
```
**Dates, nulls, commented-out:**
```python
df = pl.from_repr(
    """
    # ┌────────────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬──────┐
    # │ dt         ┆ c1  ┆ c2  ┆ c3  ┆ ... ┆ c96 ┆ c97 ┆ c98 ┆ c99  │
    # │ ---        ┆ --- ┆ --- ┆ --- ┆     ┆ --- ┆ --- ┆ --- ┆ ---  │
    # │ date       ┆ i32 ┆ i32 ┆ i32 ┆     ┆ i64 ┆ i64 ┆ i64 ┆ i64  │
    # ╞════════════╪═════╪═════╪═════╪═════╪═════╪═════╪═════╪══════╡
    # │ 2023-03-25 ┆ 1   ┆ 2   ┆ 3   ┆ ... ┆ 96  ┆ 97  ┆ 98  ┆ 99   │
    # │ 1999-12-31 ┆ 3   ┆ 6   ┆ 9   ┆ ... ┆ 288 ┆ 291 ┆ 294 ┆ null │
    # │ null       ┆ 9   ┆ 18  ┆ 27  ┆ ... ┆ 864 ┆ 873 ┆ 882 ┆ 891  │
    # └────────────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴──────┘
    """
)

df
# shape: (3, 8)
# ┌────────────┬─────┬─────┬─────┬─────┬─────┬─────┬──────┐
# │ dt         ┆ c1  ┆ c2  ┆ c3  ┆ c96 ┆ c97 ┆ c98 ┆ c99  │
# │ ---        ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---  │
# │ date       ┆ i32 ┆ i32 ┆ i32 ┆ i64 ┆ i64 ┆ i64 ┆ i64  │
# ╞════════════╪═════╪═════╪═════╪═════╪═════╪═════╪══════╡
# │ 2023-03-25 ┆ 1   ┆ 2   ┆ 3   ┆ 96  ┆ 97  ┆ 98  ┆ 99   │
# │ 1999-12-31 ┆ 3   ┆ 6   ┆ 9   ┆ 288 ┆ 291 ┆ 294 ┆ null │
# │ null       ┆ 9   ┆ 18  ┆ 27  ┆ 864 ┆ 873 ┆ 882 ┆ 891  │
# └────────────┴─────┴─────┴─────┴─────┴─────┴─────┴──────┘
```
**A bit of everything:**
```python
df = pl.from_repr(
    """
    # Wrapped column headers, truncated horizontal/vertical data (using new
    # ellipsis), formatted like a docstring, datetime with timezone

    In [2]: with pl.Config() as cfg:
       ...:     pl.Config.set_tbl_formatting("UTF8_FULL", rounded_corners=True)
       ...:     print(df)
       ...:
    shape: (1, 5)
    ╭───────────┬────────────┬───┬───────┬────────────────────────────────╮
    │ source_ac ┆ source_cha ┆ … ┆ ident ┆ timestamp                      │
    │ tor_id    ┆ nnel_id    ┆   ┆ ---   ┆ ---                            │
    │ ---       ┆ ---        ┆   ┆ str   ┆ datetime[μs, Asia/Tokyo]       │
    │ i32       ┆ i64        ┆   ┆       ┆                                │
    ╞═══════════╪════════════╪═══╪═══════╪════════════════════════════════╡
    │ 123456780 ┆ 9876543210 ┆ … ┆ a:b:c ┆ 2023-03-25 10:56:59.663053 JST │
    ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ …         ┆ …          ┆ … ┆ …     ┆ …                              │
    ├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ 803065983 ┆ 2055938745 ┆ … ┆ x:y:z ┆ 2023-03-25 12:38:18.050545 JST │
    ╰───────────┴────────────┴───┴───────┴────────────────────────────────╯
    # "Een fluitje van een cent..." :)
    """
)

df
# shape: (2, 4)
# ┌─────────────────┬───────────────────┬───────┬────────────────────────────────┐
# │ source_actor_id ┆ source_channel_id ┆ ident ┆ timestamp                      │
# │ ---             ┆ ---               ┆ ---   ┆ ---                            │
# │ i32             ┆ i64               ┆ str   ┆ datetime[μs, Asia/Tokyo]       │
# ╞═════════════════╪═══════════════════╪═══════╪════════════════════════════════╡
# │ 123456780       ┆ 9876543210        ┆ a:b:c ┆ 2023-03-25 10:56:59.663053 JST │
# │ 803065983       ┆ 2055938745        ┆ x:y:z ┆ 2023-03-25 12:38:18.050545 JST │
# └─────────────────┴───────────────────┴───────┴────────────────────────────────┘
```