### PR TITLE
fix(rust,python): escape csv header names if they contain special chars

### DIFF
--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -829,7 +829,6 @@ def test_csv_multiple_null_values() -> None:
             "b": ["2022-01-01", "__NA__", "", "NA"],
         }
     )
-
     f = io.BytesIO()
     df.write_csv(f)
     f.seek(0)
@@ -841,7 +840,6 @@ def test_csv_multiple_null_values() -> None:
             "b": ["2022-01-01", None, "", None],
         }
     )
-
     assert_frame_equal(df2, expected)
 
 
@@ -853,6 +851,21 @@ def test_different_eol_char() -> None:
     assert_frame_equal(
         pl.read_csv(csv.encode(), eol_char=";", has_header=False), expected
     )
+
+
+def test_csv_write_escape_headers() -> None:
+    df0 = pl.DataFrame({"col,1": ["data,1"], 'col"2': ['data"2'], "col:3": ["data:3"]})
+    out = io.BytesIO()
+    df0.write_csv(out)
+    assert out.getvalue() == b'"col,1","col""2",col:3\n"data,1","data""2",data:3\n'
+
+    df1 = pl.DataFrame({"c,o,l,u,m,n": [123]})
+    out = io.BytesIO()
+    df1.write_csv(out)
+
+    df2 = pl.read_csv(out)
+    assert_frame_equal(df1, df2)
+    assert df2.schema == {"c,o,l,u,m,n": pl.Int64}
 
 
 def test_csv_write_escape_newlines() -> None:


### PR DESCRIPTION
Closes #8315. 

Header names should also be escaped when writing CSV data (eg: if they contain `,` or `"` chars). No new logic, just passes the names through the existing `fmt_and_escape_str`.

## Example

**Setup:**
```python
from io import BytesIO
df = pl.DataFrame( {"c,o,l,u,m,n": [123]} )

buf = BytesIO()
df.write_csv( buf )
```
**Before:**
```python
pl.read_csv( buf )
# shape: (1, 6)
# ┌─────┬──────┬──────┬──────┬──────┬──────┐
# │ c   ┆ o    ┆ l    ┆ u    ┆ m    ┆ n    │
# │ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
# │ i64 ┆ str  ┆ str  ┆ str  ┆ str  ┆ str  │
# ╞═════╪══════╪══════╪══════╪══════╪══════╡
# │ 123 ┆ null ┆ null ┆ null ┆ null ┆ null │
# └─────┴──────┴──────┴──────┴──────┴──────┘
```
**After:**
```python
pl.read_csv( buf )
# shape: (1, 1)
# ┌─────────────┐
# │ c,o,l,u,m,n │
# │ ---         │
# │ i64         │
# ╞═════════════╡
# │ 123         │
# └─────────────┘
```