### PR TITLE
fix(rust, python): check element count in multi-column explode

### DIFF
--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -1,5 +1,6 @@
 use arrow::offset::OffsetsBuffer;
 use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
+use rayon::prelude::*;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
@@ -8,6 +9,7 @@ use crate::chunked_array::ops::explode::offsets_to_indexes;
 use crate::prelude::*;
 use crate::series::IsSorted;
 use crate::utils::try_get_supertype;
+use crate::POOL;
 
 fn get_exploded(series: &Series) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
     match series.dtype() {
@@ -52,34 +54,60 @@ impl DataFrame {
             df = df.drop(s.name())?;
         }
 
-        for (i, s) in columns.iter().enumerate() {
-            // Safety:
-            // offsets don't have indices exceeding Series length.
-            if let Ok((exploded, offsets)) = get_exploded(s) {
-                let col_idx = self.check_name_to_idx(s.name())?;
+        let exploded_columns = POOL.install(|| {
+            columns
+                .par_iter()
+                .map(get_exploded)
+                .collect::<PolarsResult<Vec<_>>>()
+        })?;
 
-                // expand all the other columns based the exploded first column
-                if i == 0 {
-                    let row_idx = offsets_to_indexes(offsets.as_slice(), exploded.len());
-                    let mut row_idx = IdxCa::from_vec("", row_idx);
-                    row_idx.set_sorted_flag(IsSorted::Ascending);
-
-                    // Safety
-                    // We just created indices that are in bounds.
-                    df = unsafe { df.take_unchecked(&row_idx) };
-                }
-                if exploded.len() == df.height() || df.width() == 0 {
-                    df.columns.insert(col_idx, exploded);
-                } else {
-                    polars_bail!(
-                        ShapeMismatch: "exploded column(s) {:?} doesn't have the same length: {} \
-                        as the dataframe: {}", exploded.name(), exploded.name(), df.height(),
-                    );
-                }
+        fn process_column(
+            original_df: &DataFrame,
+            df: &mut DataFrame,
+            exploded: Series,
+        ) -> PolarsResult<()> {
+            if exploded.len() == df.height() || df.width() == 0 {
+                let col_idx = original_df.check_name_to_idx(exploded.name())?;
+                df.columns.insert(col_idx, exploded);
             } else {
-                polars_bail!(opq = explode, s.dtype());
+                polars_bail!(
+                    ShapeMismatch: "exploded column(s) {:?} doesn't have the same length: {} \
+                    as the dataframe: {}", exploded.name(), exploded.name(), df.height(),
+                );
             }
+            Ok(())
         }
+
+        let check_offsets = || {
+            let first_offsets = exploded_columns[0].1.as_slice();
+            for (_, offsets) in &exploded_columns[1..] {
+                polars_ensure!(first_offsets == offsets.as_slice(),
+                    ShapeMismatch: "exploded columns must have matching element counts"
+                )
+            }
+            Ok(())
+        };
+        let process_first = || {
+            let (exploded, offsets) = &exploded_columns[0];
+
+            let row_idx = offsets_to_indexes(offsets.as_slice(), exploded.len());
+            let mut row_idx = IdxCa::from_vec("", row_idx);
+            row_idx.set_sorted_flag(IsSorted::Ascending);
+
+            // Safety
+            // We just created indices that are in bounds.
+            let mut df = unsafe { df.take_unchecked(&row_idx) };
+            process_column(self, &mut df, exploded.clone())?;
+            PolarsResult::Ok(df)
+        };
+        let (df, result) = POOL.join(process_first, check_offsets);
+        let mut df = df?;
+        result?;
+
+        for (exploded, _) in exploded_columns.into_iter().skip(1) {
+            process_column(self, &mut df, exploded)?
+        }
+
         Ok(df)
     }
     /// Explode `DataFrame` to long format by exploding a column with Lists.

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pyarrow as pa
+import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
@@ -265,3 +266,16 @@ def test_explode_null_list() -> None:
     assert pl.Series([["a"], None], dtype=pl.List(pl.Utf8))[
         1:2
     ].arr.min().to_list() == [None]
+
+
+def test_explode_invalid_element_count() -> None:
+    df = pl.DataFrame(
+        {
+            "col1": [["X", "Y", "Z"], ["F", "G"], ["P"]],
+            "col2": [["A", "B", "C"], ["C"], ["D", "E"]],
+        }
+    ).with_row_count()
+    with pytest.raises(
+        pl.ShapeError, match=r"exploded columns must have matching element counts"
+    ):
+        df.explode(["col1", "col2"])


### PR DESCRIPTION
fixes #8024

Also makes multi-column explode faster by parallelizing the work.