### PR TITLE
fix(rust): CsvReader reading files with columns of unix millisecond timestamps got null values

### DIFF
--- a/polars/polars-io/src/csv/read.rs
+++ b/polars/polars-io/src/csv/read.rs
@@ -381,6 +381,11 @@ impl<'a, R: MmapBytesReader + 'a> CsvReader<'a, R> {
         let fields = overwriting_schema.iter_fields().filter_map(|mut fld| {
             use DataType::*;
             match fld.data_type() {
+                Date | Datetime(_, _) => {
+                    to_cast.push(fld);
+                    // let inference decide the column type
+                    None
+                }
                 Time => {
                     to_cast.push(fld);
                     // let inference decide the column type


### PR DESCRIPTION
It seems there was a code refactoring on polars-io csv module on version 0.23. The peice of code I add was existing in the version before refactoring (such as polars-io-0.22.7/src/csv.rs, line 497), but was removed during refactoring. I am not sure wether this removing was a code edit missing or some other considersions, but this does cause problems on unix timestamps parsing, and I think it is more proper to execuate user specified schema overwriting than omit it, so I add this peice of code back. The issues link is: [https://github.com/pola-rs/polars/issues/7899](url)