### PR TITLE
docs(python): add newline in pl.DataFrame.pivot docs

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6095,6 +6095,7 @@ class DataFrame:
         └─────┴─────┴─────┴─────┘
 
         Run an expression as aggregation function
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "col1": ["a", "a", "a", "b", "b", "b"],

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6095,7 +6095,6 @@ class DataFrame:
         └─────┴─────┴─────┴─────┘
 
         Run an expression as aggregation function
-        
         >>> df = pl.DataFrame(
         ...     {
         ...         "col1": ["a", "a", "a", "b", "b", "b"],

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6095,6 +6095,7 @@ class DataFrame:
         └─────┴─────┴─────┴─────┘
 
         Run an expression as aggregation function
+        
         >>> df = pl.DataFrame(
         ...     {
         ...         "col1": ["a", "a", "a", "b", "b", "b"],


### PR DESCRIPTION
Reference - https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.pivot.html

**Very minor.**

The second example doesn't show up formatted correctly because the code block starts immediately after the previous line without a newline:

<img width="900" alt="Screenshot 2023-04-17 at 10 23 55" src="https://user-images.githubusercontent.com/66530011/232534115-d830d1a1-e4a8-40ed-bac4-d08049c6cbb2.png">

