### PR TITLE
feat(python): offer cleaner usage pattern for `Config` object in context-manager context

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -44,6 +44,9 @@ Note that ``Config`` supports setting context-scoped options. These options
 are valid *only* during scope lifetime, and are reset to their initial values
 (whatever they were before entering the new context) on scope exit.
 
+You can take advantage of this by initialising  a``Config`` instance and then
+explicitly calling one or more of the available 'set_' methods on it...
+
 .. code-block:: python
 
     with pl.Config() as cfg:
@@ -51,3 +54,11 @@ are valid *only* during scope lifetime, and are reset to their initial values
         do_various_things()
 
     # on scope exit any modified settings are restored to their previous state
+
+...or by setting the options in the ``Config`` init directly (optionally
+omitting the 'set_' prefix for brevity):
+
+.. code-block:: python
+
+    with pl.Config(verbose=True):
+        do_various_things()

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6836,8 +6836,7 @@ class DataFrame:
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> with pl.Config() as cfg:
-        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        >>> with pl.Config(auto_structify=True):
         ...     df.select(
         ...         is_odd=(pl.col(pl.INTEGER_DTYPES) % 2).suffix("_is_odd"),
         ...     )
@@ -6992,8 +6991,7 @@ class DataFrame:
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> with pl.Config() as cfg:
-        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        >>> with pl.Config(auto_structify=True):
         ...     df.drop("c").with_columns(
         ...         diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
         ...     )

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2466,8 +2466,7 @@ def duration(
     │ 2022-01-01 00:00:00 ┆ 1   │
     │ 2022-01-02 00:00:00 ┆ 2   │
     └─────────────────────┴─────┘
-    >>> with pl.Config() as cfg:
-    ...     cfg.set_tbl_width_chars(120)
+    >>> with pl.Config(tbl_width_chars=120):
     ...     df.select(
     ...         (pl.col("dt") + pl.duration(weeks="add")).alias("add_weeks"),
     ...         (pl.col("dt") + pl.duration(days="add")).alias("add_days"),
@@ -2476,7 +2475,6 @@ def duration(
     ...         (pl.col("dt") + pl.duration(hours="add")).alias("add_hours"),
     ...     )
     ...
-    <class 'polars.config.Config'>
     shape: (2, 5)
     ┌─────────────────────┬─────────────────────┬─────────────────────┬─────────────────────────┬─────────────────────┐
     │ add_weeks           ┆ add_days            ┆ add_seconds         ┆ add_millis              ┆ add_hours           │

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2120,8 +2120,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> with pl.Config() as cfg:
-        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        >>> with pl.Config(auto_structify=True):
         ...     lf.select(
         ...         is_odd=(pl.col(pl.INTEGER_DTYPES) % 2).suffix("_is_odd"),
         ...     ).collect()
@@ -3131,8 +3130,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Expressions with multiple outputs can be automatically instantiated as Structs
         by enabling the experimental setting ``Config.set_auto_structify(True)``:
 
-        >>> with pl.Config() as cfg:
-        ...     cfg.set_auto_structify(True)  # doctest: +IGNORE_RESULT
+        >>> with pl.Config(auto_structify=True):
         ...     lf.drop("c").with_columns(
         ...         diffs=pl.col(["a", "b"]).diff().suffix("_diff"),
         ...     ).collect()

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -21,8 +21,7 @@ def test_ascii_tables() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
 
     # note: expect to render ascii only within the given scope
-    with pl.Config() as cfg:
-        cfg.set_ascii_tables(True)
+    with pl.Config(set_ascii_tables=True):
         assert (
             str(df) == "shape: (3, 3)\n"
             "+-----+-----+-----+\n"
@@ -278,8 +277,7 @@ def test_set_tbl_formats() -> None:
     )
 
     pl.Config().set_tbl_formatting("ASCII_BORDERS_ONLY_CONDENSED")
-    with pl.Config() as cfg:
-        cfg.set_tbl_hide_dtype_separator(True)
+    with pl.Config(tbl_hide_dtype_separator=True):
         assert str(df) == (
             "shape: (3, 3)\n"
             "+-----------------+\n"
@@ -293,8 +291,10 @@ def test_set_tbl_formats() -> None:
         )
 
     # temporarily scope "nothing" style, with no data types
-    with pl.Config() as cfg:
-        cfg.set_tbl_formatting("NOTHING").set_tbl_hide_column_data_types(True)
+    with pl.Config(
+        tbl_formatting="NOTHING",
+        tbl_hide_column_data_types=True,
+    ):
         assert str(df) == (
             "shape: (3, 3)\n"
             " foo  bar  ham \n"


### PR DESCRIPTION
Can now optionally apply most settings at Config instance init-time, for smoother usage as a context-manager. The method's "set_" prefix can optionally be omitted from the init-kwarg name for additional brevity/clarity:

**Before:** _(call methods on instance)_
```python
# single option
with pl.Config() as cfg:
    cfg.set_verbose(True)
    do_stuff()
```
```python
# multiple options
with pl.Config() as cfg:
    cfg.set_tbl_formatting("NOTHING")
    cfg.set_tbl_hide_column_data_types(True)
    do_stuff()
```
**After:** _(provide as equivalent init kwargs)_
```python
# single option
with pl.Config(verbose=True):
    do_stuff()
```
```python
# multiple options
with pl.Config(
    tbl_formatting="NOTHING",
    tbl_hide_column_data_types=True,
):
    do_stuff()
```
Update the various doc/docstirngs to include the new pattern.