### PR TITLE
fix(rust, python): improve null/empty list construction

### DIFF
--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -1,4 +1,4 @@
-use arrow::array::{Array, ListArray};
+use arrow::array::{Array, ListArray, NullArray};
 use arrow::bitmap::MutableBitmap;
 use arrow::compute::concatenate;
 use arrow::datatypes::DataType;
@@ -91,18 +91,24 @@ impl<'a> AnonymousBuilder<'a> {
     }
 
     pub fn finish(self, inner_dtype: Option<&DataType>) -> Result<ListArray<i64>> {
-        let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());
-        let values = concatenate::concatenate(&self.arrays)?;
-        let dtype = ListArray::<i64>::default_datatype(inner_dtype.clone());
         // Safety:
         // offsets are monotonically increasing
-        unsafe {
-            Ok(ListArray::<i64>::new(
-                dtype,
-                Offsets::new_unchecked(self.offsets).into(),
-                values,
-                self.validity.map(|validity| validity.into()),
-            ))
-        }
+        let offsets = unsafe { Offsets::new_unchecked(self.offsets) };
+        let (inner_dtype, values) = if self.arrays.is_empty() {
+            let arr_len = offsets.len_proxy();
+            let values = NullArray::new(DataType::Null, arr_len).boxed();
+            (DataType::Null, values)
+        } else {
+            let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());
+            let values = concatenate::concatenate(&self.arrays)?;
+            (inner_dtype.clone(), values)
+        };
+        let dtype = ListArray::<i64>::default_datatype(inner_dtype);
+        Ok(ListArray::<i64>::new(
+            dtype,
+            offsets.into(),
+            values,
+            self.validity.map(|validity| validity.into()),
+        ))
     }
 }

--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -95,8 +95,8 @@ impl<'a> AnonymousBuilder<'a> {
         // offsets are monotonically increasing
         let offsets = unsafe { Offsets::new_unchecked(self.offsets) };
         let (inner_dtype, values) = if self.arrays.is_empty() {
-            let arr_len = offsets.len_proxy();
-            let values = NullArray::new(DataType::Null, arr_len).boxed();
+            let len = *offsets.last() as usize;
+            let values = NullArray::new(DataType::Null, len).boxed();
             (DataType::Null, values)
         } else {
             let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -860,116 +860,25 @@ fn fmt_struct(f: &mut Formatter<'_>, vals: &[AnyValue]) -> fmt::Result {
     write!(f, "}}")
 }
 
-macro_rules! impl_fmt_list {
-    ($self:ident) => {{
-        match $self.len() {
-            0 => format!("[]"),
-            1 => format!("[{}]", $self.get_any_value(0).unwrap()),
-            2 => format!(
-                "[{}, {}]",
-                $self.get_any_value(0).unwrap(),
-                $self.get_any_value(1).unwrap()
-            ),
+impl Series {
+    pub fn fmt_list(&self) -> String {
+        match self.len() {
+            0 => "[]".to_string(),
+            1 => format!("[{}]", self.get(0).unwrap()),
+            2 => format!("[{}, {}]", self.get(0).unwrap(), self.get(1).unwrap()),
             3 => format!(
                 "[{}, {}, {}]",
-                $self.get_any_value(0).unwrap(),
-                $self.get_any_value(1).unwrap(),
-                $self.get_any_value(2).unwrap()
+                self.get(0).unwrap(),
+                self.get(1).unwrap(),
+                self.get(2).unwrap()
             ),
             _ => format!(
                 "[{}, {}, … {}]",
-                $self.get_any_value(0).unwrap(),
-                $self.get_any_value(1).unwrap(),
-                $self.get_any_value($self.len() - 1).unwrap()
+                self.get(0).unwrap(),
+                self.get(1).unwrap(),
+                self.get(self.len() - 1).unwrap()
             ),
         }
-    }};
-}
-
-pub(crate) trait FmtList {
-    fn fmt_list(&self) -> String;
-}
-
-impl<T> FmtList for ChunkedArray<T>
-where
-    T: PolarsNumericType,
-    T::Native: fmt::Display,
-{
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-impl FmtList for BooleanChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-impl FmtList for Utf8Chunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-impl FmtList for BinaryChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-impl FmtList for ListChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-categorical")]
-impl FmtList for CategoricalChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-date")]
-impl FmtList for DateChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-datetime")]
-impl FmtList for DatetimeChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-duration")]
-impl FmtList for DurationChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-time")]
-impl FmtList for TimeChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "dtype-struct")]
-impl FmtList for StructChunked {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
-    }
-}
-
-#[cfg(feature = "object")]
-impl<T: PolarsObject> FmtList for ObjectChunked<T> {
-    fn fmt_list(&self) -> String {
-        impl_fmt_list!(self)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -9,7 +9,6 @@ use crate::chunked_array::ops::compare_inner::{
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
@@ -283,9 +282,6 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
     }
     fn min_as_series(&self) -> Series {
         ChunkAggSeries::min_as_series(&self.0)
-    }
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -10,7 +10,6 @@ use crate::chunked_array::ops::compare_inner::{
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::{AsSinglePtr, ChunkIdIter};
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
@@ -335,9 +334,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
             .std_as_series(_ddof)
             .cast(&DataType::Float64)
             .unwrap()
-    }
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -8,7 +8,6 @@ use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::compare_inner::{IntoPartialOrdInner, PartialOrdInner};
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 #[cfg(feature = "is_in")]
@@ -370,9 +369,6 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         Ok(CategoricalChunked::full_null(self.0.logical().name(), 1).into_series())
     }
 
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
-    }
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -17,7 +17,6 @@ use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::ops::ToBitRepr;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::*;
 use crate::prelude::*;
@@ -418,10 +417,6 @@ macro_rules! impl_dyn_series {
                     .cast(self.dtype())
                     .unwrap()
                     .into())
-            }
-
-            fn fmt_list(&self) -> String {
-                FmtList::fmt_list(&self.0)
             }
 
             fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -6,7 +6,6 @@ use ahash::RandomState;
 use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::*;
 use crate::prelude::*;
@@ -444,10 +443,6 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         Ok(Int32Chunked::full_null(self.name(), 1)
             .cast(self.dtype())
             .unwrap())
-    }
-
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -7,7 +7,6 @@ use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::*;
 use crate::prelude::*;
@@ -452,10 +451,6 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         Ok(Int32Chunked::full_null(self.name(), 1)
             .cast(self.dtype())
             .unwrap())
-    }
-
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -11,7 +11,6 @@ use crate::chunked_array::ops::compare_inner::{
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
@@ -367,9 +366,6 @@ macro_rules! impl_dyn_series {
                 QuantileAggSeries::quantile_as_series(&self.0, quantile, interpol)
             }
 
-            fn fmt_list(&self) -> String {
-                FmtList::fmt_list(&self.0)
-            }
             fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
                 Arc::new(SeriesWrap(Clone::clone(&self.0)))
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -5,7 +5,6 @@ use super::{private, IntoSeries, SeriesTrait};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
@@ -195,9 +194,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
     }
     fn min_as_series(&self) -> Series {
         ChunkAggSeries::min_as_series(&self.0)
-    }
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -39,7 +39,6 @@ use crate::chunked_array::ops::compare_inner::{
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
@@ -457,9 +456,6 @@ macro_rules! impl_dyn_series {
                 QuantileAggSeries::quantile_as_series(&self.0, quantile, interpol)
             }
 
-            fn fmt_list(&self) -> String {
-                FmtList::fmt_list(&self.0)
-            }
             fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
                 Arc::new(SeriesWrap(Clone::clone(&self.0)))
             }

--- a/polars/polars-core/src/series/implementations/null.rs
+++ b/polars/polars-core/src/series/implementations/null.rs
@@ -42,6 +42,9 @@ impl NullChunked {
 impl PrivateSeriesNumeric for NullChunked {}
 
 impl PrivateSeries for NullChunked {
+    fn compute_len(&mut self) {
+        // no-op
+    }
     fn _field(&self) -> Cow<Field> {
         Cow::Owned(Field::new(self.name(), DataType::Null))
     }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -5,7 +5,6 @@ use ahash::RandomState;
 
 use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::chunked_array::object::PolarsObjectSafe;
-use crate::fmt::FmtList;
 use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
@@ -25,6 +24,10 @@ where
         _list_capacity: usize,
     ) -> Box<dyn ListBuilderTrait> {
         ObjectChunked::<T>::get_list_builder(_name, _values_capacity, _list_capacity)
+    }
+
+    fn compute_len(&mut self) {
+        self.0.compute_len()
     }
 
     fn _field(&self) -> Cow<Field> {
@@ -205,10 +208,6 @@ where
 
     fn shift(&self, periods: i64) -> Series {
         ChunkShift::shift(&self.0, periods).into_series()
-    }
-
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -330,10 +330,6 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0.is_in(other)
     }
 
-    fn fmt_list(&self) -> String {
-        self.0.fmt_list()
-    }
-
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -9,7 +9,6 @@ use crate::chunked_array::ops::compare_inner::{
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::fmt::FmtList;
 use crate::frame::groupby::*;
 use crate::frame::hash_join::ZipOuterJoinColumn;
 use crate::prelude::*;
@@ -297,9 +296,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
     }
     fn min_as_series(&self) -> Series {
         ChunkAggSeries::min_as_series(&self.0)
-    }
-    fn fmt_list(&self) -> String {
-        FmtList::fmt_list(&self.0)
     }
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -63,9 +63,7 @@ pub(crate) mod private {
 
         fn _dtype(&self) -> &DataType;
 
-        fn compute_len(&mut self) {
-            unimplemented!()
-        }
+        fn compute_len(&mut self);
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {
             invalid_operation_panic!(explode_by_offsets, self)
@@ -464,10 +462,6 @@ pub trait SeriesTrait:
         _interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Series> {
         Ok(Series::full_null(self.name(), 1, self.dtype()))
-    }
-
-    fn fmt_list(&self) -> String {
-        "fmt implemented".into()
     }
 
     /// Clone inner ChunkedArray and wrap in a new Arc

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -465,3 +465,9 @@ def test_nested_logical() -> None:
     assert pl.select(
         pl.lit(pl.Series(["a", "b"], dtype=pl.Categorical)).implode().implode()
     ).to_dict(False) == {"": [[["a", "b"]]]}
+
+
+def test_null_list_construction_and_materialization() -> None:
+    s = pl.Series([None, []])
+    assert s.dtype == pl.List(pl.Null)
+    assert s.to_list() == [None, []]

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -107,7 +107,7 @@ def test_init_dict() -> None:
 
     # List of empty list
     df = pl.DataFrame({"a": [[]], "b": [[]]})
-    expected = {"a": pl.List(pl.Int32), "b": pl.List(pl.Int32)}
+    expected = {"a": pl.List(pl.Null), "b": pl.List(pl.Null)}
     assert df.schema == expected
     assert df.rows() == [([], [])]
 


### PR DESCRIPTION
Also removes the invalid `i32` dtype when a list is constructed with nulls and empty arrays.

supersedes #8238