### PR TITLE
perf(rust, python): improve materialization of huge cardinality group tuples

### DIFF
--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -15,8 +15,8 @@ use crate::POOL;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GroupsIdx {
     pub(crate) sorted: bool,
-    first: Vec<IdxSize>,
-    all: Vec<Vec<IdxSize>>,
+    pub(crate) first: Vec<IdxSize>,
+    pub(crate) all: Vec<Vec<IdxSize>>,
 }
 
 pub type IdxItem = (IdxSize, Vec<IdxSize>);


### PR DESCRIPTION
Iteration of a giant hash table is expensive as values are scattered all over memory. This adds an indirection during construction of the hash table. This insert is slightly more expensive this way, but it ensures we don't need to iterate the hash table upon materialization.