### PR TITLE
refactor(python)!: Use `time_unit`/`time_zone` instead of `tu`/`tz`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7919,7 +7919,9 @@ class DataFrame:
                 named
                 and _PYARROW_AVAILABLE
                 # note: 'ns' precision instantiates values as pandas types - avoid
-                and not any((getattr(tp, "tu", None) == "ns") for tp in self.dtypes)
+                and not any(
+                    (getattr(tp, "time_unit", None) == "ns") for tp in self.dtypes
+                )
             )
             for offset in range(0, self.height, buffer_size):
                 zerocopy_slice = self.slice(offset, buffer_size)

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -192,8 +192,8 @@ class Time(TemporalType):
 class Datetime(TemporalType):
     """Calendar date and time type."""
 
-    tu: TimeUnit | None = None
-    tz: str | None = None
+    time_unit: TimeUnit | None = None
+    time_zone: str | None = None
 
     def __init__(self, time_unit: TimeUnit | None = "us", time_zone: str | None = None):
         """
@@ -202,18 +202,18 @@ class Datetime(TemporalType):
         Parameters
         ----------
         time_unit : {'us', 'ns', 'ms'}
-            Time unit.
+            Unit of time.
         time_zone
-            Timezone string as defined in zoneinfo (run
+            Time zone string as defined in zoneinfo (run
             ``import zoneinfo; zoneinfo.available_timezones()`` for a full list).
 
         """
-        self.tu = time_unit or "us"
-        self.tz = time_zone
+        self.time_unit = time_unit or "us"
+        self.time_zone = time_zone
 
-        if self.tu not in ("ms", "us", "ns"):
+        if self.time_unit not in ("ms", "us", "ns"):
             raise ValueError(
-                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.tu!r}"
+                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.time_unit!r}"
             )
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
@@ -221,22 +221,26 @@ class Datetime(TemporalType):
         if type(other) is DataTypeClass and issubclass(other, Datetime):
             return True
         elif isinstance(other, Datetime):
-            return self.tu == other.tu and self.tz == other.tz
+            return (
+                self.time_unit == other.time_unit and self.time_zone == other.time_zone
+            )
         else:
             return False
 
     def __hash__(self) -> int:
-        return hash((Datetime, self.tu))
+        return hash((Datetime, self.time_unit))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}(time_unit={self.tu!r}, time_zone={self.tz!r})"
+        return (
+            f"{class_name}(time_unit={self.time_unit!r}, time_zone={self.time_zone!r})"
+        )
 
 
 class Duration(TemporalType):
     """Time duration/delta type."""
 
-    tu: TimeUnit | None = None
+    time_unit: TimeUnit | None = None
 
     def __init__(self, time_unit: TimeUnit = "us"):
         """
@@ -245,13 +249,13 @@ class Duration(TemporalType):
         Parameters
         ----------
         time_unit : {'us', 'ns', 'ms'}
-            Time unit.
+            Unit of time.
 
         """
-        self.tu = time_unit
-        if self.tu not in ("ms", "us", "ns"):
+        self.time_unit = time_unit
+        if self.time_unit not in ("ms", "us", "ns"):
             raise ValueError(
-                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.tu!r}"
+                f"Invalid time_unit; expected one of {{'ns','us','ms'}}, got {self.time_unit!r}"
             )
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
@@ -259,16 +263,16 @@ class Duration(TemporalType):
         if type(other) is DataTypeClass and issubclass(other, Duration):
             return True
         elif isinstance(other, Duration):
-            return self.tu == other.tu
+            return self.time_unit == other.time_unit
         else:
             return False
 
     def __hash__(self) -> int:
-        return hash((Duration, self.tu))
+        return hash((Duration, self.time_unit))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}(time_unit={self.tu!r})"
+        return f"{class_name}(time_unit={self.time_unit!r})"
 
 
 class Categorical(DataType):

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -407,13 +407,13 @@ def dtype_to_arrow_type(dtype: PolarsDataType) -> pa.lib.DataType:
     try:
         # special handling for mapping to tz-aware timestamp type.
         # (don't want to include every possible tz string in the lookup)
-        tz = None
+        time_zone = None
         if dtype == Datetime:
-            dtype, tz = Datetime(dtype.tu), dtype.tz  # type: ignore[union-attr]
+            dtype, time_zone = Datetime(dtype.time_unit), dtype.time_zone  # type: ignore[union-attr]
 
         arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
-        if tz:
-            arrow_type = pa.timestamp(dtype.tu or "us", tz)  # type: ignore[union-attr]
+        if time_zone:
+            arrow_type = pa.timestamp(dtype.time_unit or "us", time_zone)  # type: ignore[union-attr]
         return arrow_type
     except KeyError:  # pragma: no cover
         raise ValueError(

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -135,8 +135,8 @@ class ExprStringNameSpace:
         if datatype == Date:
             return wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
         elif datatype == Datetime:
-            tu = datatype.tu  # type: ignore[union-attr]
-            tz = datatype.tz  # type: ignore[union-attr]
+            time_unit = datatype.time_unit  # type: ignore[union-attr]
+            time_zone = datatype.time_zone  # type: ignore[union-attr]
             dtcol = wrap_expr(
                 self._pyexpr.str_parse_datetime(
                     fmt,
@@ -145,11 +145,11 @@ class ExprStringNameSpace:
                     cache,
                     tz_aware,
                     utc,
-                    tu,
-                    tz,
+                    time_unit,
+                    time_zone,
                 )
             )
-            return dtcol if (tu is None) else dtcol.dt.cast_time_unit(tu)
+            return dtcol if (time_unit is None) else dtcol.dt.cast_time_unit(time_unit)
         elif datatype == Time:
             return wrap_expr(self._pyexpr.str_parse_time(fmt, strict, exact, cache))
         else:  # pragma: no cover

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -494,18 +494,18 @@ def date_range(
         if time_zone is None and low.tzinfo is not None:
             time_zone = _tzinfo_to_str(low.tzinfo)
 
-    tu: TimeUnit
+    time_unit_: TimeUnit
     if time_unit is not None:
-        tu = time_unit
+        time_unit_ = time_unit
     elif "ns" in interval:
-        tu = "ns"
+        time_unit_ = "ns"
     else:
-        tu = "us"
+        time_unit_ = "us"
 
-    start = _datetime_to_pl_timestamp(low, tu)
-    stop = _datetime_to_pl_timestamp(high, tu)
+    start = _datetime_to_pl_timestamp(low, time_unit_)
+    stop = _datetime_to_pl_timestamp(high, time_unit_)
     dt_range = wrap_s(
-        _py_date_range(start, stop, interval, closed, name, tu, time_zone)
+        _py_date_range(start, stop, interval, closed, name, time_unit_, time_zone)
     )
     if (
         low_is_date

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3745,9 +3745,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             elif isinstance(value, float):
                 dtypes = [Float64]
             elif isinstance(value, datetime):
-                dtypes = [Datetime] + [Datetime(tu) for tu in DTYPE_TEMPORAL_UNITS]
+                dtypes = [Datetime] + [Datetime(u) for u in DTYPE_TEMPORAL_UNITS]
             elif isinstance(value, timedelta):
-                dtypes = [Duration] + [Duration(tu) for tu in DTYPE_TEMPORAL_UNITS]
+                dtypes = [Duration] + [Duration(u) for u in DTYPE_TEMPORAL_UNITS]
             elif isinstance(value, date):
                 dtypes = [Date]
             elif isinstance(value, time):

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -874,13 +874,13 @@ class DateTimeNameSpace:
 
         """
 
-    def timestamp(self, tu: TimeUnit = "us") -> Series:
+    def timestamp(self, time_unit: TimeUnit = "us") -> Series:
         """
         Return a timestamp in the given time unit.
 
         Parameters
         ----------
-        tu : {'us', 'ns', 'ms'}
+        time_unit : {'us', 'ns', 'ms'}
             Time unit.
 
         Examples
@@ -905,7 +905,7 @@ class DateTimeNameSpace:
                 978393600000000
                 978480000000000
         ]
-        >>> date.dt.timestamp(tu="ns").alias("timestamp_ns")
+        >>> date.dt.timestamp("ns").alias("timestamp_ns")
         shape: (3,)
         Series: 'timestamp_ns' [i64]
         [
@@ -916,14 +916,14 @@ class DateTimeNameSpace:
 
         """
 
-    def epoch(self, tu: EpochTimeUnit = "us") -> Series:
+    def epoch(self, time_unit: EpochTimeUnit = "us") -> Series:
         """
         Get the time passed since the Unix EPOCH in the give time unit.
 
         Parameters
         ----------
-        tu : {'us', 'ns', 'ms', 's', 'd'}
-            Time unit.
+        time_unit : {'us', 'ns', 'ms', 's', 'd'}
+            Unit of time.
 
         Examples
         --------
@@ -947,7 +947,7 @@ class DateTimeNameSpace:
                 978393600000000
                 978480000000000
         ]
-        >>> date.dt.epoch(tu="s").alias("epoch_s")
+        >>> date.dt.epoch(time_unit="s").alias("epoch_s")
         shape: (3,)
         Series: 'epoch_s' [i64]
         [
@@ -958,7 +958,7 @@ class DateTimeNameSpace:
 
         """
 
-    def with_time_unit(self, tu: TimeUnit) -> Series:
+    def with_time_unit(self, time_unit: TimeUnit) -> Series:
         """
         Set time unit a Series of dtype Datetime or Duration.
 
@@ -967,8 +967,8 @@ class DateTimeNameSpace:
 
         Parameters
         ----------
-        tu : {'ns', 'us', 'ms'}
-            Time unit for the ``Datetime`` Series.
+        time_unit : {'ns', 'us', 'ms'}
+            Unit of time for the ``Datetime`` Series.
 
         Examples
         --------
@@ -984,9 +984,9 @@ class DateTimeNameSpace:
                 2001-01-02 00:00:00
                 2001-01-03 00:00:00
         ]
-        >>> date.dt.with_time_unit(tu="us").alias("tu_us")
+        >>> date.dt.with_time_unit("us").alias("time_unit_us")
         shape: (3,)
-        Series: 'tu_us' [datetime[μs]]
+        Series: 'time_unit_us' [datetime[μs]]
         [
                 +32971-04-28 00:00:00
                 +32974-01-22 00:00:00
@@ -995,14 +995,14 @@ class DateTimeNameSpace:
 
         """
 
-    def cast_time_unit(self, tu: TimeUnit) -> Series:
+    def cast_time_unit(self, time_unit: TimeUnit) -> Series:
         """
         Cast the underlying data to another time unit. This may lose precision.
 
         Parameters
         ----------
-        tu : {'ns', 'us', 'ms'}
-            Time unit for the ``Datetime`` Series.
+        time_unit : {'ns', 'us', 'ms'}
+            Unit of time for the ``Datetime`` Series.
 
         Examples
         --------
@@ -1018,17 +1018,17 @@ class DateTimeNameSpace:
                 2001-01-02 00:00:00
                 2001-01-03 00:00:00
         ]
-        >>> date.dt.cast_time_unit(tu="ms").alias("tu_ms")
+        >>> date.dt.cast_time_unit("ms").alias("time_unit_ms")
         shape: (3,)
-        Series: 'tu_ms' [datetime[ms]]
+        Series: 'time_unit_ms' [datetime[ms]]
         [
                 2001-01-01 00:00:00
                 2001-01-02 00:00:00
                 2001-01-03 00:00:00
         ]
-        >>> date.dt.cast_time_unit(tu="ns").alias("tu_ns")
+        >>> date.dt.cast_time_unit("ns").alias("time_unit_ns")
         shape: (3,)
-        Series: 'tu_ns' [datetime[ns]]
+        Series: 'time_unit_ns' [datetime[ns]]
         [
                 2001-01-01 00:00:00
                 2001-01-02 00:00:00
@@ -1060,7 +1060,7 @@ class DateTimeNameSpace:
                 2020-04-01 00:00:00 UTC
                 2020-05-01 00:00:00 UTC
         ]
-        >>> date = date.dt.convert_time_zone(time_zone="Europe/London").alias("London")
+        >>> date = date.dt.convert_time_zone("Europe/London").alias("London")
         >>> date
         shape: (3,)
         Series: 'London' [datetime[μs, Europe/London]]
@@ -1097,7 +1097,7 @@ class DateTimeNameSpace:
                 2020-04-01 00:00:00 UTC
                 2020-05-01 00:00:00 UTC
         ]
-        >>> date.dt.epoch(tu="s")
+        >>> date.dt.epoch("s")
         shape: (3,)
         Series: '' [i64]
         [
@@ -1115,7 +1115,7 @@ class DateTimeNameSpace:
             2020-05-01 01:00:00 BST
         ]
         >>> # Timestamps have not changed after convert_time_zone
-        >>> date.dt.epoch(tu="s")
+        >>> date.dt.epoch(time_unit="s")
         shape: (3,)
         Series: 'London' [i64]
         [
@@ -1133,7 +1133,7 @@ class DateTimeNameSpace:
             2020-05-01 01:00:00 EDT
         ]
         >>> # Timestamps have changed after replace_time_zone
-        >>> date.dt.epoch(tu="s")
+        >>> date.dt.epoch(time_unit="s")
         shape: (3,)
         Series: 'NYC' [i64]
         [
@@ -1654,7 +1654,7 @@ class DateTimeNameSpace:
 
         """
 
-    def combine(self, tm: dt.time | Series, tu: TimeUnit = "us") -> Expr:
+    def combine(self, time: dt.time | Series, time_unit: TimeUnit = "us") -> Expr:
         """
         Create a naive Datetime from an existing Date/Datetime expression and a Time.
 
@@ -1663,10 +1663,10 @@ class DateTimeNameSpace:
 
         Parameters
         ----------
-        tm
+        time
             A python time literal or Series of the same length as this Series.
-        tu : {'ns', 'us', 'ms'}
-            Time unit.
+        time_unit : {'ns', 'us', 'ms'}
+            Unit of time.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5663,14 +5663,14 @@ def _resolve_datetime_dtype(
     dtype: PolarsDataType | None, ndtype: np.datetime64
 ) -> PolarsDataType | None:
     """Given polars/numpy datetime dtypes, resolve to an explicit unit."""
-    if dtype is None or (dtype == Datetime and not getattr(dtype, "tu", None)):
-        tu = getattr(dtype, "tu", None) or np.datetime_data(ndtype)[0]
+    if dtype is None or (dtype == Datetime and not getattr(dtype, "time_unit", None)):
+        time_unit = getattr(dtype, "time_unit", None) or np.datetime_data(ndtype)[0]
         # explicit formulation is verbose, but keeps mypy happy
         # (and avoids unsupported timeunits such as "s")
-        if tu == "ns":
+        if time_unit == "ns":
             dtype = Datetime("ns")
-        elif tu == "us":
+        elif time_unit == "us":
             dtype = Datetime("us")
-        elif tu == "ms":
+        elif time_unit == "ms":
             dtype = Datetime("ms")
     return dtype

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -376,7 +376,7 @@ def sequence_to_pyseries(
                 dtype = py_type_to_dtype(python_dtype)  # construct from integer
             elif dtype in py_temporal_types:
                 dtype = py_type_to_dtype(dtype)
-            time_unit = getattr(dtype, "tu", None)
+            time_unit = getattr(dtype, "time_unit", None)
 
             # we use anyvalue builder to create the datetime array
             # we store the values internally as UTC and set the timezone
@@ -387,7 +387,7 @@ def sequence_to_pyseries(
                 s = wrap_s(py_series).dt.cast_time_unit(time_unit)
             if dtype == Datetime and value.tzinfo is not None:
                 tz = _tzinfo_to_str(value.tzinfo)
-                dtype_tz = dtype.tz  # type: ignore[union-attr]
+                dtype_tz = dtype.time_zone  # type: ignore[union-attr]
                 if dtype_tz is not None and tz != dtype_tz:
                     raise ValueError(
                         "Given time_zone is different from that of timezone aware datetimes."

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -266,7 +266,7 @@ def _cast_repr_strings_with_schema(
     for c, tp in schema.items():
         if tp is not None:
             if tp.base_type() == Datetime:
-                tp_base = Datetime(tp.tu)  # type: ignore[union-attr]
+                tp_base = Datetime(tp.time_unit)  # type: ignore[union-attr]
                 d = F.col(c).str.replace(r"[A-Z ]+$", "")
                 cast_cols[c] = (
                     F.when(d.str.lengths() == 19)
@@ -275,8 +275,8 @@ def _cast_repr_strings_with_schema(
                     .str.slice(0, 29)
                     .str.strptime(tp_base, "%Y-%m-%d %H:%M:%S.%9f")
                 )
-                if getattr(tp, "tz", None) is not None:
-                    cast_cols[c] = cast_cols[c].dt.replace_time_zone(tp.tz)  # type: ignore[union-attr]
+                if getattr(tp, "time_zone", None) is not None:
+                    cast_cols[c] = cast_cols[c].dt.replace_time_zone(tp.time_zone)  # type: ignore[union-attr]
             elif tp == Date:
                 cast_cols[c] = F.col(c).str.strptime(tp, "%Y-%m-%d")  # type: ignore[arg-type]
             elif tp == Time:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -564,7 +564,7 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (fmt, strict, exact, cache, tz_aware, utc, tu, tz))]
+    #[pyo3(signature = (fmt, strict, exact, cache, tz_aware, utc, time_unit, time_zone))]
     #[allow(clippy::too_many_arguments)]
     pub fn str_parse_datetime(
         &self,
@@ -574,11 +574,11 @@ impl PyExpr {
         cache: bool,
         tz_aware: bool,
         utc: bool,
-        tu: Option<Wrap<TimeUnit>>,
-        tz: Option<TimeZone>,
+        time_unit: Option<Wrap<TimeUnit>>,
+        time_zone: Option<TimeZone>,
     ) -> PyExpr {
-        let result_tu = match (&fmt, tu) {
-            (_, Some(tu)) => tu.0,
+        let result_time_unit = match (&fmt, time_unit) {
+            (_, Some(time_unit)) => time_unit.0,
             (Some(fmt), None) => {
                 if fmt.contains("%.9f")
                     || fmt.contains("%9f")
@@ -598,7 +598,7 @@ impl PyExpr {
             .clone()
             .str()
             .strptime(StrpTimeOptions {
-                date_dtype: DataType::Datetime(result_tu, tz),
+                date_dtype: DataType::Datetime(result_time_unit, time_zone),
                 fmt,
                 strict,
                 exact,
@@ -1056,8 +1056,8 @@ impl PyExpr {
             )
             .into()
     }
-    pub fn timestamp(&self, tu: Wrap<TimeUnit>) -> PyExpr {
-        self.inner.clone().dt().timestamp(tu.0).into()
+    pub fn timestamp(&self, time_unit: Wrap<TimeUnit>) -> PyExpr {
+        self.inner.clone().dt().timestamp(time_unit.0).into()
     }
 
     pub fn dt_offset_by(&self, by: &str) -> PyExpr {
@@ -1078,28 +1078,28 @@ impl PyExpr {
             .into()
     }
 
-    pub fn dt_with_time_unit(&self, tu: Wrap<TimeUnit>) -> PyExpr {
-        self.inner.clone().dt().with_time_unit(tu.0).into()
+    pub fn dt_with_time_unit(&self, time_unit: Wrap<TimeUnit>) -> PyExpr {
+        self.inner.clone().dt().with_time_unit(time_unit.0).into()
     }
 
     #[cfg(feature = "timezones")]
-    pub fn dt_convert_time_zone(&self, tz: TimeZone) -> PyExpr {
-        self.inner.clone().dt().convert_time_zone(tz).into()
+    pub fn dt_convert_time_zone(&self, time_zone: TimeZone) -> PyExpr {
+        self.inner.clone().dt().convert_time_zone(time_zone).into()
     }
 
-    pub fn dt_cast_time_unit(&self, tu: Wrap<TimeUnit>) -> PyExpr {
-        self.inner.clone().dt().cast_time_unit(tu.0).into()
+    pub fn dt_cast_time_unit(&self, time_unit: Wrap<TimeUnit>) -> PyExpr {
+        self.inner.clone().dt().cast_time_unit(time_unit.0).into()
     }
 
     #[cfg(feature = "timezones")]
-    pub fn dt_replace_time_zone(&self, tz: Option<String>) -> PyExpr {
-        self.inner.clone().dt().replace_time_zone(tz).into()
+    pub fn dt_replace_time_zone(&self, time_zone: Option<String>) -> PyExpr {
+        self.inner.clone().dt().replace_time_zone(time_zone).into()
     }
 
     #[cfg(feature = "timezones")]
     #[allow(deprecated)]
-    pub fn dt_tz_localize(&self, tz: String) -> PyExpr {
-        self.inner.clone().dt().tz_localize(tz).into()
+    pub fn dt_tz_localize(&self, time_zone: String) -> PyExpr {
+        self.inner.clone().dt().tz_localize(time_zone).into()
     }
 
     pub fn dt_truncate(&self, every: &str, offset: &str) -> PyExpr {
@@ -1110,8 +1110,12 @@ impl PyExpr {
         self.inner.clone().dt().round(every, offset).into()
     }
 
-    pub fn dt_combine(&self, time: PyExpr, tu: Wrap<TimeUnit>) -> PyExpr {
-        self.inner.clone().dt().combine(time.inner, tu.0).into()
+    pub fn dt_combine(&self, time: PyExpr, time_unit: Wrap<TimeUnit>) -> PyExpr {
+        self.inner
+            .clone()
+            .dt()
+            .combine(time.inner, time_unit.0)
+            .into()
     }
 
     #[pyo3(signature = (lambda, window_size, weights, min_periods, center))]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -502,8 +502,8 @@ fn py_date_range(
     every: &str,
     closed: Wrap<ClosedWindow>,
     name: &str,
-    tu: Wrap<TimeUnit>,
-    tz: Option<TimeZone>,
+    time_unit: Wrap<TimeUnit>,
+    time_zone: Option<TimeZone>,
 ) -> PyResult<PySeries> {
     let date_range = polars_rs::time::date_range_impl(
         name,
@@ -511,8 +511,8 @@ fn py_date_range(
         stop,
         Duration::parse(every),
         closed.0,
-        tu.0,
-        tz.as_ref(),
+        time_unit.0,
+        time_zone.as_ref(),
     )
     .map_err(PyPolarsErr::from)?;
     Ok(date_range.into_series().into())
@@ -525,12 +525,12 @@ fn py_date_range_lazy(
     every: &str,
     closed: Wrap<ClosedWindow>,
     name: String,
-    tz: Option<TimeZone>,
+    time_zone: Option<TimeZone>,
 ) -> PyExpr {
     let start = start.inner;
     let end = end.inner;
     let every = Duration::parse(every);
-    polars_rs::lazy::dsl::functions::date_range(name, start, end, every, closed.0, tz).into()
+    polars_rs::lazy::dsl::functions::date_range(name, start, end, every, closed.0, time_zone).into()
 }
 
 #[pyfunction]

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -1175,8 +1175,10 @@ impl PySeries {
     }
 
     pub fn time_unit(&self) -> Option<&str> {
-        if let DataType::Datetime(tu, _) | DataType::Duration(tu) = self.series.dtype() {
-            Some(match tu {
+        if let DataType::Datetime(time_unit, _) | DataType::Duration(time_unit) =
+            self.series.dtype()
+        {
+            Some(match time_unit {
                 TimeUnit::Nanoseconds => "ns",
                 TimeUnit::Microseconds => "us",
                 TimeUnit::Milliseconds => "ms",

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -468,9 +468,11 @@ def test_date_range() -> None:
     assert result.dt[2] == datetime(1985, 1, 4, 0, 0)
     assert result.dt[-1] == datetime(2015, 6, 30, 12, 0)
 
-    for tu in DTYPE_TEMPORAL_UNITS:
-        rng = pl.date_range(datetime(2020, 1, 1), date(2020, 1, 2), "2h", time_unit=tu)
-        assert rng.time_unit == tu
+    for time_unit in DTYPE_TEMPORAL_UNITS:
+        rng = pl.date_range(
+            datetime(2020, 1, 1), date(2020, 1, 2), "2h", time_unit=time_unit
+        )
+        assert rng.time_unit == time_unit
         assert rng.shape == (13,)
         assert rng.dt[0] == datetime(2020, 1, 1)
         assert rng.dt[-1] == datetime(2020, 1, 2)
@@ -505,7 +507,7 @@ def test_date_range() -> None:
         datetime(2022, 1, 1), datetime(2022, 1, 1, 0, 1), "987456321ns"
     )
     assert len(result) == 61
-    assert result.dtype.tu == "ns"  # type: ignore[union-attr]
+    assert result.dtype.time_unit == "ns"  # type: ignore[union-attr]
     assert result.dt.second()[-1] == 59
     assert result.cast(pl.Utf8)[-1] == "2022-01-01 00:00:59.247379260"
 
@@ -1622,10 +1624,10 @@ def test_datetime_instance_selection() -> None:
             ("ms", pl.Datetime("ms")),
         ],
     )
-    for tu in DTYPE_TEMPORAL_UNITS:
-        res = df.select(pl.col([pl.Datetime(tu)])).dtypes
-        assert res == [pl.Datetime(tu)]
-        assert len(df.filter(pl.col(tu) == test_data[tu][0])) == 1
+    for time_unit in DTYPE_TEMPORAL_UNITS:
+        res = df.select(pl.col([pl.Datetime(time_unit)])).dtypes
+        assert res == [pl.Datetime(time_unit)]
+        assert len(df.filter(pl.col(time_unit) == test_data[time_unit][0])) == 1
 
     assert [] == list(df.select(pl.exclude(DATETIME_DTYPES)))
 
@@ -1911,14 +1913,14 @@ def test_replace_timezone() -> None:
     ],
 )
 @pytest.mark.parametrize("from_tz", ["Asia/Seoul", "-01:00", None])
-@pytest.mark.parametrize("tu", ["ms", "us", "ns"])
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_replace_timezone_from_to(
     from_tz: str,
     to_tz: str,
     tzinfo: timezone | ZoneInfo,
-    tu: TimeUnit,
+    time_unit: TimeUnit,
 ) -> None:
-    ts = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime(tu))
+    ts = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime(time_unit))
     result = ts.dt.replace_time_zone(from_tz).dt.replace_time_zone(to_tz).item()
     expected = datetime(2020, 1, 1, 0, 0, tzinfo=tzinfo)
     assert result == expected
@@ -1934,16 +1936,16 @@ def test_strptime_with_tz() -> None:
 
 
 @pytest.mark.parametrize(
-    ("tu", "tz"),
+    ("time_unit", "time_zone"),
     [
         ("us", "Europe/London"),
         ("ms", None),
         ("ns", "+01:00"),
     ],
 )
-def test_strptime_empty(tu: TimeUnit, tz: str | None) -> None:
-    ts = pl.Series([None]).cast(pl.Utf8).str.strptime(pl.Datetime(tu, tz))
-    assert ts.dtype == pl.Datetime(tu, tz)
+def test_strptime_empty(time_unit: TimeUnit, time_zone: str | None) -> None:
+    ts = pl.Series([None]).cast(pl.Utf8).str.strptime(pl.Datetime(time_unit, time_zone))
+    assert ts.dtype == pl.Datetime(time_unit, time_zone)
 
 
 def test_strptime_with_invalid_tz() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -117,7 +117,7 @@ def test_dt_datetime_date_time_invalid() -> None:
 
 
 @pytest.mark.parametrize(
-    ("temporal_unit", "expected"),
+    ("time_unit", "expected"),
     [
         ("d", pl.Series(values=[18262, 18294], dtype=pl.Int32)),
         ("s", pl.Series(values=[1_577_836_800, 1_580_613_610], dtype=pl.Int64)),
@@ -128,13 +128,13 @@ def test_dt_datetime_date_time_invalid() -> None:
     ],
 )
 def test_strptime_epoch(
-    temporal_unit: TimeUnit,
+    time_unit: TimeUnit,
     expected: pl.Series,
     series_of_str_dates: pl.Series,
 ) -> None:
     s = series_of_str_dates.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
 
-    assert_series_equal(s.dt.epoch(tu=temporal_unit), expected)
+    assert_series_equal(s.dt.epoch(time_unit=time_unit), expected)
 
 
 def test_strptime_fractional_seconds(series_of_str_dates: pl.Series) -> None:

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -58,7 +58,7 @@ def test_strptime_precision() -> None:
     )
     ds = s.str.strptime(pl.Datetime)
     assert ds.cast(pl.Date) != None  # noqa: E711  (note: *deliberately* testing "!=")
-    assert getattr(ds.dtype, "tu", None) == "us"
+    assert getattr(ds.dtype, "time_unit", None) == "us"
 
     time_units: list[TimeUnit] = ["ms", "us", "ns"]
     suffixes = ["%.3f", "%.6f", "%.9f"]
@@ -73,7 +73,7 @@ def test_strptime_precision() -> None:
     )
     for precision, suffix, expected_values in test_data:
         ds = s.str.strptime(pl.Datetime(precision), f"%Y-%m-%d %H:%M:%S{suffix}")
-        assert getattr(ds.dtype, "tu", None) == precision
+        assert getattr(ds.dtype, "time_unit", None) == precision
         assert ds.dt.nanosecond().to_list() == expected_values
 
 

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -22,12 +22,12 @@ def test_dtype_init_equivalence() -> None:
 
 def test_dtype_temporal_units() -> None:
     # check (in)equality behaviour of temporal types that take units
-    for tu in datatypes.DTYPE_TEMPORAL_UNITS:
-        assert pl.Datetime == pl.Datetime(tu)
-        assert pl.Duration == pl.Duration(tu)
+    for time_unit in datatypes.DTYPE_TEMPORAL_UNITS:
+        assert pl.Datetime == pl.Datetime(time_unit)
+        assert pl.Duration == pl.Duration(time_unit)
 
-        assert pl.Datetime(tu) == pl.Datetime()
-        assert pl.Duration(tu) == pl.Duration()
+        assert pl.Datetime(time_unit) == pl.Datetime()
+        assert pl.Duration(time_unit) == pl.Duration()
 
     assert pl.Datetime("ms") != pl.Datetime("ns")
     assert pl.Duration("ns") != pl.Duration("us")
@@ -38,7 +38,7 @@ def test_dtype_temporal_units() -> None:
         (datatypes.py_type_to_dtype(timedelta), pl.Duration),
     ):
         assert inferred_dtype == expected_dtype
-        assert inferred_dtype.tu == "us"  # type: ignore[union-attr]
+        assert inferred_dtype.time_unit == "us"  # type: ignore[union-attr]
 
     with pytest.raises(ValueError, match="Invalid time_unit"):
         pl.Datetime("?")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3202,18 +3202,18 @@ def test_init_datetimes_with_timezone() -> None:
     tz_europe = "Europe/Amsterdam"
 
     dtm = datetime(2022, 10, 12, 12, 30, tzinfo=ZoneInfo("UTC"))
-    for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
         for type_overrides in (
             {
                 "schema": [
-                    ("d1", pl.Datetime(tu, tz_us)),
-                    ("d2", pl.Datetime(tu, tz_europe)),
+                    ("d1", pl.Datetime(time_unit, tz_us)),
+                    ("d2", pl.Datetime(time_unit, tz_europe)),
                 ]
             },
             {
                 "schema_overrides": {
-                    "d1": pl.Datetime(tu, tz_us),
-                    "d2": pl.Datetime(tu, tz_europe),
+                    "d1": pl.Datetime(time_unit, tz_us),
+                    "d2": pl.Datetime(time_unit, tz_europe),
                 }
             },
         ):
@@ -3232,13 +3232,13 @@ def test_init_physical_with_timezone() -> None:
     tz_asia = "Asia/Tokyo"
 
     dtm_us = 1665577800000000
-    for tu in DTYPE_TEMPORAL_UNITS | frozenset([None]):
-        dtm = {"ms": dtm_us // 1_000, "ns": dtm_us * 1_000}.get(str(tu), dtm_us)
+    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+        dtm = {"ms": dtm_us // 1_000, "ns": dtm_us * 1_000}.get(str(time_unit), dtm_us)
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},
             schema=[
-                ("d1", pl.Datetime(tu, tz_uae)),
-                ("d2", pl.Datetime(tu, tz_asia)),
+                ("d1", pl.Datetime(time_unit, tz_uae)),
+                ("d2", pl.Datetime(time_unit, tz_asia)),
             ],
         )
         assert (df["d1"].to_physical() == df["d2"].to_physical()).all()

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1366,11 +1366,11 @@ def test_from_epoch(input_dtype: pl.PolarsDataType) -> None:
 
     ldf_result = ldf.select(
         [
-            pl.from_epoch(pl.col("timestamp_d"), unit="d"),
-            pl.from_epoch(pl.col("timestamp_s"), unit="s"),
-            pl.from_epoch(pl.col("timestamp_ms"), unit="ms"),
-            pl.from_epoch(pl.col("timestamp_us"), unit="us"),
-            pl.from_epoch(pl.col("timestamp_ns"), unit="ns"),
+            pl.from_epoch(pl.col("timestamp_d"), time_unit="d"),
+            pl.from_epoch(pl.col("timestamp_s"), time_unit="s"),
+            pl.from_epoch(pl.col("timestamp_ms"), time_unit="ms"),
+            pl.from_epoch(pl.col("timestamp_us"), time_unit="us"),
+            pl.from_epoch(pl.col("timestamp_ns"), time_unit="ns"),
         ]
     ).collect()
 
@@ -1378,7 +1378,7 @@ def test_from_epoch(input_dtype: pl.PolarsDataType) -> None:
 
     ts_col = pl.col("timestamp_s")
     with pytest.raises(ValueError):
-        _ = ldf.select(pl.from_epoch(ts_col, unit="s2"))  # type: ignore[call-overload]
+        _ = ldf.select(pl.from_epoch(ts_col, time_unit="s2"))  # type: ignore[call-overload]
 
 
 def test_cumagg_types() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -120,10 +120,10 @@ def test_init_inputs(monkeypatch: Any) -> None:
         s = pl.Series("dates", d64, dtype)
         assert s.to_list() == expected
         assert Datetime == s.dtype
-        assert s.dtype.tu == "ns"  # type: ignore[union-attr]
+        assert s.dtype.time_unit == "ns"  # type: ignore[union-attr]
 
     s = pl.Series(values=d64.astype("<M8[ms]"))
-    assert s.dtype.tu == "ms"  # type: ignore[union-attr]
+    assert s.dtype.time_unit == "ms"  # type: ignore[union-attr]
     assert expected == s.to_list()
 
     # pandas
@@ -2387,7 +2387,7 @@ def test_builtin_abs() -> None:
 
 
 @pytest.mark.parametrize(
-    ("value", "unit", "exp", "exp_type"),
+    ("value", "time_unit", "exp", "exp_type"),
     [
         (13285, "d", date(2006, 5, 17), pl.Date),
         (1147880044, "s", datetime(2006, 5, 17, 15, 34, 4), pl.Datetime),
@@ -2407,10 +2407,13 @@ def test_builtin_abs() -> None:
     ],
 )
 def test_from_epoch_expr(
-    value: int, unit: EpochTimeUnit, exp: date | datetime, exp_type: pl.PolarsDataType
+    value: int,
+    time_unit: EpochTimeUnit,
+    exp: date | datetime,
+    exp_type: pl.PolarsDataType,
 ) -> None:
     s = pl.Series("timestamp", [value, None])
-    result = pl.from_epoch(s, unit=unit)
+    result = pl.from_epoch(s, time_unit=time_unit)
 
     expected = pl.Series("timestamp", [exp, None]).cast(exp_type)
     assert_series_equal(result, expected)

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -22,15 +22,17 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
-    ("dt", "tu", "expected"),
+    ("dt", "time_unit", "expected"),
     [
         (datetime(2121, 1, 1), "ns", 4765132800000000000),
         (datetime(2121, 1, 1), "us", 4765132800000000),
         (datetime(2121, 1, 1), "ms", 4765132800000),
     ],
 )
-def test_datetime_to_pl_timestamp(dt: datetime, tu: TimeUnit, expected: int) -> None:
-    out = _datetime_to_pl_timestamp(dt, tu)
+def test_datetime_to_pl_timestamp(
+    dt: datetime, time_unit: TimeUnit, expected: int
+) -> None:
+    out = _datetime_to_pl_timestamp(dt, time_unit)
     assert out == expected
 
 
@@ -60,7 +62,7 @@ def test_timedelta_to_pl_timedelta() -> None:
     assert out == 86_400_000_000
     out = _timedelta_to_pl_timedelta(timedelta(days=1), "ms")
     assert out == 86_400_000
-    out = _timedelta_to_pl_timedelta(timedelta(days=1), tu=None)
+    out = _timedelta_to_pl_timedelta(timedelta(days=1), time_unit=None)
     assert out == 86_400_000_000
 
 


### PR DESCRIPTION
**!! BREAKING !!**

This has to be breaking due to the way class properties work on the `Datetime`/`Duration` data types.

Made a pass to make sure we're being consistent everywhere, at least on the Python side.

I'd also be fine using `unit` instead of `time_unit`. It matches pyarrow naming and is a bit shorter.