### PR TITLE
fix(rust, python): always sort in `top_k` fast path

### DIFF
--- a/polars/polars-core/src/frame/top_k.rs
+++ b/polars/polars-core/src/frame/top_k.rs
@@ -65,6 +65,7 @@ impl DataFrame {
             .collect::<Vec<_>>();
 
         let sorted = if k >= self.height() {
+            rows.sort_unstable();
             &rows
         } else {
             let (lower, _el, _upper) = rows.select_nth_unstable(k);

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -646,3 +646,19 @@ def test_arg_sort_struct() -> None:
         8,
         9,
     ]
+
+
+def test_sort_top_k_fast_path() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, None],
+            "b": [6.0, 5.0, 4.0],
+            "c": ["a", "c", "b"],
+        }
+    )
+    # this triggers fast path as head is equal to n-rows
+    assert df.lazy().sort("b").head(3).collect().to_dict(False) == {
+        "a": [None, 2, 1],
+        "b": [4.0, 5.0, 6.0],
+        "c": ["b", "c", "a"],
+    }


### PR DESCRIPTION
fixes #8234