### PR TITLE
refactor(rust, python): use `concat_owned_array_unchecked` when possible

### DIFF
--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -73,6 +73,13 @@ jobs:
             -p polars-core \
             -p polars-io \
             -p polars-lazy \
+            -p polars-sql \
+            -p polars-arrow \
+            -p polars-utils \
+            -p polars-ops \
+            -p polars-error \
+            -p polars-row \
+            -p polars-time \
             -- -D warnings
           cargo clippy -- -D warnings
 

--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -74,12 +74,6 @@ jobs:
             -p polars-io \
             -p polars-lazy \
             -p polars-sql \
-            -p polars-arrow \
-            -p polars-utils \
-            -p polars-ops \
-            -p polars-error \
-            -p polars-row \
-            -p polars-time \
             -- -D warnings
           cargo clippy -- -D warnings
 

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -30,7 +30,7 @@ clippy:
 	    -p polars-error \
 	    -p polars-row \
 	    -p polars-time \
-			-p polars-sql
+		-p polars-sql
 
 clippy-default:
 	cargo clippy

--- a/polars/polars-core/src/chunked_array/from.rs
+++ b/polars/polars-core/src/chunked_array/from.rs
@@ -15,7 +15,6 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
         // change the list-value array to the keys and store the dictionary values in the datatype.
         // if a global string cache is set, we also must modify the keys.
         DataType::List(inner) if *inner == DataType::Categorical(None) => {
-            use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
             let array = concatenate_owned_unchecked(chunks).unwrap();
             let list_arr = array.as_any().downcast_ref::<ListArray<i64>>().unwrap();
             let values_arr = list_arr.values();

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -45,6 +45,7 @@ use std::mem;
 use std::slice::Iter;
 
 use bitflags::bitflags;
+use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
 use polars_arrow::prelude::*;
 
 use crate::series::IsSorted;
@@ -236,14 +237,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     /// Shrink the capacity of this array to fit its length.
     pub fn shrink_to_fit(&mut self) {
-        self.chunks = vec![arrow::compute::concatenate::concatenate(
-            self.chunks
-                .iter()
-                .map(|a| &**a)
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-        .unwrap()];
+        self.chunks = vec![concatenate_owned_unchecked(self.chunks.as_slice()).unwrap()];
     }
 
     /// Unpack a Series to the same physical type.

--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "object")]
 use arrow::array::Array;
-use arrow::compute::concatenate;
+use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
 
 use super::*;
 #[cfg(feature = "object")]
@@ -93,10 +93,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             }
             _ => {
                 fn inner_rechunk(chunks: &[ArrayRef]) -> Vec<ArrayRef> {
-                    vec![concatenate::concatenate(
-                        chunks.iter().map(|a| &**a).collect::<Vec<_>>().as_slice(),
-                    )
-                    .unwrap()]
+                    vec![concatenate_owned_unchecked(chunks).unwrap()]
                 }
 
                 if self.chunks.len() == 1 {

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -210,8 +210,7 @@ impl Series {
                 use arrow::datatypes::IntegerType;
                 // don't spuriously call this; triggers a read on mmapped data
                 let arr = if chunks.len() > 1 {
-                    let chunks = chunks.iter().map(|arr| &**arr).collect::<Vec<_>>();
-                    arrow::compute::concatenate::concatenate(&chunks)?
+                    concatenate_owned_unchecked(&chunks)?
                 } else {
                     chunks[0].clone()
                 };

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -8,7 +8,7 @@ use arrow::compute::cast::utf8_to_large_utf8;
 ))]
 use arrow::temporal_conversions::*;
 use polars_arrow::compute::cast::cast;
-#[cfg(feature = "dtype-struct")]
+#[cfg(any(feature = "dtype-struct", feature = "dtype-categorical"))]
 use polars_arrow::kernels::concatenate::concatenate_owned_unchecked;
 
 use crate::chunked_array::cast::cast_chunks;

--- a/polars/polars-sql/src/cli/highlighter.rs
+++ b/polars/polars-sql/src/cli/highlighter.rs
@@ -9,8 +9,8 @@ use syntect::util::as_24_bit_terminal_escaped;
 
 pub(crate) struct SQLHighlighter {}
 
-const SQL_SYNTAX: &'static str = include_str!("../../assets/SQL.sublime-syntax");
-const THEME: &'static [u8] = include_bytes!("../../assets/theme");
+const SQL_SYNTAX: &str = include_str!("../../assets/SQL.sublime-syntax");
+const THEME: &[u8] = include_bytes!("../../assets/theme");
 
 impl Highlighter for SQLHighlighter {
     fn highlight(&self, line: &str, cursor: usize) -> reedline::StyledText {
@@ -24,7 +24,7 @@ impl Highlighter for SQLHighlighter {
 
         let mut styled_text = StyledText::new();
         let mut h = HighlightLines::new(syntax, &ts);
-        let ranges: Vec<(Style, &str)> = h.highlight_line(&line, &ps).unwrap();
+        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
         for (style, text) in ranges {
             let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
             let s = AnsiStyle::new().fg(fg);

--- a/polars/polars-sql/src/cli/mod.rs
+++ b/polars/polars-sql/src/cli/mod.rs
@@ -41,14 +41,13 @@ fn get_extension_from_filename(filename: &str) -> Option<&str> {
 }
 
 fn get_home_dir() -> PathBuf {
-    let home_dir = match env::var("HOME") {
+    match env::var("HOME") {
         Ok(path) => PathBuf::from(path),
         Err(_) => match env::var("USERPROFILE") {
             Ok(path) => PathBuf::from(path),
             Err(_) => panic!("Failed to get home directory"),
         },
-    };
-    home_dir
+    }
 }
 
 fn get_history_path() -> PathBuf {


### PR DESCRIPTION
As a drive by fixed clippy lints in polars-sql and add more crates to CI lint check.