### PR TITLE
fix(python): ensure that `iter_rows` doesn't return nested `Timestamp` values

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -47,6 +47,7 @@ from polars.datatypes import (
     UInt64,
     Utf8,
     py_type_to_dtype,
+    unpack_dtypes,
 )
 from polars.dependencies import (
     _PYARROW_AVAILABLE,
@@ -8129,7 +8130,8 @@ class DataFrame:
                 and _PYARROW_AVAILABLE
                 # note: 'ns' precision instantiates values as pandas types - avoid
                 and not any(
-                    (getattr(tp, "time_unit", None) == "ns") for tp in self.dtypes
+                    (getattr(tp, "time_unit", None) == "ns")
+                    for tp in unpack_dtypes(self.dtypes)
                 )
             )
             for offset in range(0, self.height, buffer_size):

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -59,6 +59,7 @@ from polars.datatypes.convert import (
     py_type_to_arrow_type,
     py_type_to_dtype,
     supported_numpy_char_code,
+    unpack_dtypes,
 )
 from polars.type_aliases import (
     OneOrMoreDataTypes,
@@ -128,6 +129,7 @@ __all__ = [
     "py_type_to_arrow_type",
     "py_type_to_dtype",
     "supported_numpy_char_code",
+    "unpack_dtypes",
     # type_aliases
     "OneOrMoreDataTypes",
     "PolarsDataType",

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -11,10 +11,12 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     ForwardRef,
     Optional,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -28,6 +30,7 @@ from polars.datatypes import (
     Datetime,
     Decimal,
     Duration,
+    Field,
     Float32,
     Float64,
     Int8,
@@ -48,6 +51,7 @@ from polars.datatypes import (
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pyarrow as pa
+from polars.type_aliases import PolarsDataType
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr as _dtype_str_repr
@@ -70,7 +74,7 @@ else:
     UnionType = type(Union[int, float])
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType, PythonDataType, SchemaDict, TimeUnit
+    from polars.type_aliases import PythonDataType, SchemaDict, TimeUnit
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -140,16 +144,71 @@ def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsD
     raise TypeError("Invalid type")
 
 
-def is_polars_dtype(data_type: Any, include_unknown: bool = False) -> bool:
+def is_polars_dtype(dtype: Any, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     try:
-        if data_type == Unknown:
+        if dtype == Unknown:
             # does not represent a realisable dtype, so ignore by default
             return include_unknown
         else:
-            return isinstance(data_type, (DataType, DataTypeClass))
+            return isinstance(dtype, (DataType, DataTypeClass))
     except ValueError:
         return False
+
+
+def unpack_dtypes(
+    dtypes: PolarsDataType | Collection[PolarsDataType] | None,
+    include_compound: bool = False,
+) -> set[PolarsDataType]:
+    """
+    Return a set of unique dtypes found in one or more (potentially compound) dtypes.
+
+    Parameters
+    ----------
+    dtypes : PolarsDataType | Collection[PolarsDataType] | None
+        polars dtype, collection of dtypes, or None.
+
+    include_compound : bool, default True
+        * if True, any parent/compound dtypes (List, Struct) are included in the result.
+        * if False, only the child/scalar dtypes are returned from these types.
+
+    Examples
+    --------
+    >>> from polars.datatypes import unpack_dtypes
+    >>> list_dtype = []  # pl.List(pl.Float64)
+    >>> struct_dtype = pl.Struct(
+    ...     [
+    ...         pl.Field("a", pl.Int64),
+    ...         pl.Field("b", pl.Utf8),
+    ...         pl.Field("c", pl.List(pl.Float64)),
+    ...     ]
+    ... )
+    >>> unpack_dtypes([struct_dtype, list_dtype])  # doctest: +IGNORE_RESULT
+    {Float64, Int64, Utf8}
+    >>> unpack_dtypes([struct_dtype, list_dtype], include_compound=True)  # doctest: +IGNORE_RESULT
+    {Float64, Int64, Utf8, List(Float64), Struct([Field('a', Int64), Field('b', Utf8), Field('c', List(Float64))])}
+
+    """  # noqa: W505
+    if not dtypes:
+        return set()
+    elif is_polars_dtype(dtypes):
+        dtypes = [dtypes]  # type: ignore[list-item]
+
+    unpacked: set[PolarsDataType] = set()
+    for tp in cast(list[PolarsDataType], dtypes):
+        if isinstance(tp, List):
+            if include_compound:
+                unpacked.add(tp)
+            unpacked.update(unpack_dtypes(tp.inner, include_compound=include_compound))
+        elif isinstance(tp, Struct):
+            if include_compound:
+                unpacked.add(tp)
+            unpacked.update(unpack_dtypes(tp.fields, include_compound=include_compound))  # type: ignore[arg-type]
+        elif isinstance(tp, Field):
+            unpacked.update(unpack_dtypes(tp.dtype, include_compound=include_compound))
+        elif is_polars_dtype(tp):
+            unpacked.add(tp)
+    return unpacked
 
 
 class _DataTypeMappings:

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -19,6 +19,9 @@ from typing import (
     cast,
     overload,
 )
+from typing import (
+    List as TypingList,
+)
 
 from polars.datatypes import (
     Binary,
@@ -175,7 +178,7 @@ def unpack_dtypes(
     Examples
     --------
     >>> from polars.datatypes import unpack_dtypes
-    >>> list_dtype = []  # pl.List(pl.Float64)
+    >>> list_dtype = [pl.List(pl.Float64)]
     >>> struct_dtype = pl.Struct(
     ...     [
     ...         pl.Field("a", pl.Int64),
@@ -185,7 +188,9 @@ def unpack_dtypes(
     ... )
     >>> unpack_dtypes([struct_dtype, list_dtype])  # doctest: +IGNORE_RESULT
     {Float64, Int64, Utf8}
-    >>> unpack_dtypes([struct_dtype, list_dtype], include_compound=True)  # doctest: +IGNORE_RESULT
+    >>> unpack_dtypes(
+    ...     [struct_dtype, list_dtype], include_compound=True
+    ... )  # doctest: +IGNORE_RESULT
     {Float64, Int64, Utf8, List(Float64), Struct([Field('a', Int64), Field('b', Utf8), Field('c', List(Float64))])}
 
     """  # noqa: W505
@@ -195,7 +200,7 @@ def unpack_dtypes(
         dtypes = [dtypes]  # type: ignore[list-item]
 
     unpacked: set[PolarsDataType] = set()
-    for tp in cast(list[PolarsDataType], dtypes):
+    for tp in cast(TypingList[PolarsDataType], dtypes):
         if isinstance(tp, List):
             if include_compound:
                 unpacked.add(tp)


### PR DESCRIPTION
Closes #8211.

In conjunction with #8354 (merged) this ensures that `ns` Datetime dtypes are spotted at _any_ level of dtype nesting, so we can avoid unsuitable usage of the fast-path (which otherwise translates `ns` datetimes to `pd.Timestamp` values).

_(New utility function `unpack_dtypes` may be useful elsewhere too...)_