### PR TITLE
fix(rust, python): don't use fast paths for sorted join if there are …

### DIFF
--- a/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
+++ b/polars/polars-core/src/frame/hash_join/single_keys_dispatch.rs
@@ -163,10 +163,12 @@ fn splitted_to_opt_vec<T>(splitted: &[ChunkedArray<T>]) -> Vec<Vec<Option<T::Nat
 where
     T: PolarsNumericType,
 {
-    splitted
-        .iter()
-        .map(|ca| ca.into_iter().collect_trusted::<Vec<_>>())
-        .collect()
+    POOL.install(|| {
+        splitted
+            .par_iter()
+            .map(|ca| ca.into_iter().collect_trusted::<Vec<_>>())
+            .collect()
+    })
 }
 
 // returns the join tuples and whether or not the lhs tuples are sorted

--- a/polars/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/polars/polars-core/src/frame/hash_join/sort_merge.rs
@@ -110,7 +110,7 @@ where
 }
 
 #[cfg(feature = "performant")]
-pub(super) fn par_sorted_merge_inner(
+pub(super) fn par_sorted_merge_inner_no_nulls(
     s_left: &Series,
     s_right: &Series,
 ) -> (Vec<IdxSize>, Vec<IdxSize>) {
@@ -198,14 +198,18 @@ pub fn _sort_or_hash_inner(
         .map(|s| s.parse::<f32>().unwrap())
         .unwrap_or(1.0);
     let is_numeric = s_left.dtype().to_physical().is_numeric();
-    match (s_left.is_sorted_flag(), s_right.is_sorted_flag()) {
-        (IsSorted::Ascending, IsSorted::Ascending) if is_numeric => {
+
+    let no_nulls = s_left.null_count() == 0 && s_right.null_count() == 0;
+    match (s_left.is_sorted_flag(), s_right.is_sorted_flag(), no_nulls) {
+        (IsSorted::Ascending, IsSorted::Ascending, true) if is_numeric => {
             if verbose {
                 eprintln!("inner join: keys are sorted: use sorted merge join");
             }
-            (par_sorted_merge_inner(s_left, s_right), true)
+            (par_sorted_merge_inner_no_nulls(s_left, s_right), true)
         }
-        (IsSorted::Ascending, _) if is_numeric && size_factor_rhs < size_factor_acceptable => {
+        (IsSorted::Ascending, _, true)
+            if is_numeric && size_factor_rhs < size_factor_acceptable =>
+        {
             if verbose {
                 eprintln!("right key will be descending sorted in inner join operation.")
             }
@@ -216,7 +220,7 @@ pub fn _sort_or_hash_inner(
                 multithreaded: true,
             });
             let s_right = unsafe { s_right.take_unchecked(&sort_idx).unwrap() };
-            let ids = par_sorted_merge_inner(s_left, &s_right);
+            let ids = par_sorted_merge_inner_no_nulls(s_left, &s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
 
             let (left, mut right) = ids;
@@ -229,7 +233,9 @@ pub fn _sort_or_hash_inner(
 
             ((left, right), true)
         }
-        (_, IsSorted::Ascending) if is_numeric && size_factor_lhs < size_factor_acceptable => {
+        (_, IsSorted::Ascending, true)
+            if is_numeric && size_factor_lhs < size_factor_acceptable =>
+        {
             if verbose {
                 eprintln!("left key will be descending sorted in inner join operation.")
             }
@@ -240,7 +246,7 @@ pub fn _sort_or_hash_inner(
                 multithreaded: true,
             });
             let s_left = unsafe { s_left.take_unchecked(&sort_idx).unwrap() };
-            let ids = par_sorted_merge_inner(&s_left, s_right);
+            let ids = par_sorted_merge_inner_no_nulls(&s_left, s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
 
             let (mut left, right) = ids;
@@ -271,15 +277,19 @@ pub(super) fn sort_or_hash_left(s_left: &Series, s_right: &Series, verbose: bool
         .unwrap_or(1.0);
     let is_numeric = s_left.dtype().to_physical().is_numeric();
 
-    match (s_left.is_sorted_flag(), s_right.is_sorted_flag()) {
-        (IsSorted::Ascending, IsSorted::Ascending) if is_numeric => {
+    let no_nulls = s_left.null_count() == 0 && s_right.null_count() == 0;
+
+    match (s_left.is_sorted_flag(), s_right.is_sorted_flag(), no_nulls) {
+        (IsSorted::Ascending, IsSorted::Ascending, true) if is_numeric => {
             if verbose {
                 eprintln!("left join: keys are sorted: use sorted merge join");
             }
             let (left_idx, right_idx) = par_sorted_merge_left(s_left, s_right);
             to_left_join_ids(left_idx, right_idx)
         }
-        (IsSorted::Ascending, _) if is_numeric && size_factor_rhs < size_factor_acceptable => {
+        (IsSorted::Ascending, _, true)
+            if is_numeric && size_factor_rhs < size_factor_acceptable =>
+        {
             if verbose {
                 eprintln!("right key will be reverse sorted in left join operation.")
             }

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -531,3 +531,22 @@ def test_join_concat_projection_pd_case_7071() -> None:
 
     expected = pl.DataFrame({"id": [1, 1, 3]}).lazy()
     assert_frame_equal(result, expected)
+
+
+def test_join_sorted_fast_paths_null() -> None:
+    df1 = pl.DataFrame({"x": [0, 1, 0]}).sort("x")
+    df2 = pl.DataFrame({"x": [0, None], "y": [0, 1]})
+    assert df1.join(df2, on="x", how="inner").to_dict(False) == {
+        "x": [0, 0],
+        "y": [0, 0],
+    }
+    assert df1.join(df2, on="x", how="left").to_dict(False) == {
+        "x": [0, 0, 1],
+        "y": [0, 0, None],
+    }
+    assert df1.join(df2, on="x", how="anti").to_dict(False) == {"x": [1]}
+    assert df1.join(df2, on="x", how="semi").to_dict(False) == {"x": [0, 0]}
+    assert df1.join(df2, on="x", how="outer").to_dict(False) == {
+        "x": [0, 0, 1, None],
+        "y": [0, 0, None, 1],
+    }


### PR DESCRIPTION
…nulls

fixes #8269