### PR TITLE
fix(python): `str.strptime` error message: utf -> utc when parsing dates with multiple utc offsets

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -411,7 +411,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
             \n\
             You might want to try:\n\
             - setting `strict=False`,\n\
-            - explicitly specifying a `fmt`,\n\
+            - explicitly specifying a `format`,\n\
             - setting `utc=True` (if you are parsing datetimes with multiple offsets)."
         );
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -412,7 +412,7 @@ pub(super) fn strptime(s: &Series, options: &StrpTimeOptions) -> PolarsResult<Se
             You might want to try:\n\
             - setting `strict=False`,\n\
             - explicitly specifying a `fmt`,\n\
-            - setting `utf=True` (if you are parsing datetimes with multiple offsets)."
+            - setting `utc=True` (if you are parsing datetimes with multiple offsets)."
         );
     }
     Ok(out.into_series())


### PR DESCRIPTION
The correct argument to pass in when parsing datetimes with multiple offsets is `utc=True` not `utf=True`.

Also updated `fmt` to `format` since that was renamed a short while ago.