### PR TITLE
perf(rust, python): parallelize `into_groups` materialization ~`-25%`

### DIFF
--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -1,7 +1,6 @@
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
 
-use polars_arrow::trusted_len::PushUnchecked;
 use polars_arrow::utils::CustomIterTools;
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::prelude::*;
@@ -47,17 +46,45 @@ impl From<Vec<IdxItem>> for GroupsIdx {
 
 impl From<Vec<Vec<IdxItem>>> for GroupsIdx {
     fn from(v: Vec<Vec<IdxItem>>) -> Self {
-        // 10% faster than `iter().flatten().collect()
+        // single threaded flatten: 10% faster than `iter().flatten().collect()
+        // this is the multi-threaded impl of that
         let cap = v.iter().map(|v| v.len()).sum::<usize>();
+        let offsets = v
+            .iter()
+            .scan(0_usize, |acc, v| {
+                let out = *acc;
+                *acc += v.len();
+                Some(out)
+            })
+            .collect::<Vec<_>>();
         let mut first = Vec::with_capacity(cap);
+        let first_ptr = first.as_ptr() as usize;
         let mut all = Vec::with_capacity(cap);
-        for inner in v {
-            for (first_val, vals) in inner {
-                unsafe {
-                    first.push_unchecked(first_val);
-                    all.push_unchecked(vals)
-                }
-            }
+        let all_ptr = all.as_ptr() as usize;
+
+        POOL.install(|| {
+            v.into_par_iter()
+                .zip(offsets)
+                .for_each(|(mut inner, offset)| {
+                    unsafe {
+                        let first = (first_ptr as *const IdxSize as *mut IdxSize).add(offset);
+                        let all = (all_ptr as *const Vec<IdxSize> as *mut Vec<IdxSize>).add(offset);
+
+                        let inner_ptr = inner.as_mut_ptr();
+                        for i in 0..inner.len() {
+                            let (first_val, vals) = std::ptr::read(inner_ptr.add(i));
+                            std::ptr::write(first.add(i), first_val);
+                            std::ptr::write(all.add(i), vals);
+                        }
+                        // set len to 0 so that the contents will not get dropped
+                        // they are moved to `first` and `all`
+                        inner.set_len(0);
+                    }
+                });
+        });
+        unsafe {
+            all.set_len(cap);
+            first.set_len(cap);
         }
         GroupsIdx {
             sorted: false,


### PR DESCRIPTION
`group_tuples` of integers with high cardinality saw a 25% speed up on my local benchmark. For low cardinality this will not matter much.