### PR TITLE
feat(python): improved hypothesis/parametric testing profile registration

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -4,7 +4,7 @@ numpy
 pandas
 pyarrow
 
-hypothesis==6.72.0
+hypothesis==6.72.1
 
 autodocsumm==0.2.9
 commonmark==0.9.1

--- a/py-polars/polars/testing/parametric/__init__.py
+++ b/py-polars/polars/testing/parametric/__init__.py
@@ -9,6 +9,7 @@ if _HYPOTHESIS_AVAILABLE:
         dataframes,
         series,
     )
+    from polars.testing.parametric.profiles import load_profile
     from polars.testing.parametric.strategies import (
         create_list_strategy,
         scalar_strategies,
@@ -24,8 +25,9 @@ else:
 __all__ = [
     "column",
     "columns",
-    "dataframes",
-    "series",
     "create_list_strategy",
+    "dataframes",
+    "load_profile",
     "scalar_strategies",
+    "series",
 ]

--- a/py-polars/polars/testing/parametric/profiles.py
+++ b/py-polars/polars/testing/parametric/profiles.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from hypothesis import settings
+
+from polars.type_aliases import ParametricProfileNames
+
+
+def load_profile(
+    profile: ParametricProfileNames | int = "fast", set_environment: bool = False
+) -> None:
+    """
+    Load a named (or custom) hypothesis profile for use with the parametric tests.
+
+    Parameters
+    ----------
+    profile : {str, int}, optional
+        Name of the profile to load; one of "fast", "balanced", "expensive", or
+        the integer number of iterations to run (which will create and register
+        a custom profile with that value).
+
+    set_environment : bool, default False
+        If True, set the environment variable "POLARS_HYPOTHESIS_PROFILE" to the
+        given profile name/value.
+
+    """
+    common_settings = {"print_blob": True, "deadline": None}
+    profile_name = str(profile)
+
+    # Register standard/named profiles
+    # --------------------------------
+    for name, iterations in (
+        ("fast", 100),
+        ("balanced", 1_000),
+        ("expensive", 10_000),
+    ):
+        settings.register_profile(
+            name=f"polars.{name}",
+            max_examples=iterations,
+            **common_settings,  # type: ignore[arg-type]
+        )
+
+    # Register a custom profile with 'n' iterations.
+    # ----------------------------------------------
+    # (Set the ideal number to balance time-vs-coverage for your machine).
+    if profile_name.isdigit() or re.match(r"polars\.custom\.[\d_]+$", profile_name):
+        n_iterations = int(profile_name.replace("polars.custom.", ""))
+        profile_name = f"polars.custom.{profile_name}"
+        settings.register_profile(
+            name=profile_name,
+            max_examples=n_iterations,
+            **common_settings,  # type: ignore[arg-type]
+        )
+
+    # Load the chosen profile
+    profile_name = f"polars.{profile_name.replace('polars.', '')}"
+    settings.load_profile(profile_name)
+
+    if set_environment:
+        set_profile(profile_name)  # type: ignore[arg-type]
+
+
+def set_profile(profile: ParametricProfileNames | int) -> None:
+    """
+    Set the env var "POLARS_HYPOTHESIS_PROFILE" to the given profile name/value.
+
+    Parameters
+    ----------
+    profile : {str, int}, optional
+        Name of the profile to load; one of "fast", "balanced", "expensive", or
+        the integer number of iterations to run (which will create and register
+        a custom profile with that value).
+
+    """
+    profile_name = str(profile).split(".")[-1]
+    if profile_name.replace("_", "").isdigit():
+        profile_name = str(int(profile_name))
+
+    if not profile_name.isdigit() and sys.version_info >= (3, 8):
+        from typing import get_args
+
+        valid_profile_names = get_args(ParametricProfileNames)
+        if profile_name not in valid_profile_names:
+            raise ValueError(
+                f"Invalid profile name {profile_name!r}; expected one of {valid_profile_names}!r"
+            )
+
+    os.environ["POLARS_HYPOTHESIS_PROFILE"] = profile_name

--- a/py-polars/polars/testing/parametric/profiles.py
+++ b/py-polars/polars/testing/parametric/profiles.py
@@ -79,7 +79,7 @@ def set_profile(profile: ParametricProfileNames | int) -> None:
     if profile_name.replace("_", "").isdigit():
         profile_name = str(int(profile_name))
 
-    if not profile_name.isdigit() and sys.version_info >= (3, 8):
+    elif sys.version_info >= (3, 8):
         from typing import get_args
 
         valid_profile_names = get_args(ParametricProfileNames)

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -163,3 +163,6 @@ RowTotalsDefinition: TypeAlias = Union[
     Collection[str],
     bool,
 ]
+
+# standard/named hypothesis profiles used for parametric testing
+ParametricProfileNames: TypeAlias = Literal["fast", "balanced", "expensive"]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -18,7 +18,7 @@ adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 connectorx==0.3.2a2; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
 
 # Tooling
-hypothesis==6.72.0
+hypothesis==6.72.1
 maturin==0.14.10
 pytest==7.3.0
 pytest-cov==4.0.0

--- a/py-polars/tests/parametric/conftest.py
+++ b/py-polars/tests/parametric/conftest.py
@@ -1,48 +1,7 @@
 import os
-import re
 
-from hypothesis import settings
+from polars.testing.parametric.profiles import load_profile
 
-
-def load_hypothesis_profile(profile: str = "polars.default") -> None:
-    """Conditionally load different hypothesis profiles."""
-    common_settings = {"print_blob": True, "deadline": None}
-
-    # Default profile (eg: running locally; quite fast)
-    settings.register_profile(
-        name="polars.default",
-        max_examples=100,
-        **common_settings,  # type: ignore[arg-type]
-    )
-    # Polars 'max' profile (10x the number of default iterations).
-    # This is a bit more expensive (though not dramatically so
-    # as it's only about 4-5x slower).
-    settings.register_profile(
-        name="polars.max",
-        max_examples=1_000,
-        **common_settings,  # type: ignore[arg-type]
-    )
-    # Polars 'ultra' profile (100x the number of default iterations).
-    # This is expensive, at about 40x the default runtime.
-    settings.register_profile(
-        name="polars.ultra",
-        max_examples=10_000,
-        **common_settings,  # type: ignore[arg-type]
-    )
-    # Polars 'custom' profile, with 'n' iterations.
-    if profile.isdigit() or re.match(r"polars\.custom\.\d+$", profile):
-        n_iterations = int(profile.replace("polars.custom.", ""))
-        profile = f"polars.custom.{profile}"
-        settings.register_profile(
-            name=profile,
-            max_examples=n_iterations,
-            **common_settings,  # type: ignore[arg-type]
-        )
-
-    profile = profile.replace("polars.", "")
-    settings.load_profile(f"polars.{profile}")
-
-
-load_hypothesis_profile(
-    profile=os.environ.get("POLARS_HYPOTHESIS_PROFILE", "default"),
+load_profile(
+    profile=os.environ.get("POLARS_HYPOTHESIS_PROFILE", "fast"),  # type: ignore[arg-type]
 )


### PR DESCRIPTION
Tidied-up hypothesis/parametric profile registration (and moved into `polars.testing.parametric.profiles`), renamed the standard profiles to be more descriptive, added some additional/explanatory notes/docs, and improved some typing.

* Recommended profile for local runs is probably `balanced`; this has a good trade off between time/iterations, running 10x more tests than `fast` (which is the default profile) but only taking ~4x longer.

* Standard profile names, test iterations, and approximate timings[^1] for release & debug builds:
       
  | Profile     | Iterations | Release         | Debug
  | ----------- | ---------- | --------------- | ---------
  | `fast`      | 100        | ~6 secs         | ~8 secs
  | `balanced`  | 1,000      | ~22 secs        | ~30 secs 
  | `expensive` | 10,000     | ~3 mins 5 secs  | ~4 mins 45 secs

* Note: not a new feature, but don't forget that as well as the _name_ of a standard profile you can also choose to set an explicit _number_ of iterations so that you can control the exact balance of time-vs-coverage for your specific machine/setup.

* If you always want to use a specific profile by default, this can be set using the the `POLARS_HYPOTHESIS_PROFILE` environment variable. For example, I have a custom value in my PyCharm test config for the parametric tests dir:

<img width="762" alt="parametric_test_config" src="https://user-images.githubusercontent.com/2613171/233792910-37a99707-d124-450c-aed2-b42013106b9a.png">

[^1]: Profile timings come from an Apple Silicon M2 Max w/12 cores, using `xdist` with `-n auto`.