### PR TITLE
fix(python): version-gate `iter_rows` fast-path that requires pyarrow >= 7.0

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8010,22 +8010,23 @@ class DataFrame:
             over the data; you should only modify this in very specific cases where the
             default value is determined not to be a good fit to your access pattern, as
             the speedup from using the buffer is significant (~2-4x). Setting this
-            value to zero disables row buffering.
+            value to zero disables row buffering (not recommended).
 
         Notes
         -----
         If you have ``ns``-precision temporal values you should be aware that python
-        natively only supports up to ``us``-precision; if this matters you should export
-        to a different format.
+        natively only supports up to ``us``-precision; if this matters in your use-case
+        you should export to a different format.
 
         Warnings
         --------
         Row iteration is not optimal as the underlying data is stored in columnar form;
-        where possible, prefer export via one of the dedicated export/output methods.
+        where possible, prefer export via one of the dedicated export/output methods
+        that deals with columnar data.
 
         Returns
         -------
-        An iterator of tuples (default) or dictionaries of python row values.
+        An iterator of tuples (default) or dictionaries (if named) of python row values.
 
         Examples
         --------

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -617,7 +617,6 @@ def _expand_dict_scalars(
                     updated_data[name] = pli.Series(
                         name=name, values=val, dtype=dtype, nan_to_null=nan_to_null
                     )
-
                 elif val is None or isinstance(  # type: ignore[redundant-expr]
                     val, (int, float, str, bool, date, datetime, time, timedelta)
                 ):


### PR DESCRIPTION
Closes #8018.

The `to_pylist()` pyarrow Table method is not available until `pyarrow >= 7.0`[^1]. Check the version and fall-back to the regular output method if caller has an older install.

[^1]: https://arrow.apache.org/release/7.0.0.html#new-features-and-improvements
