### PR TITLE
feat(rust): move all boolean expressions into `BooleanFunction` enum

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
@@ -125,7 +125,7 @@ fn is_finite(s: &Series) -> PolarsResult<Series> {
 }
 
 fn is_infinite(s: &Series) -> PolarsResult<Series> {
-    s.is_finite().map(|ca| ca.into_series())
+    s.is_infinite().map(|ca| ca.into_series())
 }
 
 pub(super) fn is_nan(s: &Series) -> PolarsResult<Series> {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
@@ -1,0 +1,157 @@
+use std::ops::Not;
+
+use super::*;
+use crate::{map, wrap};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, PartialEq, Debug, Eq, Hash)]
+pub enum BooleanFunction {
+    All,
+    Any,
+    IsNot,
+    IsNull,
+    IsNotNull,
+    IsFinite,
+    IsInfinite,
+    IsNan,
+    IsNotNan,
+    #[cfg(feature = "is_first")]
+    IsFirst,
+    #[cfg(feature = "is_unique")]
+    IsUnique,
+    #[cfg(feature = "is_unique")]
+    IsDuplicated,
+    #[cfg(feature = "is_in")]
+    IsIn,
+}
+
+impl BooleanFunction {
+    pub(super) fn dtype_out(&self) -> DataType {
+        DataType::Boolean
+    }
+}
+
+impl Display for BooleanFunction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use BooleanFunction::*;
+        let s = match self {
+            All => "all",
+            Any => "any",
+            IsNot => "is_not",
+            IsNull => "is_null",
+            IsNotNull => "is_not_null",
+            IsFinite => "is_finite",
+            IsInfinite => "is_infinite",
+            IsNan => "is_nan",
+            IsNotNan => "is_not_nan",
+            #[cfg(feature = "is_first")]
+            IsFirst => "is_first",
+            #[cfg(feature = "is_unique")]
+            IsUnique => "is_unique",
+            #[cfg(feature = "is_unique")]
+            IsDuplicated => "is_duplicated",
+            #[cfg(feature = "is_in")]
+            IsIn => "is_in",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl From<BooleanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
+    fn from(func: BooleanFunction) -> Self {
+        use BooleanFunction::*;
+        match func {
+            All => map!(all),
+            Any => map!(any),
+            IsNot => map!(is_not),
+            IsNull => map!(is_null),
+            IsNotNull => map!(is_not_null),
+            IsFinite => map!(is_finite),
+            IsInfinite => map!(is_infinite),
+            IsNan => map!(is_nan),
+            IsNotNan => map!(is_not_nan),
+            #[cfg(feature = "is_first")]
+            IsFirst => map!(is_first),
+            #[cfg(feature = "is_unique")]
+            IsUnique => map!(is_unique),
+            #[cfg(feature = "is_unique")]
+            IsDuplicated => map!(is_duplicated),
+            #[cfg(feature = "is_in")]
+            IsIn => wrap!(is_in),
+        }
+    }
+}
+
+impl From<BooleanFunction> for FunctionExpr {
+    fn from(func: BooleanFunction) -> Self {
+        FunctionExpr::Boolean(func)
+    }
+}
+
+fn all(s: &Series) -> PolarsResult<Series> {
+    let boolean = s.bool()?;
+    if boolean.all() {
+        Ok(Series::new(s.name(), [true]))
+    } else {
+        Ok(Series::new(s.name(), [false]))
+    }
+}
+
+fn any(s: &Series) -> PolarsResult<Series> {
+    let boolean = s.bool()?;
+    if boolean.any() {
+        Ok(Series::new(s.name(), [true]))
+    } else {
+        Ok(Series::new(s.name(), [false]))
+    }
+}
+
+fn is_not(s: &Series) -> PolarsResult<Series> {
+    Ok(s.bool()?.not().into_series())
+}
+
+fn is_null(s: &Series) -> PolarsResult<Series> {
+    Ok(s.is_null().into_series())
+}
+
+fn is_not_null(s: &Series) -> PolarsResult<Series> {
+    Ok(s.is_not_null().into_series())
+}
+
+fn is_finite(s: &Series) -> PolarsResult<Series> {
+    s.is_finite().map(|ca| ca.into_series())
+}
+
+fn is_infinite(s: &Series) -> PolarsResult<Series> {
+    s.is_finite().map(|ca| ca.into_series())
+}
+
+pub(super) fn is_nan(s: &Series) -> PolarsResult<Series> {
+    s.is_nan().map(|ca| ca.into_series())
+}
+
+pub(super) fn is_not_nan(s: &Series) -> PolarsResult<Series> {
+    s.is_not_nan().map(|ca| ca.into_series())
+}
+
+#[cfg(feature = "is_first")]
+fn is_first(s: &Series) -> PolarsResult<Series> {
+    polars_ops::prelude::is_first(&s).map(|ca| ca.into_series())
+}
+
+#[cfg(feature = "is_unique")]
+fn is_unique(s: &Series) -> PolarsResult<Series> {
+    polars_ops::prelude::is_unique(s).map(|ca| ca.into_series())
+}
+
+#[cfg(feature = "is_unique")]
+fn is_duplicated(s: &Series) -> PolarsResult<Series> {
+    polars_ops::prelude::is_duplicated(s).map(|ca| ca.into_series())
+}
+
+#[cfg(feature = "is_in")]
+fn is_in(s: &mut [Series]) -> PolarsResult<Option<Series>> {
+    let left = &s[0];
+    let other = &s[1];
+    left.is_in(other).map(|ca| Some(ca.into_series()))
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
@@ -1,7 +1,9 @@
 use std::ops::Not;
 
 use super::*;
-use crate::{map, wrap};
+use crate::map;
+#[cfg(feature = "is_in")]
+use crate::wrap;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
@@ -136,7 +138,7 @@ pub(super) fn is_not_nan(s: &Series) -> PolarsResult<Series> {
 
 #[cfg(feature = "is_first")]
 fn is_first(s: &Series) -> PolarsResult<Series> {
-    polars_ops::prelude::is_first(&s).map(|ca| ca.into_series())
+    polars_ops::prelude::is_first(s).map(|ca| ca.into_series())
 }
 
 #[cfg(feature = "is_unique")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -1,5 +1,3 @@
-use std::ops::Not;
-
 use super::*;
 
 pub(super) fn shift(s: &Series, periods: i64) -> PolarsResult<Series> {
@@ -8,28 +6,6 @@ pub(super) fn shift(s: &Series, periods: i64) -> PolarsResult<Series> {
 
 pub(super) fn reverse(s: &Series) -> PolarsResult<Series> {
     Ok(s.reverse())
-}
-
-pub(super) fn is_null(s: &Series) -> PolarsResult<Series> {
-    Ok(s.is_null().into_series())
-}
-
-pub(super) fn is_not_null(s: &Series) -> PolarsResult<Series> {
-    Ok(s.is_not_null().into_series())
-}
-
-pub(super) fn is_not(s: &Series) -> PolarsResult<Series> {
-    Ok(s.bool()?.not().into_series())
-}
-
-#[cfg(feature = "is_unique")]
-pub(super) fn is_unique(s: &Series) -> PolarsResult<Series> {
-    polars_ops::prelude::is_unique(s).map(|ca| ca.into_series())
-}
-
-#[cfg(feature = "is_unique")]
-pub(super) fn is_duplicated(s: &Series) -> PolarsResult<Series> {
-    polars_ops::prelude::is_duplicated(s).map(|ca| ca.into_series())
 }
 
 #[cfg(feature = "diff")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/is_in.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/is_in.rs
@@ -1,8 +1,0 @@
-use super::*;
-
-pub(super) fn is_in(s: &mut [Series]) -> PolarsResult<Option<Series>> {
-    let left = &s[0];
-    let other = &s[1];
-
-    left.is_in(other).map(|ca| Some(ca.into_series()))
-}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -39,7 +39,7 @@ use polars_core::prelude::*;
 use serde::{Deserialize, Serialize};
 
 pub(crate) use self::binary::BinaryFunction;
-pub(super) use self::boolean::BooleanFunction;
+pub use self::boolean::BooleanFunction;
 #[cfg(feature = "temporal")]
 pub(super) use self::datetime::TemporalFunction;
 #[cfg(feature = "strings")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/nan.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/nan.rs
@@ -1,24 +1,4 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 use super::*;
-use crate::{map, map_owned};
-
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Debug, Eq, Hash)]
-pub enum NanFunction {
-    IsNan,
-    IsNotNan,
-    DropNans,
-}
-
-pub(super) fn is_nan(s: &Series) -> PolarsResult<Series> {
-    s.is_nan().map(|ca| ca.into_series())
-}
-
-pub(super) fn is_not_nan(s: &Series) -> PolarsResult<Series> {
-    s.is_not_nan().map(|ca| ca.into_series())
-}
 
 pub(super) fn drop_nans(s: Series) -> PolarsResult<Series> {
     match s.dtype() {
@@ -33,38 +13,5 @@ pub(super) fn drop_nans(s: Series) -> PolarsResult<Series> {
             ca.filter(&mask).map(|ca| ca.into_series())
         }
         _ => Ok(s),
-    }
-}
-
-impl NanFunction {
-    pub(crate) fn get_field(&self, fields: &[Field]) -> PolarsResult<Field> {
-        let with_dtype = |dtype: DataType| Ok(Field::new(fields[0].name(), dtype));
-        let map_dtype = |func: &dyn Fn(&DataType) -> DataType| {
-            let dtype = func(fields[0].data_type());
-            Ok(Field::new(fields[0].name(), dtype))
-        };
-        let same_type = || map_dtype(&|dtype| dtype.clone());
-
-        match self {
-            NanFunction::IsNan => with_dtype(DataType::Boolean),
-            NanFunction::IsNotNan => with_dtype(DataType::Boolean),
-            NanFunction::DropNans => same_type(),
-        }
-    }
-}
-
-impl From<NanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
-    fn from(nan_function: NanFunction) -> Self {
-        match nan_function {
-            NanFunction::IsNan => map!(is_nan),
-            NanFunction::IsNotNan => map!(is_not_nan),
-            NanFunction::DropNans => map_owned!(drop_nans),
-        }
-    }
-}
-
-impl From<NanFunction> for FunctionExpr {
-    fn from(nan_function: NanFunction) -> Self {
-        FunctionExpr::Nan(nan_function)
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -183,7 +183,7 @@ impl FunctionExpr {
             #[cfg(all(feature = "rolling_window", feature = "moment"))]
             RollingSkew { .. } => float_dtype(),
             ShiftAndFill { .. } => same_type(),
-            Nan(n) => n.get_field(fields),
+            DropNans => same_type(),
             #[cfg(feature = "round_series")]
             Clip { .. } => same_type(),
             ListExpr(l) => {
@@ -241,9 +241,7 @@ impl FunctionExpr {
             #[cfg(feature = "top_k")]
             TopK { .. } => same_type(),
             Shift(..) | Reverse => same_type(),
-            IsNotNull | IsNull | Not => with_dtype(DataType::Boolean),
-            #[cfg(feature = "is_unique")]
-            IsUnique | IsDuplicated => with_dtype(DataType::Boolean),
+            Boolean(f) => with_dtype(f.dtype_out()),
             #[cfg(feature = "diff")]
             Diff(_, _) => map_dtype(&|dt| match dt {
                 #[cfg(feature = "dtype-datetime")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -109,8 +109,6 @@ impl FunctionExpr {
             Coalesce => super_type(),
             #[cfg(feature = "row_hash")]
             Hash(..) => with_dtype(DataType::UInt64),
-            #[cfg(feature = "is_in")]
-            IsIn => with_dtype(DataType::Boolean),
             #[cfg(feature = "arg_where")]
             ArgWhere => with_dtype(IDX_DTYPE),
             #[cfg(feature = "search_sorted")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/unique.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/unique.rs
@@ -7,13 +7,3 @@ pub(super) fn unique(s: &Series, stable: bool) -> PolarsResult<Series> {
         s.unique()
     }
 }
-
-#[cfg(feature = "is_unique")]
-pub(super) fn is_unique(s: &Series) -> PolarsResult<Series> {
-    polars_ops::prelude::is_unique(s).map(|ca| ca.into_series())
-}
-
-#[cfg(feature = "is_unique")]
-pub(super) fn is_duplicated(s: &Series) -> PolarsResult<Series> {
-    polars_ops::prelude::is_duplicated(s).map(|ca| ca.into_series())
-}

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -268,7 +268,7 @@ impl Expr {
     /// Negate `Expr`
     #[allow(clippy::should_implement_trait)]
     pub fn not(self) -> Expr {
-        self.map_private(FunctionExpr::Not)
+        self.map_private(BooleanFunction::IsNot.into())
     }
 
     /// Rename Column.
@@ -279,13 +279,13 @@ impl Expr {
     /// Run is_null operation on `Expr`.
     #[allow(clippy::wrong_self_convention)]
     pub fn is_null(self) -> Self {
-        self.map_private(FunctionExpr::IsNull)
+        self.map_private(BooleanFunction::IsNull.into())
     }
 
     /// Run is_not_null operation on `Expr`.
     #[allow(clippy::wrong_self_convention)]
     pub fn is_not_null(self) -> Self {
-        self.map_private(FunctionExpr::IsNotNull)
+        self.map_private(BooleanFunction::IsNotNull.into())
     }
 
     /// Drop null values
@@ -295,7 +295,7 @@ impl Expr {
 
     /// Drop NaN values
     pub fn drop_nans(self) -> Self {
-        self.apply_private(NanFunction::DropNans.into())
+        self.apply_private(FunctionExpr::DropNans)
     }
 
     /// Reduce groups to minimal value.
@@ -860,31 +860,23 @@ impl Expr {
     /// Get mask of finite values if dtype is Float
     #[allow(clippy::wrong_self_convention)]
     pub fn is_finite(self) -> Self {
-        self.map(
-            |s: Series| s.is_finite().map(|ca| Some(ca.into_series())),
-            GetOutput::from_type(DataType::Boolean),
-        )
-        .with_fmt("is_finite")
+        self.map_private(BooleanFunction::IsFinite.into())
     }
 
     /// Get mask of infinite values if dtype is Float
     #[allow(clippy::wrong_self_convention)]
     pub fn is_infinite(self) -> Self {
-        self.map(
-            |s: Series| s.is_infinite().map(|ca| Some(ca.into_series())),
-            GetOutput::from_type(DataType::Boolean),
-        )
-        .with_fmt("is_infinite")
+        self.map_private(BooleanFunction::IsInfinite.into())
     }
 
     /// Get mask of NaN values if dtype is Float
     pub fn is_nan(self) -> Self {
-        self.map_private(NanFunction::IsNan.into())
+        self.map_private(BooleanFunction::IsNan.into())
     }
 
     /// Get inverse mask of NaN values if dtype is Float
     pub fn is_not_nan(self) -> Self {
-        self.map_private(NanFunction::IsNotNan.into())
+        self.map_private(BooleanFunction::IsNotNan.into())
     }
 
     /// Shift the values in the array by some period. See [the eager implementation](polars_core::series::SeriesTrait::shift).
@@ -1179,14 +1171,14 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_unique")]
     pub fn is_duplicated(self) -> Self {
-        self.apply_private(FunctionExpr::IsDuplicated)
+        self.apply_private(BooleanFunction::IsDuplicated.into())
     }
 
     /// Get a mask of unique values
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_unique")]
     pub fn is_unique(self) -> Self {
-        self.apply_private(FunctionExpr::IsUnique)
+        self.apply_private(BooleanFunction::IsUnique.into())
     }
 
     /// and operation
@@ -1236,9 +1228,9 @@ impl Expr {
         let arguments = &[other];
         // we don't have to apply on groups, so this is faster
         if has_literal {
-            self.map_many_private(FunctionExpr::IsIn, arguments, true)
+            self.map_many_private(BooleanFunction::IsIn.into(), arguments, true)
         } else {
-            self.apply_many_private(FunctionExpr::IsIn, arguments, true, true)
+            self.apply_many_private(BooleanFunction::IsIn.into(), arguments, true, true)
         }
     }
 
@@ -1286,11 +1278,7 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     /// Get a mask of the first unique value.
     pub fn is_first(self) -> Expr {
-        self.apply(
-            |s| polars_ops::prelude::is_first(&s).map(|s| Some(s.into_series())),
-            GetOutput::from_type(DataType::Boolean),
-        )
-        .with_fmt("is_first")
+        self.apply_private(BooleanFunction::IsFirst.into())
     }
 
     #[cfg(feature = "dot_product")]
@@ -1898,22 +1886,11 @@ impl Expr {
 
     /// Check if any boolean value is `true`
     pub fn any(self) -> Self {
-        self.apply(
-            move |s| {
-                let boolean = s.bool()?;
-                if boolean.any() {
-                    Ok(Some(Series::new(s.name(), [true])))
-                } else {
-                    Ok(Some(Series::new(s.name(), [false])))
-                }
-            },
-            GetOutput::from_type(DataType::Boolean),
-        )
-        .with_function_options(|mut opt| {
-            opt.fmt_str = "any";
-            opt.auto_explode = true;
-            opt
-        })
+        self.apply_private(BooleanFunction::Any.into())
+            .with_function_options(|mut opt| {
+                opt.auto_explode = true;
+                opt
+            })
     }
 
     /// Shrink numeric columns to the minimal required datatype
@@ -1925,22 +1902,11 @@ impl Expr {
 
     /// Check if all boolean values are `true`
     pub fn all(self) -> Self {
-        self.apply(
-            move |s| {
-                let boolean = s.bool()?;
-                if boolean.all() {
-                    Ok(Some(Series::new(s.name(), [true])))
-                } else {
-                    Ok(Some(Series::new(s.name(), [false])))
-                }
-            },
-            GetOutput::from_type(DataType::Boolean),
-        )
-        .with_function_options(|mut opt| {
-            opt.fmt_str = "all";
-            opt.auto_explode = true;
-            opt
-        })
+        self.apply_private(BooleanFunction::All.into())
+            .with_function_options(|mut opt| {
+                opt.auto_explode = true;
+                opt
+            })
     }
 
     #[cfg(feature = "dtype-struct")]

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/drop_nulls.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/drop_nulls.rs
@@ -40,7 +40,7 @@ impl OptimizationRule for ReplaceDropNulls {
                     matches!(
                         e,
                         &AExpr::Function {
-                            function: FunctionExpr::IsNotNull,
+                            function: FunctionExpr::Boolean(BooleanFunction::IsNotNull),
                             ..
                         }
                     )

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -408,7 +408,11 @@ impl PredicatePushDown {
                     // unique and duplicated can be caused by joins
                     #[cfg(feature = "is_unique")]
                     let matches = {
-                        |e: &AExpr| matches!(e, AExpr::Function{function: FunctionExpr::IsDuplicated | FunctionExpr::IsUnique, ..})
+                        |e: &AExpr| matches!(e, AExpr::Function{
+                            function: FunctionExpr::Boolean(BooleanFunction::IsDuplicated)
+                                | FunctionExpr::Boolean(BooleanFunction::IsUnique),
+                            ..
+                        })
                     };
                     #[cfg(not(feature = "is_unique"))]
                         let matches = {
@@ -417,7 +421,11 @@ impl PredicatePushDown {
 
 
                     let checks_nulls =
-                        |e: &AExpr| matches!(e, AExpr::Function{function: FunctionExpr::IsNotNull | FunctionExpr::IsNull, ..} ) ||
+                        |e: &AExpr| matches!(e, AExpr::Function{
+                            function: FunctionExpr::Boolean(BooleanFunction::IsNotNull)
+                                | FunctionExpr::Boolean(BooleanFunction::IsNull),
+                            ..
+                        }) ||
                             // any operation that checks for equality or ordering can be wrong because
                             // the join can produce null values
                             matches!(e, AExpr::BinaryExpr {op, ..} if !matches!(op, Operator::NotEq));

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -254,7 +254,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             }
             AExpr::Function {
                 input,
-                function: FunctionExpr::Not,
+                function: FunctionExpr::Boolean(BooleanFunction::IsNot),
                 ..
             } => {
                 let y = expr_arena.get(input[0]);
@@ -263,7 +263,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                     // not(not x) => x
                     AExpr::Function {
                         input,
-                        function: FunctionExpr::Not,
+                        function: FunctionExpr::Boolean(BooleanFunction::IsNot),
                         ..
                     } => Some(expr_arena.get(input[0]).clone()),
                     // not(lit x) => !x
@@ -556,7 +556,7 @@ impl OptimizationRule for SimplifyExprRule {
                     // null == column -> column.is_null()
                     (true, Eq, false) => Some(AExpr::Function {
                         input: vec![*right],
-                        function: FunctionExpr::IsNull,
+                        function: BooleanFunction::IsNull.into(),
                         options: FunctionOptions {
                             collect_groups: ApplyOptions::ApplyGroups,
                             ..Default::default()
@@ -565,7 +565,7 @@ impl OptimizationRule for SimplifyExprRule {
                     // column == null -> column.is_null()
                     (false, Eq, true) => Some(AExpr::Function {
                         input: vec![*left],
-                        function: FunctionExpr::IsNull,
+                        function: BooleanFunction::IsNull.into(),
                         options: FunctionOptions {
                             collect_groups: ApplyOptions::ApplyGroups,
                             ..Default::default()
@@ -574,7 +574,7 @@ impl OptimizationRule for SimplifyExprRule {
                     // null != column -> column.is_not_null()
                     (true, NotEq, false) => Some(AExpr::Function {
                         input: vec![*right],
-                        function: FunctionExpr::IsNotNull,
+                        function: BooleanFunction::IsNotNull.into(),
                         options: FunctionOptions {
                             collect_groups: ApplyOptions::ApplyGroups,
                             ..Default::default()
@@ -583,7 +583,7 @@ impl OptimizationRule for SimplifyExprRule {
                     // column != null -> column.is_not_null()
                     (false, NotEq, true) => Some(AExpr::Function {
                         input: vec![*left],
-                        function: FunctionExpr::IsNotNull,
+                        function: BooleanFunction::IsNotNull.into(),
                         options: FunctionOptions {
                             collect_groups: ApplyOptions::ApplyGroups,
                             ..Default::default()

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
@@ -333,7 +333,7 @@ impl OptimizationRule for TypeCoercionRule {
             } => return process_binary(expr_arena, lp_arena, lp_node, node_left, op, node_right),
             #[cfg(feature = "is_in")]
             AExpr::Function {
-                function: FunctionExpr::IsIn,
+                function: FunctionExpr::Boolean(BooleanFunction::IsIn),
                 ref input,
                 options,
             } => {
@@ -386,7 +386,7 @@ impl OptimizationRule for TypeCoercionRule {
                 input[1] = other_input;
 
                 Some(AExpr::Function {
-                    function: FunctionExpr::IsIn,
+                    function: FunctionExpr::Boolean(BooleanFunction::IsIn),
                     input,
                     options,
                 })

--- a/polars/polars-lazy/polars-plan/src/logical_plan/pyarrow.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/pyarrow.rs
@@ -84,7 +84,7 @@ pub(super) fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Opt
             }
         }
         AExpr::Function {
-            function: FunctionExpr::Not,
+            function: FunctionExpr::Boolean(BooleanFunction::IsNot),
             input,
             ..
         } => {
@@ -93,7 +93,7 @@ pub(super) fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Opt
             Some(format!("~({input})"))
         }
         AExpr::Function {
-            function: FunctionExpr::IsNull,
+            function: FunctionExpr::Boolean(BooleanFunction::IsNull),
             input,
             ..
         } => {
@@ -102,7 +102,7 @@ pub(super) fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Opt
             Some(format!("({input}).is_null()"))
         }
         AExpr::Function {
-            function: FunctionExpr::IsNotNull,
+            function: FunctionExpr::Boolean(BooleanFunction::IsNotNull),
             input,
             ..
         } => {

--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -312,9 +312,9 @@ impl PhysicalExpr for ApplyExpr {
         };
 
         match function {
-            FunctionExpr::IsNull => Some(self),
+            FunctionExpr::Boolean(BooleanFunction::IsNull) => Some(self),
             #[cfg(feature = "is_in")]
-            FunctionExpr::IsIn => Some(self),
+            FunctionExpr::Boolean(BooleanFunction::IsIn) => Some(self),
             _ => None,
         }
     }
@@ -409,7 +409,7 @@ impl ApplyExpr {
         };
 
         match function {
-            FunctionExpr::IsNull => {
+            FunctionExpr::Boolean(BooleanFunction::IsNull) => {
                 let root = expr_to_leaf_column_name(&self.expr)?;
 
                 match stats.get_stats(&root).ok() {
@@ -421,7 +421,7 @@ impl ApplyExpr {
                 }
             }
             #[cfg(feature = "is_in")]
-            FunctionExpr::IsIn => {
+            FunctionExpr::Boolean(BooleanFunction::IsIn) => {
                 let root = match expr_to_leaf_column_name(&input[0]) {
                     Ok(root) => root,
                     Err(_) => return Ok(true),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ahash",
  "bincode",


### PR DESCRIPTION
# Motivation

This PR makes all [boolean expressions](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/boolean.html) adopt `FunctionExpr` by establishing a new `FunctionExpr::Boolean(BooleanFunction)` case.

`BooleanFunction` subsumes...

- the existing cases `IsNull`, `IsNotNull`, `IsIn`, `Not` (renamed as `IsNot`)
- the nan cases `IsNan`, `IsNotNan` (thus, dropping the `NanFunction` enum and moving `DropNulls` to `FunctionExpr`)
- new cases `All`, `Any`, `IsFinite`, `IsInfinite`, `IsFirst`