### PR TITLE
fix(python): Address a ~15% regression in `import polars` speed

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import contextlib
-import math
 import os
 import random
 import typing
@@ -6281,6 +6280,8 @@ class DataFrame:
         └────────┴────────┴────────┴────────┴────────┴────────┘
 
         """
+        import math
+
         df = self.select(columns) if columns is not None else self
 
         height = df.height

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-import importlib
 import sys
 
 from polars.utils.meta import get_index_type
 from polars.utils.polars_version import get_polars_version
-
-# metadata module must be imported explicitly
-if sys.version_info >= (3, 8):
-    import importlib.metadata
 
 
 def show_versions() -> None:
@@ -67,6 +62,13 @@ def _get_dependency_info() -> dict[str, str]:
 
 
 def _get_dependency_version(dep_name: str) -> str:
+    # note: we import 'importlib' here as a significiant optimisation for initial import
+    import importlib
+
+    if sys.version_info >= (3, 8):
+        # importlib.metadata was introduced in Python 3.8;
+        # metadata submodule must be imported explicitly
+        import importlib.metadata
     try:
         module = importlib.import_module(dep_name)
     except ImportError:
@@ -75,7 +77,6 @@ def _get_dependency_version(dep_name: str) -> str:
     if hasattr(module, "__version__"):
         module_version = module.__version__
     elif sys.version_info >= (3, 8):
-        # importlib.metadata was introduced in Python 3.8
         module_version = importlib.metadata.version(dep_name)
     else:
         module_version = "<version not detected>"


### PR DESCRIPTION
The `importlib.metadata` import for `show_versions` is actually quite heavy; moved it inside the relevant function so it isn't triggered until it's needed.

```bash
python -X importtime -c "import polars" 2> importpolars.log
tuna importpolars.log       
```
```
┌─────────────────────────────────────────────┬──────────┬────────────┐
│ import                                      ┆ own_time ┆ cumulative │
│ ---                                         ┆ ---      ┆ ---        │
│ str                                         ┆ i32      ┆ i32        │
╞═════════════════════════════════════════════╪══════════╪════════════╡
│ ---// <snip!> //---                         ┆ -        ┆ -          │
│ polars.utils                                ┆ 349      ┆ 66288      │
│   polars.utils.show_versions                ┆ 289      ┆ 62725      │
│     importlib.metadata  <<<----             ┆ 1275     ┆ 62436      │
│       importlib.abc                         ┆ 1954     ┆ 17239      │
│         importlib.resources.abc             ┆ 11       ┆ 15286      │
│           importlib.resources               ┆ 1687     ┆ 15275      │
│             importlib.resources._legacy     ┆ 844      ┆ 844        │
│             importlib.resources._common     ┆ 1778     ┆ 12744      │
│               importlib.resources._adapters ┆ 1957     ┆ 1957       │
│               importlib.resources.abc       ┆ 3707     ┆ 3707       │
│               tempfile                      ┆ 1932     ┆ 5304       │
│                 weakref                     ┆ 3373     ┆ 3373       │
│       importlib.metadata._itertools         ┆ 2709     ┆ 2709       │
│       importlib.metadata._collections       ┆ 882      ┆ 882        │
│       importlib.metadata._meta              ┆ 913      ┆ 913        │
│       importlib.metadata._adapters          ┆ 895      ┆ 7708       │
│         importlib.metadata._text            ┆ 1731     ┆ 2250       │
│           importlib.metadata._functools     ┆ 520      ┆ 520        │
│         email.message                       ┆ 818      ┆ 4563       │
│           email.iterators                   ┆ 487      ┆ 487        │
│           email._encoded_words              ┆ 712      ┆ 712        │
│           email._policybase                 ┆ 1562     ┆ 2548       │
│             email.header                    ┆ 986      ┆ 986        │
│       textwrap                              ┆ 1710     ┆ 1710       │
│       zipfile                               ┆ 1778     ┆ 27633      │
│         threading                           ┆ 6860     ┆ 8665       │
│           _weakrefset                       ┆ 1806     ┆ 1806       │
│         shutil                              ┆ 1181     ┆ 17191      │
│           lzma                              ┆ 546      ┆ 11969      │
│             _lzma                           ┆ 11424    ┆ 11424      │
│           bz2                               ┆ 577      ┆ 2726       │
│             _bz2                            ┆ 1673     ┆ 1673       │
│             _compression                    ┆ 477      ┆ 477        │
│           zlib                              ┆ 1316     ┆ 1316       │
│       csv                                   ┆ 880      ┆ 2371       │
│         _csv                                ┆ 1492     ┆ 1492       │
```