### PR TITLE
perf(rust, python): speed up csv parsing for slower datetimes formats

### DIFF
--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -438,28 +438,26 @@ where
                 }
             }
         }
-        None => {
-            match infer_pattern_single(val) {
-                None => {
-                    buf.builder.append_null();
-                    Ok(())
-                }
-                Some(pattern_with_offset) => {
-                    match DatetimeInfer::<T::Native>::try_from(pattern_with_offset.pattern) {
-                        Ok(mut infer) => {
-                            let parsed = infer.parse(val, pattern_with_offset.offset);
-                            buf.compiled = Some(infer);
-                            buf.builder.append_option(parsed);
-                            Ok(())
-                        }
-                        Err(_) => {
-                            buf.builder.append_null();
-                            Ok(())
-                        }
+        None => match infer_pattern_single(val) {
+            None => {
+                buf.builder.append_null();
+                Ok(())
+            }
+            Some(pattern_with_offset) => {
+                match DatetimeInfer::<T::Native>::try_from(pattern_with_offset.pattern) {
+                    Ok(mut infer) => {
+                        let parsed = infer.parse(val, pattern_with_offset.offset);
+                        buf.compiled = Some(infer);
+                        buf.builder.append_option(parsed);
+                        Ok(())
+                    }
+                    Err(_) => {
+                        buf.builder.append_null();
+                        Ok(())
                     }
                 }
             }
-        }
+        },
     }
 }
 

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -123,10 +123,7 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                         PatternWithOffset {
                             pattern: Pattern::DatetimeYMDZ,
                             offset,
-                        } => DataType::Datetime(
-                            TimeUnit::Microseconds,
-                            offset.map(|x| x.to_string()),
-                        ),
+                        } => DataType::Utf8,  // TODO: support this
                     },
                     None => DataType::Utf8,
                 }
@@ -162,7 +159,7 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                     PatternWithOffset {
                         pattern: Pattern::DatetimeYMDZ,
                         offset,
-                    } => DataType::Datetime(TimeUnit::Microseconds, offset.map(|x| x.to_string())),
+                    } => DataType::Utf8,  // TODO: support this
                 },
                 None => DataType::Utf8,
             }

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -122,8 +122,9 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                         } => DataType::Date,
                         PatternWithOffset {
                             pattern: Pattern::DatetimeYMDZ,
-                            offset,
-                        } => DataType::Utf8,  // TODO: support this
+                            offset: _,
+                        } => DataType::Utf8, // TODO: support tz-aware,
+                                             // need to keep track of offset
                     },
                     None => DataType::Utf8,
                 }
@@ -158,8 +159,9 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                     } => DataType::Date,
                     PatternWithOffset {
                         pattern: Pattern::DatetimeYMDZ,
-                        offset,
-                    } => DataType::Utf8,  // TODO: support this
+                        offset: _,
+                    } => DataType::Utf8, // TODO: support tz-aware,
+                                         // need to keep track of offset
                 },
                 None => DataType::Utf8,
             }

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -80,6 +80,7 @@ impl StrpTimeParser<i32> for DatetimeInfer<i32> {
 
 #[derive(Clone)]
 pub struct DatetimeInfer<T> {
+    pub pattern_with_offset: PatternWithOffset,
     patterns: &'static [&'static str],
     latest_fmt: &'static str,
     transform: fn(&str, &str, Option<FixedOffset>, bool) -> Option<T>,
@@ -96,6 +97,7 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
     fn try_from(value: Pattern) -> PolarsResult<Self> {
         match value {
             Pattern::DatetimeDMY => Ok(DatetimeInfer {
+                pattern_with_offset: PatternWithOffset{pattern: Pattern::DatetimeDMY, offset: None},
                 patterns: patterns::DATETIME_D_M_Y,
                 latest_fmt: patterns::DATETIME_D_M_Y[0],
                 transform: transform_datetime_us,
@@ -105,6 +107,7 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 utc: false,
             }),
             Pattern::DatetimeYMD => Ok(DatetimeInfer {
+                pattern_with_offset: PatternWithOffset{pattern:Pattern::DatetimeYMD, offset:None},
                 patterns: patterns::DATETIME_Y_M_D,
                 latest_fmt: patterns::DATETIME_Y_M_D[0],
                 transform: transform_datetime_us,
@@ -114,6 +117,7 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 utc: false,
             }),
             Pattern::DatetimeYMDZ => Ok(DatetimeInfer {
+                pattern_with_offset: PatternWithOffset{pattern:Pattern::DatetimeYMDZ, offset:None},
                 patterns: patterns::DATETIME_Y_M_D_Z,
                 latest_fmt: patterns::DATETIME_Y_M_D_Z[0],
                 transform: transform_tzaware_datetime_us,
@@ -134,6 +138,7 @@ impl TryFrom<Pattern> for DatetimeInfer<i32> {
     fn try_from(value: Pattern) -> PolarsResult<Self> {
         match value {
             Pattern::DateDMY => Ok(DatetimeInfer {
+                pattern_with_offset: PatternWithOffset{pattern: Pattern::DateDMY, offset: None},
                 patterns: patterns::DATE_D_M_Y,
                 latest_fmt: patterns::DATE_D_M_Y[0],
                 transform: transform_date,
@@ -143,6 +148,7 @@ impl TryFrom<Pattern> for DatetimeInfer<i32> {
                 utc: false,
             }),
             Pattern::DateYMD => Ok(DatetimeInfer {
+                pattern_with_offset: PatternWithOffset{pattern: Pattern::DateYMD, offset: None},
                 patterns: patterns::DATE_Y_M_D,
                 latest_fmt: patterns::DATE_Y_M_D[0],
                 transform: transform_date,

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -97,7 +97,10 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
     fn try_from(value: Pattern) -> PolarsResult<Self> {
         match value {
             Pattern::DatetimeDMY => Ok(DatetimeInfer {
-                pattern_with_offset: PatternWithOffset{pattern: Pattern::DatetimeDMY, offset: None},
+                pattern_with_offset: PatternWithOffset {
+                    pattern: Pattern::DatetimeDMY,
+                    offset: None,
+                },
                 patterns: patterns::DATETIME_D_M_Y,
                 latest_fmt: patterns::DATETIME_D_M_Y[0],
                 transform: transform_datetime_us,
@@ -107,7 +110,10 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 utc: false,
             }),
             Pattern::DatetimeYMD => Ok(DatetimeInfer {
-                pattern_with_offset: PatternWithOffset{pattern:Pattern::DatetimeYMD, offset:None},
+                pattern_with_offset: PatternWithOffset {
+                    pattern: Pattern::DatetimeYMD,
+                    offset: None,
+                },
                 patterns: patterns::DATETIME_Y_M_D,
                 latest_fmt: patterns::DATETIME_Y_M_D[0],
                 transform: transform_datetime_us,
@@ -117,7 +123,10 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 utc: false,
             }),
             Pattern::DatetimeYMDZ => Ok(DatetimeInfer {
-                pattern_with_offset: PatternWithOffset{pattern:Pattern::DatetimeYMDZ, offset:None},
+                pattern_with_offset: PatternWithOffset {
+                    pattern: Pattern::DatetimeYMDZ,
+                    offset: None,
+                },
                 patterns: patterns::DATETIME_Y_M_D_Z,
                 latest_fmt: patterns::DATETIME_Y_M_D_Z[0],
                 transform: transform_tzaware_datetime_us,
@@ -138,7 +147,10 @@ impl TryFrom<Pattern> for DatetimeInfer<i32> {
     fn try_from(value: Pattern) -> PolarsResult<Self> {
         match value {
             Pattern::DateDMY => Ok(DatetimeInfer {
-                pattern_with_offset: PatternWithOffset{pattern: Pattern::DateDMY, offset: None},
+                pattern_with_offset: PatternWithOffset {
+                    pattern: Pattern::DateDMY,
+                    offset: None,
+                },
                 patterns: patterns::DATE_D_M_Y,
                 latest_fmt: patterns::DATE_D_M_Y[0],
                 transform: transform_date,
@@ -148,7 +160,10 @@ impl TryFrom<Pattern> for DatetimeInfer<i32> {
                 utc: false,
             }),
             Pattern::DateYMD => Ok(DatetimeInfer {
-                pattern_with_offset: PatternWithOffset{pattern: Pattern::DateYMD, offset: None},
+                pattern_with_offset: PatternWithOffset {
+                    pattern: Pattern::DateYMD,
+                    offset: None,
+                },
                 patterns: patterns::DATE_Y_M_D,
                 latest_fmt: patterns::DATE_Y_M_D[0],
                 transform: transform_date,

--- a/polars/polars-time/src/chunkedarray/utf8/patterns.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/patterns.rs
@@ -219,6 +219,7 @@ pub enum Pattern {
     DatetimeYMDZ,
 }
 
+#[derive(Clone)]
 pub struct PatternWithOffset {
     pub pattern: Pattern,
     pub offset: Option<FixedOffset>,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -747,6 +747,7 @@ def test_fallback_chrono_parser() -> None:
     assert df.null_count().row(0) == (0, 0)
 
 
+@pytest.mark.xfail(reason="Not yet supported, GH8213", strict=True)
 def test_tz_aware_try_parse_dates() -> None:
     data = (
         "a,b,c,d\n"


### PR DESCRIPTION
For the following:
```python
from datetime import datetime, date
import datetime as dt

import polars as pl
import io

dates = pl.date_range(datetime(1000, 1, 1), datetime(9999, 1, 1)).dt.strftime('%m-%d-%Y %H:%M:%S')
data = 'my_column\\n' + '\\n'.join(dates)
print(ipython.run_line_magic("timeit", "pl.read_csv(io.StringIO(data), rechunk=False, try_parse_dates=True)"))

dates = pl.date_range(date(1000, 1, 1), date(9999, 1, 1)).dt.strftime('%m-%d-%Y')
data = 'my_column\\n' + '\\n'.join(dates)
print(ipython.run_line_magic("timeit", "pl.read_csv(io.StringIO(data), rechunk=False, try_parse_dates=True)"))

# current happy-paths
dates = pl.date_range(datetime(1000, 1, 1), datetime(9999, 1, 1)).dt.strftime('%d-%m-%Y %H:%M:%S')
data = 'my_column\\n' + '\\n'.join(dates)
print(ipython.run_line_magic("timeit", "pl.read_csv(io.StringIO(data), rechunk=False, try_parse_dates=True)"))
```
here are some timings https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=125707108

this branch:
- 5.86 s ± 170 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 760 ms ± 3.12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 540 ms ± 4.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

upstream/main:
- 27.2 s ± 140 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 25.7 s ± 191 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 593 ms ± 47.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

If the fail-fast conditions can be sorted out too, then it should become even better. But this already solves a large part of the issue