### PR TITLE
ci(python): Improvements to the Python release workflow

### DIFF
--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - py-*
 
+env:
+  RUST_TOOLCHAIN: nightly-2023-04-11
+  MATURIN_VERSION: '0.14.10'
+
 defaults:
   run:
     shell: bash
@@ -29,8 +33,8 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: nightly-2023-04-11
-          maturin-version: '0.14.10'
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
 
@@ -59,9 +63,9 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           JEMALLOC_SYS_WITH_LG_PAGE: 16
         with:
-          rust-toolchain: nightly-2023-04-11
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: aarch64-unknown-linux-gnu
-          maturin-version: '0.14.10'
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
 
@@ -90,8 +94,8 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: nightly-2023-04-11
-          maturin-version: '0.14.10'
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
 
@@ -117,8 +121,8 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
         with:
-          rust-toolchain: nightly-2023-04-11
-          maturin-version: '0.14.10'
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
 
@@ -146,8 +150,8 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
         with:
-          rust-toolchain: nightly-2023-04-11
-          maturin-version: '0.14.10'
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46
 
@@ -172,7 +176,7 @@ jobs:
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
-          maturin-version: '0.14.10'
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46
 
@@ -199,6 +203,6 @@ jobs:
   #       env:
   #         MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
   #       with:
-  #         maturin-version: '0.14.10'
+  #         maturin-version: ${{ env.MATURIN_VERSION }}
   #         command: publish
   #         args: -m py-polars/Cargo.toml --no-sdist --universal2 -o wheels -i python -u ritchie46

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -8,6 +8,7 @@ on:
 env:
   RUST_TOOLCHAIN: nightly-2023-04-11
   MATURIN_VERSION: '0.14.10'
+  MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
 
 defaults:
   run:
@@ -30,7 +31,6 @@ jobs:
       - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
           command: publish
@@ -60,7 +60,6 @@ jobs:
       - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           JEMALLOC_SYS_WITH_LG_PAGE: 16
         with:
           command: publish
@@ -91,7 +90,6 @@ jobs:
       - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
           command: publish
@@ -118,7 +116,6 @@ jobs:
       - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
         with:
           command: publish
@@ -147,7 +144,6 @@ jobs:
       - name: Publish wheel
         uses: messense/maturin-action@v1
         env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
         with:
           command: publish
@@ -173,8 +169,6 @@ jobs:
 
       - name: Publish wheel
         uses: messense/maturin-action@v1
-        env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
           command: publish
           args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -179,30 +179,3 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46
-
-  # uncomment to build a universal2 wheel
-  # we don't run it because it is twice as big and not needed because we build for both architectures separately
-  # macos-aarch64-universal:
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.7'
-
-  #     - name: Fix README symlink
-  #       run: |
-  #         rm py-polars/README.md
-  #         cp README.md py-polars/README.md
-
-  #     - name: Set up Rust targets
-  #       run: rustup target add aarch64-apple-darwin
-
-  #     - name: Publish wheel
-  #       uses: messense/maturin-action@v1
-  #       env:
-  #         MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
-  #       with:
-  #         maturin-version: ${{ env.MATURIN_VERSION }}
-  #         command: publish
-  #         args: -m py-polars/Cargo.toml --no-sdist --universal2 -o wheels -i python -u ritchie46

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -33,10 +33,10 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
   # Needed for Docker on Apple M1
   manylinux-aarch64:
@@ -63,11 +63,11 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           JEMALLOC_SYS_WITH_LG_PAGE: 16
         with:
-          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
-          target: aarch64-unknown-linux-gnu
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
+          target: aarch64-unknown-linux-gnu
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
   manylinux-bigidx:
     runs-on: ubuntu-latest
@@ -94,10 +94,10 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
         with:
-          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
   manylinux-x64_64-lts-cpu:
     runs-on: ubuntu-latest
@@ -121,10 +121,10 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
         with:
-          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
   win-macos:
     runs-on: ${{ matrix.os }}
@@ -150,10 +150,10 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
         with:
-          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
   macos-aarch64:
     runs-on: macos-latest
@@ -176,6 +176,6 @@ jobs:
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
-          maturin-version: ${{ env.MATURIN_VERSION }}
           command: publish
           args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}


### PR DESCRIPTION
Changes:
* Move the versions for the Rust toolchain and Maturin to the top of the file (`env` entry). Easier to do version bumps this way!
* Move `MATURIN_PASSWORD` to the top-level `env` as well. No need to redefine this for each job. I think this should be picked up correctly. Removes some code duplication.
* Removed the `universal2` commented out job. I haven't seen this enabled in a long time, and we have Git so easy enough to find those settings again should we ever need them.