### PR TITLE
feat(python): Support Numpy ufunc with more than one expression

### DIFF
--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3654,6 +3654,41 @@ def test_ufunc_expr_not_first() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_ufunc_multiple_expressions() -> None:
+    # example from https://github.com/pola-rs/polars/issues/6770
+    df = pl.DataFrame(
+        {
+            "v": [
+                -4.293,
+                -2.4659,
+                -1.8378,
+                -0.2821,
+                -4.5649,
+                -3.8128,
+                -7.4274,
+                3.3443,
+                3.8604,
+                -4.2200,
+            ],
+            "u": [
+                -11.2268,
+                6.3478,
+                7.1681,
+                3.4986,
+                2.7320,
+                -1.0695,
+                -10.1408,
+                11.2327,
+                6.6623,
+                -8.1412,
+            ],
+        }
+    )
+    expected = np.arctan2(df.get_column("v"), df.get_column("u"))
+    result = df.select(np.arctan2(pl.col("v"), pl.col("u")))[:, 0]  # type: ignore[call-overload]
+    assert_series_equal(expected, result)  # type: ignore[arg-type]
+
+
 def test_window_deadlock() -> None:
     np.random.seed(12)
 


### PR DESCRIPTION
We use the pl.reduce trick basically, where the limitation is that non-expressions have to be passed in as kwargs. That is probably the safest anyway.

Related issues:
https://github.com/pola-rs/polars/issues/6770 : brought up no support for multiple expression, have added a ValueError in response in #6821.

https://github.com/pola-rs/polars/issues/5713 : reminder that there is the `pl.reduce` trick