### PR TITLE
perf(python): parallelise dataframe `describe` method

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1966,7 +1966,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def filter(self, predicate: Expr | str | Series | list[bool]) -> Self:
         """
-        Filter the rows in the DataFrame based on a predicate expression.
+        Filter the rows in the LazyFrame based on a predicate expression.
 
         Parameters
         ----------
@@ -2036,7 +2036,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         **named_exprs: IntoExpr,
     ) -> Self:
         """
-        Select columns from this DataFrame.
+        Select columns from this LazyFrame.
 
         Parameters
         ----------
@@ -2330,15 +2330,19 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     "2020-01-03 19:45:32",
         ...     "2020-01-08 23:16:43",
         ... ]
-        >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
+        >>> df = pl.LazyFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
         ...     pl.col("dt").str.strptime(pl.Datetime)
         ... )
-        >>> out = df.groupby_rolling(index_column="dt", period="2d").agg(
-        ...     [
-        ...         pl.sum("a").alias("sum_a"),
-        ...         pl.min("a").alias("min_a"),
-        ...         pl.max("a").alias("max_a"),
-        ...     ]
+        >>> out = (
+        ...     df.groupby_rolling(index_column="dt", period="2d")
+        ...     .agg(
+        ...         [
+        ...             pl.sum("a").alias("sum_a"),
+        ...             pl.min("a").alias("min_a"),
+        ...             pl.max("a").alias("max_a"),
+        ...         ]
+        ...     )
+        ...     .collect()
         ... )
         >>> assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
         >>> assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1299,7 +1299,14 @@ def test_describe() -> None:
             ("median", 1.0, None, None),
         ]
 
-    assert df.describe(percentiles=(0.2, 0.4, 0.6, 0.8)).rows() == [
+    described = df.describe(percentiles=(0.2, 0.4, 0.6, 0.8))
+    assert described.schema == {
+        "describe": pl.Utf8,
+        "numerical": pl.Float64,
+        "struct": pl.Utf8,
+        "list": pl.Utf8,
+    }
+    assert described.rows() == [
         ("count", 4.0, "4", "4"),
         ("null_count", 1.0, "1", "1"),
         ("mean", 1.3333333333333333, None, None),


### PR DESCRIPTION
Ref #8434.

Reworked the `describe` method so that it runs parallelised (with identical results). This can result in _huge_ speedups for frames with a very large number of columns (and a decent speedup in general):

## Example
New approach is always faster, but as the number of columns in the target frame grows, the parallelisation advantage becomes even more significant:

* 100,000 row x 100 col frame: _(**~2.5x** faster)_
  ```python
  df = pl.DataFrame( {f"c{i}": range(i,100_000+i) for i in range(100)} )
  df.describe()
  ```
  **Before:** 0.0121 seconds
  **After:** 0.0045 seconds
 
* 100 row x 100,000 col frame: _(**~100x** faster)_
  ```python
  df = pl.DataFrame( {f"c{i}": range(i,100+i) for i in range(100_000)} )
  df.describe()
  ```
  **Before:** 221.018 seconds
  **After:** 2.258 seconds
 
