### PR TITLE
perf(rust, python): make chunks search more resilient

### DIFF
--- a/polars/polars-io/src/csv/parser.rs
+++ b/polars/polars-io/src/csv/parser.rs
@@ -48,7 +48,17 @@ pub(crate) fn next_line_position(
             }
             count += 1;
         }
-        count == expected_fields
+
+        // if the latest field is missing
+        // e.g.:
+        // a,b,c
+        // vala,valb,
+        // SplitFields returns a count that is 1 less
+        // There fore we accept:
+        // expected == count
+        // and
+        // expected == count - 1
+        expected_fields.wrapping_sub(count) <= 1
     }
 
     // we check 3 subsequent lines for `accept_line` before we accept

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -521,11 +521,13 @@ impl<'a> CoreReader<'a> {
         bytes: &[u8],
         predicate: Option<&Arc<dyn PhysicalIoExpr>>,
     ) -> PolarsResult<DataFrame> {
+        dbg!("parse", n_threads);
         let logging = verbose();
         let (file_chunks, chunk_size, total_rows, starting_point_offset, bytes, remaining_bytes) =
             self.determine_file_chunks_and_statistics(&mut n_threads, bytes, logging)?;
         let projection = self.get_projection();
         let str_columns = self.get_string_columns(&projection)?;
+        dbg!(file_chunks.len());
 
         // If the number of threads given by the user is lower than our global thread pool we create
         // new one.
@@ -661,6 +663,7 @@ impl<'a> CoreReader<'a> {
             } else {
                 std::cmp::min(rows_per_thread, max_proxy)
             };
+            dbg!(capacity, rows_per_thread, chunk_size);
 
             let str_capacities = self.init_string_size_stats(&str_columns, capacity);
 

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -521,13 +521,11 @@ impl<'a> CoreReader<'a> {
         bytes: &[u8],
         predicate: Option<&Arc<dyn PhysicalIoExpr>>,
     ) -> PolarsResult<DataFrame> {
-        dbg!("parse", n_threads);
         let logging = verbose();
         let (file_chunks, chunk_size, total_rows, starting_point_offset, bytes, remaining_bytes) =
             self.determine_file_chunks_and_statistics(&mut n_threads, bytes, logging)?;
         let projection = self.get_projection();
         let str_columns = self.get_string_columns(&projection)?;
-        dbg!(file_chunks.len());
 
         // If the number of threads given by the user is lower than our global thread pool we create
         // new one.
@@ -663,7 +661,6 @@ impl<'a> CoreReader<'a> {
             } else {
                 std::cmp::min(rows_per_thread, max_proxy)
             };
-            dbg!(capacity, rows_per_thread, chunk_size);
 
             let str_capacities = self.init_string_size_stats(&str_columns, capacity);
 


### PR DESCRIPTION
If the latest field in a csv file had many missing data, it was likely that not all threads were utilized.

This makes the search algorithm a bit more resilient to that. Locally it was the difference of running on 7 threads or 16 threads. Making a difference of 3.5x because the 7th thread had a chunk that was far too large.