### PR TITLE
tests(python): adjust pytest config so as not to inadvertently prevent test debugging in IPython consoles

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -180,7 +180,12 @@ markers = [
   "slow: Tests with a longer than average runtime.",
   "benchmark: Tests that should be run on a Polars release build.",
 ]
-filterwarnings = "error" # Fail on warnings
+filterwarnings = [
+  # Fail on warnings...
+  "error",
+  # ...except where it prevents test debugging in an IPython console
+  "ignore:.*unrecognized arguments.*PyDevIPCompleter:DeprecationWarning",
+]
 xfail_strict = true
 
 [tool.coverage.run]


### PR DESCRIPTION
Aha! Finally worked out what was happening...

When debugging from tests I was sometimes getting errors that didn't seem to make sense; had switched the project to use an IPython console under the hood, and finally realised it was the `pytest` config setting that upgrades warnings to errors. 

The debugging console itself can issue a `DeprecationWarning`, the warning gets upgraded to an error, and the debug session gets stopped in its tracks. So, have selectively ignored the _specific_ warning that prevents debugging, and can now breathe a sigh of relief  :)