### PR TITLE
fix(python): List construction with None

### DIFF
--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -94,7 +94,7 @@ impl<'a> AnonymousBuilder<'a> {
         // offsets are monotonically increasing
         let offsets = unsafe { Offsets::new_unchecked(self.offsets).into() };
         Ok(ListArray::<i64>::new(
-            ListArray::<i64>::default_datatype(inner_dtype.clone()),
+            ListArray::<i64>::default_datatype(inner_dtype),
             offsets,
             values,
             self.validity.map(|validity| validity.into()),

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -482,7 +482,7 @@ macro_rules! finish_anonymous_list_builder {
         // safety: same type
         let mut ca = unsafe { ListChunked::from_chunks(&slf.name, vec![Box::new(arr)]) };
 
-        if $self.fast_explode {
+        if slf.fast_explode {
             ca.set_fast_explode()
         }
         ca

--- a/polars/polars-core/src/chunked_array/builder/list.rs
+++ b/polars/polars-core/src/chunked_array/builder/list.rs
@@ -507,7 +507,7 @@ impl<'a> AnonymousListBuilder<'a> {
         Self {
             name: name.into(),
             builder: AnonymousBuilder::new(capacity),
-            inner_dtype: inner_dtype,
+            inner_dtype,
             fast_explode: true,
         }
     }

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -459,9 +459,23 @@ def test_list_min_max() -> None:
 
 def test_fill_null_empty_list() -> None:
     assert pl.Series([["a"], None]).fill_null([]).to_list() == [["a"], []]
+    assert pl.Series([["a"], None]).fill_null(["b"]).to_list() == [["a"], ["b"]]
 
 
 def test_nested_logical() -> None:
     assert pl.select(
         pl.lit(pl.Series(["a", "b"], dtype=pl.Categorical)).implode().implode()
     ).to_dict(False) == {"": [[["a", "b"]]]}
+
+
+def test_list_dtypes() -> None:
+    assert pl.Series([[]]).dtype == pl.List(pl.Int32)
+    assert pl.Series([[]], dtype=pl.List(pl.Int64)).dtype == pl.List(pl.Int64)
+    assert pl.Series([[]], dtype=pl.List(pl.Utf8)).dtype == pl.List(pl.Utf8)
+
+
+def test_list_empty_list() -> None:
+    assert pl.Series([[], None]).to_list() == [[], None]
+    assert pl.Series([None, []]).to_list() == [None, []]
+    assert pl.Series([["a"], None]).to_list() == [["a"], None]
+    assert pl.Series([None, ["a"]]).to_list() == [None, ["a"]]


### PR DESCRIPTION
Fixes #8027

This fixes list series initialisation by fixing the `finish()` function of the chunked array list builder.

I did some refactoring because I felt like some of the code should live in the arrow array builder, not the chunked array builder. It turns out that moving the code simplifies the code quite a bit.

The changes fix #8027 and seem to pass all tests, but to be honest, I really have no clue what I'm doing here because I'm really new to Rust and Polars. So this might be utter nonsense. I'm happy to revise the patch in that case :-)

NB. I wonder if it's possible to implement `ListBuilderTrait` for `AnonymousListBuilder` but I wasn't sure how to deal with the lifetimes.