### PR TITLE
feat(python): Support `DataFrame` init from pyarrow `RecordBatch` objects, and improve init from `Array`

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -507,15 +507,16 @@ def from_arrow(
             data=data, rechunk=rechunk, schema=schema, schema_overrides=schema_overrides
         )
     elif isinstance(data, (pa.Array, pa.ChunkedArray)):
-        if not (schema or schema_overrides):
-            schema = [""]
-        return pli.DataFrame(
-            data=pli.Series._from_arrow(
-                getattr(data, "_name", "") or "", data, rechunk=rechunk
-            ),
+        name = getattr(data, "_name", "") or ""
+        s = pli.DataFrame(
+            data=pli.Series._from_arrow(name, data, rechunk=rechunk),
             schema=schema,
             schema_overrides=schema_overrides,
         ).to_series()
+        return (
+            s if (name or schema or schema_overrides) else s.rename("", in_place=True)
+        )
+
     elif isinstance(data, Sequence) and data and isinstance(data[0], pa.RecordBatch):
         return pli.DataFrame._from_arrow(
             data=pa.Table.from_batches(data),

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1175,26 +1175,24 @@ def lit(
 
     Examples
     --------
-    Literal integer:
+    Literal scalar values:
 
     >>> pl.lit(1)  # doctest: +IGNORE_RESULT
-
-    Literal str:
-
-    >>> pl.lit("foo")  # doctest: +IGNORE_RESULT
-
-    Literal datetime:
-
-    >>> from datetime import datetime
-    >>> pl.lit(datetime(2021, 1, 20))  # doctest: +IGNORE_RESULT
-
-    Literal Null:
-
+    >>> pl.lit(5.5)  # doctest: +IGNORE_RESULT
     >>> pl.lit(None)  # doctest: +IGNORE_RESULT
+    >>> pl.lit("foo_bar")  # doctest: +IGNORE_RESULT
+    >>> pl.lit(date(2021, 1, 20))  # doctest: +IGNORE_RESULT
+    >>> pl.lit(datetime(2023, 3, 31, 10, 30, 45))  # doctest: +IGNORE_RESULT
 
-    Literal eager Series:
+    Literal list/Series data (1D):
 
-    >>> pl.lit(pl.Series("a", [1, 2, 3]))  # doctest: +IGNORE_RESULT
+    >>> pl.lit([1, 2, 3])  # doctest: +IGNORE_RESULT
+    >>> pl.lit(pl.Series("x", [1, 2, 3]))  # doctest: +IGNORE_RESULT
+
+    Literal list/Series data (2D):
+
+    >>> pl.lit([[1, 2], [3, 4]])  # doctest: +IGNORE_RESULT
+    >>> pl.lit(pl.Series("y", [[1, 2], [3, 4]]))  # doctest: +IGNORE_RESULT
 
     """
     time_unit: TimeUnit

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -596,6 +596,7 @@ def test_arrow() -> None:
     c = pl.Series("c", ["A", "BB", "CCC", None])
     out = c.to_arrow()
     assert out == pa.array(["A", "BB", "CCC", None], type=pa.large_string())
+    assert_series_equal(pl.from_arrow(out), c.rename(""))  # type: ignore[arg-type]
 
     out = c.to_frame().to_arrow()["c"]
     assert isinstance(out, (pa.Array, pa.ChunkedArray))

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -597,6 +597,11 @@ def test_arrow() -> None:
     out = c.to_arrow()
     assert out == pa.array(["A", "BB", "CCC", None], type=pa.large_string())
 
+    out = c.to_frame().to_arrow()["c"]
+    assert isinstance(out, (pa.Array, pa.ChunkedArray))
+    assert_series_equal(pl.from_arrow(out), c)  # type: ignore[arg-type]
+    assert_series_equal(pl.from_arrow(out, schema=["x"]), c.rename("x"))  # type: ignore[arg-type]
+
     d = pl.Series("d", [None, None, None], pl.Null)
     out = d.to_arrow()
     assert out == pa.nulls(3)


### PR DESCRIPTION
Closes #8007.

* Support seamless `DataFrame` init from sequence of pyarrow `RecordBatch`.

Also, when loading from a pyarrow `Array`:

* If the `Array` is _named_, we now preserve the name in the resulting polars `Series`.
* We now respect the `schema` and `schema_overrides` params.

## Example
Setup:
```python
import polars as pl
df = pl.DataFrame({
    "id": ["a123", "b345", "c567", "d789", "e101"],
    "value": [99, 45, 50, 85, 35],
})

tbl = df.to_arrow()
batches = tbl.to_batches( max_chunksize=3 )
```
Initialise `DataFrame` from RecordBatches:
```python
pl.from_arrow( batches )
# ┌──────┬───────┐
# │ id   ┆ value │
# │ ---  ┆ ---   │
# │ str  ┆ i64   │
# ╞══════╪═══════╡
# │ a123 ┆ 99    │
# │ b345 ┆ 45    │
# │ c567 ┆ 50    │
# │ d789 ┆ 85    │
# │ e101 ┆ 35    │
# └──────┴───────┘
```
Preserve array name on `Series` init (where available), and respect schema:
```python
pl.from_arrow( batches[0]["value"], schema={"value":pl.Int32} )
# shape: (3,)
# Series: 'value' [i32]
# [
#   99
#   45
#   50
# ]
```

## Bonus

* Added some extra handling for the `test_read_database` unit test on Windows; rogue file-locking can potentially cause errors during the cleanup done on `TemporaryDirectory` scope-exit, and we can't set `ignore_cleanup_errors` as that requires py3.10. (Random failure of this test has affected both @ghuls and myself in the last few days).