### PR TITLE
fix(python): update some type hints

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -682,13 +682,13 @@ def sum(column: str | Sequence[Expr | str] | Expr) -> Expr:
 
 
 @overload
-def sum(column: Series) -> int | float:
+def sum(column: Series) -> int | float | timedelta | None:
     ...
 
 
 def sum(
     column: str | Sequence[Expr | str] | Series | Expr,
-) -> Expr | Any:
+) -> Expr | int | float | timedelta | None:
     """
     Sum values in a column/Series, or horizontally across list of columns/expressions.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1296,7 +1296,7 @@ class Series:
 
         return pli.DataFrame({"statistic": stats.keys(), "value": stats.values()})
 
-    def sum(self) -> int | float:
+    def sum(self) -> int | float | timedelta | None:
         """
         Reduce this Series to the sum value.
 
@@ -1314,7 +1314,7 @@ class Series:
         """
         return self._s.sum()
 
-    def mean(self) -> int | float | None:
+    def mean(self) -> float | None:
         """
         Reduce this Series to the mean value.
 
@@ -1327,9 +1327,18 @@ class Series:
         """
         return self._s.mean()
 
-    def product(self) -> int | float:
-        """Reduce this Series to the product value."""
-        return self.to_frame().select(F.col(self.name).product()).to_series()[0]
+    def product(self) -> int | float | None:
+        """
+        Reduce this Series to the product of its elements.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s.product()
+        6
+
+        """
+        return self.to_frame().select(F.col(self.name).product()).to_series().item()
 
     def pow(self, exponent: int | float | Series) -> Series:
         """
@@ -1388,7 +1397,7 @@ class Series:
         """
         return self._s.max()
 
-    def nan_max(self) -> int | float | date | datetime | timedelta | str:
+    def nan_max(self) -> PythonLiteral | None:
         """
         Get maximum value, but propagate/poison encountered NaN values.
 
@@ -1398,7 +1407,7 @@ class Series:
         """
         return self.to_frame().select(F.col(self.name).nan_max()).item()
 
-    def nan_min(self) -> int | float | date | datetime | timedelta | str:
+    def nan_min(self) -> PythonLiteral | None:
         """
         Get minimum value, but propagate/poison encountered NaN values.
 

--- a/py-polars/tests/benchmark/run_h2oai_benchmark.py
+++ b/py-polars/tests/benchmark/run_h2oai_benchmark.py
@@ -183,7 +183,7 @@ out = (
 print(time.time() - t0)
 assert out.shape == (95001, 3)
 assert out["v1_sum"].sum() == 28501451
-assert np.isclose(out["v3_mean"].sum(), 4751358.825104358)
+assert np.isclose(out["v3_mean"].sum(), 4751358.825104358)  # type: ignore[arg-type]
 
 t0 = time.time()
 print("q4")
@@ -200,9 +200,9 @@ out = (
 )
 print(time.time() - t0)
 assert out.shape == (96, 4)
-assert np.isclose(out["v1_mean"].sum(), 288.0192364601018)
-assert np.isclose(out["v2_mean"].sum(), 767.9422306545811)
-assert np.isclose(out["v3_mean"].sum(), 4801.784316931509)
+assert np.isclose(out["v1_mean"].sum(), 288.0192364601018)  # type: ignore[arg-type]
+assert np.isclose(out["v2_mean"].sum(), 767.9422306545811)  # type: ignore[arg-type]
+assert np.isclose(out["v3_mean"].sum(), 4801.784316931509)  # type: ignore[arg-type]
 
 t0 = time.time()
 print("q5")
@@ -233,8 +233,8 @@ out = (
 )
 print(time.time() - t0)
 assert out.shape == (9216, 4)
-assert np.isclose(out["v3_median"].sum(), 460892.5487690001)
-assert np.isclose(out["v3_std"].sum(), 266052.20492321637)
+assert np.isclose(out["v3_median"].sum(), 460892.5487690001)  # type: ignore[arg-type]
+assert np.isclose(out["v3_std"].sum(), 266052.20492321637)  # type: ignore[arg-type]
 
 t0 = time.time()
 print("q7")
@@ -265,14 +265,14 @@ out = (
 )
 print(time.time() - t0)
 assert out.shape == (190002, 2)
-assert np.isclose(out["largest2_v3"].sum(), 18700642.66837202)
+assert np.isclose(out["largest2_v3"].sum(), 18700642.66837202)  # type: ignore[arg-type]
 
 t0 = time.time()
 print("q9")
 out = x.groupby(["id2", "id4"]).agg((pl.corr("v1", "v2") ** 2).alias("r2")).collect()
 print(time.time() - t0)
 assert out.shape == (9216, 3)
-assert np.isclose(out["r2"].sum(), 9.902706276948825)
+assert np.isclose(out["r2"].sum(), 9.902706276948825)  # type: ignore[arg-type]
 
 t0 = time.time()
 print("q10")

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -143,9 +143,9 @@ def test_strategy_null_probability(
     for obj in (s, df1, df2, df3):
         assert len(obj) == 50  # type: ignore[arg-type]
 
-    assert s.null_count() < df1.null_count().fold(sum).sum()
-    assert df1.null_count().fold(sum).sum() < df2.null_count().fold(sum).sum()
-    assert df2.null_count().fold(sum).sum() < df3.null_count().fold(sum).sum()
+    assert s.null_count() < df1.null_count().fold(sum).sum()  # type: ignore[operator]
+    assert df1.null_count().fold(sum).sum() < df2.null_count().fold(sum).sum()  # type: ignore[operator]
+    assert df2.null_count().fold(sum).sum() < df3.null_count().fold(sum).sum()  # type: ignore[operator]
 
     nulls_col0, nulls_col1 = df2.null_count().rows()[0]
     assert nulls_col0 > nulls_col1

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1123,7 +1123,7 @@ def test_lazy_functions() -> None:
     assert np.isclose(pl.min(df["b"]), expected)  # type: ignore[arg-type]
     expected = 6
     assert np.isclose(out.to_series(4), expected)
-    assert np.isclose(pl.sum(df["b"]), expected)
+    assert np.isclose(pl.sum(df["b"]), expected)  # type: ignore[arg-type]
     expected = 2
     assert np.isclose(out.to_series(5), expected)
     assert np.isclose(pl.mean(df["b"]), expected)
@@ -3683,7 +3683,7 @@ def test_rolling_apply() -> None:
         window_size=3, weights=[1.0, 2.1, 3.2], min_periods=2, center=True
     )
 
-    assert (roll_app_sum - roll_sum).abs().sum() < 0.0001
+    assert (roll_app_sum - roll_sum).abs().sum() < 0.0001  # type: ignore[operator]
 
     s = pl.Series("A", list(range(6)), dtype=pl.Float64)
     roll_app_std = s.rolling_apply(
@@ -3698,7 +3698,7 @@ def test_rolling_apply() -> None:
         window_size=4, weights=[1.0, 2.0, 3.0, 0.1], min_periods=3, center=False
     )
 
-    assert (roll_app_std - roll_std).abs().sum() < 0.0001
+    assert (roll_app_std - roll_std).abs().sum() < 0.0001  # type: ignore[operator]
 
 
 def test_ufunc() -> None:


### PR DESCRIPTION
I noticed some aggregate functions were missing the `None` result type that happens when input data does not contain any valid values (e.g. `pl.Series([None, None])`).

Can someone explain why we want to return `None` in these cases? It's quite annoying to check for - we have some loop where we check that the sum of some column is greater than X. Now we have to also handle possible `None` outputs.

EDIT: Yep, `mypy` complains a lot after these changes - and it makes sense. We have to handle `None` outputs explicitly in a lot of tests. Why do we even want this?

@ritchie46 could you shed some light on the logic here? Why do empty Series return `None` for aggregate functions?