### PR TITLE
build(python)!: Drop Python 3.7 support

### DIFF
--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Fix README symlink
         run: |
@@ -179,7 +179,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.7'
+  #         python-version: '3.8'
 
   #     - name: Fix README symlink
   #       run: |

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
     defaults:
       run:
         working-directory: py-polars
@@ -91,4 +91,4 @@ jobs:
 
       # Allow untyped calls for older Python versions
       - name: Run mypy
-        run: mypy ${{ (matrix.python-version == '3.7') && '--allow-untyped-calls' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.8') && '--allow-untyped-calls' || '' }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -505,22 +505,22 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.16"
+version = "0.16.17"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1"
 polars-algo = { path = "../polars/polars-algo", default-features = false }
 polars-core = { path = "../polars/polars-core", features = ["python"], default-features = false }
 polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-features = false }
-pyo3 = { version = "0.18.0", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.18.0", features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.4", optional = true }
 serde_json = { version = "1", optional = true }
 smartstring = "1"

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from polars.dependencies import json
 
@@ -18,15 +18,9 @@ with contextlib.suppress(ImportError):
     from polars.polars import set_float_fmt as _set_float_fmt
 
 if TYPE_CHECKING:
-    import sys
     from types import TracebackType
 
     from polars.type_aliases import FloatFmt
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 # note: register all Config-specific environment variable names here; need to constrain

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -524,7 +524,7 @@ def from_pandas(
 
 @overload
 def from_pandas(
-    data: pd.Series | pd.DatetimeIndex,
+    data: pd.Series[Any] | pd.DatetimeIndex,
     rechunk: bool = ...,
     nan_to_null: bool = ...,
     schema_overrides: SchemaDict | None = ...,
@@ -537,7 +537,7 @@ def from_pandas(
 @deprecate_nonkeyword_arguments()
 @deprecated_alias(nan_to_none="nan_to_null", df="data", stacklevel=4)
 def from_pandas(
-    data: pd.DataFrame | pd.Series | pd.DatetimeIndex,
+    data: pd.DataFrame | pd.Series[Any] | pd.DatetimeIndex,
     rechunk: bool = True,
     nan_to_null: bool = True,
     schema_overrides: SchemaDict | None = None,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -18,6 +18,7 @@ from typing import (
     Generator,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     NoReturn,
     Sequence,
@@ -152,11 +153,6 @@ if TYPE_CHECKING:
         UnstackDirection,
     )
     from polars.utils import NoDefault
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
     if sys.version_info >= (3, 10):
         from typing import Concatenate, ParamSpec, TypeAlias

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -12,9 +12,11 @@ from typing import (
     Any,
     Callable,
     ForwardRef,
+    Literal,
     Optional,
     TypeVar,
     Union,
+    get_args,
     overload,
 )
 
@@ -52,14 +54,6 @@ from polars.dependencies import pyarrow as pa
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr as _dtype_str_repr
 
-if sys.version_info >= (3, 8):
-    from typing import get_args
-else:
-    # pass-through (only impact is that under 3.7 we'll end-up doing
-    # standard inference for dataclass fields with an option/union)
-    def get_args(tp: Any) -> Any:
-        return tp
-
 
 OptionType = type(Optional[type])
 if sys.version_info >= (3, 10):
@@ -71,11 +65,6 @@ else:
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType, PythonDataType, SchemaDict, TimeUnit
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 T = TypeVar("T")

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import warnings
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Iterable, Literal, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import Date
@@ -28,7 +28,6 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    import sys
     from datetime import date
 
     from polars.dataframe import DataFrame
@@ -41,11 +40,6 @@ if TYPE_CHECKING:
         PolarsDataType,
         TimeUnit,
     )
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 def get_dummies(

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import warnings
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Sequence, overload
 
 from polars import internals as pli
 from polars.datatypes import (
@@ -62,8 +62,6 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    import sys
-
     from polars.dataframe import DataFrame
     from polars.expr.expr import Expr
     from polars.lazyframe import LazyFrame
@@ -78,11 +76,6 @@ if TYPE_CHECKING:
         SchemaDict,
         TimeUnit,
     )
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 def col(

--- a/py-polars/polars/io/excel/_write_utils.py
+++ b/py-polars/polars/io/excel/_write_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence, overload
 
 from polars import functions as F
 from polars.datatypes import (
@@ -21,8 +21,6 @@ from polars.dependencies import json
 from polars.exceptions import DuplicateError
 
 if TYPE_CHECKING:
-    import sys
-
     from xlsxwriter import Workbook
     from xlsxwriter.format import Format
     from xlsxwriter.worksheet import Worksheet
@@ -35,11 +33,6 @@ if TYPE_CHECKING:
         PolarsDataType,
         RowTotalsDefinition,
     )
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 def _cluster(iterable: Iterable[Any], n: int = 2) -> Iterable[Any]:

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -2,22 +2,16 @@ from __future__ import annotations
 
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, overload
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, overload
 
 from polars.io.csv.functions import read_csv
 from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
-    import sys
     from io import BytesIO
 
     from polars.dataframe import DataFrame
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
 
 
 @overload

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import math
 import os
-import typing
 import warnings
 from datetime import date, datetime, time, timedelta
 from typing import (
@@ -593,8 +592,6 @@ class Series:
 
         return self.cast(Float64) / other
 
-    # python 3.7 is not happy. Remove this when we finally ditch that
-    @typing.no_type_check
     def __floordiv__(self, other: Any) -> Series:
         if self.is_temporal():
             raise ValueError("first cast to integer before dividing datelike dtypes")

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -324,7 +324,10 @@ class Series:
     @classmethod
     @deprecated_alias(nan_to_none="nan_to_null")
     def _from_pandas(
-        cls, name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
+        cls,
+        name: str,
+        values: pd.Series[Any] | pd.DatetimeIndex,
+        nan_to_null: bool = True,
     ) -> Self:
         """Construct a Series from a pandas Series or DatetimeIndex."""
         return cls._from_pyseries(
@@ -3215,7 +3218,7 @@ class Series:
 
     def to_pandas(  # noqa: D417
         self, *args: Any, use_pyarrow_extension_array: bool = False, **kwargs: Any
-    ) -> pd.Series:
+    ) -> pd.Series[Any]:
         """
         Convert this Series to a pandas Series.
 

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import (
@@ -9,6 +8,7 @@ from typing import (
     Collection,
     Iterable,
     List,
+    Literal,
     Mapping,
     Sequence,
     Tuple,
@@ -16,12 +16,9 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 if TYPE_CHECKING:
+    import sys
+
     from polars.datatypes import DataType, DataTypeClass, TemporalType
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -435,7 +435,7 @@ def sequence_to_pyseries(
 
 @deprecated_alias(nan_to_none="nan_to_null")
 def _pandas_series_to_arrow(
-    values: pd.Series | pd.DatetimeIndex,
+    values: pd.Series[Any] | pd.Index,
     nan_to_null: bool = True,
     length: int | None = None,
 ) -> pa.Array:
@@ -444,7 +444,7 @@ def _pandas_series_to_arrow(
 
     Parameters
     ----------
-    values : :class:`pandas.Series` or :class:`pandas.DatetimeIndex`.
+    values : :class:`pandas.Series` or :class:`pandas.Index`.
         Series to convert to arrow
     nan_to_null : bool, default = True
         Interpret `NaN` as missing values.
@@ -478,7 +478,7 @@ def _pandas_series_to_arrow(
 
 @deprecated_alias(nan_to_none="nan_to_null")
 def pandas_to_pyseries(
-    name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
+    name: str, values: pd.Series[Any] | pd.DatetimeIndex, nan_to_null: bool = True
 ) -> PySeries:
     """Construct a PySeries from a pandas Series or DatetimeIndex."""
     # TODO: Change `if not name` to `if name is not None` once name is Optional[str]
@@ -979,7 +979,7 @@ def _sequence_of_numpy_to_pydf(
 
 
 def _sequence_of_pandas_to_pydf(
-    first_element: pd.Series | pd.DatetimeIndex,
+    first_element: pd.Series[Any] | pd.DatetimeIndex,
     data: Sequence[Any],
     schema: SchemaDefinition | None,
     schema_overrides: SchemaDict | None,

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -70,10 +70,7 @@ def _get_dependency_version(dep_name: str) -> str:
 
     if hasattr(module, "__version__"):
         module_version = module.__version__
-    elif sys.version_info >= (3, 8):
-        # importlib.metadata was introduced in Python 3.8
-        module_version = importlib.metadata.version(dep_name)
     else:
-        module_version = "<version not detected>"
+        module_version = importlib.metadata.version(dep_name)
 
     return module_version

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -5,12 +5,7 @@ import re
 import sys
 from collections.abc import MappingView, Sized
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
 
 from polars import functions as F
 from polars.datatypes import (

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Ritchie Vink", email = "ritchie46@gmail.com" },
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "typing_extensions >= 4.0.1; python_version < '3.11'",
 ]
@@ -24,7 +24,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -24,4 +24,4 @@ pytest-cov==4.0.0
 pytest-xdist==3.2.0
 
 # Stub files
-pandas-stubs==1.2.0.62
+pandas-stubs

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -71,10 +71,6 @@ def create_temp_sqlite_db(test_db: str) -> None:
                 "date": pl.Date,
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 8),
-                reason="connectorx not available below Python 3.8",
-            ),
         ),
         pytest.param(
             "adbc",

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -478,7 +478,7 @@ def test_init_pandas(monkeypatch: Any) -> None:
     assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
     # subclassed pandas object, with/without data & overrides
-    class XSeries(pd.Series):
+    class XSeries(pd.Series):  # type: ignore[type-arg]
         @property
         def _constructor(self) -> type:
             return XSeries

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3608,19 +3608,12 @@ def test_rolling_apply() -> None:
 
 
 def test_ufunc() -> None:
-    # NOTE: unfortunately we must use cast instead of a type: ignore comment
-    #   1. CI job with Python 3.10, numpy==1.23.1 -> mypy complains about arg-type
-    #   2. so we try to resolve it with type: ignore[arg-type]
-    #   3. CI job with Python 3.7, numpy==1.21.6 -> mypy complains about
-    #       unused type: ignore comment
-    # for more information, see: https://github.com/python/mypy/issues/8823
-
     df = pl.DataFrame([pl.Series("a", [1, 2, 3, 4], dtype=pl.UInt8)])
     out = df.select(
         [
-            np.power(cast(Any, pl.col("a")), 2).alias("power_uint8"),
-            np.power(cast(Any, pl.col("a")), 2.0).alias("power_float64"),
-            np.power(cast(Any, pl.col("a")), 2, dtype=np.uint16).alias("power_uint16"),
+            np.power(pl.col("a"), 2).alias("power_uint8"),  # type: ignore[call-overload]
+            np.power(pl.col("a"), 2.0).alias("power_float64"),  # type: ignore[call-overload]
+            np.power(pl.col("a"), 2, dtype=np.uint16).alias("power_uint16"),  # type: ignore[call-overload]
         ]
     )
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/test_interchange.py
+++ b/py-polars/tests/unit/test_interchange.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 
 import pandas as pd
@@ -57,10 +56,6 @@ def test_from_dataframe() -> None:
     assert_frame_equal(result, df)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 8),
-    reason="Pandas does not implement the protocol on Python 3.7",
-)
 def test_from_dataframe_pandas() -> None:
     data = {"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]}
 
@@ -71,10 +66,6 @@ def test_from_dataframe_pandas() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 8),
-    reason="Pandas does not implement the protocol on Python 3.7",
-)
 def test_from_dataframe_allow_copy() -> None:
     # Zero copy only allowed when input is already a Polars dataframe
     df = pl.DataFrame({"a": [1, 2]})


### PR DESCRIPTION
**!! THIS IS A BREAKING CHANGE !!**

Re-opened from #6824

Changes:
* Set required Python version to `>=3.8`
* Set PyO3 abi3 feature to Python 3.8
* Update CI to run on Python 3.8 instead of 3.7 (for release, test, and mypy jobs).
* Update some typing imports
* Remove some typing workarounds
* Update `pandas-stubs` version and update some pandas type hints

Notes:
* We still must allow untyped calls for `mypy` on Python 3.8 due to the `backports.zoneinfo` package having some [issues](https://github.com/pganssle/zoneinfo/issues/125).

I'd like to have this part of the `0.17.0` release, but if you prefer we can keep supporting Python 3.7 until end of life ([27 June 2023](https://endoflife.date/python)). In that case we'd probably merge this with the `1.0.0` release of Polars.