### PR TITLE
refactor(rust,python): Minor update to `strptime`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/options.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/options.rs
@@ -11,7 +11,7 @@ pub struct StrpTimeOptions {
     /// DataType to parse in. One of {Date, Datetime}
     pub date_dtype: DataType,
     /// Formatting string
-    pub fmt: Option<String>,
+    pub format: Option<String>,
     /// If set then polars will return an error if any date parsing fails
     pub strict: bool,
     /// If polars may parse matches that not contain the whole string
@@ -29,7 +29,7 @@ impl Default for StrpTimeOptions {
     fn default() -> Self {
         StrpTimeOptions {
             date_dtype: DataType::Datetime(TimeUnit::Microseconds, None),
-            fmt: None,
+            format: None,
             strict: false,
             exact: false,
             cache: true,

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -63,10 +63,10 @@ class ExprStringNameSpace:
             Use a cache of unique, converted dates to apply the datetime conversion.
         tz_aware
             Parse timezone aware datetimes. This may be automatically toggled by the
-            `fmt` given.
+            `format` given.
 
             .. deprecated:: 0.16.17
-                This is now auto-inferred from the given `fmt`. You can safely drop
+                This is now auto-inferred from the given `format`. You can safely drop
                 this argument, it will be removed in a future version.
         utc
             Parse timezone aware datetimes as UTC. This may be useful if you have data
@@ -122,7 +122,7 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
-        if not is_polars_dtype(dtype):  # pragma: no cover
+        if not is_polars_dtype(dtype):
             raise ValueError(f"expected: {DataType} got: {dtype}")
 
         if format is not None and "%f" in format:
@@ -147,26 +147,26 @@ class ExprStringNameSpace:
             )
 
         if dtype == Date:
-            return wrap_expr(self._pyexpr.str_parse_date(format, strict, exact, cache))
+            return wrap_expr(self._pyexpr.str_to_date(format, strict, exact, cache))
         elif dtype == Datetime:
             time_unit = dtype.time_unit  # type: ignore[union-attr]
             time_zone = dtype.time_zone  # type: ignore[union-attr]
             dtcol = wrap_expr(
-                self._pyexpr.str_parse_datetime(
+                self._pyexpr.str_to_datetime(
                     format,
+                    time_unit,
+                    time_zone,
                     strict,
                     exact,
                     cache,
                     tz_aware,
                     utc,
-                    time_unit,
-                    time_zone,
                 )
             )
             return dtcol if (time_unit is None) else dtcol.dt.cast_time_unit(time_unit)
         elif dtype == Time:
-            return wrap_expr(self._pyexpr.str_parse_time(format, strict, exact, cache))
-        else:  # pragma: no cover
+            return wrap_expr(self._pyexpr.str_to_time(format, strict, exact, cache))
+        else:
             raise ValueError("dtype should be of type {Date, Datetime, Time}")
 
     def lengths(self) -> Expr:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -550,10 +550,10 @@ impl PyExpr {
         self.inner.clone().shrink_dtype().into()
     }
 
-    #[pyo3(signature = (fmt, strict, exact, cache))]
-    pub fn str_parse_date(
+    #[pyo3(signature = (format, strict, exact, cache))]
+    pub fn str_to_date(
         &self,
-        fmt: Option<String>,
+        format: Option<String>,
         strict: bool,
         exact: bool,
         cache: bool,
@@ -563,7 +563,7 @@ impl PyExpr {
             .str()
             .strptime(StrpTimeOptions {
                 date_dtype: DataType::Date,
-                fmt,
+                format,
                 strict,
                 exact,
                 cache,
@@ -573,29 +573,29 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (fmt, strict, exact, cache, tz_aware, utc, time_unit, time_zone))]
+    #[pyo3(signature = (format, time_unit, time_zone, strict, exact, cache, tz_aware, utc))]
     #[allow(clippy::too_many_arguments)]
-    pub fn str_parse_datetime(
+    pub fn str_to_datetime(
         &self,
-        fmt: Option<String>,
+        format: Option<String>,
+        time_unit: Option<Wrap<TimeUnit>>,
+        time_zone: Option<TimeZone>,
         strict: bool,
         exact: bool,
         cache: bool,
         tz_aware: bool,
         utc: bool,
-        time_unit: Option<Wrap<TimeUnit>>,
-        time_zone: Option<TimeZone>,
     ) -> PyExpr {
-        let result_time_unit = match (&fmt, time_unit) {
+        let result_time_unit = match (&format, time_unit) {
             (_, Some(time_unit)) => time_unit.0,
-            (Some(fmt), None) => {
-                if fmt.contains("%.9f")
-                    || fmt.contains("%9f")
-                    || fmt.contains("%f")
-                    || fmt.contains("%.f")
+            (Some(format), None) => {
+                if format.contains("%.9f")
+                    || format.contains("%9f")
+                    || format.contains("%f")
+                    || format.contains("%.f")
                 {
                     TimeUnit::Nanoseconds
-                } else if fmt.contains("%.3f") || fmt.contains("%3f") {
+                } else if format.contains("%.3f") || format.contains("%3f") {
                     TimeUnit::Milliseconds
                 } else {
                     TimeUnit::Microseconds
@@ -608,7 +608,7 @@ impl PyExpr {
             .str()
             .strptime(StrpTimeOptions {
                 date_dtype: DataType::Datetime(result_time_unit, time_zone),
-                fmt,
+                format,
                 strict,
                 exact,
                 cache,
@@ -618,10 +618,10 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (fmt, strict, exact, cache))]
-    pub fn str_parse_time(
+    #[pyo3(signature = (format, strict, exact, cache))]
+    pub fn str_to_time(
         &self,
-        fmt: Option<String>,
+        format: Option<String>,
         strict: bool,
         exact: bool,
         cache: bool,
@@ -631,7 +631,7 @@ impl PyExpr {
             .str()
             .strptime(StrpTimeOptions {
                 date_dtype: DataType::Time,
-                fmt,
+                format,
                 strict,
                 exact,
                 cache,

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -450,12 +450,12 @@ def test_tz_aware_without_fmt() -> None:
     with pytest.raises(
         ComputeError,
         match=(
-            r"^passing 'tz_aware=True' without 'fmt' is not yet supported, "
-            r"please specify 'fmt'$"
+            r"^passing 'tz_aware=True' without 'format' is not yet supported, "
+            r"please specify 'format'$"
         ),
     ), pytest.warns(
         DeprecationWarning,
-        match="`tz_aware` is now auto-inferred from `fmt` and will be removed "
+        match="`tz_aware` is now auto-inferred from `format` and will be removed "
         "in a future version. You can safely drop this argument.",
     ):
         pl.Series(["2020-01-01"]).str.strptime(pl.Datetime, tz_aware=True)


### PR DESCRIPTION
Followup of #8221, forgot to rename the Rust side.