### PR TITLE
test(python): Improve some tests

### DIFF
--- a/py-polars/tests/benchmark/test_release.py
+++ b/py-polars/tests/benchmark/test_release.py
@@ -159,6 +159,6 @@ def test_max_statistic_parquet_writer() -> None:
     df = pl.arange(0, n, eager=True, dtype=pl.Int64).to_frame()
     f = "/tmp/tmp.parquet"
     df.write_parquet(f, statistics=True, use_pyarrow=False, row_group_size=n)
-    assert pl.scan_parquet(f).filter(pl.col("arange") > n - 3).collect().to_dict(
-        False
-    ) == {"arange": [149998, 149999]}
+    result = pl.scan_parquet(f).filter(pl.col("arange") > n - 3).collect()
+    expected = pl.DataFrame({"arange": [149998, 149999]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_melt.py
+++ b/py-polars/tests/unit/operations/test_melt.py
@@ -1,21 +1,25 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_melt_projection_pd_7747() -> None:
-    assert pl.LazyFrame(
+    df = pl.LazyFrame(
         {
             "number": [1, 2, 1, 2, 1],
             "age": [40, 30, 21, 33, 45],
             "weight": [100, 103, 95, 90, 110],
         }
-    ).with_columns(pl.col("age").alias("wgt")).melt(
-        id_vars="number",
-        value_vars="wgt",
-    ).select(
-        "number", "value"
-    ).collect().to_dict(
-        False
-    ) == {
-        "number": [1, 2, 1, 2, 1],
-        "value": [40, 30, 21, 33, 45],
-    }
+    )
+    result = (
+        df.with_columns(pl.col("age").alias("wgt"))
+        .melt(id_vars="number", value_vars="wgt")
+        .select("number", "value")
+        .collect()
+    )
+    expected = pl.DataFrame(
+        {
+            "number": [1, 2, 1, 2, 1],
+            "value": [40, 30, 21, 33, 45],
+        }
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_corr() -> None:
@@ -10,10 +11,14 @@ def test_corr() -> None:
             "b": [-1, 23, 8],
         }
     )
-    assert df.corr().to_dict(False) == {
-        "a": [1.0, 0.18898223650461357],
-        "b": [0.1889822365046136, 1.0],
-    }
+    result = df.corr()
+    expected = pl.DataFrame(
+        {
+            "a": [1.0, 0.18898223650461357],
+            "b": [0.1889822365046136, 1.0],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_cut() -> None:

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -6,17 +6,20 @@ from polars.testing import assert_frame_equal
 
 
 def test_transpose_supertype() -> None:
-    assert pl.DataFrame(
-        {"a": [1, 2, 3], "b": ["foo", "bar", "ham"]}
-    ).transpose().to_dict(False) == {
-        "column_0": ["1", "foo"],
-        "column_1": ["2", "bar"],
-        "column_2": ["3", "ham"],
-    }
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["foo", "bar", "ham"]})
+    result = df.transpose()
+    expected = pl.DataFrame(
+        {
+            "column_0": ["1", "foo"],
+            "column_1": ["2", "bar"],
+            "column_2": ["3", "ham"],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_transpose_struct() -> None:
-    assert pl.DataFrame(
+    df = pl.DataFrame(
         {
             "a": ["foo", "bar", "ham"],
             "b": [
@@ -25,29 +28,35 @@ def test_transpose_struct() -> None:
                 {"a": date(2022, 1, 3), "b": False},
             ],
         }
-    ).transpose().to_dict(False) == {
-        "column_0": ["foo", "{2022-01-01,true}"],
-        "column_1": ["bar", "{2022-01-02,false}"],
-        "column_2": ["ham", "{2022-01-03,false}"],
-    }
+    )
+    result = df.transpose()
+    expected = pl.DataFrame(
+        {
+            "column_0": ["foo", "{2022-01-01,true}"],
+            "column_1": ["bar", "{2022-01-02,false}"],
+            "column_2": ["ham", "{2022-01-03,false}"],
+        }
+    )
+    assert_frame_equal(result, expected)
 
-    assert (
-        pl.DataFrame(
-            {
-                "b": [
-                    {"a": date(2022, 1, 1), "b": True},
-                    {"a": date(2022, 1, 2), "b": False},
-                    {"a": date(2022, 1, 3), "b": False},
-                ]
-            }
-        )
-        .transpose()
-        .to_dict(False)
-    ) == {
-        "column_0": [{"a": date(2022, 1, 1), "b": True}],
-        "column_1": [{"a": date(2022, 1, 2), "b": False}],
-        "column_2": [{"a": date(2022, 1, 3), "b": False}],
-    }
+    df = pl.DataFrame(
+        {
+            "b": [
+                {"a": date(2022, 1, 1), "b": True},
+                {"a": date(2022, 1, 2), "b": False},
+                {"a": date(2022, 1, 3), "b": False},
+            ]
+        }
+    )
+    result = df.transpose()
+    expected = pl.DataFrame(
+        {
+            "column_0": [{"a": date(2022, 1, 1), "b": True}],
+            "column_1": [{"a": date(2022, 1, 2), "b": False}],
+            "column_2": [{"a": date(2022, 1, 3), "b": False}],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_transpose_arguments() -> None:
@@ -105,13 +114,18 @@ def test_transpose_arguments() -> None:
 
 
 def test_transpose_logical_data() -> None:
-    assert pl.DataFrame(
+    df = pl.DataFrame(
         {
             "a": [date(2022, 2, 1), date(2022, 2, 2), date(2022, 1, 3)],
             "b": [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2022, 1, 3)],
         }
-    ).transpose().to_dict(False) == {
-        "column_0": [datetime(2022, 2, 1, 0, 0), datetime(2022, 1, 1, 0, 0)],
-        "column_1": [datetime(2022, 2, 2, 0, 0), datetime(2022, 1, 2, 0, 0)],
-        "column_2": [datetime(2022, 1, 3, 0, 0), datetime(2022, 1, 3, 0, 0)],
-    }
+    )
+    result = df.transpose()
+    expected = pl.DataFrame(
+        {
+            "column_0": [datetime(2022, 2, 1, 0, 0), datetime(2022, 1, 1, 0, 0)],
+            "column_1": [datetime(2022, 2, 2, 0, 0), datetime(2022, 1, 2, 0, 0)],
+            "column_2": [datetime(2022, 1, 3, 0, 0), datetime(2022, 1, 3, 0, 0)],
+        }
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_unique.py
+++ b/py-polars/tests/unit/operations/test_unique.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_unique_predicate_pd() -> None:
@@ -10,9 +11,18 @@ def test_unique_predicate_pd() -> None:
         }
     )
 
-    assert lf.unique(subset=["x", "y"], maintain_order=True, keep="last").filter(
-        pl.col("z")
-    ).collect().to_dict(False) == {"x": [], "y": [], "z": []}
-    assert lf.unique(subset=["x", "y"], maintain_order=True, keep="any").filter(
-        pl.col("z")
-    ).collect().to_dict(False) == {"x": ["abc"], "y": ["xxx"], "z": [True]}
+    result = (
+        lf.unique(subset=["x", "y"], maintain_order=True, keep="last")
+        .filter(pl.col("z"))
+        .collect()
+    )
+    expected = pl.DataFrame(schema={"x": pl.Utf8, "y": pl.Utf8, "z": pl.Boolean})
+    assert_frame_equal(result, expected)
+
+    result = (
+        lf.unique(subset=["x", "y"], maintain_order=True, keep="any")
+        .filter(pl.col("z"))
+        .collect()
+    )
+    expected = pl.DataFrame({"x": ["abc"], "y": ["xxx"], "z": [True]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -175,24 +175,28 @@ def test_cumulative_eval_window_functions() -> None:
         }
     )
 
-    assert (
-        df.with_columns(
-            pl.col("val")
-            .cumulative_eval(pl.element().max())
-            .over("group")
-            .alias("cumulative_eval_max")
-        ).to_dict(False)
-    ) == {
-        "group": [0, 0, 0, 1, 1, 1],
-        "val": [20, 40, 30, 2, 4, 3],
-        "cumulative_eval_max": [20, 40, 40, 2, 4, 4],
-    }
+    result = df.with_columns(
+        pl.col("val")
+        .cumulative_eval(pl.element().max())
+        .over("group")
+        .alias("cumulative_eval_max")
+    )
+    expected = pl.DataFrame(
+        {
+            "group": [0, 0, 0, 1, 1, 1],
+            "val": [20, 40, 30, 2, 4, 3],
+            "cumulative_eval_max": [20, 40, 40, 2, 4, 4],
+        }
+    )
+    assert_frame_equal(result, expected)
 
     # 6394
     df = pl.DataFrame({"group": [1, 1, 2, 3], "value": [1, None, 3, None]})
-    assert df.select(
+    result = df.select(
         pl.col("value").cumulative_eval(pl.element().mean()).over("group")
-    ).to_dict(False) == {"value": [1.0, 1.0, 3.0, None]}
+    )
+    expected = pl.DataFrame({"value": [1.0, 1.0, 3.0, None]})
+    assert_frame_equal(result, expected)
 
 
 def test_count_window() -> None:
@@ -210,15 +214,11 @@ def test_count_window() -> None:
 def test_window_cached_keys_sorted_update_4183() -> None:
     df = pl.DataFrame(
         {
-            "customer_ID": [
-                "0",
-                "0",
-                "1",
-            ],
+            "customer_ID": ["0", "0", "1"],
             "date": [1, 2, 3],
         }
     )
-    assert df.sort(by=["customer_ID", "date"]).select(
+    result = df.sort(by=["customer_ID", "date"]).select(
         [
             pl.count("date").over(pl.col("customer_ID")).alias("count"),
             pl.col("date")
@@ -226,7 +226,12 @@ def test_window_cached_keys_sorted_update_4183() -> None:
             .over(pl.col("customer_ID"))
             .alias("rank"),
         ]
-    ).to_dict(False) == {"count": [2, 2, 1], "rank": [1, 2, 1]}
+    )
+    expected = pl.DataFrame(
+        {"count": [2, 2, 1], "rank": [1, 2, 1]},
+        schema={"count": pl.UInt32, "rank": pl.UInt32},
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_window_functions_list_types() -> None:
@@ -282,54 +287,53 @@ def test_nested_aggregation_window_expression() -> None:
         }
     )
 
-    assert df.with_columns(
-        [
-            pl.when(pl.col("x") >= pl.col("x").quantile(0.1))
-            .then(1)
-            .otherwise(None)
-            .over("y")
-            .alias("foo")
-        ]
-    ).to_dict(False) == {
-        "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 2, 13, 4, 15, 6, None, None, 19],
-        "y": [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-        "foo": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None, 1],
-    }
+    result = df.with_columns(
+        pl.when(pl.col("x") >= pl.col("x").quantile(0.1))
+        .then(1)
+        .otherwise(None)
+        .over("y")
+        .alias("foo")
+    )
+    expected = pl.DataFrame(
+        {
+            "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 2, 13, 4, 15, 6, None, None, 19],
+            "y": [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            "foo": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None, None, 1],
+        },
+        # Resulting column is Int32, see https://github.com/pola-rs/polars/issues/8041
+        schema_overrides={"foo": pl.Int32},
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_window_5868() -> None:
     df = pl.DataFrame({"value": [None, 2], "id": [None, 1]})
 
-    assert df.with_columns(pl.col("value").max().over("id")).to_dict(False) == {
-        "value": [None, 2],
-        "id": [None, 1],
-    }
+    result_df = df.with_columns(pl.col("value").max().over("id"))
+    expected_df = pl.DataFrame({"value": [None, 2], "id": [None, 1]})
+    assert_frame_equal(result_df, expected_df)
 
     df = pl.DataFrame({"a": [None, 1, 2, 3, 3, 3, 4, 4]})
 
-    assert df.select(pl.col("a").sum().over("a"))["a"].to_list() == [
-        None,
-        1,
-        2,
-        9,
-        9,
-        9,
-        8,
-        8,
-    ]
-    assert df.with_columns(pl.col("a").set_sorted()).select(
-        pl.col("a").sum().over("a")
-    )["a"].to_list() == [None, 1, 2, 9, 9, 9, 8, 8]
+    result = df.select(pl.col("a").sum().over("a")).get_column("a")
+    expected = pl.Series("a", [None, 1, 2, 9, 9, 9, 8, 8])
+    assert_series_equal(result, expected)
 
-    assert df.drop_nulls().select(pl.col("a").sum().over("a"))["a"].to_list() == [
-        1,
-        2,
-        9,
-        9,
-        9,
-        8,
-        8,
-    ]
-    assert df.drop_nulls().with_columns(pl.col("a").set_sorted()).select(
-        pl.col("a").sum().over("a")
-    )["a"].to_list() == [1, 2, 9, 9, 9, 8, 8]
+    result = (
+        df.with_columns(pl.col("a").set_sorted())
+        .select(pl.col("a").sum().over("a"))
+        .get_column("a")
+    )
+    assert_series_equal(result, expected)
+
+    result = df.drop_nulls().select(pl.col("a").sum().over("a")).get_column("a")
+    expected = pl.Series("a", [1, 2, 9, 9, 9, 8, 8])
+    assert_series_equal(result, expected)
+
+    result = (
+        df.drop_nulls()
+        .with_columns(pl.col("a").set_sorted())
+        .select(pl.col("a").sum().over("a"))
+        .get_column("a")
+    )
+    assert_series_equal(result, expected)


### PR DESCRIPTION
I'd like to get rid of the habit of checking test results by calling `to_dict(False)` or `rows()` and then comparing to some dict/list of values. We should use `assert_frame/series_equal`, which will also check for data types.

I've updated a few tests and already found one unexpected behaviour. It may be a bit more verbose sometimes, but the test suite will become much more reliable if we do this consistently.