### PR TITLE
feat(rust):  rename 'csv-file' to 'csv'

### DIFF
--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run cargo hack
         working-directory: polars
-        run: cargo hack check --each-feature --no-dev-deps --features private
+        run: cargo hack check --each-feature --no-dev-deps --features private --exclude-features csv-file
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -43,8 +43,7 @@ jobs:
 
       - name: Run cargo hack
         working-directory: polars
-        run: cargo hack check --each-feature --no-dev-deps --features private --exclude-features csv-file
-
+        run: cargo hack check --each-feature --no-dev-deps --features private 
   lint:
     runs-on: ubuntu-latest
     defaults:

--- a/examples/read_csv/Cargo.toml
+++ b/examples/read_csv/Cargo.toml
@@ -10,4 +10,4 @@ write_output = ["polars/ipc", "polars/parquet"]
 default = ["write_output"]
 
 [dependencies]
-polars = { path = "../../polars", features = ["lazy", "csv-file", "ipc"] }
+polars = { path = "../../polars", features = ["lazy", "csv", "ipc"] }

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -59,7 +59,6 @@ avro = ["polars-io", "polars-io/avro"]
 
 # support for arrows csv file parsing
 csv = ["polars-io", "polars-io/csv", "polars-lazy/csv"]
-csv-file = []
 
 # slower builds
 performant = [

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -21,7 +21,7 @@ random = ["polars-core/random", "polars-lazy/random"]
 default = [
   "docs",
   "zip_with",
-  "csv-file",
+  "csv",
   "temporal",
   "fmt",
   "dtype-slim",
@@ -58,7 +58,8 @@ ipc_streaming = ["polars-io", "polars-io/ipc_streaming", "polars-lazy/ipc"]
 avro = ["polars-io", "polars-io/avro"]
 
 # support for arrows csv file parsing
-csv-file = ["polars-io", "polars-io/csv-file", "polars-lazy/csv-file"]
+csv = ["polars-io", "polars-io/csv", "polars-lazy/csv"]
+csv-file = []
 
 # slower builds
 performant = [
@@ -158,7 +159,7 @@ test = [
   "rolling_window",
   "rank",
   "round_series",
-  "csv-file",
+  "csv",
   "dtype-categorical",
   "cum_agg",
   "fmt",
@@ -238,7 +239,7 @@ dtype-struct = [
 ]
 
 docs-selection = [
-  "csv-file",
+  "csv",
   "json",
   "parquet",
   "ipc",

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -73,7 +73,7 @@ pre-commit: fmt clippy clippy-default  ## Run autoformatting and linting
 
 
 check-features:
-	cargo hack check --each-feature --no-dev-deps --features private --exclude-features csv-file
+	cargo hack check --each-feature --no-dev-deps --features private 
 
 bench-save:
 	cargo bench --features=random --bench $(BENCH) -- --save-baseline $(SAVE)

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -73,7 +73,7 @@ pre-commit: fmt clippy clippy-default  ## Run autoformatting and linting
 
 
 check-features:
-	cargo hack check --each-feature --no-dev-deps --features private
+	cargo hack check --each-feature --no-dev-deps --features private --exclude-features csv-file
 
 bench-save:
 	cargo bench --features=random --bench $(BENCH) -- --save-baseline $(SAVE)

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -19,7 +19,7 @@ ipc_streaming = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrow avro parsing
 avro = ["arrow/io_avro", "arrow/io_avro_compression"]
 # ipc = []
-csv-file = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float", "simdutf8"]
+csv = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float", "simdutf8"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng"]
 dtype-categorical = ["polars-core/dtype-categorical"]

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod avro;
 #[cfg(feature = "cloud")]
 mod cloud;
-#[cfg(any(feature = "csv-file", feature = "json"))]
+#[cfg(any(feature = "csv", feature = "json"))]
 pub mod csv;
 #[cfg(feature = "parquet")]
 pub mod export;
@@ -20,7 +20,7 @@ pub mod ndjson_core;
 pub use crate::cloud::glob as async_glob;
 
 #[cfg(any(
-    feature = "csv-file",
+    feature = "csv",
     feature = "parquet",
     feature = "ipc",
     feature = "json"
@@ -34,7 +34,7 @@ pub mod predicates;
 #[cfg(not(feature = "private"))]
 pub(crate) mod predicates;
 pub mod prelude;
-#[cfg(all(test, feature = "csv-file"))]
+#[cfg(all(test, feature = "csv"))]
 mod tests;
 pub(crate) mod utils;
 

--- a/polars/polars-io/src/prelude.rs
+++ b/polars/polars-io/src/prelude.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use polars_core::prelude::*;
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 pub use crate::csv::*;
 #[cfg(any(feature = "ipc", feature = "ipc_streaming"))]
 pub use crate::ipc::*;

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -19,7 +19,7 @@ glob = "0.3"
 once_cell = "1"
 polars-arrow = { version = "0.28.0", path = "../polars-arrow" }
 polars-core = { version = "0.28.0", path = "../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
-polars-io = { version = "0.28.0", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
+polars-io = { version = "0.28.0", path = "../polars-io", features = ["lazy", "csv", "private"], default-features = false }
 polars-ops = { version = "0.28.0", path = "../polars-ops", default-features = false }
 polars-pipe = { version = "0.28.0", path = "./polars-pipe", optional = true }
 polars-plan = { version = "0.28.0", path = "./polars-plan" }
@@ -43,7 +43,7 @@ async = [
 ]
 ipc = ["polars-io/ipc", "polars-plan/ipc", "polars-pipe/ipc"]
 json = ["polars-io/json", "polars-plan/json"]
-csv-file = ["polars-io/csv-file", "polars-plan/csv-file", "polars-pipe/csv-file"]
+csv = ["polars-io/csv", "polars-plan/csv", "polars-pipe/csv"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time", "dtype-duration", "polars-plan/temporal"]
 # debugging purposes
 fmt = ["polars-core/fmt", "polars-plan/fmt"]
@@ -145,7 +145,7 @@ test = [
   "rolling_window",
   "rank",
   "round_series",
-  "csv-file",
+  "csv",
   "dtype-categorical",
   "cum_agg",
   "regex",

--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -25,7 +25,7 @@ smartstring = { version = "1" }
 
 [features]
 compile = []
-csv-file = ["polars-plan/csv-file", "polars-io/csv-file"]
+csv = ["polars-plan/csv", "polars-io/csv"]
 parquet = ["polars-plan/parquet", "polars-io/parquet"]
 ipc = ["polars-plan/ipc", "polars-io/ipc"]
 async = ["polars-plan/async", "polars-io/async"]

--- a/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sources/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 mod csv;
 mod frame;
 mod ipc_one_shot;
@@ -7,7 +7,7 @@ mod parquet;
 mod reproject;
 mod union;
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 pub(crate) use csv::CsvSource;
 pub(crate) use frame::*;
 pub(crate) use ipc_one_shot::*;

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -62,7 +62,7 @@ where
             }
             Ok(Box::new(sources::DataFrameSource::from_df(df)) as Box<dyn Source>)
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan {
             path,
             file_info,
@@ -467,7 +467,7 @@ where
                 true,
                 verbose,
             )?,
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             lp @ CsvScan { .. } => get_source(
                 lp.clone(),
                 &mut operator_objects,

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3.25", optional = true }
 once_cell.workspace = true
 polars-arrow = { version = "0.28.0", path = "../../polars-arrow" }
 polars-core = { version = "0.28.0", path = "../../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
-polars-io = { version = "0.28.0", path = "../../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }
+polars-io = { version = "0.28.0", path = "../../polars-io", features = ["lazy", "csv", "private"], default-features = false }
 polars-ops = { version = "0.28.0", path = "../../polars-ops", default-features = false }
 polars-time = { version = "0.28.0", path = "../../polars-time", optional = true }
 polars-utils = { version = "0.28.0", path = "../../polars-utils" }
@@ -40,7 +40,7 @@ parquet = ["polars-core/parquet", "polars-io/parquet"]
 async = []
 ipc = ["polars-io/ipc"]
 json = ["polars-io/json"]
-csv-file = ["polars-io/csv-file"]
+csv = ["polars-io/csv"]
 temporal = ["polars-core/temporal", "dtype-date", "dtype-datetime", "dtype-time"]
 # debugging purposes
 fmt = ["polars-core/fmt"]

--- a/polars/polars-lazy/polars-plan/src/dot.rs
+++ b/polars/polars-lazy/polars-plan/src/dot.rs
@@ -340,7 +340,7 @@ impl LogicalPlan {
                     self.write_dot(acc_str, prev_node, current_node, id_map)
                 }
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 path,
                 options,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/alp.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-#[cfg(any(feature = "ipc", feature = "csv-file", feature = "parquet"))]
+#[cfg(any(feature = "ipc", feature = "csv", feature = "parquet"))]
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ use polars_utils::arena::{Arena, Node};
 
 use crate::logical_plan::functions::FunctionNode;
 use crate::logical_plan::schema::{det_join_schema, FileInfo};
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 use crate::logical_plan::CsvParserOptions;
 #[cfg(feature = "ipc")]
 use crate::logical_plan::IpcScanOptionsInner;
@@ -43,7 +43,7 @@ pub enum ALogicalPlan {
         input: Node,
         predicate: Node,
     },
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     CsvScan {
         path: PathBuf,
         file_info: FileInfo,
@@ -163,7 +163,7 @@ impl ALogicalPlan {
         match self {
             #[cfg(feature = "python")]
             PythonScan { options, .. } => &options.schema,
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { file_info, .. } => &file_info.schema,
             #[cfg(feature = "parquet")]
             ParquetScan { file_info, .. } => &file_info.schema,
@@ -182,7 +182,7 @@ impl ALogicalPlan {
             PythonScan { .. } => "python_scan",
             Slice { .. } => "slice",
             Selection { .. } => "selection",
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { .. } => "csv_scan",
             #[cfg(feature = "ipc")]
             IpcScan { .. } => "ipc_scan",
@@ -236,7 +236,7 @@ impl ALogicalPlan {
                 ..
             } => output_schema.as_ref().unwrap_or(&file_info.schema),
             Selection { input, .. } => return arena.get(*input).schema(arena),
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 file_info,
                 output_schema,
@@ -402,7 +402,7 @@ impl ALogicalPlan {
                     cloud_options: cloud_options.clone(),
                 }
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 path,
                 file_info,
@@ -511,7 +511,7 @@ impl ALogicalPlan {
                     container.push(*node)
                 }
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { predicate, .. } => {
                 if let Some(node) = predicate {
                     container.push(*node)
@@ -587,7 +587,7 @@ impl ALogicalPlan {
             ParquetScan { .. } => return,
             #[cfg(feature = "ipc")]
             IpcScan { .. } => return,
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { .. } => return,
             DataFrameScan { .. } => return,
             AnonymousScan { .. } => return,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/builder.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 use std::io::{Read, Seek};
 
 #[cfg(feature = "parquet")]
@@ -12,9 +12,9 @@ use polars_io::ipc::IpcReader;
 use polars_io::parquet::ParquetAsyncReader;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::ParquetReader;
-#[cfg(any(feature = "parquet", feature = "parquet_async", feature = "csv-file"))]
+#[cfg(any(feature = "parquet", feature = "parquet_async", feature = "csv"))]
 use polars_io::RowCount;
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 use polars_io::{
     csv::utils::{get_reader_bytes, infer_file_schema, is_compressed},
     csv::CsvEncoding,
@@ -200,7 +200,7 @@ impl LogicalPlanBuilder {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     pub fn scan_csv<P: Into<std::path::PathBuf>>(
         path: P,
         delimiter: u8,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/conversion.rs
@@ -202,7 +202,7 @@ pub fn to_alp(
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::Slice { input, offset, len }
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         LogicalPlan::CsvScan {
             path,
             file_info,
@@ -684,7 +684,7 @@ impl ALogicalPlan {
                     predicate: p,
                 }
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             ALogicalPlan::CsvScan {
                 path,
                 file_info,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -143,7 +143,7 @@ impl LogicalPlan {
                 write!(f, "{:indent$}FILTER {predicate:?} FROM", "")?;
                 input._format(f, indent)
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 path,
                 options,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/mod.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-#[cfg(any(feature = "ipc", feature = "csv-file", feature = "parquet"))]
+#[cfg(any(feature = "ipc", feature = "csv", feature = "parquet"))]
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -45,12 +45,7 @@ pub use schema::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(
-    feature = "ipc",
-    feature = "parquet",
-    feature = "csv-file",
-    feature = "cse"
-))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv", feature = "cse"))]
 pub use crate::logical_plan::optimizer::file_caching::{
     collect_fingerprints, find_column_union_and_fingerprints, FileCacher, FileFingerPrint,
 };
@@ -159,7 +154,7 @@ pub enum LogicalPlan {
         count: usize,
     },
     /// Scan a CSV file
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     CsvScan {
         path: PathBuf,
         file_info: FileInfo,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/cse.rs
@@ -154,7 +154,7 @@ fn lp_node_equal(a: &ALogicalPlan, b: &ALogicalPlan, expr_arena: &Arena<AExpr>) 
                 && options_l == options_r
                 && predicate_equal(*predicate_l, *predicate_r, expr_arena)
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         (
             CsvScan {
                 path: path_left,
@@ -439,7 +439,7 @@ pub(crate) fn decrement_file_counters_by_cache_hits(
                 options.file_counter -= acc_count as FileCount
             }
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan { options, .. } => {
             if acc_count >= options.file_counter {
                 options.file_counter = 1;

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
@@ -42,7 +42,7 @@ impl OptimizationRule for DelayRechunk {
                             input_node = Some(node);
                             break;
                         }
-                        #[cfg(feature = "csv-file")]
+                        #[cfg(feature = "csv")]
                         CsvScan { .. } => {
                             input_node = Some(node);
                             break;
@@ -62,7 +62,7 @@ impl OptimizationRule for DelayRechunk {
 
                 if let Some(node) = input_node {
                     match lp_arena.get_mut(node) {
-                        #[cfg(feature = "csv-file")]
+                        #[cfg(feature = "csv")]
                         CsvScan { options, .. } => {
                             options.rechunk = false;
                         }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -58,7 +58,7 @@ pub fn collect_fingerprints(
 ) {
     use ALogicalPlan::*;
     match lp_arena.get(root) {
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan {
             path,
             options,
@@ -127,7 +127,7 @@ pub fn find_column_union_and_fingerprints(
 ) {
     use ALogicalPlan::*;
     match lp_arena.get(root) {
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan {
             path,
             options,
@@ -318,7 +318,7 @@ impl FileCacher {
                     );
                     lp_arena.replace(root, lp);
                 }
-                #[cfg(feature = "csv-file")]
+                #[cfg(feature = "csv")]
                 ALogicalPlan::CsvScan {
                     path,
                     file_info,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -9,12 +9,7 @@ mod cse;
 mod delay_rechunk;
 mod drop_nulls;
 mod fast_projection;
-#[cfg(any(
-    feature = "ipc",
-    feature = "parquet",
-    feature = "csv-file",
-    feature = "cse"
-))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv", feature = "cse"))]
 pub(crate) mod file_caching;
 mod flatten_union;
 mod predicate_pushdown;
@@ -28,7 +23,7 @@ mod type_coercion;
 use delay_rechunk::DelayRechunk;
 use drop_nulls::ReplaceDropNulls;
 use fast_projection::FastProjectionAndCollapse;
-#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
 use file_caching::{find_column_union_and_fingerprints, FileCacher};
 pub use predicate_pushdown::PredicatePushDown;
 pub use projection_pushdown::ProjectionPushDown;
@@ -143,12 +138,7 @@ pub fn optimize(
     // make sure that we do that once slice pushdown
     // and predicate pushdown are done. At that moment
     // the file fingerprints are finished.
-    #[cfg(any(
-        feature = "cse",
-        feature = "parquet",
-        feature = "ipc",
-        feature = "csv-file"
-    ))]
+    #[cfg(any(feature = "cse", feature = "parquet", feature = "ipc", feature = "csv"))]
     if agg_scan_projection || cse_changed {
         // we do this so that expressions are simplified created by the pushdown optimizations
         // we must clean up the predicates, because the agg_scan_projection

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -283,7 +283,7 @@ impl PredicatePushDown {
                 };
                 Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 path,
                 file_info,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -494,7 +494,7 @@ impl ProjectionPushDown {
                 };
                 Ok(PythonScan { options, predicate })
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan {
                 path,
                 file_info,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -183,7 +183,7 @@ impl SlicePushDown {
 
             }
 
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             (CsvScan {
                 path,
                 file_info,

--- a/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use polars_core::prelude::*;
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 use polars_io::csv::{CsvEncoding, NullValues};
 #[cfg(feature = "ipc")]
 use polars_io::ipc::IpcCompression;
@@ -17,7 +17,7 @@ use crate::prelude::Expr;
 
 pub type FileCount = u32;
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsvParserOptions {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/schema.rs
@@ -23,7 +23,7 @@ impl LogicalPlan {
             DataFrameScan { schema, .. } => Ok(Cow::Borrowed(schema)),
             AnonymousScan { file_info, .. } => Ok(Cow::Borrowed(&file_info.schema)),
             Selection { input, .. } => input.schema(),
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { file_info, .. } => Ok(Cow::Borrowed(&file_info.schema)),
             Projection { schema, .. } => Ok(Cow::Borrowed(schema)),
             LocalProjection { schema, .. } => Ok(Cow::Borrowed(schema)),
@@ -189,7 +189,7 @@ pub fn set_estimated_row_counts(
             let len = df.height();
             (Some(len), len, _filter_count)
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan { file_info, .. } => {
             let (known_size, estimated_size) = file_info.row_estimation;
             (known_size, estimated_size, _filter_count)

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -71,7 +71,7 @@ impl PushNode for [Option<Node>; 1] {
 
 pub(crate) fn is_scan(plan: &ALogicalPlan) -> bool {
     match plan {
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         ALogicalPlan::CsvScan { .. } => true,
         ALogicalPlan::DataFrameScan { .. } => true,
         #[cfg(feature = "parquet")]

--- a/polars/polars-lazy/src/frame/csv.rs
+++ b/polars/polars-lazy/src/frame/csv.rs
@@ -9,7 +9,7 @@ use crate::frame::LazyFileListReader;
 use crate::prelude::*;
 
 #[derive(Clone)]
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 pub struct LazyCsvReader<'a> {
     path: PathBuf,
     delimiter: u8,
@@ -34,7 +34,7 @@ pub struct LazyCsvReader<'a> {
     try_parse_dates: bool,
 }
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 impl<'a> LazyCsvReader<'a> {
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -1,5 +1,5 @@
 //! Lazy variant of a [DataFrame](polars_core::frame::DataFrame).
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 mod csv;
 #[cfg(feature = "ipc")]
 mod ipc;
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 pub use anonymous_scan::*;
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 pub use csv::*;
 pub use file_list_reader::*;
 #[cfg(feature = "ipc")]
@@ -37,7 +37,7 @@ use polars_core::prelude::*;
 use polars_io::RowCount;
 pub use polars_plan::frame::{AllowedOptimizations, OptState};
 use polars_plan::global::FETCH_ROWS;
-#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
 use polars_plan::logical_plan::collect_fingerprints;
 use polars_plan::logical_plan::optimize;
 use polars_plan::utils::expr_to_leaf_column_names;
@@ -493,13 +493,13 @@ impl LazyFrame {
             self.optimize_with_scratch(&mut lp_arena, &mut expr_arena, &mut scratch, false)?;
 
         let finger_prints = if file_caching {
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             {
                 let mut fps = Vec::with_capacity(8);
                 collect_fingerprints(lp_top, &mut fps, &lp_arena, &expr_arena);
                 Some(fps)
             }
-            #[cfg(not(any(feature = "ipc", feature = "parquet", feature = "csv-file")))]
+            #[cfg(not(any(feature = "ipc", feature = "parquet", feature = "csv")))]
             {
                 None
             }
@@ -540,7 +540,7 @@ impl LazyFrame {
         let out = physical_plan.execute(&mut state);
         #[cfg(debug_assertions)]
         {
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             state.file_cache.assert_empty();
         }
         out
@@ -1138,7 +1138,7 @@ impl LazyFrame {
     pub fn with_row_count(mut self, name: &str, offset: Option<IdxSize>) -> LazyFrame {
         let add_row_count_in_map = match &mut self.logical_plan {
             // Do the row count at scan
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             LogicalPlan::CsvScan { options, .. } => {
                 options.row_count = Some(RowCount {
                     name: name.to_string(),

--- a/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 mod csv;
 #[cfg(feature = "ipc")]
 mod ipc;
@@ -9,7 +9,7 @@ mod parquet;
 
 use std::mem;
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 pub(crate) use csv::CsvExec;
 #[cfg(feature = "ipc")]
 pub(crate) use ipc::IpcExec;
@@ -19,12 +19,7 @@ pub(crate) use parquet::ParquetExec;
 use polars_io::predicates::PhysicalIoExpr;
 use polars_io::prelude::*;
 use polars_plan::global::_set_n_rows_for_scan;
-#[cfg(any(
-    feature = "parquet",
-    feature = "csv-file",
-    feature = "ipc",
-    feature = "cse"
-))]
+#[cfg(any(feature = "parquet", feature = "csv", feature = "ipc", feature = "cse"))]
 use polars_plan::logical_plan::FileFingerPrint;
 
 use super::*;

--- a/polars/polars-lazy/src/physical_plan/file_cache.rs
+++ b/polars/polars-lazy/src/physical_plan/file_cache.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use polars_core::prelude::*;
-#[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
+#[cfg(any(feature = "parquet", feature = "csv", feature = "ipc"))]
 use polars_plan::logical_plan::FileFingerPrint;
 
 use crate::prelude::*;

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -2,7 +2,7 @@ pub mod executors;
 #[cfg(any(feature = "list_eval", feature = "pivot"))]
 pub(crate) mod exotic;
 pub mod expressions;
-#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
 mod file_cache;
 mod node_timer;
 pub mod planner;

--- a/polars/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/polars/polars-lazy/src/physical_plan/planner/lp.rs
@@ -168,7 +168,7 @@ pub fn create_physical_plan(
             let predicate = create_physical_expr(predicate, Context::Default, expr_arena, None)?;
             Ok(Box::new(executors::FilterExec::new(predicate, input)))
         }
-        #[cfg(feature = "csv-file")]
+        #[cfg(feature = "csv")]
         CsvScan {
             path,
             file_info,

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -8,10 +8,10 @@ use polars_core::config::verbose;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::frame::hash_join::JoinOptIds;
 use polars_core::prelude::*;
-#[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
+#[cfg(any(feature = "parquet", feature = "csv", feature = "ipc"))]
 use polars_plan::logical_plan::FileFingerPrint;
 
-#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+#[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
 use super::file_cache::FileCache;
 use crate::physical_plan::node_timer::NodeTimer;
 
@@ -66,7 +66,7 @@ pub struct ExecutionState {
     // cached by a `.cache` call and kept in memory for the duration of the plan.
     df_cache: Arc<Mutex<PlHashMap<usize, Arc<OnceCell<DataFrame>>>>>,
     // cache file reads until all branches got there file, then we delete it
-    #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+    #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
     pub(crate) file_cache: FileCache,
     pub(super) schema_cache: RwLock<Option<SchemaRef>>,
     /// Used by Window Expression to prevent redundant grouping
@@ -111,7 +111,7 @@ impl ExecutionState {
     pub(super) fn split(&self) -> Self {
         Self {
             df_cache: self.df_cache.clone(),
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             file_cache: self.file_cache.clone(),
             schema_cache: Default::default(),
             group_tuples: Default::default(),
@@ -127,7 +127,7 @@ impl ExecutionState {
     pub(super) fn clone(&self) -> Self {
         Self {
             df_cache: self.df_cache.clone(),
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             file_cache: self.file_cache.clone(),
             schema_cache: self.schema_cache.read().unwrap().clone().into(),
             group_tuples: self.group_tuples.clone(),
@@ -139,16 +139,16 @@ impl ExecutionState {
         }
     }
 
-    #[cfg(not(any(feature = "parquet", feature = "csv-file", feature = "ipc")))]
+    #[cfg(not(any(feature = "parquet", feature = "csv", feature = "ipc")))]
     pub(crate) fn with_finger_prints(_finger_prints: Option<usize>) -> Self {
         Self::new()
     }
-    #[cfg(any(feature = "parquet", feature = "csv-file", feature = "ipc"))]
+    #[cfg(any(feature = "parquet", feature = "csv", feature = "ipc"))]
     pub(crate) fn with_finger_prints(finger_prints: Option<Vec<FileFingerPrint>>) -> Self {
         Self {
             df_cache: Arc::new(Mutex::new(PlHashMap::default())),
             schema_cache: Default::default(),
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             file_cache: FileCache::new(finger_prints),
             group_tuples: Arc::new(Mutex::new(PlHashMap::default())),
             join_tuples: Arc::new(Mutex::new(PlHashMap::default())),
@@ -167,7 +167,7 @@ impl ExecutionState {
         Self {
             df_cache: Default::default(),
             schema_cache: Default::default(),
-            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv-file"))]
+            #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
             file_cache: FileCache::new(None),
             group_tuples: Default::default(),
             join_tuples: Default::default(),

--- a/polars/polars-lazy/src/physical_plan/streaming/convert.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/convert.rs
@@ -240,7 +240,7 @@ pub(crate) fn insert_streaming_nodes(
                     )
                 }
             }
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { .. } => {
                 if state.streamable {
                     state.sources.push(root);
@@ -304,7 +304,7 @@ pub(crate) fn insert_streaming_nodes(
                 stack.push((input_left, state_left, current_idx));
             }
             // add globbing patterns
-            #[cfg(all(feature = "csv-file", feature = "parquet"))]
+            #[cfg(all(feature = "csv", feature = "parquet"))]
             Union { inputs, .. } => {
                 if state.streamable
                     && inputs.iter().all(|node| match lp_arena.get(*node) {

--- a/polars/polars-lazy/src/tests/io.rs
+++ b/polars/polars-lazy/src/tests/io.rs
@@ -286,7 +286,7 @@ fn test_union_and_agg_projections() -> PolarsResult<()> {
 }
 
 #[test]
-#[cfg(all(feature = "ipc", feature = "csv-file"))]
+#[cfg(all(feature = "ipc", feature = "csv"))]
 fn test_slice_filter() -> PolarsResult<()> {
     init_files();
     let _guard = SINGLE_LOCK.lock().unwrap();

--- a/polars/polars-lazy/src/tests/mod.rs
+++ b/polars/polars-lazy/src/tests/mod.rs
@@ -53,7 +53,7 @@ static FOODS_CSV: &str = "../../examples/datasets/foods1.csv";
 static FOODS_IPC: &str = "../../examples/datasets/foods1.ipc";
 static FOODS_PARQUET: &str = "../../examples/datasets/foods1.parquet";
 
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 fn scan_foods_csv() -> LazyFrame {
     LazyCsvReader::new(FOODS_CSV).finish().unwrap()
 }

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -12,7 +12,7 @@ pub(crate) fn agg_source_paths(
     lp_arena.iter(root_lp).for_each(|(_, lp)| {
         use ALogicalPlan::*;
         match lp {
-            #[cfg(feature = "csv-file")]
+            #[cfg(feature = "csv")]
             CsvScan { path, .. } => {
                 paths.insert(path.clone());
             }

--- a/polars/polars-sql/Cargo.toml
+++ b/polars/polars-sql/Cargo.toml
@@ -10,7 +10,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 [features]
 cli = ["csv", "polars-lazy/fmt", "atty", "reedline", "jemallocator"]
 highlight = ["syntect", "nu-ansi-term"]
-csv = ["polars-lazy/csv-file"]
+csv = ["polars-lazy/csv"]
 default = []
 ipc = ["polars-lazy/ipc"]
 parquet = ["polars-lazy/parquet"]

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -394,6 +394,3 @@ pub use polars_io as io;
 pub use polars_lazy as lazy;
 #[cfg(feature = "temporal")]
 pub use polars_time as time;
-
-#[cfg(feature = "csv-file")]
-compile_error!("feature 'csv-file' has been removed, use 'csv' instead");

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -195,7 +195,7 @@
 //!     - `parquet` - Read Apache Parquet format
 //!     - `json` - JSON serialization
 //!     - `ipc` - Arrow's IPC format serialization
-//!     - `decompress` - Automatically infer compression of csv-files and decompress them.
+//!     - `decompress` - Automatically infer compression of csvs and decompress them.
 //!                      Supported compressions:
 //!                         * zip
 //!                         * gzip
@@ -394,3 +394,6 @@ pub use polars_io as io;
 pub use polars_lazy as lazy;
 #[cfg(feature = "temporal")]
 pub use polars_time as time;
+
+#[cfg(feature = "csv-file")]
+compile_error!("feature 'csv-file' has been removed, use 'csv' instead");

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -51,7 +51,7 @@ meta = ["polars/meta"]
 search_sorted = ["polars/search_sorted"]
 decompress = ["polars/decompress"]
 lazy_regex = ["polars/lazy_regex"]
-csv-file = ["polars/csv-file"]
+csv = ["polars/csv"]
 object = ["polars/object"]
 extract_jsonpath = ["polars/extract_jsonpath"]
 pivot = ["polars/pivot"]
@@ -84,7 +84,7 @@ all = [
   "meta",
   "decompress",
   "lazy_regex",
-  "csv-file",
+  "csv",
   "extract_jsonpath",
   "timezones",
   "object",

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -136,7 +136,7 @@ impl PyDataFrame {
 
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     #[pyo3(signature = (
         py_f, infer_schema_length, chunk_size, has_header, ignore_errors, n_rows,
         skip_rows, projection, separator, rechunk, columns, encoding, n_threads, path,

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -4,7 +4,7 @@ use std::io::BufWriter;
 use std::path::PathBuf;
 
 use polars::io::RowCount;
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 use polars::lazy::frame::LazyCsvReader;
 #[cfg(feature = "json")]
 use polars::lazy::frame::LazyJsonLineReader;
@@ -193,7 +193,7 @@ impl PyLazyFrame {
 
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     #[pyo3(signature = (path, separator, has_header, ignore_errors, skip_rows, n_rows, cache, overwrite_dtype,
         low_memory, comment_char, quote_char, null_values, missing_utf8_is_empty_string,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -15,7 +15,7 @@ mod build {
 
 pub mod apply;
 pub mod arrow_interop;
-#[cfg(feature = "csv-file")]
+#[cfg(feature = "csv")]
 mod batched_csv;
 pub mod conversion;
 pub mod dataframe;
@@ -664,7 +664,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyLazyFrame>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<dsl::PyExpr>().unwrap();
-    #[cfg(feature = "csv-file")]
+    #[cfg(feature = "csv")]
     m.add_class::<batched_csv::PyBatchedCsv>().unwrap();
     #[cfg(feature = "sql")]
     m.add_class::<sql::PySQLContext>().unwrap();


### PR DESCRIPTION
renames csv-file to csv. 

Will throw a `compile_error` if you try to use the `csv-file` feature. 


closes #8100