### PR TITLE
fix(python): add special numpy float branch in anyvalue conversion

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -738,6 +738,11 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                 }
                 "range" => materialize_list(ob),
                 _ => {
+                    // special branch for np.float as this fails isinstance float
+                    if let Ok(value) = ob.extract::<f64>() {
+                        return Ok(AnyValue::Float64(value).into());
+                    }
+
                     // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
                     // so need this workaround instead of `isinstance(ob, datetime)`.
                     let bases = ob.get_type().getattr("__bases__")?.iter()?;

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1166,3 +1166,8 @@ def test_list_null_constructor() -> None:
     s = pl.Series("a", [[None], [None]], dtype=pl.List(pl.Null))
     assert s.dtype == pl.List(pl.Null)
     assert s.to_list() == [None, None]
+
+
+def test_numpy_float_construction_av() -> None:
+    np_dict = {"a": np.float64(1)}
+    assert_frame_equal(pl.DataFrame(np_dict), pl.DataFrame({"a": 1.0}))


### PR DESCRIPTION
fixes #8242

closes #8232

This will not maintain f32 type of numpy, but then you shouldn't pass a list of numpy floats. Pass a numpy array and polars will respect the dtypes.