### PR TITLE
refactor(python, rust): Rename `strptime`/`strftime` args

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -30,10 +30,10 @@ impl DateChunked {
         Int32Chunked::from_vec(name, unit).into()
     }
 
-    /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(&self, fmt: &str) -> Utf8Chunked {
+    /// Format Date with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    pub fn strftime(&self, format: &str) -> Utf8Chunked {
         let date = NaiveDate::from_ymd_opt(2001, 1, 1).unwrap();
-        let fmted = format!("{}", date.format(fmt));
+        let fmted = format!("{}", date.format(format));
 
         let mut ca: Utf8Chunked = self.apply_kernel_cast(&|arr| {
             let mut buf = String::new();
@@ -45,7 +45,7 @@ impl DateChunked {
                     None => mutarr.push_null(),
                     Some(v) => {
                         buf.clear();
-                        let datefmt = date32_to_date(*v).format(fmt);
+                        let datefmt = date32_to_date(*v).format(format);
                         write!(buf, "{datefmt}").unwrap();
                         mutarr.push(Some(&buf))
                     }

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -149,8 +149,8 @@ impl DatetimeChunked {
         }
     }
 
-    /// Format Datetime with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(&self, fmt: &str) -> PolarsResult<Utf8Chunked> {
+    /// Format Datetime with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    pub fn strftime(&self, format: &str) -> PolarsResult<Utf8Chunked> {
         #[cfg(feature = "timezones")]
         use chrono::Utc;
         let conversion_f = match self.time_unit() {
@@ -169,13 +169,13 @@ impl DatetimeChunked {
             Some(_) => write!(
                 fmted,
                 "{}",
-                Utc.from_local_datetime(&dt).earliest().unwrap().format(fmt)
+                Utc.from_local_datetime(&dt).earliest().unwrap().format(format)
             )
             .map_err(
-                |_| polars_err!(ComputeError: "cannot format DateTime with format '{}'", fmt),
+                |_| polars_err!(ComputeError: "cannot format DateTime with format '{}'", format),
             )?,
-            _ => write!(fmted, "{}", dt.format(fmt)).map_err(
-                |_| polars_err!(ComputeError: "cannot format NaiveDateTime with format '{}'", fmt),
+            _ => write!(fmted, "{}", dt.format(format)).map_err(
+                |_| polars_err!(ComputeError: "cannot format NaiveDateTime with format '{}'", format),
             )?,
         };
         let fmted = fmted; // discard mut
@@ -184,16 +184,16 @@ impl DatetimeChunked {
             #[cfg(feature = "timezones")]
             Some(time_zone) => match parse_offset(time_zone) {
                 Ok(time_zone) => self.apply_kernel_cast(&|arr| {
-                    format_fixed_offset(time_zone, arr, fmt, &fmted, conversion_f)
+                    format_fixed_offset(time_zone, arr, format, &fmted, conversion_f)
                 }),
                 Err(_) => match time_zone.parse::<Tz>() {
                     Ok(time_zone) => self.apply_kernel_cast(&|arr| {
-                        format_tz(time_zone, arr, fmt, &fmted, conversion_f)
+                        format_tz(time_zone, arr, format, &fmted, conversion_f)
                     }),
                     Err(_) => unreachable!(),
                 },
             },
-            _ => self.apply_kernel_cast(&|arr| format_naive(arr, fmt, &fmted, conversion_f)),
+            _ => self.apply_kernel_cast(&|arr| format_naive(arr, format, &fmted, conversion_f)),
         };
         ca.rename(self.name());
         Ok(ca)

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -9,9 +9,9 @@ pub struct DateLikeNameSpace(pub(crate) Expr);
 impl DateLikeNameSpace {
     /// Format Date/datetime with a formatting rule
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(self, fmt: &str) -> Expr {
-        let fmt = fmt.to_string();
-        let function = move |s: Series| s.strftime(&fmt).map(Some);
+    pub fn strftime(self, format: &str) -> Expr {
+        let format = format.to_string();
+        let function = move |s: Series| s.strftime(&format).map(Some);
         self.0
             .map(function, GetOutput::from_type(DataType::Utf8))
             .with_fmt("strftime")

--- a/polars/polars-time/src/chunkedarray/time.rs
+++ b/polars/polars-time/src/chunkedarray/time.rs
@@ -18,8 +18,8 @@ pub(crate) fn time_to_time64ns(time: &NaiveTime) -> i64 {
 }
 
 pub trait TimeMethods {
-    /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    fn strftime(&self, fmt: &str) -> Utf8Chunked;
+    /// Format Date with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    fn strftime(&self, format: &str) -> Utf8Chunked;
 
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
@@ -42,10 +42,10 @@ pub trait TimeMethods {
 }
 
 impl TimeMethods for TimeChunked {
-    /// Format Date with a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    fn strftime(&self, fmt: &str) -> Utf8Chunked {
+    /// Format Date with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    fn strftime(&self, format: &str) -> Utf8Chunked {
         let time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
-        let fmted = format!("{}", time.format(fmt));
+        let fmted = format!("{}", time.format(format));
 
         let mut ca: Utf8Chunked = self.apply_kernel_cast(&|arr| {
             let mut buf = String::new();
@@ -57,7 +57,7 @@ impl TimeMethods for TimeChunked {
                     None => mutarr.push_null(),
                     Some(v) => {
                         buf.clear();
-                        let timefmt = time64ns_to_time(*v).format(fmt);
+                        let timefmt = time64ns_to_time(*v).format(format);
                         write!(buf, "{timefmt}").unwrap();
                         mutarr.push(Some(&buf))
                     }

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -304,18 +304,18 @@ pub trait TemporalMethods: AsSeries {
         }
     }
 
-    /// Format Date/Datetimewith a `fmt` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    fn strftime(&self, fmt: &str) -> PolarsResult<Series> {
+    /// Format Date/Datetimewith a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    fn strftime(&self, format: &str) -> PolarsResult<Series> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
-            DataType::Date => s.date().map(|ca| ca.strftime(fmt).into_series()),
+            DataType::Date => s.date().map(|ca| ca.strftime(format).into_series()),
             #[cfg(feature = "dtype-datetime")]
-            DataType::Datetime(_, _) => {
-                s.datetime().map(|ca| Ok(ca.strftime(fmt)?.into_series()))?
-            }
+            DataType::Datetime(_, _) => s
+                .datetime()
+                .map(|ca| Ok(ca.strftime(format)?.into_series()))?,
             #[cfg(feature = "dtype-time")]
-            DataType::Time => s.time().map(|ca| ca.strftime(fmt).into_series()),
+            DataType::Time => s.time().map(|ca| ca.strftime(format).into_series()),
             dt => polars_bail!(opq = strftime, dt),
         }
     }

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -9,6 +9,7 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -320,7 +321,8 @@ class ExprDateTimeNameSpace:
         time = expr_to_lit_or_expr(time)
         return wrap_expr(self._pyexpr.dt_combine(time._pyexpr, time_unit))
 
-    def strftime(self, fmt: str) -> Expr:
+    @deprecated_alias(fmt="format")
+    def strftime(self, format: str) -> Expr:
         """
         Format Date/Datetime with a formatting rule.
 
@@ -357,7 +359,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴─────────────────────┘
 
         """
-        return wrap_expr(self._pyexpr.strftime(fmt))
+        return wrap_expr(self._pyexpr.strftime(format))
 
     def year(self) -> Expr:
         """

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -326,8 +326,12 @@ class ExprDateTimeNameSpace:
         """
         Format Date/Datetime with a formatting rule.
 
-        See `chrono strftime/strptime
-        <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_.
+        Parameters
+        ----------
+        format
+            Format to use, refer to the `chrono strftime documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for specification. Example: ``"%y-%m-%d"``.
 
         Examples
         --------

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -14,6 +14,7 @@ from polars.datatypes import (
 from polars.utils import no_default
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
+from polars.utils.decorators import deprecated_alias
 from polars.utils.various import find_stacklevel
 
 if TYPE_CHECKING:
@@ -30,10 +31,11 @@ class ExprStringNameSpace:
     def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
+    @deprecated_alias(datatype="dtype", fmt="format")
     def strptime(
         self,
-        datatype: PolarsTemporalType,
-        fmt: str | None = None,
+        dtype: PolarsTemporalType,
+        format: str | None = None,
         *,
         strict: bool = True,
         exact: bool = True,
@@ -46,9 +48,9 @@ class ExprStringNameSpace:
 
         Parameters
         ----------
-        datatype
+        dtype
             Date | Datetime | Time
-        fmt
+        format
             Format to use, refer to the `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
@@ -120,27 +122,27 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
-        if not is_polars_dtype(datatype):  # pragma: no cover
-            raise ValueError(f"expected: {DataType} got: {datatype}")
+        if not is_polars_dtype(dtype):  # pragma: no cover
+            raise ValueError(f"expected: {DataType} got: {dtype}")
 
         if tz_aware is no_default:
             tz_aware = False
         else:
             warnings.warn(
-                "`tz_aware` is now auto-inferred from `fmt` and will be removed "
+                "`tz_aware` is now auto-inferred from `format` and will be removed "
                 "in a future version. You can safely drop this argument.",
                 category=DeprecationWarning,
                 stacklevel=find_stacklevel(),
             )
 
-        if datatype == Date:
-            return wrap_expr(self._pyexpr.str_parse_date(fmt, strict, exact, cache))
-        elif datatype == Datetime:
-            time_unit = datatype.time_unit  # type: ignore[union-attr]
-            time_zone = datatype.time_zone  # type: ignore[union-attr]
+        if dtype == Date:
+            return wrap_expr(self._pyexpr.str_parse_date(format, strict, exact, cache))
+        elif dtype == Datetime:
+            time_unit = dtype.time_unit  # type: ignore[union-attr]
+            time_zone = dtype.time_zone  # type: ignore[union-attr]
             dtcol = wrap_expr(
                 self._pyexpr.str_parse_datetime(
-                    fmt,
+                    format,
                     strict,
                     exact,
                     cache,
@@ -151,8 +153,8 @@ class ExprStringNameSpace:
                 )
             )
             return dtcol if (time_unit is None) else dtcol.dt.cast_time_unit(time_unit)
-        elif datatype == Time:
-            return wrap_expr(self._pyexpr.str_parse_time(fmt, strict, exact, cache))
+        elif dtype == Time:
+            return wrap_expr(self._pyexpr.str_parse_time(format, strict, exact, cache))
         else:  # pragma: no cover
             raise ValueError("dtype should be of type {Date, Datetime, Time}")
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -131,8 +131,12 @@ class DateTimeNameSpace:
         """
         Format Date/datetime with a formatting rule.
 
-        See `chrono strftime/strptime
-        <https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html>`_.
+        Parameters
+        ----------
+        format
+            Format to use, refer to the `chrono strftime documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for specification. Example: ``"%y-%m-%d"``.
 
         Returns
         -------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
 from polars.utils.convert import _to_python_datetime
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -124,7 +126,8 @@ class DateTimeNameSpace:
             return _to_python_datetime(int(out), s.dtype, s.time_unit)
         return None
 
-    def strftime(self, fmt: str) -> Series:
+    @deprecated_alias(fmt="format")
+    def strftime(self, format: str) -> Series:
         """
         Format Date/datetime with a formatting rule.
 
@@ -150,7 +153,7 @@ class DateTimeNameSpace:
                 2001-01-03 00:00:00
                 2001-01-04 00:00:00
         ]
-        >>> date.dt.strftime(fmt="%Y-%m-%d")
+        >>> date.dt.strftime(format="%Y-%m-%d")
         shape: (4,)
         Series: '' [str]
         [
@@ -161,6 +164,8 @@ class DateTimeNameSpace:
         ]
 
         """
+        s = wrap_s(self._s)
+        return s.to_frame().select(F.col(s.name).dt.strftime(format)).to_series()
 
     def year(self) -> Series:
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -920,8 +920,8 @@ impl PyExpr {
         self.inner.clone().str().count_match(pat).into()
     }
 
-    pub fn strftime(&self, fmt: &str) -> PyExpr {
-        self.inner.clone().dt().strftime(fmt).into()
+    pub fn strftime(&self, format: &str) -> PyExpr {
+        self.inner.clone().dt().strftime(format).into()
     }
     pub fn str_split(&self, by: &str) -> PyExpr {
         self.inner.clone().str().split(by).into()

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -174,10 +174,8 @@ def test_diff_datetime() -> None:
     )
     out = (
         df.with_columns(
-            [
-                pl.col("timestamp").str.strptime(pl.Date, fmt="%Y-%m-%d"),
-            ]
-        ).with_columns([pl.col("timestamp").diff().implode().over("char")])
+            pl.col("timestamp").str.strptime(pl.Date, format="%Y-%m-%d"),
+        ).with_columns(pl.col("timestamp").diff().implode().over("char"))
     )["timestamp"]
     assert (out[0] == out[1]).all()
 
@@ -799,7 +797,7 @@ def test_groupby_dynamic_when_conversion_crosses_dates_7274() -> None:
             }
         )
         .with_columns(
-            pl.col("timestamp").str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S%:z")
+            pl.col("timestamp").str.strptime(pl.Datetime, format="%Y-%m-%d %H:%M:%S%:z")
         )
         .with_columns(
             pl.col("timestamp").dt.convert_time_zone("UTC").alias("timestamp_utc")
@@ -1303,7 +1301,7 @@ def test_groupby_rolling_mean_3020() -> None:
 
 
 def test_asof_join() -> None:
-    fmt = "%F %T%.3f"
+    format = "%F %T%.3f"
     dates = [
         "2016-05-25 13:30:00.023",
         "2016-05-25 13:30:00.023",
@@ -1326,7 +1324,7 @@ def test_asof_join() -> None:
     ]
     quotes = pl.DataFrame(
         {
-            "dates": pl.Series(dates).str.strptime(pl.Datetime, fmt=fmt),
+            "dates": pl.Series(dates).str.strptime(pl.Datetime, format=format),
             "ticker": ticker,
             "bid": [720.5, 51.95, 51.97, 51.99, 720.50, 97.99, 720.50, 52.01],
         }
@@ -1347,7 +1345,7 @@ def test_asof_join() -> None:
     ]
     trades = pl.DataFrame(
         {
-            "dates": pl.Series(dates).str.strptime(pl.Datetime, fmt=fmt),
+            "dates": pl.Series(dates).str.strptime(pl.Datetime, format=format),
             "ticker": ticker,
             "bid": [51.95, 51.95, 720.77, 720.92, 98.0],
         }

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -66,7 +66,7 @@ def test_strptime_extract_times(
     series_of_int_dates: pl.Series,
     series_of_str_dates: pl.Series,
 ) -> None:
-    s = series_of_str_dates.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
+    s = series_of_str_dates.str.strptime(pl.Datetime, format="%Y-%m-%d %H:%M:%S.%9f")
 
     assert_series_equal(getattr(s.dt, unit_attr)(), expected)
 
@@ -132,13 +132,13 @@ def test_strptime_epoch(
     expected: pl.Series,
     series_of_str_dates: pl.Series,
 ) -> None:
-    s = series_of_str_dates.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
+    s = series_of_str_dates.str.strptime(pl.Datetime, format="%Y-%m-%d %H:%M:%S.%9f")
 
     assert_series_equal(s.dt.epoch(time_unit=time_unit), expected)
 
 
 def test_strptime_fractional_seconds(series_of_str_dates: pl.Series) -> None:
-    s = series_of_str_dates.str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S.%9f")
+    s = series_of_str_dates.str.strptime(pl.Datetime, format="%Y-%m-%d %H:%M:%S.%9f")
 
     assert_series_equal(
         s.dt.second(fractional=True),

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -44,11 +44,11 @@ def test_str_strptime() -> None:
 
 def test_date_parse_omit_day() -> None:
     df = pl.DataFrame({"month": ["2022-01"]})
-    assert df.select(pl.col("month").str.strptime(pl.Date, fmt="%Y-%m")).item() == date(
-        2022, 1, 1
-    )
     assert df.select(
-        pl.col("month").str.strptime(pl.Datetime, fmt="%Y-%m")
+        pl.col("month").str.strptime(pl.Date, format="%Y-%m")
+    ).item() == date(2022, 1, 1)
+    assert df.select(
+        pl.col("month").str.strptime(pl.Datetime, format="%Y-%m")
     ).item() == datetime(2022, 1, 1)
 
 
@@ -81,12 +81,12 @@ def test_strptime_precision() -> None:
     ("unit", "expected"),
     [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
 )
-@pytest.mark.parametrize("fmt", ["%Y-%m-%d %H:%M:%S.%f", None])
+@pytest.mark.parametrize("format", ["%Y-%m-%d %H:%M:%S.%f", None])
 def test_strptime_precision_with_time_unit(
-    unit: TimeUnit, expected: str, fmt: str
+    unit: TimeUnit, expected: str, format: str
 ) -> None:
     ser = pl.Series(["2020-01-01 00:00:00.123456789"])
-    result = ser.str.strptime(pl.Datetime(unit), fmt=fmt).dt.strftime("%f")[0]
+    result = ser.str.strptime(pl.Datetime(unit), format=format).dt.strftime("%f")[0]
     assert result == expected
 
 
@@ -116,7 +116,9 @@ def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
         }
     )
     assert times.with_columns(
-        pl.col("delivery_datetime").str.strptime(pl.Datetime, fmt="%Y-%m-%d %H:%M:%S%z")
+        pl.col("delivery_datetime").str.strptime(
+            pl.Datetime, format="%Y-%m-%d %H:%M:%S%z"
+        )
     ).to_dict(False) == {
         "delivery_datetime": [
             datetime(2021, 12, 5, 6, 0, tzinfo=timezone(timedelta)),
@@ -252,7 +254,7 @@ def test_datetime_strptime_patterns_consistent() -> None:
     s = df.with_columns(
         [
             pl.col("date")
-            .str.strptime(pl.Datetime, fmt=None, strict=False)
+            .str.strptime(pl.Datetime, format=None, strict=False)
             .alias("parsed"),
         ]
     )["parsed"]
@@ -280,7 +282,7 @@ def test_datetime_strptime_patterns_inconsistent() -> None:
     s = df.with_columns(
         [
             pl.col("date")
-            .str.strptime(pl.Datetime, fmt=None, strict=False)
+            .str.strptime(pl.Datetime, format=None, strict=False)
             .alias("parsed"),
         ]
     )["parsed"]
@@ -291,7 +293,7 @@ def test_datetime_strptime_patterns_inconsistent() -> None:
 @pytest.mark.parametrize(
     (
         "ts",
-        "fmt",
+        "format",
         "exp_year",
         "exp_month",
         "exp_day",
@@ -306,7 +308,7 @@ def test_datetime_strptime_patterns_inconsistent() -> None:
 )
 def test_parse_negative_dates(
     ts: str,
-    fmt: str,
+    format: str,
     exp_year: int,
     exp_month: int,
     exp_day: int,
@@ -315,7 +317,7 @@ def test_parse_negative_dates(
     exp_second: int,
 ) -> None:
     ser = pl.Series([ts])
-    result = ser.str.strptime(pl.Datetime("ms"), fmt=fmt)
+    result = ser.str.strptime(pl.Datetime("ms"), format=format)
     # Python datetime.datetime doesn't support negative dates, so comparing
     # with `result.item()` directly won't work.
     assert result.dt.year().item() == exp_year

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -108,7 +108,7 @@ def test_predicate_strptime_6558() -> None:
     assert (
         pl.DataFrame({"date": ["2022-01-03", "2020-01-04", "2021-02-03", "2019-01-04"]})
         .lazy()
-        .select(pl.col("date").str.strptime(pl.Date, fmt="%F"))
+        .select(pl.col("date").str.strptime(pl.Date, format="%F"))
         .filter((pl.col("date").dt.year() == 2022) & (pl.col("date").dt.month() == 1))
         .collect()
     ).to_dict(False) == {"date": [date(2022, 1, 3)]}


### PR DESCRIPTION
Preparing for #8215 

`strptime`
* `datatype` -> `dtype`
* `fmt` -> `format`

`strftime`
* `fmt` -> `format`