### PR TITLE
fix(python): fix detection of default integer indexes on win32 when loading from pandas frames

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1339,7 +1339,7 @@ def pandas_has_default_index(df: pd.DataFrame) -> bool:
         # finally, is the index _equivalent_ to a default unnamed
         # integer index with frame data that was previously sorted
         return (
-            df.index.dtype == "int"  # type: ignore[comparison-overlap]
+            str(df.index.dtype).startswith("int")
             and (df.index.sort_values() == np.arange(len(df))).all()
         )
 


### PR DESCRIPTION
Addresses a potential failure when loading from a pandas DataFrames on Windows (the default integer dtype there is int32, not int/int64).