### PR TITLE
fix(python): Use `check_exact` for temporal types in `assert_series_equal`

### DIFF
--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -6,7 +6,6 @@ from typing import Any
 from polars import functions as F
 from polars.dataframe import DataFrame
 from polars.datatypes import (
-    Boolean,
     Categorical,
     DataTypeClass,
     Float32,
@@ -320,7 +319,9 @@ def _assert_series_inner(
     except NotImplementedError:
         can_be_subtracted = False
 
-    check_exact = check_exact or not can_be_subtracted or left.dtype == Boolean
+    check_exact = (
+        check_exact or not can_be_subtracted or left.is_boolean() or left.is_temporal()
+    )
     if check_dtype and left.dtype != right.dtype:
         raise_assert_detail("Series", "Dtype mismatch", left.dtype, right.dtype)
 

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+from typing import Any
 
 import pytest
 
@@ -296,7 +297,7 @@ def test_assert_series_equal_int_overflow() -> None:
         ([timedelta(10, 0, 0)], [timedelta(10, 0, 10)]),
     ],
 )
-def test_assert_series_equal_temporal(data1, data2) -> None:
+def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
     s1 = pl.Series(data1)
     s2 = pl.Series(data2)
     assert_series_not_equal(s1, s2)

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, time, timedelta
+
 import pytest
 
 import polars as pl
@@ -284,3 +286,17 @@ def test_assert_series_equal_int_overflow() -> None:
         assert_series_equal(s0, s0, check_exact=check_exact)
         with pytest.raises(AssertionError):
             assert_series_equal(s1, s2, check_exact=check_exact)
+
+
+@pytest.mark.parametrize(
+    ("data1", "data2"),
+    [
+        ([datetime(2022, 10, 2, 12)], [datetime(2022, 10, 2, 13)]),
+        ([time(10, 0, 0)], [time(10, 0, 10)]),
+        ([timedelta(10, 0, 0)], [timedelta(10, 0, 10)]),
+    ],
+)
+def test_assert_series_equal_temporal(data1, data2) -> None:
+    s1 = pl.Series(data1)
+    s2 = pl.Series(data2)
+    assert_series_not_equal(s1, s2)


### PR DESCRIPTION
Closes #7892

Not sure this is the most satisfying solution, but it works for now.

Ideally, we'd also be able to check temporal types with a tolerance.