### PR TITLE
perf(rust, python): custom build hasher

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use ahash::RandomState;
 use hashbrown::hash_map::RawEntryMut;
 use once_cell::sync::Lazy;
 use polars_utils::HashSingle;
@@ -11,6 +10,7 @@ use smartstring::{LazyCompact, SmartString};
 
 use crate::datatypes::PlIdHashMap;
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::InitHashMaps;
 
 /// We use atomic reference counting
@@ -198,8 +198,8 @@ impl StringCache {
     /// The global `StringCache` will always use a predictable seed. This allows local builders to mimic
     /// the hashes in case of contention.
     #[inline]
-    pub(crate) fn get_hash_builder() -> RandomState {
-        RandomState::with_seed(0)
+    pub(crate) fn get_hash_builder() -> PlHasherBuilder {
+        PlHasherBuilder::with_seed(0)
     }
 
     /// Lock the string cache

--- a/polars/polars-core/src/datatypes/aliases.rs
+++ b/polars/polars-core/src/datatypes/aliases.rs
@@ -6,7 +6,7 @@ pub type IdxCa = UInt32Chunked;
 pub type IdxCa = UInt64Chunked;
 pub use polars_arrow::index::{IdxArr, IdxSize};
 
-use crate::hashing::IdBuildHasher;
+use crate::hashing::{IdBuildHasher, PlHasherBuilder};
 
 #[cfg(not(feature = "bigidx"))]
 pub const IDX_DTYPE: DataType = DataType::UInt32;
@@ -21,7 +21,7 @@ pub type IdxType = UInt64Type;
 pub const NULL_DTYPE: DataType = DataType::Int32;
 
 #[cfg(feature = "private")]
-pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
+pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, PlHasherBuilder>;
 #[cfg(feature = "private")]
 
 /// This hashmap has the uses an IdHasher

--- a/polars/polars-core/src/datatypes/aliases.rs
+++ b/polars/polars-core/src/datatypes/aliases.rs
@@ -27,11 +27,11 @@ pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, PlHasherBuilder>;
 /// This hashmap has the uses an IdHasher
 pub type PlIdHashMap<K, V> = hashbrown::HashMap<K, V, IdBuildHasher>;
 #[cfg(feature = "private")]
-pub type PlHashSet<V> = hashbrown::HashSet<V, RandomState>;
+pub type PlHashSet<V> = hashbrown::HashSet<V, PlHasherBuilder>;
 #[cfg(feature = "private")]
-pub type PlIndexMap<K, V> = indexmap::IndexMap<K, V, RandomState>;
+pub type PlIndexMap<K, V> = indexmap::IndexMap<K, V, PlHasherBuilder>;
 #[cfg(feature = "private")]
-pub type PlIndexSet<K> = indexmap::IndexSet<K, RandomState>;
+pub type PlIndexSet<K> = indexmap::IndexSet<K, PlHasherBuilder>;
 
 pub trait InitHashMaps {
     type HashMap;

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -19,7 +19,6 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, AddAssign, Div, Mul, Rem, Sub, SubAssign};
 
-use ahash::RandomState;
 pub use aliases::*;
 pub use any_value::*;
 use arrow::compute::comparison::Simd8;

--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -115,7 +115,7 @@ where
                 for keys in &keys {
                     let keys = keys.as_ref();
                     let len = keys.len() as IdxSize;
-                    let hasher = hash_tbl.hasher().clone();
+                    let hasher = *hash_tbl.hasher();
 
                     let mut cnt = 0;
                     keys.iter().for_each(|k| {

--- a/polars/polars-core/src/frame/groupby/into_groups.rs
+++ b/polars/polars-core/src/frame/groupby/into_groups.rs
@@ -6,6 +6,7 @@ use polars_utils::{flatten, HashSingle};
 
 use super::*;
 use crate::config::verbose;
+use crate::hashing::PlHasherBuilder;
 use crate::utils::_split_offsets;
 
 /// Used to create the tuples for a groupby operation.
@@ -251,8 +252,8 @@ impl IntoGroupsProxy for Utf8Chunked {
 impl IntoGroupsProxy for BinaryChunked {
     #[allow(clippy::needless_lifetimes)]
     fn group_tuples<'a>(&'a self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
-        let hb = RandomState::default();
-        let null_h = get_null_hash_value(hb.clone());
+        let hb = PlHasherBuilder::default();
+        let null_h = get_null_hash_value(hb);
 
         let out = if multithreaded {
             let n_partitions = _set_partition_size();
@@ -311,8 +312,8 @@ impl IntoGroupsProxy for ListChunked {
                 ComputeError: "grouping on list type is only allowed if the inner type is numeric"
             );
 
-            let hb = RandomState::default();
-            let null_h = get_null_hash_value(hb.clone());
+            let hb = PlHasherBuilder::default();
+            let null_h = get_null_hash_value(hb);
 
             let arr_to_hashes = |ca: &ListChunked| {
                 let mut out = Vec::with_capacity(ca.len());

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
-use ahash::RandomState;
 use num_traits::NumCast;
 use polars_arrow::prelude::QuantileInterpolOptions;
 use rayon::prelude::*;

--- a/polars/polars-core/src/frame/hash_join/single_keys_outer.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_outer.rs
@@ -84,7 +84,7 @@ where
 
     // prepare hash table
     let mut hash_tbls = prepare_hashed_relation_threaded(b);
-    let random_state = hash_tbls[0].hasher().clone();
+    let random_state = *hash_tbls[0].hasher();
 
     // we pre hash the probing values
     let (probe_hashes, _) = create_hash_and_keys_threaded_vectorized(a, Some(random_state));

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -37,6 +37,8 @@ use smartstring::alias::String as SmartString;
 use crate::frame::groupby::GroupsIndicator;
 #[cfg(feature = "row_hash")]
 use crate::hashing::df_rows_to_hashes_threaded;
+#[cfg(feature = "row_hash")]
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::sort::{argsort_multiple_row_fmt, prepare_arg_sort};
 use crate::series::IsSorted;
 use crate::POOL;
@@ -3126,7 +3128,7 @@ impl DataFrame {
     #[cfg(feature = "row_hash")]
     pub fn hash_rows(
         &mut self,
-        hasher_builder: Option<ahash::RandomState>,
+        hasher_builder: Option<PlHasherBuilder>,
     ) -> PolarsResult<UInt64Chunked> {
         let dfs = split_df(self, POOL.current_num_threads())?;
         let (cas, _) = df_rows_to_hashes_threaded(&dfs, hasher_builder)?;

--- a/polars/polars-core/src/hashing/fx.rs
+++ b/polars/polars-core/src/hashing/fx.rs
@@ -1,3 +1,5 @@
+use polars_utils::HashSingle;
+
 use super::*;
 
 macro_rules! fx_hash_8_bit {
@@ -27,8 +29,8 @@ pub(super) const FXHASH_K: u64 = 0x517cc1b727220a95;
 
 /// Ensure that the same hash is used as with `VecHash`.
 pub trait FxHash {
-    fn get_k(random_state: RandomState) -> u64 {
-        random_state.hash_one(FXHASH_K)
+    fn get_k(random_state: PlHasherBuilder) -> u64 {
+        random_state.hash_single(FXHASH_K)
     }
     fn _fx_hash(self, k: u64) -> u64;
 }

--- a/polars/polars-core/src/hashing/hasher.rs
+++ b/polars/polars-core/src/hashing/hasher.rs
@@ -1,0 +1,112 @@
+use polars_utils::HashSingle;
+use xxhash_rust::xxh3::xxh3_64;
+
+use super::*;
+
+pub struct PlHasher {
+    h: u64,
+}
+
+impl Hasher for PlHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.h
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let h = xxh3_64(bytes);
+        self.h = h._fx_hash(self.h);
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    fn write_u128(&mut self, i: u128) {
+        let bytes = i.to_ne_bytes();
+        let lower = u64::from_ne_bytes(bytes[..8].try_into().unwrap());
+        let upper = u64::from_ne_bytes(bytes[8..].try_into().unwrap());
+        let k = lower._fx_hash(self.h);
+        self.h = upper._fx_hash(k);
+    }
+
+    fn write_usize(&mut self, i: usize) {
+        let v = u64::from_ne_bytes(i.to_ne_bytes());
+        self.write_u64(v)
+    }
+
+    #[inline]
+    fn write_i8(&mut self, i: i8) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_i16(&mut self, i: i16) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_i32(&mut self, i: i32) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    #[inline]
+    fn write_i64(&mut self, i: i64) {
+        self.h = i._fx_hash(self.h)
+    }
+
+    fn write_i128(&mut self, i: i128) {
+        let v = u128::from_ne_bytes(i.to_ne_bytes());
+        self.write_u128(v)
+    }
+    fn write_isize(&mut self, i: isize) {
+        let v = i64::from_ne_bytes(i.to_ne_bytes());
+        self.write_i64(v)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct PlHasherBuilder {
+    seed: u64,
+}
+
+impl Default for PlHasherBuilder {
+    fn default() -> Self {
+        // TODO: use own logic for randomness
+        let seed = ahash::RandomState::default().hash_single(FXHASH_K);
+        Self { seed }
+    }
+}
+
+impl PlHasherBuilder {
+    pub fn with_seed(seed: u64) -> Self {
+        Self { seed }
+    }
+}
+
+impl BuildHasher for PlHasherBuilder {
+    type Hasher = PlHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        PlHasher {
+            h: FXHASH_K.wrapping_add(self.seed),
+        }
+    }
+}

--- a/polars/polars-core/src/hashing/mod.rs
+++ b/polars/polars-core/src/hashing/mod.rs
@@ -1,12 +1,13 @@
 mod fx;
+mod hasher;
 mod identity;
 mod partition;
-pub(crate) mod vector_hasher;
+mod vector_hasher;
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
 
-use ahash::RandomState;
 pub use fx::*;
+pub use hasher::*;
 pub use identity::*;
 pub(crate) use partition::*;
 pub use vector_hasher::*;

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -39,7 +39,7 @@ pub use crate::frame::groupby::{GroupsIdx, GroupsProxy, GroupsSlice, IntoGroupsP
 pub use crate::frame::hash_join::JoinType;
 pub(crate) use crate::frame::hash_join::*;
 pub use crate::frame::{DataFrame, UniqueKeepStrategy};
-pub use crate::hashing::{FxHash, VecHash};
+pub use crate::hashing::{FxHash, PlHasherBuilder, VecHash};
 pub use crate::named_from::{NamedFrom, NamedFromOwned};
 pub use crate::schema::*;
 #[cfg(feature = "checked_arithmetic")]

--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -37,7 +37,7 @@ where
 {
     fn from(iter: I) -> Self {
         let mut map: PlIndexMap<_, _> =
-            IndexMap::with_capacity_and_hasher(iter.size_hint().0, ahash::RandomState::default());
+            IndexMap::with_capacity_and_hasher(iter.size_hint().0, Default::default());
         for fld in iter {
             let fld = fld.into();
 
@@ -78,7 +78,7 @@ impl Schema {
     {
         let iter = flds.into_iter();
         let mut map: PlIndexMap<_, _> =
-            IndexMap::with_capacity_and_hasher(iter.size_hint().0, ahash::RandomState::default());
+            IndexMap::with_capacity_and_hasher(iter.size_hint().0, Default::default());
         for fld in iter {
             let fld = fld?;
             map.insert(fld.name().clone(), fld.data_type().clone());
@@ -92,7 +92,7 @@ impl Schema {
 
     pub fn with_capacity(capacity: usize) -> Self {
         let map: PlIndexMap<_, _> =
-            IndexMap::with_capacity_and_hasher(capacity, ahash::RandomState::default());
+            IndexMap::with_capacity_and_hasher(capacity, Default::default());
         Self { inner: map }
     }
 

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use ahash::RandomState;
-
 use super::{private, IntoSeries, SeriesTrait, *};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::compare_inner::{
@@ -12,6 +10,7 @@ use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 
@@ -48,12 +47,16 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 use std::ops::{BitAnd, BitOr, BitXor};
 
-use ahash::RandomState;
-
 use super::{private, IntoSeries, SeriesTrait, *};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::compare_inner::{
@@ -50,12 +48,16 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use ahash::RandomState;
 use polars_arrow::prelude::QuantileInterpolOptions;
 
 use super::{private, IntoSeries, SeriesTrait, *};
@@ -96,12 +95,16 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         }
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.logical().vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.logical().vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -10,7 +10,6 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
-use ahash::RandomState;
 use polars_arrow::prelude::QuantileInterpolOptions;
 
 use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
@@ -20,6 +19,7 @@ use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::*;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 
 macro_rules! impl_dyn_series {
@@ -74,14 +74,14 @@ macro_rules! impl_dyn_series {
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+            fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
                 self.0.vec_hash(random_state, buf);
                 Ok(())
             }
 
             fn vec_hash_combine(
                 &self,
-                build_hasher: RandomState,
+                build_hasher: PlHasherBuilder,
                 hashes: &mut [u64],
             ) -> PolarsResult<()> {
                 self.0.vec_hash_combine(build_hasher, hashes);

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
-use ahash::RandomState;
-
 use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
@@ -73,12 +71,16 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         })
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
-use ahash::RandomState;
-
 use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
@@ -10,6 +8,7 @@ use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::*;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 
 unsafe impl IntoSeries for DurationChunked {
@@ -77,12 +76,16 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use ahash::RandomState;
 use polars_arrow::prelude::QuantileInterpolOptions;
 
 use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
@@ -14,6 +13,7 @@ use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 #[cfg(feature = "checked_arithmetic")]
 use crate::series::arithmetic::checked::NumOpsDispatchChecked;
@@ -74,14 +74,18 @@ macro_rules! impl_dyn_series {
                 (&self.0).into_partial_ord_inner()
             }
 
-            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+            fn vec_hash(
+                &self,
+                random_state: PlHasherBuilder,
+                buf: &mut Vec<u64>,
+            ) -> PolarsResult<()> {
                 self.0.vec_hash(random_state, buf);
                 Ok(())
             }
 
             fn vec_hash_combine(
                 &self,
-                build_hasher: RandomState,
+                build_hasher: PlHasherBuilder,
                 hashes: &mut [u64],
             ) -> PolarsResult<()> {
                 self.0.vec_hash_combine(build_hasher, hashes);

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -28,7 +28,6 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::ops::{BitAnd, BitOr, BitXor, Deref};
 
-use ahash::RandomState;
 use polars_arrow::prelude::QuantileInterpolOptions;
 
 use super::{private, IntoSeries, SeriesTrait, *};
@@ -42,6 +41,7 @@ use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 #[cfg(feature = "checked_arithmetic")]
 use crate::series::arithmetic::checked::NumOpsDispatchChecked;
@@ -133,14 +133,18 @@ macro_rules! impl_dyn_series {
                 (&self.0).into_partial_ord_inner()
             }
 
-            fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+            fn vec_hash(
+                &self,
+                random_state: PlHasherBuilder,
+                buf: &mut Vec<u64>,
+            ) -> PolarsResult<()> {
                 self.0.vec_hash(random_state, buf);
                 Ok(())
             }
 
             fn vec_hash_combine(
                 &self,
-                build_hasher: RandomState,
+                build_hasher: PlHasherBuilder,
                 hashes: &mut [u64],
             ) -> PolarsResult<()> {
                 self.0.vec_hash_combine(build_hasher, hashes);

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -1,12 +1,11 @@
 use std::any::Any;
 use std::borrow::Cow;
 
-use ahash::RandomState;
-
 use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::fmt::FmtList;
 use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
+use crate::hashing::PlHasherBuilder;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
@@ -43,12 +42,16 @@ where
         (&self.0).into_partial_eq_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use ahash::RandomState;
-
 use super::{private, IntoSeries, SeriesTrait, *};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::compare_inner::{
@@ -48,12 +46,16 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         (&self.0).into_partial_ord_inner()
     }
 
-    fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {
+    fn vec_hash(&self, random_state: PlHasherBuilder, buf: &mut Vec<u64>) -> PolarsResult<()> {
         self.0.vec_hash(random_state, buf);
         Ok(())
     }
 
-    fn vec_hash_combine(&self, build_hasher: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
+    fn vec_hash_combine(
+        &self,
+        build_hasher: PlHasherBuilder,
+        hashes: &mut [u64],
+    ) -> PolarsResult<()> {
         self.0.vec_hash_combine(build_hasher, hashes);
         Ok(())
     }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -19,7 +19,6 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use ahash::RandomState;
 use arrow::compute::aggregate::estimated_bytes_size;
 pub use from::*;
 pub use iterator::{SeriesIter, SeriesPhysIter};
@@ -27,6 +26,7 @@ use num_traits::NumCast;
 use rayon::prelude::*;
 pub use series_trait::{IsSorted, *};
 
+use crate::hashing::PlHasherBuilder;
 #[cfg(feature = "rank")]
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "zip_with")]
@@ -144,7 +144,7 @@ impl Eq for Wrap<Series> {}
 
 impl Hash for Wrap<Series> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let rs = RandomState::with_seeds(0, 0, 0, 0);
+        let rs = PlHasherBuilder::default();
         let mut h = vec![];
         self.0.vec_hash(rs, &mut h).unwrap();
         let h = UInt64Chunked::from_vec("", h).sum();

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -28,12 +28,12 @@ macro_rules! invalid_operation_panic {
 }
 
 pub(crate) mod private {
-    use ahash::RandomState;
 
     use super::*;
     use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
     #[cfg(feature = "rows")]
     use crate::frame::groupby::GroupsProxy;
+    use crate::hashing::PlHasherBuilder;
 
     pub trait PrivateSeriesNumeric {
         fn bit_repr_is_large(&self) -> bool {
@@ -103,12 +103,16 @@ pub(crate) mod private {
         fn into_partial_ord_inner<'a>(&'a self) -> Box<dyn PartialOrdInner + 'a> {
             invalid_operation_panic!(into_partial_ord_inner, self)
         }
-        fn vec_hash(&self, _build_hasher: RandomState, _buf: &mut Vec<u64>) -> PolarsResult<()> {
+        fn vec_hash(
+            &self,
+            _build_hasher: PlHasherBuilder,
+            _buf: &mut Vec<u64>,
+        ) -> PolarsResult<()> {
             polars_bail!(opq = vec_hash, self._dtype());
         }
         fn vec_hash_combine(
             &self,
-            _build_hasher: RandomState,
+            _build_hasher: PlHasherBuilder,
             _hashes: &mut [u64],
         ) -> PolarsResult<()> {
             polars_bail!(opq = vec_hash_combine, self._dtype());

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/inner_left.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/inner_left.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use polars_core::error::PolarsResult;
-use polars_core::export::ahash::RandomState;
 use polars_core::frame::hash_join::{ChunkId, _finish_join};
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
@@ -29,7 +28,7 @@ pub struct GenericJoinProbe {
     //      * end = (offset + n_join_keys)
     materialized_join_cols: Arc<Vec<ArrayRef>>,
     suffix: Arc<str>,
-    hb: RandomState,
+    hb: PlHasherBuilder,
     // partitioned tables that will be used for probing
     // stores the key and the chunk_idx, df_idx of the left table
     hash_tables: Arc<Vec<PlIdHashMap<Key, Vec<ChunkId>>>>,
@@ -63,7 +62,7 @@ impl GenericJoinProbe {
         mut df_a: DataFrame,
         materialized_join_cols: Arc<Vec<ArrayRef>>,
         suffix: Arc<str>,
-        hb: RandomState,
+        hb: PlHasherBuilder,
         hash_tables: Arc<Vec<PlIdHashMap<Key, Vec<ChunkId>>>>,
         join_columns_left: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
         join_columns_right: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/utils.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/utils.rs
@@ -1,12 +1,11 @@
-use polars_core::export::ahash::RandomState;
 use polars_core::prelude::*;
 
-pub(super) fn hash_series(columns: &[Series], buf: &mut Vec<u64>, hb: &RandomState) {
+pub(super) fn hash_series(columns: &[Series], buf: &mut Vec<u64>, hb: &PlHasherBuilder) {
     let mut col_iter = columns.iter();
     let first_key = col_iter.next().unwrap();
-    first_key.vec_hash(hb.clone(), buf).unwrap();
+    first_key.vec_hash(*hb, buf).unwrap();
     for other_key in col_iter {
-        other_key.vec_hash_combine(hb.clone(), buf).unwrap();
+        other_key.vec_hash_combine(*hb, buf).unwrap();
     }
 }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/row_hash.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/row_hash.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-pub(super) fn row_hash(s: &Series, k0: u64, k1: u64, k2: u64, k3: u64) -> PolarsResult<Series> {
-    Ok(s.hash(ahash::RandomState::with_seeds(k0, k1, k2, k3))
-        .into_series())
+pub(super) fn row_hash(s: &Series, k0: u64, _k1: u64, _k2: u64, _k3: u64) -> PolarsResult<Series> {
+    Ok(s.hash(PlHasherBuilder::with_seed(k0)).into_series())
 }

--- a/polars/polars-ops/src/chunked_array/list/hash.rs
+++ b/polars/polars-ops/src/chunked_array/list/hash.rs
@@ -1,7 +1,6 @@
 use std::hash::Hash;
 
 use polars_core::export::_boost_hash_combine;
-use polars_core::export::ahash::{self};
 use polars_core::export::rayon::prelude::*;
 use polars_core::utils::NoNull;
 use polars_core::POOL;
@@ -9,7 +8,7 @@ use polars_utils::HashSingle;
 
 use super::*;
 
-fn hash_agg<T>(ca: &ChunkedArray<T>, random_state: &ahash::RandomState) -> u64
+fn hash_agg<T>(ca: &ChunkedArray<T>, random_state: &PlHasherBuilder) -> u64
 where
     T: PolarsIntegerType,
     T::Native: Hash,
@@ -43,7 +42,7 @@ where
     hash_agg
 }
 
-pub(crate) fn hash(ca: &mut ListChunked, build_hasher: ahash::RandomState) -> UInt64Chunked {
+pub(crate) fn hash(ca: &mut ListChunked, build_hasher: PlHasherBuilder) -> UInt64Chunked {
     if !ca.inner_dtype().to_physical().is_numeric() {
         panic!(
             "Hashing a list with a non-numeric inner type not supported. Got dtype: {:?}",

--- a/polars/polars-ops/src/series/ops/various.rs
+++ b/polars/polars-ops/src/series/ops/various.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "hash")]
-use polars_core::export::ahash;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 
@@ -24,7 +22,7 @@ pub trait SeriesMethods: SeriesSealed {
     }
 
     #[cfg(feature = "hash")]
-    fn hash(&self, build_hasher: ahash::RandomState) -> UInt64Chunked {
+    fn hash(&self, build_hasher: PlHasherBuilder) -> UInt64Chunked {
         let s = self.as_series().to_physical_repr();
         match s.dtype() {
             DataType::List(_) => {

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1311,8 +1311,8 @@ impl PyDataFrame {
         self.df.shrink_to_fit();
     }
 
-    pub fn hash_rows(&mut self, k0: u64, k1: u64, k2: u64, k3: u64) -> PyResult<PySeries> {
-        let hb = ahash::RandomState::with_seeds(k0, k1, k2, k3);
+    pub fn hash_rows(&mut self, k0: u64, _k1: u64, _k2: u64, _k3: u64) -> PyResult<PySeries> {
+        let hb = PlHasherBuilder::with_seed(k0);
         let hash = self.df.hash_rows(Some(hb)).map_err(PyPolarsErr::from)?;
         Ok(hash.into_series().into())
     }

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1609,18 +1609,12 @@ def test_reproducible_hash_with_seeds() -> None:
     the same seeds.
 
     """
-    import platform
-
     df = pl.DataFrame({"s": [1234, None, 5678]})
     seeds = (11, 22, 33, 44)
 
-    # TODO: introduce a platform-stable string hash...
-    #  in the meantime, try to account for arm64 (mac) hash values to reduce noise
     expected = pl.Series(
         "s",
-        [6629530352159708028, 15496313222292466864, 6048298245521876612]
-        if platform.mac_ver()[-1] == "arm64"
-        else [6629530352159708028, 988796329533502010, 6048298245521876612],
+        [15942440131956025408, 17942101829897509888, 9614471911627864000],
         dtype=pl.UInt64,
     )
     result = df.hash_rows(*seeds)


### PR DESCRIPTION
We had a high quality hash, but it was overly expensive for our use case. Several benchmarks showed that using fxhash for integers (where the cmp fn is very cheap) outperformed building a growing hash table by ~10% on several cardinality levels.

So we use this very simple hash function for primitives and for bytes we resort to xxhash3. I expect a slight increase: 5/10% on the hashmap/hashset building paths where we have primitive keys. Which are many. :)