### PR TITLE
feat(python): Allow `%f` in `strptime` format strings

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -57,6 +57,7 @@ from polars.datatypes import (
 )
 from polars.exceptions import (
     ArrowError,
+    ChronoFormatWarning,
     ColumnNotFoundError,
     ComputeError,
     DuplicateError,
@@ -186,6 +187,7 @@ __all__ = [
     "ArrowError",
     "ColumnNotFoundError",
     "ComputeError",
+    "ChronoFormatWarning",
     "DuplicateError",
     "InvalidOperationError",
     "NoDataError",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -66,10 +66,23 @@ class TooManyRowsReturnedError(RowsError):
     """Exception raised when more rows than expected are returned."""
 
 
+class ChronoFormatWarning(Warning):
+    """
+    Warning raised when a chrono format string contains dubious patterns.
+
+    Polars uses Rust's chrono crate to convert between string data and temporal data.
+    The patterns used by chrono differ slightly from Python's built-in datetime module.
+    Refer to the `chrono strftime documentation
+    <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_ for the full
+    specification.
+    """
+
+
 __all__ = [
     "ArrowError",
     "ColumnNotFoundError",
     "ComputeError",
+    "ChronoFormatWarning",
     "DuplicateError",
     "InvalidOperationError",
     "NoDataError",

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
+from polars.exceptions import ChronoFormatWarning
 from polars.utils import no_default
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
@@ -115,6 +116,8 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
+        _validate_format_argument(format)
+
         if tz_aware is no_default:
             tz_aware = False
         else:
@@ -1323,3 +1326,16 @@ class ExprStringNameSpace:
 
         """
         return wrap_expr(self._pyexpr.str_parse_int(radix, strict))
+
+
+def _validate_format_argument(format: str):
+    if ".%f" in format:
+        message = (
+            "Detected the pattern `.%f` in the chrono format string."
+            " This pattern should not be used to parse values after a decimal point."
+            " Use `%.f` instead."
+            " See the full specification: https://docs.rs/chrono/latest/chrono/format/strftime"
+        )
+        warnings.warn(
+            message, category=ChronoFormatWarning, stacklevel=find_stacklevel()
+        )

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1328,8 +1328,8 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_parse_int(radix, strict))
 
 
-def _validate_format_argument(format: str):
-    if ".%f" in format:
+def _validate_format_argument(format: str | None) -> None:
+    if format is not None and ".%f" in format:
         message = (
             "Detected the pattern `.%f` in the chrono format string."
             " This pattern should not be used to parse values after a decimal point."

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -125,17 +125,6 @@ class ExprStringNameSpace:
         if not is_polars_dtype(dtype):
             raise ValueError(f"expected: {DataType} got: {dtype}")
 
-        if format is not None and "%f" in format:
-            raise ValueError(
-                "Directive '%f' is not supported in Python Polars, "
-                "as it differs from the Python standard library.\n"
-                "Instead, please use one of:\n"
-                " - '%.f'\n"
-                " - '%3f'\n"
-                " - '%6f'\n"
-                " - '%9f'"
-            )
-
         if tz_aware is no_default:
             tz_aware = False
         else:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
-from polars.datatypes import (
-    DataType,
-    Date,
-    Datetime,
-    Time,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.utils import no_default
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
@@ -122,9 +115,6 @@ class ExprStringNameSpace:
         └────────────┘
 
         """
-        if not is_polars_dtype(dtype):
-            raise ValueError(f"expected: {DataType} got: {dtype}")
-
         if tz_aware is no_default:
             tz_aware = False
         else:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1924,25 +1924,29 @@ def test_replace_timezone_from_to(
     assert result == expected
 
 
-def test_strptime_subseconds_datetime() -> None:
-    with pytest.raises(ValueError, match="not supported"):
-        pl.Series(["2023-02-05T05:10:10.074000"]).str.strptime(
-            pl.Datetime, "%Y-%m-%dT%H:%M:%S.%f"
-        )
-    result = (
-        pl.Series(["2023-02-05T05:10:10.074000"])
-        .str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f")
-        .item()
-    )
-    expected = datetime(2023, 2, 5, 5, 10, 10, 74000)
+@pytest.mark.parametrize(
+    ("format", "expected"),
+    [
+        ("%Y-%m-%dT%H:%M:%S%.f", datetime(2023, 2, 5, 5, 10, 10, 74000)),
+        ("%Y-%m-%dT%H:%M:%S.%f", datetime(2023, 2, 5, 5, 10, 10, 74)),
+    ],
+)
+def test_strptime_subseconds_datetime(format: str, expected: time) -> None:
+    s = pl.Series(["2023-02-05T05:10:10.074000"])
+    result = s.str.strptime(pl.Datetime, format).item()
     assert result == expected
 
 
-def test_strptime_subseconds_time() -> None:
-    with pytest.raises(ValueError, match="not supported"):
-        pl.Series(["05:10:10.074000"]).str.strptime(pl.Time, "%H:%M:%S.%f")
-    result = pl.Series(["05:10:10.074000"]).str.strptime(pl.Time, "%H:%M:%S%.f").item()
-    expected = time(5, 10, 10, 74000)
+@pytest.mark.parametrize(
+    ("format", "expected"),
+    [
+        ("%H:%M:%S%.f", time(5, 10, 10, 74000)),
+        ("%H:%M:%S.%f", time(5, 10, 10, 74)),
+    ],
+)
+def test_strptime_subseconds_time(format: str, expected: time) -> None:
+    s = pl.Series(["05:10:10.074000"])
+    result = s.str.strptime(pl.Time, format).item()
     assert result == expected
 
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1924,32 +1924,6 @@ def test_replace_timezone_from_to(
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    ("format", "expected"),
-    [
-        ("%Y-%m-%dT%H:%M:%S%.f", datetime(2023, 2, 5, 5, 10, 10, 74000)),
-        ("%Y-%m-%dT%H:%M:%S.%f", datetime(2023, 2, 5, 5, 10, 10, 74)),
-    ],
-)
-def test_strptime_subseconds_datetime(format: str, expected: time) -> None:
-    s = pl.Series(["2023-02-05T05:10:10.074000"])
-    result = s.str.strptime(pl.Datetime, format).item()
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("format", "expected"),
-    [
-        ("%H:%M:%S%.f", time(5, 10, 10, 74000)),
-        ("%H:%M:%S.%f", time(5, 10, 10, 74)),
-    ],
-)
-def test_strptime_subseconds_time(format: str, expected: time) -> None:
-    s = pl.Series(["05:10:10.074000"])
-    result = s.str.strptime(pl.Time, format).item()
-    assert result == expected
-
-
 def test_strptime_with_tz() -> None:
     result = (
         pl.Series(["2020-01-01 03:00:00"])

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -481,6 +481,8 @@ def test_strptime_subseconds_datetime(data: str, format: str, expected: time) ->
     ("data", "format", "expected"),
     [
         ("05:10:10.074000", "%H:%M:%S%.f", time(5, 10, 10, 74000)),
+        ("05:10:10.074000", "%T%.6f", time(5, 10, 10, 74000)),
+        ("05:10:10.074000", "%H:%M:%S%.3f", time(5, 10, 10, 74000)),
     ],
 )
 def test_strptime_subseconds_time(data: str, format: str, expected: time) -> None:


### PR DESCRIPTION
I looked into this and I could not find a reason why this would not be permitted. I updated the tests and it all works as expected.

Pinging @MarcoGorelli as I expect he introduced this check - could you elaborate?

I also removed a check on the `dtype` input - this is already handled by the `if/elif/else` statement.