### PR TITLE
docs(python): Fix Expr.apply docstring for return_dtype parameter

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3255,8 +3255,8 @@ class Expr:
             Lambda/ function to apply.
         return_dtype
             Dtype of the output Series.
-            If not set, polars will assume that
-            the dtype remains unchanged.
+            If not set, the dtype will be
+            ``polars.Unknown``.
         skip_nulls
             Don't apply the function over values
             that contain nulls. This is faster.


### PR DESCRIPTION
Closes #8042