### PR TITLE
feat(python): support `DataFrame` init from nested `dataclass`, `pydantic`, and `NamedTuple` objects

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
-from functools import singledispatch
+from functools import lru_cache, partial, singledispatch
 from itertools import islice, zip_longest
 from sys import version_info
 from typing import (
@@ -85,16 +85,29 @@ else:
         return getattr(obj, "__annotations__", {})
 
 
-def is_namedtuple(value: Any, annotated: bool = False) -> bool:
-    """Check whether value is a NamedTuple."""
-    if all(hasattr(value, attr) for attr in ("_fields", "_field_defaults", "_replace")):
-        return len(value.__annotations__) == len(value._fields) if annotated else True
+@lru_cache(64)
+def is_namedtuple(cls: Any, annotated: bool = False) -> bool:
+    """Check whether given class derives from NamedTuple."""
+    if all(hasattr(cls, attr) for attr in ("_fields", "_field_defaults", "_replace")):
+        if len(cls.__annotations__) == len(cls._fields) if annotated else True:
+            return all(isinstance(fld, str) for fld in cls._fields)
     return False
 
 
 def is_pydantic_model(value: Any) -> bool:
-    """Check whether value is a pydantic.BaseModel."""
+    """Check whether value derives from a pydantic.BaseModel."""
     return _check_for_pydantic(value) and isinstance(value, pydantic.BaseModel)
+
+
+def contains_nested(value: Any, is_nested: Callable[[Any], bool]) -> bool:
+    """Determine if value contains (or is) nested structured data."""
+    if is_nested(value):
+        return True
+    elif isinstance(value, dict):
+        return any(contains_nested(v, is_nested) for v in value.values())
+    elif isinstance(value, (list, tuple)):
+        return any(contains_nested(v, is_nested) for v in value)
+    return False
 
 
 def include_unknowns(
@@ -105,6 +118,20 @@ def include_unknowns(
         col: (schema.get(col, Unknown) or Unknown)  # type: ignore[truthy-bool]
         for col in cols
     }
+
+
+def nt_unpack(obj: Any) -> Any:
+    """Recursively unpack a nested NamedTuple."""
+    if isinstance(obj, dict):
+        return {key: nt_unpack(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [nt_unpack(value) for value in obj]
+    elif is_namedtuple(obj):
+        return {key: nt_unpack(value) for key, value in obj._asdict().items()}
+    elif isinstance(obj, tuple):
+        return tuple(nt_unpack(value) for value in obj)
+    else:
+        return obj
 
 
 ################################
@@ -325,8 +352,8 @@ def sequence_to_pyseries(
     if value is not None:
         if (
             dataclasses.is_dataclass(value)
-            or is_namedtuple(value, annotated=True)
             or is_pydantic_model(value)
+            or is_namedtuple(value.__class__, annotated=True)
         ):
             return pli.DataFrame(values).to_struct(name)._s
         elif isinstance(value, range):
@@ -819,10 +846,10 @@ def _sequence_to_pydf_dispatcher(
         to_pydf = _sequence_of_pandas_to_pydf
 
     elif dataclasses.is_dataclass(first_element):
-        to_pydf = _sequence_of_dataclasses_to_pydf
+        to_pydf = _dataclasses_or_models_to_pydf
 
     elif is_pydantic_model(first_element):
-        to_pydf = _sequence_of_models_to_pydf
+        to_pydf = partial(_dataclasses_or_models_to_pydf, pydantic_model=True)
     else:
         to_pydf = _sequence_of_elements_to_pydf
 
@@ -860,21 +887,30 @@ def _sequence_of_sequence_to_pydf(
         column_names, schema_overrides = _unpack_schema(
             schema, schema_overrides=schema_overrides, n_expected=len(first_element)
         )
-        schema_override = (
+        local_schema_override = (
             include_unknowns(schema_overrides, column_names) if schema_overrides else {}
         )
         if column_names and len(first_element) != len(column_names):
             raise ShapeError("The row data does not match the number of columns")
 
-        for col, tp in schema_override.items():
+        unpack_nested_namedtuple = False
+        for col, tp in local_schema_override.items():
             if tp == Categorical:
-                schema_override[col] = Utf8
+                local_schema_override[col] = Utf8
+            elif tp == Unknown and not unpack_nested_namedtuple:
+                unpack_nested_namedtuple = contains_nested(
+                    getattr(first_element, col, None), is_namedtuple
+                )
 
-        pydf = PyDataFrame.read_rows(
-            data,
-            infer_schema_length,
-            schema_override or None,
-        )
+        if unpack_nested_namedtuple:
+            dicts = [nt_unpack(d) for d in data]
+            pydf = PyDataFrame.read_dicts(dicts, infer_schema_length)
+        else:
+            pydf = PyDataFrame.read_rows(
+                data,
+                infer_schema_length,
+                local_schema_override or None,
+            )
         if column_names or schema_overrides:
             pydf = _post_apply_columns(
                 pydf, column_names, schema_overrides=schema_overrides
@@ -907,11 +943,10 @@ def _sequence_of_tuple_to_pydf(
     orient: Orientation | None,
     infer_schema_length: int | None,
 ) -> PyDataFrame:
-    # infer additional meta information if named tuple or pydantic model...
-    named_tuple = is_namedtuple(first_element)
-    if named_tuple or is_pydantic_model(first_element):
+    # infer additional meta information if named tuple
+    if is_namedtuple(first_element.__class__):
         if schema is None:
-            schema = first_element._fields if named_tuple else list(data.__fields__)  # type: ignore[attr-defined]
+            schema = first_element._fields  # type: ignore[attr-defined]
             if len(first_element.__annotations__) == len(schema):
                 schema = [
                     (name, py_type_to_dtype(tp, raise_unmatched=False))
@@ -1018,7 +1053,7 @@ def _sequence_of_pandas_to_pydf(
     return PyDataFrame(data_series)
 
 
-def _sequence_of_models_to_pydf(
+def _dataclasses_or_models_to_pydf(
     first_element: Any,
     data: Sequence[Any],
     schema: SchemaDefinition | None,
@@ -1026,28 +1061,11 @@ def _sequence_of_models_to_pydf(
     infer_schema_length: int | None,
     **kwargs: Any,
 ) -> PyDataFrame:
-    kwargs["pydantic_model"] = True
-    return _sequence_of_dataclasses_to_pydf(
-        first_element=first_element,
-        data=data,
-        schema=schema,
-        schema_overrides=schema_overrides,
-        infer_schema_length=infer_schema_length,
-        **kwargs,
-    )
-
-
-def _sequence_of_dataclasses_to_pydf(
-    first_element: Any,
-    data: Sequence[Any],
-    schema: SchemaDefinition | None,
-    schema_overrides: SchemaDict | None,
-    infer_schema_length: int | None,
-    **kwargs: Any,
-) -> PyDataFrame:
-    from dataclasses import astuple
+    """Initialise DataFrame from python dataclass and/or pydantic model objects."""
+    from dataclasses import asdict, astuple
 
     from_model = kwargs.get("pydantic_model")
+    unpack_nested = False
     if schema:
         column_names, schema_overrides = _unpack_schema(schema, schema_overrides)
         schema_override = {
@@ -1058,21 +1076,37 @@ def _sequence_of_dataclasses_to_pydf(
         schema_override = {
             col: (py_type_to_dtype(tp, raise_unmatched=False) or Unknown)
             for col, tp in type_hints(first_element.__class__).items()
+            if col != "__slots__"
         }
-        if from_model:
-            schema_override.pop("__slots__", None)
         schema_override.update(schema_overrides or {})
 
     for col, tp in schema_override.items():
         if tp == Categorical:
             schema_override[col] = Utf8
+        elif tp == Unknown and not unpack_nested:
+            unpack_nested = contains_nested(
+                getattr(first_element, col, None),
+                is_pydantic_model if from_model else dataclasses.is_dataclass,  # type: ignore[arg-type]
+            )
 
-    if from_model:
-        rows = [tuple(md.__dict__.values()) for md in data]
+    if unpack_nested:
+        if from_model:
+            dicts = (
+                [md.model_dump(mode="python") for md in data]
+                if hasattr(first_element, "model_dump")
+                else [md.dict() for md in data]
+            )
+        else:
+            dicts = [asdict(md) for md in data]
+        pydf = PyDataFrame.read_dicts(dicts, infer_schema_length)
     else:
-        rows = [astuple(dc) for dc in data]
+        rows = (
+            [tuple(md.__dict__.values()) for md in data]
+            if from_model
+            else [astuple(dc) for dc in data]
+        )
+        pydf = PyDataFrame.read_rows(rows, infer_schema_length, schema_override or None)
 
-    pydf = PyDataFrame.read_rows(rows, infer_schema_length, schema_override or None)
     if schema_override:
         structs = {c: tp for c, tp in schema_override.items() if isinstance(tp, Struct)}
         pydf = _post_apply_columns(pydf, column_names, structs, schema_overrides)

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -146,13 +146,13 @@ def test_init_inputs(monkeypatch: Any) -> None:
         pl.DataFrame(np.array([1, 2, 3]), schema=["a"])
 
 
-def test_init_dataclass_namedtuple() -> None:
-    from dataclasses import dataclass
+def test_init_structured_objects() -> None:
+    # validate init from dataclass, namedtuple, and pydantic model objects
     from typing import NamedTuple
 
-    from polars.dependencies import pydantic
+    from polars.dependencies import dataclasses, pydantic
 
-    @dataclass
+    @dataclasses.dataclass
     class TeaShipmentDC:
         exporter: str
         importer: str


### PR DESCRIPTION
Building on #8178 and #4807...

Adds support for `DataFrame` init from _nested_ `dataclass`, `pydantic`, and `NamedTuple` objects; nested objects are automatically identified and unpacked as `Struct` so that we can expose the underlying data natively (instead of getting stuck with `Object` cols).

Note that nested init is noticeably slower than for non-nested objects, due to the python-side unpacking. However, unless nested data is detected the existing fast-paths will be used - there is no penalty if the input data does not actually contain nested objects.

## Example

**Note:** this example _also_ works with the equivalent `NamedTuple` and `dataclass` objects.
```python
from pydantic import BaseModel
from datetime import datetime
import polars as pl

# setup nested models
class Baz( BaseModel ):
    d: datetime
    e: float
    f: str

class Bar( BaseModel ):
    a: str
    b: int
    c: Baz

class Foo( BaseModel ):
    x: int
    y: Bar

# create nested test data
data = [
    Foo(
        x = 100,
        y = Bar(
            a = "hello",
            b = 800,
            c = Baz( 
                d = datetime(2023,4,12,10,30),
                e = -10.5,
                f = "world",
            ),
        ),
    )
]

# directly initialise frame with nested data
df = pl.DataFrame( data )

# shape: (1, 2)
# ┌─────┬───────────────────────────────────┐
# │ x   ┆ y                                 │
# │ --- ┆ ---                               │
# │ i64 ┆ struct[3]                         │
# ╞═════╪═══════════════════════════════════╡
# │ 100 ┆ {"hello",800,{2023-04-12 10:30:0… │
# └─────┴───────────────────────────────────┘

df.unnest("y")

# shape: (1, 4)
# ┌─────┬───────┬─────┬───────────────────────────────────┐
# │ x   ┆ a     ┆ b   ┆ c                                 │
# │ --- ┆ ---   ┆ --- ┆ ---                               │
# │ i64 ┆ str   ┆ i64 ┆ struct[3]                         │
# ╞═════╪═══════╪═════╪═══════════════════════════════════╡
# │ 100 ┆ hello ┆ 800 ┆ {2023-04-12 10:30:00,-10.5,"worl… │
# └─────┴───────┴─────┴───────────────────────────────────┘

df.unnest("y").unnest("c")

# shape: (1, 6)
# ┌─────┬───────┬─────┬─────────────────────┬───────┬───────┐
# │ x   ┆ a     ┆ b   ┆ d                   ┆ e     ┆ f     │
# │ --- ┆ ---   ┆ --- ┆ ---                 ┆ ---   ┆ ---   │
# │ i64 ┆ str   ┆ i64 ┆ datetime[μs]        ┆ f64   ┆ str   │
# ╞═════╪═══════╪═════╪═════════════════════╪═══════╪═══════╡
# │ 100 ┆ hello ┆ 800 ┆ 2023-04-12 10:30:00 ┆ -10.5 ┆ world │
# └─────┴───────┴─────┴─────────────────────┴───────┴───────┘
```
