### PR TITLE
feat(rust): implement `FunctionExpr` for bound and round methods

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/bounds.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/bounds.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+pub(super) fn upper_bound(s: &Series) -> PolarsResult<Series> {
+    let name = s.name();
+    use DataType::*;
+    let s = match s.dtype().to_physical() {
+        #[cfg(feature = "dtype-i8")]
+        Int8 => Series::new(name, &[i8::MAX]),
+        #[cfg(feature = "dtype-i16")]
+        Int16 => Series::new(name, &[i16::MAX]),
+        Int32 => Series::new(name, &[i32::MAX]),
+        Int64 => Series::new(name, &[i64::MAX]),
+        #[cfg(feature = "dtype-u8")]
+        UInt8 => Series::new(name, &[u8::MAX]),
+        #[cfg(feature = "dtype-u16")]
+        UInt16 => Series::new(name, &[u16::MAX]),
+        UInt32 => Series::new(name, &[u32::MAX]),
+        UInt64 => Series::new(name, &[u64::MAX]),
+        Float32 => Series::new(name, &[f32::INFINITY]),
+        Float64 => Series::new(name, &[f64::INFINITY]),
+        dt => polars_bail!(
+            ComputeError: "cannot determine upper bound for dtype `{}`", dt,
+        ),
+    };
+    Ok(s)
+}
+
+pub(super) fn lower_bound(s: &Series) -> PolarsResult<Series> {
+    let name = s.name();
+    use DataType::*;
+    let s = match s.dtype().to_physical() {
+        #[cfg(feature = "dtype-i8")]
+        Int8 => Series::new(name, &[i8::MIN]),
+        #[cfg(feature = "dtype-i16")]
+        Int16 => Series::new(name, &[i16::MIN]),
+        Int32 => Series::new(name, &[i32::MIN]),
+        Int64 => Series::new(name, &[i64::MIN]),
+        #[cfg(feature = "dtype-u8")]
+        UInt8 => Series::new(name, &[u8::MIN]),
+        #[cfg(feature = "dtype-u16")]
+        UInt16 => Series::new(name, &[u16::MIN]),
+        UInt32 => Series::new(name, &[u32::MIN]),
+        UInt64 => Series::new(name, &[u64::MIN]),
+        Float32 => Series::new(name, &[f32::NEG_INFINITY]),
+        Float64 => Series::new(name, &[f64::NEG_INFINITY]),
+        dt => polars_bail!(
+            ComputeError: "cannot determine lower bound for dtype `{}`", dt,
+        ),
+    };
+    Ok(s)
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -4,6 +4,7 @@ mod abs;
 mod arg_where;
 mod binary;
 mod boolean;
+mod bounds;
 #[cfg(feature = "round_series")]
 mod clip;
 mod cum;
@@ -18,6 +19,8 @@ mod nan;
 mod pow;
 #[cfg(all(feature = "rolling_window", feature = "moment"))]
 mod rolling;
+#[cfg(feature = "round_series")]
+mod round;
 #[cfg(feature = "row_hash")]
 mod row_hash;
 mod schema;
@@ -146,6 +149,16 @@ pub enum FunctionExpr {
     #[cfg(feature = "log")]
     Exp,
     Unique(bool),
+    #[cfg(feature = "round_series")]
+    Round {
+        decimals: u32,
+    },
+    #[cfg(feature = "round_series")]
+    Floor,
+    #[cfg(feature = "round_series")]
+    Ceil,
+    UpperBound,
+    LowerBound,
 }
 
 impl Display for FunctionExpr {
@@ -222,6 +235,14 @@ impl Display for FunctionExpr {
                     "unique"
                 }
             }
+            #[cfg(feature = "round_series")]
+            Round { .. } => "round",
+            #[cfg(feature = "round_series")]
+            Floor => "floor",
+            #[cfg(feature = "round_series")]
+            Ceil => "ceil",
+            UpperBound => "upper_bound",
+            LowerBound => "lower_bound",
         };
         write!(f, "{s}")
     }
@@ -418,6 +439,14 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "log")]
             Exp => map!(log::exp),
             Unique(stable) => map!(unique::unique, stable),
+            #[cfg(feature = "round_series")]
+            Round { decimals } => map!(round::round, decimals),
+            #[cfg(feature = "round_series")]
+            Floor => map!(round::floor),
+            #[cfg(feature = "round_series")]
+            Ceil => map!(round::ceil),
+            UpperBound => map!(bounds::upper_bound),
+            LowerBound => map!(bounds::lower_bound),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/round.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/round.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+pub(super) fn round(s: &Series, decimals: u32) -> PolarsResult<Series> {
+    s.round(decimals)
+}
+
+pub(super) fn floor(s: &Series) -> PolarsResult<Series> {
+    s.floor()
+}
+
+pub(super) fn ceil(s: &Series) -> PolarsResult<Series> {
+    s.ceil()
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -296,6 +296,9 @@ impl FunctionExpr {
             #[cfg(feature = "log")]
             Entropy { .. } | Log { .. } | Log1p | Exp => float_dtype(),
             Unique(_) => same_type(),
+            #[cfg(feature = "round_series")]
+            Round { .. } | Floor | Ceil => same_type(),
+            UpperBound | LowerBound => same_type(),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -959,25 +959,19 @@ impl Expr {
     /// Round underlying floating point array to given decimal numbers.
     #[cfg(feature = "round_series")]
     pub fn round(self, decimals: u32) -> Self {
-        self.map(
-            move |s: Series| s.round(decimals).map(Some),
-            GetOutput::same_type(),
-        )
-        .with_fmt("round")
+        self.map_private(FunctionExpr::Round { decimals })
     }
 
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.
     #[cfg(feature = "round_series")]
     pub fn floor(self) -> Self {
-        self.map(move |s: Series| s.floor().map(Some), GetOutput::same_type())
-            .with_fmt("floor")
+        self.map_private(FunctionExpr::Floor)
     }
 
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     #[cfg(feature = "round_series")]
     pub fn ceil(self) -> Self {
-        self.map(move |s: Series| s.ceil().map(Some), GetOutput::same_type())
-            .with_fmt("ceil")
+        self.map_private(FunctionExpr::Ceil)
     }
 
     /// Clip underlying values to a set boundary.
@@ -1655,66 +1649,12 @@ impl Expr {
 
     /// Get maximal value that could be hold by this dtype.
     pub fn upper_bound(self) -> Expr {
-        self.map(
-            |s| {
-                let name = s.name();
-                use DataType::*;
-                let s = match s.dtype().to_physical() {
-                    #[cfg(feature = "dtype-i8")]
-                    Int8 => Series::new(name, &[i8::MAX]),
-                    #[cfg(feature = "dtype-i16")]
-                    Int16 => Series::new(name, &[i16::MAX]),
-                    Int32 => Series::new(name, &[i32::MAX]),
-                    Int64 => Series::new(name, &[i64::MAX]),
-                    #[cfg(feature = "dtype-u8")]
-                    UInt8 => Series::new(name, &[u8::MAX]),
-                    #[cfg(feature = "dtype-u16")]
-                    UInt16 => Series::new(name, &[u16::MAX]),
-                    UInt32 => Series::new(name, &[u32::MAX]),
-                    UInt64 => Series::new(name, &[u64::MAX]),
-                    Float32 => Series::new(name, &[f32::INFINITY]),
-                    Float64 => Series::new(name, &[f64::INFINITY]),
-                    dt => polars_bail!(
-                        ComputeError: "cannot determine upper bound for dtype `{}`", dt,
-                    ),
-                };
-                Ok(Some(s))
-            },
-            GetOutput::same_type(),
-        )
-        .with_fmt("upper_bound")
+        self.map_private(FunctionExpr::UpperBound)
     }
 
     /// Get minimal value that could be hold by this dtype.
     pub fn lower_bound(self) -> Expr {
-        self.map(
-            |s| {
-                let name = s.name();
-                use DataType::*;
-                let s = match s.dtype().to_physical() {
-                    #[cfg(feature = "dtype-i8")]
-                    Int8 => Series::new(name, &[i8::MIN]),
-                    #[cfg(feature = "dtype-i16")]
-                    Int16 => Series::new(name, &[i16::MIN]),
-                    Int32 => Series::new(name, &[i32::MIN]),
-                    Int64 => Series::new(name, &[i64::MIN]),
-                    #[cfg(feature = "dtype-u8")]
-                    UInt8 => Series::new(name, &[u8::MIN]),
-                    #[cfg(feature = "dtype-u16")]
-                    UInt16 => Series::new(name, &[u16::MIN]),
-                    UInt32 => Series::new(name, &[u32::MIN]),
-                    UInt64 => Series::new(name, &[u64::MIN]),
-                    Float32 => Series::new(name, &[f32::NEG_INFINITY]),
-                    Float64 => Series::new(name, &[f64::NEG_INFINITY]),
-                    dt => polars_bail!(
-                        ComputeError: "cannot determine lower bound for dtype `{}`", dt,
-                    ),
-                };
-                Ok(Some(s))
-            },
-            GetOutput::same_type(),
-        )
-        .with_fmt("lower_bound")
+        self.map_private(FunctionExpr::LowerBound)
     }
 
     pub fn reshape(self, dims: &[i64]) -> Self {


### PR DESCRIPTION
# Motivation

This PR removes all uses of `self.map` in `polars/polars-lazy/polars-plan/src/dsl/mod.rs`. A follow-up PR could clean up all such uses such that we can solely rely on `self.map_private`.