### PR TITLE
feat(rust): adopt `FunctionExpr` for `abs` to allow for serialization

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/abs.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/abs.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+pub(super) fn abs(s: &Series) -> PolarsResult<Series> {
+    s.abs()
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "abs")]
+mod abs;
 #[cfg(feature = "arg_where")]
 mod arg_where;
 mod binary;
@@ -54,6 +56,8 @@ use super::*;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub enum FunctionExpr {
+    #[cfg(feature = "abs")]
+    Abs,
     NullCount,
     Pow,
     #[cfg(feature = "row_hash")]
@@ -130,6 +134,8 @@ impl Display for FunctionExpr {
         use FunctionExpr::*;
 
         let s = match self {
+            #[cfg(feature = "abs")]
+            Abs => "abs",
             NullCount => "null_count",
             Pow => "pow",
             #[cfg(feature = "row_hash")]
@@ -272,6 +278,8 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: FunctionExpr) -> Self {
         use FunctionExpr::*;
         match func {
+            #[cfg(feature = "abs")]
+            Abs => map!(abs::abs),
             NullCount => {
                 let f = |s: &mut [Series]| {
                     let s = &s[0];

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -104,6 +104,8 @@ impl FunctionExpr {
 
         use FunctionExpr::*;
         match self {
+            #[cfg(feature = "abs")]
+            Abs => same_type(),
             NullCount => with_dtype(IDX_DTYPE),
             Pow => float_dtype(),
             Coalesce => super_type(),

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1058,8 +1058,7 @@ impl Expr {
     /// Convert all values to their absolute/positive value.
     #[cfg(feature = "abs")]
     pub fn abs(self) -> Self {
-        self.map(move |s: Series| s.abs().map(Some), GetOutput::same_type())
-            .with_fmt("abs")
+        self.map_private(FunctionExpr::Abs)
     }
 
     /// Apply window function over a subgroup.


### PR DESCRIPTION
# Motivation

From the list of [computational functions](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/computation.html), a bunch of functions have not yet been transitioned to `FunctionExpr`. The only remaining function that `map`s over the input series is `abs`. This PR refactors its implementation.