### PR TITLE
perf(rust, python): improve hash quality

### DIFF
--- a/polars/polars-core/src/hashing/fx.rs
+++ b/polars/polars-core/src/hashing/fx.rs
@@ -1,4 +1,5 @@
 use super::*;
+// This should only be used for small integers as high bits will collide
 
 macro_rules! fx_hash_8_bit {
     ($val: expr, $k: expr ) => {{

--- a/polars/polars-core/src/hashing/partition.rs
+++ b/polars/polars-core/src/hashing/partition.rs
@@ -7,7 +7,6 @@ pub(crate) trait AsU64 {
     fn as_u64(self) -> u64;
 }
 
-#[cfg(feature = "performant")]
 impl AsU64 for u8 {
     #[inline]
     fn as_u64(self) -> u64 {
@@ -15,7 +14,6 @@ impl AsU64 for u8 {
     }
 }
 
-#[cfg(feature = "performant")]
 impl AsU64 for u16 {
     #[inline]
     fn as_u64(self) -> u64 {
@@ -34,6 +32,20 @@ impl AsU64 for u64 {
     #[inline]
     fn as_u64(self) -> u64 {
         self
+    }
+}
+
+impl AsU64 for i8 {
+    #[inline]
+    fn as_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+impl AsU64 for i16 {
+    #[inline]
+    fn as_u64(self) -> u64 {
+        self as u64
     }
 }
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1609,8 +1609,6 @@ def test_reproducible_hash_with_seeds() -> None:
     the same seeds.
 
     """
-    import platform
-
     df = pl.DataFrame({"s": [1234, None, 5678]})
     seeds = (11, 22, 33, 44)
 
@@ -1618,9 +1616,7 @@ def test_reproducible_hash_with_seeds() -> None:
     #  in the meantime, try to account for arm64 (mac) hash values to reduce noise
     expected = pl.Series(
         "s",
-        [6629530352159708028, 15496313222292466864, 6048298245521876612]
-        if platform.mac_ver()[-1] == "arm64"
-        else [6629530352159708028, 988796329533502010, 6048298245521876612],
+        [13477868900383131459, 988796329533502010, 16840582678788620208],
         dtype=pl.UInt64,
     )
     result = df.hash_rows(*seeds)


### PR DESCRIPTION
Use ahash but inline some state to reduce operations in `vec_hash`. This prevents terrible perf on large integers. On small integers we are a bit slower.