### PR TITLE
ci(python): re-enable test parallization for Windows tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -121,7 +121,7 @@ jobs:
           pip install target/wheels/polars-*.whl
 
       - name: Run tests
-        run: pytest -m "not benchmark"
+        run: pytest -n auto --dist worksteal -m "not benchmark"
 
       - name: Check import without optional dependencies
         run: |


### PR DESCRIPTION
#8158 allows us to re-enable test parallelization for Windows tests in the CI.