### PR TITLE
fix(python)!: in `sort`, `top_k`, `sort_by`, and `arg_sort_by`, raise if `descending` is a sequence and its length doesn't match the number of columns to sort by

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2078,7 +2078,7 @@ class Expr:
         if more_by:
             by.extend(selection_to_pyexpr_list(more_by))
         if isinstance(descending, bool):
-            descending = [descending] * len(by)
+            descending = [descending]
         elif len(by) != len(descending):
             raise ValueError(
                 f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2077,8 +2077,12 @@ class Expr:
         by = selection_to_pyexpr_list(by)
         if more_by:
             by.extend(selection_to_pyexpr_list(more_by))
-        if isinstance(descending, bool):  # TODO raise accordingly
+        if isinstance(descending, bool):
             descending = [descending] * len(by)
+        elif len(by) != len(descending):
+            raise ValueError(
+                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            )
         return self._from_pyexpr(self._pyexpr.sort_by(by, descending))
 
     def take(

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2074,11 +2074,11 @@ class Expr:
         └───────┴────────┴────────┘
 
         """
-        if isinstance(descending, bool):
-            descending = [descending]
         by = selection_to_pyexpr_list(by)
         if more_by:
             by.extend(selection_to_pyexpr_list(more_by))
+        if isinstance(descending, bool):  # TODO raise accordingly
+            descending = [descending] * len(by)
         return self._from_pyexpr(self._pyexpr.sort_by(by, descending))
 
     def take(

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2370,6 +2370,10 @@ def arg_sort_by(
 
     if isinstance(descending, bool):
         descending = [descending] * len(exprs)
+    elif len(exprs) != len(descending):
+        raise ValueError(
+            f"the length of `descending` ({len(descending)}) does not match the length of `exprs` ({len(exprs)})"
+        )
     return wrap_expr(py_arg_sort_by(exprs, descending))
 
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1214,7 +1214,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             by.extend(selection_to_pyexpr_list(more_by))
 
         if isinstance(descending, bool):
-            descending = [descending] * len(by)
+            descending = [descending]
         elif len(by) != len(descending):
             raise ValueError(
                 f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1214,7 +1214,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             by.extend(selection_to_pyexpr_list(more_by))
 
         if isinstance(descending, bool):
-            descending = [descending]
+            descending = [descending] * len(by)
+        elif len(by) != len(descending):
+            raise ValueError(
+                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            )
         return self._from_pyldf(self._ldf.sort_by_exprs(by, descending, nulls_last))
 
     def top_k(
@@ -1246,6 +1250,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         by = selection_to_pyexpr_list(by)
         if isinstance(descending, bool):
             descending = [descending]
+        elif len(by) != len(descending):
+            raise ValueError(
+                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            )
         return self._from_pyldf(self._ldf.top_k(k, by, descending, nulls_last))
 
     @deprecate_nonkeyword_arguments()

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -54,10 +54,10 @@ def test_sort_by() -> None:
     out = df.select(pl.col("a").sort_by("b", "c"))
     assert out["a"].to_list() == [3, 1, 2, 5, 4]
 
-    out = df.select(pl.col("a").sort_by(by, descending=[False]))
+    out = df.select(pl.col("a").sort_by(by, descending=False))
     assert out["a"].to_list() == [3, 1, 2, 5, 4]
 
-    out = df.select(pl.col("a").sort_by(by, descending=[True]))
+    out = df.select(pl.col("a").sort_by(by, descending=True))
     assert out["a"].to_list() == [4, 5, 2, 1, 3]
 
     out = df.select(pl.col("a").sort_by(by, descending=[True, False]))
@@ -590,3 +590,17 @@ def test_top_k_descending() -> None:
         match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
     ):
         df.top_k(1, by=["a", "b"], descending=[True])
+
+
+def test_sort_by_descending() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.select(pl.col("a").sort_by(["a", "b"], descending=True))
+    expected = pl.DataFrame({"a": [3, 2, 1]})
+    assert_frame_equal(result, expected)
+    result = df.select(pl.col("a").sort_by(["a", "b"], descending=[True, True]))
+    assert_frame_equal(result, expected)
+    with pytest.raises(
+        ValueError,
+        match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
+    ):
+        df.select(pl.col("a").sort_by(["a", "b"], descending=[True]))

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -604,3 +604,17 @@ def test_sort_by_descending() -> None:
         match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
     ):
         df.select(pl.col("a").sort_by(["a", "b"], descending=[True]))
+
+
+def test_arg_sort_by_descending() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.select(pl.arg_sort_by(["a", "b"], descending=True))
+    expected = pl.DataFrame({"a": [2, 1, 0]}).select(pl.col("a").cast(pl.UInt32))
+    assert_frame_equal(result, expected)
+    result = df.select(pl.arg_sort_by(["a", "b"], descending=[True, True]))
+    assert_frame_equal(result, expected)
+    with pytest.raises(
+        ValueError,
+        match=r"the length of `descending` \(1\) does not match the length of `exprs` \(2\)",
+    ):
+        df.select(pl.arg_sort_by(["a", "b"], descending=[True]))

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -562,3 +562,31 @@ def test_sort_by_struct() -> None:
         "row_nr": [1, 2, 0],
         "st": [{"a": 20}, {"a": 55}, {"a": 300}],
     }
+
+
+def test_sort_descending() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.sort(["a", "b"], descending=True)
+    expected = pl.DataFrame({"a": [3, 2, 1], "b": [6, 5, 4]})
+    assert_frame_equal(result, expected)
+    result = df.sort(["a", "b"], descending=[True, True])
+    assert_frame_equal(result, expected)
+    with pytest.raises(
+        ValueError,
+        match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
+    ):
+        df.sort(["a", "b"], descending=[True])
+
+
+def test_top_k_descending() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    result = df.top_k(1, by=["a", "b"], descending=True)
+    expected = pl.DataFrame({"a": [1], "b": [4]})
+    assert_frame_equal(result, expected)
+    result = df.top_k(1, by=["a", "b"], descending=[True, True])
+    assert_frame_equal(result, expected)
+    with pytest.raises(
+        ValueError,
+        match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
+    ):
+        df.top_k(1, by=["a", "b"], descending=[True])


### PR DESCRIPTION
closes #7956 