### PR TITLE
fix(rust, python): fix chunked literals in expression engine

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/group_iter.rs
@@ -11,7 +11,7 @@ impl<'a> AggregationContext<'a> {
         match self.agg_state() {
             AggState::Literal(_) => {
                 self.groups();
-                let s = self.series();
+                let s = self.series().rechunk();
                 Box::new(LitIter::new(s.array_ref(0).clone(), self.groups.len()))
             }
             AggState::AggregatedFlat(_) => {

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -144,3 +144,10 @@ def test_mean_null_simd() -> None:
 
     s = df["a"]
     assert s.mean() == s.to_pandas().mean()
+
+
+def test_literal_group_agg_chunked_7968() -> None:
+    df = pl.DataFrame({"A": [1, 1], "B": [1, 3]})
+
+    ser = pl.concat([pl.Series([3]), pl.Series([4, 5])], rechunk=False)
+    assert df.groupby("A").agg(pl.col("B").search_sorted(ser)).to_dict(False)


### PR DESCRIPTION
fixes #7968