### PR TITLE
fix(python): fix precision issue when converting pl.Datetime("ms") to Python datetime

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -181,7 +181,7 @@ def _to_python_datetime(
                 dt = EPOCH + timedelta(microseconds=value)
             elif time_unit == "ms":
                 # milliseconds to seconds
-                dt = datetime.utcfromtimestamp(value / 1000)
+                dt = EPOCH + timedelta(milliseconds=value)
             else:
                 raise ValueError(
                     f"time_unit must be one of {{'ns', 'us', 'ms'}}, got {time_unit}"

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2794,3 +2794,8 @@ def test_microsecond_precision_any_value_conversion() -> None:
     assert pl.Series([dt]).to_list() == [dt]
     dt = datetime(2514, 5, 30, 1, 53, 4, 986754)
     assert pl.Series([dt]).to_list() == [dt]
+
+
+def test_millisecond_precision_any_value_conversion_8311() -> None:
+    dt = datetime(2243, 1, 1, 0, 0, 0, 1000)
+    assert pl.Series([dt]).cast(pl.Datetime("ms")).to_list() == [dt]


### PR DESCRIPTION
closes #8311