### PR TITLE
test(python): enhanced parametric testing for temporal dtypes 

### DIFF
--- a/polars/polars-core/src/datatypes/aliases.rs
+++ b/polars/polars-core/src/datatypes/aliases.rs
@@ -18,8 +18,6 @@ pub type IdxType = UInt32Type;
 #[cfg(feature = "bigidx")]
 pub type IdxType = UInt64Type;
 
-pub const NULL_DTYPE: DataType = DataType::Int32;
-
 #[cfg(feature = "private")]
 pub type PlHashMap<K, V> = hashbrown::HashMap<K, V, RandomState>;
 #[cfg(feature = "private")]

--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -150,13 +150,10 @@ impl<T: AsRef<[Option<Series>]>> NamedFrom<T, [Option<Series>]> for Series {
         let values_cap = series_slice.iter().fold(0, |acc, opt_s| {
             acc + opt_s.as_ref().map(|s| s.len()).unwrap_or(0)
         });
-
-        let dt = series_slice
-            .iter()
-            .filter_map(|opt| opt.as_ref())
-            .next()
-            .expect("cannot create List Series from a slice of nulls")
-            .dtype();
+        let dt = match series_slice.iter().filter_map(|opt| opt.as_ref()).next() {
+            Some(series) => series.dtype(),
+            None => &DataType::Null,
+        };
 
         let mut builder = get_list_builder(dt, values_cap, series_slice.len(), name).unwrap();
         for series in series_slice {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -15,7 +15,7 @@ impl FunctionExpr {
             Abs => mapper.with_same_dtype(),
             NullCount => mapper.with_dtype(IDX_DTYPE),
             Pow => mapper.map_to_float_dtype(),
-            Coalesce => mapper.map_to_list_supertype(),
+            Coalesce => mapper.map_to_supertype(),
             #[cfg(feature = "row_hash")]
             Hash(..) => mapper.with_dtype(DataType::UInt64),
             #[cfg(feature = "arg_where")]

--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -97,16 +97,16 @@ fn run_per_sublist(
             })
             .collect_trusted()
     };
+    if let Some(err) = err {
+        return Err(err);
+    }
 
     ca.rename(s.name());
 
     if ca.dtype() != output_field.data_type() {
         ca.cast(output_field.data_type()).map(Some)
     } else {
-        match err {
-            None => Ok(Some(ca.into_series())),
-            Some(e) => Err(e),
-        }
+        Ok(Some(ca.into_series()))
     }
 }
 

--- a/polars/tests/it/lazy/expressions/arity.rs
+++ b/polars/tests/it/lazy/expressions/arity.rs
@@ -384,28 +384,3 @@ fn test_binary_group_consistency() -> PolarsResult<()> {
 
     Ok(())
 }
-
-#[test]
-fn test_binary_null_prop() -> PolarsResult<()> {
-    let df = df![
-        "a" => [0, 0],
-        "b" => [1, 2]
-    ]?
-    .lazy();
-
-    let expr = col("a").filter(col("a").gt(lit(0)));
-
-    let out = df
-        .groupby([col("b")])
-        .agg([(expr.clone() - expr.mean()).alias("a_mean")])
-        .sort("b", Default::default())
-        .collect()?;
-
-    let a_mean: [Option<f64>; 2] = [None, None];
-    assert!(out.frame_equal_missing(&df![
-        "b" => [1, 2],
-        "a_mean" => a_mean,
-    ]?));
-
-    Ok(())
-}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1519,6 +1519,14 @@ class DataFrame:
         ),
     ) -> DataFrame | Series:
         """Get item. Does quite a lot. Read the comments."""
+        # fail on ['col1', 'col2', ..., 'coln']
+        if (
+            isinstance(item, tuple)
+            and len(item) > 1
+            and all(isinstance(x, str) for x in item)
+        ):
+            raise KeyError(item)
+
         # select rows and columns at once
         # every 2d selection, i.e. tuple is row column order, just like numpy
         if isinstance(item, tuple) and len(item) == 2:

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -27,6 +27,7 @@ DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
 DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
         # TODO: ideally need a mechanism to wildcard timezones here too
+        Datetime,
         Datetime("ms"),
         Datetime("us"),
         Datetime("ns"),
@@ -34,6 +35,7 @@ DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
 )
 DURATION_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
+        Duration,
         Duration("ms"),
         Duration("us"),
         Duration("ns"),

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7479,6 +7479,9 @@ def _prepare_rolling_window_args(
     min_periods: int | None = None,
 ) -> tuple[str, int]:
     if isinstance(window_size, int):
+        if window_size < 1:
+            raise ValueError("'window_size' should be positive")
+
         if min_periods is None:
             min_periods = window_size
         window_size = f"{window_size}i"

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -49,8 +49,8 @@ def between(draw: DrawFn, type_: type, min_: Any, max_: Any) -> Any:
     return draw(strategy_init(min_, max_))
 
 
-# scalar dtype strategies are straightforward, mapping directly onto
-# the associated hypothesis strategy, with dtype-defined limits
+# scalar dtype strategies are largely straightforward, mapping directly
+# onto the associated hypothesis strategy, with dtype-defined limits
 strategy_bool = booleans()
 strategy_f32 = floats(width=32)
 strategy_f64 = floats(width=64)
@@ -69,15 +69,19 @@ strategy_utf8 = text(
     max_size=8,
     alphabet=characters(max_codepoint=1000, blacklist_categories=("Cs", "Cc")),
 )
-
-# TODO: confirm datetime min/max limits with different timeunit
-#  granularity. support datetime/duration time_units (ms, us, ns).
-strategy_datetime = datetimes(min_value=datetime(1970, 1, 1))
+strategy_datetime_ns = datetimes(
+    min_value=datetime(1677, 9, 22, 0, 12, 43, 145225),
+    max_value=datetime(2262, 4, 11, 23, 47, 16, 854775),
+)
+strategy_datetime_us = strategy_datetime_ms = datetimes(
+    min_value=datetime(1, 1, 1),
+    max_value=datetime(9999, 12, 31, 23, 59, 59, 999000),
+)
 strategy_time = times()
 strategy_date = dates()
 strategy_duration = timedeltas(
-    min_value=timedelta(microseconds=-(2**63)),
-    max_value=timedelta(microseconds=(2**63) - 1),
+    min_value=timedelta(microseconds=-(2**46)),
+    max_value=timedelta(microseconds=(2**46) - 1),
 )
 
 scalar_strategies: dict[PolarsDataType, Any] = {
@@ -92,10 +96,16 @@ scalar_strategies: dict[PolarsDataType, Any] = {
     UInt16: strategy_u16,
     UInt32: strategy_u32,
     UInt64: strategy_u64,
-    Categorical: strategy_categorical,
-    Utf8: strategy_utf8,
     Time: strategy_time,
     Date: strategy_date,
+    Datetime("ns"): strategy_datetime_ns,
+    Datetime("us"): strategy_datetime_us,
+    Datetime("ms"): strategy_datetime_ms,
+    Datetime: strategy_datetime_us,
+    Duration("ns"): strategy_duration,
+    Duration("us"): strategy_duration,
+    Duration("ms"): strategy_duration,
     Duration: strategy_duration,
-    Datetime: strategy_datetime,
+    Categorical: strategy_categorical,
+    Utf8: strategy_utf8,
 }

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -181,7 +181,7 @@ def _to_python_datetime(
                 dt = EPOCH + timedelta(microseconds=value)
             elif time_unit == "ms":
                 # milliseconds to seconds
-                dt = datetime.utcfromtimestamp(value / 1000)
+                dt = EPOCH + timedelta(milliseconds=value)
             else:
                 raise ValueError(
                     f"time_unit must be one of {{'ns', 'us', 'ms'}}, got {time_unit}"

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -180,7 +180,12 @@ markers = [
   "slow: Tests with a longer than average runtime.",
   "benchmark: Tests that should be run on a Polars release build.",
 ]
-filterwarnings = "error" # Fail on warnings
+filterwarnings = [
+  # Fail on warnings...
+  "error",
+  # ...except where it prevents test debugging in an IPython console
+  "ignore:.*unrecognized arguments.*PyDevIPCompleter:DeprecationWarning",
+]
 xfail_strict = true
 
 [tool.coverage.run]

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -387,7 +387,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     "Float64" => DataType::Float64,
                     #[cfg(feature = "object")]
                     "Object" => DataType::Object(OBJECT_NAME),
-                    "List" => DataType::List(Box::new(DataType::Boolean)),
+                    "List" => DataType::List(Box::new(DataType::Null)),
                     "Null" => DataType::Null,
                     "Unknown" => DataType::Unknown,
                     dt => {

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -1368,6 +1368,7 @@ impl PyExpr {
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
     ) -> Self {
+        dbg!(window_size);
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
             weights,

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -12,15 +12,13 @@ from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
 from hypothesis.strategies import sampled_from
 
 import polars as pl
+from polars.datatypes import TEMPORAL_DTYPES
 from polars.testing.parametric import (
     column,
     columns,
     dataframes,
     series,
 )
-
-# TODO: make dtype categories flexible and available from datatypes module
-TEMPORAL_DTYPES = [pl.Datetime, pl.Date, pl.Time, pl.Duration]
 
 
 @given(df=dataframes(), lf=dataframes(lazy=True), srs=series())

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2794,3 +2794,8 @@ def test_microsecond_precision_any_value_conversion() -> None:
     assert pl.Series([dt]).to_list() == [dt]
     dt = datetime(2514, 5, 30, 1, 53, 4, 986754)
     assert pl.Series([dt]).to_list() == [dt]
+
+
+def test_millisecond_precision_any_value_conversion_8311() -> None:
+    dt = datetime(2243, 1, 1, 0, 0, 0, 1000)
+    assert pl.Series([dt]).cast(pl.Datetime("ms")).to_list() == [dt]

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -26,13 +26,20 @@ def test_read_excel(excel_file_path: Path) -> None:
 
 
 def test_read_excel_all_sheets(excel_file_path: Path) -> None:
-    df = pl.read_excel(excel_file_path, sheet_id=None)  # type: ignore[call-overload]
+    df = pl.read_excel(excel_file_path, sheet_id=0)
 
     expected1 = pl.DataFrame({"hello": ["Row 1", "Row 2"]})
     expected2 = pl.DataFrame({"world": ["Row 3", "Row 4"]})
 
     assert_frame_equal(df["Sheet1"], expected1)
     assert_frame_equal(df["Sheet2"], expected2)
+
+
+def test_read_excel_all_sheets_with_sheet_name(excel_file_path: Path) -> None:
+    with pytest.raises(
+        ValueError, match="Cannot specify both `sheet_name` and `sheet_id`"
+    ):
+        pl.read_excel(excel_file_path, sheet_id=1, sheet_name="Sheet1")
 
 
 # the parameters don't change the data, only the formatting, so we expect
@@ -154,7 +161,7 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
     _wb = df.write_excel(workbook=xls, worksheet="data", **write_params)
 
     # ...and read it back again:
-    xldf = pl.read_excel(  # type: ignore[call-overload]
+    xldf = pl.read_excel(
         xls,
         sheet_name="data",
         read_csv_options=header_opts,
@@ -173,7 +180,7 @@ def test_excel_compound_types() -> None:
     xls = BytesIO()
     df.write_excel(xls, worksheet="data")
 
-    xldf = pl.read_excel(xls, sheet_name="data")  # type: ignore[call-overload]
+    xldf = pl.read_excel(xls, sheet_name="data")
     assert xldf.rows() == [
         ("[1, 2]", "{'y': 'a', 'z': 9}"),
         ("[3, 4]", "{'y': 'b', 'z': 8}"),
@@ -233,7 +240,7 @@ def test_excel_sparklines() -> None:
     tables = {tbl["name"] for tbl in wb.get_worksheet_by_name("frame_data").tables}
     assert "Frame0" in tables
 
-    xldf = pl.read_excel(xls, sheet_name="frame_data")  # type: ignore[call-overload]
+    xldf = pl.read_excel(xls, sheet_name="frame_data")
     # ┌─────┬──────┬─────┬─────┬─────┬─────┬───────┬─────┬─────┐
     # │ id  ┆ +/-  ┆ q1  ┆ q2  ┆ q3  ┆ q4  ┆ trend ┆ h1  ┆ h2  │
     # │ --- ┆ ---  ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---   ┆ --- ┆ --- │
@@ -289,4 +296,4 @@ def test_excel_write_multiple_tables() -> None:
             tbl["name"] for tbl in wb.get_worksheet_by_name(sheet).tables
         )
     assert table_names == {f"Frame{n}" for n in range(4)}
-    assert pl.read_excel(xls, sheet_name="sheet3").rows() == []  # type: ignore[call-overload]
+    assert pl.read_excel(xls, sheet_name="sheet3").rows() == []

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -558,3 +558,11 @@ def test_window_size_validation() -> None:
 
     with pytest.raises(ValueError, match=r"'window_size' should be positive"):
         df.with_columns(trailing_min=pl.col("x").rolling_min(window_size=-3))
+
+
+@typing.no_type_check
+def test_invalid_getitem_key_err() -> None:
+    df = pl.DataFrame({"x": [1.0], "y": [1.0]})
+
+    with pytest.raises(KeyError, match=r"('x', 'y')"):
+        df["x", "y"]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -551,3 +551,10 @@ def test_groupby_dynamic_validation(every: str, match: str) -> None:
 def test_lit_agg_err() -> None:
     with pytest.raises(pl.ComputeError, match=r"cannot aggregate a literal"):
         pl.DataFrame({"y": [1]}).with_columns(pl.lit(1).sum().over("y"))
+
+
+def test_window_size_validation() -> None:
+    df = pl.DataFrame({"x": [1.0]})
+
+    with pytest.raises(ValueError, match=r"'window_size' should be positive"):
+        df.with_columns(trailing_min=pl.col("x").rolling_min(window_size=-3))

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -445,3 +445,11 @@ def test_schemas() -> None:
         schema = df.groupby(pl.lit(1)).agg(arg["expr"]).schema
         for key, dtype in arg["expected_gb"].items():
             assert schema[key] == dtype
+
+
+def test_list_null_constructor_schema() -> None:
+    expected = pl.List(pl.Null)
+    assert pl.Series([[]]).dtype == expected
+    assert pl.Series([[]], dtype=pl.List).dtype == expected
+    assert pl.DataFrame({"a": [[]]}).dtypes[0] == expected
+    assert pl.DataFrame(schema={"a": pl.List}).dtypes[0] == expected

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -84,3 +84,9 @@ def test_pickle_lazyframe() -> None:
 
     s = pickle.dumps(q)
     assert_frame_equal(pickle.loads(s).collect(), pl.DataFrame({"a": [1, 3, 4]}))
+
+
+def test_deser_empty_list() -> None:
+    s = pickle.loads(pickle.dumps(pl.Series([[[42.0]], []])))
+    assert s.dtype == pl.List(pl.List(pl.Float64))
+    assert s.to_list() == [[[42.0]], []]


### PR DESCRIPTION
Parametric `Datetime` and `Duration` data generation now exercises all three timeunits (`ms`,`us`,`ns`) and, since the [merge](https://github.com/pola-rs/polars/pull/8298) of some upstream [fixes](https://github.com/jorgecarleitao/arrow2/pull/1467), will also now generate `Datetime` values from before the unix epoch.