### PR TITLE
feat(python): .to_numpy(use_pyarrow=False) for Object and Boolean

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -38,6 +38,7 @@ from polars.datatypes import (
     Int32,
     Int64,
     List,
+    Object,
     Time,
     UInt8,
     UInt16,
@@ -3252,7 +3253,12 @@ class Series:
                 tp = f"datetime64[{self.time_unit}]"
             return arr.astype(tp)
 
-        if use_pyarrow and _PYARROW_AVAILABLE and not self.is_temporal(excluding=Time):
+        if (
+            use_pyarrow
+            and _PYARROW_AVAILABLE
+            and self.dtype != Object
+            and not self.is_temporal(excluding=Time)
+        ):
             return self.to_arrow().to_numpy(
                 *args, zero_copy_only=zero_copy_only, writable=writable
             )

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -822,6 +822,9 @@ impl PySeries {
 
     pub fn to_arrow(&mut self) -> PyResult<PyObject> {
         self.rechunk(true);
+        if matches!(self.series.dtype(), DataType::Object(_)) {
+            panic!("'to_arrow' not implemented for Object dtype");
+        }
         Python::with_gil(|py| {
             let pyarrow = py.import("pyarrow")?;
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -822,9 +822,6 @@ impl PySeries {
 
     pub fn to_arrow(&mut self) -> PyResult<PyObject> {
         self.rechunk(true);
-        if matches!(self.series.dtype(), DataType::Object(_)) {
-            panic!("'to_arrow' not implemented for Object dtype");
-        }
         Python::with_gil(|py| {
             let pyarrow = py.import("pyarrow")?;
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/7689
Fixes https://github.com/pola-rs/polars/issues/8393 (partly)

This disables the Arrow route with a panic because on the Arrow route objects are converted to binary strings for some reasons I don't understand (`object_series_to_arrow_array`)