### PR TITLE
perf(python): ~2-3x speedup for `DataFrame` init from `pydantic` models

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1068,16 +1068,15 @@ def _sequence_of_dataclasses_to_pydf(
             schema_override[col] = Utf8
 
     if from_model:
-        pydf = PyDataFrame.read_dicts([md.dict() for md in data], infer_schema_length)
+        rows = [tuple(md.__dict__.values()) for md in data]
     else:
-        pydf = PyDataFrame.read_rows(
-            [astuple(dc) for dc in data],
-            infer_schema_length,
-            schema_override or None,
-        )
+        rows = [astuple(dc) for dc in data]
+
+    pydf = PyDataFrame.read_rows(rows, infer_schema_length, schema_override or None)
     if schema_override:
         structs = {c: tp for c, tp in schema_override.items() if isinstance(tp, Struct)}
         pydf = _post_apply_columns(pydf, column_names, structs, schema_overrides)
+
     return pydf
 
 


### PR DESCRIPTION
Large optimisation for the [earlier](https://github.com/pola-rs/polars/pull/8178) `pydantic` PR - didn't seem fast enough to me, so I dug around in the source to better understand what was going on and found what appears to be the optimal loading path; this update makes it 2-3x faster.