### PR TITLE
perf(rust, python): use online variance kernel for aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ either = "1.8"
 [workspace.dependencies.arrow]
 package = "arrow2"
 git = "https://github.com/jorgecarleitao/arrow2"
-#git = "https://github.com/ritchie46/arrow2"
+# git = "https://github.com/ritchie46/arrow2"
 rev = "1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
 # path = "../arrow2"
 # branch = "polars_2023-04-05"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ either = "1.8"
 
 [workspace.dependencies.arrow]
 package = "arrow2"
-# git = "https://github.com/jorgecarleitao/arrow2"
-git = "https://github.com/ritchie46/arrow2"
+git = "https://github.com/jorgecarleitao/arrow2"
+#git = "https://github.com/ritchie46/arrow2"
 rev = "1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
 # path = "../arrow2"
 # branch = "polars_2023-04-05"

--- a/polars/polars-arrow/src/kernels/take_agg/boolean.rs
+++ b/polars/polars-arrow/src/kernels/take_agg/boolean.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+#[inline]
+pub unsafe fn take_min_bool_iter_unchecked_nulls<I: IntoIterator<Item = usize>>(
+    arr: &BooleanArray,
+    indices: I,
+    len: IdxSize,
+) -> Option<bool> {
+    let mut null_count = 0 as IdxSize;
+    let validity = arr.validity().unwrap();
+
+    for idx in indices {
+        if validity.get_bit_unchecked(idx) {
+            if !arr.value_unchecked(idx) {
+                return Some(false);
+            }
+        } else {
+            null_count += 1;
+        }
+    }
+    if null_count == len {
+        None
+    } else {
+        Some(true)
+    }
+}
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+#[inline]
+pub unsafe fn take_min_bool_iter_unchecked_no_nulls<I: IntoIterator<Item = usize>>(
+    arr: &BooleanArray,
+    indices: I,
+) -> Option<bool> {
+    if arr.is_empty() {
+        return None;
+    }
+
+    for idx in indices {
+        if !arr.value_unchecked(idx) {
+            return Some(false);
+        }
+    }
+    Some(true)
+}
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+#[inline]
+pub unsafe fn take_max_bool_iter_unchecked_nulls<I: IntoIterator<Item = usize>>(
+    arr: &BooleanArray,
+    indices: I,
+    len: IdxSize,
+) -> Option<bool> {
+    let mut null_count = 0 as IdxSize;
+    let validity = arr.validity().unwrap();
+
+    for idx in indices {
+        if validity.get_bit_unchecked(idx) {
+            if arr.value_unchecked(idx) {
+                return Some(true);
+            }
+        } else {
+            null_count += 1;
+        }
+    }
+    if null_count == len {
+        None
+    } else {
+        Some(false)
+    }
+}
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+#[inline]
+pub unsafe fn take_max_bool_iter_unchecked_no_nulls<I: IntoIterator<Item = usize>>(
+    arr: &BooleanArray,
+    indices: I,
+) -> Option<bool> {
+    if arr.is_empty() {
+        return None;
+    }
+
+    for idx in indices {
+        if arr.value_unchecked(idx) {
+            return Some(true);
+        }
+    }
+    Some(false)
+}

--- a/polars/polars-arrow/src/kernels/take_agg/mod.rs
+++ b/polars/polars-arrow/src/kernels/take_agg/mod.rs
@@ -1,7 +1,12 @@
 //! kernels that combine take and aggregations.
+mod boolean;
+mod var;
+
 use arrow::array::{Array, BooleanArray, PrimitiveArray, Utf8Array};
 use arrow::types::NativeType;
+pub use boolean::*;
 use num_traits::{NumCast, ToPrimitive};
+pub use var::*;
 
 use crate::array::PolarsArray;
 use crate::index::IdxSize;
@@ -48,7 +53,7 @@ pub unsafe fn take_agg_primitive_iter_unchecked<
     len: IdxSize,
 ) -> Option<T> {
     let array_values = arr.values().as_slice();
-    let validity = arr.validity().expect("null buffer should be there");
+    let validity = arr.validity().unwrap();
     let mut null_count = 0 as IdxSize;
 
     let out = indices.into_iter().fold(init, |acc, idx| {
@@ -162,100 +167,4 @@ pub unsafe fn take_agg_utf8_iter_unchecked_no_null<
         .into_iter()
         .map(|idx| arr.value_unchecked(idx))
         .reduce(|acc, str_val| f(acc, str_val))
-}
-
-/// Take kernel for single chunk and an iterator as index.
-/// # Safety
-/// caller must ensure iterators indexes are in bounds
-#[inline]
-pub unsafe fn take_min_bool_iter_unchecked_nulls<I: IntoIterator<Item = usize>>(
-    arr: &BooleanArray,
-    indices: I,
-    len: IdxSize,
-) -> Option<bool> {
-    let mut null_count = 0 as IdxSize;
-    let validity = arr.validity().unwrap();
-
-    for idx in indices {
-        if validity.get_bit_unchecked(idx) {
-            if !arr.value_unchecked(idx) {
-                return Some(false);
-            }
-        } else {
-            null_count += 1;
-        }
-    }
-    if null_count == len {
-        None
-    } else {
-        Some(true)
-    }
-}
-
-/// Take kernel for single chunk and an iterator as index.
-/// # Safety
-/// caller must ensure iterators indexes are in bounds
-#[inline]
-pub unsafe fn take_min_bool_iter_unchecked_no_nulls<I: IntoIterator<Item = usize>>(
-    arr: &BooleanArray,
-    indices: I,
-) -> Option<bool> {
-    if arr.is_empty() {
-        return None;
-    }
-
-    for idx in indices {
-        if !arr.value_unchecked(idx) {
-            return Some(false);
-        }
-    }
-    Some(true)
-}
-
-/// Take kernel for single chunk and an iterator as index.
-/// # Safety
-/// caller must ensure iterators indexes are in bounds
-#[inline]
-pub unsafe fn take_max_bool_iter_unchecked_nulls<I: IntoIterator<Item = usize>>(
-    arr: &BooleanArray,
-    indices: I,
-    len: IdxSize,
-) -> Option<bool> {
-    let mut null_count = 0 as IdxSize;
-    let validity = arr.validity().unwrap();
-
-    for idx in indices {
-        if validity.get_bit_unchecked(idx) {
-            if arr.value_unchecked(idx) {
-                return Some(true);
-            }
-        } else {
-            null_count += 1;
-        }
-    }
-    if null_count == len {
-        None
-    } else {
-        Some(false)
-    }
-}
-
-/// Take kernel for single chunk and an iterator as index.
-/// # Safety
-/// caller must ensure iterators indexes are in bounds
-#[inline]
-pub unsafe fn take_max_bool_iter_unchecked_no_nulls<I: IntoIterator<Item = usize>>(
-    arr: &BooleanArray,
-    indices: I,
-) -> Option<bool> {
-    if arr.is_empty() {
-        return None;
-    }
-
-    for idx in indices {
-        if arr.value_unchecked(idx) {
-            return Some(true);
-        }
-    }
-    Some(false)
 }

--- a/polars/polars-arrow/src/kernels/take_agg/var.rs
+++ b/polars/polars-arrow/src/kernels/take_agg/var.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+/// Numerical stable online variance aggregation
+/// See:
+/// Welford, B. P. (1962). "Note on a method for calculating corrected sums of squares and products".
+/// Technometrics. 4 (3): 419–420. doi:10.2307/1266577. JSTOR 1266577.
+/// and:
+/// Ling, Robert F. (1974). "Comparison of Several Algorithms for Computing Sample Means and Variances".
+/// Journal of the American Statistical Association. 69 (348): 859–866. doi:10.2307/2286154. JSTOR 2286154.
+
+pub fn online_variance<I>(
+    // iterator producing values
+    iter: I,
+    ddof: u8,
+) -> Option<f64>
+where
+    I: IntoIterator<Item = f64>,
+{
+    let mut m2 = 0.0;
+    let mut mean = 0.0;
+    let mut count = 0u64;
+
+    for value in iter {
+        let new_count = count + 1;
+        let delta_1 = value - mean;
+        let new_mean = delta_1 / new_count as f64 + mean;
+        let delta_2 = value - new_mean;
+        let new_m2 = m2 + delta_1 * delta_2;
+
+        count += 1;
+        mean = new_mean;
+        m2 = new_m2;
+    }
+    match count {
+        0 => None,
+        1 => Some(0.0),
+        _ => Some(m2 / (count as f64 - ddof as f64)),
+    }
+}
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+pub unsafe fn take_var_no_null_primitive_iter_unchecked<
+    T: NativeType + ToPrimitive,
+    I: IntoIterator<Item = usize>,
+>(
+    arr: &PrimitiveArray<T>,
+    indices: I,
+    ddof: u8,
+) -> Option<f64>
+where
+    T: ToPrimitive,
+{
+    debug_assert!(arr.null_count() == 0);
+    let array_values = arr.values().as_slice();
+    let iter = unsafe {
+        indices.into_iter().map(|idx| {
+            let value = *array_values.get_unchecked(idx);
+            value.to_f64().unwrap_unchecked()
+        })
+    };
+    online_variance(iter, ddof)
+}
+
+/// Take kernel for single chunk and an iterator as index.
+/// # Safety
+/// caller must ensure iterators indexes are in bounds
+pub unsafe fn take_var_nulls_primitive_iter_unchecked<
+    T: NativeType + ToPrimitive,
+    I: IntoIterator<Item = usize>,
+>(
+    arr: &PrimitiveArray<T>,
+    indices: I,
+    ddof: u8,
+) -> Option<f64>
+where
+    T: ToPrimitive,
+{
+    debug_assert!(arr.null_count() > 0);
+    let array_values = arr.values().as_slice();
+    let validity = arr.validity().unwrap();
+
+    let iter = unsafe {
+        indices.into_iter().flat_map(|idx| {
+            if validity.get_bit_unchecked(idx) {
+                let value = *array_values.get_unchecked(idx);
+                value.to_f64()
+            } else {
+                None
+            }
+        })
+    };
+    online_variance(iter, ddof)
+}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.0"
-source = "git+https://github.com/ritchie46/arrow2?rev=192decd20314d3b35f98206a4eda951043031a5f#192decd20314d3b35f98206a4eda951043031a5f"
+source = "git+https://github.com/ritchie46/arrow2?rev=1491c6e8f4fd100f53c358e4f3ef1536d9e75090#1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.0"
-source = "git+https://github.com/ritchie46/arrow2?rev=1491c6e8f4fd100f53c358e4f3ef1536d9e75090#1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=1491c6e8f4fd100f53c358e4f3ef1536d9e75090#1491c6e8f4fd100f53c358e4f3ef1536d9e75090"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -202,3 +202,20 @@ def test_string_par_materialize_8207() -> None:
         "a": ["a", "b", "c", "d", "e"],
         "b": ["P", "L", "T", "R", "a long string"],
     }
+
+
+def test_online_variance() -> None:
+    df = pl.DataFrame(
+        {
+            "id": [1] * 5,
+            "no_nulls": [1, 2, 3, 4, 5],
+            "nulls": [1, None, 3, None, 5],
+        }
+    )
+
+    assert_frame_equal(
+        df.groupby("id")
+        .agg(pl.all().exclude("id").std())
+        .select(["no_nulls", "nulls"]),
+        df.select(pl.all().exclude("id").std()),
+    )


### PR DESCRIPTION
This speeds up variance and std aggregation by computing in a single pass.