### PR TITLE
feat(rust, python): support datetime/date subclasses (e.g. FreezeGun)

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -119,9 +119,9 @@ def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsD
         return Datetime("us")
     if issubclass(python_dtype, date):
         return Date
-    if issubclass(python_dtype, timedelta):
+    if python_dtype is timedelta:
         return Duration("us")
-    if issubclass(python_dtype, time):
+    if python_dtype is time:
         return Time
     if python_dtype is list:
         return List

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -87,6 +87,57 @@ def cache(function: Callable[..., T]) -> T:
     return functools.lru_cache()(function)  # type: ignore[return-value]
 
 
+PY_STR_TO_DTYPE: SchemaDict = {
+    "float": Float64,
+    "int": Int64,
+    "str": Utf8,
+    "bool": Boolean,
+    "date": Date,
+    "datetime": Datetime("us"),
+    "timedelta": Duration("us"),
+    "time": Time,
+    "list": List,
+    "tuple": List,
+    "Decimal": Decimal,
+    "bytes": Binary,
+    "object": Object,
+    "NoneType": Null,
+}
+
+
+@functools.lru_cache
+def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsDataType:
+    if python_dtype is float:
+        return Float64
+    if python_dtype is int:
+        return Int64
+    if python_dtype is str:
+        return Utf8
+    if python_dtype is bool:
+        return Boolean
+    if issubclass(python_dtype, datetime):
+        return Datetime("us")
+    if issubclass(python_dtype, date):
+        return Date
+    if issubclass(python_dtype, timedelta):
+        return Duration("us")
+    if issubclass(python_dtype, time):
+        return Time
+    if python_dtype is list:
+        return List
+    if python_dtype is tuple:
+        return List
+    if python_dtype is PyDecimal:
+        return Decimal
+    if python_dtype is bytes:
+        return Binary
+    if python_dtype is object:
+        return Object
+    if python_dtype is None.__class__:
+        return Null
+    raise TypeError("Invalid type")
+
+
 def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     try:
@@ -146,31 +197,6 @@ class _DataTypeMappings:
             Duration: ctypes.c_int64,
             Time: ctypes.c_int64,
         }
-
-    @property
-    @cache
-    def PY_TYPE_TO_DTYPE(self) -> dict[PythonDataType | type[object], PolarsDataType]:
-        return {
-            float: Float64,
-            int: Int64,
-            str: Utf8,
-            bool: Boolean,
-            date: Date,
-            datetime: Datetime("us"),
-            timedelta: Duration("us"),
-            time: Time,
-            list: List,
-            tuple: List,
-            PyDecimal: Decimal,
-            bytes: Binary,
-            object: Object,
-            None.__class__: Null,
-        }
-
-    @property
-    @cache
-    def PY_STR_TO_DTYPE(self) -> SchemaDict:
-        return {str(tp.__name__): dtype for tp, dtype in self.PY_TYPE_TO_DTYPE.items()}
 
     @property
     @cache
@@ -333,7 +359,7 @@ def py_type_to_dtype(
     if isinstance(data_type, ForwardRef):
         annotation = data_type.__forward_arg__
         data_type = (
-            DataTypeMappings.PY_STR_TO_DTYPE.get(
+            PY_STR_TO_DTYPE.get(
                 re.sub(r"(^None \|)|(\| None$)", "", annotation).strip(), data_type
             )
             if isinstance(annotation, str)  # type: ignore[redundant-expr]
@@ -355,7 +381,7 @@ def py_type_to_dtype(
         if is_polars_dtype(data_type):
             return data_type
     try:
-        return DataTypeMappings.PY_TYPE_TO_DTYPE[data_type]
+        return map_py_type_to_dtype(data_type)
     except (KeyError, TypeError):  # pragma: no cover
         if not raise_unmatched:
             return None

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -116,6 +116,8 @@ def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsD
     if python_dtype is bool:
         return Boolean
     if issubclass(python_dtype, datetime):
+        # `datetime` is a subclass of `date`,
+        # so need to check `datetime` first
         return Datetime("us")
     if issubclass(python_dtype, date):
         return Date

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -105,7 +105,7 @@ PY_STR_TO_DTYPE: SchemaDict = {
 }
 
 
-@functools.lru_cache
+@functools.lru_cache(16)
 def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsDataType:
     if python_dtype is float:
         return Float64

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -597,7 +597,7 @@ fn materialize_list(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
     }
 }
 
-fn _convert_date(ob: & PyAny) -> PyResult<Wrap<polars_rs::prelude::AnyValue>> {
+fn convert_date(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
     Python::with_gil(|py| {
         let date = UTILS
             .as_ref(py)
@@ -609,7 +609,7 @@ fn _convert_date(ob: & PyAny) -> PyResult<Wrap<polars_rs::prelude::AnyValue>> {
         Ok(Wrap(AnyValue::Date(v)))
     })
 }
-fn _convert_datetime(ob: & PyAny) -> PyResult<Wrap<polars_rs::prelude::AnyValue>> {
+fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
     Python::with_gil(|py| {
         // windows
         #[cfg(target_arch = "windows")]
@@ -700,8 +700,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                 return Ok(AnyValue::Float64(v).into());
             };
             match type_name {
-                "datetime" => _convert_datetime(ob),
-                "date" => _convert_date(ob),
+                "datetime" => convert_datetime(ob),
+                "date" => convert_date(ob),
                 "timedelta" => Python::with_gil(|py| {
                     let td = UTILS
                         .as_ref(py)
@@ -747,10 +747,10 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                             "<class 'datetime.datetime'>" => {
                                 // `datetime.datetime` is a subclass of `datetime.date`,
                                 // so need to check `datetime.datetime` first
-                                return _convert_datetime(ob);
+                                return convert_datetime(ob);
                             }
                             "<class 'datetime.date'>" => {
-                                return _convert_date(ob);
+                                return convert_date(ob);
                             }
                             _ => (),
                         }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -600,6 +600,11 @@ fn materialize_list(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
 impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
     fn extract(ob: &'s PyAny) -> PyResult<Self> {
         let type_name = ob.get_type().name()?;
+        let parent_type = ob.get_type().getattr("__bases__")?.get_item(0)?;
+        let parent_type_name = parent_type.str()?.to_str()?;
+        // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
+        // so need to compare types as strings.
+
         if ob.is_instance_of::<PyBool>().unwrap() {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
         } else if let Ok(v) = ob.extract::<i64>() {
@@ -632,8 +637,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
         } else if let Ok(v) = ob.extract::<&'s [u8]>() {
             Ok(AnyValue::Binary(v).into())
         } else {
-            match type_name {
-                "datetime" => {
+            match (type_name, parent_type_name) {
+                ("datetime", _) | (_, "<class 'datetime.datetime'>") => {
                     Python::with_gil(|py| {
                         // windows
                         #[cfg(target_arch = "windows")]
@@ -686,7 +691,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                         Ok(AnyValue::Datetime(v, TimeUnit::Microseconds, &None).into())
                     })
                 }
-                "date" => Python::with_gil(|py| {
+                ("date", _) | (_, "<class 'datetime.date'>") => Python::with_gil(|py| {
                     let date = UTILS
                         .as_ref(py)
                         .getattr("_date_to_pl_date")
@@ -696,7 +701,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let v = date.extract::<i32>().unwrap();
                     Ok(Wrap(AnyValue::Date(v)))
                 }),
-                "timedelta" => Python::with_gil(|py| {
+                ("timedelta", _) | (_, "<class 'datetime.timedelta'>") => Python::with_gil(|py| {
                     let td = UTILS
                         .as_ref(py)
                         .getattr("_timedelta_to_pl_timedelta")
@@ -706,7 +711,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let v = td.extract::<i64>().unwrap();
                     Ok(Wrap(AnyValue::Duration(v, TimeUnit::Microseconds)))
                 }),
-                "time" => Python::with_gil(|py| {
+                ("time", _) | (_, "<class 'datetime.time'>") => Python::with_gil(|py| {
                     let time = UTILS
                         .as_ref(py)
                         .getattr("_time_to_pl_time")
@@ -716,7 +721,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     let v = time.extract::<i64>().unwrap();
                     Ok(Wrap(AnyValue::Time(v)))
                 }),
-                "Decimal" => {
+                ("Decimal", _) => {
                     let (sign, digits, exp): (i8, Vec<u8>, i32) =
                         ob.call_method0("as_tuple").unwrap().extract().unwrap();
                     // note: using Vec<u8> is not the most efficient thing here (input is a tuple)
@@ -730,8 +735,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                     }
                     Ok(Wrap(AnyValue::Decimal(v, scale)))
                 }
-                "range" => materialize_list(ob),
-                _ => Err(PyErr::from(PyPolarsErr::Other(format!(
+                ("range", _) => materialize_list(ob),
+                (_, _) => Err(PyErr::from(PyPolarsErr::Other(format!(
                     "object type not supported {ob:?}",
                 )))),
             }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -638,8 +638,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             if (type_name != "datetime") && (type_name != "date") {
                 let bases = ob.get_type().getattr("__bases__")?.iter()?;
                 for base in bases {
-                    let unwrapped = base.unwrap().str().unwrap().to_str().unwrap();
-                    match unwrapped {
+                    let parent_type = base.unwrap().str().unwrap().to_str().unwrap();
+                    match parent_type {
                         "<class 'datetime.datetime'>" => {
                             type_name = "datetime";
                             break;

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -635,7 +635,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             };
             // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
             // so need this workaround instead of `isinstance(ob, datetime)`.
-            if (type_name != "datetime") && (type_name != "date") {
+            if !["datetime", "date", "timedelta", "time"].contains(&type_name) {
                 let bases = ob.get_type().getattr("__bases__")?.iter()?;
                 for base in bases {
                     let parent_type = base.unwrap().str().unwrap().to_str().unwrap();

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -965,3 +965,13 @@ def test_nested_categorical() -> None:
     s = pl.Series([["a"]], dtype=pl.List(pl.Categorical))
     assert s.to_list() == [["a"]]
     assert s.dtype == pl.List(pl.Categorical)
+
+def test_datetime_date_subclasses() -> None:
+    class FakeDatetime(datetime):...
+    class FakeDate(date):...
+    result = pl.Series([FakeDatetime(2020, 1, 1, 3)])
+    expected = pl.Series([datetime(2020, 1, 1, 3)])
+    assert_series_equal(result, expected)
+    result = pl.Series([FakeDate(2020, 1, 1)])
+    expected = pl.Series([date(2020, 1, 1)])
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -966,9 +966,14 @@ def test_nested_categorical() -> None:
     assert s.to_list() == [["a"]]
     assert s.dtype == pl.List(pl.Categorical)
 
+
 def test_datetime_date_subclasses() -> None:
-    class FakeDatetime(datetime):...
-    class FakeDate(date):...
+    class FakeDate(date):
+        ...
+
+    class FakeDatetime(FakeDate, datetime):
+        ...
+
     result = pl.Series([FakeDatetime(2020, 1, 1, 3)])
     expected = pl.Series([datetime(2020, 1, 1, 3)])
     assert_series_equal(result, expected)


### PR DESCRIPTION
closes #7809 

was getting issues from the cached methods in the `_DataTypeMappings` class (which might be a risky practice anyway? https://youtu.be/sVjtp6tGo0g) so I've moved `PY_STR_TO_DTYPE` and `PY_TYPE_TO_DTYPE` out to be top-level dict/function

---

local demo:
```python
with freeze_time("2012-01-14"):
    df = pl.Series([datetime.datetime.now()])
    print(df)
    df = pl.Series([datetime.date.today()])
    print(df)
df = pl.Series([datetime.datetime.now()])
print(df)
df = pl.Series([datetime.date.today()])
print(df)
```
outputs
```python
shape: (1,)
Series: '' [datetime[μs]]
[
        2012-01-14 00:00:00
]
shape: (1,)
Series: '' [date]
[
        2012-01-14
]
shape: (1,)
Series: '' [datetime[μs]]
[
        2023-03-28 14:20:31.228598
]
shape: (1,)
Series: '' [date]
[
        2023-03-28
]
```