### PR TITLE
docs(python): add a series of parametric/hypothesis example tests to the main testing docs page

### DIFF
--- a/py-polars/docs/source/reference/testing.rst
+++ b/py-polars/docs/source/reference/testing.rst
@@ -8,6 +8,8 @@ Testing
 Asserts
 -------
 
+Polars provides some standard asserts for use with unit tests:
+
 .. autosummary::
    :toctree: api/
 
@@ -87,3 +89,124 @@ and may vary significantly depending on your own hardware setup):
 +---------------+------------+----------------+-----------------+
 | ``expensive`` | 10,000     | ~3 mins 5 secs | ~4 mins 45 secs |
 +---------------+------------+----------------+-----------------+
+
+Examples
+~~~~~~~~
+
+**Basic:** Create a parametric unit test that will receive a series of
+generated DataFrames, each having 5 numeric columns with a 10% chance
+of any generated value being ``null`` (this is distinct from ``NaN``).
+
+.. code-block:: python
+
+    from polars.testing.parametric import dataframes
+    from polars import NUMERIC_DTYPES
+    from hypothesis import given
+
+
+    @given(
+        dataframes(
+            cols=5,
+            null_probabililty=0.1,
+            allowed_dtypes=NUMERIC_DTYPES,
+        )
+    )
+    def test_numeric(df):
+        assert all(df[col].is_numeric() for col in df.columns)
+
+        # Example frame:
+        # ┌──────┬────────┬───────┬────────────┬────────────┐
+        # │ col0 ┆ col1   ┆ col2  ┆ col3       ┆ col4       │
+        # │ ---  ┆ ---    ┆ ---   ┆ ---        ┆ ---        │
+        # │ u8   ┆ i16    ┆ u16   ┆ i32        ┆ f64        │
+        # ╞══════╪════════╪═══════╪════════════╪════════════╡
+        # │ 54   ┆ -29096 ┆ 485   ┆ 2147483647 ┆ -2.8257e14 │
+        # │ null ┆ 7508   ┆ 37338 ┆ 7264       ┆ 1.5        │
+        # │ 0    ┆ 321    ┆ null  ┆ 16996      ┆ NaN        │
+        # │ 121  ┆ -361   ┆ 63204 ┆ 1          ┆ 1.1443e235 │
+        # └──────┴────────┴───────┴────────────┴────────────┘
+
+**Intermediate:** Integrate hypothesis-native strategies into specifically-named columns,
+generating a series of LazyFrames, with a minimum size of five rows and values that
+conform to the given strategies:
+
+.. code-block:: python
+
+    from polars.testing.parametric import column, dataframes
+    from hypothesis.strategies import floats, sampled_from, text
+    from hypothesis import given
+
+    from string import ascii_letters, digits
+
+    id_chars = ascii_letters + digits
+
+
+    @given(
+        dataframes(
+            cols=[
+                column("id", strategy=text(min_size=4, max_size=4, alphabet=id_chars)),
+                column("ccy", strategy=sampled_from(["GBP", "EUR", "JPY", "USD"])),
+                column("price", strategy=floats(min_value=0.0, max_value=1000.0)),
+            ],
+            min_size=5,
+            lazy=True,
+        )
+    )
+    def test_price_calculations(lf):
+        ...
+        print(lf.collect())
+
+        # Example frame:
+        # ┌──────┬─────┬─────────┐
+        # │ id   ┆ ccy ┆ price   │
+        # │ ---  ┆ --- ┆ ---     │
+        # │ str  ┆ str ┆ f64     │
+        # ╞══════╪═════╪═════════╡
+        # │ A101 ┆ GBP ┆ 1.1     │
+        # │ 8nIn ┆ JPY ┆ 1.5     │
+        # │ QHoO ┆ EUR ┆ 714.544 │
+        # │ i0e0 ┆ GBP ┆ 0.0     │
+        # │ 0000 ┆ USD ┆ 999.0   │
+        # └──────┴─────┴─────────┘
+
+**Advanced:** Create and use a ``List[UInt8]`` dtype strategy as a hypothesis
+`composite <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.composite>`_
+that generates pairs of pairs of small integer values in which the first value in each nested pair
+is always less than or equal to the second value:
+
+.. code-block:: python
+
+    from polars.testing.parametric import create_list_strategy, dataframes, column
+    from hypothesis.strategies import composite
+    from hypothesis import given
+
+
+    @composite
+    def uint8_pairs(draw, uints=create_list_strategy(pl.UInt8, size=2)):
+        pairs = list(zip(draw(uints), draw(uints)))
+        return [sorted(ints) for ints in pairs]
+
+
+    @given(
+        dataframes(
+            cols=[
+                column("colx", strategy=uint8_pairs()),
+                column("coly", strategy=uint8_pairs()),
+                column("colz", strategy=uint8_pairs()),
+            ],
+            size=3,
+        )
+    )
+    def test_miscellaneous(df):
+        ...
+
+        # Example frame:
+        # ┌─────────────────────────┬─────────────────────────┬──────────────────────────┐
+        # │ colx                    ┆ coly                    ┆ colz                     │
+        # │ ---                     ┆ ---                     ┆ ---                      │
+        # │ list[list[i64]]         ┆ list[list[i64]]         ┆ list[list[i64]]          │
+        # ╞═════════════════════════╪═════════════════════════╪══════════════════════════╡
+        # │ [[143, 235], [75, 101]] ┆ [[143, 235], [75, 101]] ┆ [[31, 41], [57, 250]]    │
+        # │ [[87, 186], [174, 179]] ┆ [[87, 186], [174, 179]] ┆ [[112, 213], [149, 221]] │
+        # │ [[23, 85], [7, 86]]     ┆ [[23, 85], [7, 86]]     ┆ [[22, 255], [27, 28]]    │
+        # └─────────────────────────┴─────────────────────────┴──────────────────────────┘

--- a/py-polars/polars/testing/parametric/primitives.py
+++ b/py-polars/polars/testing/parametric/primitives.py
@@ -33,6 +33,7 @@ from polars.series import Series
 from polars.string_cache import StringCache
 from polars.testing.asserts import is_categorical_dtype
 from polars.testing.parametric.strategies import (
+    _hash,
     between,
     create_list_strategy,
     scalar_strategies,
@@ -391,7 +392,7 @@ def series(
                         dtype_strategy,
                         min_size=series_size,
                         max_size=series_size,
-                        unique=unique,
+                        unique_by=(_hash if unique else None),
                     )
                 )
 

--- a/py-polars/polars/testing/parametric/profiles.py
+++ b/py-polars/polars/testing/parametric/profiles.py
@@ -26,6 +26,12 @@ def load_profile(
         If True, also set the environment variable ``POLARS_HYPOTHESIS_PROFILE``
         to the given profile name/value.
 
+    Examples
+    --------
+    >>> # load a custom profile that will run with 1500 iterations
+    >>> from polars.testing.parametric.profiles import load_profile
+    >>> load_profile(1500)
+
     """
     common_settings = {"print_blob": True, "deadline": None}
     profile_name = str(profile)
@@ -73,6 +79,12 @@ def set_profile(profile: ParametricProfileNames | int) -> None:
         Name of the profile to load; one of "fast", "balanced", "expensive", or
         the integer number of iterations to run (which will create and register
         a custom profile with that value).
+
+    Examples
+    --------
+    >>> # prefer the 'balanced' profile for running parametric tests
+    >>> from polars.testing.parametric.profiles import set_profile
+    >>> set_profile("balanced")
 
     """
     profile_name = str(profile).split(".")[-1]


### PR DESCRIPTION
Took advantage of https://github.com/pola-rs/polars/pull/8452 to quickly iterate/add several new parametric testing examples.