### PR TITLE
chore(python): Rename `venv` folder to `.venv`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Create virtual environment
         working-directory: py-polars
         run: |
-          python -m venv venv
-          echo "$GITHUB_WORKSPACE/py-polars/venv/bin" >> $GITHUB_PATH
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Python dependencies
         working-directory: py-polars

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Create virtual environment
         run: |
-          python -m venv venv
-          echo "$GITHUB_WORKSPACE/py-polars/venv/bin" >> $GITHUB_PATH
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ data/
 node_modules/
 polars/vendor
 target/
-venv/
+.venv/
 .vim

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ make test
 
 This will do a number of things:
 
-- Use Python to create a virtual environment in the `py-polars/venv` folder.
+- Use Python to create a virtual environment in the `py-polars/.venv` folder.
 - Use [pip](https://pip.pypa.io/) to install all Python dependencies for development, linting, and building documentation.
 - Use Rust to compile and install Polars in your virtual environment.
 - Use [pytest](https://docs.pytest.org/) to run the Python unittests in your virtual environment

--- a/dprint.json
+++ b/dprint.json
@@ -4,7 +4,8 @@
   ],
   "excludes": [
     "**/target",
-    "py-polars/venv"
+    "py-polars/.pytest_cache",
+    "py-polars/.venv"
   ],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.15.2.wasm",

--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -1,7 +1,7 @@
 wheels/
 !Cargo.lock
 target/
-venv/
+.venv/
 .hypothesis
 .DS_Store
 .ruff_cache/

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -2,7 +2,7 @@
 
 PYTHONPATH=
 SHELL=/bin/bash
-VENV = venv
+VENV = .venv
 
 ifeq ($(OS),Windows_NT)
 	VENV_BIN=$(VENV)/Scripts
@@ -10,27 +10,27 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
-venv:  ## Set up virtual environment and install requirements
+.venv:  ## Set up virtual environment and install requirements
 	python3 -m venv $(VENV)
 	$(MAKE) requirements
 
 .PHONY: requirements
-requirements: venv  ## Install/refresh all project requirements
+requirements: .venv  ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
 	$(VENV_BIN)/pip install -r requirements-dev.txt
 	$(VENV_BIN)/pip install -r requirements-lint.txt
 	$(VENV_BIN)/pip install -r docs/requirements-docs.txt
 
 .PHONY: build
-build: venv  ## Compile and install Polars for development
+build: .venv  ## Compile and install Polars for development
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
 
 .PHONY: build-release
-build-release: venv  ## Compile and install a faster Polars binary
+build-release: .venv  ## Compile and install a faster Polars binary
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release
 
 .PHONY: fmt
-fmt: venv  ## Run autoformatting and linting
+fmt: .venv  ## Run autoformatting and linting
 	$(VENV_BIN)/black .
 	$(VENV_BIN)/blackdoc .
 	$(VENV_BIN)/ruff .
@@ -48,25 +48,25 @@ clippy:  ## Run clippy
 pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
-test: venv build  ## Run fast unittests
+test: .venv build  ## Run fast unittests
 	$(VENV_BIN)/pytest -n auto --dist worksteal
 
 .PHONY: doctest
-doctest: venv build  ## Run doctests
+doctest: .venv build  ## Run doctests
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: test-all
-test-all: venv build  ## Run all tests
+test-all: .venv build  ## Run all tests
 	$(VENV_BIN)/pytest -n auto --dist worksteal -m "slow or not slow"
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: coverage
-coverage: venv build  ## Run tests and report coverage
+coverage: .venv build  ## Run tests and report coverage
 	$(VENV_BIN)/pytest --cov -n auto --dist worksteal -m "not benchmark"
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts
-	@rm -rf venv/
+	@rm -rf .venv/
 	@rm -rf target/
 	@rm -rf docs/build/
 	@rm -rf docs/source/reference/api/


### PR DESCRIPTION
Triggered by #7782

I actually wanted to make this change a while ago. The naming of the venv folder does not matter much, but I think `.venv` is a bit nicer than simply `venv` for a few reasons, explained well in [PEP 704](https://peps.python.org/pep-0704/#use-a-different-name-for-the-virtual-environment-directory):

> The name .venv was picked since it:
>
> * does not conflict with any valid Python import name
> * does not conflict venv module in the standard library
> * has pre-existing usage in the Python community
> * has support for auto-detection in common text editors
> * can be typed without modifier keys on common keyboard layouts

Now that `maturin` will offer some automatic support when using `.venv`, I think that's a valid reason for switching.