### PR TITLE
fix(python): Add missing type hint for `is_between`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -50,7 +50,6 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
-    from datetime import date, datetime, time
 
     from polars.dataframe import DataFrame
     from polars.lazyframe import LazyFrame
@@ -3655,10 +3654,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
 
     def is_between(
-        self,
-        start: Expr | datetime | date | time | int | float | str,
-        end: Expr | datetime | date | time | int | float | str,
-        closed: ClosedInterval = "both",
+        self, start: IntoExpr, end: IntoExpr, closed: ClosedInterval = "both"
     ) -> Self:
         """
         Check if this expression is between the given start and end values.
@@ -3666,9 +3662,11 @@ class Expr:
         Parameters
         ----------
         start
-            Lower bound value (can be an expression or literal).
+            Lower bound value. Accepts expression input. Strings are parsed as column
+            names, other non-expression inputs are parsed as literals.
         end
-            Upper bound value (can be an expression or literal).
+            Upper bound value. Accepts expression input. Strings are parsed as column
+            names, other non-expression inputs are parsed as literals.
         closed : {'both', 'left', 'right', 'none'}
             Define which sides of the interval are closed (inclusive).
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -109,6 +109,7 @@ if TYPE_CHECKING:
         ComparisonOperator,
         FillNullStrategy,
         InterpolationMethod,
+        IntoExpr,
         NullBehavior,
         OneOrMoreDataTypes,
         PolarsDataType,
@@ -2902,10 +2903,7 @@ class Series:
         """
 
     def is_between(
-        self,
-        start: Expr | datetime | date | time | int | float | str,
-        end: Expr | datetime | date | time | int | float | str,
-        closed: ClosedInterval = "both",
+        self, start: IntoExpr, end: IntoExpr, closed: ClosedInterval = "both"
     ) -> Series:
         """
         Get a boolean mask of the values that fall between the given start/end values.
@@ -2913,9 +2911,11 @@ class Series:
         Parameters
         ----------
         start
-            Lower bound value (can be an expression or literal).
+            Lower bound value. Accepts expression input. Non-expression inputs
+            (including strings) are parsed as literals.
         end
-            Upper bound value (can be an expression or literal).
+            Upper bound value. Accepts expression input. Non-expression inputs
+            (including strings) are parsed as literals.
         closed : {'both', 'left', 'right', 'none'}
             Define which sides of the interval are closed (inclusive).
 


### PR DESCRIPTION
I tried to use `is_between` on a duration column with timedelta inputs, and `mypy` complained. Simply a missing type hint. I replaced the type hint with `IntoExpr`, as it's parsed into expressions.

While doing so, I noticed two things about this method:

* Series and Expr handle the inputs differently. For Series, strings are parsed as literals, while for Expr, strings are parsed as column names. I think we should be consistent here: if we accept Expr input, we should parse strings as column names. We could also decide not to support Expr input here for Series.is_between, as it doesn't make much sense to me anyway.
* The argument names `start` and `end` only make sense when using this on temporal data. I would prefer `lower_bound` and `upper_bound` as argument names.