### PR TITLE
feat(rust): adopt `FunctionExpr` for `cum*` functions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/cum.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/cum.rs
@@ -15,7 +15,7 @@ pub(super) fn cumcount(s: &Series, reverse: bool) -> PolarsResult<Series> {
 }
 
 pub(super) fn cumsum(s: &Series, reverse: bool) -> PolarsResult<Series> {
-    Ok(s.cumprod(reverse))
+    Ok(s.cumsum(reverse))
 }
 
 pub(super) fn cumprod(s: &Series, reverse: bool) -> PolarsResult<Series> {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/cum.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/cum.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+pub(super) fn cumcount(s: &Series, reverse: bool) -> PolarsResult<Series> {
+    if reverse {
+        let ca: NoNull<UInt32Chunked> = (0u32..s.len() as u32).rev().collect();
+        let mut ca = ca.into_inner();
+        ca.rename(s.name());
+        Ok(ca.into_series())
+    } else {
+        let ca: NoNull<UInt32Chunked> = (0u32..s.len() as u32).collect();
+        let mut ca = ca.into_inner();
+        ca.rename(s.name());
+        Ok(ca.into_series())
+    }
+}
+
+pub(super) fn cumsum(s: &Series, reverse: bool) -> PolarsResult<Series> {
+    Ok(s.cumprod(reverse))
+}
+
+pub(super) fn cumprod(s: &Series, reverse: bool) -> PolarsResult<Series> {
+    Ok(s.cumprod(reverse))
+}
+
+pub(super) fn cummin(s: &Series, reverse: bool) -> PolarsResult<Series> {
+    Ok(s.cummin(reverse))
+}
+
+pub(super) fn cummax(s: &Series, reverse: bool) -> PolarsResult<Series> {
+    Ok(s.cummax(reverse))
+}
+
+pub(super) mod dtypes {
+    use DataType::*;
+
+    use super::*;
+
+    pub fn cumsum(dt: &DataType) -> DataType {
+        if dt.is_logical() {
+            dt.clone()
+        } else {
+            match dt {
+                Boolean => UInt32,
+                Int32 => Int32,
+                UInt32 => UInt32,
+                UInt64 => UInt64,
+                Float32 => Float32,
+                Float64 => Float64,
+                _ => Int64,
+            }
+        }
+    }
+
+    pub fn cumprod(dt: &DataType) -> DataType {
+        match dt {
+            Boolean => Int64,
+            UInt64 => UInt64,
+            Float32 => Float32,
+            Float64 => Float64,
+            _ => Int64,
+        }
+    }
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -3,6 +3,7 @@ mod arg_where;
 mod binary;
 #[cfg(feature = "round_series")]
 mod clip;
+mod cum;
 #[cfg(feature = "temporal")]
 mod datetime;
 mod dispatch;
@@ -102,6 +103,21 @@ pub enum FunctionExpr {
         descending: bool,
     },
     Shift(i64),
+    Cumcount {
+        reverse: bool,
+    },
+    Cumsum {
+        reverse: bool,
+    },
+    Cumprod {
+        reverse: bool,
+    },
+    Cummin {
+        reverse: bool,
+    },
+    Cummax {
+        reverse: bool,
+    },
     Reverse,
     IsNull,
     IsNotNull,
@@ -173,6 +189,11 @@ impl Display for FunctionExpr {
             #[cfg(feature = "top_k")]
             TopK { .. } => "top_k",
             Shift(_) => "shift",
+            Cumcount { .. } => "cumcount",
+            Cumsum { .. } => "cumsum",
+            Cumprod { .. } => "cumprod",
+            Cummin { .. } => "cummin",
+            Cummax { .. } => "cummax",
             Reverse => "reverse",
             Not => "is_not",
             IsNull => "is_null",
@@ -360,6 +381,11 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 map!(top_k, k, descending)
             }
             Shift(periods) => map!(dispatch::shift, periods),
+            Cumcount { reverse } => map!(cum::cumcount, reverse),
+            Cumsum { reverse } => map!(cum::cumsum, reverse),
+            Cumprod { reverse } => map!(cum::cumprod, reverse),
+            Cummin { reverse } => map!(cum::cummin, reverse),
+            Cummax { reverse } => map!(cum::cummax, reverse),
             Reverse => map!(dispatch::reverse),
             IsNull => map!(dispatch::is_null),
             IsNotNull => map!(dispatch::is_not_null),

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -241,6 +241,11 @@ impl FunctionExpr {
             #[cfg(feature = "top_k")]
             TopK { .. } => same_type(),
             Shift(..) | Reverse => same_type(),
+            Cumcount { .. } => with_dtype(IDX_DTYPE),
+            Cumsum { .. } => map_dtype(&cum::dtypes::cumsum),
+            Cumprod { .. } => map_dtype(&cum::dtypes::cumprod),
+            Cummin { .. } => same_type(),
+            Cummax { .. } => same_type(),
             IsNotNull | IsNull | Not => with_dtype(DataType::Boolean),
             #[cfg(feature = "is_unique")]
             IsUnique | IsDuplicated => with_dtype(DataType::Boolean),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ahash",
  "bincode",


### PR DESCRIPTION
# Motivation

In the process of using `FunctionExpr` for all [computational functions](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/computation.html), this PR adopts them for the `cum*` functions:

- `cumcount`
- `cumsum`
- `cumprod`
- `cummin`
- `cummax`