### PR TITLE
chore(python): Rename argument `f` to `function` in reduce docstring

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1867,7 +1867,7 @@ def reduce(
     Horizontally sum over all columns.
 
     >>> df.select(
-    ...     pl.reduce(f=lambda acc, x: acc + x, exprs=pl.col("*")).alias("sum"),
+    ...     pl.reduce(function=lambda acc, x: acc + x, exprs=pl.col("*")).alias("sum"),
     ... )
     shape: (3, 1)
     ┌─────┐


### PR DESCRIPTION
Otherwise we get a deprecation warning.