### PR TITLE
chore(python): fixup stacklevels

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -31,6 +31,7 @@ fmt: venv  ## Run autoformatting and linting
 	$(VENV_BIN)/blackdoc .
 	$(VENV_BIN)/ruff .
 	$(VENV_BIN)/typos ..
+	$(VENV_BIN)/python scripts/check_decorators_stacklevels.py
 	cargo fmt --all
 	-dprint fmt
 	-$(VENV_BIN)/mypy

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -73,7 +73,7 @@ def from_dict(
 
 
 @deprecate_nonkeyword_arguments(allowed_args=["data", "schema"])
-@deprecated_alias(dicts="data")
+@deprecated_alias(dicts="data", stacklevel=4)
 def from_dicts(
     data: Sequence[dict[str, Any]],
     infer_schema_length: int | None = N_INFER_DEFAULT,
@@ -413,7 +413,7 @@ def from_pandas(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(nan_to_none="nan_to_null", df="data")
+@deprecated_alias(nan_to_none="nan_to_null", df="data", stacklevel=4)
 def from_pandas(
     data: pd.DataFrame | pd.Series | pd.DatetimeIndex,
     rechunk: bool = True,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -528,7 +528,7 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema")
+    @deprecated_alias(columns="schema", stacklevel=4)
     def _from_numpy(
         cls,
         data: np.ndarray[Any, Any],
@@ -573,7 +573,7 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema")
+    @deprecated_alias(columns="schema", stacklevel=4)
     def _from_arrow(
         cls,
         data: pa.Table,
@@ -2259,7 +2259,7 @@ class DataFrame:
         ...
 
     @deprecated_alias(sep="separator")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"], stacklevel=3)
     def write_csv(
         self,
         file: BytesIO | str | Path | None = None,
@@ -5020,7 +5020,9 @@ class DataFrame:
         )
 
     @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self", "function", "return_dtype"], stacklevel=3
+    )
     def apply(
         self,
         function: Callable[[tuple[Any, ...]], Any],
@@ -5739,7 +5741,8 @@ class DataFrame:
 
     @deprecated_alias(aggregate_fn="aggregate_function")
     @deprecate_nonkeyword_arguments(
-        allowed_args=["self", "values", "index", "columns", "aggregate_function"]
+        allowed_args=["self", "values", "index", "columns", "aggregate_function"],
+        stacklevel=3,
     )
     def pivot(
         self,
@@ -5807,8 +5810,8 @@ class DataFrame:
 
         if aggregate_function is no_default:
             warnings.warn(
-                "In a future version of polars, the default `aggregation_function` "
-                "will change from 'first' to None. Please pass `'first'` to keep the "
+                "In a future version of polars, the default `aggregate_function` "
+                "will change from `'first'` to `None`. Please pass `'first'` to keep the "
                 "current behaviour, or `None` to accept the new one.",
                 DeprecationWarning,
                 stacklevel=4,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1756,7 +1756,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.cast(dtype, strict))
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments()
+    @deprecate_nonkeyword_arguments(stacklevel=3)
     def sort(self, descending: bool = False, nulls_last: bool = False) -> Self:
         """
         Sort this column.
@@ -1885,7 +1885,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.top_k(k, descending))
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments()
+    @deprecate_nonkeyword_arguments(stacklevel=3)
     def arg_sort(self, descending: bool = False, nulls_last: bool = False) -> Self:
         """
         Get the index values that would sort this column.
@@ -3175,7 +3175,9 @@ class Expr:
         return self.filter(predicate)
 
     @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self", "function", "return_dtype"], stacklevel=3
+    )
     def map(
         self,
         function: Callable[[Series], Series | Any],
@@ -3226,7 +3228,9 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.map(function, return_dtype, agg_list))
 
     @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self", "function", "return_dtype"], stacklevel=3
+    )
     def apply(
         self,
         function: Callable[[Series], Series] | Callable[[Any], Any],

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -131,7 +131,7 @@ class ExprListNameSpace:
         return wrap_expr(self._pyexpr.lst_mean())
 
     @deprecate_nonkeyword_arguments()
-    @deprecated_alias(reverse="descending")
+    @deprecated_alias(reverse="descending", stacklevel=4)
     def sort(self, descending: bool = False) -> Expr:
         """
         Sort the arrays in this column.

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1606,7 +1606,9 @@ def map(
 
 
 @deprecated_alias(f="function")
-@deprecate_nonkeyword_arguments(allowed_args=["exprs", "function", "return_dtype"])
+@deprecate_nonkeyword_arguments(
+    allowed_args=["exprs", "function", "return_dtype"], stacklevel=3
+)
 def apply(
     exprs: Sequence[str | Expr],
     function: Callable[[Sequence[Series]], Series | Any],
@@ -1862,7 +1864,7 @@ def reduce(
 
 
 @deprecated_alias(f="function")
-@deprecate_nonkeyword_arguments()
+@deprecate_nonkeyword_arguments(stacklevel=3)
 def cumfold(
     acc: IntoExpr,
     function: Callable[[Series, Series], Series],
@@ -2274,7 +2276,7 @@ def arange(
 
 
 @deprecated_alias(reverse="descending")
-@deprecate_nonkeyword_arguments()
+@deprecate_nonkeyword_arguments(stacklevel=3)
 def arg_sort_by(
     exprs: IntoExpr | Iterable[IntoExpr],
     descending: bool | Sequence[bool] = False,
@@ -2536,7 +2538,7 @@ def date_(
 
 
 @deprecated_alias(sep="separator")
-@deprecate_nonkeyword_arguments()
+@deprecate_nonkeyword_arguments(stacklevel=3)
 def concat_str(exprs: IntoExpr | Iterable[IntoExpr], separator: str = "") -> Expr:
     """
     Horizontally concatenate columns into a single string column.

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def read_avro(
     source: str | Path | BytesIO | BinaryIO,
     columns: list[int] | list[str] | None = None,

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", sep="separator", parse_dates="try_parse_dates")
+@deprecated_alias(
+    file="source", sep="separator", parse_dates="try_parse_dates", stacklevel=4
+)
 def read_csv(
     source: str | TextIO | BytesIO | Path | BinaryIO | bytes,
     has_header: bool = True,
@@ -387,7 +389,7 @@ def read_csv(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", sep="separator")
+@deprecated_alias(file="source", sep="separator", stacklevel=4)
 def read_csv_batched(
     source: str | Path,
     has_header: bool = True,
@@ -682,7 +684,9 @@ def read_csv_batched(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", sep="separator", parse_dates="try_parse_dates")
+@deprecated_alias(
+    file="source", sep="separator", parse_dates="try_parse_dates", stacklevel=4
+)
 def scan_csv(
     source: str | Path,
     has_header: bool = True,

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -109,7 +109,7 @@ def read_database(
 
 
 @deprecated_alias(sql="query")
-@deprecate_nonkeyword_arguments()
+@deprecate_nonkeyword_arguments(stacklevel=3)
 def read_sql(
     query: list[str] | str,
     connection_uri: str,

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(table_uri="source")
+@deprecated_alias(table_uri="source", stacklevel=4)
 def read_delta(
     source: str,
     version: int | None = None,
@@ -142,7 +142,7 @@ def read_delta(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(table_uri="source")
+@deprecated_alias(table_uri="source", stacklevel=4)
 def scan_delta(
     source: str,
     version: int | None = None,

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -54,7 +54,7 @@ def read_excel(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
     sheet_id: int | None = 1,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def read_ipc(
     source: str | BinaryIO | BytesIO | Path | bytes,
     columns: list[int] | list[str] | None = None,
@@ -135,7 +135,7 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def scan_ipc(
     source: str | Path,
     n_rows: int | None = None,

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -30,7 +30,7 @@ def read_ndjson(source: str | Path | IOBase) -> DataFrame:
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def scan_ndjson(
     source: str | Path,
     infer_schema_length: int | None = N_INFER_DEFAULT,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -160,7 +160,7 @@ def read_parquet_schema(
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source")
+@deprecated_alias(file="source", stacklevel=4)
 def scan_parquet(
     source: str | Path,
     n_rows: int | None = None,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4316,7 +4316,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
 
     @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments()
+    @deprecate_nonkeyword_arguments(stacklevel=3)
     def map(
         self,
         function: Callable[[DataFrame], DataFrame],

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2173,7 +2173,7 @@ class Series:
             return self._from_pyseries(self._s.sort(descending))
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"], stacklevel=3)
     def top_k(self, k: int = 5, descending: bool = False) -> Series:
         r"""
         Return the `k` largest elements.
@@ -2199,7 +2199,7 @@ class Series:
         )
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments()
+    @deprecate_nonkeyword_arguments(stacklevel=3)
     def arg_sort(self, descending: bool = False, nulls_last: bool = False) -> Series:
         """
         Get the index values that would sort this Series.
@@ -3894,7 +3894,9 @@ class Series:
         """
 
     @deprecated_alias(func="function")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "function", "return_dtype"])
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self", "function", "return_dtype"], stacklevel=3
+    )
     def apply(
         self,
         function: Callable[[Any], Any],
@@ -4748,7 +4750,7 @@ class Series:
         """
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "method"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "method"], stacklevel=3)
     def rank(self, method: RankMethod = "average", descending: bool = False) -> Series:
         """
         Assign ranks to data, dealing with ties appropriately.
@@ -5481,7 +5483,7 @@ class Series:
         """
 
     @deprecated_alias(reverse="descending")
-    @deprecate_nonkeyword_arguments()
+    @deprecate_nonkeyword_arguments(stacklevel=3)
     def set_sorted(self, descending: bool = False) -> Self:
         """
         Flags the Series as 'sorted'.

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -20,7 +20,7 @@ from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_a
 
 
 @deprecate_nonkeyword_arguments()
-@deprecated_alias(check_column_names="check_column_order")
+@deprecated_alias(check_column_names="check_column_order", stacklevel=4)
 def assert_frame_equal(
     left: DataFrame | LazyFrame,
     right: DataFrame | LazyFrame,

--- a/py-polars/scripts/check_decorators_stacklevels.py
+++ b/py-polars/scripts/check_decorators_stacklevels.py
@@ -1,0 +1,77 @@
+"""
+Check that warnings decorators are set with the correct stacklevel.
+
+By default, `deprecated_nonkeyword_arguments` has stacklevel 2, and `deprecated_alias`
+stacklevel 3. If called together, then the stacklevel may need setting manually for
+some.
+"""
+import ast
+import subprocess
+import sys
+from ast import NodeVisitor
+
+DEFAULT_STACKLEVEL = {
+    "deprecate_nonkeyword_arguments": 2,
+    "deprecated_alias": 3,
+}
+
+
+def _stacklevel_is_correct(keywords, expected_stacklevel):
+    for keyword in keywords:
+        if (
+            keyword.arg == "stacklevel"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value == expected_stacklevel
+        ):
+            return True
+    return False
+
+
+class StackLevelChecker(NodeVisitor):
+    def __init__(self, file) -> None:
+        self.file = file
+        self.violations = set()
+
+    def _check_decorator_stacklevel(self, decorator: ast.Call, idx: int):
+        if (
+            isinstance(decorator.func, ast.Name)
+            and decorator.func.id in DEFAULT_STACKLEVEL
+            and idx != 0
+        ):
+            decorator_name = decorator.func.id
+            expected_stacklevel = idx + DEFAULT_STACKLEVEL[decorator_name]
+            if not _stacklevel_is_correct(decorator.keywords, expected_stacklevel):
+                self.violations.add(
+                    f"{self.file}:{decorator.lineno}:{decorator.col_offset}: "
+                    f"found incorrect stacklevel. "
+                    f"Please set `{decorator_name}`'s stacklevel to {expected_stacklevel}"
+                )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        call_decorators = [
+            decorator
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+        ]
+        for idx, decorator in enumerate(call_decorators):
+            self._check_decorator_stacklevel(decorator, idx)
+        self.generic_visit(node)
+
+
+if __name__ == "__main__":
+    files = subprocess.run(
+        ["git", "ls-files", "polars"], capture_output=True, text=True
+    ).stdout.split()
+    ret = 0
+    for file in files:
+        if not file.endswith(".py"):
+            continue
+        with open(file) as fd:
+            content = fd.read()
+        tree = ast.parse(content)
+        stacklevel_checker = StackLevelChecker(file)
+        stacklevel_checker.visit(tree)
+        for violation in stacklevel_checker.violations:
+            print(violation)
+            ret |= 1
+    sys.exit(ret)

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -287,6 +287,6 @@ def test_aggregate_function_deprecation_warning() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["foo", "foo"], "c": ["x", "x"]})
     with pytest.warns(
         DeprecationWarning,
-        match="the default `aggregation_function` will change from 'first' to None",
+        match="the default `aggregate_function` will change from `'first'` to `None`",
     ):
         df.pivot("a", "b", "c")


### PR DESCRIPTION
closes #7795 

Demo:

with the latest release:
```python
In [7]: data = [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
   ...: df = pl.from_dicts(dicts=data)

In [8]: import pandas as pd
   ...: pd_df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
   ...: df = pl.from_pandas(pd_df, nan_to_none=True)
   ...:
```

Here:
```python
In [1]: data = [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
   ...: df = pl.from_dicts(dicts=data)
<ipython-input-1-78a761bb55c8>:2: DeprecationWarning: `dicts` is deprecated as an argument to `from_dicts`; use `data` instead.
  df = pl.from_dicts(dicts=data)

In [2]: import pandas as pd
   ...: pd_df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
   ...: df = pl.from_pandas(pd_df, nan_to_none=True)
<ipython-input-2-6984e8025b58>:3: DeprecationWarning: `nan_to_none` is deprecated as an argument to `from_pandas`; use `nan_to_null` instead.
  df = pl.from_pandas(pd_df, nan_to_none=True)
```

Likewise, for the example from the issue:
```python
In [1]: df = pl.DataFrame({'a': [1,2], 'b': [1,2]})
   ...: df.with_columns(pl.col('a').sort(True))
<ipython-input-1-da82a41e8139>:2: DeprecationWarning: All arguments of Expr.sort will be keyword-only in the next breaking release. Use keyword arguments to silence this warning.
  df.with_columns(pl.col('a').sort(True))
Out[1]: 
shape: (2, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ 2   ┆ 1   │
│ 1   ┆ 2   │
└─────┴─────┘
```