### PR TITLE
refactor(python): Another small `strptime` refactor

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -53,7 +53,7 @@ class ExprStringNameSpace:
         format
             Format to use, refer to the `chrono strftime documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
-            for specification. Example: ``"%y-%m-%d"``.
+            for specification. Example: ``"%Y-%m-%d"``.
         strict
             Raise an error if any conversion fails.
         exact
@@ -124,17 +124,6 @@ class ExprStringNameSpace:
         """
         if not is_polars_dtype(dtype):
             raise ValueError(f"expected: {DataType} got: {dtype}")
-
-        if format is not None and "%f" in format:
-            raise ValueError(
-                "Directive '%f' is not supported in Python Polars, "
-                "as it differs from the Python standard library.\n"
-                "Instead, please use one of:\n"
-                " - '%.f'\n"
-                " - '%3f'\n"
-                " - '%6f'\n"
-                " - '%9f'"
-            )
 
         if tz_aware is no_default:
             tz_aware = False

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
-from polars.datatypes import (
-    DataType,
-    Date,
-    Datetime,
-    Time,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.utils import no_default
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
@@ -122,9 +115,6 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
-        if not is_polars_dtype(dtype):
-            raise ValueError(f"expected: {DataType} got: {dtype}")
-
         if tz_aware is no_default:
             tz_aware = False
         else:

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -13,7 +13,7 @@ use smartstring::alias::String as SmartString;
 use super::apply::*;
 use crate::conversion::{parse_fill_null_strategy, Wrap};
 use crate::lazy::map_single;
-use crate::lazy::utils::py_exprs_to_exprs;
+use crate::lazy::utils::{check_strptime_format, py_exprs_to_exprs};
 use crate::prelude::ObjectValue;
 use crate::series::PySeries;
 use crate::utils::reinterpret;
@@ -557,8 +557,11 @@ impl PyExpr {
         strict: bool,
         exact: bool,
         cache: bool,
-    ) -> PyExpr {
-        self.inner
+    ) -> PyResult<Self> {
+        check_strptime_format(format.as_deref())?;
+
+        Ok(self
+            .inner
             .clone()
             .str()
             .strptime(StrpTimeOptions {
@@ -570,7 +573,7 @@ impl PyExpr {
                 tz_aware: false,
                 utc: false,
             })
-            .into()
+            .into())
     }
 
     #[pyo3(signature = (format, time_unit, time_zone, strict, exact, cache, tz_aware, utc))]
@@ -585,7 +588,9 @@ impl PyExpr {
         cache: bool,
         tz_aware: bool,
         utc: bool,
-    ) -> PyExpr {
+    ) -> PyResult<Self> {
+        check_strptime_format(format.as_deref())?;
+
         let result_time_unit = match (&format, time_unit) {
             (_, Some(time_unit)) => time_unit.0,
             (Some(format), None) => {
@@ -603,7 +608,8 @@ impl PyExpr {
             }
             (None, None) => TimeUnit::Microseconds,
         };
-        self.inner
+        Ok(self
+            .inner
             .clone()
             .str()
             .strptime(StrpTimeOptions {
@@ -615,7 +621,7 @@ impl PyExpr {
                 tz_aware,
                 utc,
             })
-            .into()
+            .into())
     }
 
     #[pyo3(signature = (format, strict, exact, cache))]
@@ -625,8 +631,11 @@ impl PyExpr {
         strict: bool,
         exact: bool,
         cache: bool,
-    ) -> PyExpr {
-        self.inner
+    ) -> PyResult<Self> {
+        check_strptime_format(format.as_deref())?;
+
+        Ok(self
+            .inner
             .clone()
             .str()
             .strptime(StrpTimeOptions {
@@ -638,7 +647,7 @@ impl PyExpr {
                 tz_aware: false,
                 utc: false,
             })
-            .into()
+            .into())
     }
 
     pub fn str_strip(&self, matches: Option<String>) -> PyExpr {

--- a/py-polars/src/lazy/utils.rs
+++ b/py-polars/src/lazy/utils.rs
@@ -1,4 +1,6 @@
 use polars::lazy::dsl::Expr;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 use crate::lazy::dsl::PyExpr;
 
@@ -6,4 +8,19 @@ pub fn py_exprs_to_exprs(py_exprs: Vec<PyExpr>) -> Vec<Expr> {
     // Safety:
     // transparent struct
     unsafe { std::mem::transmute(py_exprs) }
+}
+
+pub fn check_strptime_format(format: Option<&str>) -> PyResult<()> {
+    if let Some(format) = format {
+        if format.contains("%f") {
+            let message = "directive '%f' is not supported in Python Polars, as it differs from the Python standard library.\n\
+                Instead, please use one of:\n\
+                 - '%.f'\n\
+                 - '%3f'\n\
+                 - '%6f'\n\
+                 - '%9f'";
+            return Err(PyValueError::new_err(message));
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
Preparing for #8215 

Changes:
* Move the check that `%f` is not in the format string from Python to the Rust bindings
* Remove an unnecessary dtype check on the Python side