### PR TITLE
perf(rust, python): remove false sharing in perfect hash table `>2x`

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -261,7 +261,7 @@ impl<'df> GroupBy<'df> {
                 .map(|s| {
                     match groups {
                         GroupsProxy::Idx(groups) => {
-                            let mut iter = groups.iter().map(|(first, _idx)| first as usize);
+                            let mut iter = groups.first().iter().map(|first| *first as usize);
                             // Safety:
                             // groups are always in bounds
                             let mut out = unsafe { s.take_iter_unchecked(&mut iter) };

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -146,6 +146,11 @@ impl GroupsIdx {
         &self.all
     }
 
+    #[cfg(feature = "dtype-categorical")]
+    pub(crate) unsafe fn all_mut(&mut self) -> &mut Vec<Vec<IdxSize>> {
+        &mut self.all
+    }
+
     pub fn first(&self) -> &[IdxSize] {
         &self.first
     }

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -146,11 +146,6 @@ impl GroupsIdx {
         &self.all
     }
 
-    #[cfg(feature = "dtype-categorical")]
-    pub(crate) unsafe fn all_mut(&mut self) -> &mut Vec<Vec<IdxSize>> {
-        &mut self.all
-    }
-
     pub fn first(&self) -> &[IdxSize] {
         &self.first
     }


### PR DESCRIPTION
Went from 416 entries to 40 entries in perf c2c report