### PR TITLE
chore(python): fixup overloads of read_excel

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.0"
-source = "git+https://github.com/ritchie46/arrow2?rev=192decd20314d3b35f98206a4eda951043031a5f#192decd20314d3b35f98206a4eda951043031a5f"
+source = "git+https://github.com/ritchie46/arrow2?rev=1491c6e8f4fd100f53c358e4f3ef1536d9e75090#1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -102,9 +102,10 @@ def read_excel(
         By file-like object, we refer to objects with a ``read()`` method, such as a
         file handler (e.g. via builtin ``open`` function) or ``BytesIO``.
     sheet_id
-        Sheet number to convert (``0`` for all sheets).
+        Sheet number to convert (``0`` for all sheets). Defaults to `1` if neither this
+        nor `sheet_name` are specified.
     sheet_name
-        Sheet name to convert.
+        Sheet name to convert. Cannot be used in conjunction with `sheet_id`.
     xlsx2csv_options
         Extra options passed to ``xlsx2csv.Xlsx2csv()``.
         e.g.: ``{"skip_empty_lines": True}``
@@ -163,6 +164,7 @@ def read_excel(
         raise ImportError(
             "xlsx2csv is not installed. Please run `pip install xlsx2csv`."
         ) from None
+
     if isinstance(source, (str, Path)):
         source = normalise_filepath(source)
 

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -8,10 +8,15 @@ from polars.io.csv.functions import read_csv
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
+    import sys
     from io import BytesIO
-    from typing import Literal
 
     from polars.dataframe import DataFrame
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 
 @overload

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -8,37 +8,19 @@ from polars.io.csv.functions import read_csv
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
-    import sys
     from io import BytesIO
 
     from polars.dataframe import DataFrame
 
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
-
 
 @overload
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
     *,
-    sheet_id: Literal[None],
-    sheet_name: Literal[None],
-    xlsx2csv_options: dict[str, Any] | None,
-    read_csv_options: dict[str, Any] | None,
-) -> dict[str, DataFrame]:
-    ...
-
-
-@overload
-def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
-    *,
-    sheet_id: Literal[None],
+    sheet_id: int = ...,
     sheet_name: str,
-    xlsx2csv_options: dict[str, Any] | None = None,
-    read_csv_options: dict[str, Any] | None = None,
+    xlsx2csv_options: dict[str, Any] | None = ...,
+    read_csv_options: dict[str, Any] | None = ...,
 ) -> DataFrame:
     ...
 
@@ -47,10 +29,34 @@ def read_excel(
 def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
     *,
-    sheet_id: int,
-    sheet_name: Literal[None],
-    xlsx2csv_options: dict[str, Any] | None = None,
-    read_csv_options: dict[str, Any] | None = None,
+    sheet_id: None,
+    sheet_name: None = ...,
+    xlsx2csv_options: dict[str, Any] | None = ...,
+    read_csv_options: dict[str, Any] | None = ...,
+) -> dict[str, DataFrame]:
+    ...
+
+
+@overload
+def read_excel(
+    source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
+    sheet_id: None,
+    sheet_name: str,
+    xlsx2csv_options: dict[str, Any] | None = ...,
+    read_csv_options: dict[str, Any] | None = ...,
+) -> DataFrame:
+    ...
+
+
+@overload
+def read_excel(
+    source: str | BytesIO | Path | BinaryIO | bytes,
+    *,
+    sheet_id: int = ...,
+    sheet_name: None = ...,
+    xlsx2csv_options: dict[str, Any] | None = ...,
+    read_csv_options: dict[str, Any] | None = ...,
 ) -> DataFrame:
     ...
 

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -55,10 +55,10 @@ def read_excel(
     ...
 
 
-@overload
 # mypy wants the return value for Literal[0] to
 # overlap with the return value for other integers.
-def read_excel(  # type: ignore[misc]
+@overload  # type: ignore[misc]
+def read_excel(
     source: str | BytesIO | Path | BinaryIO | bytes,
     *,
     sheet_id: Literal[0],

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -26,13 +26,20 @@ def test_read_excel(excel_file_path: Path) -> None:
 
 
 def test_read_excel_all_sheets(excel_file_path: Path) -> None:
-    df = pl.read_excel(excel_file_path, sheet_id=None)
+    df = pl.read_excel(excel_file_path, sheet_id=0)
 
     expected1 = pl.DataFrame({"hello": ["Row 1", "Row 2"]})
     expected2 = pl.DataFrame({"world": ["Row 3", "Row 4"]})
 
     assert_frame_equal(df["Sheet1"], expected1)
     assert_frame_equal(df["Sheet2"], expected2)
+
+
+def test_read_excel_all_sheets_with_sheet_name(excel_file_path: Path) -> None:
+    with pytest.raises(
+        ValueError, match="Cannot specify both `sheet_name` and `sheet_id`"
+    ):
+        pl.read_excel(excel_file_path, sheet_id=1, sheet_name="Sheet1")
 
 
 # the parameters don't change the data, only the formatting, so we expect

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -26,7 +26,7 @@ def test_read_excel(excel_file_path: Path) -> None:
 
 
 def test_read_excel_all_sheets(excel_file_path: Path) -> None:
-    df = pl.read_excel(excel_file_path, sheet_id=None)  # type: ignore[call-overload]
+    df = pl.read_excel(excel_file_path, sheet_id=None)
 
     expected1 = pl.DataFrame({"hello": ["Row 1", "Row 2"]})
     expected2 = pl.DataFrame({"world": ["Row 3", "Row 4"]})
@@ -154,7 +154,7 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
     _wb = df.write_excel(workbook=xls, worksheet="data", **write_params)
 
     # ...and read it back again:
-    xldf = pl.read_excel(  # type: ignore[call-overload]
+    xldf = pl.read_excel(
         xls,
         sheet_name="data",
         read_csv_options=header_opts,
@@ -173,7 +173,7 @@ def test_excel_compound_types() -> None:
     xls = BytesIO()
     df.write_excel(xls, worksheet="data")
 
-    xldf = pl.read_excel(xls, sheet_name="data")  # type: ignore[call-overload]
+    xldf = pl.read_excel(xls, sheet_name="data")
     assert xldf.rows() == [
         ("[1, 2]", "{'y': 'a', 'z': 9}"),
         ("[3, 4]", "{'y': 'b', 'z': 8}"),
@@ -233,7 +233,7 @@ def test_excel_sparklines() -> None:
     tables = {tbl["name"] for tbl in wb.get_worksheet_by_name("frame_data").tables}
     assert "Frame0" in tables
 
-    xldf = pl.read_excel(xls, sheet_name="frame_data")  # type: ignore[call-overload]
+    xldf = pl.read_excel(xls, sheet_name="frame_data")
     # ┌─────┬──────┬─────┬─────┬─────┬─────┬───────┬─────┬─────┐
     # │ id  ┆ +/-  ┆ q1  ┆ q2  ┆ q3  ┆ q4  ┆ trend ┆ h1  ┆ h2  │
     # │ --- ┆ ---  ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---   ┆ --- ┆ --- │
@@ -289,4 +289,4 @@ def test_excel_write_multiple_tables() -> None:
             tbl["name"] for tbl in wb.get_worksheet_by_name(sheet).tables
         )
     assert table_names == {f"Frame{n}" for n in range(4)}
-    assert pl.read_excel(xls, sheet_name="sheet3").rows() == []  # type: ignore[call-overload]
+    assert pl.read_excel(xls, sheet_name="sheet3").rows() == []


### PR DESCRIPTION
closes #8296

demo:

`t.py`:
```python
# ruff: noqa
from datetime import *

import polars as pl

excel_file_path = "test.xlsx"
reveal_type(pl.read_excel(excel_file_path))  # dataframe
reveal_type(pl.read_excel(excel_file_path, sheet_name="foo"))  # dataframe
reveal_type(pl.read_excel(excel_file_path, sheet_id=0, sheet_name="foo"))  # no return
reveal_type(pl.read_excel(excel_file_path, sheet_id=0))  # dict
reveal_type(pl.read_excel(excel_file_path, sheet_id=1))  # dataframe
```

```console
$ mypy t.py 
t.py:7: note: Revealed type is "polars.dataframe.frame.DataFrame"
t.py:8: note: Revealed type is "polars.dataframe.frame.DataFrame"
t.py:9: note: Revealed type is "<nothing>"
t.py:10: note: Revealed type is "builtins.dict[builtins.str, polars.dataframe.frame.DataFrame]"
t.py:11: note: Revealed type is "polars.dataframe.frame.DataFrame"
Success: no issues found in 1 source file
```