### PR TITLE
refactor(python)!: Instantiate Polars datatypes

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -156,7 +156,6 @@ from polars.string_cache import (
 from polars.type_aliases import PolarsDataType
 from polars.utils import (
     build_info,
-    get_idx_type,
     get_index_type,
     show_versions,
     threadpool_size,
@@ -326,7 +325,6 @@ __all__ = [
     "SQLContext",
     # polars.utils
     "build_info",
-    "get_idx_type",
     "get_index_type",
     "show_versions",
     "threadpool_size",

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -355,11 +355,11 @@ def from_repr(tbl: str) -> DataFrame:
     schema = dict(zip(headers, (dtype_short_repr_to_dtype(d) for d in dtypes)))
     for tp in set(schema.values()):
         # TODO: handle basic compound types
-        if tp in (List, Struct):
+        if isinstance(tp, (List, Struct)):
             raise NotImplementedError(
                 f"'from_repr' does not (yet) support {tp} dtype columns"
             )
-        elif tp == Object:
+        elif isinstance(tp, Object):
             raise ValueError("'from_repr' does not (and cannot) support Object dtype")
 
     # construct DataFrame from string series and cast from repr to native dtype

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3508,7 +3508,6 @@ class DataFrame:
         max_num_values = min(10, self.height)
 
         def _parse_column(col_name: str, dtype: DataType) -> tuple[str, str, str]:
-            # TODO: Normalize first?
             dtype_str = f"<{dtype._string_repr()}>"
             val = self[:max_num_values][col_name].to_list()
             val_str = ", ".join(map(str, val))

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -3,7 +3,6 @@ from polars.datatypes.classes import (
     Boolean,
     Categorical,
     DataType,
-    DataTypeClass,
     Date,
     Datetime,
     Decimal,
@@ -11,6 +10,7 @@ from polars.datatypes.classes import (
     Field,
     Float32,
     Float64,
+    FloatType,
     FractionalType,
     Int8,
     Int16,
@@ -48,6 +48,7 @@ from polars.datatypes.constructor import (
     py_type_to_constructor,
 )
 from polars.datatypes.convert import (
+    _normalize_polars_dtype,
     dtype_to_arrow_type,
     dtype_to_ctype,
     dtype_to_ffiname,
@@ -74,7 +75,6 @@ __all__ = [
     "Boolean",
     "Categorical",
     "DataType",
-    "DataTypeClass",
     "Date",
     "Datetime",
     "Decimal",
@@ -82,6 +82,7 @@ __all__ = [
     "Field",
     "Float32",
     "Float64",
+    "FloatType",
     "FractionalType",
     "Int16",
     "Int32",
@@ -116,6 +117,7 @@ __all__ = [
     "polars_type_to_constructor",
     "py_type_to_constructor",
     # convert
+    "_normalize_polars_dtype",
     "dtype_to_arrow_type",
     "dtype_to_ctype",
     "dtype_to_ffiname",

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -38,7 +38,9 @@ from polars.datatypes.constants import (
     FLOAT_DTYPES,
     INTEGER_DTYPES,
     N_INFER_DEFAULT,
+    NESTED_DTYPES,
     NUMERIC_DTYPES,
+    POLARS_DTYPES,
     TEMPORAL_DTYPES,
 )
 from polars.datatypes.constructor import (
@@ -109,7 +111,9 @@ __all__ = [
     "FLOAT_DTYPES",
     "INTEGER_DTYPES",
     "N_INFER_DEFAULT",
+    "NESTED_DTYPES",
     "NUMERIC_DTYPES",
+    "POLARS_DTYPES",
     "TEMPORAL_DTYPES",
     # constructor
     "numpy_type_to_constructor",

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -4,7 +4,7 @@ import contextlib
 from inspect import isclass
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
 
-import polars.datatypes as dt
+import polars.datatypes as pldt
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr as _dtype_str_repr
@@ -308,7 +308,7 @@ class List(NestedType):
             The `DataType` of values within the list
 
         """
-        self.inner = dt.py_type_to_dtype(inner)
+        self.inner = pldt.py_type_to_dtype(inner)
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # The comparison allows comparing objects to classes
@@ -398,7 +398,7 @@ class Field:
 
         """
         self.name = name
-        self.dtype = dt.py_type_to_dtype(dtype)
+        self.dtype = pldt.py_type_to_dtype(dtype)
 
     def __eq__(self, other: Field) -> bool:  # type: ignore[override]
         return (self.name == other.name) & (self.dtype == other.dtype)

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -53,11 +53,11 @@ class DataType:
         Examples
         --------
         >>> pl.Datetime("ns").base_type()
-        Datetime
+        <class 'polars.datatypes.classes.Datetime'>
         >>> pl.List(pl.Int32).base_type()
-        List
+        <class 'polars.datatypes.classes.List'>
         >>> pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)]).base_type()
-        Struct
+        <class 'polars.datatypes.classes.Struct'>
         """
         return cls
 

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars.datatypes import (
+    Binary,
+    Boolean,
+    Categorical,
     Date,
     Datetime,
     Decimal,
@@ -13,17 +16,23 @@ from polars.datatypes import (
     Int16,
     Int32,
     Int64,
+    List,
+    Null,
+    Object,
+    Struct,
     Time,
     UInt8,
     UInt16,
     UInt32,
     UInt64,
+    Utf8,
 )
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType, TimeUnit
 
 DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
+
 DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
         # TODO: ideally need a mechanism to wildcard timezones here too
@@ -42,6 +51,7 @@ DURATION_DTYPES: frozenset[PolarsDataType] = frozenset(
 TEMPORAL_DTYPES: frozenset[PolarsDataType] = (
     frozenset([Date, Time]) | DATETIME_DTYPES | DURATION_DTYPES
 )
+
 INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
         UInt8,
@@ -57,6 +67,16 @@ INTEGER_DTYPES: frozenset[PolarsDataType] = frozenset(
 FLOAT_DTYPES: frozenset[PolarsDataType] = frozenset([Float32, Float64])
 NUMERIC_DTYPES: frozenset[PolarsDataType] = (
     FLOAT_DTYPES | INTEGER_DTYPES | frozenset([Decimal])
+)
+
+NESTED_DTYPES: frozenset[PolarsDataType] = frozenset([List, Struct])
+
+POLARS_DTYPES: frozenset[PolarsDataType] = (
+    NUMERIC_DTYPES
+    # Not using instantiated Datetime/Duration types here
+    | frozenset([Date, Time, Duration, Datetime])
+    | NESTED_DTYPES
+    | frozenset([Boolean, Utf8, Binary, Categorical, Null, Object])
 )
 
 # number of rows to scan by default when inferring datatypes

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -323,22 +323,18 @@ def dtype_to_py_type(dtype: PolarsDataType) -> PythonDataType:
 
 
 @overload
-def py_type_to_dtype(
-    data_type: Any, raise_unmatched: Literal[True] = True
-) -> PolarsDataType:
+def py_type_to_dtype(data_type: Any, raise_unmatched: Literal[True] = True) -> DataType:
     ...
 
 
 @overload
 def py_type_to_dtype(
     data_type: Any, raise_unmatched: Literal[False]
-) -> PolarsDataType | None:
+) -> DataType | None:
     ...
 
 
-def py_type_to_dtype(
-    data_type: Any, raise_unmatched: bool = True
-) -> PolarsDataType | None:
+def py_type_to_dtype(data_type: Any, raise_unmatched: bool = True) -> DataType | None:
     """Convert a Python dtype (or type annotation) to a Polars dtype."""
     if isinstance(data_type, ForwardRef):
         annotation = data_type.__forward_arg__
@@ -363,7 +359,7 @@ def py_type_to_dtype(
     elif isinstance(data_type, str):
         data_type = DataTypeMappings.REPR_TO_DTYPE.get(data_type, data_type)
         if is_polars_dtype(data_type):
-            return data_type
+            return _normalize_polars_dtype(data_type)
     try:
         dtype = map_py_type_to_dtype(data_type)
         return _normalize_polars_dtype(dtype)
@@ -422,7 +418,8 @@ def dtype_short_repr_to_dtype(dtype_string: str | None) -> PolarsDataType | None
             return dtype(*subtype)  # type: ignore[operator]
         except ValueError:
             pass
-    return _normalize_polars_dtype(dtype)
+
+    return _normalize_polars_dtype(dtype)  # type: ignore[arg-type]
 
 
 def supported_numpy_char_code(dtype_char: str) -> bool:

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -19,7 +19,7 @@ from typing import (
     overload,
 )
 
-import polars.datatypes as dt
+import polars.datatypes as pldt
 from polars.dependencies import numpy as np
 from polars.dependencies import pyarrow as pa
 
@@ -63,74 +63,74 @@ def cache(function: Callable[..., T]) -> T:
 
 
 def _normalize_polars_dtype(data_type: PolarsDataType) -> DataType:
-    if isclass(data_type) and issubclass(data_type, dt.DataType):
+    if isclass(data_type) and issubclass(data_type, pldt.DataType):
         return data_type()
     else:
         return data_type  # type: ignore[return-value]
 
 
 PY_STR_TO_DTYPE: dict[str, PolarsDataType] = {
-    "float": dt.Float64,
-    "int": dt.Int64,
-    "str": dt.Utf8,
-    "bool": dt.Boolean,
-    "date": dt.Date,
-    "datetime": dt.Datetime("us"),
-    "timedelta": dt.Duration("us"),
-    "time": dt.Time,
-    "list": dt.List,
-    "tuple": dt.List,
-    "Decimal": dt.Decimal,
-    "bytes": dt.Binary,
-    "object": dt.Object,
-    "NoneType": dt.Null,
+    "float": pldt.Float64,
+    "int": pldt.Int64,
+    "str": pldt.Utf8,
+    "bool": pldt.Boolean,
+    "date": pldt.Date,
+    "datetime": pldt.Datetime("us"),
+    "timedelta": pldt.Duration("us"),
+    "time": pldt.Time,
+    "list": pldt.List,
+    "tuple": pldt.List,
+    "Decimal": pldt.Decimal,
+    "bytes": pldt.Binary,
+    "object": pldt.Object,
+    "NoneType": pldt.Null,
 }
 
 
 @functools.lru_cache(16)
 def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsDataType:
     if python_dtype is float:
-        return dt.Float64
+        return pldt.Float64
     if python_dtype is int:
-        return dt.Int64
+        return pldt.Int64
     if python_dtype is str:
-        return dt.Utf8
+        return pldt.Utf8
     if python_dtype is bool:
-        return dt.Boolean
+        return pldt.Boolean
     if issubclass(python_dtype, datetime):
         # `datetime` is a subclass of `date`,
         # so need to check `datetime` first
-        return dt.Datetime("us")
+        return pldt.Datetime("us")
     if issubclass(python_dtype, date):
-        return dt.Date
+        return pldt.Date
     if python_dtype is timedelta:
-        return dt.Duration("us")
+        return pldt.Duration("us")
     if python_dtype is time:
-        return dt.Time
+        return pldt.Time
     if python_dtype is list:
-        return dt.List
+        return pldt.List
     if python_dtype is tuple:
-        return dt.List
+        return pldt.List
     if python_dtype is PyDecimal:
-        return dt.Decimal
+        return pldt.Decimal
     if python_dtype is bytes:
-        return dt.Binary
+        return pldt.Binary
     if python_dtype is object:
-        return dt.Object
+        return pldt.Object
     if python_dtype is None.__class__:
-        return dt.Null
+        return pldt.Null
     raise TypeError("Invalid type")
 
 
 def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     try:
-        if data_type == dt.Unknown:
+        if data_type == pldt.Unknown:
             # does not represent a realisable dtype, so ignore by default
             return include_unknown
         else:
-            return isinstance(data_type, dt.DataType) or (
-                isclass(data_type) and issubclass(data_type, dt.DataType)
+            return isinstance(data_type, pldt.DataType) or (
+                isclass(data_type) and issubclass(data_type, pldt.DataType)
             )
     except ValueError:
         return False
@@ -141,73 +141,73 @@ class _DataTypeMappings:
     @cache
     def DTYPE_TO_FFINAME(self) -> dict[PolarsDataType, str]:
         return {
-            dt.Int8: "i8",
-            dt.Int16: "i16",
-            dt.Int32: "i32",
-            dt.Int64: "i64",
-            dt.UInt8: "u8",
-            dt.UInt16: "u16",
-            dt.UInt32: "u32",
-            dt.UInt64: "u64",
-            dt.Float32: "f32",
-            dt.Float64: "f64",
-            dt.Boolean: "bool",
-            dt.Utf8: "str",
-            dt.List: "list",
-            dt.Date: "date",
-            dt.Datetime: "datetime",
-            dt.Duration: "duration",
-            dt.Time: "time",
-            dt.Object: "object",
-            dt.Categorical: "categorical",
-            dt.Struct: "struct",
-            dt.Binary: "binary",
+            pldt.Int8: "i8",
+            pldt.Int16: "i16",
+            pldt.Int32: "i32",
+            pldt.Int64: "i64",
+            pldt.UInt8: "u8",
+            pldt.UInt16: "u16",
+            pldt.UInt32: "u32",
+            pldt.UInt64: "u64",
+            pldt.Float32: "f32",
+            pldt.Float64: "f64",
+            pldt.Boolean: "bool",
+            pldt.Utf8: "str",
+            pldt.List: "list",
+            pldt.Date: "date",
+            pldt.Datetime: "datetime",
+            pldt.Duration: "duration",
+            pldt.Time: "time",
+            pldt.Object: "object",
+            pldt.Categorical: "categorical",
+            pldt.Struct: "struct",
+            pldt.Binary: "binary",
         }
 
     @property
     @cache
     def DTYPE_TO_CTYPE(self) -> dict[PolarsDataType, Any]:
         return {
-            dt.UInt8: ctypes.c_uint8,
-            dt.UInt16: ctypes.c_uint16,
-            dt.UInt32: ctypes.c_uint32,
-            dt.UInt64: ctypes.c_uint64,
-            dt.Int8: ctypes.c_int8,
-            dt.Int16: ctypes.c_int16,
-            dt.Int32: ctypes.c_int32,
-            dt.Date: ctypes.c_int32,
-            dt.Int64: ctypes.c_int64,
-            dt.Float32: ctypes.c_float,
-            dt.Float64: ctypes.c_double,
-            dt.Datetime: ctypes.c_int64,
-            dt.Duration: ctypes.c_int64,
-            dt.Time: ctypes.c_int64,
+            pldt.UInt8: ctypes.c_uint8,
+            pldt.UInt16: ctypes.c_uint16,
+            pldt.UInt32: ctypes.c_uint32,
+            pldt.UInt64: ctypes.c_uint64,
+            pldt.Int8: ctypes.c_int8,
+            pldt.Int16: ctypes.c_int16,
+            pldt.Int32: ctypes.c_int32,
+            pldt.Date: ctypes.c_int32,
+            pldt.Int64: ctypes.c_int64,
+            pldt.Float32: ctypes.c_float,
+            pldt.Float64: ctypes.c_double,
+            pldt.Datetime: ctypes.c_int64,
+            pldt.Duration: ctypes.c_int64,
+            pldt.Time: ctypes.c_int64,
         }
 
     @property
     @cache
     def DTYPE_TO_PY_TYPE(self) -> dict[PolarsDataType, PythonDataType]:
         return {
-            dt.Float64: float,
-            dt.Float32: float,
-            dt.Int64: int,
-            dt.Int32: int,
-            dt.Int16: int,
-            dt.Int8: int,
-            dt.Utf8: str,
-            dt.UInt8: int,
-            dt.UInt16: int,
-            dt.UInt32: int,
-            dt.UInt64: int,
-            dt.Decimal: PyDecimal,
-            dt.Boolean: bool,
-            dt.Duration: timedelta,
-            dt.Datetime: datetime,
-            dt.Date: date,
-            dt.Time: time,
-            dt.Binary: bytes,
-            dt.List: list,
-            dt.Null: None.__class__,
+            pldt.Float64: float,
+            pldt.Float32: float,
+            pldt.Int64: int,
+            pldt.Int32: int,
+            pldt.Int16: int,
+            pldt.Int8: int,
+            pldt.Utf8: str,
+            pldt.UInt8: int,
+            pldt.UInt16: int,
+            pldt.UInt32: int,
+            pldt.UInt64: int,
+            pldt.Decimal: PyDecimal,
+            pldt.Boolean: bool,
+            pldt.Duration: timedelta,
+            pldt.Datetime: datetime,
+            pldt.Date: date,
+            pldt.Time: time,
+            pldt.Binary: bytes,
+            pldt.List: list,
+            pldt.Null: None.__class__,
         }
 
     @property
@@ -215,16 +215,16 @@ class _DataTypeMappings:
     def NUMPY_KIND_AND_ITEMSIZE_TO_DTYPE(self) -> dict[tuple[str, int], PolarsDataType]:
         return {
             # (np.dtype().kind, np.dtype().itemsize)
-            ("i", 1): dt.Int8,
-            ("i", 2): dt.Int16,
-            ("i", 4): dt.Int32,
-            ("i", 8): dt.Int64,
-            ("u", 1): dt.UInt8,
-            ("u", 2): dt.UInt16,
-            ("u", 4): dt.UInt32,
-            ("u", 8): dt.UInt64,
-            ("f", 4): dt.Float32,
-            ("f", 8): dt.Float64,
+            ("i", 1): pldt.Int8,
+            ("i", 2): pldt.Int16,
+            ("i", 4): pldt.Int32,
+            ("i", 8): pldt.Int64,
+            ("u", 1): pldt.UInt8,
+            ("u", 2): pldt.UInt16,
+            ("u", 4): pldt.UInt32,
+            ("u", 8): pldt.UInt64,
+            ("f", 4): pldt.Float32,
+            ("f", 8): pldt.Float64,
         }
 
     @property
@@ -246,27 +246,27 @@ class _DataTypeMappings:
     @cache
     def DTYPE_TO_ARROW_TYPE(self) -> dict[PolarsDataType, pa.lib.DataType]:
         return {
-            dt.Int8(): pa.int8(),
-            dt.Int16(): pa.int16(),
-            dt.Int32(): pa.int32(),
-            dt.Int64(): pa.int64(),
-            dt.UInt8(): pa.uint8(),
-            dt.UInt16(): pa.uint16(),
-            dt.UInt32(): pa.uint32(),
-            dt.UInt64(): pa.uint64(),
-            dt.Float32(): pa.float32(),
-            dt.Float64(): pa.float64(),
-            dt.Boolean(): pa.bool_(),
-            dt.Utf8(): pa.large_utf8(),
-            dt.Date(): pa.date32(),
-            dt.Datetime("ms"): pa.timestamp("ms"),
-            dt.Datetime("us"): pa.timestamp("us"),
-            dt.Datetime("ns"): pa.timestamp("ns"),
-            dt.Duration("ms"): pa.duration("ms"),
-            dt.Duration("us"): pa.duration("us"),
-            dt.Duration("ns"): pa.duration("ns"),
-            dt.Time(): pa.time64("us"),
-            dt.Null(): pa.null(),
+            pldt.Int8(): pa.int8(),
+            pldt.Int16(): pa.int16(),
+            pldt.Int32(): pa.int32(),
+            pldt.Int64(): pa.int64(),
+            pldt.UInt8(): pa.uint8(),
+            pldt.UInt16(): pa.uint16(),
+            pldt.UInt32(): pa.uint32(),
+            pldt.UInt64(): pa.uint64(),
+            pldt.Float32(): pa.float32(),
+            pldt.Float64(): pa.float64(),
+            pldt.Boolean(): pa.bool_(),
+            pldt.Utf8(): pa.large_utf8(),
+            pldt.Date(): pa.date32(),
+            pldt.Datetime("ms"): pa.timestamp("ms"),
+            pldt.Datetime("us"): pa.timestamp("us"),
+            pldt.Datetime("ns"): pa.timestamp("ns"),
+            pldt.Duration("ms"): pa.duration("ms"),
+            pldt.Duration("us"): pa.duration("us"),
+            pldt.Duration("ns"): pa.duration("ns"),
+            pldt.Time(): pa.time64("us"),
+            pldt.Null(): pa.null(),
         }
 
     @property
@@ -280,7 +280,7 @@ class _DataTypeMappings:
 
         return {
             _dtype_str_repr_safe(obj): obj  # type: ignore[misc]
-            for obj in dt.POLARS_DTYPES
+            for obj in pldt.POLARS_DTYPES
             if _dtype_str_repr_safe(obj) is not None
         }
 
@@ -387,8 +387,8 @@ def dtype_to_arrow_type(dtype: PolarsDataType) -> pa.lib.DataType:
     try:
         # special handling for mapping to tz-aware timestamp type.
         # (don't want to include every possible tz string in the lookup)
-        if isinstance(dtype, dt.Datetime):
-            dtype, time_zone = dt.Datetime(dtype.time_unit), dtype.time_zone
+        if isinstance(dtype, pldt.Datetime):
+            dtype, time_zone = pldt.Datetime(dtype.time_unit), dtype.time_zone
             arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
             if time_zone is not None:
                 arrow_type = pa.timestamp(dtype.time_unit, time_zone)

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -280,8 +280,8 @@ class _DataTypeMappings:
 
         return {
             _dtype_str_repr_safe(obj): obj  # type: ignore[misc]
-            for obj in globals().values()
-            if is_polars_dtype(obj) and _dtype_str_repr_safe(obj) is not None
+            for obj in dt.POLARS_DTYPES
+            if _dtype_str_repr_safe(obj) is not None
         }
 
 
@@ -422,7 +422,7 @@ def dtype_short_repr_to_dtype(dtype_string: str | None) -> PolarsDataType | None
             return dtype(*subtype)  # type: ignore[operator]
         except ValueError:
             pass
-    return dtype
+    return _normalize_polars_dtype(dtype)
 
 
 def supported_numpy_char_code(dtype_char: str) -> bool:

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -7,6 +7,7 @@ import re
 import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
+from inspect import isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -18,34 +19,7 @@ from typing import (
     overload,
 )
 
-from polars.datatypes import (
-    Binary,
-    Boolean,
-    Categorical,
-    DataType,
-    DataTypeClass,
-    Date,
-    Datetime,
-    Decimal,
-    Duration,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    List,
-    Null,
-    Object,
-    Struct,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Unknown,
-    Utf8,
-)
+import polars.datatypes as dt
 from polars.dependencies import numpy as np
 from polars.dependencies import pyarrow as pa
 
@@ -70,7 +44,8 @@ else:
     UnionType = type(Union[int, float])
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType, PythonDataType, SchemaDict, TimeUnit
+    from polars.datatypes import DataType
+    from polars.type_aliases import PolarsDataType, PythonDataType, TimeUnit
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -87,67 +62,76 @@ def cache(function: Callable[..., T]) -> T:
     return functools.lru_cache()(function)  # type: ignore[return-value]
 
 
-PY_STR_TO_DTYPE: SchemaDict = {
-    "float": Float64,
-    "int": Int64,
-    "str": Utf8,
-    "bool": Boolean,
-    "date": Date,
-    "datetime": Datetime("us"),
-    "timedelta": Duration("us"),
-    "time": Time,
-    "list": List,
-    "tuple": List,
-    "Decimal": Decimal,
-    "bytes": Binary,
-    "object": Object,
-    "NoneType": Null,
+def _normalize_polars_dtype(data_type: PolarsDataType) -> DataType:
+    if isclass(data_type) and issubclass(data_type, dt.DataType):
+        return data_type()
+    else:
+        return data_type  # type: ignore[return-value]
+
+
+PY_STR_TO_DTYPE: dict[str, PolarsDataType] = {
+    "float": dt.Float64,
+    "int": dt.Int64,
+    "str": dt.Utf8,
+    "bool": dt.Boolean,
+    "date": dt.Date,
+    "datetime": dt.Datetime("us"),
+    "timedelta": dt.Duration("us"),
+    "time": dt.Time,
+    "list": dt.List,
+    "tuple": dt.List,
+    "Decimal": dt.Decimal,
+    "bytes": dt.Binary,
+    "object": dt.Object,
+    "NoneType": dt.Null,
 }
 
 
 @functools.lru_cache(16)
 def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsDataType:
     if python_dtype is float:
-        return Float64
+        return dt.Float64
     if python_dtype is int:
-        return Int64
+        return dt.Int64
     if python_dtype is str:
-        return Utf8
+        return dt.Utf8
     if python_dtype is bool:
-        return Boolean
+        return dt.Boolean
     if issubclass(python_dtype, datetime):
         # `datetime` is a subclass of `date`,
         # so need to check `datetime` first
-        return Datetime("us")
+        return dt.Datetime("us")
     if issubclass(python_dtype, date):
-        return Date
+        return dt.Date
     if python_dtype is timedelta:
-        return Duration("us")
+        return dt.Duration("us")
     if python_dtype is time:
-        return Time
+        return dt.Time
     if python_dtype is list:
-        return List
+        return dt.List
     if python_dtype is tuple:
-        return List
+        return dt.List
     if python_dtype is PyDecimal:
-        return Decimal
+        return dt.Decimal
     if python_dtype is bytes:
-        return Binary
+        return dt.Binary
     if python_dtype is object:
-        return Object
+        return dt.Object
     if python_dtype is None.__class__:
-        return Null
+        return dt.Null
     raise TypeError("Invalid type")
 
 
 def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     try:
-        if data_type == Unknown:
+        if data_type == dt.Unknown:
             # does not represent a realisable dtype, so ignore by default
             return include_unknown
         else:
-            return isinstance(data_type, (DataType, DataTypeClass))
+            return isinstance(data_type, dt.DataType) or (
+                isclass(data_type) and issubclass(data_type, dt.DataType)
+            )
     except ValueError:
         return False
 
@@ -157,73 +141,73 @@ class _DataTypeMappings:
     @cache
     def DTYPE_TO_FFINAME(self) -> dict[PolarsDataType, str]:
         return {
-            Int8: "i8",
-            Int16: "i16",
-            Int32: "i32",
-            Int64: "i64",
-            UInt8: "u8",
-            UInt16: "u16",
-            UInt32: "u32",
-            UInt64: "u64",
-            Float32: "f32",
-            Float64: "f64",
-            Boolean: "bool",
-            Utf8: "str",
-            List: "list",
-            Date: "date",
-            Datetime: "datetime",
-            Duration: "duration",
-            Time: "time",
-            Object: "object",
-            Categorical: "categorical",
-            Struct: "struct",
-            Binary: "binary",
+            dt.Int8: "i8",
+            dt.Int16: "i16",
+            dt.Int32: "i32",
+            dt.Int64: "i64",
+            dt.UInt8: "u8",
+            dt.UInt16: "u16",
+            dt.UInt32: "u32",
+            dt.UInt64: "u64",
+            dt.Float32: "f32",
+            dt.Float64: "f64",
+            dt.Boolean: "bool",
+            dt.Utf8: "str",
+            dt.List: "list",
+            dt.Date: "date",
+            dt.Datetime: "datetime",
+            dt.Duration: "duration",
+            dt.Time: "time",
+            dt.Object: "object",
+            dt.Categorical: "categorical",
+            dt.Struct: "struct",
+            dt.Binary: "binary",
         }
 
     @property
     @cache
     def DTYPE_TO_CTYPE(self) -> dict[PolarsDataType, Any]:
         return {
-            UInt8: ctypes.c_uint8,
-            UInt16: ctypes.c_uint16,
-            UInt32: ctypes.c_uint32,
-            UInt64: ctypes.c_uint64,
-            Int8: ctypes.c_int8,
-            Int16: ctypes.c_int16,
-            Int32: ctypes.c_int32,
-            Date: ctypes.c_int32,
-            Int64: ctypes.c_int64,
-            Float32: ctypes.c_float,
-            Float64: ctypes.c_double,
-            Datetime: ctypes.c_int64,
-            Duration: ctypes.c_int64,
-            Time: ctypes.c_int64,
+            dt.UInt8: ctypes.c_uint8,
+            dt.UInt16: ctypes.c_uint16,
+            dt.UInt32: ctypes.c_uint32,
+            dt.UInt64: ctypes.c_uint64,
+            dt.Int8: ctypes.c_int8,
+            dt.Int16: ctypes.c_int16,
+            dt.Int32: ctypes.c_int32,
+            dt.Date: ctypes.c_int32,
+            dt.Int64: ctypes.c_int64,
+            dt.Float32: ctypes.c_float,
+            dt.Float64: ctypes.c_double,
+            dt.Datetime: ctypes.c_int64,
+            dt.Duration: ctypes.c_int64,
+            dt.Time: ctypes.c_int64,
         }
 
     @property
     @cache
     def DTYPE_TO_PY_TYPE(self) -> dict[PolarsDataType, PythonDataType]:
         return {
-            Float64: float,
-            Float32: float,
-            Int64: int,
-            Int32: int,
-            Int16: int,
-            Int8: int,
-            Utf8: str,
-            UInt8: int,
-            UInt16: int,
-            UInt32: int,
-            UInt64: int,
-            Decimal: PyDecimal,
-            Boolean: bool,
-            Duration: timedelta,
-            Datetime: datetime,
-            Date: date,
-            Time: time,
-            Binary: bytes,
-            List: list,
-            Null: None.__class__,
+            dt.Float64: float,
+            dt.Float32: float,
+            dt.Int64: int,
+            dt.Int32: int,
+            dt.Int16: int,
+            dt.Int8: int,
+            dt.Utf8: str,
+            dt.UInt8: int,
+            dt.UInt16: int,
+            dt.UInt32: int,
+            dt.UInt64: int,
+            dt.Decimal: PyDecimal,
+            dt.Boolean: bool,
+            dt.Duration: timedelta,
+            dt.Datetime: datetime,
+            dt.Date: date,
+            dt.Time: time,
+            dt.Binary: bytes,
+            dt.List: list,
+            dt.Null: None.__class__,
         }
 
     @property
@@ -231,16 +215,16 @@ class _DataTypeMappings:
     def NUMPY_KIND_AND_ITEMSIZE_TO_DTYPE(self) -> dict[tuple[str, int], PolarsDataType]:
         return {
             # (np.dtype().kind, np.dtype().itemsize)
-            ("i", 1): Int8,
-            ("i", 2): Int16,
-            ("i", 4): Int32,
-            ("i", 8): Int64,
-            ("u", 1): UInt8,
-            ("u", 2): UInt16,
-            ("u", 4): UInt32,
-            ("u", 8): UInt64,
-            ("f", 4): Float32,
-            ("f", 8): Float64,
+            ("i", 1): dt.Int8,
+            ("i", 2): dt.Int16,
+            ("i", 4): dt.Int32,
+            ("i", 8): dt.Int64,
+            ("u", 1): dt.UInt8,
+            ("u", 2): dt.UInt16,
+            ("u", 4): dt.UInt32,
+            ("u", 8): dt.UInt64,
+            ("f", 4): dt.Float32,
+            ("f", 8): dt.Float64,
         }
 
     @property
@@ -262,29 +246,27 @@ class _DataTypeMappings:
     @cache
     def DTYPE_TO_ARROW_TYPE(self) -> dict[PolarsDataType, pa.lib.DataType]:
         return {
-            Int8: pa.int8(),
-            Int16: pa.int16(),
-            Int32: pa.int32(),
-            Int64: pa.int64(),
-            UInt8: pa.uint8(),
-            UInt16: pa.uint16(),
-            UInt32: pa.uint32(),
-            UInt64: pa.uint64(),
-            Float32: pa.float32(),
-            Float64: pa.float64(),
-            Boolean: pa.bool_(),
-            Utf8: pa.large_utf8(),
-            Date: pa.date32(),
-            Datetime: pa.timestamp("us"),
-            Datetime("ms"): pa.timestamp("ms"),
-            Datetime("us"): pa.timestamp("us"),
-            Datetime("ns"): pa.timestamp("ns"),
-            Duration: pa.duration("us"),
-            Duration("ms"): pa.duration("ms"),
-            Duration("us"): pa.duration("us"),
-            Duration("ns"): pa.duration("ns"),
-            Time: pa.time64("us"),
-            Null: pa.null(),
+            dt.Int8(): pa.int8(),
+            dt.Int16(): pa.int16(),
+            dt.Int32(): pa.int32(),
+            dt.Int64(): pa.int64(),
+            dt.UInt8(): pa.uint8(),
+            dt.UInt16(): pa.uint16(),
+            dt.UInt32(): pa.uint32(),
+            dt.UInt64(): pa.uint64(),
+            dt.Float32(): pa.float32(),
+            dt.Float64(): pa.float64(),
+            dt.Boolean(): pa.bool_(),
+            dt.Utf8(): pa.large_utf8(),
+            dt.Date(): pa.date32(),
+            dt.Datetime("ms"): pa.timestamp("ms"),
+            dt.Datetime("us"): pa.timestamp("us"),
+            dt.Datetime("ns"): pa.timestamp("ns"),
+            dt.Duration("ms"): pa.duration("ms"),
+            dt.Duration("us"): pa.duration("us"),
+            dt.Duration("ns"): pa.duration("ns"),
+            dt.Time(): pa.time64("us"),
+            dt.Null(): pa.null(),
         }
 
     @property
@@ -369,7 +351,7 @@ def py_type_to_dtype(
         )
 
     if is_polars_dtype(data_type):
-        return data_type
+        return _normalize_polars_dtype(data_type)
 
     elif isinstance(data_type, (OptionType, UnionType)):
         # not exhaustive; handles the common "type | None" case, but
@@ -383,7 +365,8 @@ def py_type_to_dtype(
         if is_polars_dtype(data_type):
             return data_type
     try:
-        return map_py_type_to_dtype(data_type)
+        dtype = map_py_type_to_dtype(data_type)
+        return _normalize_polars_dtype(dtype)
     except (KeyError, TypeError):  # pragma: no cover
         if not raise_unmatched:
             return None
@@ -404,16 +387,17 @@ def py_type_to_arrow_type(dtype: PythonDataType) -> pa.lib.DataType:
 
 def dtype_to_arrow_type(dtype: PolarsDataType) -> pa.lib.DataType:
     """Convert a Polars dtype to an Arrow dtype."""
+    dtype = _normalize_polars_dtype(dtype)
     try:
         # special handling for mapping to tz-aware timestamp type.
         # (don't want to include every possible tz string in the lookup)
-        time_zone = None
-        if dtype == Datetime:
-            dtype, time_zone = Datetime(dtype.time_unit), dtype.time_zone  # type: ignore[union-attr]
-
-        arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
-        if time_zone:
-            arrow_type = pa.timestamp(dtype.time_unit or "us", time_zone)  # type: ignore[union-attr]
+        if isinstance(dtype, dt.Datetime):
+            dtype, time_zone = dt.Datetime(dtype.time_unit), dtype.time_zone
+            arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
+            if time_zone is not None:
+                arrow_type = pa.timestamp(dtype.time_unit, time_zone)
+        else:
+            arrow_type = DataTypeMappings.DTYPE_TO_ARROW_TYPE[dtype]
         return arrow_type
     except KeyError:  # pragma: no cover
         raise ValueError(

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -135,8 +135,10 @@ class ExprStringNameSpace:
         if datatype == Date:
             return wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
         elif datatype == Datetime:
-            time_unit = datatype.time_unit  # type: ignore[union-attr]
-            time_zone = datatype.time_zone  # type: ignore[union-attr]
+            if isinstance(datatype, Datetime):
+                time_unit, time_zone = datatype.time_unit, datatype.time_zone
+            else:
+                time_unit, time_zone = None, None
             dtcol = wrap_expr(
                 self._pyexpr.str_parse_datetime(
                     fmt,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3001,11 +3001,11 @@ def repeat(
             name = ""
         dtype = py_type_to_dtype(type(value))
         if (
-            dtype == Int64
+            isinstance(dtype, Int64)
             and isinstance(value, int)
             and -(2**31) <= value <= 2**31 - 1
         ):
-            dtype = Int32
+            dtype = Int32()
         s = pli.Series._repeat(name, value, n, dtype)  # type: ignore[arg-type]
         return s
     else:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -40,6 +40,7 @@ from polars.datatypes import (
     UInt32,
     UInt64,
     Utf8,
+    _normalize_polars_dtype,
     py_type_to_dtype,
 )
 from polars.dependencies import subprocess
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars.dataframe import DataFrame
+    from polars.datatypes import DataType
     from polars.expr.expr import Expr
     from polars.series import Series
     from polars.type_aliases import (
@@ -574,7 +576,7 @@ class LazyFrame:
         return self._ldf.columns()
 
     @property
-    def dtypes(self) -> list[PolarsDataType]:
+    def dtypes(self) -> list[DataType]:
         """
         Get dtypes of columns in LazyFrame.
 
@@ -595,10 +597,11 @@ class LazyFrame:
         schema : Returns a {colname:dtype} mapping.
 
         """
-        return self._ldf.dtypes()
+        dtypes = self._ldf.dtypes()
+        return [_normalize_polars_dtype(dtype) for dtype in dtypes]
 
     @property
-    def schema(self) -> SchemaDict:
+    def schema(self) -> dict[str, DataType]:
         """
         Get a dict[column name, DataType].
 
@@ -615,7 +618,7 @@ class LazyFrame:
         {'foo': Int64, 'bar': Float64, 'ham': Utf8}
 
         """
-        return self._ldf.schema()
+        return dict(zip(self.columns, self.dtypes))
 
     @property
     def width(self) -> int:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -247,7 +247,7 @@ class Series:
                 raise ValueError("Series name must be a string.")
 
         # Handle when dtype is passed uninstantiated
-        dtype = _normalize_polars_dtype(dtype)
+        dtype = _normalize_polars_dtype(dtype)  # type: ignore[arg-type]
 
         if values is None:
             self._s = sequence_to_pyseries(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -27,11 +27,14 @@ from polars.datatypes import (
     Duration,
     Float32,
     Float64,
+    FloatType,
     Int8,
     Int16,
     Int32,
     Int64,
     List,
+    NumericType,
+    TemporalType,
     Time,
     UInt8,
     UInt16,
@@ -39,6 +42,7 @@ from polars.datatypes import (
     UInt64,
     Unknown,
     Utf8,
+    _normalize_polars_dtype,
     dtype_to_ctype,
     is_polars_dtype,
     maybe_cast,
@@ -96,6 +100,7 @@ if TYPE_CHECKING:
     import sys
 
     from polars.dataframe import DataFrame
+    from polars.datatypes import DataType
     from polars.expr.expr import Expr
     from polars.series._numpy import SeriesView
     from polars.type_aliases import (
@@ -340,7 +345,7 @@ class Series:
         return self._s.get_ptr()
 
     @property
-    def dtype(self) -> PolarsDataType:
+    def dtype(self) -> DataType:
         """
         Get the data type of this Series.
 
@@ -351,7 +356,8 @@ class Series:
         Int64
 
         """
-        return self._s.dtype()
+        dtype = self._s.dtype()
+        return _normalize_polars_dtype(dtype)
 
     @property
     def flags(self) -> dict[str, bool]:
@@ -2974,18 +2980,7 @@ class Series:
         True
 
         """
-        return self.dtype in (
-            Int8,
-            Int16,
-            Int32,
-            Int64,
-            UInt8,
-            UInt16,
-            UInt32,
-            UInt64,
-            Float32,
-            Float64,
-        )
+        return isinstance(self.dtype, NumericType)
 
     def is_temporal(self, excluding: OneOrMoreDataTypes | None = None) -> bool:
         """
@@ -3012,7 +3007,7 @@ class Series:
             if self.dtype in excluding:
                 return False
 
-        return self.dtype in (Date, Datetime, Duration, Time)
+        return isinstance(self.dtype, TemporalType)
 
     def is_float(self) -> bool:
         """
@@ -3025,7 +3020,7 @@ class Series:
         True
 
         """
-        return self.dtype in (Float32, Float64)
+        return isinstance(self.dtype, FloatType)
 
     def is_boolean(self) -> bool:
         """
@@ -3038,7 +3033,7 @@ class Series:
         True
 
         """
-        return self.dtype is Boolean
+        return isinstance(self.dtype, Boolean)
 
     def is_utf8(self) -> bool:
         """
@@ -3051,7 +3046,7 @@ class Series:
         True
 
         """
-        return self.dtype is Utf8
+        return isinstance(self.dtype, Utf8)
 
     def view(self, *, ignore_nulls: bool = False) -> SeriesView:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -246,6 +246,9 @@ class Series:
             else:
                 raise ValueError("Series name must be a string.")
 
+        # Handle when dtype is passed uninstantiated
+        dtype = _normalize_polars_dtype(dtype)
+
         if values is None:
             self._s = sequence_to_pyseries(
                 name, [], dtype=dtype, dtype_if_empty=dtype_if_empty

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -160,7 +160,7 @@ class column:
     >>> from hypothesis.strategies import sampled_from
     >>> from polars.testing.parametric import column
     >>> column(name="unique_small_ints", dtype=pl.UInt8, unique=True)
-    column(name='unique_small_ints', dtype=UInt8, strategy=None, null_probability=None, unique=True)
+    column(name='unique_small_ints', dtype=<class 'polars.datatypes.classes.UInt8'>, strategy=None, null_probability=None, unique=True)
     >>> column(name="ccy", strategy=sampled_from(["GBP", "EUR", "JPY"]))
     column(name='ccy', dtype=Utf8, strategy=sampled_from(['GBP', 'EUR', 'JPY']), null_probability=None, unique=False)
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -392,7 +392,6 @@ def raise_assert_detail(
 
 def is_categorical_dtype(data_type: Any) -> bool:
     """Check if the input is a polars Categorical dtype."""
-    # TODO: Normalize?
     return isinstance(data_type, Categorical)
 
 

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -7,7 +7,6 @@ from polars import functions as F
 from polars.dataframe import DataFrame
 from polars.datatypes import (
     Categorical,
-    DataTypeClass,
     Float32,
     Float64,
     dtype_to_py_type,
@@ -393,11 +392,8 @@ def raise_assert_detail(
 
 def is_categorical_dtype(data_type: Any) -> bool:
     """Check if the input is a polars Categorical dtype."""
-    return (
-        type(data_type) is DataTypeClass
-        and issubclass(data_type, Categorical)
-        or isinstance(data_type, Categorical)
-    )
+    # TODO: Normalize?
+    return isinstance(data_type, Categorical)
 
 
 def assert_frame_equal_local_categoricals(df_a: DataFrame, df_b: DataFrame) -> None:

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -22,7 +22,7 @@ else:
     from typing_extensions import Literal
 
 if TYPE_CHECKING:
-    from polars.datatypes import DataType, DataTypeClass, TemporalType
+    from polars.datatypes import DataType, TemporalType
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
 
 # Data types
-PolarsDataType: TypeAlias = Union["DataTypeClass", "DataType"]
+PolarsDataType: TypeAlias = Union[Type["DataType"], "DataType"]
 PolarsTemporalType: TypeAlias = Union[Type["TemporalType"], "TemporalType"]
 OneOrMoreDataTypes: TypeAlias = Union[PolarsDataType, Iterable[PolarsDataType]]
 PythonDataType: TypeAlias = Union[

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -15,7 +15,7 @@ from polars.utils.convert import (
     _to_python_timedelta,
     _tzinfo_to_str,
 )
-from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
+from polars.utils.meta import get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
 from polars.utils.various import NoDefault, no_default
 
@@ -24,7 +24,6 @@ __all__ = [
     "no_default",
     "build_info",
     "show_versions",
-    "get_idx_type",
     "get_index_type",
     "threadpool_size",
     # Required for Rust bindings

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -95,10 +95,7 @@ def include_unknowns(
     schema: SchemaDict, cols: Sequence[str]
 ) -> MutableMapping[str, PolarsDataType]:
     """Complete partial schema dict by including Unknown type."""
-    return {
-        col: (schema.get(col, Unknown) or Unknown)  # type: ignore[truthy-bool]
-        for col in cols
-    }
+    return {col: (schema.get(col, Unknown) or Unknown) for col in cols}
 
 
 ################################

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import contextlib
-import warnings
 from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -10,10 +9,10 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import threadpool_size as _threadpool_size
 
 if TYPE_CHECKING:
-    from polars.datatypes import DataTypeClass
+    from polars.datatypes import DataType
 
 
-def get_index_type() -> DataTypeClass:
+def get_index_type() -> DataType:
     """
     Get the datatype used for Polars indexing.
 
@@ -23,17 +22,6 @@ def get_index_type() -> DataTypeClass:
 
     """
     return _get_index_type()
-
-
-def get_idx_type() -> DataTypeClass:
-    """Get the datatype used for Polars indexing."""
-    warnings.warn(
-        "`get_idx_type` has been renamed; this"
-        " redirect is temporary, please use `get_index_type` instead",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return get_index_type()
 
 
 def threadpool_size() -> int:

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -362,7 +362,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
         let type_name = ob.get_type().name()?;
 
         let dtype = match type_name {
-            "DataTypeClass" => {
+            "type" => {
                 // just the class, not an object
                 let name = ob.getattr("__name__")?.str()?.to_str()?;
                 match name {
@@ -397,6 +397,22 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     }
                 }
             }
+            "UInt8" => DataType::UInt8,
+            "UInt16" => DataType::UInt16,
+            "UInt32" => DataType::UInt32,
+            "UInt64" => DataType::UInt64,
+            "Int8" => DataType::Int8,
+            "Int16" => DataType::Int16,
+            "Int32" => DataType::Int32,
+            "Int64" => DataType::Int64,
+            "Float32" => DataType::Float32,
+            "Float64" => DataType::Float64,
+            "Utf8" => DataType::Utf8,
+            "Binary" => DataType::Binary,
+            "Boolean" => DataType::Boolean,
+            "Categorical" => DataType::Categorical(None),
+            "Date" => DataType::Date,
+            "Time" => DataType::Time,
             "Duration" => {
                 let time_unit = ob.getattr("time_unit").unwrap();
                 let time_unit = time_unit.extract::<Wrap<TimeUnit>>()?.0;
@@ -428,10 +444,12 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     .collect::<Vec<Field>>();
                 DataType::Struct(fields)
             }
+            "Object" => DataType::Object(OBJECT_NAME),
+            "Null" => DataType::Null,
+            "Unknown" => DataType::Unknown,
             dt => {
                 return Err(PyTypeError::new_err(format!(
-                    "A {dt} object is not a correct polars DataType. \
-                    Hint: use the class without instantiating it.",
+                    "A {dt} object is not a correct polars DataType.",
                 )))
             }
         };

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -74,7 +74,12 @@ def test_strategy_shape(
     )
 )
 def test_strategy_frame_columns(lf: pl.LazyFrame) -> None:
-    assert lf.schema == {"a": pl.UInt8, "b": pl.UInt8, "c": pl.Boolean, "d": pl.Utf8}
+    assert lf.schema == {
+        "a": pl.UInt8(),
+        "b": pl.UInt8(),
+        "c": pl.Boolean(),
+        "d": pl.Utf8(),
+    }
     assert lf.columns == ["a", "b", "c", "d"]
     df = lf.collect()
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -13,7 +13,7 @@ def test_dtype() -> None:
     a = pl.Series("a", [[1, 2, 3], [2, 5], [6, 7, 8, 9]])
     assert a.dtype == pl.List
     assert a.inner_dtype == pl.Int64
-    assert a.dtype.inner == pl.Int64  # type: ignore[union-attr]
+    assert a.dtype.inner == pl.Int64  # type: ignore[attr-defined]
 
     # explicit
     df = pl.DataFrame(
@@ -36,7 +36,7 @@ def test_dtype() -> None:
         "dt": pl.List(pl.Date),
         "dtm": pl.List(pl.Datetime),
     }
-    assert df.schema["i"].inner == pl.Int8  # type: ignore[union-attr]
+    assert df.schema["i"].inner == pl.Int8  # type: ignore[attr-defined]
     assert df.rows() == [
         (
             [1, 2, 3],
@@ -141,7 +141,7 @@ def test_cast_inner() -> None:
     # this creates an inner null type
     df = pl.from_pandas(pd.DataFrame(data=[[[]], [[]]], columns=["A"]))
     assert (
-        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64()  # type: ignore[union-attr]
+        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64()  # type: ignore[attr-defined]
     )
 
 
@@ -201,7 +201,7 @@ def test_empty_list_construction() -> None:
     ) == {"array": [[]], "not_array": [1234]}
 
     df = pl.DataFrame(schema=[("col", pl.List)])
-    assert df.schema == {"col": pl.List}
+    assert df.schema == {"col": pl.List(pl.Float64)}
     assert df.rows() == []
 
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -141,7 +141,7 @@ def test_cast_inner() -> None:
     # this creates an inner null type
     df = pl.from_pandas(pd.DataFrame(data=[[[]], [[]]], columns=["A"]))
     assert (
-        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64  # type: ignore[union-attr]
+        df["A"].cast(pl.List(int)).dtype.inner == pl.Int64()  # type: ignore[union-attr]
     )
 
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -205,7 +205,7 @@ def test_struct_cols() -> None:
     # struct column
     df = build_struct_df([{"struct_col": {"inner": 1}}])
     assert df.columns == ["struct_col"]
-    assert df.schema == {"struct_col": pl.Struct}
+    assert df.schema == {"struct_col": pl.Struct({"inner": pl.Int64})}
     assert df["struct_col"].struct.field("inner").to_list() == [1]
 
     # struct in struct
@@ -697,7 +697,7 @@ def test_concat_list_reverse_struct_fields() -> None:
 
 
 def test_struct_any_value_get_after_append() -> None:
-    schema = {"a": pl.Int8, "b": pl.Int32}
+    schema = {"a": pl.Int8(), "b": pl.Int32()}
     struct_def = pl.Struct(schema)
 
     a = pl.Series("s", [{"a": 1, "b": 2}], dtype=struct_def)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1354,17 +1354,17 @@ def test_asof_join() -> None:
     )
     assert trades.schema == {
         "dates": pl.Datetime("ms"),
-        "ticker": pl.Utf8,
-        "bid": pl.Float64,
+        "ticker": pl.Utf8(),
+        "bid": pl.Float64(),
     }
     out = trades.join_asof(quotes, on="dates", strategy="backward")
 
     assert out.schema == {
-        "bid": pl.Float64,
-        "bid_right": pl.Float64,
+        "bid": pl.Float64(),
+        "bid_right": pl.Float64(),
         "dates": pl.Datetime("ms"),
-        "ticker": pl.Utf8,
-        "ticker_right": pl.Utf8,
+        "ticker": pl.Utf8(),
+        "ticker_right": pl.Utf8(),
     }
     assert out.columns == ["dates", "ticker", "bid", "ticker_right", "bid_right"]
     assert (out["dates"].cast(int)).to_list() == [

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -507,7 +507,7 @@ def test_date_range() -> None:
         datetime(2022, 1, 1), datetime(2022, 1, 1, 0, 1), "987456321ns"
     )
     assert len(result) == 61
-    assert result.dtype.time_unit == "ns"  # type: ignore[union-attr]
+    assert result.dtype.time_unit == "ns"  # type: ignore[attr-defined]
     assert result.dt.second()[-1] == 59
     assert result.cast(pl.Utf8)[-1] == "2022-01-01 00:00:59.247379260"
 

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -262,7 +262,7 @@ def test_groupby_sorted_empty_dataframe_3680() -> None:
     )
     assert df.rows() == []
     assert df.shape == (0, 2)
-    assert df.schema == {"key": pl.Categorical, "val": pl.Float64}
+    assert df.schema == {"key": pl.Categorical(), "val": pl.Float64()}
 
 
 def test_groupby_custom_agg_empty_list() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -68,7 +68,7 @@ def test_asof_join_schema_5211() -> None:
             df2.lazy(), left_on="today", right_on="next_friday", strategy="forward"
         )
         .schema
-    ) == {"today": pl.Int64, "next_friday": pl.Int64}
+    ) == {"today": pl.Int64(), "next_friday": pl.Int64()}
 
 
 def test_asof_join_schema_5684() -> None:
@@ -101,7 +101,7 @@ def test_asof_join_schema_5684() -> None:
     assert (
         q.schema
         == projected_result.schema
-        == {"id": pl.Int64, "a": pl.Int64, "b_right": pl.Int64}
+        == {"id": pl.Int64(), "a": pl.Int64(), "b_right": pl.Int64()}
     )
 
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -315,7 +315,7 @@ def test_unset_sorted_flag_after_extend() -> None:
 def test_set_sorted_schema() -> None:
     assert (
         pl.DataFrame({"A": [0, 1]}).lazy().with_columns(pl.col("A").set_sorted()).schema
-    ) == {"A": pl.Int64}
+    ) == {"A": pl.Int64()}
 
 
 def test_sort_slice_fast_path_5245() -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -144,9 +144,9 @@ def test_init_dataclasses_and_namedtuple(monkeypatch: Any) -> None:
             df = DF(data=trades)  # type: ignore[operator]
             assert df.schema == {
                 "timestamp": pl.Datetime("us"),
-                "ticker": pl.Utf8,
+                "ticker": pl.Utf8(),
                 "price": pl.Decimal(None, 1),
-                "size": pl.Int64,
+                "size": pl.Int64(),
             }
             assert df.rows() == raw_data
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import sys
 import typing
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from random import shuffle
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,7 @@ import pytest
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.testing import assert_frame_equal, assert_series_equal
+from polars.utils._construction import dataclass_type_hints
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
@@ -114,12 +116,7 @@ def test_init_dict() -> None:
 
 
 def test_init_dataclasses_and_namedtuple(monkeypatch: Any) -> None:
-    from dataclasses import dataclass
-    from typing import NamedTuple
-
     monkeypatch.setenv("POLARS_ACTIVATE_DECIMAL", "1")
-
-    from polars.utils._construction import dataclass_type_hints
 
     @dataclass
     class TradeDC:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -34,14 +34,14 @@ def test_init_dict() -> None:
     # Empty dictionary/values
     df = pl.DataFrame({"a": [], "b": []})
     assert df.shape == (0, 2)
-    assert df.schema == {"a": pl.Float32, "b": pl.Float32}
+    assert df.schema == {"a": pl.Float32(), "b": pl.Float32()}
 
     for df in (
         pl.DataFrame({}, schema={"a": pl.Date, "b": pl.Utf8}),
         pl.DataFrame({"a": [], "b": []}, schema={"a": pl.Date, "b": pl.Utf8}),
     ):
         assert df.shape == (0, 2)
-        assert df.schema == {"a": pl.Date, "b": pl.Utf8}
+        assert df.schema == {"a": pl.Date(), "b": pl.Utf8()}
 
     # List of empty list
     df = pl.DataFrame({"a": [[]], "b": [[]]})
@@ -59,7 +59,7 @@ def test_init_dict() -> None:
         data={"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
         schema=[("a", pl.Int8), ("b", pl.Float32)],
     )
-    assert df.schema == {"a": pl.Int8, "b": pl.Float32}
+    assert df.schema == {"a": pl.Int8(), "b": pl.Float32()}
 
     # Values contained in tuples
     df = pl.DataFrame({"a": (1, 2, 3), "b": [1.0, 2.0, 3.0]})
@@ -86,7 +86,7 @@ def test_init_dict() -> None:
             data={"dt": dates, "dtm": datetimes},
             schema=coldefs,
         )
-        assert df.schema == {"dt": pl.Date, "dtm": pl.Datetime}
+        assert df.schema == {"dt": pl.Date(), "dtm": pl.Datetime()}
         assert df.rows() == list(zip(py_dates, py_datetimes))
 
     # Overriding dict column names/types
@@ -97,12 +97,12 @@ def test_init_dict() -> None:
         {"a": [1, 2, 3], "b": [4, 5, 6]},
         schema=["c", ("d", pl.Int8)],
     )  # partial type info (allowed, but mypy doesn't like it ;p)
-    assert df.schema == {"c": pl.Int64, "d": pl.Int8}
+    assert df.schema == {"c": pl.Int64(), "d": pl.Int8()}
 
     df = pl.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6]}, schema=[("c", pl.Int8), ("d", pl.Int16)]
     )
-    assert df.schema == {"c": pl.Int8, "d": pl.Int16}
+    assert df.schema == {"c": pl.Int8(), "d": pl.Int16()}
 
     dfe = df.clear()
     assert df.schema == dfe.schema
@@ -219,7 +219,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
         orient="row",
     )
     assert df.rows() == [(True, 2, "a"), (None, None, None)]
-    assert df.schema == {"x": pl.Boolean, "y": pl.Int32, "z": pl.Utf8}
+    assert df.schema == {"x": pl.Boolean(), "y": pl.Int32(), "z": pl.Utf8()}
 
     # 2D array - default to column orientation
     df = pl.DataFrame(np.array([[1, 2], [3, 4]], dtype=np.int64))
@@ -316,7 +316,7 @@ def test_init_arrow() -> None:
         pa.table({"a": [1, 2], None: [3, 4]}),
         schema=[("c", pl.Int32), ("d", pl.Float32)],
     )
-    assert df.schema == {"c": pl.Int32, "d": pl.Float32}
+    assert df.schema == {"c": pl.Int32(), "d": pl.Float32()}
     assert df.rows() == [(1, 3.0), (2, 4.0)]
 
     # Bad columns argument
@@ -338,7 +338,7 @@ def test_init_series() -> None:
         (pl.Series("a", (1, 2, 3)), pl.Series("b", (4, 5, 6))),
         schema=[("x", pl.Float64), ("y", pl.Float64)],
     )
-    assert df.schema == {"x": pl.Float64, "y": pl.Float64}
+    assert df.schema == {"x": pl.Float64(), "y": pl.Float64()}
     assert df.rows() == [(1.0, 4.0), (2.0, 5.0), (3.0, 6.0)]
 
     # List of unnamed Series
@@ -349,25 +349,25 @@ def test_init_series() -> None:
     assert_frame_equal(df, expected)
 
     df = pl.DataFrame([pl.Series([0.0]), pl.Series([1.0])])
-    assert df.schema == {"column_0": pl.Float64, "column_1": pl.Float64}
+    assert df.schema == {"column_0": pl.Float64(), "column_1": pl.Float64()}
     assert df.rows() == [(0.0, 1.0)]
 
     df = pl.DataFrame(
         [pl.Series([None]), pl.Series([1.0])],
         schema=[("x", pl.Date), ("y", pl.Boolean)],
     )
-    assert df.schema == {"x": pl.Date, "y": pl.Boolean}
+    assert df.schema == {"x": pl.Date(), "y": pl.Boolean()}
     assert df.rows() == [(None, True)]
 
     # Single Series
     df = pl.DataFrame(pl.Series("a", [1, 2, 3]))
     expected = pl.DataFrame({"a": [1, 2, 3]})
-    assert df.schema == {"a": pl.Int64}
+    assert df.schema == {"a": pl.Int64()}
     assert_frame_equal(df, expected)
 
     df = pl.DataFrame(pl.Series("a", [1, 2, 3]), schema=[("a", pl.UInt32)])
     assert df.rows() == [(1,), (2,), (3,)]
-    assert df.schema == {"a": pl.UInt32}
+    assert df.schema == {"a": pl.UInt32()}
 
     # nested list, with/without explicit dtype
     s1 = pl.Series([[[2, 2]]])
@@ -398,7 +398,7 @@ def test_init_seq_of_seq() -> None:
         [[1, 2, 3], [4, 5, 6]],
         schema=[("a", pl.Int8), ("b", pl.Int16), ("c", pl.Int32)],
     )
-    assert df.schema == {"a": pl.Int8, "b": pl.Int16, "c": pl.Int32}
+    assert df.schema == {"a": pl.Int8(), "b": pl.Int16(), "c": pl.Int32()}
     assert df.rows() == [(1, 2, 3), (4, 5, 6)]
 
     # Tuple of tuples, default to column orientation
@@ -414,7 +414,7 @@ def test_init_seq_of_seq() -> None:
     df = pl.DataFrame(
         ((1, 2), (3, 4)), schema=(("a", pl.Float32), ("b", pl.Float32)), orient="row"
     )
-    assert df.schema == {"a": pl.Float32, "b": pl.Float32}
+    assert df.schema == {"a": pl.Float32(), "b": pl.Float32()}
     assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
     # Wrong orient value
@@ -435,7 +435,7 @@ def test_init_1d_sequence() -> None:
         assert_frame_equal(df, expected)
 
     df = pl.DataFrame([None, True, False], schema=[("xx", pl.Int8)])
-    assert df.schema == {"xx": pl.Int8}
+    assert df.schema == {"xx": pl.Int8()}
     assert df.rows() == [(None,), (1,), (0,)]
 
     # String sequence
@@ -467,11 +467,11 @@ def test_init_pandas(monkeypatch: Any) -> None:
     df = pl.DataFrame(pandas_df)
     expected = pl.DataFrame({"1": [1, 3], "2": [2, 4]})
     assert_frame_equal(df, expected)
-    assert df.schema == {"1": pl.Int64, "2": pl.Int64}
+    assert df.schema == {"1": pl.Int64(), "2": pl.Int64()}
 
     # override column names, types
     df = pl.DataFrame(pandas_df, schema=[("x", pl.Float64), ("y", pl.Float64)])
-    assert df.schema == {"x": pl.Float64, "y": pl.Float64}
+    assert df.schema == {"x": pl.Float64(), "y": pl.Float64()}
     assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]
 
     # subclassed pandas object, with/without data & overrides
@@ -598,8 +598,8 @@ def test_init_only_columns() -> None:
 
         assert df.shape == (0, 4)
         assert_frame_equal(df, expected)
-        assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
-        assert df.schema["d"].inner == pl.UInt8  # type: ignore[union-attr]
+        assert df.dtypes == [pl.Date(), pl.UInt64(), pl.Int8(), pl.List(pl.UInt8)]
+        assert df.schema["d"].inner == pl.UInt8()  # type: ignore[attr-defined]
 
         dfe = df.clear()
         assert len(dfe) == 0
@@ -852,7 +852,7 @@ def test_from_categorical_in_struct_defined_by_schema() -> None:
         schema={"a": pl.Struct({"value": pl.Categorical, "counts": pl.UInt32})},
     )
     out = df.unnest("a")
-    assert out.schema == {"value": pl.Categorical, "counts": pl.UInt32}
+    assert out.schema == {"value": pl.Categorical(), "counts": pl.UInt32()}
     assert out.to_dict(False) == {"value": ["foo", "bar"], "counts": [1, 2]}
 
 
@@ -950,7 +950,7 @@ def test_arrow_to_pyseries_with_one_chunk_does_not_copy_data() -> None:
 
 def test_init_with_explicit_binary_schema() -> None:
     df = pl.DataFrame({"a": [b"hello", b"world"]}, schema={"a": pl.Binary})
-    assert df.schema == {"a": pl.Binary}
+    assert df.schema == {"a": pl.Binary()}
     assert df["a"].to_list() == [b"hello", b"world"]
 
     s = pl.Series("a", [b"hello", b"world"], dtype=pl.Binary)

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -27,7 +27,7 @@ def test_dtype_temporal_units() -> None:
         (datatypes.py_type_to_dtype(timedelta), pl.Duration),
     ):
         assert inferred_dtype == expected_dtype
-        assert inferred_dtype.time_unit == "us"  # type: ignore[union-attr]
+        assert inferred_dtype.time_unit == "us"  # type: ignore[attr-defined]
 
     with pytest.raises(ValueError, match="Invalid time_unit"):
         pl.Datetime("?")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -9,25 +9,14 @@ import polars as pl
 from polars import datatypes
 
 
-def test_dtype_init_equivalence() -> None:
-    # check "DataType.__new__" behaviour for all datatypes
-    all_datatypes = {
-        dtype
-        for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
-        if isinstance(dtype, datatypes.DataTypeClass)
-    }
-    for dtype in all_datatypes:
-        assert dtype == dtype()
-
-
 def test_dtype_temporal_units() -> None:
     # check (in)equality behaviour of temporal types that take units
     for time_unit in datatypes.DTYPE_TEMPORAL_UNITS:
         assert pl.Datetime == pl.Datetime(time_unit)
         assert pl.Duration == pl.Duration(time_unit)
 
-        assert pl.Datetime(time_unit) == pl.Datetime()
-        assert pl.Duration(time_unit) == pl.Duration()
+        assert pl.Datetime(time_unit) == pl.Datetime
+        assert pl.Duration(time_unit) == pl.Duration
 
     assert pl.Datetime("ms") != pl.Datetime("ns")
     assert pl.Duration("ns") != pl.Duration("us")
@@ -86,20 +75,34 @@ def test_dtypes_hashable() -> None:
 @pytest.mark.parametrize(
     ("dtype", "representation"),
     [
-        (pl.Boolean, "Boolean"),
-        (pl.Datetime, "Datetime"),
+        (pl.Boolean(), "Boolean"),
+        (pl.Datetime(), "Datetime(time_unit='us', time_zone=None)"),
         (
             pl.Datetime(time_zone="Europe/Amsterdam"),
             "Datetime(time_unit='us', time_zone='Europe/Amsterdam')",
         ),
         (pl.List(pl.Int8), "List(Int8)"),
         (pl.List(pl.Duration(time_unit="ns")), "List(Duration(time_unit='ns'))"),
-        (pl.Struct, "Struct"),
+        (pl.Struct(), "Struct([Field('', Null)])"),
         (
             pl.Struct({"name": pl.Utf8, "ids": pl.List(pl.UInt32)}),
             "Struct([Field('name', Utf8), Field('ids', List(UInt32))])",
         ),
     ],
 )
-def test_repr(dtype: pl.PolarsDataType, representation: str) -> None:
+def test_repr_datatype_instantiated(dtype: pl.DataType, representation: str) -> None:
+    assert repr(dtype) == representation
+
+
+@pytest.mark.parametrize(
+    ("dtype", "representation"),
+    [
+        (pl.Boolean, "<class 'polars.datatypes.classes.Boolean'>"),
+        (pl.Datetime, "<class 'polars.datatypes.classes.Datetime'>"),
+        (pl.Struct, "<class 'polars.datatypes.classes.Struct'>"),
+    ],
+)
+def test_repr_datatype_uninstantiated(
+    dtype: type[pl.DataType], representation: str
+) -> None:
     assert repr(dtype) == representation

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -272,7 +272,7 @@ def test_from_dict_with_column_order() -> None:
         # │ 2   ┆ 4   │
         # └─────┴─────┘
         assert df.columns == ["a", "b"]
-        assert df.schema == {"a": pl.UInt8, "b": pl.UInt32}
+        assert df.schema == {"a": pl.UInt8(), "b": pl.UInt32()}
         assert df.rows() == [(1, 3), (2, 4)]
 
         # expect an error
@@ -332,10 +332,10 @@ def test_from_dict_with_scalars() -> None:
         "key": [1, 2, 3],
     }
     assert df4.schema == {
-        "value": pl.Utf8,
-        "other": pl.Float32,
-        "misc": pl.Int32,
-        "key": pl.Int8,
+        "value": pl.Utf8(),
+        "other": pl.Float32(),
+        "misc": pl.Int32(),
+        "key": pl.Int8(),
     }
 
     # mixed with struct cols
@@ -374,10 +374,10 @@ def test_from_dict_with_scalars() -> None:
     )
     assert df7[999:].rows() == [(0, 1, 0, 1), (0, 1, 0, 1)]
     assert df7.schema == {
-        "w": pl.UInt8,
-        "x": pl.UInt8,
-        "y": pl.UInt8,
-        "z": pl.UInt8,
+        "w": pl.UInt8(),
+        "x": pl.UInt8(),
+        "y": pl.UInt8(),
+        "z": pl.UInt8(),
     }
 
     # a bit of everything
@@ -1433,10 +1433,10 @@ def test_from_generator_or_iterable() -> None:
     ):
         assert_frame_equal(expected, generated_frame)
         assert generated_frame.schema == {
-            "a": pl.Utf8,
-            "b": pl.Int64,
-            "c": pl.Int64,
-            "d": pl.Int64,
+            "a": pl.Utf8(),
+            "b": pl.Int64(),
+            "c": pl.Int64(),
+            "d": pl.Int64(),
         }
 
     # test 'iterable_to_pydf' directly to validate 'chunk_size' behaviour
@@ -1673,7 +1673,7 @@ def test_create_df_from_object() -> None:
 
     # from mixed-type input
     df = pl.DataFrame({"x": [["abc", 12, 34.5]], "y": [1]})
-    assert df.schema == {"x": pl.Object, "y": pl.Int64}
+    assert df.schema == {"x": pl.Object(), "y": pl.Int64()}
     assert df.rows() == [(["abc", 12, 34.5], 1)]
 
 
@@ -1952,7 +1952,7 @@ def test_schema() -> None:
     df = pl.DataFrame(
         {"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0], "ham": ["a", "b", "c"]}
     )
-    expected = {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.Utf8}
+    expected = {"foo": pl.Int64(), "bar": pl.Float64(), "ham": pl.Utf8()}
     assert df.schema == expected
 
 
@@ -2597,7 +2597,7 @@ def test_empty_is_in() -> None:
     )
     assert df_empty_isin.shape == (0, 1)
     assert df_empty_isin.rows() == []
-    assert df_empty_isin.schema == {"foo": pl.Utf8}
+    assert df_empty_isin.schema == {"foo": pl.Utf8()}
 
 
 def test_groupby_slice_expression_args() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2478,7 +2478,7 @@ def test_df_broadcast() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]}, schema_overrides={"a": pl.UInt8})
     out = df.with_columns(pl.Series("s", [[1, 2]]))
     assert out.shape == (3, 2)
-    assert out.schema == {"a": pl.UInt8, "s": pl.List(pl.Int64)}
+    assert out.schema == {"a": pl.UInt8(), "s": pl.List(pl.Int64)}
     assert out.rows() == [(1, [1, 2]), (2, [1, 2]), (3, [1, 2])]
 
 
@@ -3202,7 +3202,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_europe = "Europe/Amsterdam"
 
     dtm = datetime(2022, 10, 12, 12, 30, tzinfo=ZoneInfo("UTC"))
-    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for time_unit in DTYPE_TEMPORAL_UNITS:
         for type_overrides in (
             {
                 "schema": [
@@ -3232,7 +3232,7 @@ def test_init_physical_with_timezone() -> None:
     tz_asia = "Asia/Tokyo"
 
     dtm_us = 1665577800000000
-    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for time_unit in DTYPE_TEMPORAL_UNITS:
         dtm = {"ms": dtm_us // 1_000, "ns": dtm_us * 1_000}.get(str(time_unit), dtm_us)
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},
@@ -3531,21 +3531,21 @@ def test_rolling_apply() -> None:
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 4.358898943540674
-    assert out.dtype is pl.Float64
+    assert isinstance(out.dtype, pl.Float64)
 
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
     out = s.rolling_apply(function=lambda s: s.std(), window_size=3)
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 4.358899116516113
-    assert out.dtype is pl.Float32
+    assert isinstance(out.dtype, pl.Float32)
 
     s = pl.Series("A", [1, 2, 9, 2, 13], dtype=pl.Int32)
     out = s.rolling_apply(function=lambda s: s.sum(), window_size=3)
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 12
-    assert out.dtype is pl.Int32
+    assert isinstance(out.dtype, pl.Int32)
 
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float64)
     out = s.rolling_apply(
@@ -3554,7 +3554,7 @@ def test_rolling_apply() -> None:
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 14.224392195567912
-    assert out.dtype is pl.Float64
+    assert isinstance(out.dtype, pl.Float64)
 
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=pl.Float32)
     out = s.rolling_apply(
@@ -3563,7 +3563,7 @@ def test_rolling_apply() -> None:
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 14.22439193725586
-    assert out.dtype is pl.Float32
+    assert isinstance(out.dtype, pl.Float32)
 
     s = pl.Series("A", [1, 2, 9, None, 13], dtype=pl.Int32)
     out = s.rolling_apply(
@@ -3572,7 +3572,7 @@ def test_rolling_apply() -> None:
     assert out[0] is None
     assert out[1] is None
     assert out[2] == 32.0
-    assert out.dtype is pl.Float64
+    assert isinstance(out.dtype, pl.Float64)
     s = pl.Series("A", [1, 2, 9, 2, 10])
 
     # compare rolling_apply to specific rolling functions

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -5,9 +5,9 @@ from polars.testing import assert_frame_equal
 def test_empty_str_concat_lit() -> None:
     df = pl.DataFrame({"a": [], "b": []}, schema=[("a", pl.Utf8), ("b", pl.Utf8)])
     assert df.with_columns(pl.lit("asd") + pl.col("a")).schema == {
-        "a": pl.Utf8,
-        "b": pl.Utf8,
-        "literal": pl.Utf8,
+        "a": pl.Utf8(),
+        "b": pl.Utf8(),
+        "literal": pl.Utf8(),
     }
 
 
@@ -21,7 +21,10 @@ def test_empty_cross_join() -> None:
     a = pl.LazyFrame(schema={"a": pl.Int32})
     b = pl.LazyFrame(schema={"b": pl.Int32})
 
-    assert (a.join(b, how="cross").collect()).schema == {"a": pl.Int32, "b": pl.Int32}
+    assert (a.join(b, how="cross").collect()).schema == {
+        "a": pl.Int32(),
+        "b": pl.Int32(),
+    }
 
 
 def test_empty_string_replace() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -153,7 +153,7 @@ def test_err_bubbling_up_to_lit() -> None:
     df = pl.DataFrame({"date": [date(2020, 1, 1)], "value": [42]})
 
     with pytest.raises(ValueError):
-        df.filter(pl.col("date") == pl.Date("2020-01-01"))
+        df.filter(pl.col("date") == pl.Date)
 
 
 def test_error_on_double_agg() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -853,7 +853,7 @@ def test_lit_dtypes() -> None:
             "dtm_aware_0": lit_series(d, pl.Datetime("us", "Asia/Kathmandu")),
             "dtm_aware_1": lit_series(d_tz, pl.Datetime("us")),
             "dtm_aware_2": lit_series(d_tz, None),
-            "dtm_aware_3": lit_series(d, pl.Datetime(None, "Asia/Kathmandu")),
+            "dtm_aware_3": lit_series(d, pl.Datetime(time_zone="Asia/Kathmandu")),
             "dur_ms": lit_series(td, pl.Duration("ms")),
             "dur_us": lit_series(td, pl.Duration("us")),
             "dur_ns": lit_series(td, pl.Duration("ns")),
@@ -875,10 +875,10 @@ def test_lit_dtypes() -> None:
         pl.Duration("ms"),
         pl.Duration("us"),
         pl.Duration("ns"),
-        pl.Float32,
-        pl.UInt16,
-        pl.Int16,
-        pl.Int64,
+        pl.Float32(),
+        pl.UInt16(),
+        pl.Int16(),
+        pl.Int64(),
         pl.List(pl.Int64),
     ]
     assert df.row(0) == (

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -626,7 +626,7 @@ def test_from_null_column() -> None:
 
     assert df.shape == (2, 1)
     assert df.columns == ["n/a"]
-    assert df.dtypes[0] is pl.Null
+    assert isinstance(df.dtypes[0], pl.Null)
 
 
 def test_to_pandas_series() -> None:
@@ -791,18 +791,22 @@ def test_from_repr() -> None:
             .collect()
         )
 
+        print(df)
+
         assert df.schema == {
-            "a": pl.Int64,
-            "b": pl.Float64,
-            "c": pl.Categorical,
-            "d": pl.Boolean,
-            "e": pl.Utf8,
-            "f": pl.Date,
-            "g": pl.Time,
+            "a": pl.Int64(),
+            "b": pl.Float64(),
+            "c": pl.Categorical(),
+            "d": pl.Boolean(),
+            "e": pl.Utf8(),
+            "f": pl.Date(),
+            "g": pl.Time(),
             "h": pl.Datetime("ns"),
         }
-        assert_frame_equal(df, pl.from_repr(repr(df)))
 
+        print(pl.from_repr(repr(df)))
+        assert_frame_equal(df, pl.from_repr(repr(df)))
+    return
     # empty frame; confirm schema is inferred
     df = pl.from_repr(
         """
@@ -817,12 +821,12 @@ def test_from_repr() -> None:
     assert df.shape == (0, 6)
     assert df.rows() == []
     assert df.schema == {
-        "id": pl.Utf8,
-        "q1": pl.Int8,
-        "q2": pl.Int16,
-        "q3": pl.Int32,
-        "q4": pl.Int64,
-        "total": pl.Float64,
+        "id": pl.Utf8(),
+        "q1": pl.Int8(),
+        "q2": pl.Int16(),
+        "q3": pl.Int32(),
+        "q4": pl.Int64(),
+        "total": pl.Float64(),
     }
 
     df = pl.from_repr(
@@ -840,14 +844,14 @@ def test_from_repr() -> None:
         """
     )
     assert df.schema == {
-        "dt": pl.Date,
-        "c1": pl.Int32,
-        "c2": pl.Int32,
-        "c3": pl.Int32,
-        "c96": pl.Int64,
-        "c97": pl.Int64,
-        "c98": pl.Int64,
-        "c99": pl.Int64,
+        "dt": pl.Date(),
+        "c1": pl.Int32(),
+        "c2": pl.Int32(),
+        "c3": pl.Int32(),
+        "c96": pl.Int64(),
+        "c97": pl.Int64(),
+        "c98": pl.Int64(),
+        "c99": pl.Int64(),
     }
     assert df.rows() == [
         (date(2023, 3, 25), 1, 2, 3, 96, 97, 98, 99),
@@ -879,9 +883,9 @@ def test_from_repr() -> None:
     )
     assert df.shape == (2, 4)
     assert df.schema == {
-        "source_actor_id": pl.Int32,
-        "source_channel_id": pl.Int64,
-        "ident": pl.Utf8,
+        "source_actor_id": pl.Int32(),
+        "source_channel_id": pl.Int64(),
+        "ident": pl.Utf8(),
         "timestamp": pl.Datetime("us", "Asia/Tokyo"),
     }
 

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -113,15 +113,15 @@ def test_from_pandas() -> None:
     out = pl.from_pandas(df)
     assert out.shape == (3, 9)
     assert out.schema == {
-        "bools": pl.Boolean,
-        "bools_nulls": pl.Boolean,
-        "int": pl.Int64,
-        "int_nulls": pl.Float64,
-        "floats": pl.Float64,
-        "floats_nulls": pl.Float64,
-        "strings": pl.Utf8,
-        "strings_nulls": pl.Utf8,
-        "strings-cat": pl.Categorical,
+        "bools": pl.Boolean(),
+        "bools_nulls": pl.Boolean(),
+        "int": pl.Int64(),
+        "int_nulls": pl.Float64(),
+        "floats": pl.Float64(),
+        "floats_nulls": pl.Float64(),
+        "strings": pl.Utf8(),
+        "strings_nulls": pl.Utf8(),
+        "strings-cat": pl.Categorical(),
     }
     assert out.rows() == [
         (False, None, 1, 1.0, 1.0, 1.0, "foo", "foo", "foo"),
@@ -306,7 +306,10 @@ def test_from_dict_struct() -> None:
     assert df.shape == (2, 2)
     assert df["a"][0] == {"b": 1, "c": 2}
     assert df["a"][1] == {"b": 3, "c": 4}
-    assert df.schema == {"a": pl.Struct, "d": pl.Int64}
+    assert df.schema == {
+        "a": pl.Struct({"b": pl.Int64(), "c": pl.Int64()}),
+        "d": pl.Int64(),
+    }
 
 
 def test_from_dicts() -> None:
@@ -314,7 +317,7 @@ def test_from_dicts() -> None:
     df = pl.from_dicts(data)  # type: ignore[arg-type]
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, None)]
-    assert df.schema == {"a": pl.Int64, "b": pl.Int64}
+    assert df.schema == {"a": pl.Int64(), "b": pl.Int64()}
 
 
 def test_from_dict_no_inference() -> None:
@@ -327,7 +330,7 @@ def test_from_dicts_schema_override() -> None:
     schema = {
         "a": pl.Utf8,
         "b": pl.Int64,
-        "c": pl.List(pl.Struct({"x": pl.Int64, "y": pl.Utf8, "z": pl.Float64})),
+        "c": pl.List(pl.Struct({"x": pl.Int64(), "y": pl.Utf8(), "z": pl.Float64()})),
     }
 
     # initial data matches the expected schema
@@ -397,7 +400,7 @@ def test_from_numpy() -> None:
     )
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]
-    assert df.schema == {"a": pl.UInt32, "b": pl.UInt32}
+    assert df.schema == {"a": pl.UInt32(), "b": pl.UInt32()}
 
 
 def test_from_arrow() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1232,7 +1232,7 @@ def test_lazy_schema() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-    assert ldf.schema == {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.Utf8}
+    assert ldf.schema == {"foo": pl.Int64(), "bar": pl.Float64(), "ham": pl.Utf8()}
 
     ldf = pl.LazyFrame(
         {
@@ -1241,7 +1241,7 @@ def test_lazy_schema() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-    assert ldf.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
+    assert ldf.dtypes == [pl.Int64(), pl.Float64(), pl.Utf8()]
 
     ldfe = ldf.clear()
     assert ldfe.schema == ldf.schema

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -61,7 +61,7 @@ def test_rows() -> None:
 
     # Rows with nullarray cols
     df = df.with_columns(c=pl.lit(None))
-    assert df.schema == {"a": pl.Int64, "b": pl.Int64, "c": pl.Null}
+    assert df.schema == {"a": pl.Int64(), "b": pl.Int64(), "c": pl.Null()}
     assert df.rows() == [(1, 1, None), (2, 2, None)]
     assert df.rows(named=True) == [
         {"a": 1, "b": 1, "c": None},

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -20,12 +20,12 @@ def test_schema_on_agg() -> None:
             ]
         )
     ).schema == {
-        "a": pl.Utf8,
-        "min": pl.Int64,
-        "max": pl.Int64,
-        "sum": pl.Int64,
-        "first": pl.Int64,
-        "last": pl.Int64,
+        "a": pl.Utf8(),
+        "min": pl.Int64(),
+        "max": pl.Int64(),
+        "sum": pl.Int64(),
+        "first": pl.Int64(),
+        "last": pl.Int64(),
     }
 
 
@@ -196,7 +196,7 @@ def test_fill_null_static_schema_4843() -> None:
 
     df2 = df1.select([pl.col(pl.Int64).fill_null(0)])
     df3 = df2.select(pl.col(pl.Int64))
-    assert df3.schema == {"a": pl.Int64, "b": pl.Int64}
+    assert df3.schema == {"a": pl.Int64(), "b": pl.Int64()}
 
 
 def test_shrink_dtype() -> None:
@@ -261,7 +261,7 @@ def test_boolean_agg_schema() -> None:
         assert (
             agg_df.collect(streaming=streaming).schema
             == agg_df.schema
-            == {"x": pl.Int64, "max_y": pl.Boolean}
+            == {"x": pl.Int64(), "max_y": pl.Boolean()}
         )
 
 
@@ -353,7 +353,7 @@ def test_duration_division_schema() -> None:
         .select(pl.col("a") / pl.col("a"))
     )
 
-    assert q.schema == {"a": pl.Float64}
+    assert q.schema == {"a": pl.Float64()}
     assert q.collect().to_dict(False) == {"a": [1.0]}
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -120,10 +120,10 @@ def test_init_inputs(monkeypatch: Any) -> None:
         s = pl.Series("dates", d64, dtype)
         assert s.to_list() == expected
         assert Datetime == s.dtype
-        assert s.dtype.time_unit == "ns"  # type: ignore[union-attr]
+        assert s.dtype.time_unit == "ns"  # type: ignore[attr-defined]
 
     s = pl.Series(values=d64.astype("<M8[ms]"))
-    assert s.dtype.time_unit == "ms"  # type: ignore[union-attr]
+    assert s.dtype.time_unit == "ms"  # type: ignore[attr-defined]
     assert expected == s.to_list()
 
     # pandas
@@ -167,7 +167,7 @@ def test_init_dataclass_namedtuple() -> None:
         s = pl.Series("t", [t0, t1])
 
         assert isinstance(s, pl.Series)
-        assert s.dtype.fields == [  # type: ignore[union-attr]
+        assert s.dtype.fields == [  # type: ignore[attr-defined]
             Field("exporter", pl.Utf8),
             Field("importer", pl.Utf8),
             Field("product", pl.Utf8),

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -116,7 +116,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
     d64[1] = None
 
     expected = [datetime(2021, 8, 1, 0), None, datetime(2021, 8, 3, 0)]
-    for dtype in (None, Datetime, Datetime("ns")):
+    for dtype in (None, Datetime("ns")):
         s = pl.Series("dates", d64, dtype)
         assert s.to_list() == expected
         assert Datetime == s.dtype

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -48,20 +48,20 @@ def test_streaming_groupby_types() -> None:
             .collect(streaming=True)
         )
         assert out.schema == {
-            "str_first": pl.Utf8,
-            "str_last": pl.Utf8,
-            "str_mean": pl.Utf8,
-            "str_sum": pl.Utf8,
-            "bool_first": pl.Boolean,
-            "bool_last": pl.Boolean,
-            "bool_mean": pl.Boolean,
-            "bool_sum": pl.UInt32,
-            "date_sum": pl.Date,
-            "date_mean": pl.Date,
-            "date_first": pl.Date,
-            "date_last": pl.Date,
-            "date_min": pl.Date,
-            "date_max": pl.Date,
+            "str_first": pl.Utf8(),
+            "str_last": pl.Utf8(),
+            "str_mean": pl.Utf8(),
+            "str_sum": pl.Utf8(),
+            "bool_first": pl.Boolean(),
+            "bool_last": pl.Boolean(),
+            "bool_mean": pl.Boolean(),
+            "bool_sum": pl.UInt32(),
+            "date_sum": pl.Date(),
+            "date_mean": pl.Date(),
+            "date_first": pl.Date(),
+            "date_last": pl.Date(),
+            "date_min": pl.Date(),
+            "date_max": pl.Date(),
         }
 
         assert out.to_dict(False) == {


### PR DESCRIPTION
Closes #6163 

The way we handle data types on the Python side is a big mess and leads to a lot of unexpected behaviour and bugs. This PR will lay the groundwork to start improving this.

The aim of this PR is to make the minimal required changes to make things work with 'instantiated' data types (see linked issue). I am **not** trying to solve all spaghetti code in one go. In fact, some things will be uglier now, but hopefully it's clear how this will lead to better code in the long run.

Some of the implications of these changes:
* Users can still provide schemas by specifying either instantiated (`Datetime()`) or uninstantiated (`Datetime`) dtypes. The latter is just a shorthand for the first. Behind the scenes, these are 'normalized' to all be instantiated.
* This means datatypes like `Datetime` and `List` no longer have class variables - only instance variables. Defaults for these are specified in the constructor (e.g. `List` defaults to `List(Float64)`). The concept of a generic `List` dtype without an inner dtype no longer really exists in the same way as before.
* Datatypes will always be exposed to the user in an instantiated way - e.g. `dtypes` and `schema` properties now return instantiated datatypes. _(This is a breaking change)_
* Checking for certain datatypes is simpler and can be done with `isinstance` checks.

Feedback is welcome! A lot of work is left, but as I said, I cannot solve all spaghetti in one go.