### PR TITLE
feat(python): add `Series` support to `pl.from_repr`

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -448,9 +448,14 @@ def dtype_short_repr_to_dtype(dtype_string: str | None) -> PolarsDataType | None
     dtype_base, subtype = m.groups()
     dtype = DataTypeMappings.REPR_TO_DTYPE.get(dtype_base)
     if dtype and subtype:
-        # TODO: better-handle nested types (such as List,Struct)
-        subtype = (s.strip("""'" """) for s in subtype.replace("μs", "us").split(","))
+        # TODO: further-improve handling for nested types (such as List,Struct)
         try:
+            if dtype == Decimal:
+                subtype = (None, int(subtype))
+            else:
+                subtype = (
+                    s.strip("'\" ") for s in subtype.replace("μs", "us").split(",")
+                )
             return dtype(*subtype)  # type: ignore[operator]
         except ValueError:
             pass

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -741,10 +741,10 @@ def test_from_fixed_size_binary_list() -> None:
     assert s.to_list() == val
 
 
-def test_from_repr() -> None:
+def test_dataframe_from_repr() -> None:
     # round-trip various types
     with pl.StringCache():
-        df = (
+        frame = (
             pl.LazyFrame(
                 {
                     "a": [1, 2, None],
@@ -768,7 +768,7 @@ def test_from_repr() -> None:
             .collect()
         )
 
-        assert df.schema == {
+        assert frame.schema == {
             "a": pl.Int64,
             "b": pl.Float64,
             "c": pl.Categorical,
@@ -778,11 +778,14 @@ def test_from_repr() -> None:
             "g": pl.Time,
             "h": pl.Datetime("ns"),
         }
-        assert_frame_equal(df, pl.from_repr(repr(df)))
+        df = cast(pl.DataFrame, pl.from_repr(repr(frame)))
+        assert_frame_equal(frame, df)
 
     # empty frame; confirm schema is inferred
-    df = pl.from_repr(
-        """
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
         ┌─────┬─────┬─────┬─────┬─────┬───────┐
         │ id  ┆ q1  ┆ q2  ┆ q3  ┆ q4  ┆ total │
         │ --- ┆ --- ┆ --- ┆ --- ┆ --- ┆ ---   │
@@ -790,6 +793,7 @@ def test_from_repr() -> None:
         ╞═════╪═════╪═════╪═════╪═════╪═══════╡
         └─────┴─────┴─────┴─────┴─────┴───────┘
         """
+        ),
     )
     assert df.shape == (0, 6)
     assert df.rows() == []
@@ -802,8 +806,10 @@ def test_from_repr() -> None:
         "total": pl.Float64,
     }
 
-    df = pl.from_repr(
-        """
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
         # >>> Missing cols with old-style ellipsis, nulls, commented out
         # ┌────────────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬──────┐
         # │ dt         ┆ c1  ┆ c2  ┆ c3  ┆ ... ┆ c96 ┆ c97 ┆ c98 ┆ c99  │
@@ -815,6 +821,7 @@ def test_from_repr() -> None:
         # │ null       ┆ 9   ┆ 18  ┆ 27  ┆ ... ┆ 864 ┆ 873 ┆ 882 ┆ 891  │
         # └────────────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┴──────┘
         """
+        ),
     )
     assert df.schema == {
         "dt": pl.Date,
@@ -832,8 +839,10 @@ def test_from_repr() -> None:
         (None, 9, 18, 27, 864, 873, 882, 891),
     ]
 
-    df = pl.from_repr(
-        """
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
         In [2]: with pl.Config() as cfg:
            ...:     pl.Config.set_tbl_formatting("UTF8_FULL", rounded_corners=True)
            ...:     print(df)
@@ -853,6 +862,7 @@ def test_from_repr() -> None:
         ╰───────────┴────────────┴───┴───────┴────────────────────────────────╯
         # "Een fluitje van een cent..." :)
         """
+        ),
     )
     assert df.shape == (2, 4)
     assert df.schema == {
@@ -861,6 +871,66 @@ def test_from_repr() -> None:
         "ident": pl.Utf8,
         "timestamp": pl.Datetime("us", "Asia/Tokyo"),
     }
+
+
+def test_series_from_repr() -> None:
+    with pl.StringCache():
+        frame = (
+            pl.LazyFrame(
+                {
+                    "a": [1, 2, None],
+                    "b": [4.5, 5.5, 6.5],
+                    "c": ["x", "y", "z"],
+                    "d": [True, False, True],
+                    "e": [None, "", None],
+                    "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
+                    "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
+                    "h": [
+                        datetime(2022, 7, 5, 10, 30, 45, 4560),
+                        datetime(2023, 10, 12, 20, 3, 8, 11),
+                        None,
+                    ],
+                },
+            )
+            .with_columns(
+                pl.col("c").cast(pl.Categorical),
+                pl.col("h").cast(pl.Datetime("ns")),
+            )
+            .collect()
+        )
+
+        for col in frame.columns:
+            srs = cast(pl.Series, pl.from_repr(repr(frame[col])))
+            assert_series_equal(srs, frame[col])
+
+    srs = cast(
+        pl.Series,
+        pl.from_repr(
+            """
+            Out[3]:
+            shape: (3,)
+            Series: 's' [str]
+            [
+                "a"
+                 …
+                "c"
+            ]
+            """
+        ),
+    )
+    assert_series_equal(srs, pl.Series("s", ["a", "c"]))
+
+    srs = cast(
+        pl.Series,
+        pl.from_repr(
+            """
+            Series: 'flt' [f32]
+            [
+            ]
+            """
+        ),
+    )
+    assert_series_equal(srs, pl.Series("flt", [], dtype=pl.Float32))
 
 
 def test_to_init_repr() -> None:


### PR DESCRIPTION
Follow-up to https://github.com/pola-rs/polars/pull/7781.

Adds the missing `Series` support to `from_repr`, so we can quickly reconstruct small data/examples by copy/pasting the `repr` output into this utility function. Handles `Series` that have been commented-out, are empty, etc...

## Examples

_Empty, missing 'shape' header:_
```python
srs = pl.from_repr(
  """
    Series: 'flt' [f32]
    [
    ]
  """
)
srs.to_list()
# []

srs.dtype
# Float32
```
_Commented-out, leading prompt, varied-length time formatting:_
```python
srs = pl.from_repr(
  """
    # Out[1]: s
    # shape: (3,)
    # Series: 'tm' [time]
    # [
    # 	00:00:00.000001
    # 	12:30:45
    # 	23:59:59.999
    # ]
  """)

srs.to_list()
# [time(0, 0, 0, 1),
#  time(12, 30, 45),
#  time(23, 59, 59, 999000)]
```