### PR TITLE
feat(python): allow Series init with `Unknown` dtype to proceed as if dtype is `None`, to allow inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ data/
 node_modules/
 polars/vendor
 target/
+venv/
 .venv/
 .vim

--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -1,6 +1,7 @@
 wheels/
 !Cargo.lock
 target/
+venv/
 .venv/
 .hypothesis
 .DS_Store

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -11,12 +11,15 @@ from polars.datatypes.classes import (
     Field,
     Float32,
     Float64,
+    FractionalType,
     Int8,
     Int16,
     Int32,
     Int64,
+    IntegralType,
     List,
     Null,
+    NumericType,
     Object,
     Struct,
     TemporalType,
@@ -55,6 +58,14 @@ from polars.datatypes.convert import (
     py_type_to_arrow_type,
     py_type_to_dtype,
     supported_numpy_char_code,
+)
+from polars.type_aliases import (
+    OneOrMoreDataTypes,
+    PolarsDataType,
+    PolarsTemporalType,
+    PythonDataType,
+    SchemaDefinition,
+    SchemaDict,
 )
 
 __all__ = [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -38,6 +38,7 @@ from polars.datatypes import (
     UInt16,
     UInt32,
     UInt64,
+    Unknown,
     Utf8,
     dtype_to_ctype,
     is_polars_dtype,
@@ -226,7 +227,11 @@ class Series:
         nan_to_null: bool = False,
         dtype_if_empty: PolarsDataType | None = None,
     ):
-        # Raise error if dtype is not valid
+        # If 'Unknown' treat as None to attempt inference
+        if dtype == Unknown:
+            dtype = None
+
+        # Raise early error on invalid dtype
         if (
             dtype is not None
             and not is_polars_dtype(dtype)


### PR DESCRIPTION
The `Unknown` dtype isn't invalid, it's just... "unknown". So, this PR allows for  inference if a `Series` is declared as having `Unknown` dtype at init time; this is equivalent to dtype=None, and is also consistent with the the way that PyDataFrame `read_rows` and `read_dicts` schema overrides behave.

#### Also:

* Added missing imports that were declared in `polars.datatypes.__init__.__all__`, but that weren't actually being imported at that level.

* Reinstated `venv` into gitignore for the time-being; otherwise ~18,000 files show up as unversioned and `typos` sprays megabytes of text into your terminal on `pre-commit` if you haven't both created the new/preferred `.venv` _and_ deleted the old `venv`. Will smooth things over until everyone has transitioned.