### PR TITLE
fix(rust, python)!: don't create duplicate pivot names

### DIFF
--- a/polars/polars-ops/src/frame/pivot/mod.rs
+++ b/polars/polars-ops/src/frame/pivot/mod.rs
@@ -188,9 +188,9 @@ fn pivot_impl(
 
     let mut count = 0;
     let out: PolarsResult<()> = POOL.install(|| {
-        for column in columns {
+        for column_column_name in columns {
             let mut groupby = index.to_vec();
-            groupby.push(column.clone());
+            groupby.push(column_column_name.clone());
 
             let groups = pivot_df.groupby_stable(groupby)?.take_groups();
 
@@ -200,7 +200,7 @@ fn pivot_impl(
             };
 
             let (col, row) = POOL.join(
-                || positioning::compute_col_idx(pivot_df, column, &groups),
+                || positioning::compute_col_idx(pivot_df, column_column_name, &groups),
                 || positioning::compute_row_idx(pivot_df, index, &groups, count),
             );
             let (col_locations, column_agg) = col?;
@@ -241,7 +241,7 @@ fn pivot_impl(
                 let headers = column_agg.unique_stable()?.cast(&DataType::Utf8)?;
                 let mut headers = headers.utf8().unwrap().clone();
                 if values.len() > 1 {
-                    headers = headers.apply(|v| Cow::from(format!("{value_col_name}{sep}{v}")))
+                    headers = headers.apply(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
                 }
 
                 let n_cols = headers.len();

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -142,7 +142,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
     )
 
     with pytest.raises(ComputeError, match="found multiple elements in the same group"):
-        result = df.pivot(
+        df.pivot(
             values=["x1", "x2"],
             index="c1",
             columns="c2",
@@ -159,12 +159,29 @@ def test_pivot_multiple_values_column_names_5116() -> None:
     )
     expected = {
         "c1": ["A", "B"],
-        "x1|C": [1, 2],
-        "x1|D": [3, 4],
-        "x2|C": [8, 7],
-        "x2|D": [6, 5],
+        "x1|c2|C": [1, 2],
+        "x1|c2|D": [3, 4],
+        "x2|c2|C": [8, 7],
+        "x2|c2|D": [6, 5],
     }
     assert result.to_dict(False) == expected
+
+
+def test_pivot_duplicate_names_7731() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 4], "b": [1, 2], "c": ["x", "x"], "d": [7, 8], "e": ["x", "y"]}
+    )
+    assert df.pivot(values=["a", "d"], index="b", columns=["c", "e"]).to_dict(
+        False
+    ) == {
+        "b": [1, 2],
+        "a_c_x": [1, 4],
+        "d_c_x": [7, 8],
+        "a_e_x": [1, None],
+        "a_e_y": [None, 4],
+        "d_e_x": [7, None],
+        "d_e_y": [None, 8],
+    }
 
 
 def test_pivot_floats() -> None:

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -171,9 +171,9 @@ def test_pivot_duplicate_names_7731() -> None:
     df = pl.DataFrame(
         {"a": [1, 4], "b": [1, 2], "c": ["x", "x"], "d": [7, 8], "e": ["x", "y"]}
     )
-    assert df.pivot(values=["a", "d"], index="b", columns=["c", "e"]).to_dict(
-        False
-    ) == {
+    assert df.pivot(
+        values=["a", "d"], index="b", columns=["c", "e"], aggregate_function="first"
+    ).to_dict(False) == {
         "b": [1, 2],
         "a_c_x": [1, 4],
         "d_c_x": [7, 8],


### PR DESCRIPTION
fixes #7731