### PR TITLE
refactor(python)!: Remove deprecated behaviour

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -15,7 +15,6 @@ from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import _cast_repr_strings_with_schema
 
 if TYPE_CHECKING:
@@ -25,7 +24,6 @@ if TYPE_CHECKING:
     from polars.type_aliases import Orientation, SchemaDefinition, SchemaDict
 
 
-@deprecated_alias(columns="schema")
 def from_dict(
     data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
     schema: SchemaDefinition | None = None,
@@ -80,14 +78,12 @@ def from_dict(
     )
 
 
-@deprecate_nonkeyword_arguments(allowed_args=["data", "schema"])
-@deprecated_alias(dicts="data", stacklevel=4)
 def from_dicts(
     data: Sequence[dict[str, Any]],
-    infer_schema_length: int | None = N_INFER_DEFAULT,
-    *,
     schema: SchemaDefinition | None = None,
+    *,
     schema_overrides: SchemaDict | None = None,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> DataFrame:
     """
     Construct a DataFrame from a sequence of dictionaries. This operation clones data.
@@ -96,9 +92,6 @@ def from_dicts(
     ----------
     data
         Sequence with dictionaries mapping column name to value
-    infer_schema_length
-        How many dictionaries/rows to scan to determine the data types
-        if set to `None` then ALL dicts are scanned; this will be slow.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
@@ -117,6 +110,9 @@ def from_dicts(
         them to the schema.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
+    infer_schema_length
+        How many dictionaries/rows to scan to determine the data types
+        if set to `None` then ALL dicts are scanned; this will be slow.
 
     Returns
     -------
@@ -184,7 +180,6 @@ def from_dicts(
     )
 
 
-@deprecated_alias(columns="schema")
 def from_records(
     data: Sequence[Sequence[Any]],
     schema: SchemaDefinition | None = None,
@@ -367,7 +362,6 @@ def from_repr(tbl: str) -> DataFrame:
     return _cast_repr_strings_with_schema(df, schema)
 
 
-@deprecated_alias(columns="schema")
 def from_numpy(
     data: np.ndarray[Any, Any],
     schema: SchemaDefinition | None = None,
@@ -429,12 +423,12 @@ def from_numpy(
     )
 
 
-@deprecate_nonkeyword_arguments(allowed_args=["data", "schema"])
 def from_arrow(
     data: pa.Table | pa.Array | pa.ChunkedArray,
-    rechunk: bool = True,
     schema: SchemaDefinition | None = None,
+    *,
     schema_overrides: SchemaDict | None = None,
+    rechunk: bool = True,
 ) -> DataFrame | Series:
     """
     Create a DataFrame or Series from an Arrow Table or Array.
@@ -446,8 +440,6 @@ def from_arrow(
     ----------
     data : :class:`pyarrow.Table` or :class:`pyarrow.Array`
         Data representing an Arrow Table or Array.
-    rechunk : bool, default True
-        Make sure that all data is in contiguous memory.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
@@ -461,6 +453,8 @@ def from_arrow(
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
+    rechunk : bool, default True
+        Make sure that all data is in contiguous memory.
 
     Returns
     -------
@@ -513,10 +507,10 @@ def from_arrow(
 @overload
 def from_pandas(
     data: pd.DataFrame,
+    *,
+    schema_overrides: SchemaDict | None = ...,
     rechunk: bool = ...,
     nan_to_null: bool = ...,
-    schema_overrides: SchemaDict | None = ...,
-    *,
     include_index: bool = ...,
 ) -> DataFrame:
     ...
@@ -525,23 +519,21 @@ def from_pandas(
 @overload
 def from_pandas(
     data: pd.Series | pd.DatetimeIndex,
+    *,
+    schema_overrides: SchemaDict | None = ...,
     rechunk: bool = ...,
     nan_to_null: bool = ...,
-    schema_overrides: SchemaDict | None = ...,
-    *,
     include_index: bool = ...,
 ) -> Series:
     ...
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(nan_to_none="nan_to_null", df="data", stacklevel=4)
 def from_pandas(
     data: pd.DataFrame | pd.Series | pd.DatetimeIndex,
+    *,
+    schema_overrides: SchemaDict | None = None,
     rechunk: bool = True,
     nan_to_null: bool = True,
-    schema_overrides: SchemaDict | None = None,
-    *,
     include_index: bool = False,
 ) -> DataFrame | Series:
     """
@@ -555,12 +547,12 @@ def from_pandas(
     ----------
     data: :class:`pandas.DataFrame`, :class:`pandas.Series`, :class:`pandas.DatetimeIndex`
         Data represented as a pandas DataFrame, Series, or DatetimeIndex.
+    schema_overrides : dict, default None
+        Support override of inferred types for one or more columns.
     rechunk : bool, default True
         Make sure that all data is in contiguous memory.
     nan_to_null : bool, default True
         If data contains `NaN` values PyArrow will convert the ``NaN`` to ``None``
-    schema_overrides : dict, default None
-        Support override of inferred types for one or more columns.
     include_index : bool, default False
         Load any non-default pandas indexes as columns.
 
@@ -615,8 +607,7 @@ def from_pandas(
         raise ValueError(f"Expected pandas DataFrame or Series, got {type(data)}.")
 
 
-@deprecate_nonkeyword_arguments()
-def from_dataframe(df: Any, allow_copy: bool = True) -> DataFrame:
+def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
     """
     Build a Polars DataFrame from any dataframe supporting the interchange protocol.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -86,11 +86,6 @@ from polars.utils._construction import (
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import (
-    deprecate_nonkeyword_arguments,
-    deprecated_alias,
-    redirect,
-)
 from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _prepare_row_count_args,
@@ -182,14 +177,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-@redirect(
-    {
-        "cleared": "clear",
-        "iterrows": "iter_rows",
-        "pearson_corr": "corr",
-        "with_column": "with_columns",
-    }
-)
 class DataFrame:
     """
     Two-dimensional data structure representing data as a table with rows and columns.
@@ -346,7 +333,6 @@ class DataFrame:
 
     _accessors: set[str] = set()
 
-    @deprecated_alias(columns="schema")
     def __init__(
         self,
         data: FrameInitTypes | None = None,
@@ -476,11 +462,11 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema")
     def _from_records(
         cls,
         data: Sequence[Sequence[Any]],
         schema: SchemaDefinition | None = None,
+        *,
         schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
@@ -528,11 +514,11 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema", stacklevel=4)
     def _from_numpy(
         cls,
         data: np.ndarray[Any, Any],
         schema: SchemaDefinition | None = None,
+        *,
         schema_overrides: SchemaDict | None = None,
         orient: Orientation | None = None,
     ) -> Self:
@@ -573,11 +559,11 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema", stacklevel=4)
     def _from_arrow(
         cls,
         data: pa.Table,
         schema: SchemaDefinition | None = None,
+        *,
         schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
     ) -> Self:
@@ -622,11 +608,11 @@ class DataFrame:
         )
 
     @classmethod
-    @deprecated_alias(columns="schema", nan_to_none="nan_to_null")
     def _from_pandas(
         cls,
         data: pd.DataFrame,
         schema: SchemaDefinition | None = None,
+        *,
         schema_overrides: SchemaDict | None = None,
         rechunk: bool = True,
         nan_to_null: bool = True,
@@ -2182,10 +2168,10 @@ class DataFrame:
     ) -> None:
         ...
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"])
     def write_json(
         self,
         file: IOBase | str | Path | None = None,
+        *,
         pretty: bool = False,
         row_oriented: bool = False,
     ) -> str | None:
@@ -2316,11 +2302,10 @@ class DataFrame:
     ) -> None:
         ...
 
-    @deprecated_alias(sep="separator")
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "file"], stacklevel=3)
     def write_csv(
         self,
         file: BytesIO | str | Path | None = None,
+        *,
         has_header: bool = True,
         separator: str = ",",
         quote: str = '"',
@@ -3160,9 +3145,9 @@ class DataFrame:
         sz = self._df.estimated_size()
         return scale_bytes(sz, unit)
 
-    @deprecate_nonkeyword_arguments()
     def transpose(
         self,
+        *,
         include_header: bool = False,
         header_name: str = "column",
         column_names: Iterator[str] | Sequence[str] | None = None,
@@ -3457,8 +3442,7 @@ class DataFrame:
     def glimpse(self, return_as_string: Literal[True]) -> str:
         ...
 
-    @deprecate_nonkeyword_arguments()
-    def glimpse(self, return_as_string: bool = False) -> str | None:
+    def glimpse(self, *, return_as_string: bool = False) -> str | None:
         """
         Return a dense preview of the dataframe.
 
@@ -3677,7 +3661,6 @@ class DataFrame:
         self._df.replace_at_idx(index, series._s)
         return self
 
-    @deprecated_alias(reverse="descending")
     def sort(
         self,
         by: IntoExpr | Iterable[IntoExpr],
@@ -3850,8 +3833,7 @@ class DataFrame:
             ._df
         )
 
-    @deprecate_nonkeyword_arguments()
-    def frame_equal(self, other: DataFrame, null_equal: bool = True) -> bool:
+    def frame_equal(self, other: DataFrame, *, null_equal: bool = True) -> bool:
         """
         Check if DataFrame is equal to other.
 
@@ -4889,10 +4871,10 @@ class DataFrame:
             self._df.upsample(by, time_column, every, offset, maintain_order)
         )
 
-    @deprecate_nonkeyword_arguments()
     def join_asof(
         self,
         other: DataFrame,
+        *,
         left_on: str | None | Expr = None,
         right_on: str | None | Expr = None,
         on: str | None | Expr = None,
@@ -5038,19 +5020,14 @@ class DataFrame:
             ._df
         )
 
-    @deprecate_nonkeyword_arguments(
-        message=(
-            "All arguments of DataFrame.join except for 'other', 'on', and 'how' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this warning."
-        )
-    )
     def join(
         self,
         other: DataFrame,
-        left_on: str | Expr | Sequence[str | Expr] | None = None,
-        right_on: str | Expr | Sequence[str | Expr] | None = None,
         on: str | Expr | Sequence[str | Expr] | None = None,
         how: JoinStrategy = "inner",
+        *,
+        left_on: str | Expr | Sequence[str | Expr] | None = None,
+        right_on: str | Expr | Sequence[str | Expr] | None = None,
         suffix: str = "_right",
     ) -> Self:
         """
@@ -5060,14 +5037,14 @@ class DataFrame:
         ----------
         other
             DataFrame to join with.
-        left_on
-            Name(s) of the left join column(s).
-        right_on
-            Name(s) of the right join column(s).
         on
             Name(s) of the join columns in both DataFrames.
         how : {'inner', 'left', 'outer', 'semi', 'anti', 'cross'}
             Join strategy.
+        left_on
+            Name(s) of the left join column(s).
+        right_on
+            Name(s) of the right join column(s).
         suffix
             Suffix to append to columns with a duplicate name.
 
@@ -5175,14 +5152,11 @@ class DataFrame:
             ._df
         )
 
-    @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments(
-        allowed_args=["self", "function", "return_dtype"], stacklevel=3
-    )
     def apply(
         self,
         function: Callable[[tuple[Any, ...]], Any],
         return_dtype: PolarsDataType | None = None,
+        *,
         inference_size: int = 256,
     ) -> Self:
         """
@@ -5270,11 +5244,8 @@ class DataFrame:
         else:
             return self._from_pydf(wrap_s(out).to_frame()._df)
 
-    @deprecate_nonkeyword_arguments()
     def hstack(
-        self,
-        columns: list[Series] | DataFrame,
-        in_place: bool = False,
+        self, columns: list[Series] | DataFrame, *, in_place: bool = False
     ) -> Self:
         """
         Return a new DataFrame grown horizontally by stacking multiple Series to it.
@@ -5317,8 +5288,7 @@ class DataFrame:
         else:
             return self._from_pydf(self._df.hstack([s._s for s in columns]))
 
-    @deprecate_nonkeyword_arguments()
-    def vstack(self, df: DataFrame, in_place: bool = False) -> Self:
+    def vstack(self, df: DataFrame, *, in_place: bool = False) -> Self:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
 
@@ -5684,12 +5654,12 @@ class DataFrame:
         """
         return self[name]
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "value", "strategy", "limit"])
     def fill_null(
         self,
         value: Any | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
+        *,
         matches_supertype: bool = True,
     ) -> Self:
         """
@@ -5895,17 +5865,13 @@ class DataFrame:
             ._df
         )
 
-    @deprecated_alias(aggregate_fn="aggregate_function")
-    @deprecate_nonkeyword_arguments(
-        allowed_args=["self", "values", "index", "columns", "aggregate_function"],
-        stacklevel=3,
-    )
     def pivot(
         self,
         values: Sequence[str] | str,
         index: Sequence[str] | str,
         columns: Sequence[str] | str,
         aggregate_function: PivotAgg | Expr | None | NoDefault = no_default,
+        *,
         maintain_order: bool = True,
         sort_columns: bool = False,
         separator: str = "_",
@@ -6222,7 +6188,6 @@ class DataFrame:
     ) -> dict[Any, Self]:
         ...
 
-    @deprecated_alias(groups="by")
     def partition_by(
         self,
         by: str | Iterable[str],
@@ -7076,9 +7041,9 @@ class DataFrame:
     ) -> Self | Series:
         ...
 
-    @deprecate_nonkeyword_arguments()
     def mean(
         self,
+        *,
         axis: int = 0,
         null_strategy: NullStrategy = "ignore",
     ) -> Self | Series:
@@ -7338,28 +7303,18 @@ class DataFrame:
             columns = [columns]
         return self._from_pydf(self._df.to_dummies(columns, separator))
 
-    @deprecate_nonkeyword_arguments(
-        message=(
-            "All arguments of DataFrame.unique except for 'subset' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this warning."
-        )
-    )
     def unique(
         self,
-        maintain_order: bool = False,
         subset: str | Sequence[str] | None = None,
+        *,
         keep: UniqueKeepStrategy = "any",
+        maintain_order: bool = False,
     ) -> Self:
         """
         Drop duplicate rows from this dataframe.
 
         Parameters
         ----------
-        maintain_order
-            Keep the same order as the original DataFrame. This is more expensive to
-            compute.
-            Settings this to ``True`` blocks the possibility
-            to run on the streaming engine.
         subset
             Column name(s) to consider when identifying duplicates.
             If set to ``None`` (default), use all columns.
@@ -7371,6 +7326,11 @@ class DataFrame:
             * 'none': Don't keep duplicate rows.
             * 'first': Keep first unique row.
             * 'last': Keep last unique row.
+        maintain_order
+            Keep the same order as the original DataFrame. This is more expensive to
+            compute.
+            Settings this to ``True`` blocks the possibility
+            to run on the streaming engine.
 
         Returns
         -------
@@ -7425,7 +7385,7 @@ class DataFrame:
         """
         return self._from_pydf(
             self.lazy()
-            .unique(maintain_order=maintain_order, subset=subset, keep=keep)
+            .unique(subset=subset, keep=keep, maintain_order=maintain_order)
             .collect(no_optimization=True)
             ._df
         )
@@ -7535,10 +7495,10 @@ class DataFrame:
         """
         return self._from_pydf(self._df.null_count())
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"])
     def sample(
         self,
         n: int | None = None,
+        *,
         frac: float | None = None,
         with_replacement: bool = False,
         shuffle: bool = False,
@@ -7831,8 +7791,9 @@ class DataFrame:
     def rows(self, named: Literal[True]) -> list[dict[str, Any]]:
         ...
 
-    @deprecate_nonkeyword_arguments()
-    def rows(self, named: bool = False) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
+    def rows(
+        self, *, named: bool = False
+    ) -> list[tuple[Any, ...]] | list[dict[str, Any]]:
         """
         Returns all data in the DataFrame as a list of rows of python-native values.
 
@@ -7895,9 +7856,8 @@ class DataFrame:
     ) -> Iterator[dict[str, Any]]:
         ...
 
-    @deprecate_nonkeyword_arguments()
     def iter_rows(
-        self, named: bool = False, buffer_size: int = 500
+        self, *, named: bool = False, buffer_size: int = 500
     ) -> Iterator[tuple[Any, ...]] | Iterator[dict[str, Any]]:
         """
         Returns an iterator over the DataFrame of rows of python-native values.
@@ -8034,8 +7994,7 @@ class DataFrame:
         for offset in range(0, self.height, n_rows):
             yield self.slice(offset, n_rows)
 
-    @deprecate_nonkeyword_arguments()
-    def shrink_to_fit(self, in_place: bool = False) -> Self:
+    def shrink_to_fit(self, *, in_place: bool = False) -> Self:
         """
         Shrink DataFrame memory usage.
 
@@ -8194,7 +8153,6 @@ class DataFrame:
         """
         return wrap_s(self._df.to_struct(name))
 
-    @deprecated_alias(names="columns")
     def unnest(self, columns: str | Sequence[str], *more_columns: str) -> Self:
         """
         Decompose struct columns into separate columns for each of their fields.

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2154,6 +2154,7 @@ class DataFrame:
     def write_json(
         self,
         file: None = ...,
+        *,
         pretty: bool = ...,
         row_oriented: bool = ...,
     ) -> str:
@@ -2163,6 +2164,7 @@ class DataFrame:
     def write_json(
         self,
         file: IOBase | str | Path,
+        *,
         pretty: bool = ...,
         row_oriented: bool = ...,
     ) -> None:
@@ -2274,6 +2276,7 @@ class DataFrame:
     def write_csv(
         self,
         file: None = None,
+        *,
         has_header: bool = ...,
         separator: str = ...,
         quote: str = ...,
@@ -2290,6 +2293,7 @@ class DataFrame:
     def write_csv(
         self,
         file: BytesIO | str | Path,
+        *,
         has_header: bool = ...,
         separator: str = ...,
         quote: str = ...,
@@ -3435,11 +3439,11 @@ class DataFrame:
         )
 
     @overload
-    def glimpse(self, return_as_string: Literal[False]) -> None:
+    def glimpse(self, *, return_as_string: Literal[False]) -> None:
         ...
 
     @overload
-    def glimpse(self, return_as_string: Literal[True]) -> str:
+    def glimpse(self, *, return_as_string: Literal[True]) -> str:
         ...
 
     def glimpse(self, *, return_as_string: bool = False) -> str | None:
@@ -7784,11 +7788,11 @@ class DataFrame:
             raise ValueError("One of 'index' or 'by_predicate' must be set")
 
     @overload
-    def rows(self, named: Literal[False] = ...) -> list[tuple[Any, ...]]:
+    def rows(self, *, named: Literal[False] = ...) -> list[tuple[Any, ...]]:
         ...
 
     @overload
-    def rows(self, named: Literal[True]) -> list[dict[str, Any]]:
+    def rows(self, *, named: Literal[True]) -> list[dict[str, Any]]:
         ...
 
     def rows(
@@ -7846,13 +7850,13 @@ class DataFrame:
 
     @overload
     def iter_rows(
-        self, named: Literal[False] = ..., buffer_size: int = ...
+        self, *, named: Literal[False] = ..., buffer_size: int = ...
     ) -> Iterator[tuple[Any, ...]]:
         ...
 
     @overload
     def iter_rows(
-        self, named: Literal[True], buffer_size: int = ...
+        self, *, named: Literal[True], buffer_size: int = ...
     ) -> Iterator[dict[str, Any]]:
         ...
 

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -6,7 +6,6 @@ from polars import functions as F
 from polars import internals as pli
 from polars.functions.whenthen import WhenThen, WhenThenThen
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import deprecated_alias, redirect
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -23,7 +22,6 @@ if TYPE_CHECKING:
 DF = TypeVar("DF", bound="DataFrame")
 
 
-@redirect({"agg_list": "all"})
 class GroupBy(Generic[DF]):
     """Starts a new GroupBy operation."""
 
@@ -231,7 +229,6 @@ class GroupBy(Generic[DF]):
         )
         return self.df.__class__._from_pydf(df._df)
 
-    @deprecated_alias(f="function")
     def apply(self, function: Callable[[DataFrame], DataFrame]) -> DF:
         """
         Apply a custom/user-defined function (UDF) over the groups as a sub-DataFrame.

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -14,7 +14,6 @@ from polars.utils.convert import (
     _timedelta_to_pl_duration,
     _tzinfo_to_str,
 )
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import concat_df as _concat_df
@@ -139,13 +138,13 @@ def concat(
     ...
 
 
-@deprecate_nonkeyword_arguments()
 def concat(
     items: (
         Iterable[DataFrame] | Iterable[Series] | Iterable[LazyFrame] | Iterable[Expr]
     ),
-    rechunk: bool = True,
+    *,
     how: ConcatMethod = "vertical",
+    rechunk: bool = True,
     parallel: bool = True,
 ) -> DataFrame | Series | LazyFrame | Expr:
     """
@@ -155,8 +154,6 @@ def concat(
     ----------
     items
         DataFrames/Series/LazyFrames to concatenate.
-    rechunk
-        Make sure that all data is in contiguous memory.
     how : {'vertical', 'diagonal', 'horizontal'}
         Series only supports the `vertical` strategy.
         LazyFrames only supports `vertical` and `diagonal` strategy.
@@ -166,6 +163,8 @@ def concat(
             values with null.
         - Horizontal: stacks Series from DataFrames horizontally and fills with nulls
             if the lengths don't match.
+    rechunk
+        Make sure that all data is in contiguous memory.
     parallel
         Only relevant for LazyFrames. This determines if the concatenated
         lazy computations may be executed in parallel.
@@ -603,7 +602,6 @@ def align_frames(
     ...
 
 
-@deprecated_alias(reverse="descending")
 def align_frames(
     *frames: DataFrame | LazyFrame,
     on: str | Expr | Sequence[str] | Sequence[Expr] | Sequence[str | Expr],

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -101,9 +101,10 @@ def get_dummies(
 @overload
 def concat(
     items: Iterable[DataFrame],
-    rechunk: bool = True,
-    how: ConcatMethod = "vertical",
-    parallel: bool = True,
+    *,
+    how: ConcatMethod = ...,
+    rechunk: bool = ...,
+    parallel: bool = ...,
 ) -> DataFrame:
     ...
 
@@ -111,9 +112,10 @@ def concat(
 @overload
 def concat(
     items: Iterable[Series],
-    rechunk: bool = True,
-    how: ConcatMethod = "vertical",
-    parallel: bool = True,
+    *,
+    how: ConcatMethod = ...,
+    rechunk: bool = ...,
+    parallel: bool = ...,
 ) -> Series:
     ...
 
@@ -121,9 +123,10 @@ def concat(
 @overload
 def concat(
     items: Iterable[LazyFrame],
-    rechunk: bool = True,
-    how: ConcatMethod = "vertical",
-    parallel: bool = True,
+    *,
+    how: ConcatMethod = ...,
+    rechunk: bool = ...,
+    parallel: bool = ...,
 ) -> LazyFrame:
     ...
 
@@ -131,9 +134,10 @@ def concat(
 @overload
 def concat(
     items: Iterable[Expr],
-    rechunk: bool = True,
-    how: ConcatMethod = "vertical",
-    parallel: bool = True,
+    *,
+    how: ConcatMethod = ...,
+    rechunk: bool = ...,
+    parallel: bool = ...,
 ) -> Expr:
     ...
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -28,7 +28,6 @@ from polars.utils.convert import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import arange as pyarange
@@ -472,7 +471,6 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
-@deprecated_alias(column="exprs")
 def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | Any:
     """
     Get the maximum value.
@@ -565,7 +563,6 @@ def min(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
-@deprecated_alias(column="exprs")
 def min(
     exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
 ) -> Expr | PythonLiteral | None:
@@ -1159,9 +1156,8 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
     return col(column).tail(n)
 
 
-@deprecate_nonkeyword_arguments(allowed_args=["value", "dtype"])
 def lit(
-    value: Any, dtype: PolarsDataType | None = None, allow_object: bool = False
+    value: Any, dtype: PolarsDataType | None = None, *, allow_object: bool = False
 ) -> Expr:
     """
     Return an expression representing a literal value.
@@ -1363,9 +1359,8 @@ def cumsum(
     return cumfold(lit(0).cast(UInt32), lambda a, b: a + b, column).alias("cumsum")
 
 
-@deprecate_nonkeyword_arguments(allowed_args=["a", "b", "ddof"])
 def spearman_rank_corr(
-    a: str | Expr, b: str | Expr, ddof: int = 1, propagate_nans: bool = False
+    a: str | Expr, b: str | Expr, ddof: int = 1, *, propagate_nans: bool = False
 ) -> Expr:
     """
     Compute the spearman rank correlation between two columns.
@@ -1572,7 +1567,6 @@ def cov(a: str | Expr, b: str | Expr) -> Expr:
     return wrap_expr(pycov(a._pyexpr, b._pyexpr))
 
 
-@deprecated_alias(f="function")
 def map(
     exprs: Sequence[str] | Sequence[Expr],
     function: Callable[[Sequence[Series]], Series],
@@ -1635,14 +1629,11 @@ def map(
     )
 
 
-@deprecated_alias(f="function")
-@deprecate_nonkeyword_arguments(
-    allowed_args=["exprs", "function", "return_dtype"], stacklevel=3
-)
 def apply(
     exprs: Sequence[str | Expr],
     function: Callable[[Sequence[Series]], Series | Any],
     return_dtype: PolarsDataType | None = None,
+    *,
     returns_scalar: bool = True,
 ) -> Expr:
     """
@@ -1719,7 +1710,6 @@ def apply(
     )
 
 
-@deprecated_alias(f="function")
 def fold(
     acc: IntoExpr,
     function: Callable[[Series, Series], Series],
@@ -1828,7 +1818,6 @@ def fold(
     return wrap_expr(pyfold(acc._pyexpr, function, exprs))
 
 
-@deprecated_alias(f="function")
 def reduce(
     function: Callable[[Series, Series], Series],
     exprs: Sequence[Expr | str] | Expr,
@@ -1893,12 +1882,11 @@ def reduce(
     return wrap_expr(pyreduce(function, exprs))
 
 
-@deprecated_alias(f="function")
-@deprecate_nonkeyword_arguments(stacklevel=3)
 def cumfold(
     acc: IntoExpr,
     function: Callable[[Series, Series], Series],
     exprs: Sequence[Expr | str] | Expr,
+    *,
     include_init: bool = False,
 ) -> Expr:
     """
@@ -1971,7 +1959,6 @@ def cumfold(
     return wrap_expr(pycumfold(acc._pyexpr, function, exprs, include_init))
 
 
-@deprecated_alias(f="function")
 def cumreduce(
     function: Callable[[Series, Series], Series],
     exprs: Sequence[Expr | str] | Expr,
@@ -2703,9 +2690,9 @@ def concat_list(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> 
     return wrap_expr(_concat_lst(exprs))
 
 
-@deprecate_nonkeyword_arguments()
 def collect_all(
     lazy_frames: Sequence[LazyFrame],
+    *,
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1758,9 +1758,9 @@ def fold(
     Horizontally sum over all columns and add 1.
 
     >>> df.select(
-    ...     pl.fold(acc=pl.lit(1), f=lambda acc, x: acc + x, exprs=pl.col("*")).alias(
-    ...         "sum"
-    ...     ),
+    ...     pl.fold(
+    ...         acc=pl.lit(1), function=lambda acc, x: acc + x, exprs=pl.col("*")
+    ...     ).alias("sum"),
     ... )
     shape: (3, 1)
     ┌─────┐
@@ -1796,7 +1796,7 @@ def fold(
     >>> df.filter(
     ...     pl.fold(
     ...         acc=pl.lit(True),
-    ...         f=lambda acc, x: acc & x,
+    ...         function=lambda acc, x: acc & x,
     ...         exprs=pl.col("*") > 1,
     ...     )
     ... )
@@ -1935,7 +1935,7 @@ def cumfold(
 
     >>> df.select(
     ...     pl.cumfold(
-    ...         acc=pl.lit(1), f=lambda acc, x: acc + x, exprs=pl.col("*")
+    ...         acc=pl.lit(1), function=lambda acc, x: acc + x, exprs=pl.col("*")
     ...     ).alias("cumfold"),
     ... )
     shape: (3, 1)
@@ -1998,7 +1998,7 @@ def cumreduce(
     └─────┴─────┴─────┘
 
     >>> df.select(
-    ...     pl.cumreduce(f=lambda acc, x: acc + x, exprs=pl.col("*")).alias(
+    ...     pl.cumreduce(function=lambda acc, x: acc + x, exprs=pl.col("*")).alias(
     ...         "cumreduce"
     ...     ),
     ... )

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, BinaryIO
 
 from polars import internals as pli
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -12,10 +11,9 @@ if TYPE_CHECKING:
     from polars.dataframe import DataFrame
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def read_avro(
     source: str | Path | BytesIO | BinaryIO,
+    *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
 ) -> DataFrame:

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -16,7 +16,6 @@ from polars.datatypes import N_INFER_DEFAULT, Utf8
 from polars.io._utils import _prepare_file_arg
 from polars.io.csv._utils import _check_arg_is_1byte, _update_columns
 from polars.io.csv.batched_reader import BatchedCsvReader
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import handle_projection_columns, normalise_filepath
 
 if TYPE_CHECKING:
@@ -27,12 +26,9 @@ if TYPE_CHECKING:
     from polars.type_aliases import CsvEncoding, PolarsDataType, SchemaDict
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(
-    file="source", sep="separator", parse_dates="try_parse_dates", stacklevel=4
-)
 def read_csv(
     source: str | TextIO | BytesIO | Path | BinaryIO | bytes,
+    *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
     new_columns: Sequence[str] | None = None,
@@ -388,10 +384,9 @@ def read_csv(
     return df
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", sep="separator", stacklevel=4)
 def read_csv_batched(
     source: str | Path,
+    *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
     new_columns: Sequence[str] | None = None,
@@ -683,12 +678,9 @@ def read_csv_batched(
     )
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(
-    file="source", sep="separator", parse_dates="try_parse_dates", stacklevel=4
-)
 def scan_csv(
     source: str | Path,
+    *,
     has_header: bool = True,
     separator: str = ",",
     comment_char: str | None = None,

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -4,7 +4,6 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from polars.convert import from_arrow
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from polars.dataframe import DataFrame
@@ -108,16 +107,14 @@ def read_database(
         raise ValueError("Engine is not implemented, try either connectorx or adbc.")
 
 
-@deprecated_alias(sql="query")
-@deprecate_nonkeyword_arguments(stacklevel=3)
 def read_sql(
     query: list[str] | str,
     connection_uri: str,
+    *,
     partition_on: str | None = None,
     partition_range: tuple[int, int] | None = None,
     partition_num: int | None = None,
     protocol: str | None = None,
-    *,
     engine: DbReadEngine = "connectorx",
 ) -> DataFrame:
     """

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -7,17 +7,15 @@ from urllib.parse import urlparse
 from polars.convert import from_arrow
 from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 if TYPE_CHECKING:
     from polars.dataframe import DataFrame
     from polars.lazyframe import LazyFrame
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(table_uri="source", stacklevel=4)
 def read_delta(
     source: str,
+    *,
     version: int | None = None,
     columns: list[str] | None = None,
     storage_options: dict[str, Any] | None = None,
@@ -141,10 +139,9 @@ def read_delta(
     return from_arrow(dl_tbl.to_pyarrow_table(columns=columns, **pyarrow_options))  # type: ignore[return-value]
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(table_uri="source", stacklevel=4)
 def scan_delta(
     source: str,
+    *,
     version: int | None = None,
     storage_options: dict[str, Any] | None = None,
     delta_table_options: dict[str, Any] | None = None,

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 @overload
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
     sheet_id: Literal[None],
     sheet_name: Literal[None],
     xlsx2csv_options: dict[str, Any] | None,
@@ -33,6 +34,7 @@ def read_excel(
 @overload
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
     sheet_id: Literal[None],
     sheet_name: str,
     xlsx2csv_options: dict[str, Any] | None = None,
@@ -44,6 +46,7 @@ def read_excel(
 @overload
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
     sheet_id: int,
     sheet_name: Literal[None],
     xlsx2csv_options: dict[str, Any] | None = None,

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, overload
 
 from polars.io.csv.functions import read_csv
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
@@ -53,10 +52,9 @@ def read_excel(
     ...
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
     sheet_id: int | None = 1,
     sheet_name: str | None = None,
     xlsx2csv_options: dict[str, Any] | None = None,

--- a/py-polars/polars/io/ipc/anonymous_scan.py
+++ b/py-polars/polars/io/ipc/anonymous_scan.py
@@ -14,21 +14,21 @@ if TYPE_CHECKING:
 
 
 def _scan_ipc_fsspec(
-    file: str,
+    source: str,
     storage_options: dict[str, object] | None = None,
 ) -> LazyFrame:
-    func = partial(_scan_ipc_impl, file, storage_options=storage_options)
+    func = partial(_scan_ipc_impl, source, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 
     storage_options = storage_options or {}
-    with _prepare_file_arg(file, **storage_options) as data:
+    with _prepare_file_arg(source, **storage_options) as data:
         schema = polars.io.ipc.read_ipc_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)
 
 
 def _scan_ipc_impl(  # noqa: D417
-    uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
+    source: str, columns: list[str] | None, **kwargs: Any
 ) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
@@ -37,10 +37,10 @@ def _scan_ipc_impl(  # noqa: D417
     ----------
     uri
         Source URI
-    with_columns
+    columns
         Columns that are projected
 
     """
     import polars as pl
 
-    return pl.read_ipc(uri, with_columns, *args, **kwargs)
+    return pl.read_ipc(source, columns=columns, **kwargs)

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, BinaryIO
 from polars import internals as pli
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):
@@ -21,10 +20,9 @@ if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def read_ipc(
     source: str | BinaryIO | BytesIO | Path | bytes,
+    *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
     use_pyarrow: bool = False,
@@ -113,7 +111,6 @@ def read_ipc(
         )
 
 
-@deprecated_alias(file="source")
 def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
     """
     Get the schema of an IPC file without reading data.
@@ -134,10 +131,9 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
     return _ipc_schema(source)
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def scan_ipc(
     source: str | Path,
+    *,
     n_rows: int | None = None,
     cache: bool = True,
     rechunk: bool = True,

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars import internals as pli
-from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from io import IOBase
@@ -12,7 +11,6 @@ if TYPE_CHECKING:
     from polars.dataframe import DataFrame
 
 
-@deprecated_alias(file="source")
 def read_json(source: str | Path | IOBase) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from polars import internals as pli
 from polars.datatypes import N_INFER_DEFAULT
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
     from polars.lazyframe import LazyFrame
 
 
-@deprecated_alias(file="source")
 def read_ndjson(source: str | Path | IOBase) -> DataFrame:
     """
     Read into a DataFrame from a newline delimited JSON file.
@@ -29,10 +27,9 @@ def read_ndjson(source: str | Path | IOBase) -> DataFrame:
     return pli.DataFrame._read_ndjson(source)
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def scan_ndjson(
     source: str | Path,
+    *,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,
     n_rows: int | None = None,

--- a/py-polars/polars/io/parquet/anonymous_scan.py
+++ b/py-polars/polars/io/parquet/anonymous_scan.py
@@ -14,21 +14,21 @@ if TYPE_CHECKING:
 
 
 def _scan_parquet_fsspec(
-    file: str,
+    source: str,
     storage_options: dict[str, object] | None = None,
 ) -> LazyFrame:
-    func = partial(_scan_parquet_impl, file, storage_options=storage_options)
+    func = partial(_scan_parquet_impl, source, storage_options=storage_options)
     func_serialized = pickle.dumps(func)
 
     storage_options = storage_options or {}
-    with _prepare_file_arg(file, **storage_options) as data:
+    with _prepare_file_arg(source, **storage_options) as data:
         schema = polars.io.parquet.read_parquet_schema(data)
 
     return pli.LazyFrame._scan_python_function(schema, func_serialized)
 
 
 def _scan_parquet_impl(  # noqa: D417
-    uri: str, with_columns: list[str] | None, *args: Any, **kwargs: Any
+    uri: str, columns: list[str] | None, **kwargs: Any
 ) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
@@ -37,10 +37,10 @@ def _scan_parquet_impl(  # noqa: D417
     ----------
     uri
         Source URI
-    with_columns
+    columns
         Columns that are projected
 
     """
     import polars as pl
 
-    return pl.read_parquet(uri, with_columns, *args, **kwargs)
+    return pl.read_parquet(uri, columns=columns, **kwargs)

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -8,7 +8,6 @@ from polars import internals as pli
 from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):
@@ -22,9 +21,9 @@ if TYPE_CHECKING:
     from polars.type_aliases import ParallelStrategy, PolarsDataType
 
 
-@deprecate_nonkeyword_arguments()
 def read_parquet(
     source: str | Path | BinaryIO | BytesIO | bytes,
+    *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
     use_pyarrow: bool = False,
@@ -35,7 +34,6 @@ def read_parquet(
     row_count_offset: int = 0,
     low_memory: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
-    *,
     use_statistics: bool = True,
     rechunk: bool = True,
 ) -> DataFrame:
@@ -136,7 +134,6 @@ def read_parquet(
         )
 
 
-@deprecated_alias(file="source")
 def read_parquet_schema(
     source: str | BinaryIO | Path | bytes,
 ) -> dict[str, PolarsDataType]:
@@ -159,10 +156,9 @@ def read_parquet_schema(
     return _parquet_schema(source)
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(file="source", stacklevel=4)
 def scan_parquet(
     source: str | Path,
+    *,
     n_rows: int | None = None,
     cache: bool = True,
     parallel: ParallelStrategy = "auto",
@@ -171,7 +167,6 @@ def scan_parquet(
     row_count_offset: int = 0,
     storage_options: dict[str, Any] | None = None,
     low_memory: bool = False,
-    *,
     use_statistics: bool = True,
 ) -> LazyFrame:
     """

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -4,7 +4,6 @@ import warnings
 from typing import TYPE_CHECKING
 
 from polars.io.pyarrow_dataset.anonymous_scan import _scan_pyarrow_dataset
-from polars.utils.decorators import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
     from polars.dependencies import pyarrow as pa
@@ -56,8 +55,7 @@ def scan_pyarrow_dataset(
     return _scan_pyarrow_dataset(source, allow_pyarrow_filter=allow_pyarrow_filter)
 
 
-@deprecate_nonkeyword_arguments()
-def scan_ds(ds: pa.dataset.Dataset, allow_pyarrow_filter: bool = True) -> LazyFrame:
+def scan_ds(ds: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -51,11 +51,6 @@ from polars.slice import LazyPolarsSlice
 from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
 from polars.utils._wrap import wrap_df
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import (
-    deprecate_nonkeyword_arguments,
-    deprecated_alias,
-    redirect,
-)
 from polars.utils.various import (
     _in_notebook,
     _prepare_row_count_args,
@@ -110,12 +105,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-@redirect(
-    {
-        "cleared": "clear",
-        "with_column": "with_columns",
-    }
-)
 class LazyFrame:
     """
     Representation of a Lazy computation graph/query against a DataFrame.
@@ -950,9 +939,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             return ldf.describe_optimized_plan()
         return self._ldf.describe_plan()
 
-    @deprecate_nonkeyword_arguments()
     def describe_optimized_plan(
         self,
+        *,
         type_coercion: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
@@ -979,11 +968,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return ldf.describe_optimized_plan()
 
-    @deprecate_nonkeyword_arguments()
     def show_graph(
         self,
-        optimized: bool = True,
         *,
+        optimized: bool = True,
         show: bool = True,
         output_path: str | None = None,
         raw_output: bool = False,
@@ -1115,7 +1103,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self.map(inspect, predicate_pushdown=True, projection_pushdown=True)
 
-    @deprecated_alias(reverse="descending")
     def sort(
         self,
         by: IntoExpr | Iterable[IntoExpr],
@@ -1287,9 +1274,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             descending = [descending]
         return self._from_pyldf(self._ldf.bottom_k(k, by, descending, nulls_last))
 
-    @deprecate_nonkeyword_arguments()
     def profile(
         self,
+        *,
         type_coercion: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
@@ -2580,10 +2567,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
         return LazyGroupBy(lgb, lazyframe_class=self.__class__)
 
-    @deprecate_nonkeyword_arguments()
     def join_asof(
         self,
         other: LazyFrame,
+        *,
         left_on: str | None | Expr = None,
         right_on: str | None | Expr = None,
         on: str | None | Expr = None,
@@ -2757,19 +2744,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
         )
 
-    @deprecate_nonkeyword_arguments(
-        message=(
-            "All arguments of LazyFrame.join except for 'other', 'on', and 'how' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this warning."
-        )
-    )
     def join(
         self,
         other: LazyFrame,
-        left_on: str | Expr | Sequence[str | Expr] | None = None,
-        right_on: str | Expr | Sequence[str | Expr] | None = None,
         on: str | Expr | Sequence[str | Expr] | None = None,
         how: JoinStrategy = "inner",
+        *,
+        left_on: str | Expr | Sequence[str | Expr] | None = None,
+        right_on: str | Expr | Sequence[str | Expr] | None = None,
         suffix: str = "_right",
         allow_parallel: bool = True,
         force_parallel: bool = False,
@@ -2781,15 +2763,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         other
             Lazy DataFrame to join with.
-        left_on
-            Join column of the left DataFrame.
-        right_on
-            Join column of the right DataFrame.
         on
             Join column of both DataFrames. If set, `left_on` and `right_on` should be
             None.
         how : {'inner', 'left', 'outer', 'semi', 'anti', 'cross'}
             Join strategy.
+        left_on
+            Join column of the left DataFrame.
+        right_on
+            Join column of the right DataFrame.
         suffix
             Suffix to append to columns with a duplicate name.
         allow_parallel
@@ -3672,12 +3654,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self.select(F.col("*").take_every(n))
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "value", "strategy", "limit"])
     def fill_null(
         self,
         value: Any | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
+        *,
         matches_supertype: bool = True,
     ) -> Self:
         """
@@ -4132,28 +4114,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             columns.extend(selection_to_pyexpr_list(more_columns))
         return self._from_pyldf(self._ldf.explode(columns))
 
-    @deprecate_nonkeyword_arguments(
-        message=(
-            "All arguments of LazyFrame.unique except for 'subset' will be keyword-only in the next breaking release."
-            " Use keyword arguments to silence this warning."
-        )
-    )
     def unique(
         self,
-        maintain_order: bool = False,
         subset: str | Sequence[str] | None = None,
+        *,
         keep: UniqueKeepStrategy = "any",
+        maintain_order: bool = False,
     ) -> Self:
         """
         Drop duplicate rows from this dataframe.
 
         Parameters
         ----------
-        maintain_order
-            Keep the same order as the original DataFrame. This is more expensive to
-            compute.
-            Settings this to ``True`` blocks the possibility
-            to run on the streaming engine.
         subset
             Column name(s) to consider when identifying duplicates.
             If set to ``None`` (default), use all columns.
@@ -4165,6 +4137,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * 'none': Don't keep duplicate rows.
             * 'first': Keep first unique row.
             * 'last': Keep last unique row.
+        maintain_order
+            Keep the same order as the original DataFrame. This is more expensive to
+            compute.
+            Settings this to ``True`` blocks the possibility
+            to run on the streaming engine.
 
         Returns
         -------
@@ -4369,11 +4346,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             self._ldf.melt(id_vars, value_vars, value_name, variable_name, streamable)
         )
 
-    @deprecated_alias(f="function")
-    @deprecate_nonkeyword_arguments(stacklevel=3)
     def map(
         self,
         function: Callable[[DataFrame], DataFrame],
+        *,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         slice_pushdown: bool = True,
@@ -4488,7 +4464,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self.select(F.col("*").interpolate())
 
-    @deprecated_alias(names="columns")
     def unnest(self, columns: str | Sequence[str], *more_columns: str) -> Self:
         """
         Decompose struct columns into separate columns for each of their fields.

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 
 from polars import functions as F
 from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
-from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.dataframe import DataFrame
@@ -134,7 +133,6 @@ class LazyGroupBy(Generic[LDF]):
 
         return self._lazyframe_class._from_pyldf(self.lgb.agg(exprs))
 
-    @deprecated_alias(f="function")
     def apply(
         self,
         function: Callable[[DataFrame], DataFrame],

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Sequence
 
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_df
-from polars.utils.decorators import redirect
 from polars.utils.various import sphinx_accessor
 
 if TYPE_CHECKING:
@@ -17,7 +16,6 @@ elif os.getenv("BUILDING_SPHINX_DOCS"):
 
 
 @expr_dispatch
-@redirect({"to_frame": "unnest"})
 class StructNameSpace:
     """Series.struct namespace."""
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -15,14 +15,12 @@ from polars.datatypes import (
 from polars.exceptions import ComputeError, InvalidAssert
 from polars.lazyframe import LazyFrame
 from polars.series import Series
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
 
 
-@deprecate_nonkeyword_arguments()
-@deprecated_alias(check_column_names="check_column_order", stacklevel=4)
 def assert_frame_equal(
     left: DataFrame | LazyFrame,
     right: DataFrame | LazyFrame,
+    *,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
@@ -120,10 +118,10 @@ def assert_frame_equal(
             raise AssertionError(msg) from exc
 
 
-@deprecate_nonkeyword_arguments()
 def assert_frame_not_equal(
     left: DataFrame | LazyFrame,
     right: DataFrame | LazyFrame,
+    *,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
@@ -186,10 +184,10 @@ def assert_frame_not_equal(
         raise AssertionError("Expected the input frames to be unequal.")
 
 
-@deprecate_nonkeyword_arguments()
 def assert_series_equal(
     left: Series,
     right: Series,
+    *,
     check_dtype: bool = True,
     check_names: bool = True,
     check_exact: bool = False,
@@ -245,10 +243,10 @@ def assert_series_equal(
     )
 
 
-@deprecate_nonkeyword_arguments()
 def assert_series_not_equal(
     left: Series,
     right: Series,
+    *,
     check_dtype: bool = True,
     check_names: bool = True,
     check_exact: bool = False,

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -56,7 +56,6 @@ from polars.dependencies import pyarrow as pa
 from polars.exceptions import ComputeError, ShapeError
 from polars.utils._wrap import wrap_df, wrap_s
 from polars.utils.convert import _tzinfo_to_str
-from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import threadpool_size
 from polars.utils.various import _is_generator, arrlen, range_to_series
 
@@ -433,7 +432,6 @@ def sequence_to_pyseries(
             return _construct_series_with_fallbacks(constructor, name, values, strict)
 
 
-@deprecated_alias(nan_to_none="nan_to_null")
 def _pandas_series_to_arrow(
     values: pd.Series | pd.DatetimeIndex,
     nan_to_null: bool = True,
@@ -476,7 +474,6 @@ def _pandas_series_to_arrow(
         )
 
 
-@deprecated_alias(nan_to_none="nan_to_null")
 def pandas_to_pyseries(
     name: str, values: pd.Series | pd.DatetimeIndex, nan_to_null: bool = True
 ) -> PySeries:
@@ -1346,7 +1343,6 @@ def pandas_has_default_index(df: pd.DataFrame) -> bool:
         )
 
 
-@deprecated_alias(nan_to_none="nan_to_null")
 def pandas_to_pydf(
     data: pd.DataFrame,
     schema: SchemaDefinition | None = None,

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -69,11 +69,6 @@ def test_special_char_colname_init() -> None:
         assert len(df.rows()) == 0
         assert df.is_empty()
 
-        # TODO: remove once 'columns' -> 'schema' transition complete
-        with pytest.deprecated_call():
-            df2 = pl.DataFrame(columns=cols)  # type: ignore[call-arg]
-            assert_frame_equal(df, df2)
-
 
 def test_comparisons() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -90,15 +90,6 @@ def test_iter_rows() -> None:
     with pytest.raises(StopIteration):
         next(it)
 
-    # TODO: Remove this section once iterrows is removed
-    with pytest.deprecated_call():
-        it = df.iterrows()  # type: ignore[attr-defined]
-        assert next(it) == (1, True, c1)
-        assert next(it) == (2, False, c2)
-        assert next(it) == (3, None, c3)
-        with pytest.raises(StopIteration):
-            next(it)
-
     # Apply explicit row-buffer size
     for sz in (0, 1, 2, 3, 4):
         it = df.iter_rows(buffer_size=sz)

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -234,12 +234,7 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     with pytest.raises(AssertionError, match="Columns are not in the same order"):
         assert_frame_equal(df1, df2)
 
-    # preferred/new param name
     assert_frame_equal(df1, df2, check_column_order=False)
-
-    # deprecated param name
-    with pytest.deprecated_call():
-        assert_frame_equal(df1, df2, check_column_names=False)  # type: ignore[call-arg]
 
 
 def test_assert_frame_equal_ignore_row_order() -> None:


### PR DESCRIPTION
Removing some deprecated behaviour, mostly:
* Removed deprecated variable names
* Made some arguments keyword-only
* Removed the redirects on DataFrame/LazyFrame.