### PR TITLE
perf(rust, python): speed up from_par_iter Option<bool> `~2.5x`

### DIFF
--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -515,7 +515,7 @@ impl FromParallelIterator<Option<bool>> for BooleanChunked {
         let capacity: usize = get_capacity_from_par_results_slice(&vectors);
         let offsets = get_offsets(&vectors);
 
-        // We initialize the vec, as setting bits only doesn't seem to initalize the memory
+        // We initialize the vec, as setting bits only doesn't seem to initialize the memory
         let mut values_buf: Vec<u8> = vec![0; capacity.saturating_add(7) / 8];
         let values_buf_ptr = unsafe { SyncPtr::new(values_buf.as_mut_ptr()) };
 

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -6,9 +6,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
-#[cfg(feature = "object")]
-use arrow::bitmap::Bitmap;
-use arrow::bitmap::MutableBitmap;
+use arrow::bitmap::{Bitmap, MutableBitmap};
+use polars_arrow::bit_util::{set_bit_raw, unset_bit_raw};
 use polars_utils::sync::SyncPtr;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator};
 use rayon::prelude::*;
@@ -410,6 +409,25 @@ where
     }
 }
 
+fn finish_validities(
+    validities: Vec<(Option<MutableBitmap>, usize)>,
+    capacity: usize,
+) -> Option<Bitmap> {
+    if validities.iter().any(|(v, _)| v.is_some()) {
+        let mut bitmap = MutableBitmap::with_capacity(capacity);
+        for (valids, len) in validities {
+            if let Some(valids) = valids {
+                bitmap.extend_from_bitmap(&(valids.into()))
+            } else {
+                bitmap.extend_constant(len, true)
+            }
+        }
+        Some(bitmap.into())
+    } else {
+        None
+    }
+}
+
 impl<T> FromParallelIterator<Option<T::Native>> for ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -466,19 +484,7 @@ where
             .collect::<Vec<_>>();
         unsafe { values_buf.set_len(capacity) };
 
-        let validity = if validities.iter().any(|(v, _)| v.is_some()) {
-            let mut bitmap = MutableBitmap::with_capacity(capacity);
-            for (valids, len) in validities {
-                if let Some(valids) = valids {
-                    bitmap.extend_from_bitmap(&(valids.into()))
-                } else {
-                    bitmap.extend_constant(len, true)
-                }
-            }
-            Some(bitmap.into())
-        } else {
-            None
-        };
+        let validity = finish_validities(validities, capacity);
 
         let arr = PrimitiveArray::from_data_default(values_buf.into(), validity);
         unsafe { Self::from_chunks("", vec![Box::new(arr)]) }
@@ -502,15 +508,95 @@ impl FromParallelIterator<bool> for BooleanChunked {
 
 impl FromParallelIterator<Option<bool>> for BooleanChunked {
     fn from_par_iter<I: IntoParallelIterator<Item = Option<bool>>>(iter: I) -> Self {
+        // Get linkedlist filled with different vec result from different threads
         let vectors = collect_into_linked_list(iter);
 
-        let capacity: usize = get_capacity_from_par_results(&vectors);
+        let vectors = vectors.into_iter().collect::<Vec<_>>();
+        let capacity: usize = get_capacity_from_par_results_slice(&vectors);
+        let offsets = get_offsets(&vectors);
 
-        let arr = unsafe {
-            BooleanArray::from_trusted_len_iter(
-                vectors.into_iter().flatten().trust_my_length(capacity),
-            )
-        };
+        // We initialize the vec, as setting bits only doesn't seem to initalize the memory
+        let mut values_buf: Vec<u8> = vec![0; capacity.saturating_add(7) / 8];
+        let values_buf_ptr = unsafe { SyncPtr::new(values_buf.as_mut_ptr()) };
+
+        let validities = offsets
+            .par_iter()
+            .zip(vectors.par_iter())
+            .map(|(&offset, vector)| {
+                let mut local_validity = None;
+                let local_len = vector.len();
+                let mut latest_validy_written = 0;
+                unsafe {
+                    // don't add the offset here, we set bits, not bytes!
+                    let values_buf_ptr = values_buf_ptr.get();
+
+                    // this may/will race on the leading and trailing bits
+                    // we allow this racing and set the bits to the correct value in a second
+                    // single threaded pass
+                    for (i, opt_v) in vector.iter().enumerate() {
+                        match opt_v {
+                            Some(v) => {
+                                if *v {
+                                    set_bit_raw(values_buf_ptr, i + offset);
+                                };
+                            }
+                            None => {
+                                let validity = match &mut local_validity {
+                                    None => {
+                                        let validity = MutableBitmap::with_capacity(local_len);
+                                        local_validity = Some(validity);
+                                        local_validity.as_mut().unwrap_unchecked()
+                                    }
+                                    Some(validity) => validity,
+                                };
+                                validity.extend_constant(i - latest_validy_written, true);
+                                latest_validy_written = i + 1;
+                                validity.push_unchecked(false);
+                            }
+                        }
+                    }
+                }
+                if let Some(validity) = &mut local_validity {
+                    validity.extend_constant(local_len - latest_validy_written, true);
+                }
+                (local_validity, local_len)
+            })
+            .collect::<Vec<_>>();
+        unsafe { values_buf.set_len(capacity.saturating_add(7) / 8) };
+
+        // set the leading and trailing bits
+        // those can be in an invalid state due to racing threads
+        let ptr = values_buf_ptr.get();
+        for (vector, offset) in vectors.into_iter().zip(offsets) {
+            // set leading bits
+            for (i, opt_v) in vector.iter().enumerate().take(8) {
+                unsafe {
+                    if let Some(v) = opt_v {
+                        if *v {
+                            set_bit_raw(ptr, i + offset)
+                        } else {
+                            unset_bit_raw(ptr, i + offset)
+                        }
+                    }
+                }
+            }
+            // set trailing bits
+            for (i, opt_v) in vector.iter().enumerate().rev().take(8) {
+                unsafe {
+                    if let Some(v) = opt_v {
+                        if *v {
+                            set_bit_raw(ptr, i + offset)
+                        } else {
+                            unset_bit_raw(ptr, i + offset)
+                        }
+                    }
+                }
+            }
+        }
+
+        let validity = finish_validities(validities, capacity);
+        let values = Bitmap::from_u8_vec(values_buf, capacity);
+        let arr = BooleanArray::from_data_default(values, validity);
         unsafe { Self::from_chunks("", vec![Box::new(arr)]) }
     }
 }


### PR DESCRIPTION
# master

```
null density: 0 took 828ms
null density: 0.2 took 960ms
null density: 0.5 took 1035ms
null density: 0.8 took 660ms
```

# PR

```
null density: 0 took 308ms
null density: 0.2 took 406ms
null density: 0.5 took 405ms
null density: 0.8 took 307ms
```


