### PR TITLE
feat(python,rust): Add `dt.to_string` alias for `dt.strftime`

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -60,6 +60,14 @@ impl DateChunked {
         ca
     }
 
+    /// Convert from Date to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(&self, format: &str) -> Utf8Chunked {
+        self.to_string(format)
+    }
+
     /// Construct a new [`DateChunked`] from an iterator over optional [`NaiveDate`].
     pub fn from_naive_date_options<I: IntoIterator<Item = Option<NaiveDate>>>(
         name: &str,

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -60,14 +60,6 @@ impl DateChunked {
         ca
     }
 
-    /// Convert from Date to Utf8 with the given format.
-    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    ///
-    /// Alias for `to_string`.
-    pub fn strftime(&self, format: &str) -> Utf8Chunked {
-        self.to_string(format)
-    }
-
     /// Construct a new [`DateChunked`] from an iterator over optional [`NaiveDate`].
     pub fn from_naive_date_options<I: IntoIterator<Item = Option<NaiveDate>>>(
         name: &str,

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -30,8 +30,9 @@ impl DateChunked {
         Int32Chunked::from_vec(name, unit).into()
     }
 
-    /// Format Date with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(&self, format: &str) -> Utf8Chunked {
+    /// Convert from Date to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    pub fn to_string(&self, format: &str) -> Utf8Chunked {
         let date = NaiveDate::from_ymd_opt(2001, 1, 1).unwrap();
         let fmted = format!("{}", date.format(format));
 
@@ -57,6 +58,14 @@ impl DateChunked {
         });
         ca.rename(self.name());
         ca
+    }
+
+    /// Convert from Date to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(&self, format: &str) -> Utf8Chunked {
+        self.to_string(format)
     }
 
     /// Construct a new [`DateChunked`] from an iterator over optional [`NaiveDate`].

--- a/polars/polars-core/src/chunked_array/temporal/date.rs
+++ b/polars/polars-core/src/chunked_array/temporal/date.rs
@@ -30,7 +30,7 @@ impl DateChunked {
         Int32Chunked::from_vec(name, unit).into()
     }
 
-    /// Convert from Date to Utf8 with the given format.
+    /// Convert from Date into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn to_string(&self, format: &str) -> Utf8Chunked {
         let date = NaiveDate::from_ymd_opt(2001, 1, 1).unwrap();
@@ -60,7 +60,7 @@ impl DateChunked {
         ca
     }
 
-    /// Convert from Date to Utf8 with the given format.
+    /// Convert from Date into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     ///
     /// Alias for `to_string`.

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -219,6 +219,14 @@ impl DatetimeChunked {
         Ok(ca)
     }
 
+    /// Convert from Datetime to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(&self, format: &str) -> PolarsResult<Utf8Chunked> {
+        self.to_string(format)
+    }
+
     /// Construct a new [`DatetimeChunked`] from an iterator over [`NaiveDateTime`].
     pub fn from_naive_datetime<I: IntoIterator<Item = NaiveDateTime>>(
         name: &str,

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -168,8 +168,9 @@ impl DatetimeChunked {
         Ok(out)
     }
 
-    /// Format Datetime with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(&self, format: &str) -> PolarsResult<Utf8Chunked> {
+    /// Convert from Datetime to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    pub fn to_string(&self, format: &str) -> PolarsResult<Utf8Chunked> {
         #[cfg(feature = "timezones")]
         use chrono::Utc;
         let conversion_f = match self.time_unit() {
@@ -216,6 +217,14 @@ impl DatetimeChunked {
         };
         ca.rename(self.name());
         Ok(ca)
+    }
+
+    /// Convert from Datetime to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(&self, format: &str) -> PolarsResult<Utf8Chunked> {
+        self.to_string(format)
     }
 
     /// Construct a new [`DatetimeChunked`] from an iterator over [`NaiveDateTime`].

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -168,7 +168,7 @@ impl DatetimeChunked {
         Ok(out)
     }
 
-    /// Convert from Datetime to Utf8 with the given format.
+    /// Convert from Datetime into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn to_string(&self, format: &str) -> PolarsResult<Utf8Chunked> {
         #[cfg(feature = "timezones")]
@@ -219,7 +219,7 @@ impl DatetimeChunked {
         Ok(ca)
     }
 
-    /// Convert from Datetime to Utf8 with the given format.
+    /// Convert from Datetime into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     ///
     /// Alias for `to_string`.

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -219,14 +219,6 @@ impl DatetimeChunked {
         Ok(ca)
     }
 
-    /// Convert from Datetime to Utf8 with the given format.
-    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    ///
-    /// Alias for `to_string`.
-    pub fn strftime(&self, format: &str) -> PolarsResult<Utf8Chunked> {
-        self.to_string(format)
-    }
-
     /// Construct a new [`DatetimeChunked`] from an iterator over [`NaiveDateTime`].
     pub fn from_naive_datetime<I: IntoIterator<Item = NaiveDateTime>>(
         name: &str,

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -18,8 +18,9 @@ pub(crate) fn time_to_time64ns(time: &NaiveTime) -> i64 {
 }
 
 impl TimeChunked {
-    /// Format Time with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(&self, format: &str) -> Utf8Chunked {
+    /// Convert from Time to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    pub fn to_string(&self, format: &str) -> Utf8Chunked {
         let time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
         let fmted = format!("{}", time.format(format));
 

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -18,7 +18,7 @@ pub(crate) fn time_to_time64ns(time: &NaiveTime) -> i64 {
 }
 
 impl TimeChunked {
-    /// Convert from Time to Utf8 with the given format.
+    /// Convert from Time into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn to_string(&self, format: &str) -> Utf8Chunked {
         let time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
@@ -49,7 +49,7 @@ impl TimeChunked {
         ca
     }
 
-    /// Convert from Time to Utf8 with the given format.
+    /// Convert from Time into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     ///
     /// Alias for `to_string`.

--- a/polars/polars-core/src/chunked_array/temporal/time.rs
+++ b/polars/polars-core/src/chunked_array/temporal/time.rs
@@ -49,6 +49,14 @@ impl TimeChunked {
         ca
     }
 
+    /// Convert from Time to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(&self, format: &str) -> Utf8Chunked {
+        self.to_string(format)
+    }
+
     pub fn as_time_iter(&self) -> impl Iterator<Item = Option<NaiveTime>> + TrustedLen + '_ {
         // we know the iterators len
         unsafe {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -309,7 +309,7 @@ macro_rules! impl_dyn_series {
                         .into_series()
                         .time()
                         .unwrap()
-                        .strftime("%T")
+                        .to_string("%T")
                         .into_series()),
                     #[cfg(feature = "dtype-datetime")]
                     (DataType::Time, DataType::Datetime(_, _)) => {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -301,7 +301,7 @@ macro_rules! impl_dyn_series {
                         .into_series()
                         .date()
                         .unwrap()
-                        .strftime("%Y-%m-%d")
+                        .to_string("%Y-%m-%d")
                         .into_series()),
                     (DataType::Time, DataType::Utf8) => Ok(self
                         .0

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -323,13 +323,13 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn cast(&self, data_type: &DataType) -> PolarsResult<Series> {
         match (data_type, self.0.time_unit()) {
             (DataType::Utf8, TimeUnit::Milliseconds) => {
-                Ok(self.0.strftime("%F %T%.3f")?.into_series())
+                Ok(self.0.to_string("%F %T%.3f")?.into_series())
             }
             (DataType::Utf8, TimeUnit::Microseconds) => {
-                Ok(self.0.strftime("%F %T%.6f")?.into_series())
+                Ok(self.0.to_string("%F %T%.6f")?.into_series())
             }
             (DataType::Utf8, TimeUnit::Nanoseconds) => {
-                Ok(self.0.strftime("%F %T%.9f")?.into_series())
+                Ok(self.0.to_string("%F %T%.9f")?.into_series())
             }
             _ => self.0.cast(data_type),
         }

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -7,14 +7,22 @@ use crate::prelude::function_expr::TemporalFunction;
 pub struct DateLikeNameSpace(pub(crate) Expr);
 
 impl DateLikeNameSpace {
-    /// Format Date/datetime with a formatting rule
+    /// Convert from Date/Time/Datetime to Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    pub fn strftime(self, format: &str) -> Expr {
+    pub fn to_string(self, format: &str) -> Expr {
         let format = format.to_string();
-        let function = move |s: Series| s.strftime(&format).map(Some);
+        let function = move |s: Series| TemporalMethods::to_string(&s, &format).map(Some);
         self.0
             .map(function, GetOutput::from_type(DataType::Utf8))
-            .with_fmt("strftime")
+            .with_fmt("to_string")
+    }
+
+    /// Convert from Date/Time/Datetime to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    pub fn strftime(self, format: &str) -> Expr {
+        self.to_string(format)
     }
 
     /// Change the underlying [`TimeUnit`]. And update the data accordingly.

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -7,7 +7,7 @@ use crate::prelude::function_expr::TemporalFunction;
 pub struct DateLikeNameSpace(pub(crate) Expr);
 
 impl DateLikeNameSpace {
-    /// Convert from Date/Time/Datetime to Utf8 with the given format.
+    /// Convert from Date/Time/Datetime into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn to_string(self, format: &str) -> Expr {
         let format = format.to_string();
@@ -17,7 +17,7 @@ impl DateLikeNameSpace {
             .with_fmt("to_string")
     }
 
-    /// Convert from Date/Time/Datetime to Utf8 with the given format.
+    /// Convert from Date/Time/Datetime into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     ///
     /// Alias for `to_string`.

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -310,13 +310,13 @@ pub trait TemporalMethods: AsSeries {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
-            DataType::Date => s.date().map(|ca| ca.strftime(format).into_series()),
+            DataType::Date => s.date().map(|ca| ca.to_string(format).into_series()),
             #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(_, _) => s
                 .datetime()
-                .map(|ca| Ok(ca.strftime(format)?.into_series()))?,
+                .map(|ca| Ok(ca.to_string(format)?.into_series()))?,
             #[cfg(feature = "dtype-time")]
-            DataType::Time => s.time().map(|ca| ca.strftime(format).into_series()),
+            DataType::Time => s.time().map(|ca| ca.to_string(format).into_series()),
             dt => polars_bail!(opq = to_string, dt),
         }
     }

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -304,7 +304,7 @@ pub trait TemporalMethods: AsSeries {
         }
     }
 
-    /// Convert Time to Utf8 with the given format.
+    /// Convert Time into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     fn to_string(&self, format: &str) -> PolarsResult<Series> {
         let s = self.as_series();
@@ -321,7 +321,7 @@ pub trait TemporalMethods: AsSeries {
         }
     }
 
-    /// Convert from Time to Utf8 with the given format.
+    /// Convert from Time into Utf8 with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     ///
     /// Alias for `to_string`.

--- a/polars/polars-time/src/series/mod.rs
+++ b/polars/polars-time/src/series/mod.rs
@@ -304,8 +304,9 @@ pub trait TemporalMethods: AsSeries {
         }
     }
 
-    /// Format Date/Datetimewith a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
-    fn strftime(&self, format: &str) -> PolarsResult<Series> {
+    /// Convert Time to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    fn to_string(&self, format: &str) -> PolarsResult<Series> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -316,8 +317,16 @@ pub trait TemporalMethods: AsSeries {
                 .map(|ca| Ok(ca.strftime(format)?.into_series()))?,
             #[cfg(feature = "dtype-time")]
             DataType::Time => s.time().map(|ca| ca.strftime(format).into_series()),
-            dt => polars_bail!(opq = strftime, dt),
+            dt => polars_bail!(opq = to_string, dt),
         }
+    }
+
+    /// Convert from Time to Utf8 with the given format.
+    /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
+    ///
+    /// Alias for `to_string`.
+    fn strftime(&self, format: &str) -> PolarsResult<Series> {
+        self.to_string(format)
     }
 
     #[cfg(all(feature = "dtype-date", feature = "dtype-datetime"))]

--- a/polars/tests/it/core/pivot.rs
+++ b/polars/tests/it/core/pivot.rs
@@ -24,7 +24,7 @@ fn test_pivot_date() -> PolarsResult<()> {
     let mut out = pivot_stable(&df, ["C"], ["B"], ["A"], true, Some(PivotAgg::First), None)?;
     out.try_apply("1", |s| {
         let ca = s.date()?;
-        Ok(ca.strftime("%Y-%d-%m"))
+        Ok(ca.to_string("%Y-%d-%m"))
     })?;
 
     let expected = df![

--- a/polars/tests/it/lazy/expressions/expand.rs
+++ b/polars/tests/it/lazy/expressions/expand.rs
@@ -31,7 +31,7 @@ fn test_expand_datetimes_3042() -> PolarsResult<()> {
     .with_column(
         dtype_col(&DataType::Datetime(TimeUnit::Milliseconds, None))
             .dt()
-            .strftime("%m/%d/%Y"),
+            .to_string("%m/%d/%Y"),
     )
     .limit(3)
     .collect()?;

--- a/py-polars/docs/source/reference/expressions/temporal.rst
+++ b/py-polars/docs/source/reference/expressions/temporal.rst
@@ -41,6 +41,7 @@ The following methods are available under the `expr.dt` attribute.
     Expr.dt.strftime
     Expr.dt.time
     Expr.dt.timestamp
+    Expr.dt.to_string
     Expr.dt.truncate
     Expr.dt.week
     Expr.dt.weekday

--- a/py-polars/docs/source/reference/series/temporal.rst
+++ b/py-polars/docs/source/reference/series/temporal.rst
@@ -45,6 +45,7 @@ The following methods are available under the `Series.dt` attribute.
     Series.dt.strftime
     Series.dt.time
     Series.dt.timestamp
+    Series.dt.to_string
     Series.dt.truncate
     Series.dt.week
     Series.dt.weekday

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -333,7 +333,7 @@ class ExprDateTimeNameSpace:
 
     def to_string(self, format: str) -> Expr:
         """
-        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+        Convert a Date/Time/Datetime column into a Utf8 column with the given format.
 
         Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
         formatting of the resulting string.
@@ -379,7 +379,7 @@ class ExprDateTimeNameSpace:
     @deprecated_alias(fmt="format")
     def strftime(self, format: str) -> Expr:
         """
-        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+        Convert a Date/Time/Datetime column into a Utf8 column with the given format.
 
         Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
         formatting of the resulting string.

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -331,10 +331,12 @@ class ExprDateTimeNameSpace:
         time = expr_to_lit_or_expr(time)
         return wrap_expr(self._pyexpr.dt_combine(time._pyexpr, time_unit))
 
-    @deprecated_alias(fmt="format")
-    def strftime(self, format: str) -> Expr:
+    def to_string(self, format: str) -> Expr:
         """
-        Format Date/Datetime with a formatting rule.
+        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+
+        Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
+        formatting of the resulting string.
 
         Parameters
         ----------
@@ -345,25 +347,24 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
-        >>> from datetime import timedelta, datetime
+        >>> from datetime import datetime
         >>> df = pl.DataFrame(
         ...     {
-        ...         "date": pl.date_range(
-        ...             datetime(2020, 3, 1), datetime(2020, 5, 1), "1mo", eager=True
-        ...         ),
+        ...         "datetime": [
+        ...             datetime(2020, 3, 1),
+        ...             datetime(2020, 4, 1),
+        ...             datetime(2020, 5, 1),
+        ...         ]
         ...     }
         ... )
-        >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date")
-        ...         .dt.strftime("%Y/%m/%d %H:%M:%S")
-        ...         .alias("date_formatted"),
-        ...     ]
+        >>> df.with_columns(
+        ...     pl.col("datetime")
+        ...     .dt.to_string("%Y/%m/%d %H:%M:%S")
+        ...     .alias("datetime_string")
         ... )
         shape: (3, 2)
         ┌─────────────────────┬─────────────────────┐
-        │ date                ┆ date_formatted      │
+        │ datetime            ┆ datetime_string     │
         │ ---                 ┆ ---                 │
         │ datetime[μs]        ┆ str                 │
         ╞═════════════════════╪═════════════════════╡
@@ -374,6 +375,58 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.dt_strftime(format))
+
+    @deprecated_alias(fmt="format")
+    def strftime(self, format: str) -> Expr:
+        """
+        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+
+        Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
+        formatting of the resulting string.
+
+        Alias for :func:`to_string`.
+
+        Parameters
+        ----------
+        format
+            Format to use, refer to the `chrono strftime documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for specification. Example: ``"%y-%m-%d"``.
+
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "datetime": [
+        ...             datetime(2020, 3, 1),
+        ...             datetime(2020, 4, 1),
+        ...             datetime(2020, 5, 1),
+        ...         ]
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("datetime")
+        ...     .dt.to_string("%Y/%m/%d %H:%M:%S")
+        ...     .alias("datetime_string")
+        ... )
+        shape: (3, 2)
+        ┌─────────────────────┬─────────────────────┐
+        │ datetime            ┆ datetime_string     │
+        │ ---                 ┆ ---                 │
+        │ datetime[μs]        ┆ str                 │
+        ╞═════════════════════╪═════════════════════╡
+        │ 2020-03-01 00:00:00 ┆ 2020/03/01 00:00:00 │
+        │ 2020-04-01 00:00:00 ┆ 2020/04/01 00:00:00 │
+        │ 2020-05-01 00:00:00 ┆ 2020/05/01 00:00:00 │
+        └─────────────────────┴─────────────────────┘
+
+        See Also
+        --------
+        to_string : The identical expression for which ``strftime`` is an alias.
+
+        """
+        return self.to_string(format)
 
     def year(self) -> Expr:
         """

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -374,7 +374,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴─────────────────────┘
 
         """
-        return wrap_expr(self._pyexpr.dt_strftime(format))
+        return wrap_expr(self._pyexpr.dt_to_string(format))
 
     @deprecated_alias(fmt="format")
     def strftime(self, format: str) -> Expr:
@@ -407,7 +407,7 @@ class ExprDateTimeNameSpace:
         ... )
         >>> df.with_columns(
         ...     pl.col("datetime")
-        ...     .dt.to_string("%Y/%m/%d %H:%M:%S")
+        ...     .dt.strftime("%Y/%m/%d %H:%M:%S")
         ...     .alias("datetime_string")
         ... )
         shape: (3, 2)

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -142,7 +142,7 @@ class DateTimeNameSpace:
 
     def to_string(self, format: str) -> Series:
         """
-        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+        Convert a Date/Time/Datetime column into a Utf8 column with the given format.
 
         Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
         formatting of the resulting string.
@@ -175,10 +175,12 @@ class DateTimeNameSpace:
     @deprecated_alias(fmt="format")
     def strftime(self, format: str) -> Series:
         """
-        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+        Convert a Date/Time/Datetime column into a Utf8 column with the given format.
 
         Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
         formatting of the resulting string.
+
+        Alias for :func:`to_string`.
 
         Parameters
         ----------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars import functions as F
 from polars.datatypes import Date
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
@@ -141,10 +140,12 @@ class DateTimeNameSpace:
                 return _to_python_datetime(int(out), s.time_unit)
         return None
 
-    @deprecated_alias(fmt="format")
-    def strftime(self, format: str) -> Series:
+    def to_string(self, format: str) -> Series:
         """
-        Format Date/datetime with a formatting rule.
+        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+
+        Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
+        formatting of the resulting string.
 
         Parameters
         ----------
@@ -153,38 +154,61 @@ class DateTimeNameSpace:
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for specification. Example: ``"%y-%m-%d"``.
 
-        Returns
-        -------
-        Utf8 Series
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> s = pl.Series(
+        ...     "datetime",
+        ...     [datetime(2020, 3, 1), datetime(2020, 4, 1), datetime(2020, 5, 1)],
+        ... )
+        >>> s.dt.to_string("%Y/%m/%d")
+        shape: (3,)
+        Series: 'datetime' [str]
+        [
+                "2020/03/01"
+                "2020/04/01"
+                "2020/05/01"
+        ]
+
+        """
+
+    @deprecated_alias(fmt="format")
+    def strftime(self, format: str) -> Series:
+        """
+        Convert a Date/Time/Datetime column to a Utf8 column with the given format.
+
+        Similar to ``cast(pl.Utf8)``, but this method allows you to customize the
+        formatting of the resulting string.
+
+        Parameters
+        ----------
+        format
+            Format to use, refer to the `chrono strftime documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for specification. Example: ``"%y-%m-%d"``.
 
         Examples
         --------
         >>> from datetime import datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 4)
-        >>> date = pl.date_range(start, stop, interval="1d", eager=True)
-        >>> date
-        shape: (4,)
-        Series: '' [datetime[μs]]
+        >>> s = pl.Series(
+        ...     "datetime",
+        ...     [datetime(2020, 3, 1), datetime(2020, 4, 1), datetime(2020, 5, 1)],
+        ... )
+        >>> s.dt.strftime("%Y/%m/%d")
+        shape: (3,)
+        Series: 'datetime' [str]
         [
-                2001-01-01 00:00:00
-                2001-01-02 00:00:00
-                2001-01-03 00:00:00
-                2001-01-04 00:00:00
-        ]
-        >>> date.dt.strftime(format="%Y-%m-%d")
-        shape: (4,)
-        Series: '' [str]
-        [
-                "2001-01-01"
-                "2001-01-02"
-                "2001-01-03"
-                "2001-01-04"
+                "2020/03/01"
+                "2020/04/01"
+                "2020/05/01"
         ]
 
+        See Also
+        --------
+        to_string : The identical Series method for which ``strftime`` is an alias.
+
         """
-        s = wrap_s(self._s)
-        return s.to_frame().select(F.col(s.name).dt.strftime(format)).to_series()
+        return self.to_string(format)
 
     def year(self) -> Series:
         """

--- a/py-polars/src/expr/datetime.rs
+++ b/py-polars/src/expr/datetime.rs
@@ -6,8 +6,8 @@ use crate::PyExpr;
 
 #[pymethods]
 impl PyExpr {
-    fn dt_strftime(&self, format: &str) -> Self {
-        self.inner.clone().dt().strftime(format).into()
+    fn dt_to_string(&self, format: &str) -> Self {
+        self.inner.clone().dt().to_string(format).into()
     }
 
     fn dt_offset_by(&self, by: &str) -> Self {

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1935,7 +1935,7 @@ def test_datetime_string_casts() -> None:
         ],
     )
     assert df.select(
-        [pl.col("x").dt.strftime("%F %T").alias("w")]
+        [pl.col("x").dt.to_string("%F %T").alias("w")]
         + [pl.col(d).cast(str) for d in df.columns]
     ).rows() == [
         (
@@ -2467,17 +2467,17 @@ def test_tz_aware_truncate() -> None:
     }
 
 
-def test_strftime_invalid_format() -> None:
+def test_to_string_invalid_format() -> None:
     tz_naive = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime)
     with pytest.raises(
         ComputeError, match="cannot format NaiveDateTime with format '%z'"
     ):
-        tz_naive.dt.strftime("%z")
+        tz_naive.dt.to_string("%z")
     with pytest.raises(ComputeError, match="cannot format DateTime with format '%q'"):
-        tz_naive.dt.replace_time_zone("UTC").dt.strftime("%q")
+        tz_naive.dt.replace_time_zone("UTC").dt.to_string("%q")
 
 
-def test_tz_aware_strftime() -> None:
+def test_tz_aware_to_string() -> None:
     df = pl.DataFrame(
         {
             "dt": pl.date_range(
@@ -2488,7 +2488,7 @@ def test_tz_aware_strftime() -> None:
             ).dt.replace_time_zone("America/New_York")
         }
     )
-    assert df.with_columns(pl.col("dt").dt.strftime("%c").alias("fmt")).to_dict(
+    assert df.with_columns(pl.col("dt").dt.to_string("%c").alias("fmt")).to_dict(
         False
     ) == {
         "dt": [
@@ -2520,7 +2520,7 @@ def test_tz_aware_with_timezone_directive(
 ) -> None:
     tz_naive = pl.Series(["2020-01-01 03:00:00"]).str.strptime(pl.Datetime)
     tz_aware = tz_naive.dt.replace_time_zone(time_zone)
-    result = tz_aware.dt.strftime(directive).item()
+    result = tz_aware.dt.to_string(directive).item()
     assert result == expected
 
 

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -34,10 +34,13 @@ def series_of_str_dates() -> pl.Series:
     return pl.Series(["2020-01-01 00:00:00.000000000", "2020-02-02 03:20:10.987654321"])
 
 
-def test_dt_strftime(series_of_int_dates: pl.Series) -> None:
+def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
     expected_str_dates = pl.Series(["1997-05-19", "2024-10-04", "2052-02-20"])
 
     assert series_of_int_dates.dtype == pl.Date
+    assert_series_equal(series_of_int_dates.dt.to_string("%F"), expected_str_dates)
+
+    # Check strftime alias as well
     assert_series_equal(series_of_int_dates.dt.strftime("%F"), expected_str_dates)
 
 

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -86,7 +86,7 @@ def test_to_datetime_precision_with_time_unit(
     time_unit: TimeUnit, expected: str, format: str
 ) -> None:
     s = pl.Series(["2020-01-01 00:00:00.123456789"])
-    result = s.str.to_datetime(format, time_unit=time_unit).dt.strftime("%f")[0]
+    result = s.str.to_datetime(format, time_unit=time_unit).dt.to_string("%f")[0]
     assert result == expected
 
 


### PR DESCRIPTION
Closes #8215 

Changes:
* Add `to_string` to the temporal namespace. `strftime` is now an alias for this method - we give users the option to use the familiar `strftime`, but internally we use the more readable `to_string`.
* Update references, docstrings, etc.

I'm planning to make the `format` parameter optional, and move the logic for determining a default format from `cast` to this method, and have `cast` call this method. But I'll do that refactor in another PR.