### PR TITLE
feat(rust, python): deal with null values in cut/qcut

### DIFF
--- a/polars/polars-core/src/chunked_array/from.rs
+++ b/polars/polars-core/src/chunked_array/from.rs
@@ -69,6 +69,21 @@ where
         out.compute_len();
         out
     }
+
+    /// # Safety
+    /// The Arrow datatype of all chunks must match the [`PolarsDataType`] `T`.
+    pub unsafe fn with_chunks(&self, chunks: Vec<ArrayRef>) -> Self {
+        let field = self.field.clone();
+        let mut out = ChunkedArray {
+            field,
+            chunks,
+            phantom: PhantomData,
+            bit_settings: Default::default(),
+            length: 0,
+        };
+        out.compute_len();
+        out
+    }
 }
 
 impl ListChunked {

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -31,6 +31,7 @@ mod interpolate;
 #[cfg(feature = "is_in")]
 mod is_in;
 mod len;
+mod nulls;
 mod peaks;
 #[cfg(feature = "repeat_by")]
 mod repeat_by;

--- a/polars/polars-core/src/chunked_array/ops/nulls.rs
+++ b/polars/polars-core/src/chunked_array/ops/nulls.rs
@@ -1,0 +1,74 @@
+use arrow::bitmap::Bitmap;
+
+use super::*;
+
+impl<T: PolarsDataType> ChunkedArray<T> {
+    /// Get a mask of the null values.
+    pub fn is_null(&self) -> BooleanChunked {
+        if !self.has_validity() {
+            return BooleanChunked::full(self.name(), false, self.len());
+        }
+        // dispatch to non-generic function
+        is_null(self.name(), &self.chunks)
+    }
+
+    /// Get a mask of the valid values.
+    pub fn is_not_null(&self) -> BooleanChunked {
+        if self.null_count() == 0 {
+            return BooleanChunked::full(self.name(), true, self.len());
+        }
+        // dispatch to non-generic function
+        is_not_null(self.name(), &self.chunks)
+    }
+
+    pub(crate) fn coalesce_nulls(&self, other: &[ArrayRef]) -> Self {
+        let chunks = coalesce_nulls(&self.chunks, other);
+        self.copy_with_chunks(chunks, true, false)
+    }
+}
+pub fn is_not_null(name: &str, chunks: &[ArrayRef]) -> BooleanChunked {
+    let chunks = chunks
+        .iter()
+        .map(|arr| {
+            let bitmap = arr
+                .validity()
+                .cloned()
+                .unwrap_or_else(|| !(&Bitmap::new_zeroed(arr.len())));
+            Box::new(BooleanArray::from_data_default(bitmap, None)) as ArrayRef
+        })
+        .collect::<Vec<_>>();
+    unsafe { BooleanChunked::from_chunks(name, chunks) }
+}
+
+pub fn is_null(name: &str, chunks: &[ArrayRef]) -> BooleanChunked {
+    let chunks = chunks
+        .iter()
+        .map(|arr| {
+            let bitmap = arr
+                .validity()
+                .map(|bitmap| !bitmap)
+                .unwrap_or_else(|| Bitmap::new_zeroed(arr.len()));
+            Box::new(BooleanArray::from_data_default(bitmap, None)) as ArrayRef
+        })
+        .collect::<Vec<_>>();
+    unsafe { BooleanChunked::from_chunks(name, chunks) }
+}
+
+pub(crate) fn coalesce_nulls(chunks: &[ArrayRef], other: &[ArrayRef]) -> Vec<ArrayRef> {
+    assert_eq!(chunks.len(), other.len());
+    chunks
+        .iter()
+        .zip(other)
+        .map(|(a, b)| {
+            assert_eq!(a.len(), b.len());
+            let validity = match (a.validity(), b.validity()) {
+                (None, Some(b)) => Some(b.clone()),
+                (Some(a), Some(b)) => Some(a & b),
+                (Some(a), None) => Some(a.clone()),
+                (None, None) => None,
+            };
+
+            a.with_validity(validity)
+        })
+        .collect()
+}

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -173,7 +173,7 @@ impl Series {
 
     /// # Safety
     /// The caller must ensure the length and the data types of `ArrayRef` does not change.
-    pub(crate) unsafe fn chunks_mut(&mut self) -> &mut Vec<ArrayRef> {
+    pub unsafe fn chunks_mut(&mut self) -> &mut Vec<ArrayRef> {
         #[allow(unused_mut)]
         let mut ca = self._get_inner_mut();
         let chunks = ca.chunks() as *const Vec<ArrayRef> as *mut Vec<ArrayRef>;

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -74,3 +74,15 @@ def test_hist() -> None:
         str(a.hist(bin_count=4).to_dict(False))
         == "{'break_point': [0.0, 2.25, 4.5, 6.75, inf], 'category': ['(-inf, 0.0]', '(0.0, 2.25]', '(2.25, 4.5]', '(4.5, 6.75]', '(6.75, inf]'], 'a_count': [0, 3, 2, 0, 2]}"
     )
+
+
+def test_cut_null_values() -> None:
+    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
+    assert (
+        str(s.qcut([0.2, 0.3], maintain_order=True).to_dict(False))
+        == "{'': [-1.0, None, 1.0, 2.0, None, 8.0, 4.0], 'break_point': [0.5999999999999996, None, 1.2000000000000002, inf, None, inf, inf], 'category': ['(-inf, 0.5999999999999996]', None, '(0.5999999999999996, 1.2000000000000002]', '(1.2000000000000002, inf]', None, '(1.2000000000000002, inf]', '(1.2000000000000002, inf]']}"
+    )
+    assert (
+        str(s.qcut([0.2, 0.3], maintain_order=False).to_dict(False))
+        == "{'': [-1.0, 1.0, 2.0, 4.0, 8.0, None, None], 'break_point': [0.5999999999999996, 1.2000000000000002, inf, inf, inf, None, None], 'category': ['(-inf, 0.5999999999999996]', '(0.5999999999999996, 1.2000000000000002]', '(1.2000000000000002, inf]', '(1.2000000000000002, inf]', '(1.2000000000000002, inf]', None, None]}"
+    )


### PR DESCRIPTION
Also added fast path for boolean sorts.

closes #7864
