### PR TITLE
fix(rust,python): don't inadvertently set `Series` initialised with nested tuple data as `Object` dtype

### DIFF
--- a/py-polars/src/apply/dataframe.rs
+++ b/py-polars/src/apply/dataframe.rs
@@ -122,7 +122,9 @@ pub fn apply_lambda_unknown<'a>(
                 .into_py(py),
                 true,
             ));
-        } else if out.is_instance_of::<PyList>().unwrap() {
+        } else if out.is_instance_of::<PyList>().unwrap()
+            || out.is_instance_of::<PyTuple>().unwrap()
+        {
             return Err(PyPolarsErr::Other(
                 "A list output type is invalid. Do you mean to create polars List Series?\
 Then return a Series object."

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -44,7 +44,7 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
         applyer
             .apply_lambda_with_list_out_type(py, lambda.to_object(py), null_count, &series, dt)
             .map(|ca| ca.into_series().into())
-    } else if out.is_instance_of::<PyList>().unwrap() {
+    } else if out.is_instance_of::<PyList>().unwrap() || out.is_instance_of::<PyTuple>().unwrap() {
         let series = SERIES.call1(py, (out,))?;
         let py_pyseries = series.getattr(py, "_s").unwrap();
         let series = py_pyseries.extract::<PySeries>(py).unwrap().series;

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -687,7 +687,7 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                 vals.push(val)
             }
             Ok(Wrap(AnyValue::StructOwned(Box::new((vals, keys)))))
-        } else if ob.is_instance_of::<PyList>()? {
+        } else if ob.is_instance_of::<PyList>()? || ob.is_instance_of::<PyTuple>()? {
             materialize_list(ob)
         } else if let Ok(value) = ob.extract::<u64>() {
             Ok(AnyValue::UInt64(value).into())

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -852,6 +852,19 @@ def test_set_list_and_tuple(idx: list[int] | tuple[int]) -> None:
     assert_series_equal(a, pl.Series("a", [4, 2, 4]))
 
 
+def test_init_nested_tuple() -> None:
+    s1 = pl.Series("s", (1, 2, 3))
+    assert s1.to_list() == [1, 2, 3]
+
+    s2 = pl.Series("s", ((1, 2, 3),), dtype=pl.List(pl.UInt8))
+    assert s2.to_list() == [[1, 2, 3]]
+    assert s2.dtype == pl.List(pl.UInt8)
+
+    s3 = pl.Series("s", ((1, 2, 3), (1, 2, 3)), dtype=pl.List(pl.Int32))
+    assert s3.to_list() == [[1, 2, 3], [1, 2, 3]]
+    assert s3.dtype == pl.List(pl.Int32)
+
+
 def test_fill_null() -> None:
     s = pl.Series("a", [1, 2, None])
     assert_series_equal(s.fill_null(strategy="forward"), pl.Series("a", [1, 2, 2]))


### PR DESCRIPTION
Python tuple is just an immutable list. Fixing the inferred type addresses some cast/misc errors with nested data initialised from tuples, and ensures that `Series` behaviour is consistent with `DataFrame`:

**Before:**
```python
pl.Series("s", ((1, 2, 3), (1, 2, 3)))
# Series: 's' [o][object]    << should load as list[i64]
# [                              not consistent with DataFrame (below)
#     (1, 2, 3)
#     (1, 2, 3)
# ]

pl.DataFrame({"s": ((1, 2, 3), (1, 2, 3))})
# shape: (2, 1)
# ┌───────────┐
# │ s         │
# │ ---       │
# │ list[i64] │    << correctly loads as list[i64]
# ╞═══════════╡
# │ [1, 2, 3] │
# │ [1, 2, 3] │
# └───────────┘
```
**After:**
```python
pl.Series("s", ((1, 2, 3), (1, 2, 3)))
# Series: 's' [list[i64]]
# [
#     [1, 2, 3]
#     [1, 2, 3]
# ]
```