### PR TITLE
refactor(python,rust)!: rename `toggle_string_cache` to `enable_string_cache`

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -481,7 +481,7 @@ impl CategoricalChunked {
 mod test {
     use crate::chunked_array::categorical::CategoricalChunkedBuilder;
     use crate::prelude::*;
-    use crate::{reset_string_cache, toggle_string_cache, SINGLE_LOCK};
+    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
 
     #[test]
     fn test_categorical_rev() -> PolarsResult<()> {
@@ -501,7 +501,7 @@ mod test {
         assert_eq!(out.get_rev_map().len(), 2);
 
         // test the global branch
-        toggle_string_cache(true);
+        enable_string_cache(true);
         // empty global cache
         let out = ca.cast(&DataType::Categorical(None))?;
         let out = out.categorical().unwrap().clone();
@@ -525,11 +525,11 @@ mod test {
 
     #[test]
     fn test_categorical_builder() {
-        use crate::{reset_string_cache, toggle_string_cache};
+        use crate::{enable_string_cache, reset_string_cache};
         let _lock = crate::SINGLE_LOCK.lock();
         for b in &[false, true] {
             reset_string_cache();
-            toggle_string_cache(*b);
+            enable_string_cache(*b);
 
             // Use 2 builders to check if the global string cache
             // does not interfere with the index mapping

--- a/polars/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -90,13 +90,13 @@ impl CategoricalChunked {
 mod test {
     use super::*;
     use crate::chunked_array::categorical::CategoricalChunkedBuilder;
-    use crate::{reset_string_cache, toggle_string_cache};
+    use crate::{enable_string_cache, reset_string_cache};
 
     #[test]
     fn test_merge_rev_map() {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        toggle_string_cache(true);
+        enable_string_cache(true);
 
         let mut builder1 = CategoricalChunkedBuilder::new("foo", 10);
         let mut builder2 = CategoricalChunkedBuilder::new("foo", 10);

--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -228,7 +228,7 @@ mod test {
     use std::convert::TryFrom;
 
     use super::*;
-    use crate::{reset_string_cache, toggle_string_cache, SINGLE_LOCK};
+    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
 
     #[test]
     fn test_categorical_round_trip() -> PolarsResult<()> {
@@ -259,7 +259,7 @@ mod test {
     fn test_append_categorical() {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        toggle_string_cache(true);
+        enable_string_cache(true);
 
         let mut s1 = Series::new("1", vec!["a", "b", "c"])
             .cast(&DataType::Categorical(None))
@@ -293,7 +293,7 @@ mod test {
     fn test_categorical_flow() -> PolarsResult<()> {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        toggle_string_cache(false);
+        enable_string_cache(false);
 
         // tests several things that may loose the dtype information
         let s = Series::new("a", vec!["a", "b", "c"]).cast(&DataType::Categorical(None))?;

--- a/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -34,21 +34,21 @@ impl Default for IUseStringCache {
 impl IUseStringCache {
     /// Hold the StringCache
     pub fn new() -> IUseStringCache {
-        toggle_string_cache(true);
+        enable_string_cache(true);
         IUseStringCache { private_zst: () }
     }
 }
 
 impl Drop for IUseStringCache {
     fn drop(&mut self) {
-        toggle_string_cache(false)
+        enable_string_cache(false)
     }
 }
 
 pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
-    toggle_string_cache(true);
+    enable_string_cache(true);
     let out = func();
-    toggle_string_cache(false);
+    enable_string_cache(false);
     out
 }
 
@@ -56,7 +56,7 @@ pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
 ///
 /// This is used to cache the string categories locally.
 /// This allows join operations on categorical types.
-pub fn toggle_string_cache(toggle: bool) {
+pub fn enable_string_cache(toggle: bool) {
     if toggle {
         USE_STRING_CACHE.fetch_add(1, Ordering::Release);
     } else {

--- a/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -147,7 +147,7 @@ impl CategoricalChunked {
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
-    use crate::{reset_string_cache, toggle_string_cache, SINGLE_LOCK};
+    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
 
     fn assert_order(ca: &CategoricalChunked, cmp: &[&str]) {
         let s = ca.cast(&DataType::Utf8).unwrap();
@@ -162,7 +162,7 @@ mod test {
         let _lock = SINGLE_LOCK.lock();
         for toggle in [true, false] {
             reset_string_cache();
-            toggle_string_cache(toggle);
+            enable_string_cache(toggle);
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical = ca.clone();
@@ -189,8 +189,8 @@ mod test {
         let init = &["c", "b", "a", "a"];
 
         let _lock = SINGLE_LOCK.lock();
-        for toggle in [true, false] {
-            toggle_string_cache(toggle);
+        for enable in [true, false] {
+            enable_string_cache(enable);
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical: CategoricalChunked = ca.clone();

--- a/polars/src/docs/performance.rs
+++ b/polars/src/docs/performance.rs
@@ -56,11 +56,11 @@
 //!
 //! ```rust
 //! use polars::prelude::*;
-//! use polars::toggle_string_cache;
+//! use polars::enable_string_cache;
 //!
 //! fn example(mut df_a: DataFrame, mut df_b: DataFrame) -> PolarsResult<DataFrame> {
 //!     // Set a global string cache
-//!     toggle_string_cache(true);
+//!     enable_string_cache(true);
 //!
 //!     df_a.try_apply("a", |s| s.categorical().cloned())?;
 //!     df_b.try_apply("b", |s| s.categorical().cloned())?;

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -387,7 +387,7 @@ pub use polars_core::{
     series, testing,
 };
 #[cfg(feature = "dtype-categorical")]
-pub use polars_core::{toggle_string_cache, using_string_cache};
+pub use polars_core::{enable_string_cache, using_string_cache};
 #[cfg(feature = "polars-io")]
 pub use polars_io as io;
 #[cfg(feature = "lazy")]

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -49,5 +49,5 @@ StringCache
 .. autosummary::
    :toctree: api/
 
-    toggle_string_cache
+    enable_string_cache
     StringCache

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -147,7 +147,12 @@ from polars.io import (
 from polars.lazyframe import LazyFrame
 from polars.series import Series
 from polars.sql import SQLContext
-from polars.string_cache import StringCache, toggle_string_cache, using_string_cache
+from polars.string_cache import (
+    StringCache,
+    enable_string_cache,
+    toggle_string_cache,
+    using_string_cache,
+)
 from polars.type_aliases import PolarsDataType
 from polars.utils import (
     build_info,
@@ -243,6 +248,7 @@ __all__ = [
     "scan_pyarrow_dataset",
     # polars.stringcache
     "StringCache",
+    "enable_string_cache",
     "toggle_string_cache",
     "using_string_cache",
     # polars.config

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -242,7 +242,8 @@ class Expr:
         - :func:`polars.datatypes.Time` -> :func:`polars.datatypes.Int64`
         - :func:`polars.datatypes.Duration` -> :func:`polars.datatypes.Int64`
         - :func:`polars.datatypes.Categorical` -> :func:`polars.datatypes.UInt32`
-        - Other data types will be left unchanged.
+
+        Other data types will be left unchanged.
 
         Examples
         --------

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import toggle_string_cache as _toggle_string_cache
+    from polars.polars import enable_string_cache as _enable_string_cache
     from polars.polars import using_string_cache as _using_string_cache
 
 if TYPE_CHECKING:
@@ -23,22 +24,18 @@ class StringCache:
     --------
     >>> with pl.StringCache():
     ...     df1 = pl.DataFrame(
-    ...         [
-    ...             pl.Series(
-    ...                 "color", ["red", "green", "blue", "orange"], pl.Categorical
-    ...             ),
-    ...             pl.Series("uint8", [1, 2, 3, 4], pl.UInt8),
-    ...         ]
+    ...         data={
+    ...             "color": ["red", "green", "blue", "orange"],
+    ...             "value": [1, 2, 3, 4],
+    ...         },
+    ...         schema={"color": pl.Categorical, "value": pl.UInt8},
     ...     )
     ...     df2 = pl.DataFrame(
-    ...         [
-    ...             pl.Series(
-    ...                 "color",
-    ...                 ["yellow", "green", "orange", "black", "red"],
-    ...                 pl.Categorical,
-    ...             ),
-    ...             pl.Series("char", ["a", "b", "c", "d", "e"], pl.Utf8),
-    ...         ]
+    ...         data={
+    ...             "color": ["yellow", "green", "orange", "black", "red"],
+    ...             "char": ["a", "b", "c", "d", "e"],
+    ...         },
+    ...         schema={"color": pl.Categorical, "char": pl.Utf8},
     ...     )
     ...
     ...     # Both dataframes use the same string cache for the categorical column,
@@ -48,7 +45,7 @@ class StringCache:
     >>> df_join
     shape: (3, 3)
     ┌────────┬───────┬──────┐
-    │ color  ┆ uint8 ┆ char │
+    │ color  ┆ value ┆ char │
     │ ---    ┆ ---   ┆ ---  │
     │ cat    ┆ u8    ┆ str  │
     ╞════════╪═══════╪══════╡
@@ -62,7 +59,7 @@ class StringCache:
     def __enter__(self) -> StringCache:
         self._already_enabled = _using_string_cache()
         if not self._already_enabled:
-            _toggle_string_cache(True)
+            _enable_string_cache(True)
         return self
 
     def __exit__(
@@ -74,18 +71,69 @@ class StringCache:
         # note: if global string cache was already enabled
         # on __enter__, do NOT reset it on __exit__
         if not self._already_enabled:
-            _toggle_string_cache(False)
+            _enable_string_cache(False)
+
+
+def enable_string_cache(enable: bool) -> None:
+    """
+    Enable (or disable) the global string cache.
+
+    This ensures that casts to Categorical dtypes will have
+    the same category values when string values are equal.
+
+    Parameters
+    ----------
+    enable
+        Enable or disable the global string cache.
+
+    Examples
+    --------
+    >>> pl.enable_string_cache(True)
+    >>> df1 = pl.DataFrame(
+    ...     data={"color": ["red", "green", "blue", "orange"], "value": [1, 2, 3, 4]},
+    ...     schema={"color": pl.Categorical, "value": pl.UInt8},
+    ... )
+    >>> df2 = pl.DataFrame(
+    ...     data={
+    ...         "color": ["yellow", "green", "orange", "black", "red"],
+    ...         "char": ["a", "b", "c", "d", "e"],
+    ...     },
+    ...     schema={"color": pl.Categorical, "char": pl.Utf8},
+    ... )
+    >>> df_join = df1.join(df2, how="inner", on="color")
+    >>> df_join
+    shape: (3, 3)
+    ┌────────┬───────┬──────┐
+    │ color  ┆ value ┆ char │
+    │ ---    ┆ ---   ┆ ---  │
+    │ cat    ┆ u8    ┆ str  │
+    ╞════════╪═══════╪══════╡
+    │ green  ┆ 2     ┆ b    │
+    │ orange ┆ 4     ┆ c    │
+    │ red    ┆ 1     ┆ e    │
+    └────────┴───────┴──────┘
+
+    """
+    _enable_string_cache(enable)
 
 
 def toggle_string_cache(toggle: bool) -> None:
     """
-    Turn on/off the global string cache.
+    Enable (or disable) the global string cache.
 
-    This ensures that casts to Categorical types have the categories when string values
-    are equal.
+    This ensures that casts to Categorical dtypes will have
+    the same category values when string values are equal.
+
+    .. deprecated:: 0.17.0
 
     """
-    _toggle_string_cache(toggle)
+    warnings.warn(
+        "`toggle_string_cache` has been renamed; this"
+        " redirect is temporary, please use `enable_string_cache` instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    enable_string_cache(toggle)
 
 
 def using_string_cache() -> bool:

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -225,8 +225,8 @@ fn get_polars_version() -> &'static str {
 }
 
 #[pyfunction]
-fn toggle_string_cache(toggle: bool) {
-    polars_rs::toggle_string_cache(toggle)
+fn enable_string_cache(toggle: bool) {
+    polars_rs::enable_string_cache(toggle)
 }
 
 #[pyfunction]
@@ -670,7 +670,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(arg_sort_by)).unwrap();
     m.add_wrapped(wrap_pyfunction!(when)).unwrap();
     m.add_wrapped(wrap_pyfunction!(get_polars_version)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(toggle_string_cache))
+    m.add_wrapped(wrap_pyfunction!(enable_string_cache))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(using_string_cache)).unwrap();
     m.add_wrapped(wrap_pyfunction!(concat_str)).unwrap();

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -44,8 +44,9 @@ if TYPE_CHECKING:
 
 
 def doctest_teardown(d: doctest.DocTest) -> None:
-    # don't let config changes leak between tests
+    # don't let config changes or string cache state leak between tests
     polars.Config.restore_defaults()
+    polars.enable_string_cache(False)
 
 
 def modules_in_path(p: Path) -> Iterator[ModuleType]:

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -466,7 +466,7 @@ def test_string_cache() -> None:
     df2 = pl.DataFrame({"a": ["foo", "spam", "eggs"], "c": [3, 2, 2]})
 
     # ensure cache is off when casting to categorical; the join will fail
-    pl.toggle_string_cache(False)
+    pl.enable_string_cache(False)
     assert pl.using_string_cache() is False
 
     df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
@@ -475,7 +475,7 @@ def test_string_cache() -> None:
         _ = df1a.join(df2a, on="a", how="inner")
 
     # now turn on the cache
-    pl.toggle_string_cache(True)
+    pl.enable_string_cache(True)
     assert pl.using_string_cache() is True
 
     df1b = df1.with_columns(pl.col("a").cast(pl.Categorical))


### PR DESCRIPTION
Ref #7815 (breaking changes for `0.17`).

Have kept a Python-side redirect (with a suitable deprecation warning) for `toggle_string_cache` → `enable_string_cache` for now; can remove to complete the transition. Change is breaking on the Rust side. 

Also, spotted that the string-cache state was leaking between doctests; this is now handled in the per-test teardown.