### PR TITLE
perf(python): ensure primitives are parsed first in anyvalue conversion

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -18,7 +18,7 @@ use pyo3::basic::CompareOp;
 use pyo3::conversion::{FromPyObject, IntoPy};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyList, PySequence, PyTuple};
+use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple};
 use pyo3::{PyAny, PyResult};
 use smartstring::alias::String as SmartString;
 
@@ -673,12 +673,17 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
 
 impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
     fn extract(ob: &'s PyAny) -> PyResult<Self> {
-        if ob.is_instance_of::<PyBool>().unwrap() {
+        if ob.is_instance_of::<PyBool>()? {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
-        } else if let Ok(v) = ob.extract::<i64>() {
-            Ok(AnyValue::Int64(v).into())
-        } else if let Ok(v) = ob.extract::<&'s str>() {
-            Ok(AnyValue::Utf8(v).into())
+        } else if ob.is_instance_of::<PyInt>()? {
+            let value = ob.extract::<i64>().unwrap();
+            Ok(AnyValue::Int64(value).into())
+        } else if ob.is_instance_of::<PyFloat>()? {
+            let value = ob.extract::<f64>().unwrap();
+            Ok(AnyValue::Float64(value).into())
+        } else if ob.is_instance_of::<PyString>()? {
+            let value = ob.extract::<&'s str>().unwrap();
+            Ok(AnyValue::Utf8(value).into())
         } else if ob.is_none() {
             Ok(AnyValue::Null.into())
         } else if ob.is_instance_of::<PyDict>()? {
@@ -704,9 +709,6 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Binary(v).into())
         } else {
             let type_name = ob.get_type().name()?;
-            if let Some(Ok(v)) = (type_name != "Decimal").then_some(ob.extract::<f64>()) {
-                return Ok(AnyValue::Float64(v).into());
-            };
             match type_name {
                 "datetime" => convert_datetime(ob),
                 "date" => convert_date(ob),

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -18,7 +18,7 @@ use pyo3::basic::CompareOp;
 use pyo3::conversion::{FromPyObject, IntoPy};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple};
+use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyList, PySequence, PyString, PyTuple};
 use pyo3::{PyAny, PyResult};
 use smartstring::alias::String as SmartString;
 
@@ -675,8 +675,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
     fn extract(ob: &'s PyAny) -> PyResult<Self> {
         if ob.is_instance_of::<PyBool>()? {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
-        } else if ob.is_instance_of::<PyInt>()? {
-            let value = ob.extract::<i64>().unwrap();
+        } else if let Ok(value) = ob.extract::<i64>() {
             Ok(AnyValue::Int64(value).into())
         } else if ob.is_instance_of::<PyFloat>()? {
             let value = ob.extract::<f64>().unwrap();


### PR DESCRIPTION
Should fix #7926