### PR TITLE
fix(python): Fix regression in scan_parquet

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.16.18"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/py-polars/polars/io/ipc/anonymous_scan.py
+++ b/py-polars/polars/io/ipc/anonymous_scan.py
@@ -28,14 +28,18 @@ def _scan_ipc_fsspec(
 
 
 def _scan_ipc_impl(  # noqa: D417
-    source: str, columns: list[str] | None, **kwargs: Any
+    source: str,
+    columns: list[str] | None,
+    predicate: str | None,
+    n_rows: int | None,
+    **kwargs: Any,
 ) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
     Parameters
     ----------
-    uri
+    source
         Source URI
     columns
         Columns that are projected
@@ -43,4 +47,4 @@ def _scan_ipc_impl(  # noqa: D417
     """
     import polars as pl
 
-    return pl.read_ipc(source, columns=columns, **kwargs)
+    return pl.read_ipc(source, columns=columns, n_rows=n_rows, **kwargs)

--- a/py-polars/polars/io/parquet/anonymous_scan.py
+++ b/py-polars/polars/io/parquet/anonymous_scan.py
@@ -28,14 +28,18 @@ def _scan_parquet_fsspec(
 
 
 def _scan_parquet_impl(  # noqa: D417
-    uri: str, columns: list[str] | None, **kwargs: Any
+    source: str,
+    columns: list[str] | None,
+    predicate: str | None,
+    n_rows: int | None,
+    **kwargs: Any,
 ) -> DataFrame:
     """
     Take the projected columns and materialize an arrow table.
 
     Parameters
     ----------
-    uri
+    source
         Source URI
     columns
         Columns that are projected
@@ -43,4 +47,4 @@ def _scan_parquet_impl(  # noqa: D417
     """
     import polars as pl
 
-    return pl.read_parquet(uri, columns=columns, **kwargs)
+    return pl.read_parquet(source, columns=columns, n_rows=n_rows, **kwargs)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -502,7 +502,7 @@ class LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, dict):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
-                [(name, dt) for name, dt in schema.items()], scan_fn, pyarrow
+                list(schema.items()), scan_fn, pyarrow
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(


### PR DESCRIPTION
Closes #8063

Changes to this code were required because `read_parquet` now has mostly keyword-only arguments.

I'm not actually sure this fixes things, I don't have access to a cloud container right now (maybe I can fix something later this weekend). Seems weird to pass *args to a function that doesn't take any *args?

Work in progress, I guess...