### PR TITLE
feat(python): support `DataFrame` init from `pydantic` model data

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -8,13 +8,14 @@ from importlib.util import find_spec
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Hashable, cast
 
+_DELTALAKE_AVAILABLE = True
 _FSSPEC_AVAILABLE = True
+_HYPOTHESIS_AVAILABLE = True
 _NUMPY_AVAILABLE = True
 _PANDAS_AVAILABLE = True
 _PYARROW_AVAILABLE = True
+_PYDANTIC_AVAILABLE = True
 _ZONEINFO_AVAILABLE = True
-_HYPOTHESIS_AVAILABLE = True
-_DELTALAKE_AVAILABLE = True
 
 
 class _LazyModule(ModuleType):
@@ -154,6 +155,7 @@ if TYPE_CHECKING:
     import numpy
     import pandas
     import pyarrow
+    import pydantic
 
     if sys.version_info >= (3, 9):
         import zoneinfo
@@ -167,13 +169,14 @@ else:
     pickle, _ = _lazy_import("pickle")
     subprocess, _ = _lazy_import("subprocess")
 
-    # heavy third party libs
+    # heavy/optional third party libs
     deltalake, _DELTALAKE_AVAILABLE = _lazy_import("deltalake")
     fsspec, _FSSPEC_AVAILABLE = _lazy_import("fsspec")
     hypothesis, _HYPOTHESIS_AVAILABLE = _lazy_import("hypothesis")
     numpy, _NUMPY_AVAILABLE = _lazy_import("numpy")
     pandas, _PANDAS_AVAILABLE = _lazy_import("pandas")
     pyarrow, _PYARROW_AVAILABLE = _lazy_import("pyarrow")
+    pydantic, _PYDANTIC_AVAILABLE = _lazy_import("pydantic")
     zoneinfo, _ZONEINFO_AVAILABLE = (
         _lazy_import("zoneinfo")
         if sys.version_info >= (3, 9)
@@ -203,6 +206,10 @@ def _check_for_pyarrow(obj: Any) -> bool:
     return _PYARROW_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pyarrow")
 
 
+def _check_for_pydantic(obj: Any) -> bool:
+    return _PYDANTIC_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pydantic")
+
+
 __all__ = [
     # lazy-load rarely-used/heavy builtins (for fast startup)
     "dataclasses",
@@ -215,12 +222,14 @@ __all__ = [
     "fsspec",
     "numpy",
     "pandas",
+    "pydantic",
     "pyarrow",
     "zoneinfo",
     # lazy utilities
     "_check_for_numpy",
     "_check_for_pandas",
     "_check_for_pyarrow",
+    "_check_for_pydantic",
     "_LazyModule",
     # exported flags/guards
     "_DELTALAKE_AVAILABLE",

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -70,21 +70,19 @@ disable_error_code = [
 
 [[tool.mypy.overrides]]
 module = [
+  "IPython.*",
   "backports",
-  "pyarrow.*",
-  "polars.polars",
-  "matplotlib.*",
-  "fsspec.*",
   "connectorx",
   "deltalake",
-  "IPython.*",
-  "xlsx2csv",
-  "xlsxwriter",
-  "xlsxwriter.format",
-  "xlsxwriter.utility",
-  "xlsxwriter.worksheet",
-  "zoneinfo",
+  "fsspec.*",
+  "matplotlib.*",
+  "polars.polars",
+  "pyarrow.*",
+  "pydantic",
   "sqlalchemy",
+  "xlsx2csv",
+  "xlsxwriter.*",
+  "zoneinfo",
 ]
 ignore_missing_imports = true
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -9,6 +9,7 @@ deltalake >= 0.8.0
 numpy
 pandas
 pyarrow
+pydantic
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 xlsx2csv


### PR DESCRIPTION
Closes #8154.

This was a simple addition; `pydantic` model data is largely equivalent to `@dataclass` or `NamedTuple` data, which we already support. Only needed a few minor tweaks to leverage the existing code.

No additional dependencies (except for unit tests).
Integration is entirely optional/lazy.

## Example

```python
from pydantic import BaseModel
import polars as pl

class Shipment( BaseModel ):
    exporter: str
    importer: str
    tonnes: int
    
shipments = [
    Shipment( exporter="Sri Lanka", importer="USA", tonnes=10 ),
    Shipment( exporter="India", importer="UK", tonnes=25 ),
    Shipment( exporter="China", importer="UK", tonnes=40 ),
]

pl.DataFrame( shipments )

# shape: (3, 3)
# ┌───────────┬──────────┬────────┐
# │ exporter  ┆ importer ┆ tonnes │
# │ ---       ┆ ---      ┆ ---    │
# │ str       ┆ str      ┆ i64    │
# ╞═══════════╪══════════╪════════╡
# │ Sri Lanka ┆ USA      ┆ 10     │
# │ India     ┆ UK       ┆ 25     │
# │ China     ┆ UK       ┆ 40     │
# └───────────┴──────────┴────────┘
```