### PR TITLE
fix(python): Output correct dtype for values of remapping dict in map…

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -25,8 +25,12 @@ from typing import (
 from polars import functions as F
 from polars import internals as pli
 from polars.datatypes import (
+    FLOAT_DTYPES,
+    INTEGER_DTYPES,
+    Categorical,
     Struct,
     UInt32,
+    Utf8,
     is_polars_dtype,
     py_type_to_dtype,
 )
@@ -6854,7 +6858,7 @@ class Expr:
             Value to use when the remapping dict does not contain the lookup value.
             Use ``pl.first()``, to keep the original value.
         dtype
-            Override output dtype.
+            Set output dtype to override automatic output dtype determination.
 
         Examples
         --------
@@ -7000,7 +7004,9 @@ class Expr:
         def _remap_key_or_value_series(
             name: str,
             values: Iterable[Any],
-            dtype: PolarsDataType,
+            dtype: PolarsDataType | None,
+            dtype_if_empty: PolarsDataType | None,
+            dtype_keys: PolarsDataType | None,
             is_keys: bool,
         ) -> Series:
             """
@@ -7010,23 +7016,88 @@ class Expr:
             the specified dtype and check that none of the values are accidentally
             lost (replaced by nulls) during the conversion.
 
+            Parameters
+            ----------
+            name
+                Name of the keys or values series.
+            values
+                Values for the series: `remapping.keys()` or `remapping.values()`.
+            dtype
+                User specified dtype. If None,
+            dtype_if_empty
+                If no dtype is specified and values contains None, an empty list,
+                or a list with only None values, set the Polars dtype of the Series
+                data.
+            dtype_keys
+                If user set dtype is None, try to see if Series for remapping.values()
+                can be converted to same dtype as the remapping.keys() Series dtype.
+            is_keys
+                If values contains keys or values from remapping dict.
+
             """
             try:
-                s = pli.Series(
-                    name,
-                    values,
-                    dtype=dtype,
-                    strict=True,
-                )
-                if dtype != s.dtype:
-                    raise ValueError(
-                        f"Remapping {'keys' if is_keys else 'values'} could not be converted to {dtype}: found {s.dtype}"
+                if dtype is None:
+                    # If no dtype was set, which should only happen when:
+                    #     values = remapping.values()
+                    # create a Series from those values and infer the dtype.
+                    s = pli.Series(
+                        name,
+                        values,
+                        dtype=None,
+                        dtype_if_empty=dtype_if_empty,
+                        strict=True,
                     )
 
-            except TypeError as exc:
-                raise ValueError(
-                    f"Remapping {'keys' if is_keys else 'values'} could not be converted to {dtype}: {str(exc)}"
-                ) from exc
+                    if dtype_keys is not None:
+                        if s.dtype == dtype_keys:
+                            # Values Series has same dtype as keys Series.
+                            dtype = s.dtype
+                        elif (
+                            (s.dtype in INTEGER_DTYPES and dtype_keys in INTEGER_DTYPES)
+                            or (s.dtype in FLOAT_DTYPES and dtype_keys in FLOAT_DTYPES)
+                            or (s.dtype == Utf8 and dtype_keys == Categorical)
+                        ):
+                            # Values Series and keys Series are of similar dtypes,
+                            # that we can assume that the user wants the values Series
+                            # of the same dtype as the key Series.
+                            dtype = dtype_keys
+                            s = pli.Series(
+                                name,
+                                values,
+                                dtype=dtype_keys,
+                                dtype_if_empty=dtype_if_empty,
+                                strict=True,
+                            )
+                            if dtype != s.dtype:
+                                raise ValueError(
+                                    f"Remapping values for map_dict could not be converted to {dtype}: found {s.dtype}"
+                                )
+                else:
+                    # dtype was set, which should always be the case when:
+                    #     values = remapping.keys()
+                    # and in cases where the user set the output dtype when:
+                    #     values = remapping.values()
+                    s = pli.Series(
+                        name,
+                        values,
+                        dtype=dtype,
+                        dtype_if_empty=dtype_if_empty,
+                        strict=True,
+                    )
+                    if dtype != s.dtype:
+                        raise ValueError(
+                            f"Remapping {'keys' if is_keys else 'values'} for map_dict could not be converted to {dtype}: found {s.dtype}"
+                        )
+
+            except OverflowError as exc:
+                if is_keys:
+                    raise ValueError(
+                        f"Remapping keys for map_dict could not be converted to {dtype}: {str(exc)}"
+                    ) from exc
+                else:
+                    raise ValueError(
+                        f"Choose a more suitable output dtype for map_dict as remapping value could not be converted to {dtype}: {str(exc)}"
+                    ) from exc
 
             if is_keys:
                 # values = remapping.keys()
@@ -7036,7 +7107,7 @@ class Expr:
                     pass
                 else:
                     raise ValueError(
-                        f"Remapping keys could not be converted to {dtype} without losing values in the conversion."
+                        f"Remapping keys for map_dict could not be converted to {dtype} without losing values in the conversion."
                     )
             else:
                 # values = remapping.values()
@@ -7046,7 +7117,7 @@ class Expr:
                     pass
                 else:
                     raise ValueError(
-                        f"Remapping values could not be converted to {dtype} without losing values in the conversion."
+                        f"Remapping values for map_dict could not be converted to {dtype} without losing values in the conversion."
                     )
 
             return s
@@ -7080,6 +7151,8 @@ class Expr:
                 name=remap_key_column,
                 values=remapping.keys(),
                 dtype=input_dtype,
+                dtype_if_empty=input_dtype,
+                dtype_keys=input_dtype,
                 is_keys=True,
             )
 
@@ -7092,22 +7165,17 @@ class Expr:
                     dtype_if_empty=input_dtype,
                 )
             else:
-                try:
-                    # First, try to create a value Series with same dtype as input
-                    # column.
-                    remap_value_s = _remap_key_or_value_series(
-                        name=remap_value_column,
-                        values=remapping.values(),
-                        dtype=remap_key_s.dtype,
-                        is_keys=False,
-                    )
-                except ValueError:
-                    # If that fails create a value Series without a specific dtype.
-                    remap_value_s = pli.Series(
-                        remap_value_column,
-                        remapping.values(),
-                        dtype_if_empty=input_dtype,
-                    )
+                # Create remap value Series with same output dtype as remap key Series,
+                # if possible (if both are integers, both are floats or remap value
+                # Series is pl.Utf8 and remap key Series is pl.Categorical).
+                remap_value_s = _remap_key_or_value_series(
+                    name=remap_value_column,
+                    values=remapping.values(),
+                    dtype=None,
+                    dtype_if_empty=input_dtype,
+                    dtype_keys=input_dtype,
+                    is_keys=False,
+                )
 
             return (
                 (
@@ -7147,6 +7215,8 @@ class Expr:
                 name=remap_key_column,
                 values=list(remapping.keys()),
                 dtype=input_dtype,
+                dtype_if_empty=input_dtype,
+                dtype_keys=input_dtype,
                 is_keys=True,
             )
 
@@ -7159,22 +7229,17 @@ class Expr:
                     dtype_if_empty=input_dtype,
                 )
             else:
-                try:
-                    # First, try to create a value Series with same dtype as input
-                    # column.
-                    remap_value_s = _remap_key_or_value_series(
-                        name=remap_value_column,
-                        values=remapping.values(),
-                        dtype=remap_key_s.dtype,
-                        is_keys=False,
-                    )
-                except ValueError:
-                    # If that fails create a value Series without a specific dtype.
-                    remap_value_s = pli.Series(
-                        remap_value_column,
-                        remapping.values(),
-                        dtype_if_empty=input_dtype,
-                    )
+                # Create remap value Series with same output dtype as remap key Series,
+                # if possible (if both are integers, both are floats or remap value
+                # Series is pl.Utf8 and remap key Series is pl.Categorical).
+                remap_value_s = _remap_key_or_value_series(
+                    name=remap_value_column,
+                    values=remapping.values(),
+                    dtype=None,
+                    dtype_if_empty=input_dtype,
+                    dtype_keys=input_dtype,
+                    is_keys=False,
+                )
 
             return (
                 (

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5215,7 +5215,7 @@ class Series:
             Value to use when the remapping dict does not contain the lookup value.
             Use ``pl.first()``, to keep the original value.
         dtype
-            Override output dtype.
+            Set output dtype to override automatic output dtype determination.
 
         Examples
         --------

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -295,7 +295,9 @@ def _cast_repr_strings_with_schema(
                     .cast(tp)
                 )
             elif tp == Boolean:
-                cast_cols[c] = F.col(c).map_dict({"true": True, "false": False})
+                cast_cols[c] = F.col(c).map_dict(
+                    {"true": True, "false": False}, dtype=Boolean
+                )
             elif tp != df.schema[c]:
                 cast_cols[c] = F.col(c).cast(tp)
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -803,7 +803,8 @@ def test_map_dict() -> None:
     float_dict = {1.0: "b", 3.0: "d"}
 
     with pytest.raises(
-        pl.ComputeError, match="Remapping keys could not be converted to Int16: "
+        pl.ComputeError,
+        match="Remapping keys for map_dict could not be converted to Int16: ",
     ):
         df.with_columns(pl.col("int").map_dict(float_dict))
 
@@ -811,13 +812,13 @@ def test_map_dict() -> None:
 
     with pytest.raises(
         pl.ComputeError,
-        match="Remapping keys could not be converted to Utf8 without losing values in the conversion.",
+        match="Remapping keys for map_dict could not be converted to Utf8 without losing values in the conversion.",
     ):
         df_int_as_str.with_columns(pl.col("int").map_dict(int_dict))
 
     with pytest.raises(
         pl.ComputeError,
-        match="Remapping keys could not be converted to Utf8 without losing values in the conversion.",
+        match="Remapping keys for map_dict could not be converted to Utf8 without losing values in the conversion.",
     ):
         df_int_as_str.with_columns(pl.col("int").map_dict(int_with_none_dict))
 
@@ -829,6 +830,27 @@ def test_map_dict() -> None:
         pl.DataFrame(
             [
                 pl.Series("text", ["-23"], dtype=pl.Utf8),
+            ]
+        ),
+    )
+
+    assert_frame_equal(
+        pl.DataFrame(
+            [
+                pl.Series("float_to_boolean", [1.0, None]),
+                pl.Series("boolean_to_int", [True, False]),
+                pl.Series("boolean_to_str", [True, False]),
+            ]
+        ).with_columns(
+            pl.col("float_to_boolean").map_dict({1.0: True}),
+            pl.col("boolean_to_int").map_dict({True: 1, False: 0}),
+            pl.col("boolean_to_str").map_dict({True: "1", False: "0"}),
+        ),
+        pl.DataFrame(
+            [
+                pl.Series("float_to_boolean", [True, None], dtype=pl.Boolean),
+                pl.Series("boolean_to_int", [1, 0], dtype=pl.Int64),
+                pl.Series("boolean_to_str", ["1", "0"], dtype=pl.Utf8),
             ]
         ),
     )

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2550,6 +2550,16 @@ def test_map_dict() -> None:
         pl.Series("s", [9.0, 22.0, 9.0, 44.0, 9.0], dtype=pl.Float32),
     )
 
+    assert_series_equal(
+        pl.Series("boolean_to_int", [True, False]).map_dict({True: 1, False: 0}),
+        pl.Series("boolean_to_int", [1, 0]),
+    )
+
+    assert_series_equal(
+        pl.Series("boolean_to_str", [True, False]).map_dict({True: "1", False: "0"}),
+        pl.Series("boolean_to_str", ["1", "0"]),
+    )
+
 
 @pytest.mark.parametrize(
     ("dtype", "lower", "upper"),


### PR DESCRIPTION
…_dict

Output correct dtype for values of remapping dict in map_dict even if they could be casted without loss to dtype of keys.

Closes: #7917 and #7992