### PR TITLE
feat(rust, python): auto-infer detecting time-zone-awareness of fmt argument in strptime; deprecate tz_aware argument

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -9,7 +9,8 @@ use regex::{escape, Regex};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "timezones")]
-static TZ_AWARE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(%z)|(%:z)|(%#z)|(^%\+$)").unwrap());
+static TZ_AWARE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(%z)|(%:z)|(%::z)|(%:::z)|(%#z)|(^%\+$)").unwrap());
 
 use super::*;
 
@@ -341,7 +342,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
                 (Some(tz), false, false) => Some(tz.clone()),
                 (Some(_), true, _) => polars_bail!(
                     ComputeError:
-                    "cannot use strptime with both 'tz_aware=True' and tz-aware datetime, \
+                    "cannot use strptime with both a tz-aware format and a tz-aware dtype, \
                     please drop time zone from the dtype"
                 ),
                 (Some(_), _, true) => polars_bail!(

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1936,10 +1936,10 @@ def test_strptime_with_invalid_tz() -> None:
         pl.Series(["2020-01-01 03:00:00"]).str.strptime(pl.Datetime("us", "foo"))
     with pytest.raises(
         ComputeError,
-        match="cannot use strptime with both 'tz_aware=True' and tz-aware datetime",
+        match="cannot use strptime with both a tz-aware format and a tz-aware dtype",
     ):
         pl.Series(["2020-01-01 03:00:00+01:00"]).str.strptime(
-            pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S%z", tz_aware=True
+            pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S%z"
         )
     with pytest.raises(
         ComputeError,

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -387,5 +387,9 @@ def test_tz_aware_without_fmt() -> None:
             r"^passing 'tz_aware=True' without 'fmt' is not yet supported, "
             r"please specify 'fmt'$"
         ),
+    ), pytest.warns(
+        DeprecationWarning,
+        match="`tz_aware` is now auto-inferred from `fmt` and will be removed "
+        "in a future version. You can safely drop this argument.",
     ):
         pl.Series(["2020-01-01"]).str.strptime(pl.Datetime, tz_aware=True)


### PR DESCRIPTION
closes #7885 