### PR TITLE
perf(python): ~15% speedup for timestamp → python time conversion

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -131,16 +131,16 @@ def _timedelta_to_pl_timedelta(td: timedelta, time_unit: TimeUnit | None = None)
 
 
 def _to_python_time(value: int) -> time:
+    """Convert polars int64 (ns) timestamp to python time object."""
     if value == 0:
         return time(microsecond=0)
-    value = value // 1_000
-    microsecond = value
-    seconds = (microsecond // 1000_000) % 60
-    minutes = (microsecond // (1000_000 * 60)) % 60
-    hours = (microsecond // (1000_000 * 60 * 60)) % 24
-    microsecond = microsecond - (seconds + minutes * 60 + hours * 3600) * 1000_000
-
-    return time(hour=hours, minute=minutes, second=seconds, microsecond=microsecond)
+    else:
+        seconds, nanoseconds = divmod(value, 1_000_000_000)
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        return time(
+            hour=hours, minute=minutes, second=seconds, microsecond=nanoseconds // 1000
+        )
 
 
 def _to_python_timedelta(value: int | float, time_unit: TimeUnit = "ns") -> timedelta:
@@ -168,7 +168,7 @@ def _to_python_datetime(
     time_unit: TimeUnit | None = "ns",
     time_zone: str | None = None,
 ) -> date | datetime:
-    """Converts polars timestamp to Python date/datetime."""
+    """Convert polars int64 timestamp to Python date/datetime."""
     if dtype == Date:
         # important to create from utc; not doing this leads to
         # inconsistencies dependent on the timezone you are in.

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2812,3 +2812,17 @@ def test_misc_precision_any_value_conversion(time_zone: Any) -> None:
     # ns precision
     dt = datetime(2256, 1, 1, 0, 0, 0, 1, tzinfo=tz)
     assert pl.Series([dt]).cast(pl.Datetime("ns", time_zone)).to_list() == [dt]
+
+
+@pytest.mark.parametrize(
+    "tm",
+    [
+        time(0, 20, 30, 1),
+        time(8, 40, 15, 8888),
+        time(15, 10, 20, 123456),
+        time(23, 59, 59, 999999),
+    ],
+)
+def test_pytime_conversion(tm: time) -> None:
+    s = pl.Series("tm", [tm])
+    assert s.to_list() == [tm]


### PR DESCRIPTION
Simplified and optimised `_to_python_time`; use of `divmod` gets us a speedup.