### PR TITLE
Running polars-sql without the highlight feature failed 

### DIFF
--- a/polars/polars-sql/src/cli/mod.rs
+++ b/polars/polars-sql/src/cli/mod.rs
@@ -19,9 +19,17 @@ use reedline::{
 use sqlparser::ast::{Select, SetExpr, Statement, TableFactor, TableWithJoins};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
+
+#[cfg(feature = "highlight")]
 use syntect::easy::HighlightLines;
+
+#[cfg(feature = "highlight")]
 use syntect::highlighting::{Style, ThemeSet};
+
+#[cfg(feature = "highlight")]
 use syntect::parsing::SyntaxSet;
+
+#[cfg(feature = "highlight")]
 use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
 
 use crate::cli::prompt::SQLPrompt;

--- a/polars/polars-sql/src/cli/mod.rs
+++ b/polars/polars-sql/src/cli/mod.rs
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 use std::io::{self, BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+
 #[cfg(feature = "highlight")]
 use highlighter::SQLHighlighter;
 use polars_core::prelude::*;

--- a/polars/polars-sql/src/cli/mod.rs
+++ b/polars/polars-sql/src/cli/mod.rs
@@ -7,7 +7,6 @@ use std::ffi::OsStr;
 use std::io::{self, BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
-
 #[cfg(feature = "highlight")]
 use highlighter::SQLHighlighter;
 use polars_core::prelude::*;
@@ -19,16 +18,12 @@ use reedline::{
 use sqlparser::ast::{Select, SetExpr, Statement, TableFactor, TableWithJoins};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
-
 #[cfg(feature = "highlight")]
 use syntect::easy::HighlightLines;
-
 #[cfg(feature = "highlight")]
 use syntect::highlighting::{Style, ThemeSet};
-
 #[cfg(feature = "highlight")]
 use syntect::parsing::SyntaxSet;
-
 #[cfg(feature = "highlight")]
 use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
 


### PR DESCRIPTION
Running polars-sql without the highlight feature failed because some additional imports needed to be feature gated behind the ``highlight`` feature.

``cargo run --release --features=cli,parquet,csv,ipc`` 

Got various errors below

use syntect::highlighting::{Style, ThemeSet};
^^^^^^^ use of undeclared crate or module `syntect`

This PR fixes that.