### PR TITLE
feat(rust, python): infer tz-aware formats with try_parse_dates in read_csv

### DIFF
--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn cast_columns(
             .as_date(None, false)
             .map(|ca| ca.into_series()),
         #[cfg(feature = "temporal")]
-        (DataType::Utf8, DataType::Datetime(tu, _)) => s
+        (DataType::Utf8, DataType::Datetime(tu, tz)) => s
             .utf8()
             .unwrap()
             .as_datetime(None, *tu, false, false, false, None)

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn cast_columns(
             .as_date(None, false)
             .map(|ca| ca.into_series()),
         #[cfg(feature = "temporal")]
-        (DataType::Utf8, DataType::Datetime(tu, tz)) => s
+        (DataType::Utf8, DataType::Datetime(tu, _)) => s
             .utf8()
             .unwrap()
             .as_datetime(None, *tu, false, false, false, None)

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -7,6 +7,7 @@ use polars_core::datatypes::PlHashSet;
 use polars_core::prelude::*;
 #[cfg(feature = "polars-time")]
 use polars_time::chunkedarray::utf8::infer as date_infer;
+use polars_time::chunkedarray::utf8::PatternWithOffset;
 #[cfg(feature = "polars-time")]
 use polars_time::prelude::utf8::Pattern;
 use regex::{Regex, RegexBuilder};
@@ -110,12 +111,22 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
             #[cfg(feature = "polars-time")]
             {
                 match date_infer::infer_pattern_single(&string[1..string.len() - 1]) {
-                    Some(pattern_with_offset) => match pattern_with_offset.pattern {
-                        Pattern::DatetimeYMD | Pattern::DatetimeDMY => {
-                            DataType::Datetime(TimeUnit::Microseconds, None)
-                        }
-                        Pattern::DateYMD | Pattern::DateDMY => DataType::Date,
-                        _ => DataType::Utf8, // TODO: support tz-aware patterns
+                    Some(pattern_with_offset) => match pattern_with_offset {
+                        PatternWithOffset {
+                            pattern: Pattern::DatetimeYMD | Pattern::DatetimeDMY,
+                            offset: _,
+                        } => DataType::Datetime(TimeUnit::Microseconds, None),
+                        PatternWithOffset {
+                            pattern: Pattern::DateYMD | Pattern::DateDMY,
+                            offset: _,
+                        } => DataType::Date,
+                        PatternWithOffset {
+                            pattern: Pattern::DatetimeYMDZ,
+                            offset,
+                        } => DataType::Datetime(
+                            TimeUnit::Microseconds,
+                            offset.map(|x| x.to_string()),
+                        ),
                     },
                     None => DataType::Utf8,
                 }
@@ -139,12 +150,19 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
         #[cfg(feature = "polars-time")]
         {
             match date_infer::infer_pattern_single(string) {
-                Some(pattern_with_offset) => match pattern_with_offset.pattern {
-                    Pattern::DatetimeYMD | Pattern::DatetimeDMY => {
-                        DataType::Datetime(TimeUnit::Microseconds, None)
-                    }
-                    Pattern::DateYMD | Pattern::DateDMY => DataType::Date,
-                    _ => DataType::Utf8, // TODO: support tz-aware patterns
+                Some(pattern_with_offset) => match pattern_with_offset {
+                    PatternWithOffset {
+                        pattern: Pattern::DatetimeYMD | Pattern::DatetimeDMY,
+                        offset: _,
+                    } => DataType::Datetime(TimeUnit::Microseconds, None),
+                    PatternWithOffset {
+                        pattern: Pattern::DateYMD | Pattern::DateDMY,
+                        offset: _,
+                    } => DataType::Date,
+                    PatternWithOffset {
+                        pattern: Pattern::DatetimeYMDZ,
+                        offset,
+                    } => DataType::Datetime(TimeUnit::Microseconds, offset.map(|x| x.to_string())),
                 },
                 None => DataType::Utf8,
             }

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -3,7 +3,7 @@ mod patterns;
 mod strptime;
 
 use chrono::ParseError;
-pub use patterns::Pattern;
+pub use patterns::{Pattern, PatternWithOffset};
 
 use super::*;
 #[cfg(feature = "dtype-date")]

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -117,7 +117,7 @@ def read_csv(
         ``infer_schema_length=0`` to read all columns as ``pl.Utf8`` to check which
         values might cause an issue.
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like time zone naive formats can
+        Try to automatically parse dates. Most ISO8601-like formats can
         be inferred, as well as a handful of others. If this does not succeed,
         the column remains of data type ``pl.Utf8``.
         If ``use_pyarrow=True``, dates will always be parsed.
@@ -467,7 +467,7 @@ def read_csv_batched(
         First try ``infer_schema_length=0`` to read all columns as
         ``pl.Utf8`` to check which values might cause an issue.
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like time zone naive formats can
+        Try to automatically parse dates. Most ISO8601-like formats can
         be inferred, as well as a handful of others. If this does not succeed,
         the column remains of data type ``pl.Utf8``.
     n_threads
@@ -775,7 +775,7 @@ def scan_csv(
     row_count_offset
         Offset to start the row_count column (only used if the name is set).
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like time zone naive formats
+        Try to automatically parse dates. Most ISO8601-like formats
         can be inferred, as well as a handful of others. If this does not succeed,
         the column remains of data type ``pl.Utf8``.
     eol_char

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -748,6 +748,31 @@ def test_fallback_chrono_parser() -> None:
     assert df.null_count().row(0) == (0, 0)
 
 
+def test_tz_aware_try_parse_dates() -> None:
+    data = (
+        "a,b,c,d\n"
+        "2020-01-01T01:00:00+01:00,2021-04-28T00:00:00+02:00,2021-03-28T00:00:00+01:00,2\n"
+        "2020-01-01T02:00:00+01:00,2021-04-29T00:00:00+02:00,2021-03-29T00:00:00+02:00,3\n"
+    )
+    result = pl.read_csv(io.StringIO(data), try_parse_dates=True)
+    expected = pl.DataFrame(
+        {
+            "a": [
+                datetime(2020, 1, 1, 1, tzinfo=timezone(timedelta(hours=1))),
+                datetime(2020, 1, 1, 2, tzinfo=timezone(timedelta(hours=1))),
+            ],
+            "b": [
+                datetime(2021, 4, 28, tzinfo=timezone(timedelta(hours=2))),
+                datetime(2021, 4, 29, tzinfo=timezone(timedelta(hours=2))),
+            ],
+            # column 'c' has mixed offsets, so `try_parse_dates`  can't parse it
+            "c": ["2021-03-28T00:00:00+01:00", "2021-03-29T00:00:00+02:00"],
+            "d": [2, 3],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_csv_string_escaping() -> None:
     df = pl.DataFrame({"a": ["Free trip to A,B", '''Special rate "1.79"''']})
     f = io.BytesIO()


### PR DESCRIPTION
follow-up to #7405

