### PR TITLE
test(python): enhanced parametric testing for temporal dtypes 

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -4,7 +4,7 @@ numpy
 pandas
 pyarrow
 
-hypothesis==6.71.0
+hypothesis==6.72.0
 
 autodocsumm==0.2.9
 commonmark==0.9.1

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from datetime import timezone
 from inspect import isclass
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
 
@@ -195,7 +196,9 @@ class Datetime(TemporalType):
     time_unit: TimeUnit | None = None
     time_zone: str | None = None
 
-    def __init__(self, time_unit: TimeUnit | None = "us", time_zone: str | None = None):
+    def __init__(
+        self, time_unit: TimeUnit | None = "us", time_zone: str | timezone | None = None
+    ):
         """
         Calendar date and time type.
 
@@ -208,6 +211,9 @@ class Datetime(TemporalType):
             ``import zoneinfo; zoneinfo.available_timezones()`` for a full list).
 
         """
+        if isinstance(time_zone, timezone):
+            time_zone = str(time_zone)
+
         self.time_unit = time_unit or "us"
         self.time_zone = time_zone
 

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -27,6 +27,7 @@ DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
 DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
         # TODO: ideally need a mechanism to wildcard timezones here too
+        Datetime,
         Datetime("ms"),
         Datetime("us"),
         Datetime("ns"),
@@ -34,6 +35,7 @@ DATETIME_DTYPES: frozenset[PolarsDataType] = frozenset(
 )
 DURATION_DTYPES: frozenset[PolarsDataType] = frozenset(
     [
+        Duration,
         Duration("ms"),
         Duration("us"),
         Duration("ns"),

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -49,8 +49,8 @@ def between(draw: DrawFn, type_: type, min_: Any, max_: Any) -> Any:
     return draw(strategy_init(min_, max_))
 
 
-# scalar dtype strategies are straightforward, mapping directly onto
-# the associated hypothesis strategy, with dtype-defined limits
+# scalar dtype strategies are largely straightforward, mapping directly
+# onto the associated hypothesis strategy, with dtype-defined limits
 strategy_bool = booleans()
 strategy_f32 = floats(width=32)
 strategy_f64 = floats(width=64)
@@ -69,15 +69,19 @@ strategy_utf8 = text(
     max_size=8,
     alphabet=characters(max_codepoint=1000, blacklist_categories=("Cs", "Cc")),
 )
-
-# TODO: confirm datetime min/max limits with different timeunit
-#  granularity. support datetime/duration time_units (ms, us, ns).
-strategy_datetime = datetimes(min_value=datetime(1970, 1, 1))
+strategy_datetime_ns = datetimes(
+    min_value=datetime(1677, 9, 22, 0, 12, 43, 145225),
+    max_value=datetime(2262, 4, 11, 23, 47, 16, 854775),
+)
+strategy_datetime_us = strategy_datetime_ms = datetimes(
+    min_value=datetime(1, 1, 1),
+    max_value=datetime(9999, 12, 31, 23, 59, 59, 999000),
+)
 strategy_time = times()
 strategy_date = dates()
 strategy_duration = timedeltas(
-    min_value=timedelta(microseconds=-(2**63)),
-    max_value=timedelta(microseconds=(2**63) - 1),
+    min_value=timedelta(microseconds=-(2**46)),
+    max_value=timedelta(microseconds=(2**46) - 1),
 )
 
 scalar_strategies: dict[PolarsDataType, Any] = {
@@ -92,10 +96,16 @@ scalar_strategies: dict[PolarsDataType, Any] = {
     UInt16: strategy_u16,
     UInt32: strategy_u32,
     UInt64: strategy_u64,
-    Categorical: strategy_categorical,
-    Utf8: strategy_utf8,
     Time: strategy_time,
     Date: strategy_date,
+    Datetime("ns"): strategy_datetime_ns,
+    Datetime("us"): strategy_datetime_us,
+    Datetime("ms"): strategy_datetime_ms,
+    Datetime: strategy_datetime_us,
+    Duration("ns"): strategy_duration,
+    Duration("us"): strategy_duration,
+    Duration("ms"): strategy_duration,
     Duration: strategy_duration,
-    Datetime: strategy_datetime,
+    Categorical: strategy_categorical,
+    Utf8: strategy_utf8,
 }

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -18,7 +18,7 @@ adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 connectorx==0.3.2a2; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
 
 # Tooling
-hypothesis==6.71.0
+hypothesis==6.72.0
 maturin==0.14.10
 pytest==7.3.0
 pytest-cov==4.0.0

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -3,7 +3,6 @@
 # -------------------------------------------------
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import no_type_check
 
 import numpy as np
@@ -120,45 +119,67 @@ def test_series_slice(
 
 
 @given(
-    s1=series(min_size=1, max_size=10, dtype=pl.Datetime),
-    s2=series(min_size=1, max_size=10, dtype=pl.Duration),
+    s=series(min_size=1, max_size=10, dtype=pl.Datetime),
 )
-def test_series_timeunits(
-    s1: pl.Series,
-    s2: pl.Series,
+def test_series_datetime_timeunits(
+    s: pl.Series,
 ) -> None:
     # datetime
-    assert s1.to_list() == list(s1)
-    assert list(s1.dt.millisecond()) == [v.microsecond // 1000 for v in s1]
-    assert list(s1.dt.nanosecond()) == [v.microsecond * 1000 for v in s1]
-    assert list(s1.dt.microsecond()) == [v.microsecond for v in s1]
+    assert s.to_list() == list(s)
+    assert list(s.dt.millisecond()) == [v.microsecond // 1000 for v in s]
+    assert list(s.dt.nanosecond()) == [v.microsecond * 1000 for v in s]
+    assert list(s.dt.microsecond()) == [v.microsecond for v in s]
 
-    # duration
-    millis = s2.dt.milliseconds().to_list()
-    micros = s2.dt.microseconds().to_list()
 
-    assert s1.to_list() == list(s1)
-    assert millis == [int(Decimal(v) / 1000) for v in s2.cast(int)]
-    assert micros == list(s2.cast(int))
+@given(
+    s=series(min_size=1, max_size=10, dtype=pl.Duration),
+)
+def test_series_duration_timeunits(
+    s: pl.Series,
+) -> None:
+    nanos = s.dt.nanoseconds().to_list()
+    micros = s.dt.microseconds().to_list()
+    millis = s.dt.milliseconds().to_list()
+
+    scale = {
+        "ns": 1,
+        "us": 1_000,
+        "ms": 1_000_000,
+    }
+    assert nanos == [v * scale[s.dtype.time_unit] for v in s.to_physical()]  # type: ignore[union-attr]
+    assert micros == [int(v / 1_000) for v in nanos]
+    assert millis == [int(v / 1_000) for v in micros]
 
     # special handling for ns timeunit (as we may generate a microsecs-based
     # timedelta that results in 64bit overflow on conversion to nanosecs)
+    micros = s.dt.microseconds().to_list()
     lower_bound, upper_bound = -(2**63), (2**63) - 1
     if all(
         (lower_bound <= (us * 1000) <= upper_bound)
         for us in micros
         if isinstance(us, int)
     ):
-        for ns, us in zip(s2.dt.nanoseconds(), micros):
+        for ns, us in zip(s.dt.nanoseconds(), micros):
             assert ns == (us * 1000)
 
 
 @given(
-    s=series(min_size=1, max_size=10, excluded_dtypes=[pl.Categorical]),
+    s=series(min_size=1, max_size=10, excluded_dtypes=[pl.Categorical]).filter(
+        lambda x: (
+            getattr(x.dtype, "time_unit", None) in (None, "us", "ns")
+            and (x.dtype != pl.Utf8 or not x.str.contains("\x00").any())
+        )
+    ),
 )
+@settings(max_examples=250)
 def test_series_to_numpy(
     s: pl.Series,
 ) -> None:
-    if s.dtype != pl.Utf8 or not s.str.contains("\x00").any():
-        np_array = np.array(s.to_list())
-        assert_array_equal(np_array, s.to_numpy())
+    dtype = {
+        pl.Datetime("ns"): "datetime64[ns]",
+        pl.Datetime("us"): "datetime64[us]",
+        pl.Duration("ns"): "timedelta64[ns]",
+        pl.Duration("us"): "timedelta64[us]",
+    }
+    np_array = np.array(s.to_list(), dtype=dtype.get(s.dtype))  # type: ignore[call-overload]
+    assert_array_equal(np_array, s.to_numpy())

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -12,15 +12,13 @@ from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
 from hypothesis.strategies import sampled_from
 
 import polars as pl
+from polars.datatypes import TEMPORAL_DTYPES
 from polars.testing.parametric import (
     column,
     columns,
     dataframes,
     series,
 )
-
-# TODO: make dtype categories flexible and available from datatypes module
-TEMPORAL_DTYPES = [pl.Datetime, pl.Date, pl.Time, pl.Duration]
 
 
 @given(df=dataframes(), lf=dataframes(lazy=True), srs=series())

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from datetime import date, datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING, cast, no_type_check
+from typing import TYPE_CHECKING, Any, cast, no_type_check
 
 import numpy as np
 import pandas as pd
@@ -2789,17 +2789,36 @@ def test_series_is_temporal() -> None:
         assert s.is_temporal(excluding=tp) is False
 
 
-def test_misc_precision_any_value_conversion() -> None:
-    # default precision
-    dt = datetime(2514, 5, 30, 1, 53, 4, 986754, tzinfo=timezone.utc)
-    assert pl.Series([dt]).to_list() == [dt]
-    dt = datetime(2514, 5, 30, 1, 53, 4, 986754)
+@pytest.mark.parametrize(
+    "time_zone",
+    [
+        None,
+        timezone.utc,
+        "America/Caracas",
+        "Asia/Kathmandu",
+        "Asia/Taipei",
+        "Europe/Amsterdam",
+        "Europe/Lisbon",
+        "Indian/Maldives",
+        "Pacific/Norfolk",
+        "Pacific/Samoa",
+        "Turkey",
+        "US/Eastern",
+        "UTC",
+        "Zulu",
+    ],
+)
+def test_misc_precision_any_value_conversion(time_zone: Any) -> None:
+    tz = ZoneInfo(time_zone) if isinstance(time_zone, str) else time_zone
+
+    # default precision (μs)
+    dt = datetime(2514, 5, 30, 1, 53, 4, 986754, tzinfo=tz)
     assert pl.Series([dt]).to_list() == [dt]
 
     # ms precision
-    dt = datetime(2243, 1, 1, 0, 0, 0, 1000)
-    assert pl.Series([dt]).cast(pl.Datetime("ms")).to_list() == [dt]
+    dt = datetime(2243, 1, 1, 0, 0, 0, 1000, tzinfo=tz)
+    assert pl.Series([dt]).cast(pl.Datetime("ms", time_zone)).to_list() == [dt]
 
     # ns precision
-    dt = datetime(2256, 1, 1, 0, 0, 0, 1)
-    assert pl.Series([dt]).cast(pl.Datetime("ns")).to_list() == [dt]
+    dt = datetime(2256, 1, 1, 0, 0, 0, 1, tzinfo=tz)
+    assert pl.Series([dt]).cast(pl.Datetime("ns", time_zone)).to_list() == [dt]


### PR DESCRIPTION
_Reopened and rebased, following [additional](https://github.com/pola-rs/polars/pull/8337) temporal-related [fixes](https://github.com/pola-rs/polars/pull/8332), found by these tests._
_(TODO: timezones :)_

---

* Parametric `Datetime` and `Duration` data generation now exercises all three timeunits (`ms`,`us`,`ns`) and, since the [merge](https://github.com/pola-rs/polars/pull/8298) of some upstream [fixes](https://github.com/jorgecarleitao/arrow2/pull/1467), will also now generate `Datetime` values from before the unix epoch.

* Extended some existing temporal tests to increase coverage.
