### PR TITLE
docs(python): integrate live refresh/reload facility while writing docs

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -8,6 +8,7 @@ hypothesis==6.72.1
 
 autodocsumm==0.2.9
 commonmark==0.9.1
+livereload==2.6.3
 numpydoc==1.5.0
 pydata-sphinx-theme==0.13.0
 sphinx-autosummary-accessors==2022.4.0

--- a/py-polars/docs/run_live_docs_server.py
+++ b/py-polars/docs/run_live_docs_server.py
@@ -1,0 +1,27 @@
+from livereload import Server, shell
+from source.conf import html_static_path, templates_path
+
+# -------------------------------------------------------------------------
+# To use, just execute `python run_live_docs_server.py` in a terminal
+# and a local server will run the docs in your browser, automatically
+# refreshing/reloading the pages you're working on as they are modified.
+# Extremely helpful to see the real output before it gets uploaded, and
+# a much smoother experience that constantly running `make html` yourself.
+# -------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # establish a local docs server
+    svr = Server()
+
+    # command to rebuild the docs
+    refresh_docs = shell("make html")
+
+    # watch for source file changes and trigger rebuild/refresh
+    svr.watch("*.rst", refresh_docs, delay=1)
+    svr.watch("*.md", refresh_docs, delay=1)
+    svr.watch("source/reference/*", refresh_docs, delay=1)
+    for path in html_static_path + templates_path:
+        svr.watch(f"source/{path}/*", refresh_docs, delay=1)
+
+    # path from which to serve the docs
+    svr.serve(root="build/html")

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -64,7 +64,7 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
While updating/writing docs, having a browser window open that reflects the state of what you're writing _live_ (well, technically with a small delay ;) can be a game-changer (especially if you're using a dual monitor setup).

This PR sets-up a live refresh/reload facility in our own `docs` directory.

## To use:
```bash
cd polars/py-polars/docs
python3 run_live_docs_server.py
```
Then, as you write docs (or update static images or templates), any saves will automatically trigger a quick build and a live refresh/reload of the page you're working on, reflecting those changes directly in the browser:

<img width="826" alt="live_docs_refresh" src="https://user-images.githubusercontent.com/2613171/233844959-ced02b58-4de3-4848-b6f6-952430b06606.png">
