### PR TITLE
fix(python): ensure `_repr_html_` escapes column names in addition to data/body elements

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -88,7 +88,7 @@ class HTMLFormatter:
                         if c == -1:
                             self.elements.append("&hellip;")
                         else:
-                            self.elements.append(columns[c])
+                            self.elements.append(html.escape(columns[c]))
             with Tag(self.elements, "tr"):
                 dtypes = self.df._df.dtype_strings()
                 for c in self.col_idx:
@@ -110,7 +110,6 @@ class HTMLFormatter:
                                 self.elements.append("&hellip;")
                             else:
                                 series = self.df[:, c]
-
                                 self.elements.append(
                                     html.escape(series._s.get_fmt(r, str_lengths))
                                 )

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1341,10 +1341,30 @@ def test_literal_series() -> None:
     )
 
 
-def test_to_html(df: pl.DataFrame) -> None:
-    # check it does not panic/error, and appears to contain a table
+def test_to_html() -> None:
+    # check it does not panic/error, and appears to contain
+    # a reasonable table with suitably escaped html entities.
+    df = pl.DataFrame(
+        {
+            "foo": [1, 2, 3],
+            "<bar>": ["a", "b", "c"],
+            "<baz": ["a", "b", "c"],
+            "spam>": ["a", "b", "c"],
+        }
+    )
     html = df._repr_html_()
-    assert "<table" in html
+    for match in (
+        "<table",
+        'class="dataframe"',
+        "<th>foo</th>",
+        "<th>&lt;bar&gt;</th>",
+        "<th>&lt;baz</th>",
+        "<th>spam&gt;</th>",
+        "<td>1</td>",
+        "<td>2</td>",
+        "<td>3</td>",
+    ):
+        assert match in html, f"Expected to find {match!r} in html repr"
 
 
 def test_rename(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Closes #7874.