### PR TITLE
feat(rust): add `str_slice` method to `StringNameSpace`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -515,6 +515,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             RStrip(matches) => map!(strings::rstrip, matches.as_deref()),
             #[cfg(feature = "string_from_radix")]
             FromRadix(radix, strict) => map!(strings::from_radix, radix, strict),
+            Slice(start, length) => map!(strings::str_slice, start, length),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -406,4 +406,12 @@ impl StringNameSpace {
                 radix, strict,
             )))
     }
+
+    /// Slice the string values.
+    pub fn str_slice(self, start: i64, length: Option<u64>) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StringExpr(StringFunction::Slice(
+                start, length,
+            )))
+    }
 }

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -654,15 +654,7 @@ impl PyExpr {
     }
 
     pub fn str_slice(&self, start: i64, length: Option<u64>) -> PyExpr {
-        let function = move |s: Series| {
-            let ca = s.utf8()?;
-            Ok(Some(ca.str_slice(start, length)?.into_series()))
-        };
-        self.clone()
-            .inner
-            .map(function, GetOutput::from_type(DataType::Utf8))
-            .with_fmt("str.slice")
-            .into()
+        self.inner.clone().str().str_slice(start, length).into()
     }
 
     pub fn str_to_uppercase(&self) -> PyExpr {


### PR DESCRIPTION
Fixes #8426

Continued with `str_slice` convention as not confuse with array `slice`.