### PR TITLE
Fix `cargo build` from repo root

### DIFF
--- a/examples/python_rust_compiled_function/Cargo.toml
+++ b/examples/python_rust_compiled_function/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 polars = { path = "../../polars" }
 polars-arrow = { path = "../../polars/polars-arrow" }
-pyo3 = { version = "0.18.0", features = ["extension-module"] }
+pyo3 = { version = "0.18.0" }

--- a/examples/python_rust_compiled_function/pyproject.toml
+++ b/examples/python_rust_compiled_function/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "maturin"
 [project]
 name = "my_polars_functions"
 version = "0.1.0"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]


### PR DESCRIPTION
When I run `cargo build` from the root it fails with the following

```
...
                pyo3::types::string::PyString::to_str::h1b2380df10cf6a5e in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.8.rcgu.o)
            "_PyUnicode_FromStringAndSize", referenced from:
                pyo3::types::string::PyString::new::h212b9fef98307627 in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.8.rcgu.o)
                pyo3::types::string::PyString::intern::h6baa778e3f4a373f in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.8.rcgu.o)
            "_PyUnicode_InternInPlace", referenced from:
                pyo3::types::string::PyString::intern::h6baa778e3f4a373f in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.8.rcgu.o)
            "_Py_InitializeEx", referenced from:
                pyo3::gil::prepare_freethreaded_python::_$u7b$$u7b$closure$u7d$$u7d$::h814b7fa86d9638c1 in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.9.rcgu.o)
            "_Py_IsInitialized", referenced from:
                pyo3::gil::prepare_freethreaded_python::_$u7b$$u7b$closure$u7d$$u7d$::h814b7fa86d9638c1 in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.9.rcgu.o)
                pyo3::gil::GILGuard::acquire::_$u7b$$u7b$closure$u7d$$u7d$::h8a7de97b6a8ddc72 in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.9.rcgu.o)
            "__Py_Dealloc", referenced from:
                pyo3_ffi::object::Py_DECREF::h89b7b26b0927ddaf in my_polars_functions.f635n1ffqjmyvkj.rcgu.o
                pyo3_ffi::object::Py_DECREF::h86d7d17165fc7693 in libpyo3-2e8e489f5870369f.rlib(pyo3-2e8e489f5870369f.pyo3.06995dd5-cgu.15.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `python_rust_compiled_function` (lib) due to previous error
```

This is because `examples/python_rust_compiled_function` is included in the Cargo workspace. Without removing it from the workspace we can fix the compiling using the recommendation from the pyo3 FAQ [here](https://pyo3.rs/v0.18.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror) to make maturin inject the feature from `pyproject.toml`.

After this change `cargo build` from root works.