### PR TITLE
feat(python): initial parametric/hypothesis `Decimal` dtype testing strategy (note: disabled by default)

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -313,14 +313,11 @@ class List(NestedType):
         self.inner = polars.datatypes.py_type_to_dtype(inner)
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
-        # The comparison allows comparing objects to classes
-        # and specific inner types to none specific.
-        # if one of the arguments is not specific about its inner type
-        # we infer it as being equal.
-        # List[i64] == List[i64] == True
-        # List[i64] == List == True
-        # List[i64] == List[None] == True
-        # List[i64] == List[f32] == False
+        # This equality check allows comparison of type classes and type instances.
+        # If a parent type is not specific about its inner type, we infer it as equal:
+        # > list[i64] == list[i64] -> True
+        # > list[i64] == list[f32] -> False
+        # > list[i64] == list      -> True
 
         # allow comparing object instances to class
         if type(other) is DataTypeClass and issubclass(other, List):

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -231,6 +231,7 @@ class _DataTypeMappings:
             UInt64: "u64",
             Float32: "f32",
             Float64: "f64",
+            Decimal: "decimal",
             Boolean: "bool",
             Utf8: "str",
             List: "list",

--- a/py-polars/polars/testing/parametric/primitives.py
+++ b/py-polars/polars/testing/parametric/primitives.py
@@ -21,6 +21,8 @@ from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     FLOAT_DTYPES,
     Categorical,
+    DataType,
+    DataTypeClass,
     Datetime,
     Duration,
     List,
@@ -256,8 +258,8 @@ def series(
     allow_infinities: bool = True,
     unique: bool = False,
     chunked: bool | None = None,
-    allowed_dtypes: Collection[PolarsDataType] | None = None,
-    excluded_dtypes: Collection[PolarsDataType] | None = None,
+    allowed_dtypes: Collection[PolarsDataType] | PolarsDataType | None = None,
+    excluded_dtypes: Collection[PolarsDataType] | PolarsDataType | None = None,
 ) -> SearchStrategy[Series]:
     """
     Strategy for producing a polars Series.
@@ -325,6 +327,11 @@ def series(
     ]
 
     """
+    if isinstance(allowed_dtypes, (DataType, DataTypeClass)):
+        allowed_dtypes = [allowed_dtypes]
+    if isinstance(excluded_dtypes, (DataType, DataTypeClass)):
+        excluded_dtypes = [excluded_dtypes]
+
     selectable_dtypes = [
         dtype
         for dtype in (allowed_dtypes or strategy_dtypes)
@@ -427,8 +434,8 @@ def dataframes(
     include_cols: Sequence[column] | None = None,
     null_probability: float | dict[str, float] = 0.0,
     allow_infinities: bool = True,
-    allowed_dtypes: Collection[PolarsDataType] | None = None,
-    excluded_dtypes: Collection[PolarsDataType] | None = None,
+    allowed_dtypes: Collection[PolarsDataType] | PolarsDataType | None = None,
+    excluded_dtypes: Collection[PolarsDataType] | PolarsDataType | None = None,
 ) -> SearchStrategy[DataFrame | LazyFrame]:
     """
     Provides a strategy for producing a DataFrame or LazyFrame.
@@ -527,6 +534,10 @@ def dataframes(
 
     if isinstance(min_size, int) and min_cols in (0, None):
         min_cols = 1
+    if isinstance(allowed_dtypes, (DataType, DataTypeClass)):
+        allowed_dtypes = [allowed_dtypes]
+    if isinstance(excluded_dtypes, (DataType, DataTypeClass)):
+        excluded_dtypes = [excluded_dtypes]
 
     selectable_dtypes = [
         dtype

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta
 from random import choice
 from string import ascii_letters, ascii_uppercase, digits, punctuation
@@ -10,6 +11,7 @@ from hypothesis.strategies import (
     characters,
     dates,
     datetimes,
+    decimals,
     floats,
     from_type,
     integers,
@@ -25,6 +27,7 @@ from polars.datatypes import (
     Categorical,
     Date,
     Datetime,
+    Decimal,
     Duration,
     Float32,
     Float64,
@@ -66,6 +69,16 @@ strategy_u8 = integers(min_value=0, max_value=(2**8) - 1)
 strategy_u16 = integers(min_value=0, max_value=(2**16) - 1)
 strategy_u32 = integers(min_value=0, max_value=(2**32) - 1)
 strategy_u64 = integers(min_value=0, max_value=(2**64) - 1)
+
+# TODO: once fixed, re-enable decimal nan/inf values.
+# TODO: vary the number of decimal places.
+strategy_decimal = decimals(
+    allow_nan=False,
+    allow_infinity=False,
+    min_value=-(2**66),
+    max_value=(2**66) - 1,
+    places=18,
+)
 
 strategy_ascii = text(max_size=8, alphabet=ascii_letters + digits + punctuation)
 strategy_categorical = text(max_size=2, alphabet=ascii_uppercase)
@@ -113,6 +126,11 @@ scalar_strategies: dict[PolarsDataType, Any] = {
     Categorical: strategy_categorical,
     Utf8: strategy_utf8,
 }
+
+# note: decimal support is in early development and requires opt-in
+if os.environ.get("POLARS_ACTIVATE_DECIMAL") == "1":
+    scalar_strategies[Decimal] = strategy_decimal
+
 _strategy_dtypes = list(scalar_strategies) + [List]
 
 

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -3,6 +3,7 @@
 # -------------------------------------------------
 from __future__ import annotations
 
+# from decimal import Decimal as D
 from typing import no_type_check
 
 import numpy as np
@@ -95,27 +96,23 @@ def test_ewm_methods(
             assert_series_equal(ewm_var_pl, ewm_var_pd, atol=1e-07)
 
 
-@given(
-    srs=series(max_size=10, dtype=pl.Int64),
-    start=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
-    stop=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
-    step=sampled_from([-5, -4, -3, -2, -1, None, 1, 2, 3, 4, 5]),
-)
-@settings(max_examples=500)
-def test_series_slice(
-    srs: pl.Series,
-    start: int | None,
-    stop: int | None,
-    step: int | None,
-) -> None:
-    py_data = srs.to_list()
-
-    s = slice(start, stop, step)
-    sliced_py_data = py_data[s]
-    sliced_pl_data = srs[s].to_list()
-
-    assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
-    assert_series_equal(srs, srs, check_exact=True)
+# TODO: once Decimal is a little further along, start actively probing it
+# @given(
+#     s=series(max_size=10, dtype=pl.Decimal, null_probability=0.1),
+# )
+# def test_series_decimal(
+#     s: pl.Series,
+# ) -> None:
+#     with pl.Config(activate_decimals=True):
+#         assert s.dtype == pl.Decimal
+#         assert s.to_list() == list(s)
+#
+#         s_div = s / D(123)
+#         s_mul = s * D(123)
+#         s_sub = s - D(123)
+#         s_add = s - D(123)
+#
+# etc...
 
 
 @given(
@@ -161,6 +158,29 @@ def test_series_duration_timeunits(
     ):
         for ns, us in zip(s.dt.nanoseconds(), micros):
             assert ns == (us * 1000)
+
+
+@given(
+    srs=series(max_size=10, dtype=pl.Int64),
+    start=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
+    stop=sampled_from([-5, -4, -3, -2, -1, None, 0, 1, 2, 3, 4, 5]),
+    step=sampled_from([-5, -4, -3, -2, -1, None, 1, 2, 3, 4, 5]),
+)
+@settings(max_examples=500)
+def test_series_slice(
+    srs: pl.Series,
+    start: int | None,
+    stop: int | None,
+    step: int | None,
+) -> None:
+    py_data = srs.to_list()
+
+    s = slice(start, stop, step)
+    sliced_py_data = py_data[s]
+    sliced_pl_data = srs[s].to_list()
+
+    assert sliced_py_data == sliced_pl_data, f"slice [{start}:{stop}:{step}] failed"
+    assert_series_equal(srs, srs, check_exact=True)
 
 
 @given(


### PR DESCRIPTION
First-cut decimal dtype strategy...

* `Decimal` support is in the early stages, so no decimal-related parametric tests are enabled/run by default.
* Opt-in is required, by setting the `POLARS_ACTIVATE_DECIMAL` environment variable to "1" before importing anything from `polars.testing.parametric` (can set this using `pl.Config.activate_decimals(True)`).
* If the feature is enabled, a `Decimal` entry is added to `scalar_strategies`, enabling use with parametric primitives.

## Example
```python
import polars as pl
with pl.Config( activate_decimals=True, set_fmt_str_lengths=100 ):
    from polars.testing.parametric import dataframes 
    df = dataframes(
        cols = 3,
        size = 5,
        allowed_dtypes = pl.Decimal,
    ).example()
    
print(df)
# shape: (5, 3)
# ┌──────────────────────────────────────────┬───────────────────────┬──────────────────────────────────────────┐
# │ col0                                     ┆ col1                  ┆ col2                                     │
# │ ---                                      ┆ ---                   ┆ ---                                      │
# │ decimal[18]                              ┆ decimal[18]           ┆ decimal[18]                              │
# ╞══════════════════════════════════════════╪═══════════════════════╪══════════════════════════════════════════╡
# │ -20968321166882327901.235240065768658235 ┆ 0.000000000000000007  ┆ -20968321166882327901.235240065768658235 │
# │ -73786976294838206463.999999999999999999 ┆ 0.000000000752846702  ┆ -73786976294838206463.999999999999999999 │
# │ -53444167305840588799.271191974963763117 ┆ 0.000000000000007729  ┆ -53444167305840588799.271191974963763117 │
# │ 0.000000000000032405                     ┆ -0.000000000000044686 ┆ 0.000000000000032405                     │
# │ -0.00000000286256564                     ┆ 0.000000000000003575  ┆ -0.00000000286256564                     │
# └──────────────────────────────────────────┴───────────────────────┴──────────────────────────────────────────┘
