### PR TITLE
fix(python): add missing `__hash__` support to `Field`, include "time_zone" in `Datetime` hash, fix `Struct` hash

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -167,7 +167,7 @@ class Decimal(FractionalType):
             return False
 
     def __hash__(self) -> int:
-        return hash((Decimal, self.precision, self.scale))
+        return hash((self.__class__, self.precision, self.scale))
 
 
 class Boolean(DataType):
@@ -234,7 +234,7 @@ class Datetime(TemporalType):
             return False
 
     def __hash__(self) -> int:
-        return hash((Datetime, self.time_unit))
+        return hash((self.__class__, self.time_unit, self.time_zone))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -274,7 +274,7 @@ class Duration(TemporalType):
             return False
 
     def __hash__(self) -> int:
-        return hash((Duration, self.time_unit))
+        return hash((self.__class__, self.time_unit))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -334,7 +334,7 @@ class List(NestedType):
             return False
 
     def __hash__(self) -> int:
-        return hash((List, self.inner))
+        return hash((self.__class__, self.inner))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -359,6 +359,9 @@ class Field:
 
     def __eq__(self, other: Field) -> bool:  # type: ignore[override]
         return (self.name == other.name) & (self.dtype == other.dtype)
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.dtype))
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -396,7 +399,7 @@ class Struct(NestedType):
             return False
 
     def __hash__(self) -> int:
-        return hash(Struct)
+        return hash((self.__class__, tuple(self.fields)))
 
     def __iter__(self) -> Iterator[tuple[str, PolarsDataType]]:
         for fld in self.fields or []:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -41,6 +41,15 @@ def test_apply_unnest() -> None:
     assert_frame_equal(df, expected)
 
 
+def test_struct_hashes() -> None:
+    dtypes = (
+        pl.Struct,
+        pl.Struct([pl.Field("a", pl.Int64)]),
+        pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.List(pl.Int64))]),
+    )
+    assert len({hash(tp) for tp in (dtypes)}) == 3
+
+
 def test_struct_unnesting() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     out = df.select(

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1851,6 +1851,16 @@ def test_date_timedelta() -> None:
     }
 
 
+def test_datetime_hashes() -> None:
+    dtypes = (
+        pl.Datetime,
+        pl.Datetime("us"),
+        pl.Datetime("us", "UTC"),
+        pl.Datetime("us", "Zulu"),
+    )
+    assert len({hash(tp) for tp in (dtypes)}) == 4
+
+
 def test_datetime_string_casts() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
* `Datetime` dtype hashes were not unique across different timezones.
* `Field` dtype was missing a `__hash__` implementation.
* `Struct` hash didn't account for its own fields.

_(Note: required for upcoming #8211 fix)._