### PR TITLE
chore(python): Update docs requirements

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -6,18 +6,19 @@ pyarrow
 
 hypothesis==6.72.1
 
-autodocsumm==0.2.9
+autodocsumm==0.2.10
 commonmark==0.9.1
 livereload==2.6.3
 numpydoc==1.5.0
-pydata-sphinx-theme==0.13.0
-sphinx-autosummary-accessors==2022.4.0
+pydata-sphinx-theme==0.13.3
+sphinx==6.2.1
+sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.1
-sphinx-design==0.3.0
-sphinx==5.3.0
-sphinxcontrib-applehelp==1.0.2
+sphinx-design==0.4.1
+sphinx-favicon==1.0.1
+sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-qthelp==1.0.3

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx_autosummary_accessors",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_favicon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -114,23 +115,24 @@ html_theme_options = {
             "icon": "fa-brands fa-twitter",
         },
     ],
-    "favicons": [
-        {
-            "rel": "icon",
-            "sizes": "32x32",
-            "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/favicon-32x32.png",
-        },
-        {
-            "rel": "apple-touch-icon",
-            "sizes": "180x180",
-            "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/touchicon-180x180.png",
-        },
-    ],
     "logo": {
         "image_light": "https://raw.githubusercontent.com/pola-rs/polars-static/master/logos/polars-logo-dark-medium.png",
         "image_dark": "https://raw.githubusercontent.com/pola-rs/polars-static/master/logos/polars-logo-dimmed-medium.png",
     },
 }
+
+favicons = [
+    {
+        "rel": "icon",
+        "sizes": "32x32",
+        "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/favicon-32x32.png",
+    },
+    {
+        "rel": "apple-touch-icon",
+        "sizes": "180x180",
+        "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/touchicon-180x180.png",
+    },
+]
 
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
New release of sphinx-design makes this possible. I'll have to verify everything looks good locally before merging.

Changes:
* Upgrade to new major Sphinx version (6.1.3).
* Use new `sphinx-favicon` extension, as the previous functionality was deprecated.