### PR TITLE
fix(rust, python): Fix lazy encode schema

### DIFF
--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -809,7 +809,7 @@ impl PyExpr {
             .inner
             .map(
                 move |s| s.binary().map(|s| Some(s.hex_encode().into_series())),
-                GetOutput::same_type(),
+                GetOutput::from_type(DataType::Utf8),
             )
             .with_fmt("binary.hex_encode")
             .into()
@@ -836,7 +836,7 @@ impl PyExpr {
             .inner
             .map(
                 move |s| s.binary().map(|s| Some(s.base64_encode().into_series())),
-                GetOutput::same_type(),
+                GetOutput::from_type(DataType::Utf8),
             )
             .with_fmt("binary.base64_encode")
             .into()

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -19,8 +19,6 @@ from polars.testing.asserts import assert_series_equal
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
-    from polars.type_aliases import TransferEncoding
-
 
 def test_init_signature_match() -> None:
     # eager/lazy init signatures are expected to match; if this test fails, it
@@ -1486,36 +1484,4 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     result_eager = df.select(func.over("y")).select("x")
     dtype_eager = result_eager["x"].dtype
     result_lazy = df.lazy().select(func.over("y")).select(pl.col(dtype_eager)).collect()
-    assert result_eager.frame_equal(result_lazy)
-
-
-@pytest.mark.parametrize(
-    "encoding",
-    [
-        "hex",
-        "base64",
-    ],
-)
-def test_compare_encode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
-    df = pl.DataFrame({"x": [b"aa", b"bb", b"cc"]})
-    expr = pl.col("x").bin.encode(encoding)
-    result_eager = df.select(expr)
-    dtype = result_eager["x"].dtype
-    result_lazy = df.lazy().select(expr).select(pl.col(dtype)).collect()
-    assert result_eager.frame_equal(result_lazy)
-
-
-@pytest.mark.parametrize(
-    "encoding",
-    [
-        "hex",
-        "base64",
-    ],
-)
-def test_compare_decode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
-    df = pl.DataFrame({"x": [b"d3d3", b"abcd", b"1234"]})
-    expr = pl.col("x").bin.decode(encoding)
-    result_eager = df.select(expr)
-    dtype = result_eager["x"].dtype
-    result_lazy = df.lazy().select(expr).select(pl.col(dtype)).collect()
     assert result_eager.frame_equal(result_lazy)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -19,6 +19,8 @@ from polars.testing.asserts import assert_series_equal
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
+    from polars.type_aliases import TransferEncoding
+
 
 def test_init_signature_match() -> None:
     # eager/lazy init signatures are expected to match; if this test fails, it
@@ -1484,4 +1486,36 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     result_eager = df.select(func.over("y")).select("x")
     dtype_eager = result_eager["x"].dtype
     result_lazy = df.lazy().select(func.over("y")).select(pl.col(dtype_eager)).collect()
+    assert result_eager.frame_equal(result_lazy)
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        "hex",
+        "base64",
+    ],
+)
+def test_compare_encode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
+    df = pl.DataFrame({"x": [b"a", b"b", b"c"]})
+    expr = pl.col("x").bin.encode(encoding)
+    result_eager = df.select(expr)
+    dtype = result_eager["x"].dtype
+    result_lazy = df.lazy().select(expr).select(pl.col(dtype)).collect()
+    assert result_eager.frame_equal(result_lazy)
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        "hex",
+        "base64",
+    ],
+)
+def test_compare_decode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
+    df = pl.DataFrame({"x": [b"aa", b"bb", b"cc"]})
+    expr = pl.col("x").bin.decode(encoding)
+    result_eager = df.select(expr)
+    dtype = result_eager["x"].dtype
+    result_lazy = df.lazy().select(expr).select(pl.col(dtype)).collect()
     assert result_eager.frame_equal(result_lazy)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1497,7 +1497,7 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     ],
 )
 def test_compare_encode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
-    df = pl.DataFrame({"x": [b"a", b"b", b"c"]})
+    df = pl.DataFrame({"x": [b"aa", b"bb", b"cc"]})
     expr = pl.col("x").bin.encode(encoding)
     result_eager = df.select(expr)
     dtype = result_eager["x"].dtype
@@ -1513,7 +1513,7 @@ def test_compare_encode_between_lazy_and_eager_6814(encoding: TransferEncoding) 
     ],
 )
 def test_compare_decode_between_lazy_and_eager_6814(encoding: TransferEncoding) -> None:
-    df = pl.DataFrame({"x": [b"aa", b"bb", b"cc"]})
+    df = pl.DataFrame({"x": [b"d3d3", b"abcd", b"1234"]})
     expr = pl.col("x").bin.decode(encoding)
     result_eager = df.select(expr)
     dtype = result_eager["x"].dtype


### PR DESCRIPTION
Relates-to: #6814 

This PR contains a fix for the wrong dtype in lazy `encode`.

Two things i was unsure about in my fix
1. Is `py-polars/tests/unit/test_lazy.py` the right file to add the tests to?
2. Should tests for `decode` also be added? should the test name link to the same issue?