### PR TITLE
feat(python): allow `write_ipc` to take `file=None` (returning `BytesIO`)

### DIFF
--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -20,10 +20,15 @@ COMPRESSIONS = ["uncompressed", "lz4", "zstd"]
 
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 def test_from_to_buffer(df: pl.DataFrame, compression: IpcCompression) -> None:
-    buf = io.BytesIO()
-    df.write_ipc(buf, compression=compression)
-    buf.seek(0)
-    read_df = pl.read_ipc(buf, use_pyarrow=False)
+    # use an ad-hoc buffer (file=None)
+    buf1 = df.write_ipc(None, compression=compression)
+    assert_frame_equal_local_categoricals(df, pl.read_ipc(buf1, use_pyarrow=False))
+
+    # explicitly supply an existing buffer
+    buf2 = io.BytesIO()
+    df.write_ipc(buf2, compression=compression)
+    buf2.seek(0)
+    read_df = pl.read_ipc(buf2, use_pyarrow=False)
     assert_frame_equal_local_categoricals(df, read_df)
 
 


### PR DESCRIPTION
* Aligns `write_ipc` with similar `write_csv` behaviour when `file=None`. 
* Creates and returns a BytesIO object containing the IPC binary data, without needing to set one up outside the method.

## Example

```python
import polars as pl
df = pl.DataFrame( {"x":[1,2,3]} )
ipc = df.write_ipc( None )

ipc
# <_io.BytesIO at 0x10597f420>

ipc.getvalue()
# b'ARROW1\x00\x00\xff\xff\xff\xffx\x00\x00\x00\x04\x00\x00\x00\xf2\xff\xff\xff\x14\x00 // ...
```