### PR TITLE
Reading more tiny CSVs than workers in parallel will deadlock

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -21,6 +21,11 @@ def test_scan_csv(io_files_path: Path) -> None:
     assert df.collect().shape == (4, 3)
 
 
+def test_scan_csv_no_cse_deadlock(io_files_path: Path) -> None:
+    dfs = [pl.scan_csv(io_files_path / "small.csv")] * (pl.threadpool_size() + 1)
+    pl.concat(dfs, parallel=True).collect(common_subplan_elimination=False)
+
+
 def test_scan_empty_csv(io_files_path: Path) -> None:
     with pytest.raises(Exception) as excinfo:
         pl.scan_csv(io_files_path / "empty.csv").collect()


### PR DESCRIPTION
Kinda wild and very specific deadlock condition I ran into. Boiled down to the smallest reproducible case. I wanted to push this up as a PR to see if this can be verified in CI. **Update** [Confirmed test timeouts in CI after 3 hours](https://github.com/pola-rs/polars/actions/runs/4776689482?pr=8441)

Some conditions and my theory after some debugging:

* Fill the [global thread pool](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-core/src/lib.rs#L49) with tasks that are waiting on a shared cache node to initialize.
* One of these threads won't be blocked and will proceed with the subplan (call it Thread A). The others will be blocking their threads. Not great for utilization, but still _okay_, Thread A can still continue processing tasks almost as if it's single threaded mode.
* Thread A will proceed with `scan_csv`. Because the CSV file [is consider small](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L428-L434), it's [`n_threads` flag will be overriden and set to 1](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L429).
* Next, because [`n_threads != POOL.current_num_threads()`](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L535), [a new thread pool is allocated](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L537-L542) for processing the CSV file chunks.
* The Thread A will now block on this subprocessing [after `pool.install` is called](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L667). Now the global thread pool is totally blocked.
* But this new pool can continue for now. However it seems like it maybe attempting to enqueue work back in the global pool or interacting with it in some way. I haven't quite figured out exactly which computation is triggering it. I'm at least not seeing [`pool.install` ever return](https://github.com/pola-rs/polars/blob/9704d091225a8e16dc03916ee2b4b694dbf70e69/polars/polars-io/src/csv/read_impl/mod.rs#L667), that's where it's deadlocked.

If the CSV is "big", the global threadpool is just used and Thread A itself can just continue processing the work. So there's no issue.

Using cache waiters was one way I stumbled into this bug. <del>But it seems like it could be theoretically possible if a ton of CSV readers fill up the global queue blocking themselves from finishing their subtasks. Though I haven't figure out how to make a test case work reliably for this.</del> **Update** I found another way to reproduce the deadlock unrelated to caching. If CSE is disabled, queuing up more scan calls then global pool workers will also deadlocked. Added `test_scan_csv_no_cse_deadlock` for this case.

I'm curious why the CSV reader has this edge case of allocating a separate pool? Nothing else in the codebase seems to do this. It's pretty much the only place where the global thread pool can interact with a different threadpool.

Possible solutions:

* Remove the separate processing pool, always use global pool.
* Try to make cache node locking more cooperative with Rayon's scheduler. Not a theoretically perfect fix, but freeing up those blocked threads by using something like [yield_now](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html#method.yield_now) could give more headroom for CSV reader's tasks to get processed. But probably limited help if the CPU has few cores. (I first discovered this issue with my low resource CI environment being flaky.)

Thanks for your help! 🙏🏻