### PR TITLE
chore(python): fix failing xfailed windows test

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -86,7 +86,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             ["2020-01-01", "2021-12-31"],
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
+                sys.version_info < (3, 9) or sys.platform.startswith("win"),
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
             ),
         ),
@@ -161,7 +161,7 @@ def test_read_database_exceptions(
             "create",
             id="create",
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
+                sys.version_info < (3, 9) or sys.platform.startswith("win"),
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
             ),
         ),
@@ -170,7 +170,7 @@ def test_read_database_exceptions(
             "append",
             id="append",
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
+                sys.version_info < (3, 9) or sys.platform.startswith("win"),
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
             ),
         ),

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -38,7 +38,7 @@ def test_from_to_buffer(df: pl.DataFrame, compression: IpcCompression) -> None:
         pytest.param(
             "uncompressed",
             marks=pytest.mark.xfail(
-                sys.platform == "win32", reason="Does not work on Windows"
+                sys.platform.startswith("win"), reason="Does not work on Windows"
             ),
         ),
         "lz4",
@@ -60,7 +60,7 @@ def test_from_to_file(
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
+@pytest.mark.xfail(sys.platform.startswith("win"), reason="Does not work on Windows")
 def test_select_columns_from_file(df: pl.DataFrame) -> None:
     with TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"
@@ -167,7 +167,7 @@ def test_ipc_column_order() -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.xfail(sys.platform == "win32", reason="Does not work on Windows")
+@pytest.mark.xfail(sys.platform.startswith("win"), reason="Does not work on Windows")
 def test_glob_ipc(df: pl.DataFrame) -> None:
     with TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "small.ipc"

--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -40,7 +40,7 @@ def _import_timings_as_frame(best_of: int) -> pl.DataFrame:
     )
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unreliable on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Unreliable on Windows")
 def test_polars_import() -> None:
     # note: take the fastest of three runs to reduce noise.
     df_import = _import_timings_as_frame(best_of=3)


### PR DESCRIPTION
got an odd failure for a windows test in https://github.com/pola-rs/polars/pull/8263, even though it was xfailed

trying to see if this fixes it, this is the pattern in the pytest docs https://docs.pytest.org/en/7.1.x/how-to/skipping.html