### PR TITLE
feat(python): fail loudly on .%f directive, as it differs from the Python standard library

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -125,6 +125,17 @@ class ExprStringNameSpace:
         if not is_polars_dtype(dtype):  # pragma: no cover
             raise ValueError(f"expected: {DataType} got: {dtype}")
 
+        if format is not None and "%f" in format:
+            raise ValueError(
+                "Directive '%f' is not supported in Python Polars, "
+                "as it differs from the Python standard library.\n"
+                "Instead, please use one of:\n"
+                " - '%.f'\n"
+                " - '%3f'\n"
+                " - '%6f'\n"
+                " - '%9f'"
+            )
+
         if tz_aware is no_default:
             tz_aware = False
         else:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1924,6 +1924,28 @@ def test_replace_timezone_from_to(
     assert result == expected
 
 
+def test_strptime_subseconds_datetime() -> None:
+    with pytest.raises(ValueError, match="not supported"):
+        pl.Series(["2023-02-05T05:10:10.074000"]).str.strptime(
+            pl.Datetime, "%Y-%m-%dT%H:%M:%S.%f"
+        )
+    result = (
+        pl.Series(["2023-02-05T05:10:10.074000"])
+        .str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f")
+        .item()
+    )
+    expected = datetime(2023, 2, 5, 5, 10, 10, 74000)
+    assert result == expected
+
+
+def test_strptime_subseconds_time() -> None:
+    with pytest.raises(ValueError, match="not supported"):
+        pl.Series(["05:10:10.074000"]).str.strptime(pl.Time, "%H:%M:%S.%f")
+    result = pl.Series(["05:10:10.074000"]).str.strptime(pl.Time, "%H:%M:%S%.f").item()
+    expected = time(5, 10, 10, 74000)
+    assert result == expected
+
+
 def test_strptime_with_tz() -> None:
     result = (
         pl.Series(["2020-01-01 03:00:00"])

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -81,7 +81,7 @@ def test_strptime_precision() -> None:
     ("unit", "expected"),
     [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
 )
-@pytest.mark.parametrize("format", ["%Y-%m-%d %H:%M:%S.%f", None])
+@pytest.mark.parametrize("format", ["%Y-%m-%d %H:%M:%S%.f", None])
 def test_strptime_precision_with_time_unit(
     unit: TimeUnit, expected: str, format: str
 ) -> None:
@@ -334,7 +334,7 @@ def test_short_formats() -> None:
         None,
         date(2020, 1, 1),
     ]
-    assert s.str.strptime(pl.Date, "%foo", strict=False).to_list() == [None, None]
+    assert s.str.strptime(pl.Date, "%bar", strict=False).to_list() == [None, None]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #8203 