### PR TITLE
perf(rust, python): numeric grouptuples with nulls hash in single pass `~25%`

### DIFF
--- a/polars/polars-core/src/frame/groupby/hashing.rs
+++ b/polars/polars-core/src/frame/groupby/hashing.rs
@@ -84,19 +84,15 @@ where
     }
 }
 
-/// Determine group tuples over different threads. The hash of the key is used to determine the partitions.
-/// Note that rehashing of the keys should be cheap and the keys small to allow efficient rehashing and improved cache locality.
-///
-/// Besides numeric values, we can also use this for pre hashed strings. The keys are simply a ptr to the str + precomputed hash.
-/// The hash will be used to rehash, and the str will be used for equality.
-pub(crate) fn groupby_threaded_num<T, IntoSlice>(
-    keys: Vec<IntoSlice>,
+pub(crate) fn groupby_threaded_num2<T, I>(
+    keys: &[I],
     n_partitions: u64,
     sorted: bool,
 ) -> GroupsProxy
 where
+    I: IntoIterator<Item = T> + Send + Sync + Copy,
+    I::IntoIter: ExactSizeIterator,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
-    IntoSlice: AsRef<[T]> + Send + Sync,
 {
     assert!(n_partitions.is_power_of_two());
 
@@ -111,24 +107,24 @@ where
                     PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
 
                 let mut offset = 0;
-                for keys in &keys {
-                    let keys = keys.as_ref();
+                for keys in keys {
+                    let keys = keys.into_iter();
                     let len = keys.len() as IdxSize;
                     let hasher = hash_tbl.hasher().clone();
 
                     let mut cnt = 0;
-                    keys.iter().for_each(|k| {
+                    keys.for_each(|k| {
                         let idx = cnt + offset;
                         cnt += 1;
 
                         if this_partition(k.as_u64(), thread_no, n_partitions) {
                             let hash = hasher.hash_single(k);
-                            let entry = hash_tbl.raw_entry_mut().from_key_hashed_nocheck(hash, k);
+                            let entry = hash_tbl.raw_entry_mut().from_key_hashed_nocheck(hash, &k);
 
                             match entry {
                                 RawEntryMut::Vacant(entry) => {
                                     let tuples = vec![idx];
-                                    entry.insert_with_hasher(hash, *k, (idx, tuples), |k| {
+                                    entry.insert_with_hasher(hash, k, (idx, tuples), |k| {
                                         hasher.hash_single(k)
                                     });
                                 }

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1104,26 +1104,6 @@ mod test {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn test_groupby_threaded() {
-        for slice in &[
-            vec![1, 2, 3, 4, 4, 4, 2, 1],
-            vec![1, 2, 3, 4, 4, 4, 2, 1, 1],
-            vec![1, 2, 3, 4, 4, 4],
-        ] {
-            let ca = UInt32Chunked::new("", slice);
-            let split = split_ca(&ca, 4).unwrap();
-
-            let a = groupby(ca.into_iter(), true).into_idx();
-
-            let keys = split.iter().map(|ca| ca.cont_slice().unwrap()).collect();
-            let b = groupby_threaded_num(keys, split.len() as u64, true).into_idx();
-
-            assert_eq!(a, b);
-        }
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_groupby_null_handling() -> PolarsResult<()> {
         let df = df!(
             "a" => ["a", "a", "a", "b", "b"],

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -899,7 +899,7 @@ pub fn fmt_groupby_column(name: &str, method: GroupByMethod) -> String {
 mod test {
     use num_traits::FloatConst;
 
-    use crate::frame::groupby::{groupby, groupby_threaded_num};
+    use crate::frame::groupby::groupby;
     use crate::prelude::*;
     use crate::utils::split_ca;
 

--- a/polars/polars-core/src/hashing/partition.rs
+++ b/polars/polars-core/src/hashing/partition.rs
@@ -64,6 +64,23 @@ impl AsU64 for i64 {
     }
 }
 
+impl<T: AsU64 + Copy> AsU64 for Option<&T> {
+    #[inline]
+    fn as_u64(self) -> u64 {
+        match self {
+            Some(v) => v.as_u64(),
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
+        }
+    }
+}
+
+impl<T: AsU64 + Copy> AsU64 for &T {
+    fn as_u64(self) -> u64 {
+        (*self).as_u64()
+    }
+}
+
 impl AsU64 for Option<u32> {
     #[inline]
     fn as_u64(self) -> u64 {


### PR DESCRIPTION
This still had two passes over the data. Refactor so that we can process/hash data in a single pass.

A local group_tuples on 1M rows with 256 rows showed 25% improvement.