### PR TITLE
docs(python): Fix read_csv docstring formatting

### DIFF
--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -116,7 +116,7 @@ def read_csv(
     ignore_errors
         Try to keep reading lines if some lines yield errors.
         Before using this option, try to increase the number of lines used for schema
-        inference with e.g ```infer_schema_length=10000`` or override automatic dtype
+        inference with e.g ``infer_schema_length=10000`` or override automatic dtype
         inference for specific columns with the ``dtypes`` option or use
         ``infer_schema_length=0`` to read all columns as ``pl.Utf8`` to check which
         values might cause an issue.


### PR DESCRIPTION
This PR addresses a small typo introduced with #7156 that causes the formatting of the read_csv docstring to be rendered incorrectly 

Current formatting:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/81423796/228807631-01796c73-de18-4b77-8ec9-5e453314628a.png">
