### PR TITLE
chore(python): Upgrade ruff

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -143,7 +143,6 @@ ignore = [
   # ruff
   "RUF005", # unpack-instead-of-concatenating-to-collection-literal
   # pycodestyle
-  "W191", # Indentation contains tabs - disabled because of https://github.com/charliermarsh/ruff/issues/3438
   # TODO: Remove errors below to further improve docstring linting
   # Ordered from most common to least common errors.
   "D105",
@@ -165,7 +164,7 @@ strict = true
 
 [tool.ruff.per-file-ignores]
 "polars/datatypes.py" = ["B019"]
-"tests/**/*.py" = ["D100", "D103"]
+"tests/**/*.py" = ["D100", "D103", "B018"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,5 +1,5 @@
 black==23.3.0
 blackdoc==0.3.8
 mypy==1.2.0
-ruff==0.0.259
+ruff==0.0.262
 typos==1.14.3


### PR DESCRIPTION
Changes:
* Bump ruff version
* Remove an ignored lint thanks to a bugfix
* Ignore a new lint for test files, as 'unused expressions' can still be useful to check for exceptions.