### PR TITLE
feat(rust, python): warn if argument is not explicitly sorted

### DIFF
--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
 
 use crate::prelude::*;
-use crate::utils::slice_slice;
+use crate::utils::{ensure_sorted_arg, slice_slice};
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -39,6 +39,8 @@ fn check_asof_columns(a: &Series, b: &Series) -> PolarsResult<()> {
         a.null_count() == 0 && b.null_count() == 0,
         ComputeError: "asof join must not have null values in 'on' arguments"
     );
+    ensure_sorted_arg(a);
+    ensure_sorted_arg(b);
     Ok(())
 }
 

--- a/polars/polars-core/src/utils/series.rs
+++ b/polars/polars-core/src/utils/series.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::series::unstable::UnstableSeries;
+use crate::series::IsSorted;
 
 /// Transform to physical type and coerce floating point and similar sized integer to a bit representation
 /// to reduce compiler bloat
@@ -28,4 +29,18 @@ where
     let mut us = UnstableSeries::new(&mut container);
 
     f(&mut us)
+}
+
+pub fn ensure_sorted_arg(s: &Series) {
+    if !matches!(s.is_sorted_flag(), IsSorted::Ascending) {
+        eprintln!(
+            r#"argument is not explicitly sorted
+
+- If your data is ALREADY sorted, set the sorted flag with: '.set_sorted()'.
+- If your data is NOT sorted, sort the 'expr/series/column' first.
+
+This might become an error in a future version.
+    "#
+        );
+    }
 }

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -8,6 +8,7 @@ use polars_core::export::rayon::prelude::*;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
+use polars_core::utils::ensure_sorted_arg;
 use polars_core::POOL;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -238,6 +239,7 @@ impl Wrap<&DataFrame> {
         if dt.is_empty() {
             return dt.cast(time_type).map(|s| (s, by, GroupsProxy::default()));
         }
+        ensure_sorted_arg(&dt);
 
         let sorted_set = matches!(dt.is_sorted_flag(), IsSorted::Ascending);
         // a requirement for the index
@@ -461,6 +463,7 @@ impl Wrap<&DataFrame> {
         tz: Option<impl PolarsTimeZone>,
         time_type: &DataType,
     ) -> PolarsResult<(Series, Vec<Series>, GroupsProxy)> {
+        ensure_sorted_arg(&dt);
         let mut dt = dt.rechunk();
         // a requirement for the index
         // so we can set this such that downstream code has this info

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -575,3 +575,14 @@ def test_invalid_groupby_arg() -> None:
         match=r"'aggs' argument should be one or multiple expressions, got: '{'a': 'sum'}'",
     ):
         df.groupby(1).agg({"a": "sum"})
+
+
+def test_no_sorted_warning(capfd: typing.Any) -> None:
+    df = pl.DataFrame(
+        {
+            "dt": [datetime(2001, 1, 1), datetime(2001, 1, 2)],
+        }
+    )
+    df.groupby_dynamic("dt", every="1h").agg(pl.all().count().suffix("_foo"))
+    (_, err) = capfd.readouterr()
+    assert "argument is not explicitly sorted" in err


### PR DESCRIPTION
Currently we print a warning, but this will become a hard error in the future, so that it explodes in your face rather than producing flawed output.