### PR TITLE
fix: Remove duplicated content in error messages

### DIFF
--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -33,9 +33,6 @@ fn error_messages() {
     let base_err_msg =
         format!("xyz\n\nError originated just after this operation:\n{INITIAL_PROJECTION}");
 
-    let err_msg =
-        format!("xyz\n\nError originated just after this operation:\n{INITIAL_PROJECTION}");
-
     let df = df! [
         "c1" => [0, 1],
     ]

--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -1,0 +1,67 @@
+use polars_core::error::ErrString;
+
+use super::*;
+
+#[test]
+fn error_messages() {
+    fn test_it(df: &LazyFrame, n: usize, base_err_msg: &str) {
+        let plan_err_str;
+        let collect_err;
+
+        if n == 0 {
+            plan_err_str = format!(
+                "ErrorState(NotYetEncountered { \
+                 err: ColumnNotFound(ErrString(\"{base_err_msg}\")) })"
+            );
+            collect_err = PolarsError::ColumnNotFound(ErrString::from(&base_err_msg));
+        } else {
+            plan_err_str = format!(
+                "ErrorState(AlreadyEncountered { \
+                 n_times: {n}, prev_err_msg: \"not found: {base_err_msg}\" })"
+            );
+            collect_err = PolarsError::ComputeError(ErrString::from(format!(
+                "LogicalPlan already failed (depth: {n}) \
+                 with error: 'not found: {base_err_msg}"
+            )))
+        };
+
+        assert_eq!(df.describe_plan(), plan_err_str);
+        assert_eq!(df.collect().unwrap_err(), collect_err);
+    }
+
+    let initial_projection: &str = r#"DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None""#;
+    let base_err_msg =
+        format!("xyz\n\nError originated just after this operation:\n{INITIAL_PROJECTION}");
+
+    let err_msg =
+        format!("xyz\n\nError originated just after this operation:\n{INITIAL_PROJECTION}");
+
+    let df = df! [
+        "c1" => [0, 1],
+    ]
+    .unwrap()
+    .lazy();
+
+    assert_eq!(df.describe_plan(), initial_projection);
+
+    let df0 = df.clone().select([col("xyz")]);
+    test_it(&df0, 0, &base_err_msg);
+
+    let df1 = df.clone().select([col("xyz")]).select([col("c1")]);
+    test_it(&df1, 1, &base_err_msg);
+
+    let df2 = df
+        .clone()
+        .select([col("xyz")])
+        .select([col("c1")])
+        .select([col("c2")]);
+    test_it(&df2, 2, &base_err_msg);
+
+    let df3 = df
+        .clone()
+        .select([col("xyz")])
+        .select([col("c1")])
+        .select([col("c2")])
+        .select([col("c3")]);
+    test_it(&df3, 3, &base_err_msg);
+}

--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -23,6 +23,23 @@ fn assert_errors_eq(e1: &PolarsError, e2: &PolarsError) {
 
 #[test]
 fn col_not_found_error_messages() {
+    fn get_err_msg(err_msg: &str, n: usize) -> String {
+        let plural_s;
+        let was_were;
+
+        if n == 1 {
+            plural_s = "";
+            was_were = "was"
+        } else {
+            plural_s = "s";
+            was_were = "were";
+        };
+        format!(
+            "{err_msg}\n\nLogicalPlan had already failed with the above error; \
+             after failure, {n} additional operation{plural_s} \
+             {was_were} attempted on the LazyFrame"
+        )
+    }
     fn test_col_not_found(df: LazyFrame, n: usize) {
         let err_msg = format!(
             "xyz\n\nError originated just after this \
@@ -35,9 +52,7 @@ fn col_not_found_error_messages() {
         let collect_err = if n == 0 {
             PolarsError::ColumnNotFound(ErrString::from(err_msg.to_owned()))
         } else {
-            PolarsError::ColumnNotFound(ErrString::from(format!(
-                "LogicalPlan already failed (depth: {n}) with error: '{err_msg}'"
-            )))
+            PolarsError::ColumnNotFound(ErrString::from(get_err_msg(&err_msg, n)))
         };
 
         assert_eq!(df.describe_plan(), plan_err_str);

--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -2,27 +2,32 @@ use polars_core::error::ErrString;
 
 use super::*;
 
-#[test]
-fn error_messages() {
-    fn assert_errors_eq(e1: &PolarsError, e2: &PolarsError) {
-        use PolarsError::*;
-        match (e1, e2) {
-            (ColumnNotFound(s1), ColumnNotFound(s2)) => {
-                assert_eq!(s1.as_ref(), s2.as_ref());
-            },
-            (ComputeError(s1), ComputeError(s2)) => {
-                assert_eq!(s1.as_ref(), s2.as_ref());
-            },
-            _ => panic!("{e1:?} != {e2:?}"),
-        }
-    }
+const INITIAL_PROJECTION_STR: &str = r#"DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None""#;
 
-    fn test_it(df: LazyFrame, n: usize) {
-        let base_err_msg = format!(
+fn make_df() -> LazyFrame {
+    df! [ "c1" => [0, 1] ].unwrap().lazy()
+}
+
+fn assert_errors_eq(e1: &PolarsError, e2: &PolarsError) {
+    use PolarsError::*;
+    match (e1, e2) {
+        (ColumnNotFound(s1), ColumnNotFound(s2)) => {
+            assert_eq!(s1.as_ref(), s2.as_ref());
+        },
+        (ComputeError(s1), ComputeError(s2)) => {
+            assert_eq!(s1.as_ref(), s2.as_ref());
+        },
+        _ => panic!("{e1:?} != {e2:?}"),
+    }
+}
+
+#[test]
+fn col_not_found_error_messages() {
+    fn test_col_not_found(df: LazyFrame, n: usize) {
+        let err_msg = format!(
             "xyz\n\nError originated just after this \
              operation:\n{INITIAL_PROJECTION_STR}"
         );
-        let col_not_found_err_msg = format!("not found: {base_err_msg}");
 
         let plan_err_str;
         let collect_err;
@@ -30,17 +35,16 @@ fn error_messages() {
         if n == 0 {
             plan_err_str = format!(
                 "ErrorState(NotYetEncountered {{ \
-                 err: ColumnNotFound(ErrString({base_err_msg:?})) }})"
+                 err: ColumnNotFound(ErrString({err_msg:?})) }})"
             );
-            collect_err = PolarsError::ColumnNotFound(ErrString::from(base_err_msg.to_owned()));
+            collect_err = PolarsError::ColumnNotFound(ErrString::from(err_msg.to_owned()));
         } else {
             plan_err_str = format!(
                 "ErrorState(AlreadyEncountered {{ n_times: {n}, \
-                 prev_err_msg: {col_not_found_err_msg:?} }})",
+                 orig_err: ColumnNotFound(ErrString({err_msg:?})) }})",
             );
-            collect_err = PolarsError::ComputeError(ErrString::from(format!(
-                "LogicalPlan already failed (depth: {n}) \
-                 with error: '{col_not_found_err_msg}'"
+            collect_err = PolarsError::ColumnNotFound(ErrString::from(format!(
+                "LogicalPlan already failed (depth: {n}) with error: '{err_msg}'"
             )))
         };
 
@@ -48,34 +52,25 @@ fn error_messages() {
         assert_errors_eq(&df.collect().unwrap_err(), &collect_err);
     }
 
-    const INITIAL_PROJECTION_STR: &str = r#"DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None""#;
-
-    let df = df! [
-        "c1" => [0, 1],
-    ]
-    .unwrap()
-    .lazy();
+    let df = make_df();
 
     assert_eq!(df.describe_plan(), INITIAL_PROJECTION_STR);
 
-    let df0 = df.clone().select([col("xyz")]);
-    test_it(df0, 0);
-
-    let df1 = df.clone().select([col("xyz")]).select([col("c1")]);
-    test_it(df1, 1);
-
-    let df2 = df
-        .clone()
-        .select([col("xyz")])
-        .select([col("c1")])
-        .select([col("c2")]);
-    test_it(df2, 2);
-
-    let df3 = df
-        .clone()
-        .select([col("xyz")])
-        .select([col("c1")])
-        .select([col("c2")])
-        .select([col("c3")]);
-    test_it(df3, 3);
+    test_col_not_found(df.clone().select([col("xyz")]), 0);
+    test_col_not_found(df.clone().select([col("xyz")]).select([col("c1")]), 1);
+    test_col_not_found(
+        df.clone()
+            .select([col("xyz")])
+            .select([col("c1")])
+            .select([col("c2")]),
+        2,
+    );
+    test_col_not_found(
+        df.clone()
+            .select([col("xyz")])
+            .select([col("c1")])
+            .select([col("c2")])
+            .select([col("c3")]),
+        3,
+    );
 }

--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -29,21 +29,13 @@ fn col_not_found_error_messages() {
              operation:\n{INITIAL_PROJECTION_STR}"
         );
 
-        let plan_err_str;
-        let collect_err;
+        let plan_err_str =
+            format!("ErrorState {{ n_times: {n}, err: ColumnNotFound(ErrString({err_msg:?})) }}");
 
-        if n == 0 {
-            plan_err_str = format!(
-                "ErrorState(NotYetEncountered {{ \
-                 err: ColumnNotFound(ErrString({err_msg:?})) }})"
-            );
-            collect_err = PolarsError::ColumnNotFound(ErrString::from(err_msg.to_owned()));
+        let collect_err = if n == 0 {
+            PolarsError::ColumnNotFound(ErrString::from(err_msg.to_owned()))
         } else {
-            plan_err_str = format!(
-                "ErrorState(AlreadyEncountered {{ n_times: {n}, \
-                 orig_err: ColumnNotFound(ErrString({err_msg:?})) }})",
-            );
-            collect_err = PolarsError::ColumnNotFound(ErrString::from(format!(
+            PolarsError::ColumnNotFound(ErrString::from(format!(
                 "LogicalPlan already failed (depth: {n}) with error: '{err_msg}'"
             )))
         };

--- a/crates/polars-lazy/src/tests/err_msg.rs
+++ b/crates/polars-lazy/src/tests/err_msg.rs
@@ -4,34 +4,51 @@ use super::*;
 
 #[test]
 fn error_messages() {
-    fn test_it(df: &LazyFrame, n: usize, base_err_msg: &str) {
+    fn assert_errors_eq(e1: &PolarsError, e2: &PolarsError) {
+        use PolarsError::*;
+        match (e1, e2) {
+            (ColumnNotFound(s1), ColumnNotFound(s2)) => {
+                assert_eq!(s1.as_ref(), s2.as_ref());
+            },
+            (ComputeError(s1), ComputeError(s2)) => {
+                assert_eq!(s1.as_ref(), s2.as_ref());
+            },
+            _ => panic!("{e1:?} != {e2:?}"),
+        }
+    }
+
+    fn test_it(df: LazyFrame, n: usize) {
+        let base_err_msg = format!(
+            "xyz\n\nError originated just after this \
+             operation:\n{INITIAL_PROJECTION_STR}"
+        );
+        let col_not_found_err_msg = format!("not found: {base_err_msg}");
+
         let plan_err_str;
         let collect_err;
 
         if n == 0 {
             plan_err_str = format!(
-                "ErrorState(NotYetEncountered { \
-                 err: ColumnNotFound(ErrString(\"{base_err_msg}\")) })"
+                "ErrorState(NotYetEncountered {{ \
+                 err: ColumnNotFound(ErrString({base_err_msg:?})) }})"
             );
-            collect_err = PolarsError::ColumnNotFound(ErrString::from(&base_err_msg));
+            collect_err = PolarsError::ColumnNotFound(ErrString::from(base_err_msg.to_owned()));
         } else {
             plan_err_str = format!(
-                "ErrorState(AlreadyEncountered { \
-                 n_times: {n}, prev_err_msg: \"not found: {base_err_msg}\" })"
+                "ErrorState(AlreadyEncountered {{ n_times: {n}, \
+                 prev_err_msg: {col_not_found_err_msg:?} }})",
             );
             collect_err = PolarsError::ComputeError(ErrString::from(format!(
                 "LogicalPlan already failed (depth: {n}) \
-                 with error: 'not found: {base_err_msg}"
+                 with error: '{col_not_found_err_msg}'"
             )))
         };
 
         assert_eq!(df.describe_plan(), plan_err_str);
-        assert_eq!(df.collect().unwrap_err(), collect_err);
+        assert_errors_eq(&df.collect().unwrap_err(), &collect_err);
     }
 
-    let initial_projection: &str = r#"DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None""#;
-    let base_err_msg =
-        format!("xyz\n\nError originated just after this operation:\n{INITIAL_PROJECTION}");
+    const INITIAL_PROJECTION_STR: &str = r#"DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None""#;
 
     let df = df! [
         "c1" => [0, 1],
@@ -39,20 +56,20 @@ fn error_messages() {
     .unwrap()
     .lazy();
 
-    assert_eq!(df.describe_plan(), initial_projection);
+    assert_eq!(df.describe_plan(), INITIAL_PROJECTION_STR);
 
     let df0 = df.clone().select([col("xyz")]);
-    test_it(&df0, 0, &base_err_msg);
+    test_it(df0, 0);
 
     let df1 = df.clone().select([col("xyz")]).select([col("c1")]);
-    test_it(&df1, 1, &base_err_msg);
+    test_it(df1, 1);
 
     let df2 = df
         .clone()
         .select([col("xyz")])
         .select([col("c1")])
         .select([col("c2")]);
-    test_it(&df2, 2, &base_err_msg);
+    test_it(df2, 2);
 
     let df3 = df
         .clone()
@@ -60,5 +77,5 @@ fn error_messages() {
         .select([col("c1")])
         .select([col("c2")])
         .select([col("c3")]);
-    test_it(&df3, 3, &base_err_msg);
+    test_it(df3, 3);
 }

--- a/crates/polars-lazy/src/tests/mod.rs
+++ b/crates/polars-lazy/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod aggregations;
 mod arity;
 #[cfg(all(feature = "strings", feature = "cse"))]
 mod cse;
+mod err_msg;
 #[cfg(feature = "parquet")]
 mod io;
 mod logical;

--- a/crates/polars-plan/src/dot.rs
+++ b/crates/polars-plan/src/dot.rs
@@ -406,7 +406,7 @@ impl LogicalPlan {
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
             },
             Error { err, .. } => {
-                let fmt = format!("{:?}", &**err);
+                let fmt = format!("{:?}", &err.0);
                 let current_node = DotNode {
                     branch,
                     id,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -60,15 +60,16 @@ fn format_err(msg: &str, input: &LogicalPlan) -> String {
     format!("{msg}\n\nError originated just after this operation:\n{input:?}")
 }
 
-/// Returns every error or msg: &str as `ComputeError`.
-/// It also shows the logical plan node where the error
-/// originated.
+/// Returns every error or msg: &str as `ComputeError`. It also shows the logical plan node where the error originated.
+/// If `input` is already a `LogicalPlan::Error`, then return it as is; errors already keep track of their previous
+/// inputs, so we don't have to do it again here.
 macro_rules! raise_err {
     ($err:expr, $input:expr, $convert:ident) => {{
-        let (input, err): (Box<LogicalPlan>, ErrorState) = match $input {
-            LogicalPlan::Error { input, err } => (input.clone(), ErrorState(Arc::clone(&err.0))),
+        let input: LogicalPlan = $input.clone();
+        match &input {
+            LogicalPlan::Error { .. } => input,
             _ => {
-                let format_err_outer = |msg: &str| format_err(msg, &$input);
+                let format_err_outer = |msg: &str| format_err(msg, &input);
                 let err = $err.wrap_msg(&format_err_outer);
 
                 (Box::new($input.clone()), err.into())

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -74,7 +74,7 @@ macro_rules! raise_err {
 
                 LogicalPlan::Error {
                     input: Box::new(input),
-                    err: err.into(), // PolarsError -> ErrorState(NotYetEncountered)
+                    err: err.into(), // PolarsError -> ErrorState
                 }
             },
         }

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -34,7 +34,6 @@ use crate::dsl::functions::horizontal::all_horizontal;
 use crate::logical_plan::functions::FunctionNode;
 use crate::logical_plan::projection::{is_regex_projection, rewrite_projections};
 use crate::logical_plan::schema::{det_join_schema, FileInfo};
-use crate::logical_plan::ErrorState;
 #[cfg(feature = "python")]
 use crate::prelude::python_udf::PythonFunction;
 use crate::prelude::*;

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -72,11 +72,13 @@ macro_rules! raise_err {
                 let format_err_outer = |msg: &str| format_err(msg, &input);
                 let err = $err.wrap_msg(&format_err_outer);
 
-                (Box::new($input.clone()), err.into())
+                LogicalPlan::Error {
+                    input: Box::new(input),
+                    err: err.into(), // PolarsError -> ErrorState(NotYetEncountered)
+                }
             },
-        };
-
-        LogicalPlan::Error { input, err }.$convert()
+        }
+        .$convert()
     }};
 }
 

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -216,7 +216,7 @@ impl LogicalPlan {
                 write!(f, "{:indent$}{function_fmt}", "")?;
                 input._format(f, sub_indent)
             },
-            Error { input, err } => write!(f, "{err:?}\n{input:?}"),
+            Error { input, err } => write!(f, "{err:?}"),
             ExtContext { input, .. } => {
                 write!(f, "{:indent$}EXTERNAL_CONTEXT", "")?;
                 input._format(f, sub_indent)

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -216,7 +216,7 @@ impl LogicalPlan {
                 write!(f, "{:indent$}{function_fmt}", "")?;
                 input._format(f, sub_indent)
             },
-            Error { input, err } => write!(f, "{err:?}"),
+            Error { err, .. } => write!(f, "{err:?}"),
             ExtContext { input, .. } => {
                 write!(f, "{:indent$}EXTERNAL_CONTEXT", "")?;
                 input._format(f, sub_indent)

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -111,9 +111,22 @@ impl ErrorState {
             this.err.wrap_msg(&|msg| msg.to_owned())
         } else {
             this.err.wrap_msg(&|msg| {
+                let n_times = this.n_times;
+
+                let plural_s;
+                let was_were;
+
+                if n_times == 1 {
+                    plural_s = "";
+                    was_were = "was"
+                } else {
+                    plural_s = "s";
+                    was_were = "were";
+                };
                 format!(
-                    "LogicalPlan already failed (depth: {}) with error: '{}'",
-                    this.n_times, msg
+                    "{msg}\n\nLogicalPlan had already failed with the above error; \
+                     after failure, {n_times} additional operation{plural_s} \
+                     {was_were} attempted on the LazyFrame",
                 )
             })
         };

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -85,21 +85,8 @@ pub(crate) enum ErrorStateEncounters {
     },
 }
 
-impl std::fmt::Display for ErrorState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ErrorState::NotYetEncountered { err } => write!(f, "NotYetEncountered({err})")?,
-            ErrorState::AlreadyEncountered { prev_err_msg } => {
-                write!(f, "AlreadyEncountered({prev_err_msg})")?
-            },
-        };
-
-        Ok(())
-    }
-}
-
 #[derive(Clone)]
-pub struct ErrorStateSync(Arc<Mutex<ErrorState>>);
+pub struct ErrorState(pub(crate) Arc<Mutex<ErrorStateEncounters>>);
 
 impl std::fmt::Debug for ErrorState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -110,41 +97,7 @@ impl std::fmt::Debug for ErrorState {
     }
 }
 
-impl std::fmt::Debug for ErrorStateSync {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ErrorStateSync({})", &*self.0.lock().unwrap())
-    }
-}
-
-impl ErrorStateSync {
-    fn take(&self) -> PolarsError {
-        let mut curr_err = self.0.lock().unwrap();
-
-        match &*curr_err {
-            ErrorState::NotYetEncountered { err: polars_err } => {
-                // Need to finish using `polars_err` here so that NLL considers `err` dropped
-                let prev_err_msg = polars_err.to_string();
-                // Place AlreadyEncountered in `self` for future users of `self`
-                let prev_err = std::mem::replace(
-                    &mut *curr_err,
-                    ErrorState::AlreadyEncountered { prev_err_msg },
-                );
-                // Since we're in this branch, we know err was a NotYetEncountered
-                match prev_err {
-                    ErrorState::NotYetEncountered { err } => err,
-                    ErrorState::AlreadyEncountered { .. } => unreachable!(),
-                }
-            },
-            ErrorState::AlreadyEncountered { prev_err_msg } => {
-                polars_err!(
-                    ComputeError: "LogicalPlan already failed with error: '{}'", prev_err_msg,
-                )
-            },
-        }
-    }
-}
-
-impl From<PolarsError> for ErrorStateSync {
+impl From<PolarsError> for ErrorState {
     fn from(err: PolarsError) -> Self {
         Self(Arc::new(Mutex::new(
             ErrorStateEncounters::NotYetEncountered { err },

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -689,3 +689,13 @@ def test_error_list_to_array() -> None:
         pl.DataFrame(
             data={"a": [[1, 2], [3, 4, 5]]}, schema={"a": pl.List(pl.Int8)}
         ).with_columns(array=pl.col("a").list.to_array(2))
+
+
+# https://github.com/pola-rs/polars/issues/8079
+def test_error_lazyframe_not_repeating() -> None:
+    lf = pl.LazyFrame({"a": 1, "b": range(2)})
+    with pytest.raises(pl.ColumnNotFoundError) as exc_info:
+        lf.select("c").select("d").select("e").collect()
+
+    match = "Error originated just after this operation:"
+    assert str(exc_info).count(match) == 1


### PR DESCRIPTION
Should fix #8079 , but ***please avoid merging for now***, as I have only tested a small subset of the things this might affect (and I have not yet added any formal tests at all; what's below is the extent of my testing). I would also like input on this to see if this the ideal way to handle this problem and to report errors in general.

# Changes

- Prevented exponential growth of error messages by avoiding nesting of error messages
- Instead, used a counter to track how many operations had been applied to a LazyFrame after an error
- Error message contains stack depth and original error
- Renamed `ErrorState` to `ErrorStateEncounters` and made it crate-private
- Renamed `ErrorStateSync` to `ErrorState` and removed its `Deref` impl so that the only way to access its data is through (crate-private) accessors, thus reducing the size of its public API

Error messages are now O(1) in length (well, technically O(log(n)), if you take into account that the depth counter has log10(n) digits, but this is *effectively* O(1)).

# Test case (singular)

## Input

In each case we print `> title of test case`, `= df.describe_plan()`, and `# df.collect().unwrap_err()`

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    fn report_err(df: LazyFrame, ops_after: usize) {
        println!("> select xyz, then {ops_after} ops after");
        println!("= {}", df.describe_plan());
        println!("# {:?}", df.collect().unwrap_err());
        println!();
    }

    let df = df! [
        "c1" => [0, 1],
    ]
    .unwrap()
    .lazy();

    println!("> initial df");
    println!("= {}", df.describe_plan());
    println!("# NO ERROR");
    println!();

    let df0 = df.clone().select([col("xyz")]);
    report_err(df0, 0);

    let df1 = df.clone().select([col("xyz")]).select([col("c1")]);
    report_err(df1, 1);

    let df2 = df
        .clone()
        .select([col("xyz")])
        .select([col("c1")])
        .select([col("c2")]);
    report_err(df2, 2);

    let df3 = df
        .clone()
        .select([col("xyz")])
        .select([col("c1")])
        .select([col("c2")])
        .select([col("c3")]);
    report_err(df3, 3);

    Ok(())
}
```

## Output

In each case we print `> title of test case`, `= df.describe_plan()`, and `# df.collect().unwrap_err()`

```
> initial df
= DF ["c1"]; PROJECT */1 COLUMNS; SELECTION: "None"
# NO ERROR

> select xyz, then 0 ops after
= ErrorState(NotYetEncountered { err: ColumnNotFound(ErrString("xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"")) })
# ColumnNotFound(ErrString("xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\""))

> select xyz, then 1 ops after
= ErrorState(AlreadyEncountered { n_times: 1, prev_err_msg: "not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"" })
# ComputeError(ErrString("LogicalPlan already failed (depth: 1) with error: 'not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"'"))

> select xyz, then 2 ops after
= ErrorState(AlreadyEncountered { n_times: 2, prev_err_msg: "not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"" })
# ComputeError(ErrString("LogicalPlan already failed (depth: 2) with error: 'not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"'"))

> select xyz, then 3 ops after
= ErrorState(AlreadyEncountered { n_times: 3, prev_err_msg: "not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"" })
# ComputeError(ErrString("LogicalPlan already failed (depth: 3) with error: 'not found: xyz\n\nError originated just after this operation:\nDF [\"c1\"]; PROJECT */1 COLUMNS; SELECTION: \"None\"'"))
```