### PR TITLE
chore(python): Drop `ruff` target version

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -744,7 +744,7 @@ class DataFrame:
         if isinstance(source, str) and "*" in source:
             dtypes_dict = None
             if dtype_list is not None:
-                dtypes_dict = {name: dt for (name, dt) in dtype_list}
+                dtypes_dict = dict(dtype_list)
             if dtype_slice is not None:
                 raise ValueError(
                     "cannot use glob patterns and unnamed dtypes as `dtypes` argument;"

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -288,7 +288,7 @@ def read_csv(
         # Map list of dtypes when used together with selected columns as a dtypes dict
         # so the dtypes are applied to the correct column instead of the first x
         # columns.
-        dtypes = {column: dtype for column, dtype in zip(columns, dtypes)}
+        dtypes = dict(zip(columns, dtypes))
 
     if new_columns and dtypes and isinstance(dtypes, dict):
         current_columns = None
@@ -344,10 +344,7 @@ def read_csv(
                     dtypes = dtype_list
 
         if current_columns and isinstance(dtypes, dict):
-            new_to_current = {
-                new_column: current_column
-                for new_column, current_column in zip(new_columns, current_columns)
-            }
+            new_to_current = dict(zip(new_columns, current_columns))
             # Change new column names to current column names in dtype.
             dtypes = {
                 new_to_current.get(column_name, column_name): column_dtype
@@ -592,7 +589,7 @@ def read_csv_batched(
         # Map list of dtypes when used together with selected columns as a dtypes dict
         # so the dtypes are applied to the correct column instead of the first x
         # columns.
-        dtypes = {column: dtype for column, dtype in zip(columns, dtypes)}
+        dtypes = dict(zip(columns, dtypes))
 
     if new_columns and dtypes and isinstance(dtypes, dict):
         current_columns = None
@@ -648,10 +645,7 @@ def read_csv_batched(
                     dtypes = dtype_list
 
         if current_columns and isinstance(dtypes, dict):
-            new_to_current = {
-                new_column: current_column
-                for new_column, current_column in zip(new_columns, current_columns)
-            }
+            new_to_current = dict(zip(new_columns, current_columns))
             # Change new column names to current column names in dtype.
             dtypes = {
                 new_to_current.get(column_name, column_name): column_dtype

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -104,7 +104,6 @@ module = ["polars.*"]
 warn_return_any = false
 
 [tool.ruff]
-target-version = "py37"
 line-length = 88
 fix = true
 

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,5 +1,5 @@
 black==23.1.0
 blackdoc==0.3.8
 mypy==1.1.1
-ruff==0.0.257
+ruff==0.0.259
 typos==1.14.3

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1090,7 +1090,8 @@ def test_describe() -> None:
     date_s = pl.Series([date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)])
     empty_s = pl.Series(np.empty(0))
 
-    assert {k: v for k, v in num_s.describe().rows()} == {
+    pl.DataFrame
+    assert dict(num_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": 3.0,
         "max": 3.0,
         "mean": 2.0,
@@ -1098,7 +1099,7 @@ def test_describe() -> None:
         "null_count": 0.0,
         "std": 1.0,
     }
-    assert {k: v for k, v in float_s.describe().rows()} == {
+    assert dict(float_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": 3.0,
         "max": 8.9,
         "mean": 4.933333333333334,
@@ -1106,17 +1107,17 @@ def test_describe() -> None:
         "null_count": 0.0,
         "std": 3.8109491381194442,
     }
-    assert {k: v for k, v in str_s.describe().rows()} == {
+    assert dict(str_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": 3,
         "null_count": 0,
         "unique": 3,
     }
-    assert {k: v for k, v in bool_s.describe().rows()} == {
+    assert dict(bool_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": 5,
         "null_count": 1,
         "sum": 3,
     }
-    assert {k: v for k, v in date_s.describe().rows()} == {
+    assert dict(date_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": "3",
         "max": "2021-01-03",
         "min": "2021-01-01",


### PR DESCRIPTION
`ruff` autodetects its target version from our package specification `requires-python = ">=3.7` - no need to specify it in the ruff config.

Also bumped to the latest version.