### PR TITLE
fix(python): Only allow correct type for get_column and to_series arg…

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2083,6 +2083,10 @@ class DataFrame:
         index
             Location of selection.
 
+        See Also
+        --------
+        get_column
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -2102,6 +2106,11 @@ class DataFrame:
         ]
 
         """
+        if not isinstance(index, int):
+            raise ValueError(
+                f'Index value "{index}" should be be an int, but is {type(index)}.'
+            )
+
         if index < 0:
             index = len(self.columns) + index
         return wrap_s(self._df.select_at_idx(index))
@@ -5669,6 +5678,10 @@ class DataFrame:
         name : str
             Name of the column to retrieve.
 
+        See Also
+        --------
+        to_series
+
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
@@ -5682,6 +5695,10 @@ class DataFrame:
         ]
 
         """
+        if not isinstance(name, str):
+            raise ValueError(
+                f'Column name "{name}" should be be a string, but is {type(name)}.'
+            )
         return self[name]
 
     @deprecate_nonkeyword_arguments(allowed_args=["self", "value", "strategy", "limit"])

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -116,8 +116,12 @@ def test_comparisons() -> None:
 def test_selection() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]})
 
-    # get_column by name
-    assert df.get_column("a").to_list() == [1, 2, 3]
+    # get column by name
+    assert_series_equal(df.get_column("b"), pl.Series("b", [1.0, 2.0, 3.0]))
+
+    # get column by index
+    assert_series_equal(df.to_series(1), pl.Series("b", [1.0, 2.0, 3.0]))
+    assert_series_equal(df.to_series(-1), pl.Series("c", ["a", "b", "c"]))
 
     # select columns by mask
     assert df[:2, :1].rows() == [(1,), (2,)]


### PR DESCRIPTION
…ument

Only allow correct type for get_column and to_series argument as before this patch df.get_column(1) would return the second row, instead of the second column. Now it will raise an error.