### PR TITLE
feat(python): Improve automatic output dtype setting for `map_dict`.

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6289,6 +6289,7 @@ class Expr:
         remapping: dict[Any, Any],
         *,
         default: Any = None,
+        dtype: PolarsDataType | None = None,
     ) -> Self:
         """
         Replace values in column according to remapping dictionary.
@@ -6303,6 +6304,8 @@ class Expr:
         default
             Value to use when the remapping dict does not contain the lookup value.
             Use ``pl.first()``, to keep the original value.
+        dtype
+            Override output dtype.
 
         Examples
         --------
@@ -6424,48 +6427,80 @@ class Expr:
         │ 3      ┆ Germany       │
         └────────┴───────────────┘
 
+        Override output dtype:
+
+        >>> df.with_columns(
+        ...     pl.col("row_nr")
+        ...     .map_dict({1: 7, 3: 4}, default=3, dtype=pl.UInt8)
+        ...     .alias("remapped")
+        ... )
+        shape: (4, 3)
+        ┌────────┬──────────────┬──────────┐
+        │ row_nr ┆ country_code ┆ remapped │
+        │ ---    ┆ ---          ┆ ---      │
+        │ u32    ┆ str          ┆ u8       │
+        ╞════════╪══════════════╪══════════╡
+        │ 0      ┆ FR           ┆ 3        │
+        │ 1      ┆ null         ┆ 7        │
+        │ 2      ┆ ES           ┆ 3        │
+        │ 3      ┆ DE           ┆ 4        │
+        └────────┴──────────────┴──────────┘
+
         """
 
-        def _remap_key_series(
-            remap_key_column: str,
-            remapping: dict[Any, Any],
-            input_dtype: PolarsDataType,
+        def _remap_key_or_value_series(
+            name: str,
+            values: Iterable[Any],
+            dtype: PolarsDataType,
+            is_keys: bool,
         ) -> Series:
             """
-            Convert remapping dict key values to `Series` with `input_dtype`.
+            Convert remapping keys or remapping values to `Series` with `dtype`.
 
-            Try to convert the remapping dict key values to `Series` with the same dtype
-            as the column from which the values are being replaced and make sure that
-            no keys are accidentally lost (replaced by nulls) during the conversion.
+            Try to convert the remapping keys or remapping values to `Series` with
+            the specified dtype and check that none of the values are accidentally
+            lost (replaced by nulls) during the conversion.
 
             """
             try:
-                remap_key_s = pli.Series(
-                    remap_key_column,
-                    list(remapping.keys()),
-                    dtype=input_dtype,
+                s = pli.Series(
+                    name,
+                    values,
+                    dtype=dtype,
                     strict=True,
                 )
-                if input_dtype != remap_key_s.dtype:
+                if dtype != s.dtype:
                     raise ValueError(
-                        f"Remapping keys could not be converted to {input_dtype}: found {remap_key_s.dtype}"
+                        f"Remapping {'keys' if is_keys else 'values'} could not be converted to {dtype}: found {s.dtype}"
                     )
 
             except TypeError as exc:
                 raise ValueError(
-                    f"Remapping keys could not be converted to {input_dtype}: {str(exc)}"
+                    f"Remapping {'keys' if is_keys else 'values'} could not be converted to {dtype}: {str(exc)}"
                 ) from exc
 
-            if remap_key_s.null_count() == 0:  # noqa: SIM114
-                pass
-            elif remap_key_s.null_count() == 1 and None in remapping:
-                pass
+            if is_keys:
+                # values = remapping.keys()
+                if s.null_count() == 0:  # noqa: SIM114
+                    pass
+                elif s.null_count() == 1 and None in remapping:
+                    pass
+                else:
+                    raise ValueError(
+                        f"Remapping keys could not be converted to {dtype} without losing values in the conversion."
+                    )
             else:
-                raise ValueError(
-                    f"Remapping keys could not be converted to {input_dtype} without losing values in the conversion."
-                )
+                # values = remapping.values()
+                if s.null_count() == 0:  # noqa: SIM114
+                    pass
+                elif s.len() - s.null_count() == len(list(filter(None, values))):
+                    pass
+                else:
+                    raise ValueError(
+                        f"Remapping values could not be converted to {dtype} without losing values in the conversion."
+                    )
 
-            return remap_key_s
+            return s
 
         # Use two functions to save unneeded work.
         # This factors out allocations and branches.
@@ -6482,12 +6517,48 @@ class Expr:
             remap_value_column = f"__POLARS_REMAP_VALUE_{column}"
             is_remapped_column = f"__POLARS_REMAP_IS_REMAPPED_{column}"
 
-            remap_key_s = _remap_key_series(remap_key_column, remapping, input_dtype)
-            remap_value_s = pli.Series(
-                remap_value_column,
-                list(remapping.values()),
-                dtype_if_empty=input_dtype,
+            # Set output dtype:
+            #  - to dtype, if specified.
+            #  - to same dtype as expression specified as default value.
+            #  - to None, if dtype was not specified and default was not an expression.
+            output_dtype = (
+                df.lazy().select(default).dtypes[0]
+                if dtype is None and isinstance(default, Expr)
+                else dtype
             )
+
+            remap_key_s = _remap_key_or_value_series(
+                name=remap_key_column,
+                values=remapping.keys(),
+                dtype=input_dtype,
+                is_keys=True,
+            )
+
+            if output_dtype:
+                # Create remap value Series with specified output dtype.
+                remap_value_s = pli.Series(
+                    remap_value_column,
+                    remapping.values(),
+                    dtype=output_dtype,
+                    dtype_if_empty=input_dtype,
+                )
+            else:
+                try:
+                    # First, try to create a value Series with same dtype as input
+                    # column.
+                    remap_value_s = _remap_key_or_value_series(
+                        name=remap_value_column,
+                        values=remapping.values(),
+                        dtype=remap_key_s.dtype,
+                        is_keys=False,
+                    )
+                except ValueError:
+                    # If that fails create a value Series without a specific dtype.
+                    remap_value_s = pli.Series(
+                        remap_value_column,
+                        remapping.values(),
+                        dtype_if_empty=input_dtype,
+                    )
 
             return (
                 (
@@ -6523,12 +6594,38 @@ class Expr:
             remap_value_column = f"__POLARS_REMAP_VALUE_{column}"
             is_remapped_column = f"__POLARS_REMAP_IS_REMAPPED_{column}"
 
-            remap_key_s = _remap_key_series(remap_key_column, remapping, input_dtype)
-            remap_value_s = pli.Series(
-                remap_value_column,
-                list(remapping.values()),
-                dtype_if_empty=input_dtype,
+            remap_key_s = _remap_key_or_value_series(
+                name=remap_key_column,
+                values=list(remapping.keys()),
+                dtype=input_dtype,
+                is_keys=True,
             )
+
+            if dtype:
+                # Create remap value Series with specified output dtype.
+                remap_value_s = pli.Series(
+                    remap_value_column,
+                    remapping.values(),
+                    dtype=dtype,
+                    dtype_if_empty=input_dtype,
+                )
+            else:
+                try:
+                    # First, try to create a value Series with same dtype as input
+                    # column.
+                    remap_value_s = _remap_key_or_value_series(
+                        name=remap_value_column,
+                        values=remapping.values(),
+                        dtype=remap_key_s.dtype,
+                        is_keys=False,
+                    )
+                except ValueError:
+                    # If that fails create a value Series without a specific dtype.
+                    remap_value_s = pli.Series(
+                        remap_value_column,
+                        remapping.values(),
+                        dtype_if_empty=input_dtype,
+                    )
 
             return (
                 (

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5098,6 +5098,7 @@ class Series:
         remapping: dict[Any, Any],
         *,
         default: Any = None,
+        dtype: PolarsDataType | None = None,
     ) -> Self:
         """
         Replace values in the Series using a remapping dictionary.
@@ -5109,6 +5110,8 @@ class Series:
         default
             Value to use when the remapping dict does not contain the lookup value.
             Use ``pl.first()``, to keep the original value.
+        dtype
+            Override output dtype.
 
         Examples
         --------
@@ -5153,6 +5156,18 @@ class Series:
             "???"
             "Japan"
             "Netherlands"
+        ]
+
+        Override output dtype:
+
+        >>> s = pl.Series("int8", [5, 2, 3], dtype=pl.Int8)
+        >>> s.map_dict({2: 7}, default=pl.first(), dtype=pl.Int16)
+        shape: (3,)
+        Series: 'int8' [i16]
+        [
+            5
+            7
+            3
         ]
 
         """

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -553,10 +553,10 @@ def test_map_dict() -> None:
         None: "Not specified",
     }
     df = pl.DataFrame(
-        {
-            "int": [None, 1, None, 3],
-            "country_code": ["FR", None, "ES", "DE"],
-        }
+        [
+            pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
+            pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
+        ]
     )
 
     assert_frame_equal(
@@ -567,7 +567,7 @@ def test_map_dict() -> None:
         ),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series(
                     "remapped",
@@ -586,7 +586,7 @@ def test_map_dict() -> None:
         ),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series(
                     "remapped",
@@ -603,7 +603,7 @@ def test_map_dict() -> None:
         ),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series(
                     "remapped",
@@ -626,7 +626,7 @@ def test_map_dict() -> None:
         pl.DataFrame(
             [
                 pl.Series("row_nr", [0, 1, 2, 3], dtype=pl.UInt32),
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series(
                     "remapped",
@@ -647,12 +647,12 @@ def test_map_dict() -> None:
             ),
             pl.DataFrame(
                 [
-                    pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                    pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                     pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                     pl.Series(
                         "remapped",
                         ["France", "Not specified", "ES", "Germany"],
-                        dtype=pl.Utf8,
+                        dtype=pl.Categorical,
                     ),
                 ]
             ),
@@ -671,18 +671,31 @@ def test_map_dict() -> None:
             ).collect(),
             pl.DataFrame(
                 [
-                    pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                    pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                     pl.Series(
                         "country_code", ["FR", None, "ES", "DE"], dtype=pl.Categorical
                     ),
                     pl.Series(
                         "remapped",
                         ["France", "Not specified", "ES", "Germany"],
-                        dtype=pl.Utf8,
+                        dtype=pl.Categorical,
                     ),
                 ]
             ),
         )
+
+    int_to_int_dict = {1: 5, 3: 7}
+
+    assert_frame_equal(
+        df.with_columns(pl.col("int").map_dict(int_to_int_dict).alias("remapped")),
+        pl.DataFrame(
+            [
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
+                pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
+                pl.Series("remapped", [None, 5, None, 7], dtype=pl.Int16),
+            ]
+        ),
+    )
 
     int_dict = {1: "b", 3: "d"}
 
@@ -690,7 +703,7 @@ def test_map_dict() -> None:
         df.with_columns(pl.col("int").map_dict(int_dict).alias("remapped")),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series("remapped", [None, "b", None, "d"], dtype=pl.Utf8),
             ]
@@ -703,7 +716,7 @@ def test_map_dict() -> None:
         df.with_columns(pl.col("int").map_dict(int_with_none_dict).alias("remapped")),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
                 pl.Series("remapped", ["e", "b", "e", "d"], dtype=pl.Utf8),
             ]
@@ -720,9 +733,37 @@ def test_map_dict() -> None:
         ),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
-                pl.Series("remapped", [6, 6, 6, None], dtype=pl.Int64),
+                pl.Series("remapped", [6, 6, 6, None], dtype=pl.Int16),
+            ]
+        ),
+    )
+
+    assert_frame_equal(
+        df.with_columns(
+            pl.col("int")
+            .map_dict(int_with_only_none_values_dict, default=6, dtype=pl.Int32)
+            .alias("remapped")
+        ),
+        pl.DataFrame(
+            [
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
+                pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
+                pl.Series("remapped", [6, 6, 6, None], dtype=pl.Int32),
+            ]
+        ),
+    )
+
+    assert_frame_equal(
+        df.with_columns(
+            pl.col("int").map_dict(int_with_only_none_values_dict).alias("remapped")
+        ),
+        pl.DataFrame(
+            [
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
+                pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
+                pl.Series("remapped", [None, None, None, None], dtype=pl.Int16),
             ]
         ),
     )
@@ -735,9 +776,9 @@ def test_map_dict() -> None:
         ),
         pl.DataFrame(
             [
-                pl.Series("int", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("int", [None, 1, None, 3], dtype=pl.Int16),
                 pl.Series("country_code", ["FR", None, "ES", "DE"], dtype=pl.Utf8),
-                pl.Series("remapped", [None, 1, None, 3], dtype=pl.Int64),
+                pl.Series("remapped", [None, 1, None, 3], dtype=pl.Int16),
             ]
         ),
     )
@@ -745,7 +786,7 @@ def test_map_dict() -> None:
     float_dict = {1.0: "b", 3.0: "d"}
 
     with pytest.raises(
-        pl.ComputeError, match="Remapping keys could not be converted to Int64: "
+        pl.ComputeError, match="Remapping keys could not be converted to Int16: "
     ):
         df.with_columns(pl.col("int").map_dict(float_dict))
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2496,6 +2496,31 @@ def test_map_dict() -> None:
         pl.Series("s", [-1, 22, None, 44, -5]),
     )
 
+    assert_series_equal(
+        s.cast(pl.Int16).map_dict(remap_int),
+        pl.Series("s", [None, 22, None, 44, None], dtype=pl.Int16),
+    )
+
+    assert_series_equal(
+        s.cast(pl.Int16).map_dict(remap_int, default=pl.first()),
+        pl.Series("s", [-1, 22, None, 44, -5], dtype=pl.Int16),
+    )
+
+    assert_series_equal(
+        s.cast(pl.Int16).map_dict(remap_int, default=pl.first(), dtype=pl.Float32),
+        pl.Series("s", [-1.0, 22.0, None, 44.0, -5.0], dtype=pl.Float32),
+    )
+
+    assert_series_equal(
+        s.cast(pl.Int16).map_dict(remap_int, default=9),
+        pl.Series("s", [9, 22, 9, 44, 9], dtype=pl.Int16),
+    )
+
+    assert_series_equal(
+        s.cast(pl.Int16).map_dict(remap_int, default=9, dtype=pl.Float32),
+        pl.Series("s", [9.0, 22.0, 9.0, 44.0, 9.0], dtype=pl.Float32),
+    )
+
 
 @pytest.mark.parametrize(
     ("dtype", "lower", "upper"),


### PR DESCRIPTION
Improve automatic output dtype setting for `map_dict`:
  - Added `dtype` option to specify output dtype if automatic output dtype setting is not correct.
  - If no output dtype is specified:
    - Set to same dtype as expression specified as default value: e.g. `default=pl.first()` or `default=pl.col("c")`
    - If the default value was not an expression, try to convert mapping values first to the same dtype as the input column. If that fails, just convert the mapping values to a normal Series.

Closes: #7788