### PR TITLE
fix(python): version gate pyarrow version for `to_pandas=(use_pyarrow…

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -15,7 +15,7 @@ from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
-from polars.utils.various import _cast_repr_strings_with_schema
+from polars.utils.various import _cast_repr_strings_with_schema, parse_version
 
 if TYPE_CHECKING:
     from polars.dataframe import DataFrame
@@ -672,7 +672,7 @@ def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
             f"`df` of type {type(df)} does not support the dataframe interchange"
             " protocol."
         )
-    if not _PYARROW_AVAILABLE or int(pa.__version__.split(".")[0]) < 11:
+    if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version("11"):
         raise ImportError(
             "pyarrow>=11.0.0 is required for converting a dataframe interchange object"
             " to a Polars dataframe."

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1194,7 +1194,9 @@ class DataFrame:
         dtypes is added, this value should be propagated to columns.
 
         """
-        if not _PYARROW_AVAILABLE or int(pa.__version__.split(".")[0]) < 11:
+        if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version(
+            "11"
+        ):
             raise ImportError(
                 "pyarrow>=11.0.0 is required for converting a Polars dataframe to a"
                 " dataframe interchange object."
@@ -2050,7 +2052,16 @@ class DataFrame:
         if use_pyarrow_extension_array:
             if parse_version(pd.__version__) < parse_version("1.5"):
                 raise ModuleNotFoundError(
-                    f'"use_pyarrow_extension_array=True" requires Pandas 1.5.x or higher, found Pandas {pd.__version__}.'
+                    f'pandas>=1.5.0 is required for `to_pandas("use_pyarrow_extension_array=True")`, found Pandas {pd.__version__}.'
+                )
+            if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version(
+                "8"
+            ):
+                raise ModuleNotFoundError(
+                    f'pyarrow>=8.0.0 is required for `to_pandas("use_pyarrow_extension_array=True")`'
+                    f", found pyarrow {pa.__version__}."
+                    if _PYARROW_AVAILABLE
+                    else "."
                 )
 
         record_batches = self._df.to_pandas()

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -82,6 +82,7 @@ from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _is_generator,
     is_int_sequence,
+    parse_version,
     range_to_series,
     range_to_slice,
     scale_bytes,
@@ -3262,14 +3263,18 @@ class Series:
 
         """
         if use_pyarrow_extension_array:
-            pandas_version_major, pandas_version_minor = (
-                int(x) for x in pd.__version__.split(".")[0:2]
-            )
-            if pandas_version_major == 0 or (
-                pandas_version_major == 1 and pandas_version_minor < 5
+            if parse_version(pd.__version__) < parse_version("1.5"):
+                raise ModuleNotFoundError(
+                    f'pandas>=1.5.0 is required for `to_pandas("use_pyarrow_extension_array=True")`, found Pandas {pd.__version__}.'
+                )
+            if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version(
+                "8"
             ):
                 raise ModuleNotFoundError(
-                    f'"use_pyarrow_extension_array=True" requires Pandas 1.5.x or higher, found Pandas {pd.__version__}.'
+                    f'pyarrow>=8.0.0 is required for `to_pandas("use_pyarrow_extension_array=True")`'
+                    f", found pyarrow {pa.__version__}."
+                    if _PYARROW_AVAILABLE
+                    else "."
                 )
 
         pd_series = (

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -40,11 +40,9 @@ Repository = "https://github.com/pola-rs/polars"
 Changelog = "https://github.com/pola-rs/polars/releases"
 
 [project.optional-dependencies]
-# the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS
-# (which the Rust libraries use to take advantage of Rust API changes).
 # NOTE: keep this list in sync with show_versions()
-pyarrow = ["pyarrow>=4.0.0"]
-pandas = ["pyarrow>=4.0.0", "pandas"]
+pyarrow = ["pyarrow>=7.0.0"]
+pandas = ["pyarrow>=7.0.0", "pandas"]
 numpy = ["numpy >= 1.16.0"]
 fsspec = ["fsspec"]
 connectorx = ["connectorx"]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -534,7 +534,7 @@ def test_to_pandas() -> None:
             vals_c = [None if x is pd.NA else x for x in c.tolist()]
             assert vals_c == test_data
         except ModuleNotFoundError:
-            # Skip test if Pandas 1.5.x is not installed.
+            # Skip test if pandas>=1.5.0 or Pyarrow>=8.0.0 is not installed.
             pass
 
 


### PR DESCRIPTION
…_extension_array=True)`

Version gate pyarrow version for `to_pandas=(use_pyarrow_extension_array=True)` as it requires pyarrow>=8.0.0.

Update minimum pyarrow version to 7.0.0 as recent pandas and deltalake versions require it anyway.

Make use of parse_version in more places.