### PR TITLE
feat(rust, python): preserve time zone in combine

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -58,7 +58,7 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
         DataType::Date => None,
         DataType::Datetime(_, tz) => tz.as_ref(),
         _dtype => {
-            polars_bail!(ComputeError: format!("expected Date or Datetime dtype, got: {}", _dtype))
+            polars_bail!(ComputeError: format!("expected Date or Datetime, got {}", _dtype))
         }
     };
 

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -72,7 +72,7 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
         Some(tz) => Ok(result_naive
             .datetime()
             .unwrap()
-            .replace_time_zone(Some(tz))?
+            .replace_time_zone(Some(tz), None)?
             .into()),
         _ => Ok(result_naive),
     }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -348,7 +348,11 @@ def test_combine_unsupported_types() -> None:
         (None, None),
     ],
 )
-def test_combine_lazy_schema_datetime(tzinfo, expected_time_zone, time_unit) -> None:
+def test_combine_lazy_schema_datetime(
+    tzinfo: ZoneInfo | None,
+    expected_time_zone: str | None,
+    time_unit: TimeUnit,
+) -> None:
     df = pl.DataFrame({"ts": pl.Series([datetime(2020, 1, 1, tzinfo=tzinfo)])})
     result = (
         df.lazy()
@@ -360,7 +364,7 @@ def test_combine_lazy_schema_datetime(tzinfo, expected_time_zone, time_unit) -> 
 
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
-def test_combine_lazy_schema_date(time_unit) -> None:
+def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
     df = pl.DataFrame({"ts": pl.Series([date(2020, 1, 1)])})
     result = (
         df.lazy()


### PR DESCRIPTION
In the latest release (note how the time zone is dropped after `combine`):
```python
In [22]: tzinfo = ZoneInfo("Asia/Kathmandu")
    ...: s = pl.Series(
    ...:     "dtm",
    ...:     [
    ...:         datetime(2022, 12, 31, 10, 30, 45, tzinfo=tzinfo),
    ...:         datetime(2023, 7, 5, 23, 59, 59, tzinfo=tzinfo),
    ...:     ],
    ...: )
    ...: print(s)
    ...: print(s.dt.combine(time(1, 2, 3, 456000)))
shape: (2,)
Series: 'dtm' [datetime[μs, Asia/Kathmandu]]
[
        2022-12-31 10:30:45 +0545
        2023-07-05 23:59:59 +0545
]
shape: (2,)
Series: 'dtm' [datetime[μs]]
[
        2022-12-31 01:02:03.456
        2023-07-05 01:02:03.456
]
```

Here:
```python
In [6]: tzinfo = ZoneInfo("Asia/Kathmandu")
   ...: s = pl.Series(
   ...:     "dtm",
   ...:     [
   ...:         datetime(2022, 12, 31, 10, 30, 45, tzinfo=tzinfo),
   ...:         datetime(2023, 7, 5, 23, 59, 59, tzinfo=tzinfo),
   ...:     ],
   ...: )
   ...: print(s)
   ...: print(s.dt.combine(time(1, 2, 3, 456000)))
shape: (2,)
Series: 'dtm' [datetime[μs, Asia/Kathmandu]]
[
        2022-12-31 10:30:45 +0545
        2023-07-05 23:59:59 +0545
]
shape: (2,)
Series: 'dtm' [datetime[μs, Asia/Kathmandu]]
[
        2022-12-31 01:02:03.456 +0545
        2023-07-05 01:02:03.456 +0545
]
```