### PR TITLE
chore(python): add a `make requirements` option to install/refresh dependencies without having to recreate the `venv`

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -10,8 +10,12 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
-venv:  ## Set up virtual environment
+venv:  ## Set up virtual environment and install requirements
 	python3 -m venv $(VENV)
+	$(MAKE) requirements
+
+.PHONY: requirements
+requirements: ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
 	$(VENV_BIN)/pip install -r requirements-dev.txt
 	$(VENV_BIN)/pip install -r requirements-lint.txt

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -15,7 +15,7 @@ venv:  ## Set up virtual environment and install requirements
 	$(MAKE) requirements
 
 .PHONY: requirements
-requirements: ## Install/refresh all project requirements
+requirements: venv  ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
 	$(VENV_BIN)/pip install -r requirements-dev.txt
 	$(VENV_BIN)/pip install -r requirements-lint.txt


### PR DESCRIPTION
Inspired by a Discord [thread](https://discord.com/channels/908022250106667068/908022461751234570/1089265752550416385), I've added...
```
make requirements
```
...which will update/install everything listed in our various `requirements` files _without_ having to delete/recreate the associated `venv`. Slightly less friction staying up to date as dependencies advance.