### PR TITLE
chore(rust): remove unnecessary copy in rolling function

### DIFF
--- a/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -252,7 +252,6 @@ where
     let arr = if options.window_size.parsed_int {
         let options: RollingOptionsFixedWindow = options.into();
         check_input(options.window_size, options.min_periods)?;
-        let ca = ca.rechunk();
 
         match ca.null_count() {
             0 => rolling_agg_fn(


### PR DESCRIPTION
In rolling_agg function second rechunk (case of integer window size) creates an unnecessary copy.