### PR TITLE
fix(rust, python): fix abs logical type

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -825,7 +825,7 @@ impl Series {
             Float64 => a.f64().unwrap().abs().into_series(),
             dt => polars_bail!(opq = abs, dt),
         };
-        Ok(out)
+        out.cast(self.dtype())
     }
 
     #[cfg(feature = "private")]

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from datetime import timedelta
 
 import numpy as np
 import pytest
@@ -357,3 +358,8 @@ def test_max() -> None:
 
     result = df.select(pl.max("a", 3))
     assert_frame_equal(result, pl.DataFrame({"max": [3, 4]}))
+
+
+def test_abs_logical_type() -> None:
+    s = pl.Series([timedelta(hours=1), timedelta(hours=-1)])
+    assert s.abs().to_list() == [timedelta(hours=1), timedelta(hours=1)]


### PR DESCRIPTION
fixes #7893