### PR TITLE
fix(rust): fix features serde and dtype-struct not compiling together

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -99,6 +99,7 @@ parquet = ["arrow/io_parquet"]
 bigidx = ["polars-arrow/bigidx"]
 python = []
 
+serde = ["dep:serde", "smartstring/serde"]
 serde-lazy = ["serde", "polars-arrow/serde", "indexmap/serde", "smartstring/serde", "chrono/serde"]
 
 docs-selection = [

--- a/polars/polars-core/src/datatypes/field.rs
+++ b/polars/polars-core/src/datatypes/field.rs
@@ -4,7 +4,10 @@ use super::*;
 
 /// Characterizes the name and the [`DataType`] of a column.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    any(feature = "serde", feature = "serde-lazy"),
+    derive(Serialize, Deserialize)
+)]
 pub struct Field {
     pub name: SmartString,
     pub dtype: DataType,


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/8438: features `serde` and `dtype-struct` not compiling when used together, unless using `serde-lazy` too.

- derive traits `Serialize` and `Deserialize` for struct `Field` when using feature `serde`
- enable feature `serde` for `smartstring` when using polars's `serde` feature