### PR TITLE
Fix is_in with struct

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/is_in.rs
+++ b/polars/polars-core/src/chunked_array/ops/is_in.rs
@@ -371,8 +371,7 @@ impl IsIn for StructChunked {
 
                 let mut set = HashSet::with_capacity(other.len());
                 set.extend(other.into_iter().map(|opt_val| opt_val.to_vec()));
-                let mut ca: BooleanChunked =
-                    self.into_iter().map(|v| set.contains(v)).collect();
+                let mut ca: BooleanChunked = self.into_iter().map(|v| set.contains(v)).collect();
                 ca.rename(self.name());
                 Ok(ca)
             }

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -551,18 +551,33 @@ def test_arr_unique() -> None:
 def test_is_in_struct() -> None:
     df = pl.DataFrame(
         {
-            "struct_elem": [{"a": 1, "b": 11}, {"a": 1, "b": 90}],
+            "struct_elem": [
+                {"a": 1, "b": None},
+                {"a": 1, "b": 90},
+                {"a": None, "b": 90},
+            ],
             "struct_list": [
-                [{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 3, "b": 13}],
+                [{"a": 1, "b": None}, {"a": 2, "b": 12}, {"a": 3, "b": 13}],
                 [{"a": 3, "b": 3}],
+                [],
             ],
         }
     )
 
     assert df.filter(pl.col("struct_elem").is_in("struct_list")).to_dict(False) == {
-        "struct_elem": [{"a": 1, "b": 11}],
-        "struct_list": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 3, "b": 13}]],
+        "struct_elem": [{"a": 1, "b": None}],
+        "struct_list": [[{"a": 1, "b": None}, {"a": 2, "b": 12}, {"a": 3, "b": 13}]],
     }
+
+    df2 = pl.DataFrame(
+        {
+            "struct_elem2": [{"a": 1, "b": 0}, {"a": 0, "b": 90}, {"a": None, "b": 90}],
+        }
+    )
+
+    assert df.filter(pl.col("struct_elem").is_in(df2["struct_elem2"])).to_dict(
+        False
+    ) == {"struct_elem": [{"a": None, "b": 90}], "struct_list": [[]]}
 
 
 def test_nested_explode_4026() -> None:


### PR DESCRIPTION
Fixes #7606

This changes struct-dtype `.is_in` to work on tuples of fields rather than per-field:

```py
s1 = pl.Series([{"x": 3, "y": 2}, {"x": 1, "y": 4}])
s2 = pl.Series([{"x": 1 ¹, "y": 2 ²}, {"x": 3 ³, "y": 4 ⁴}])

s1.is_in(s2)

# Previously, this evaluated to:

pl.Series([
  3 in [1 ¹, 3 ³] and 2 in [2 ², 4 ⁴],  # True
  1 in [1 ¹, 3 ³] and 4 in [2 ², 4 ⁴],  # True
])

# Now, this evaluates to:

pl.Series([
  (3, 2) in [(1 ¹, 2 ²), (3 ³, 4 ⁴)],  # False
  (1, 4) in [(1 ¹, 2 ²), (3 ³, 4 ⁴)],  # False
])
```

Performance compared to the previous incorrect version got worse ~10x. 50% of that time is spent in set construction, and 50% in lookup (benchmarked with a non-release build).