### PR TITLE
fix(rust, python): bubble up logical type in recursive list cast

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -271,7 +271,10 @@ impl ChunkCast for ListChunked {
 
                 match (self.inner_dtype(), &**child_type) {
                     #[cfg(feature = "dtype-categorical")]
-                    (Utf8, Categorical(_)) => {
+                    (Utf8, Categorical(_)) |
+                    // ensure the inner logical type bubbles up
+                    (List(_), List(_))
+                    => {
                         let (arr, child_type) = cast_list(self, child_type)?;
                         Ok(unsafe {
                             Series::from_chunks_and_dtype_unchecked(
@@ -280,7 +283,7 @@ impl ChunkCast for ListChunked {
                                 &List(Box::new(child_type)),
                             )
                         })
-                    }
+                    },
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None)) => {
                         polars_bail!(ComputeError: "cannot cast list inner type: '{:?}' to Categorical", dt)

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -509,3 +509,12 @@ def test_logical_parallel_list_collect() -> None:
         "Values": ["Value1", "Value2"],
         "counts": [2, 1],
     }
+
+
+def test_list_recursive_categorical_cast() -> None:
+    # go 3 deep, just to show off
+    dtype = pl.List(pl.List(pl.List(pl.Categorical)))
+    values = [[[["x"], ["y"]]], [[["x"]]]]
+    s = pl.Series(values).cast(dtype)
+    assert s.dtype == dtype
+    assert s.to_list() == values


### PR DESCRIPTION
We can recurse all the way down now. :)

Fixes #8262