### PR TITLE
feat(python): pl.Config.set_auto_tbl_cols

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     import sys
     from types import TracebackType
 
-    from polars.internals import _DataFrame
+    from polars.internals import DataFrame
 
     from polars.type_aliases import FloatFmt
 
@@ -677,7 +677,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: _DataFrame, column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 
@@ -727,7 +727,7 @@ def set_optimal_columns_to_display(df: _DataFrame, column_spacing: float = 3.0) 
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df: _DataFrame) -> List[int]:
+    def _get_column_name_lengths(df: "DataFrame") -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -735,7 +735,7 @@ def set_optimal_columns_to_display(df: _DataFrame, column_spacing: float = 3.0) 
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df: _DataFrame, row_idx: int) -> List[int]:
+    def _get_row_value_lengths(df: "DataFrame", row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -726,7 +726,7 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
-            length if length <= 24 else 24 for length in column_name_lengths
+            length if length <= 22 else 22 for length in column_name_lengths
         ]
         return column_name_lengths
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -676,7 +676,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 
@@ -723,7 +723,7 @@ def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df: DataFrame) -> List[int]:
+    def _get_column_name_lengths(df: "DataFrame") -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -731,7 +731,7 @@ def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df: DataFrame, row_idx: int) -> List[int]:
+    def _get_row_value_lengths(df: "DataFrame", row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -676,7 +676,9 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: pl.DataFrame, column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(
+    df: pl.DataFrame, column_spacing: float = 3.0
+) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -803,7 +803,7 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     # Calculate the length of each column name
     column_name_lengths = _get_column_name_lengths(df[:, col_indices])
 
-    # Calculate the average length of each row value
+    # Calculate the average length of row values
     row_value_lengths_lst = [
         _get_row_value_lengths(df[:, col_indices], row_idx) for row_idx in row_indices
     ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -753,24 +753,24 @@ def set_optimal_columns_to_display(df: pl.DataFrame, column_spacing: float = 3.0
 
         width_used, num_cols_to_print, left_column_idx, right_column_idx = 0, 0, 0, -1
         for _ in width_list:
-            width_used += width_list[left_column_idx] + column_spacing
+            width_used += int(width_list[left_column_idx] + column_spacing)
             num_cols_to_print += 1
             left_column_idx += 1
             if width_used > terminal_width:
                 # reverse last
                 num_cols_to_print -= 1
                 left_column_idx -= 1
-                width_used -= width_list[left_column_idx] + column_spacing
+                width_used -= int(width_list[left_column_idx] + column_spacing)
                 break
 
-            width_used += width_list[right_column_idx] + column_spacing
+            width_used += int(width_list[right_column_idx] + column_spacing)
             num_cols_to_print += 1
             right_column_idx -= 1
             if width_used > terminal_width:
                 # reverse last
                 num_cols_to_print -= 1
                 right_column_idx += 1
-                width_used -= width_list[right_column_idx] + column_spacing
+                width_used -= int(width_list[right_column_idx] + column_spacing)
                 break
 
         last_column_missing_spacing = 1
@@ -778,7 +778,7 @@ def set_optimal_columns_to_display(df: pl.DataFrame, column_spacing: float = 3.0
             width_used += last_column_missing_spacing
         else:
             dots_column_width = 1  # | … | -> len("…")
-            width_used += dots_column_width + column_spacing
+            width_used += int(dots_column_width + column_spacing)
             width_used += last_column_missing_spacing
 
         num_cols_to_print = (

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -676,9 +676,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(
-    df: DataFrame, column_spacing: float = 3.0
-) -> None:
+def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -404,7 +404,7 @@ class Config:
     @classmethod
     def set_tbl_column_data_type_inline(cls, active: bool = True) -> type[Config]:
         """
-        Moves the data type inline with the column name (to the right, in parentheses)
+        Moves the data type inline with the column name (to the right, in parentheses).
 
         Examples
         --------

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -719,7 +719,7 @@ def set_optimal_columns_to_display(
 
     def _get_element_display_length(element: Union[numbers.Number, str]) -> int:
         if isinstance(element, numbers.Number):
-            return min(len(str(round(float(element), 6))), 13)
+            return min(len(str(round(element, 6))), 13)
         elif isinstance(element, str):
             return min(len(element), 33)
         else:

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import os
+import shutil
+import numbers
 from typing import TYPE_CHECKING
 
 from polars.dependencies import json
@@ -798,19 +800,19 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     )
 
     # Calculate the length of each column name
-    column_name_lenght = _get_column_name_lengths(df[:, col_indices])
+    column_name_lengths = _get_column_name_lengths(df[:, col_indices])
 
     # Calculate the average length of each row value
     row_value_lengths_lst = [
         _get_row_value_lengths(df[:, col_indices], row_idx) for row_idx in row_indices
     ]
-    row_value_length = _average_element_lengths(*row_value_lengths_lst)
+    row_value_lengths = _average_element_lengths(*row_value_lengths_lst)
 
     # Compare lengths of the row values and column names, and keep the largest for each column
-    real_column_length = _max_element_lengths(*[column_name_lenght, row_value_length])
+    real_column_lengths = _max_element_lengths(*[column_name_lengths, row_value_lengths])
 
     # Determine the optimal number of columns to print based on the calculated lengths
     num_cols_to_print = _determine_optimal_display_columns(
-        real_column_length, terminal_width, num_columns_df, column_spacing
+        real_column_lengths, terminal_width, num_columns_df, column_spacing
     )
     os.environ["POLARS_FMT_MAX_COLS"] = str(num_cols_to_print)

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -717,7 +717,10 @@ def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0)
 
     def _get_element_display_length(element: Union[numbers.Number, str]) -> int:
         if isinstance(element, numbers.Number):
-            return return min(len(str(round(float(float(element)), 6))), 13)
+            formatted_number = (
+                str(round(element, 6)) if isinstance(element, float) else str(element)
+            )
+            return min(len(formatted_number), 13)
         elif isinstance(element, str):
             return min(len(element), 33)
         else:

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -370,15 +370,15 @@ class Config:
     def set_auto_tbl_cols(cls, active: bool = True) -> type[Config]:
         """
         Automatically set the number of columns that are visible when displaying tables.
-    
+
         When active, it adjusts the number of columns displayed in the table based on the terminal width.
-    
+
         Parameters
         ----------
         active : bool, optional, default: True
             If True, automatically adjusts the number of columns displayed in the table based on the terminal width.
             If False, displays all columns.
-    
+
         Examples
         --------
         >>> import polars as pl
@@ -723,7 +723,6 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
                 len(str(element)), 33
             )  # 33 max characters returned by lists, tuples, dicts, datetime
 
-
     def _get_column_name_lengths(df):
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line. Usually 20 to 24 characters are kept
@@ -733,18 +732,16 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
         ]
         return column_name_lengths
 
-
     def _get_row_value_lengths(df, row_idx):
-        return [_get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]]
-
+        return [
+            _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
+        ]
 
     def _average_element_lengths(*lists):
         return [int(sum(elements) / len(elements)) for elements in zip(*lists)]
 
-
     def _max_element_lengths(*lists):
         return [int(max(elements)) for elements in zip(*lists)]
-
 
     def _determine_optimal_display_columns(
         width_list, terminal_width, num_columns_df, column_spacing=3
@@ -788,7 +785,7 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
         num_cols_to_print = (
             1 if num_cols_to_print == 0 else num_cols_to_print
         )  # minimal of 1 column
-    
+
         return num_cols_to_print
 
     terminal_width = shutil.get_terminal_size().columns
@@ -815,7 +812,9 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     row_value_lengths = _average_element_lengths(*row_value_lengths_lst)
 
     # Compare lengths of the row values and column names, and keep the largest for each column
-    real_column_lengths = _max_element_lengths(*[column_name_lengths, row_value_lengths])
+    real_column_lengths = _max_element_lengths(
+        *[column_name_lengths, row_value_lengths]
+    )
 
     # Determine the optimal number of columns to print based on the calculated lengths
     num_cols_to_print = _determine_optimal_display_columns(

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -369,15 +369,18 @@ class Config:
     @classmethod
     def set_auto_tbl_cols(cls, active: bool = True) -> type[Config]:
         """
-        Automatically set the number of columns that are visible when displaying tables.
+        Automatically set the number of columns that are visible when
+        displaying tables.
 
-        When active, it adjusts the number of columns displayed in the table based on the terminal width.
+        When active, it adjusts the number of columns displayed in the
+        table based on the terminal width.
 
         Parameters
         ----------
         active : bool, optional, default: True
-            If True, automatically adjusts the number of columns displayed in the table based on the terminal width.
-            If False, displays all columns.
+            If True, automatically adjusts the number of columns displayed
+            in the table based on the terminal width. If False, displays
+            all columns.
 
         Examples
         --------
@@ -402,7 +405,8 @@ class Config:
     @classmethod
     def set_tbl_column_data_type_inline(cls, active: bool = True) -> type[Config]:
         """
-        Moves the data type inline with the column name (to the right, in parentheses).
+        Moves the data type inline with the column name (to the right, in
+        parentheses).
 
         Examples
         --------
@@ -675,11 +679,13 @@ class Config:
 
 def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     """
-    Set the optimal number of columns to display for a DataFrame based on the terminal width.
+    Set the optimal number of columns to display for a DataFrame based on the
+    terminal width.
 
-    This function sets the optimal number of columns to display for a given DataFrame based on the
-    terminal width, column names width, and element widths. It aims to provide a better user experience
-    when displaying DataFrames in the terminal by minimizing vertical scrolling.
+    This function sets the optimal number of columns to display for a given
+    DataFrame based on the    terminal width, column names width, and element
+    widths. It aims to provide a better user experience when displaying
+    DataFrames in the terminal by minimizing vertical scrolling.
 
     Parameters
     ----------
@@ -713,20 +719,15 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
 
     def _get_element_display_length(element):
         if isinstance(element, numbers.Number):
-            return min(
-                len(str(round(element, 6))), 13
-            )  # 13 max characters returned by numbers
+            return min(len(str(round(element, 6))), 13)
         elif isinstance(element, str):
-            return min(len(element), 33)  # 33 max characters returned by strings
+            return min(len(element), 33)
         else:
-            return min(
-                len(str(element)), 33
-            )  # 33 max characters returned by lists, tuples, dicts, datetime
+            return min(len(str(element)), 33)
 
     def _get_column_name_lengths(df):
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
-        # allow really big column names to "break" to 2nd line. Usually 20 to 24 characters are kept
-        # on first line
+        # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
             length if length <= 24 else 24 for length in column_name_lengths
         ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -725,7 +725,13 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
 
 
     def _get_column_name_lengths(df):
-        return [_get_element_display_length(col) for col in df.columns]
+        column_name_lengths = [_get_element_display_length(col) for col in df.columns]
+        # allow really big column names to "break" to 2nd line. Usually 20 to 24 characters are kept
+        # on first line
+        column_name_lengths = [
+            length if length <= 24 else 24 for length in column_name_lengths
+        ]
+        return column_name_lengths
 
 
     def _get_row_value_lengths(df, row_idx):

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -4,7 +4,6 @@ import contextlib
 import os
 import shutil
 import numbers
-import polars as pl
 from typing import TYPE_CHECKING, List, Union
 
 from polars.dependencies import json
@@ -22,6 +21,7 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     import sys
+    import polars as pl
     from types import TracebackType
 
     from polars.type_aliases import FloatFmt

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import shutil
 import numbers
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Union
 
 from polars.dependencies import json
 
@@ -675,7 +675,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
+def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 
@@ -714,15 +714,15 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     └─────┴─────┴─────┴─────┴─────┴─────┘
     """
 
-    def _get_element_display_length(element):
+    def _get_element_display_length(element: Union[numbers.Number, str]) -> int:
         if isinstance(element, numbers.Number):
-            return min(len(str(round(element, 6))), 13)
+            return min(len(str(round(float(element), 6))), 13)
         elif isinstance(element, str):
             return min(len(element), 33)
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df):
+    def _get_column_name_lengths(df: DataFrame) -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -730,20 +730,23 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df, row_idx):
+    def _get_row_value_lengths(df: DataFrame, row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]
 
-    def _average_element_lengths(*lists):
+    def _average_element_lengths(*lists: List[int]) -> List[int]:
         return [int(sum(elements) / len(elements)) for elements in zip(*lists)]
 
-    def _max_element_lengths(*lists):
+    def _max_element_lengths(*lists: List[int]) -> List[int]:
         return [int(max(elements)) for elements in zip(*lists)]
 
     def _determine_optimal_display_columns(
-        width_list, terminal_width, num_columns_df, column_spacing=3
-    ):
+        width_list: List[int],
+        terminal_width: int,
+        num_columns_df: int,
+        column_spacing: float = 3.0,
+    ) -> int:
         if num_columns_df == 0:
             return 0
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -369,8 +369,7 @@ class Config:
     @classmethod
     def set_auto_tbl_cols(cls, active: bool = True) -> type[Config]:
         """
-        Automatically set the number of columns that are visible when
-        displaying tables.
+        Automatically set the number of columns for display.
 
         When active, it adjusts the number of columns displayed in the
         table based on the terminal width.
@@ -405,8 +404,7 @@ class Config:
     @classmethod
     def set_tbl_column_data_type_inline(cls, active: bool = True) -> type[Config]:
         """
-        Moves the data type inline with the column name (to the right, in
-        parentheses).
+        Moves the data type inline with the column name (to the right, in parentheses)
 
         Examples
         --------
@@ -812,7 +810,7 @@ def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     ]
     row_value_lengths = _average_element_lengths(*row_value_lengths_lst)
 
-    # Compare lengths of the row values and column names, and keep the largest for each column
+    # Compare lengths of the row values and column names, keep the largest
     real_column_lengths = _max_element_lengths(
         *[column_name_lengths, row_value_lengths]
     )

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -387,7 +387,7 @@ class Config:
         --------
         >>> import polars as pl
         >>> with pl.Config() as cfg:
-        ...     cfg.set_auto_tbl_cols()  # doctest: +IGNORE_RESULT
+        ...     cfg.set_auto_tbl_cols()  # doctest: +SKIP
         ...     df = pl.DataFrame({str(i): [i] for i in range(100)})
         ...     print(df)
         ...
@@ -703,7 +703,7 @@ def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0)
     >>> df = pl.DataFrame({str(i): [i] for i in range(20)})
     >>> set_optimal_columns_to_display(df)
     >>> with pl.Config() as cfg:
-    ...     cfg.set_auto_tbl_cols()  # doctest: +IGNORE_RESULT
+    ...     cfg.set_auto_tbl_cols()  # doctest: +SKIP
     ...     print(df)
     ...
     shape: (1, 20)

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import shutil
 import numbers
+import polars as pl
 from typing import TYPE_CHECKING, List, Union
 
 from polars.dependencies import json
@@ -675,7 +676,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(df: pl.DataFrame, column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 
@@ -722,7 +723,7 @@ def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df: DataFrame) -> List[int]:
+    def _get_column_name_lengths(df: pl.DataFrame) -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -730,7 +731,7 @@ def set_optimal_columns_to_display(df: DataFrame, column_spacing: float = 3.0) -
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df: DataFrame, row_idx: int) -> List[int]:
+    def _get_row_value_lengths(df: pl.DataFrame, row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -677,8 +677,7 @@ class Config:
 
 def set_optimal_columns_to_display(df, column_spacing: float = 3.0):
     """
-    Set the optimal number of columns to display for a DataFrame based on the
-    terminal width.
+    Set the optimal number of columns to display for a DataFrame.
 
     This function sets the optimal number of columns to display for a given
     DataFrame based on the    terminal width, column names width, and element

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
     import sys
     from types import TracebackType
 
-    from polars import DataFrame
+    from polars.internals import _DataFrame
+
     from polars.type_aliases import FloatFmt
 
     if sys.version_info >= (3, 8):
@@ -676,7 +677,7 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(df: _DataFrame, column_spacing: float = 3.0) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 
@@ -726,7 +727,7 @@ def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0)
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df: "DataFrame") -> List[int]:
+    def _get_column_name_lengths(df: _DataFrame) -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -734,7 +735,7 @@ def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0)
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df: "DataFrame", row_idx: int) -> List[int]:
+    def _get_row_value_lengths(df: _DataFrame, row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -677,7 +677,9 @@ class Config:
         return cls
 
 
-def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0) -> None:
+def set_optimal_columns_to_display(
+    df: "DataFrame", column_spacing: float = 3.0
+) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -717,7 +717,7 @@ def set_optimal_columns_to_display(df: "DataFrame", column_spacing: float = 3.0)
 
     def _get_element_display_length(element: Union[numbers.Number, str]) -> int:
         if isinstance(element, numbers.Number):
-            return min(len(str(round(element, 6))), 13)
+            return return min(len(str(round(float(float(element)), 6))), 13)
         elif isinstance(element, str):
             return min(len(element), 33)
         else:

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -21,9 +21,9 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     import sys
-    import polars as pl
     from types import TracebackType
 
+    from polars import DataFrame
     from polars.type_aliases import FloatFmt
 
     if sys.version_info >= (3, 8):
@@ -677,7 +677,7 @@ class Config:
 
 
 def set_optimal_columns_to_display(
-    df: pl.DataFrame, column_spacing: float = 3.0
+    df: DataFrame, column_spacing: float = 3.0
 ) -> None:
     """
     Set the optimal number of columns to display for a DataFrame.
@@ -725,7 +725,7 @@ def set_optimal_columns_to_display(
         else:
             return min(len(str(element)), 33)
 
-    def _get_column_name_lengths(df: pl.DataFrame) -> List[int]:
+    def _get_column_name_lengths(df: DataFrame) -> List[int]:
         column_name_lengths = [_get_element_display_length(col) for col in df.columns]
         # allow really big column names to "break" to 2nd line.
         column_name_lengths = [
@@ -733,7 +733,7 @@ def set_optimal_columns_to_display(
         ]
         return column_name_lengths
 
-    def _get_row_value_lengths(df: pl.DataFrame, row_idx: int) -> List[int]:
+    def _get_row_value_lengths(df: DataFrame, row_idx: int) -> List[int]:
         return [
             _get_element_display_length(col[0]) for col in df[row_idx : row_idx + 1]
         ]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -27,6 +27,7 @@ from typing import (
 
 from polars import functions as F
 from polars import internals as pli
+from polars.config import set_optimal_columns_to_display
 from polars.dataframe._html import NotebookFormatter
 from polars.dataframe.groupby import DynamicGroupBy, GroupBy, RollingGroupBy
 from polars.datatypes import (
@@ -1380,6 +1381,8 @@ class DataFrame:
         return self._from_pydf(self._df.rem(other._s))
 
     def __str__(self) -> str:
+        if os.environ.get("POLARS_AUTO_FMT_COLS") == "1":
+            set_optimal_columns_to_display(self._df)
         return self._df.as_str()
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Solution for the optimal number of columns when printing a DataFrame. Fixes: https://github.com/pola-rs/polars/issues/6447, https://github.com/pola-rs/polars/issues/6105, https://github.com/pola-rs/polars/issues/7665, https://github.com/pola-rs/polars/issues/7282

Although I tested the functions, I got `TypeError: 'builtin_function_or_method' object is not subscriptable` when trying a modified version of polars on my environment, so some adjustments are needed here. 

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/artur/mambaforge/envs/py_polars_test/lib/python3.10/site-packages/polars/dataframe/frame.py", line 1382, in __str__
    set_optimal_columns_to_display(self._df)
  File "/home/artur/mambaforge/envs/py_polars_test/lib/python3.10/site-packages/polars/config.py", line 793, in set_optimal_columns_to_display
    num_rows_df = df.shape[0]
TypeError: 'builtin_function_or_method' object is not subscriptable
```