### PR TITLE
Internal file caching count is off when inside nested cache

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -216,3 +216,8 @@ def test_glob_n_rows(io_files_path: Path) -> None:
         "fats_g": [0.5, 6.0],
         "sugars_g": [2, 2],
     }
+
+
+def test_nested_file_cache_count(io_files_path: Path) -> None:
+    df = pl.scan_csv(io_files_path / "small.csv").with_columns(pl.lit(1)).cache()
+    pl.concat([df, df]).collect()

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -463,3 +463,10 @@ def test_nested_null_roundtrip() -> None:
     f.seek(0)
     df_read = pl.read_parquet(f)
     assert_frame_equal(df_read, df)
+
+
+def test_nested_file_cache_count(io_files_path: Path) -> None:
+    df = (
+        pl.scan_parquet(io_files_path / "small.parquet").with_columns(pl.lit(1)).cache()
+    )
+    pl.concat([df, df], parallel=True).collect()


### PR DESCRIPTION
https://github.com/pola-rs/polars/blob/bc1319fac34d4384686770aa2bf506942e94c002/polars/polars-lazy/src/physical_plan/file_cache.rs#L31-L37

This internal debug assertion seems to check that a file cache is accessed equal to the number of times it exists in the graph. However, if a file is nested under another cache node, it may only be tracked as read once while the parent cache node is the one being reused.

Any thoughts on how this tracking could be fixed? It doesn't seem super easy. I realize it's only a debug assertions, should we just disable it? Maybe it just prints a `POLARS_VERBOSE` warning instead?

I bumped into this crafting a test for #8441, but it seemed like the issue wasn't specific to csv reads, but any cached files.