### PR TITLE
chore: Update references from `master` to `main`

### DIFF
--- a/.github/workflows/docs-deploy-python.yml
+++ b/.github/workflows/docs-deploy-python.yml
@@ -3,7 +3,7 @@ name: Deploy Python documentation
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - py-polars/docs/**
       - py-polars/polars/**
@@ -38,14 +38,14 @@ jobs:
         run: make html
 
       - name: Deploy Python docs for latest development version
-        if: ${{ github.ref_name == 'master' }}
+        if: ${{ github.ref_name == 'main' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
           target-folder: py-polars/dev
 
       - name: Deploy Python docs for latest release version
-        if: ${{ github.ref_name != 'master' }}
+        if: ${{ github.ref_name != 'main' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/docs-deploy-rust.yml
+++ b/.github/workflows/docs-deploy-rust.yml
@@ -3,7 +3,7 @@ name: Deploy Rust documentation
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - polars/**
       - .github/workflows/docs-deploy-rust.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Update draft releases
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ If this all runs correctly, you're ready to start contributing to the Polars cod
 
 ### Working on your issue
 
-Create a new git branch from the `master` branch in your local repository, and start coding!
+Create a new git branch from the `main` branch in your local repository, and start coding!
 
 The Rust codebase is located in the `polars` directory, while the Python codebase is located in the `py-polars` directory.
 Both directories contain a `Makefile` with helpful commands. Most notably:
@@ -137,7 +137,7 @@ Please adhere to the following guidelines:
 - Use a descriptive title. This text will end up in the [changelog](https://github.com/pola-rs/polars/releases).
 - In the pull request description, [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to the issue you were working on.
 - Add any relevant information to the description that you think may help the maintainers review your code.
-- Make sure your branch is [rebased](https://docs.github.com/en/get-started/using-git/about-git-rebase) against the latest version of the `master` branch.
+- Make sure your branch is [rebased](https://docs.github.com/en/get-started/using-git/about-git-rebase) against the latest version of the `main` branch.
 - Make sure all GitHub Actions checks pass.
 
 After you have opened your pull request, a maintainer will review it and possibly leave some comments.
@@ -216,11 +216,11 @@ Start by bumping the version number in the source code:
 3. Bump the version number.
 
 - _Rust:_ Update the version number in all `Cargo.toml` files in the `polars` directory and subdirectories. You'll probably want to use some search/replace strategy, as there are quite a few crates that need to be updated.
-- _Python:_ Update the version number in [`py-polars/Cargo.toml`](https://github.com/pola-rs/polars/blob/master/py-polars/Cargo.toml#L3) to match the version of the draft release.
+- _Python:_ Update the version number in [`py-polars/Cargo.toml`](https://github.com/pola-rs/polars/blob/main/py-polars/Cargo.toml#L3) to match the version of the draft release.
 
 4. From the `py-polars` directory, run `make build` to generate a new `Cargo.lock` file.
 5. Create a new commit with all files added. The name of the commit should follow the format `release(<language>): <Language> Polars <version-number>`. For example: `release(python): Python Polars 0.16.1`
-6. Push your branch and open a new pull request to the `master` branch of the main Polars repository.
+6. Push your branch and open a new pull request to the `main` branch of the main Polars repository.
 7. Wait for the GitHub Actions checks to pass, then squash and merge your pull request.
 
 Directly after merging your pull request, release the new version:
@@ -233,7 +233,7 @@ Directly after merging your pull request, release the new version:
 
 It may happen that one or multiple release jobs fail. If so, you should first try to simply re-run the failed jobs from the GitHub Actions UI.
 
-If that doesn't help, you will have to figure out what's wrong and commit a fix. Once your fix has made it to the `master` branch, re-trigger the release workflow by updating the git tag associated with the release. Note the commit hash of your fix, and run the following command:
+If that doesn't help, you will have to figure out what's wrong and commit a fix. Once your fix has made it to the `main` branch, re-trigger the release workflow by updating the git tag associated with the release. Note the commit hash of your fix, and run the following command:
 
 ```shell
 git tag -f <version-number> <commit-hash> && git push -f origin <version-number>

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Releases happen quite often (weekly / every few days) at the moment, so updating
 ### Rust
 
 You can take latest release from `crates.io`, or if you want to use the latest features / performance improvements
-point to the `master` branch of this repo.
+point to the `main` branch of this repo.
 
 ```toml
 polars = { git = "https://github.com/pola-rs/polars", rev = "<optional git tag>" }

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-BASE ?= master
+BASE ?= main
 
 .PHONY: fmt check check-features clippy clippy-default test test-doc integration-tests
 

--- a/polars/polars-core/src/chunked_array/ops/zip.rs
+++ b/polars/polars-core/src/chunked_array/ops/zip.rs
@@ -13,7 +13,7 @@ fn ternary_apply<T>(predicate: bool, truthy: T, falsy: T) -> T {
 }
 
 fn prepare_mask(mask: &BooleanArray) -> BooleanArray {
-    // make sure that zip works same as master branch
+    // make sure that zip works same as main branch
     // that is that null are ignored from mask and that we take from the right array
 
     match mask.validity() {

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -195,7 +195,7 @@ def linkcode_resolve(domain, info):
     fn = os.path.relpath(fn, start=polars_root)
 
     return (
-        f"https://github.com/pola-rs/polars/blob/master/py-polars/polars/{fn}{linespec}"
+        f"https://github.com/pola-rs/polars/blob/main/py-polars/polars/{fn}{linespec}"
     )
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1246,7 +1246,7 @@ def test_read_csv_chunked() -> None:
 
 @pytest.mark.slow()
 def test_read_web_file() -> None:
-    url = "https://raw.githubusercontent.com/pola-rs/polars/master/examples/datasets/foods1.csv"
+    url = "https://raw.githubusercontent.com/pola-rs/polars/main/examples/datasets/foods1.csv"
     df = pl.read_csv(url)
     assert df.shape == (27, 4)
 


### PR DESCRIPTION
Closes #8049

First [rename](https://github.com/github/renaming/#rename-existing) the branch, then merge this.

I'll go ahead with this after `0.17.1` has been released.