### PR TITLE
feat(rust, python): add `log1p` to list of mathematical functions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -45,14 +45,3 @@ pub(super) fn interpolate(s: &Series, method: InterpolationMethod) -> PolarsResu
 pub(super) fn dot_impl(s: &[Series]) -> PolarsResult<Series> {
     Ok((&s[0] * &s[1]).sum_as_series())
 }
-
-#[cfg(feature = "log")]
-pub(super) fn entropy(s: &Series, base: f64, normalize: bool) -> PolarsResult<Series> {
-    let out = s.entropy(base, normalize);
-    if matches!(s.dtype(), DataType::Float32) {
-        let out = out.map(|v| v as f32);
-        Ok(Series::new(s.name(), [out]))
-    } else {
-        Ok(Series::new(s.name(), [out]))
-    }
-}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/log.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/log.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+pub(super) fn entropy(s: &Series, base: f64, normalize: bool) -> PolarsResult<Series> {
+    let out = s.entropy(base, normalize);
+    if matches!(s.dtype(), DataType::Float32) {
+        let out = out.map(|v| v as f32);
+        Ok(Series::new(s.name(), [out]))
+    } else {
+        Ok(Series::new(s.name(), [out]))
+    }
+}
+
+pub(super) fn log1p(s: &Series) -> PolarsResult<Series> {
+    Ok(s.log1p())
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -10,6 +10,8 @@ mod fill_null;
 #[cfg(feature = "is_in")]
 mod is_in;
 mod list;
+#[cfg(feature = "log")]
+mod log;
 mod nan;
 mod pow;
 #[cfg(all(feature = "rolling_window", feature = "moment"))]
@@ -123,6 +125,8 @@ pub enum FunctionExpr {
         base: f64,
         normalize: bool,
     },
+    #[cfg(feature = "log")]
+    Log1p,
 }
 
 impl Display for FunctionExpr {
@@ -191,6 +195,8 @@ impl Display for FunctionExpr {
             Dot => "dot",
             #[cfg(feature = "log")]
             Entropy { .. } => "entropy",
+            #[cfg(feature = "log")]
+            Log1p => "log1p",
         };
         write!(f, "{s}")
     }
@@ -381,7 +387,9 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 map_as_slice!(dispatch::dot_impl)
             }
             #[cfg(feature = "log")]
-            Entropy { base, normalize } => map!(dispatch::entropy, base, normalize),
+            Entropy { base, normalize } => map!(log::entropy, base, normalize),
+            #[cfg(feature = "log")]
+            Log1p => map!(log::log1p),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -292,6 +292,8 @@ impl FunctionExpr {
             }),
             #[cfg(feature = "log")]
             Entropy { .. } => float_dtype(),
+            #[cfg(feature = "log")]
+            Log1p => float_dtype(),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1995,6 +1995,22 @@ impl Expr {
     }
 
     #[cfg(feature = "log")]
+    /// Compute the natural logarithm of all elements plus one in the input array
+    pub fn log1p(self) -> Self {
+        self.map(
+            move |s| Ok(Some(s.log1p())),
+            GetOutput::map_dtype(|dt| {
+                if matches!(dt, DataType::Float32) {
+                    DataType::Float32
+                } else {
+                    DataType::Float64
+                }
+            }),
+        )
+        .with_fmt("log1p")
+    }
+
+    #[cfg(feature = "log")]
     /// Calculate the exponential of all elements in the input array
     pub fn exp(self) -> Self {
         self.map(

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1997,7 +1997,7 @@ impl Expr {
     #[cfg(feature = "log")]
     /// Compute the natural logarithm of all elements plus one in the input array
     pub fn log1p(self) -> Self {
-        self.apply_private(FunctionExpr::Log1p)
+        self.map_private(FunctionExpr::Log1p)
     }
 
     #[cfg(feature = "log")]

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1997,17 +1997,7 @@ impl Expr {
     #[cfg(feature = "log")]
     /// Compute the natural logarithm of all elements plus one in the input array
     pub fn log1p(self) -> Self {
-        self.map(
-            move |s| Ok(Some(s.log1p())),
-            GetOutput::map_dtype(|dt| {
-                if matches!(dt, DataType::Float32) {
-                    DataType::Float32
-                } else {
-                    DataType::Float64
-                }
-            }),
-        )
-        .with_fmt("log1p")
+        self.apply_private(FunctionExpr::Log1p)
     }
 
     #[cfg(feature = "log")]

--- a/polars/polars-ops/src/series/ops/log.rs
+++ b/polars/polars-ops/src/series/ops/log.rs
@@ -6,6 +6,10 @@ fn log<T: PolarsNumericType>(ca: &ChunkedArray<T>, base: f64) -> Float64Chunked 
     ca.cast_and_apply_in_place(|v: f64| v.log(base))
 }
 
+fn log1p<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Float64Chunked {
+    ca.cast_and_apply_in_place(|v: f64| v.ln_1p())
+}
+
 fn exp<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Float64Chunked {
     ca.cast_and_apply_in_place(|v: f64| v.exp())
 }
@@ -25,6 +29,23 @@ pub trait LogSeries: SeriesSealed {
             Float32 => s.f32().unwrap().apply(|v| v.log(base as f32)).into_series(),
             Float64 => s.f64().unwrap().apply(|v| v.log(base)).into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log(base),
+        }
+    }
+
+    /// Compute the natural logarithm of all elements plus one in the input array
+    fn log1p(&self) -> Series {
+        let s = self.as_series().to_physical_repr();
+        let s = s.as_ref();
+
+        use DataType::*;
+        match s.dtype() {
+            Int32 => log1p(s.i32().unwrap()).into_series(),
+            Int64 => log1p(s.i64().unwrap()).into_series(),
+            UInt32 => log1p(s.u32().unwrap()).into_series(),
+            UInt64 => log1p(s.u64().unwrap()).into_series(),
+            Float32 => s.f32().unwrap().apply(|v| v.ln_1p()).into_series(),
+            Float64 => s.f64().unwrap().apply(|v| v.ln_1p()).into_series(),
+            _ => s.cast(&DataType::Float64).unwrap().log1p(),
         }
     }
 

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -73,6 +73,11 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT LOG(column_1, 10) from df;
     /// ```
     Log,
+    /// SQL 'log1p' function
+    /// ```sql
+    /// SELECT LOG1P(column_1) from df;
+    /// ```
+    Log1p,
     /// SQL 'pow' function
     /// ```sql
     /// SELECT POW(column_1, 2) from df;
@@ -247,6 +252,7 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             "log2" => Self::Log2,
             "log10" => Self::Log10,
             "log" => Self::Log,
+            "log1p" => Self::Log1p,
             "pow" => Self::Pow,
             // ----
             // String functions
@@ -308,6 +314,7 @@ impl SqlFunctionVisitor<'_> {
             Log2 => self.visit_unary(|e| e.log(2.0)),
             Log10 => self.visit_unary(|e| e.log(10.0)),
             Log => self.visit_binary(Expr::log),
+            Log1p => self.visit_unary(Expr::log1p),
             Pow => self.visit_binary::<Expr>(Expr::pow),
             // ----
             // String functions

--- a/polars/polars-sql/src/lib.rs
+++ b/polars/polars-sql/src/lib.rs
@@ -321,6 +321,7 @@ mod test {
                 LOG2(a) AS log2,
                 LOG10(a) AS log10,
                 LOG(a, 5) AS log5,
+                LOG1P(a) AS log1p,
                 POW(a, 2) AS pow
             FROM df"#;
         let df_sql = context.execute(sql).unwrap().collect().unwrap();
@@ -339,6 +340,7 @@ mod test {
                 col("a").log(2.0).alias("log2"),
                 col("a").log(10.0).alias("log10"),
                 col("a").log(5.0).alias("log5"),
+                col("a").log1p().alias("log1p"),
                 col("a").pow(2.0).alias("pow"),
             ])
             .collect()

--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -33,6 +33,7 @@ Computation
     Expr.kurtosis
     Expr.log
     Expr.log10
+    Expr.log1p
     Expr.mode
     Expr.n_unique
     Expr.null_count

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -34,6 +34,7 @@ Computation
     Series.kurtosis
     Series.log
     Series.log10
+    Series.log1p
     Series.map_dict
     Series.pct_change
     Series.peak_max

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6656,6 +6656,30 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.log(base))
 
+    def log1p(self) -> Self:
+        """
+        Compute the natural logarithm of each element plus one.
+
+        This computes `log(1 + x)` but is more numerically stable for `x` close to zero.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1, 2, 3]})
+        >>> df.select(pl.col("a").log1p())
+        shape: (3, 1)
+        ┌──────────┐
+        │ a        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 0.693147 │
+        │ 1.098612 │
+        │ 1.386294 │
+        └──────────┘
+
+        """
+        return self._from_pyexpr(self._pyexpr.log1p())
+
     def entropy(self, base: float = math.e, *, normalize: bool = True) -> Self:
         """
         Computes the entropy.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1085,6 +1085,9 @@ class Series:
     def log(self, base: float = math.e) -> Series:
         """Compute the logarithm to a given base."""
 
+    def log1p(self) -> Series:
+        """Compute the natural logarithm of the input array plus one, element-wise."""
+
     def log10(self) -> Series:
         """Compute the base 10 logarithm of the input array, element-wise."""
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1807,6 +1807,10 @@ impl PyExpr {
         self.inner.clone().log(base).into()
     }
 
+    pub fn log1p(&self) -> Self {
+        self.inner.clone().log1p().into()
+    }
+
     pub fn exp(&self) -> Self {
         self.inner.clone().exp().into()
     }

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1941,6 +1941,9 @@ def test_log_exp() -> None:
     expected = pl.Series("a", np.exp(b.to_numpy()))
     assert_series_equal(b.exp(), expected)
 
+    expected = pl.Series("a", np.log1p(a.to_numpy()))
+    assert_series_equal(a.log1p(), expected)
+
 
 def test_shuffle() -> None:
     a = pl.Series("a", [1, 2, 3])


### PR DESCRIPTION
# Motivation

A common operation in scientific computing is `log(1 + x)` where `x` is possibly close to 0, resulting in an output value close to 0. Unfortunately, executing `log(1 + x)` is numerically unstable. For that reason, `log1p(x) = log(1 + x)` is a commonly implemented function that provides a more numerically stable computation _for the natural logarithm_.

This PR adds `log1p` to polars which currently only implements `log`.

# Changes

- Add `log1p` to the eager API, expression API, and the SQL engine
- Add a simple test case

# Discussion

While the implementation is straightforward, the naming of the function is (as it often is) not super trivial. I opted for `log1p` since it corresponds to the naming [in NumPy](https://numpy.org/doc/stable/reference/generated/numpy.log1p.html) as well as DBMSs which implement this function (e.g. [Databricks](https://docs.databricks.com/sql/language-manual/functions/log1p.html)).

However, polars' SQL engine already implements `LN` (and `LN1P` would, thus, be a more accurate addition) and Rust calls this function `ln_1p`. This would suggest naming the new function `ln1p`.