### PR TITLE
docs(python): add description of ddof

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6973,7 +6973,9 @@ class DataFrame:
         Parameters
         ----------
         ddof
-            Degrees of freedom
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
 
         Examples
         --------
@@ -7013,7 +7015,9 @@ class DataFrame:
         Parameters
         ----------
         ddof
-            Degrees of freedom
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2481,7 +2481,9 @@ class Expr:
         Parameters
         ----------
         ddof
-            Degrees of freedom.
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
 
         Examples
         --------
@@ -2506,7 +2508,9 @@ class Expr:
         Parameters
         ----------
         ddof
-            Degrees of freedom.
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
 
         Examples
         --------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -388,6 +388,15 @@ def std(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     Get the standard deviation.
 
+    Parameters
+    ----------
+    column
+        Column to get the standard deviation from.
+    ddof
+        “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
+
     Examples
     --------
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
@@ -422,6 +431,15 @@ def var(column: Series, ddof: int = 1) -> float | None:
 def var(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     Get the variance.
+
+    Parameters
+    ----------
+    column
+        Column to get the variance of.
+    ddof
+        “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
 
     Examples
     --------
@@ -1359,7 +1377,9 @@ def spearman_rank_corr(
     b
         Column name or Expression.
     ddof
-        Delta degrees of freedom
+        “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
     propagate_nans
         If `True` any `NaN` encountered will lead to `NaN` in the output.
         Defaults to `False` where `NaN` are regarded as larger than any finite number
@@ -1408,7 +1428,9 @@ def pearson_corr(a: str | Expr, b: str | Expr, ddof: int = 1) -> Expr:
     b
         Column name or Expression.
     ddof
-        Delta degrees of freedom
+        “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
 
     See Also
     --------
@@ -1457,7 +1479,9 @@ def corr(
     b
         Column name or Expression.
     ddof
-        Delta degrees of freedom
+        “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
     method : {'pearson', 'spearman'}
         Correlation method.
     propagate_nans

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3805,6 +3805,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Aggregate the columns in the DataFrame to their standard deviation value.
 
+        Parameters
+        ----------
+        ddof
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
+
         Examples
         --------
         >>> lf = pl.LazyFrame(
@@ -3838,6 +3845,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def var(self, ddof: int = 1) -> Self:
         """
         Aggregate the columns in the DataFrame to their variance value.
+
+        Parameters
+        ----------
+        ddof
+            “Delta Degrees of Freedom”: the divisor used in the calculation is N - ddof,
+            where N represents the number of elements.
+            By default ddof is 1.
 
         Examples
         --------


### PR DESCRIPTION
Add the missing description of `ddof` to the `var` and `std` methods by copying the description in `Series`.