### PR TITLE
feat(python, rust): deprecate default value of `aggregation_function` being `'first'` in `pivot`. In a future version, it will default to `None`

### DIFF
--- a/polars/polars-core/src/frame/groupby/aggregations/dispatch.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/dispatch.rs
@@ -205,39 +205,4 @@ impl Series {
         };
         self.restore_logical(out)
     }
-
-    #[doc(hidden)]
-    // Takes the single element (if there is one) per group.
-    // Panics if there are multiple elements.
-    pub unsafe fn _agg_single(&self, groups: &GroupsProxy) -> PolarsResult<Series> {
-        let out = match groups {
-            GroupsProxy::Idx(groups) => {
-                let mut iter = groups.all().iter().map(|idx| {
-                    if idx.is_empty() {
-                        None
-                    } else {
-                        match idx.len() {
-                            1 => Some(idx[0] as usize),
-                            _ => panic!("found multiple elements in group, please specify a different aggregation function"),
-                        }
-                    }
-                });
-                self.take_opt_iter_unchecked(&mut iter)
-            }
-            GroupsProxy::Slice { groups, .. } => {
-                let mut iter = groups.iter().map(|&[first, len]| {
-                    if len == 0 {
-                        None
-                    } else {
-                        match len {
-                            1 => Some(first as usize),
-                            _ => panic!("found multiple elements in group, please specify a different aggregation function"),
-                        }
-                    }
-                });
-                self.take_opt_iter_unchecked(&mut iter)
-            }
-        };
-        Ok(self.restore_logical(out))
-    }
 }

--- a/polars/polars-lazy/src/frame/pivot.rs
+++ b/polars/polars-lazy/src/frame/pivot.rs
@@ -36,8 +36,8 @@ pub fn pivot<I0, S0, I1, S1, I2, S2>(
     values: I0,
     index: I1,
     columns: I2,
-    agg_expr: Expr,
     sort_columns: bool,
+    agg_expr: Option<Expr>,
     // used as separator/delimiter in generated column names.
     separator: Option<&str>,
 ) -> PolarsResult<DataFrame>
@@ -50,14 +50,17 @@ where
     S2: AsRef<str>,
 {
     // make sure that the root column is replaced
-    let expr = prepare_eval_expr(agg_expr);
+    let agg_expr = agg_expr.map(|agg_expr| {
+        let expr = prepare_eval_expr(agg_expr);
+        PivotAgg::Expr(Arc::new(PivotExpr(expr)))
+    });
     polars_ops::pivot::pivot(
         df,
         values,
         index,
         columns,
-        PivotAgg::Expr(Arc::new(PivotExpr(expr))),
         sort_columns,
+        agg_expr,
         separator,
     )
 }
@@ -67,8 +70,8 @@ pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
     values: I0,
     index: I1,
     columns: I2,
-    agg_expr: Expr,
     sort_columns: bool,
+    agg_expr: Option<Expr>,
     // used as separator/delimiter in generated column names.
     separator: Option<&str>,
 ) -> PolarsResult<DataFrame>
@@ -81,14 +84,17 @@ where
     S2: AsRef<str>,
 {
     // make sure that the root column is replaced
-    let expr = prepare_eval_expr(agg_expr);
+    let agg_expr = agg_expr.map(|agg_expr| {
+        let expr = prepare_eval_expr(agg_expr);
+        PivotAgg::Expr(Arc::new(PivotExpr(expr)))
+    });
     polars_ops::pivot::pivot_stable(
         df,
         values,
         index,
         columns,
-        PivotAgg::Expr(Arc::new(PivotExpr(expr))),
         sort_columns,
+        agg_expr,
         separator,
     )
 }

--- a/polars/polars-ops/src/frame/pivot/mod.rs
+++ b/polars/polars-ops/src/frame/pivot/mod.rs
@@ -212,8 +212,8 @@ fn pivot_impl(
                 use PivotAgg::*;
                 let value_agg = unsafe {
                     match &agg_fn {
-                        None => match (value_col.len() > groups.len()) {
-                            true => polars_bail!(ComputeError: "found multiple elements in group, please specify a different aggregation function"),
+                        None => match value_col.len() > groups.len() {
+                            true => polars_bail!(ComputeError: "found multiple elements in the same group, please specify an aggregation function"),
                             false => value_col.agg_first(&groups),
                         }
                         Some(agg_fn) => match agg_fn {

--- a/polars/polars-ops/src/frame/pivot/mod.rs
+++ b/polars/polars-ops/src/frame/pivot/mod.rs
@@ -212,7 +212,10 @@ fn pivot_impl(
                 use PivotAgg::*;
                 let value_agg = unsafe {
                     match &agg_fn {
-                        None => value_col._agg_single(&groups)?,
+                        None => match (value_col.len() > groups.len()) {
+                            true => polars_bail!(ComputeError: "found multiple elements in group, please specify a different aggregation function"),
+                            false => value_col.agg_first(&groups),
+                        }
                         Some(agg_fn) => match agg_fn {
                             Sum => value_col.agg_sum(&groups),
                             Min => value_col.agg_min(&groups),

--- a/polars/tests/it/core/pivot.rs
+++ b/polars/tests/it/core/pivot.rs
@@ -12,7 +12,7 @@ fn test_pivot_date() -> PolarsResult<()> {
     ]?;
     df.try_apply("C", |s| s.cast(&DataType::Date))?;
 
-    let out = pivot(&df, ["A"], ["B"], ["C"], PivotAgg::Count, true, None)?;
+    let out = pivot(&df, ["A"], ["B"], ["C"], true, Some(PivotAgg::Count), None)?;
 
     let first = 1 as IdxSize;
     let expected = df![
@@ -21,7 +21,7 @@ fn test_pivot_date() -> PolarsResult<()> {
     ]?;
     assert!(out.frame_equal_missing(&expected));
 
-    let mut out = pivot_stable(&df, ["C"], ["B"], ["A"], PivotAgg::First, true, None)?;
+    let mut out = pivot_stable(&df, ["C"], ["B"], ["A"], true, Some(PivotAgg::First), None)?;
     out.try_apply("1", |s| {
         let ca = s.date()?;
         Ok(ca.strftime("%Y-%d-%m"))
@@ -43,28 +43,73 @@ fn test_pivot_old() {
     let s2 = Series::new("bar", ["k", "l", "m", "m", "l"].as_ref());
     let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
 
-    let pvt = pivot(&df, ["N"], ["foo"], ["bar"], PivotAgg::Sum, false, None).unwrap();
+    let pvt = pivot(
+        &df,
+        ["N"],
+        ["foo"],
+        ["bar"],
+        false,
+        Some(PivotAgg::Sum),
+        None,
+    )
+    .unwrap();
     assert_eq!(pvt.get_column_names(), &["foo", "k", "l", "m"]);
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().i32().unwrap().sort(false)),
         &[None, None, Some(6)]
     );
-    let pvt = pivot(&df, ["N"], ["foo"], ["bar"], PivotAgg::Min, false, None).unwrap();
+    let pvt = pivot(
+        &df,
+        ["N"],
+        ["foo"],
+        ["bar"],
+        false,
+        Some(PivotAgg::Min),
+        None,
+    )
+    .unwrap();
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().i32().unwrap().sort(false)),
         &[None, None, Some(2)]
     );
-    let pvt = pivot(&df, ["N"], ["foo"], ["bar"], PivotAgg::Max, false, None).unwrap();
+    let pvt = pivot(
+        &df,
+        ["N"],
+        ["foo"],
+        ["bar"],
+        false,
+        Some(PivotAgg::Max),
+        None,
+    )
+    .unwrap();
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().i32().unwrap().sort(false)),
         &[None, None, Some(4)]
     );
-    let pvt = pivot(&df, ["N"], ["foo"], ["bar"], PivotAgg::Mean, false, None).unwrap();
+    let pvt = pivot(
+        &df,
+        ["N"],
+        ["foo"],
+        ["bar"],
+        false,
+        Some(PivotAgg::Mean),
+        None,
+    )
+    .unwrap();
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().f64().unwrap().sort(false)),
         &[None, None, Some(3.0)]
     );
-    let pvt = pivot(&df, ["N"], ["foo"], ["bar"], PivotAgg::Count, false, None).unwrap();
+    let pvt = pivot(
+        &df,
+        ["N"],
+        ["foo"],
+        ["bar"],
+        false,
+        Some(PivotAgg::Count),
+        None,
+    )
+    .unwrap();
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().idx().unwrap().sort(false)),
         &[None, None, Some(2)]
@@ -81,7 +126,7 @@ fn test_pivot_categorical() -> PolarsResult<()> {
     ]?;
     df.try_apply("C", |s| s.cast(&DataType::Categorical(None)))?;
 
-    let out = pivot(&df, ["A"], ["B"], ["C"], PivotAgg::Count, true, None)?;
+    let out = pivot(&df, ["A"], ["B"], ["C"], true, Some(PivotAgg::Count), None)?;
     assert_eq!(out.get_column_names(), &["B", "a", "b", "c"]);
 
     Ok(())
@@ -101,7 +146,15 @@ fn test_pivot_new() -> PolarsResult<()> {
         "E"=> [2, 4, 5, 5, 6, 6, 8, 9, 9]
     ]?;
 
-    let out = (pivot_stable(&df, ["D"], ["A", "B"], ["C"], PivotAgg::Sum, true, None))?;
+    let out = (pivot_stable(
+        &df,
+        ["D"],
+        ["A", "B"],
+        ["C"],
+        true,
+        Some(PivotAgg::Sum),
+        None,
+    ))?;
     let expected = df![
         "A" => ["foo", "foo", "bar", "bar"],
         "B" => ["one", "two", "one", "two"],
@@ -115,8 +168,8 @@ fn test_pivot_new() -> PolarsResult<()> {
         ["D"],
         ["A", "B"],
         ["C", "breaky"],
-        PivotAgg::Sum,
         true,
+        Some(PivotAgg::Sum),
         None,
     )?;
     let expected = df![
@@ -146,8 +199,8 @@ fn test_pivot_2() -> PolarsResult<()> {
         ["wght"],
         ["err"],
         ["name"],
-        PivotAgg::First,
         false,
+        Some(PivotAgg::First),
         None,
     )?;
     let expected = df![
@@ -174,7 +227,15 @@ fn test_pivot_datetime() -> PolarsResult<()> {
         "val" => [100, 50, 500, -80]
     ]?;
 
-    let out = pivot(&df, ["val"], ["dt"], ["key"], PivotAgg::Sum, false, None)?;
+    let out = pivot(
+        &df,
+        ["val"],
+        ["dt"],
+        ["key"],
+        false,
+        Some(PivotAgg::Sum),
+        None,
+    )?;
     let expected = df![
         "dt" => [dt],
         "x" => [150],

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.15"
+version = "0.16.16"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -17,8 +17,11 @@ from polars.utils.convert import (
 )
 from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
+from polars.utils.various import NoDefault, no_default
 
 __all__ = [
+    "NoDefault",
+    "no_default",
     "build_info",
     "show_versions",
     "get_idx_type",

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -5,7 +5,12 @@ import re
 import sys
 from collections.abc import MappingView, Sized
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 from polars import functions as F
 from polars.datatypes import Int64, is_polars_dtype

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -4,7 +4,8 @@ import os
 import re
 import sys
 from collections.abc import MappingView, Sized
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
 
 from polars import functions as F
 from polars.datatypes import Int64, is_polars_dtype
@@ -213,3 +214,16 @@ class sphinx_accessor(property):
             )
         except AttributeError:
             return None  # type: ignore[return-value]
+
+
+class _NoDefault(Enum):
+    # "borrowed" from
+    # https://github.com/pandas-dev/pandas/blob/e7859983a814b1823cf26e3b491ae2fa3be47c53/pandas/_libs/lib.pyx#L2736-L2748
+    no_default = "NO_DEFAULT"
+
+    def __repr__(self) -> str:
+        return "<no_default>"
+
+
+no_default = _NoDefault.no_default  # Sentinel indicating the default value.
+NoDefault = Literal[_NoDefault.no_default]

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1122,22 +1122,26 @@ impl PyDataFrame {
         values: Vec<String>,
         index: Vec<String>,
         columns: Vec<String>,
-        aggregate_expr: PyExpr,
         maintain_order: bool,
         sort_columns: bool,
+        aggregate_expr: Option<PyExpr>,
         separator: Option<&str>,
     ) -> PyResult<Self> {
         let fun = match maintain_order {
             true => pivot_stable,
             false => pivot,
         };
+        let agg_expr = match aggregate_expr {
+            Some(aggregate_expr) => Some(aggregate_expr.inner),
+            None => None,
+        };
         let df = fun(
             &self.df,
             values,
             index,
             columns,
-            aggregate_expr.inner,
             sort_columns,
+            agg_expr,
             separator,
         )
         .map_err(PyPolarsErr::from)?;

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
-from polars.exceptions import PanicException
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -141,7 +141,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
         }
     )
 
-    with pytest.raises(PanicException, match="found multiple elements in group"):
+    with pytest.raises(ComputeError, match="found multiple elements in group"):
         result = df.pivot(
             values=["x1", "x2"],
             index="c1",
@@ -177,7 +177,7 @@ def test_pivot_floats() -> None:
         }
     )
 
-    with pytest.raises(PanicException, match="found multiple elements in group"):
+    with pytest.raises(ComputeError, match="found multiple elements in group"):
         result = df.pivot(
             values="price", index="weight", columns="quantity", aggregate_function=None
         )

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+from polars.exceptions import PanicException
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ def test_pivot() -> None:
             "bar": ["k", "l", "m", "n", "o"],
         }
     )
-    result = df.pivot(values="N", index="foo", columns="bar")
+    result = df.pivot(values="N", index="foo", columns="bar", aggregate_function=None)
 
     expected = pl.DataFrame(
         [
@@ -139,7 +140,23 @@ def test_pivot_multiple_values_column_names_5116() -> None:
             "c2": ["C", "C", "D", "D"] * 2,
         }
     )
-    result = df.pivot(values=["x1", "x2"], index="c1", columns="c2", separator="|")
+
+    with pytest.raises(PanicException, match="found multiple elements in group"):
+        result = df.pivot(
+            values=["x1", "x2"],
+            index="c1",
+            columns="c2",
+            separator="|",
+            aggregate_function=None,
+        )
+
+    result = df.pivot(
+        values=["x1", "x2"],
+        index="c1",
+        columns="c2",
+        separator="|",
+        aggregate_function="first",
+    )
     expected = {
         "c1": ["A", "B"],
         "x1|C": [1, 2],
@@ -160,7 +177,14 @@ def test_pivot_floats() -> None:
         }
     )
 
-    result = df.pivot(values="price", index="weight", columns="quantity")
+    with pytest.raises(PanicException, match="found multiple elements in group"):
+        result = df.pivot(
+            values="price", index="weight", columns="quantity", aggregate_function=None
+        )
+
+    result = df.pivot(
+        values="price", index="weight", columns="quantity", aggregate_function="first"
+    )
     expected = {
         "weight": [1.0, 4.4, 8.8],
         "1.0": [1.0, 3.0, 5.0],
@@ -169,7 +193,12 @@ def test_pivot_floats() -> None:
     }
     assert result.to_dict(False) == expected
 
-    result = df.pivot(values="price", index=["article", "weight"], columns="quantity")
+    result = df.pivot(
+        values="price",
+        index=["article", "weight"],
+        columns="quantity",
+        aggregate_function=None,
+    )
     expected = {
         "article": ["a", "a", "b", "b"],
         "weight": [1.0, 4.4, 1.0, 8.8],
@@ -215,7 +244,9 @@ def test_pivot_temporal_logical_types() -> None:
             "value": [0] * 8,
         }
     )
-    assert df.pivot(index="idx", columns="foo", values="value").to_dict(False) == {
+    assert df.pivot(
+        index="idx", columns="foo", values="value", aggregate_function=None
+    ).to_dict(False) == {
         "idx": [
             datetime(1977, 1, 1, 0, 0),
             datetime(1978, 1, 1, 0, 0),
@@ -238,7 +269,9 @@ def test_pivot_negative_duration() -> None:
     df = df1.join(df2, how="cross").with_columns(
         [pl.Series(name="value", values=range(len(df1) * len(df2)))]
     )
-    assert df.pivot(index="delta", columns="root", values="value").to_dict(False) == {
+    assert df.pivot(
+        index="delta", columns="root", values="value", aggregate_function=None
+    ).to_dict(False) == {
         "delta": [
             timedelta(days=-2),
             timedelta(days=-1),
@@ -248,3 +281,12 @@ def test_pivot_negative_duration() -> None:
         "2020-01-15": [0, 1, 2, 3],
         "2020-02-15": [4, 5, 6, 7],
     }
+
+
+def test_aggregate_function_deprecation_warning() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": ["foo", "foo"], "c": ["x", "x"]})
+    with pytest.warns(
+        DeprecationWarning,
+        match="the default `aggregation_function` will change from 'first' to None",
+    ):
+        df.pivot("a", "b", "c")

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -141,7 +141,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
         }
     )
 
-    with pytest.raises(ComputeError, match="found multiple elements in group"):
+    with pytest.raises(ComputeError, match="found multiple elements in the same group"):
         result = df.pivot(
             values=["x1", "x2"],
             index="c1",
@@ -177,7 +177,7 @@ def test_pivot_floats() -> None:
         }
     )
 
-    with pytest.raises(ComputeError, match="found multiple elements in group"):
+    with pytest.raises(ComputeError, match="found multiple elements in the same group"):
         result = df.pivot(
             values="price", index="weight", columns="quantity", aggregate_function=None
         )


### PR DESCRIPTION
closes #7780 