### PR TITLE
feat(rust, python): expand list of tz-aware formats which can be auto-inferred

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -207,8 +207,8 @@ pub(super) static DATETIME_Y_M_D_Z: &[&str] = &[
     "%Y-%m-%d %H%M%S.%3f%#z",
     "%Y%m%d %H%M%S.%3f%#z",
     // other
-    "%+"
-    ];
+    "%+",
+];
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub enum Pattern {

--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -57,7 +57,7 @@ pub(super) static DATETIME_D_M_Y: &[&str] = &[
 /// polars parsers does not support them, so it will be slower
 pub(super) static DATETIME_Y_M_D: &[&str] = &[
     // ---
-    // ISO8601, generated via the `iso8601_format_datetime` test fixture
+    // ISO8601-like, generated via the `iso8601_format_datetime` test fixture
     // ---
     "%Y/%m/%dT%H:%M:%S",
     "%Y-%m-%dT%H:%M:%S",
@@ -142,7 +142,73 @@ pub(super) static DATETIME_Y_M_D: &[&str] = &[
     "%FT%H:%M:%S%.f",
 ];
 
-pub(super) static DATETIME_Y_M_D_Z: &[&str] = &["%+"];
+pub(super) static DATETIME_Y_M_D_Z: &[&str] = &[
+    // ---
+    // ISO8601-like, generated via the `iso8601_tz_aware_format_datetime` test fixture
+    // ---
+    "%Y/%m/%dT%H:%M:%S%#z",
+    "%Y-%m-%dT%H:%M:%S%#z",
+    "%Y%m%dT%H:%M:%S%#z",
+    "%Y/%m/%dT%H%M%S%#z",
+    "%Y-%m-%dT%H%M%S%#z",
+    "%Y%m%dT%H%M%S%#z",
+    "%Y/%m/%dT%H:%M%#z",
+    "%Y-%m-%dT%H:%M%#z",
+    "%Y%m%dT%H:%M%#z",
+    "%Y/%m/%dT%H%M%#z",
+    "%Y-%m-%dT%H%M%#z",
+    "%Y%m%dT%H%M%#z",
+    "%Y/%m/%dT%H:%M:%S.%9f%#z",
+    "%Y-%m-%dT%H:%M:%S.%9f%#z",
+    "%Y%m%dT%H:%M:%S.%9f%#z",
+    "%Y/%m/%dT%H:%M:%S.%6f%#z",
+    "%Y-%m-%dT%H:%M:%S.%6f%#z",
+    "%Y%m%dT%H:%M:%S.%6f%#z",
+    "%Y/%m/%dT%H:%M:%S.%3f%#z",
+    "%Y-%m-%dT%H:%M:%S.%3f%#z",
+    "%Y%m%dT%H:%M:%S.%3f%#z",
+    "%Y/%m/%dT%H%M%S.%9f%#z",
+    "%Y-%m-%dT%H%M%S.%9f%#z",
+    "%Y%m%dT%H%M%S.%9f%#z",
+    "%Y/%m/%dT%H%M%S.%6f%#z",
+    "%Y-%m-%dT%H%M%S.%6f%#z",
+    "%Y%m%dT%H%M%S.%6f%#z",
+    "%Y/%m/%dT%H%M%S.%3f%#z",
+    "%Y-%m-%dT%H%M%S.%3f%#z",
+    "%Y%m%dT%H%M%S.%3f%#z",
+    "%Y/%m/%d %H:%M:%S%#z",
+    "%Y-%m-%d %H:%M:%S%#z",
+    "%Y%m%d %H:%M:%S%#z",
+    "%Y/%m/%d %H%M%S%#z",
+    "%Y-%m-%d %H%M%S%#z",
+    "%Y%m%d %H%M%S%#z",
+    "%Y/%m/%d %H:%M%#z",
+    "%Y-%m-%d %H:%M%#z",
+    "%Y%m%d %H:%M%#z",
+    "%Y/%m/%d %H%M%#z",
+    "%Y-%m-%d %H%M%#z",
+    "%Y%m%d %H%M%#z",
+    "%Y/%m/%d %H:%M:%S.%9f%#z",
+    "%Y-%m-%d %H:%M:%S.%9f%#z",
+    "%Y%m%d %H:%M:%S.%9f%#z",
+    "%Y/%m/%d %H:%M:%S.%6f%#z",
+    "%Y-%m-%d %H:%M:%S.%6f%#z",
+    "%Y%m%d %H:%M:%S.%6f%#z",
+    "%Y/%m/%d %H:%M:%S.%3f%#z",
+    "%Y-%m-%d %H:%M:%S.%3f%#z",
+    "%Y%m%d %H:%M:%S.%3f%#z",
+    "%Y/%m/%d %H%M%S.%9f%#z",
+    "%Y-%m-%d %H%M%S.%9f%#z",
+    "%Y%m%d %H%M%S.%9f%#z",
+    "%Y/%m/%d %H%M%S.%6f%#z",
+    "%Y-%m-%d %H%M%S.%6f%#z",
+    "%Y%m%d %H%M%S.%6f%#z",
+    "%Y/%m/%d %H%M%S.%3f%#z",
+    "%Y-%m-%d %H%M%S.%3f%#z",
+    "%Y%m%d %H%M%S.%3f%#z",
+    // other
+    "%+"
+    ];
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub enum Pattern {

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -82,6 +82,29 @@ def iso8601_format_datetime(request: pytest.FixtureRequest) -> list[str]:
     return cast(List[str], request.param)
 
 
+ISO8601_TZ_AWARE_FORMATS_DATETIME = []
+
+for T in ["T", " "]:
+    for hms in (
+        [
+            f"{T}%H:%M:%S",
+            f"{T}%H%M%S",
+            f"{T}%H:%M",
+            f"{T}%H%M",
+        ]
+        + [f"{T}%H:%M:%S.{fraction}" for fraction in ["%9f", "%6f", "%3f"]]
+        + [f"{T}%H%M%S.{fraction}" for fraction in ["%9f", "%6f", "%3f"]]
+    ):
+        for date_sep in ("/", "-", ""):
+            fmt = f"%Y{date_sep}%m{date_sep}%d{hms}%#z"
+            ISO8601_TZ_AWARE_FORMATS_DATETIME.append(fmt)
+
+
+@pytest.fixture(params=ISO8601_TZ_AWARE_FORMATS_DATETIME)
+def iso8601_tz_aware_format_datetime(request: pytest.FixtureRequest) -> list[str]:
+    return cast(List[str], request.param)
+
+
 ISO8601_FORMATS_DATE = []
 
 for date_sep in ("/", "-", ""):

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2672,6 +2672,37 @@ def test_infer_iso8601_datetime(iso8601_format_datetime: str) -> None:
     if "%3f" in iso8601_format_datetime:
         assert parsed.dt.nanosecond().item() == 123000000
 
+def test_infer_iso8601_tz_aware_datetime(iso8601_tz_aware_format_datetime: str) -> None:
+    # construct an example time string
+    time_string = (
+        iso8601_tz_aware_format_datetime.replace("%Y", "2134")
+        .replace("%m", "12")
+        .replace("%d", "13")
+        .replace("%H", "01")
+        .replace("%M", "12")
+        .replace("%S", "34")
+        .replace("%3f", "123")
+        .replace("%6f", "123456")
+        .replace("%9f", "123456789")
+        .replace("%#z", "+01:00")
+    )
+    parsed = pl.Series([time_string]).str.strptime(pl.Datetime("ns"))
+    assert parsed.dt.year().item() == 2134
+    assert parsed.dt.month().item() == 12
+    assert parsed.dt.day().item() == 13
+    if "%H" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.hour().item() == 1
+    if "%M" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.minute().item() == 12
+    if "%S" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.second().item() == 34
+    if "%9f" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.nanosecond().item() == 123456789
+    if "%6f" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.nanosecond().item() == 123456000
+    if "%3f" in iso8601_tz_aware_format_datetime:
+        assert parsed.dt.nanosecond().item() == 123000000
+    assert parsed.dtype == pl.Datetime('ns', '+01:00')
 
 def test_infer_iso8601_date(iso8601_format_date: str) -> None:
     # construct an example date string

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2672,6 +2672,7 @@ def test_infer_iso8601_datetime(iso8601_format_datetime: str) -> None:
     if "%3f" in iso8601_format_datetime:
         assert parsed.dt.nanosecond().item() == 123000000
 
+
 def test_infer_iso8601_tz_aware_datetime(iso8601_tz_aware_format_datetime: str) -> None:
     # construct an example time string
     time_string = (
@@ -2702,7 +2703,8 @@ def test_infer_iso8601_tz_aware_datetime(iso8601_tz_aware_format_datetime: str) 
         assert parsed.dt.nanosecond().item() == 123456000
     if "%3f" in iso8601_tz_aware_format_datetime:
         assert parsed.dt.nanosecond().item() == 123000000
-    assert parsed.dtype == pl.Datetime('ns', '+01:00')
+    assert parsed.dtype == pl.Datetime("ns", "+01:00")
+
 
 def test_infer_iso8601_date(iso8601_format_date: str) -> None:
     # construct an example date string


### PR DESCRIPTION
another follow-up to https://github.com/pola-rs/polars/pull/7405