### PR TITLE
feat(rust, python): support mode for floats and categoricals

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -296,6 +296,12 @@ impl ChunkUnique<Float32Type> for Float32Chunked {
     fn arg_unique(&self) -> PolarsResult<IdxCa> {
         self.bit_repr_small().arg_unique()
     }
+    #[cfg(feature = "mode")]
+    fn mode(&self) -> PolarsResult<ChunkedArray<Float32Type>> {
+        let s = self.apply_as_ints(|v| v.mode().unwrap());
+        let ca = s.f32().unwrap().clone();
+        Ok(ca)
+    }
 }
 
 impl ChunkUnique<Float64Type> for Float64Chunked {
@@ -307,6 +313,12 @@ impl ChunkUnique<Float64Type> for Float64Chunked {
 
     fn arg_unique(&self) -> PolarsResult<IdxCa> {
         self.bit_repr_large().arg_unique()
+    }
+    #[cfg(feature = "mode")]
+    fn mode(&self) -> PolarsResult<ChunkedArray<Float64Type>> {
+        let s = self.apply_as_ints(|v| v.mode().unwrap());
+        let ca = s.f64().unwrap().clone();
+        Ok(ca)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -386,7 +386,8 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
 
     #[cfg(feature = "mode")]
     fn mode(&self) -> PolarsResult<Series> {
-        Ok(CategoricalChunked::full_null(self.0.logical().name(), 1).into_series())
+        let cats = self.0.logical().mode()?;
+        Ok(self.finish_with_state(false, cats).into_series())
     }
 }
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1238,6 +1238,11 @@ def test_mode() -> None:
 
     df = pl.DataFrame([s])
     assert df.select([pl.col("a").mode()])["a"].to_list() == [1]
+    assert (
+        pl.Series(["foo", "bar", "buz", "bar"], dtype=pl.Categorical).mode().item()
+        == "bar"
+    )
+    assert pl.Series([1.0, 2.0, 3.0, 2.0]).mode().item() == 2.0
 
 
 def test_rank() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1426,7 +1426,6 @@ def test_invalid_categorical() -> None:
     assert s.var() is None
     assert s.median() is None
     assert s.quantile(0.5) is None
-    assert s.mode().to_list() == [None]
 
 
 def test_bitwise() -> None:


### PR DESCRIPTION
closes #7772