### PR TITLE
fix(rust,python): fix row-wise init of `UInt64` values that exceed `UInt64` upper bound

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -692,6 +692,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
         } else if let Ok(value) = ob.extract::<i64>() {
             Ok(AnyValue::Int64(value).into())
+        } else if let Ok(value) = ob.extract::<u64>() {
+            Ok(AnyValue::UInt64(value).into())
         } else if ob.is_instance_of::<PyFloat>()? {
             let value = ob.extract::<f64>().unwrap();
             Ok(AnyValue::Float64(value).into())
@@ -780,7 +782,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                         }
                     }
                     Err(PyErr::from(PyPolarsErr::Other(format!(
-                        "object type not supported {ob:?}",
+                        "given type/value not supported: {ob:?}",
                     ))))
                 }
             }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -692,8 +692,6 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
         } else if let Ok(value) = ob.extract::<i64>() {
             Ok(AnyValue::Int64(value).into())
-        } else if let Ok(value) = ob.extract::<u64>() {
-            Ok(AnyValue::UInt64(value).into())
         } else if ob.is_instance_of::<PyFloat>()? {
             let value = ob.extract::<f64>().unwrap();
             Ok(AnyValue::Float64(value).into())
@@ -717,6 +715,8 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
             Ok(Wrap(AnyValue::StructOwned(Box::new((vals, keys)))))
         } else if ob.is_instance_of::<PyList>()? {
             materialize_list(ob)
+        } else if let Ok(value) = ob.extract::<u64>() {
+            Ok(AnyValue::UInt64(value).into())
         } else if ob.hasattr("_s")? {
             let py_pyseries = ob.getattr("_s").unwrap();
             let series = py_pyseries.extract::<PySeries>().unwrap().series;

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -150,3 +150,12 @@ def test_row_constructor_schema() -> None:
         )
         assert out.dtypes == [primitive]
         assert out.to_dict(False) == expected
+
+
+def test_row_constructor_uint64() -> None:
+    # validate init with a valid UInt64 that exceeds Int64 upper bound
+    df = pl.DataFrame(
+        data=[[0], [int(2**63) + 1]],
+        schema={"x": pl.UInt64},
+    )
+    assert df.rows() == [(0,), (9223372036854775809,)]


### PR DESCRIPTION
Closes #8144.