### PR TITLE
fix(rust, python): respect dtype in anonymous list builder in case of…

### DIFF
--- a/polars/polars-arrow/src/array/list.rs
+++ b/polars/polars-arrow/src/array/list.rs
@@ -97,8 +97,16 @@ impl<'a> AnonymousBuilder<'a> {
         let offsets = unsafe { Offsets::new_unchecked(self.offsets) };
         let (inner_dtype, values) = if self.arrays.is_empty() {
             let len = *offsets.last() as usize;
-            let values = NullArray::new(DataType::Null, len).boxed();
-            (DataType::Null, values)
+            match inner_dtype {
+                None => {
+                    let values = NullArray::new(DataType::Null, len).boxed();
+                    (DataType::Null, values)
+                }
+                Some(inner_dtype) => {
+                    let values = new_null_array(inner_dtype.clone(), len);
+                    (inner_dtype.clone(), values)
+                }
+            }
         } else {
             let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -512,6 +512,13 @@ def test_list_new_from_index_logical() -> None:
     assert s.dtype == pl.List(pl.Struct([pl.Field("a", pl.Date)]))
     assert s.to_list() == [[{"a": date(2001, 1, 1)}]]
 
+    # empty new_from_index # 8420
+    dtype = pl.List(pl.Struct({"c": pl.Boolean}))
+    s = pl.Series("b", values=[[]], dtype=dtype)
+    s = s.new_from_index(0, 2)
+    assert s.dtype == dtype
+    assert s.to_list() == [[], []]
+
 
 def test_list_recursive_time_unit_cast() -> None:
     values = [[datetime(2000, 1, 1, 0, 0, 0)]]


### PR DESCRIPTION
… empty

fixes #8420