### PR TITLE
perf(rust, python): use streaming instead of partitioned groupby

### DIFF
--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -403,6 +403,14 @@ pub fn create_physical_plan(
                     }
                 });
                 let input = create_physical_plan(input, lp_arena, expr_arena)?;
+                let keys = keys
+                    .iter()
+                    .map(|node| node_to_expr(*node, expr_arena))
+                    .collect::<Vec<_>>();
+                let aggs = aggs
+                    .iter()
+                    .map(|node| node_to_expr(*node, expr_arena))
+                    .collect::<Vec<_>>();
                 Ok(Box::new(executors::PartitionGroupByExec::new(
                     input,
                     phys_keys,
@@ -412,6 +420,8 @@ pub fn create_physical_plan(
                     input_schema,
                     schema,
                     from_partitioned_ds,
+                    keys,
+                    aggs,
                 )))
             } else {
                 let input = create_physical_plan(input, lp_arena, expr_arena)?;

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -176,14 +176,12 @@ impl ExecutionState {
             node_timer: None,
         }
     }
-    #[cfg(not(feature = "streaming"))]
     pub(crate) fn set_schema(&self, schema: SchemaRef) {
         let mut lock = self.schema_cache.write().unwrap();
         *lock = Some(schema);
     }
 
     /// Clear the schema. Typically at the end of a projection.
-    #[cfg(not(feature = "streaming"))]
     pub(crate) fn clear_schema_cache(&self) {
         let mut lock = self.schema_cache.write().unwrap();
         *lock = None;

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -176,12 +176,14 @@ impl ExecutionState {
             node_timer: None,
         }
     }
+    #[cfg(not(feature = "streaming"))]
     pub(crate) fn set_schema(&self, schema: SchemaRef) {
         let mut lock = self.schema_cache.write().unwrap();
         *lock = Some(schema);
     }
 
     /// Clear the schema. Typically at the end of a projection.
+    #[cfg(not(feature = "streaming"))]
     pub(crate) fn clear_schema_cache(&self) {
         let mut lock = self.schema_cache.write().unwrap();
         *lock = None;

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -331,6 +331,7 @@ def test_streaming_categorical() -> None:
                 .groupby("name")
                 .agg(pl.col("amount").sum())
                 .collect()
+                .sort("name")
             )
             expected = pl.DataFrame(
                 {"name": ["Bob", "Alice"], "amount": [400, 200]},


### PR DESCRIPTION
Still runs streaming groupby, but first estimate cardinality.