### PR TITLE
fix(rust, python): validate groupby_dynamic inputs

### DIFF
--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -816,25 +816,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_panic_integer_temporal_combine() {
-        let df = DataFrame::new_no_checks(vec![]);
-        let _ = df.groupby_dynamic(
-            vec![],
-            &DynamicGroupOptions {
-                index_column: "date".into(),
-                every: Duration::parse("1h"),
-                period: Duration::parse("1i"),
-                offset: Duration::parse("0h"),
-                truncate: true,
-                include_boundaries: true,
-                closed_window: ClosedWindow::Both,
-                start_by: Default::default(),
-            },
-        );
-    }
-
-    #[test]
     fn test_truncate_offset() -> PolarsResult<()> {
         let start = NaiveDate::from_ymd_opt(2021, 3, 1)
             .unwrap()

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -152,31 +152,19 @@ pub fn groupby_windows(
         Bounds::new_checked(start, stop)
     };
 
-    let size = if include_lower_bound || include_upper_bound {
+    let size = {
         match tu {
             TimeUnit::Nanoseconds => window.estimate_overlapping_bounds_ns(boundary),
             TimeUnit::Microseconds => window.estimate_overlapping_bounds_us(boundary),
             TimeUnit::Milliseconds => window.estimate_overlapping_bounds_ms(boundary),
         }
-    } else {
-        0
     };
     let size_lower = if include_lower_bound { size } else { 0 };
     let size_upper = if include_upper_bound { size } else { 0 };
     let mut lower_bound = Vec::with_capacity(size_lower);
     let mut upper_bound = Vec::with_capacity(size_upper);
 
-    let mut groups = match tu {
-        TimeUnit::Nanoseconds => {
-            Vec::with_capacity(window.estimate_overlapping_bounds_ns(boundary))
-        }
-        TimeUnit::Microseconds => {
-            Vec::with_capacity(window.estimate_overlapping_bounds_us(boundary))
-        }
-        TimeUnit::Milliseconds => {
-            Vec::with_capacity(window.estimate_overlapping_bounds_ms(boundary))
-        }
-    };
+    let mut groups = Vec::with_capacity(size);
     let start_offset = 0;
 
     match tz {

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -22,6 +22,7 @@ pub struct Window {
 
 impl Window {
     pub fn new(every: Duration, period: Duration, offset: Duration) -> Self {
+        debug_assert!(!every.negative);
         Self {
             every,
             period,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -499,3 +499,28 @@ def test_invalid_inner_type_cast_list() -> None:
         pl.ComputeError, match=r"cannot cast list inner type: 'Int64' to Categorical"
     ):
         s.cast(pl.List(pl.Categorical))
+
+
+@pytest.mark.parametrize(
+    ("every", "match"),
+    [
+        ("-1i", r"'every' argument must be positive"),
+        (
+            "2h",
+            r"you cannot combine time durations like '2h' with integer durations like '3i'",
+        ),
+    ],
+)
+def test_groupby_dynamic_validation(every: str, match: str) -> None:
+    df = pl.DataFrame(
+        {
+            "index": [0, 0, 1, 1],
+            "group": ["banana", "pear", "banana", "pear"],
+            "weight": [2, 3, 5, 7],
+        }
+    )
+
+    with pytest.raises(pl.ComputeError, match=match):
+        df.groupby_dynamic("index", by="group", every=every, period="2i").agg(
+            pl.col("weight")
+        )


### PR DESCRIPTION
Don't panic, but return proper errors and check `every` input.

Fixes #7859