### PR TITLE
test(python): Do not parallelize Windows tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -121,7 +121,7 @@ jobs:
           pip install target/wheels/polars-*.whl
 
       - name: Run tests
-        run: pytest -n auto --dist worksteal -m "not benchmark"
+        run: pytest -m "not benchmark"
 
       - name: Check import without optional dependencies
         run: |

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -179,6 +179,7 @@ markers = [
   "benchmark: Tests that should be run on a Polars release build.",
 ]
 filterwarnings = "error" # Fail on warnings
+xfail_strict = true
 
 [tool.coverage.run]
 source = ["polars"]

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gzip
 import io
-import sys
 import tempfile
 import textwrap
 import typing
@@ -1224,7 +1223,6 @@ def test_csv_statistics_offset() -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_csv_scan_categorical() -> None:
     N = 5_000
     df = pl.DataFrame({"x": ["A"] * N})

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -32,8 +32,19 @@ def test_from_to_buffer(df: pl.DataFrame, compression: IpcCompression) -> None:
     assert_frame_equal_local_categoricals(df, read_df)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
-@pytest.mark.parametrize("compression", COMPRESSIONS)
+@pytest.mark.parametrize(
+    "compression",
+    [
+        pytest.param(
+            "uncompressed",
+            marks=pytest.mark.xfail(
+                sys.platform == "win32", reason="Does not work on Windows"
+            ),
+        ),
+        "lz4",
+        "zstd",
+    ],
+)
 @pytest.mark.parametrize("path_type", [str, Path])
 @pytest.mark.write_disk()
 def test_from_to_file(
@@ -108,7 +119,6 @@ def test_ipc_schema(compression: IpcCompression) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 @pytest.mark.parametrize("path_type", [str, Path])
 def test_ipc_schema_from_file(

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -311,7 +310,6 @@ def test_parquet_statistics(monkeypatch: Any, capfd: Any) -> None:
     )
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 @pytest.mark.write_disk()
 def test_streaming_categorical() -> None:
     df = pl.DataFrame(
@@ -340,7 +338,6 @@ def test_streaming_categorical() -> None:
             assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 @pytest.mark.write_disk()
 def test_parquet_struct_categorical() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import sys
 import tempfile
 import typing
 from pathlib import Path
@@ -357,7 +356,6 @@ def test_parquet_nested_dictionaries_6217() -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_sink_parquet(io_files_path: Path) -> None:
     file = io_files_path / "small.parquet"
 
@@ -374,7 +372,6 @@ def test_sink_parquet(io_files_path: Path) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_sink_ipc(io_files_path: Path) -> None:
     file = io_files_path / "small.parquet"
 
@@ -391,7 +388,6 @@ def test_sink_ipc(io_files_path: Path) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_fetch_union() -> None:
     df1 = pl.DataFrame({"a": [0, 1, 2], "b": [1, 2, 3]})
     df2 = pl.DataFrame({"a": [3, 4, 5], "b": [4, 5, 6]})
@@ -416,7 +412,6 @@ def test_fetch_union() -> None:
 
 @pytest.mark.slow()
 @typing.no_type_check
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_struct_pyarrow_dataset_5796() -> None:
     num_rows = 2**17 + 1
 

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import tempfile
 import typing
 from datetime import date, datetime, time
@@ -23,7 +22,6 @@ def helper_dataset_test(file_path: Path, query) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
 def test_dataset(df: pl.DataFrame) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"


### PR DESCRIPTION
Test parallelization for Windows is unreliable in combination with temporary directories.

I removed the parallization in the Windows test workflow, and updated `xfail` markers.

This makes it more clear which functionality works on Windows, and which functionality doesn't.