### PR TITLE
feat(python): allow existing `item` method to optionally take row/col indices

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1032,25 +1032,29 @@ class Series:
         """Format output data in HTML for display in Jupyter Notebooks."""
         return self.to_frame()._repr_html_(from_series=True)
 
-    def item(self) -> Any:
+    def item(self, row: int | None = None) -> Any:
         """
-        Return the series as a scalar.
+        Return the series as a scalar, or return the element at the given row index.
 
-        Equivalent to ``s[0]``, with a check that the shape is (1,).
+        If no row index is provided, this is equivalent to ``s[0]``, with a check
+        that the shape is (1,). With a row index, this is equivalent to ``s[row]``.
 
         Examples
         --------
-        >>> s = pl.Series("a", [1])
-        >>> s.item()
+        >>> s1 = pl.Series("a", [1])
+        >>> s1.item()
         1
+        >>> s2 = pl.Series("a", [9, 8, 7])
+        >>> s2.cumsum().item(-1)
+        24
 
         """
-        if len(self) != 1:
+        if row is None and len(self) != 1:
             raise ValueError(
-                f"Can only call .item() if the series is of length 1, "
-                f"series is of length {len(self)}"
+                f"Can only call '.item()' if the series is of length 1, or an "
+                f"explicit row index is provided (series is of length {len(self)})"
             )
-        return self[0]
+        return self[row or 0]
 
     def estimated_size(self, unit: SizeUnit = "b") -> int | float:
         """

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3419,9 +3419,15 @@ def test_item() -> None:
     with pytest.raises(ValueError):
         df.item()
 
+    assert df.item(0, 0) == 1
+    assert df.item(1, "a") == 2
+
     df = pl.DataFrame({"a": [1], "b": [2]})
     with pytest.raises(ValueError):
         df.item()
+
+    assert df.item(0, "a") == 1
+    assert df.item(0, "b") == 2
 
     df = pl.DataFrame({})
     with pytest.raises(ValueError):

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2464,6 +2464,9 @@ def test_item() -> None:
     with pytest.raises(ValueError):
         s.item()
 
+    assert s.item(0) == 1
+    assert s.item(-1) == 2
+
     s = pl.Series("a", [])
     with pytest.raises(ValueError):
         s.item()


### PR DESCRIPTION
Closes #8406, _without_ introducing new methods or changing existing behaviour.

Slightly extends the existing `item()` method to enable it to return items at other row/col indexes than just `[0,0]` on a 1x1 frame. More discoverable/explicit than the somewhat overloaded frame selectors.

* Allows `DataFrame.item` method to take optional row index and col index/name.
* Allows `Series.item` method to take an optional row index.
* No change in default behaviour for either method.
* Also: slight cleanup for `DataFrame.__getitem__` typing.

## Example
```python
import polars as pl
df = pl.DataFrame( {"a": [9,8,7], "b": [4,5,6]} )

df.item(1, 0)
# 8
df.item(2, "b")
# 6
```