### PR TITLE
feat(python): add a "signed" param to `Series.is_integer`

### DIFF
--- a/py-polars/docs/source/reference/series/descriptive.rst
+++ b/py-polars/docs/source/reference/series/descriptive.rst
@@ -18,6 +18,7 @@ Descriptive
     Series.is_float
     Series.is_in
     Series.is_infinite
+    Series.is_integer
     Series.is_nan
     Series.is_not_nan
     Series.is_not_null

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -25,6 +25,7 @@ from polars.datatypes import (
     NUMERIC_DTYPES,
     SIGNED_INTEGER_DTYPES,
     TEMPORAL_DTYPES,
+    UNSIGNED_INTEGER_DTYPES,
     Boolean,
     Categorical,
     Date,
@@ -3075,18 +3076,36 @@ class Series:
         """
         return self.dtype in NUMERIC_DTYPES
 
-    def is_integer(self) -> bool:
+    def is_integer(self, signed: bool | None = None) -> bool:
         """
-        Check if this Series datatype is integer.
+        Check if this Series datatype is an integer (signed or unsigned).
+
+        Parameters
+        ----------
+        signed
+            * if `None`, both signed and unsigned integer dtypes will match.
+            * if `True`, only signed integer dtypes will be considered a match.
+            * if `False`, only unsigned integer dtypes will be considered a match.
 
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s = pl.Series("a", [1, 2, 3], dtype=pl.UInt32)
         >>> s.is_integer()
         True
+        >>> s.is_integer(signed=False)
+        True
+        >>> s.is_integer(signed=True)
+        False
 
         """
-        return self.dtype in INTEGER_DTYPES
+        if signed is None:
+            return self.dtype in INTEGER_DTYPES
+        elif signed is True:
+            return self.dtype in SIGNED_INTEGER_DTYPES
+        elif signed is False:
+            return self.dtype in UNSIGNED_INTEGER_DTYPES
+
+        raise ValueError(f"'signed' must be None, True or False; given {signed!r}")
 
     def is_temporal(self, excluding: OneOrMoreDataTypes | None = None) -> bool:
         """


### PR DESCRIPTION
Extends recent #8373 with a `signed` param (and adds the docs entry ;)

* If `None`, both signed and unsigned integer dtypes match.
* If `False`, only unsigned integer dtypes match.
* If `True`, only signed integer dtypes match.


## Example

```python
import polars as pl
s = pl.Series( "ints", [1,2,3], dtype=pl.UInt32 )

s.is_integer()
# True

s.is_integer( signed=True )
# False

s.is_integer( signed=False )
# True
```

**Note:** on the Rust side we have two separate methods for this, `is_signed` and `is_unsigned`, but it's cleaner here to simply have a param on `is_integer`.