### PR TITLE
test(python): additional test coverage for dtype groups

### DIFF
--- a/py-polars/docs/run_live_docs_server.py
+++ b/py-polars/docs/run_live_docs_server.py
@@ -6,7 +6,7 @@ from source.conf import html_static_path, templates_path
 # and a local server will run the docs in your browser, automatically
 # refreshing/reloading the pages you're working on as they are modified.
 # Extremely helpful to see the real output before it gets uploaded, and
-# a much smoother experience that constantly running `make html` yourself.
+# a much smoother experience than constantly running `make html` yourself.
 # -------------------------------------------------------------------------
 
 if __name__ == "__main__":

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -74,16 +74,20 @@ def _custom_reconstruct(
 
 
 class DataTypeGroup(frozenset):  # type: ignore[type-arg]
-    def __new__(cls, items: Any) -> DataTypeGroup:
+    _match_base_type: bool
+
+    def __new__(cls, items: Any, *, match_base_type: bool = True) -> DataTypeGroup:
         for it in items:
             if not isinstance(it, (DataType, DataTypeClass)):
                 raise TypeError(
-                    f"DataTypeGroup items must be polars dtypes; found {it!r}"
+                    f"DataTypeGroup items must be dtypes; found {type(it).__name__!r}"
                 )
-        return super().__new__(cls, items)
+        dtype_group = super().__new__(cls, items)
+        dtype_group._match_base_type = match_base_type
+        return dtype_group
 
     def __contains__(self, item: Any) -> bool:
-        if isinstance(item, (DataType, DataTypeClass)):
+        if self._match_base_type and isinstance(item, (DataType, DataTypeClass)):
             item = item.base_type()
         return super().__contains__(item)
 

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -74,10 +74,13 @@ def test_to_from_pydecimal_and_format() -> None:
 
 
 def test_init_decimal_dtype() -> None:
-    _ = pl.Series("a", [D("-0.01"), D("1.2345678"), D("500")], dtype=pl.Decimal)
-    _ = pl.DataFrame(
+    s = pl.Series("a", [D("-0.01"), D("1.2345678"), D("500")], dtype=pl.Decimal)
+    assert s.is_numeric()
+
+    df = pl.DataFrame(
         {"a": [D("-0.01"), D("1.2345678"), D("500")]}, schema={"a": pl.Decimal}
     )
+    assert df["a"].is_numeric()
 
 
 def test_decimal_cast() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2758,7 +2758,10 @@ def test_infer_iso8601_date(iso8601_format_date: str) -> None:
 
 
 def test_series_is_temporal() -> None:
-    for tp in TEMPORAL_DTYPES:
+    for tp in TEMPORAL_DTYPES | {
+        pl.Datetime("ms", "UTC"),
+        pl.Datetime("ns", "Europe/Amsterdam"),
+    }:
         s = pl.Series([None], dtype=tp)
         assert s.is_temporal() is True
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -470,10 +470,36 @@ def test_various() -> None:
     assert_series_equal(a.arg_unique(), pl.Series("a", [0, 1, 3], dtype=UInt32))
 
     assert_series_equal(a.take([2, 3]), pl.Series("a", [1, 4]))
-    assert a.is_numeric()
 
-    a = pl.Series("bool", [True, False])
-    assert not a.is_numeric()
+
+def test_series_dtype_is() -> None:
+    s = pl.Series("s", [1, 2, 3])
+
+    assert s.is_numeric()
+    assert s.is_integer()
+    assert s.is_integer(signed=True)
+    assert not s.is_integer(signed=False)
+    assert (s * 0.99).is_float()
+
+    s = pl.Series("s", [1, 2, 3], dtype=pl.UInt8)
+    assert s.is_numeric()
+    assert s.is_integer()
+    assert not s.is_integer(signed=True)
+    assert s.is_integer(signed=False)
+
+    s = pl.Series("bool", [True, None, False])
+    assert not s.is_numeric()
+
+    s = pl.Series("s", ["testing..."])
+    assert s.is_utf8()
+
+    s = pl.Series("s", [], dtype=pl.Decimal(20, 15))
+    assert not s.is_float()
+    assert s.is_numeric()
+    assert s.is_empty()
+
+    s = pl.Series("s", [], dtype=pl.Datetime("ms", time_zone="UTC"))
+    assert s.is_temporal()
 
 
 def test_series_head_tail_limit() -> None:


### PR DESCRIPTION
* Additional test coverage relating to `DataTypeGroup` and dtype classification on `Series`.
* Allow `DataTypeGroup` to be initialised with/without `base_type` matching feature.
* Fixed a small typo in [live docs server](https://github.com/pola-rs/polars/pull/8452) notes.