### PR TITLE
feat(rust, python): clearer error message if strptime without a fmt specified fails

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -378,7 +378,13 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
     if options.strict {
         polars_ensure!(
             out.null_count() == ca.null_count(),
-            ComputeError: "strict conversion to dates failed, try setting strict=False",
+            ComputeError:
+            "strict conversion to date(time)s failed.\n\
+            \n\
+            You might want to try:\n\
+            - setting `strict=False`,\n\
+            - explicitly specifying a `fmt`,\n\
+            - setting `utf=True` (if you are parsing datetimes with multiple offsets)."
         );
     }
     Ok(out.into_series())


### PR DESCRIPTION
Demo:
```python
In [1]: pl.Series(['01-12-2000', '01-13-2000']).str.strptime(pl.Datetime)
---------------------------------------------------------------------------
ComputeError                              Traceback (most recent call last)
Cell In[1], line 1
----> 1 pl.Series(['01-12-2000', '01-13-2000']).str.strptime(pl.Datetime)

File ~/polars-dev/py-polars/polars/series/utils.py:102, in call_expr.<locals>.wrapper(self, *args, **kwargs)
    100     expr = getattr(expr, namespace)
    101 f = getattr(expr, func.__name__)
--> 102 return s.to_frame().select(f(*args, **kwargs)).to_series()

File ~/polars-dev/py-polars/polars/dataframe/frame.py:6804, in DataFrame.select(self, exprs, *more_exprs, **named_exprs)
   6696 def select(
   6697     self,
   6698     exprs: IntoExpr | Iterable[IntoExpr] | None = None,
   6699     *more_exprs: IntoExpr,
   6700     **named_exprs: IntoExpr,
   6701 ) -> Self:
   6702     """
   6703     Select columns from this DataFrame.
   6704 
   (...)
   6801 
   6802     """
   6803     return self._from_pydf(
-> 6804         self.lazy()
   6805         .select(exprs, *more_exprs, **named_exprs)
   6806         .collect(no_optimization=True)
   6807         ._df
   6808     )

File ~/polars-dev/py-polars/polars/lazyframe/frame.py:1598, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, no_optimization, slice_pushdown, common_subplan_elimination, streaming)
   1587     common_subplan_elimination = False
   1589 ldf = self._ldf.optimization_toggle(
   1590     type_coercion,
   1591     predicate_pushdown,
   (...)
   1596     streaming,
   1597 )
-> 1598 return wrap_df(ldf.collect())

ComputeError: strict conversion to date(time)s failed.

You might want to try:
- setting `strict=False`,
- explicitly specifying a `fmt`,
- setting `utf=True` (if you are parsing datetimes with multiple offsets).
```