### PR TITLE
fix(rust, python): fix boolean min/max output type and null handling

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_null.rs
@@ -326,10 +326,10 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
             Ok(out.into_series())
         }
         FillNullStrategy::Min => ca
-            .fill_null_with_values(1 == ca.min().ok_or_else(err_fill_null)?)
+            .fill_null_with_values(ca.min().ok_or_else(err_fill_null)?)
             .map(|ca| ca.into_series()),
         FillNullStrategy::Max => ca
-            .fill_null_with_values(1 == ca.max().ok_or_else(err_fill_null)?)
+            .fill_null_with_values(ca.max().ok_or_else(err_fill_null)?)
             .map(|ca| ca.into_series()),
         FillNullStrategy::Mean => polars_bail!(opq = mean, "Boolean"),
         FillNullStrategy::One | FillNullStrategy::MaxBound => {

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -232,7 +232,7 @@ impl BooleanChunked {
                     // TODO! optimize this
                     // can just check if any is false and early stop
                     let take = { self.take_unchecked(idx.into()) };
-                    take.min().map(|v| v == 1)
+                    take.min()
                 }
             }),
             GroupsProxy::Slice {
@@ -245,7 +245,7 @@ impl BooleanChunked {
                     1 => self.get(first as usize),
                     _ => {
                         let arr_group = _slice_from_offsets(self, first, len);
-                        arr_group.min().map(|v| v == 1)
+                        arr_group.min()
                     }
                 }
             }),
@@ -274,7 +274,7 @@ impl BooleanChunked {
                     // TODO! optimize this
                     // can just check if any is true and early stop
                     let take = { self.take_unchecked(idx.into()) };
-                    take.max().map(|v| v == 1)
+                    take.max()
                 }
             }),
             GroupsProxy::Slice {
@@ -287,7 +287,7 @@ impl BooleanChunked {
                     1 => self.get(first as usize),
                     _ => {
                         let arr_group = _slice_from_offsets(self, first, len);
-                        arr_group.max().map(|v| v == 1)
+                        arr_group.max()
                     }
                 }
             }),

--- a/polars/polars-ops/src/chunked_array/list/min_max.rs
+++ b/polars/polars-ops/src/chunked_array/list/min_max.rs
@@ -77,7 +77,7 @@ pub(super) fn list_min_function(ca: &ListChunked) -> Series {
     fn inner(ca: &ListChunked) -> Series {
         match ca.inner_dtype() {
             DataType::Boolean => {
-                let out: IdxCa = ca
+                let out: BooleanChunked = ca
                     .amortized_iter()
                     .map(|s| s.and_then(|s| s.as_ref().bool().unwrap().min()))
                     .collect_trusted();
@@ -183,7 +183,7 @@ pub(super) fn list_max_function(ca: &ListChunked) -> Series {
     fn inner(ca: &ListChunked) -> Series {
         match ca.inner_dtype() {
             DataType::Boolean => {
-                let out: IdxCa = ca
+                let out: BooleanChunked = ca
                     .amortized_iter()
                     .map(|s| s.and_then(|s| s.as_ref().bool().unwrap().max()))
                     .collect_trusted();

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -26,3 +26,16 @@ def test_bool_arg_min_max() -> None:
 
 def test_bool_sum_empty() -> None:
     assert pl.Series([], dtype=pl.Boolean).sum() == 0
+
+
+def test_bool_min_max() -> None:
+    assert pl.Series([None, True]).min()
+    assert not pl.Series([None, True, False]).min()
+    assert not pl.Series([False, True]).min()
+    assert pl.Series([True, True]).min()
+    assert not pl.Series([False, False]).min()
+    assert pl.Series([None, True]).max()
+    assert pl.Series([None, True, False]).max()
+    assert pl.Series([False, True]).max()
+    assert pl.Series([True, True]).max()
+    assert not pl.Series([False, False]).max()


### PR DESCRIPTION
fixes #7890