### PR TITLE
fix(rust): ensure cached nodes are initialized once

### DIFF
--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1"
 ahash.workspace = true
 bitflags.workspace = true
 glob = "0.3"
+once_cell = "1"
 polars-arrow = { version = "0.28.0", path = "../polars-arrow" }
 polars-core = { version = "0.28.0", path = "../polars-core", features = ["lazy", "private", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.28.0", path = "../polars-io", features = ["lazy", "csv-file", "private"], default-features = false }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "ahash",
  "bitflags",
  "glob",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-io",

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1335,6 +1335,64 @@ def test_lazy_cache_hit(monkeypatch: Any, capfd: Any) -> None:
     assert "CACHE HIT" in out
 
 
+def test_lazy_cache_parallel() -> None:
+    df_evaluated = 0
+
+    def map_df(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_evaluated
+        df_evaluated += 1
+        return df
+
+    df = pl.LazyFrame({"a": [1]}).map(map_df).cache()
+
+    df = pl.concat(
+        [
+            df.select(pl.col("a") + 1),
+            df.select(pl.col("a") + 2),
+            df.select(pl.col("a") + 3),
+        ],
+        parallel=True,
+    )
+
+    assert df_evaluated == 0
+
+    df.collect()
+    assert df_evaluated == 1
+
+
+def test_lazy_cache_nested_parallel() -> None:
+    df_inner_evaluated = 0
+    df_outer_evaluated = 0
+
+    def map_df_inner(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_inner_evaluated
+        df_inner_evaluated += 1
+        return df
+
+    def map_df_outer(df: pl.DataFrame) -> pl.DataFrame:
+        nonlocal df_outer_evaluated
+        df_outer_evaluated += 1
+        return df
+
+    df_inner = pl.LazyFrame({"a": [1]}).map(map_df_inner).cache()
+    df_outer = df_inner.select(pl.col("a") + 1).map(map_df_outer).cache()
+
+    df = pl.concat(
+        [
+            df_outer.select(pl.col("a") + 2),
+            df_outer.select(pl.col("a") + 3),
+        ],
+        parallel=True,
+    )
+
+    assert df_inner_evaluated == 0
+    assert df_outer_evaluated == 0
+
+    df.collect()
+    assert df_inner_evaluated == 1
+    assert df_outer_evaluated == 1
+
+
 def test_quadratic_behavior_4736() -> None:
     # no assert; if this function does not stall our tests it has passed!
     ldf = pl.LazyFrame(schema=list(ascii_letters))


### PR DESCRIPTION
Cached nodes are currently exposed to a race condition where an identical plan may be initialized multiple times. This would repeat unnecessary work which seems to contradict the purpose of `CacheExec`. The executor currently locks setting values in it's internal `df_cache`, but the actual expensive initialize is not covered.

This PR wraps the initialization step in a `OnceCell` (an existing crate dependency) to ensure it's only ran once. Each cache id has its own `OnceCell` instance/lock. This allows distinct cache ids to be initialized in parallel and avoids any kind of deadlocking. A nested initialization test case helps cover this concern.

The common use case I've ran into this bug is by doing something like:

```python
ldf = load_and_prepare_data().cache()
pl.collect_all([task_a(ldf), task_b(ldf)])
```

where `load_and_prepare_data`'s plan is ran twice which could be very expensive. This type of thing isn't a concern with eager data frames, but is something you have to think about when moving towards lazy frames.

Within polar's own codebase, `pl.align_frames` uses cached nodes and is also affected by the race condition. A workaround is to avoid `collect_all` and collect lazy frames in sequence. When using `pl.concat`, I've found setting `parallel=False` helps. But with Polars using parallelization throughout the codebase, there's likely other functions affected.