### PR TITLE
feat(python): apply thousand-separators to "shape" html output, consi…

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -115,12 +115,14 @@ class HTMLFormatter:
                                 )
 
     def write(self, inner: str) -> None:
+        """Append a raw string to the inner HTML."""
         self.elements.append(inner)
 
     def render(self) -> list[str]:
-        shape: tuple[int, ...] = self.df.shape
-        if self.series:
-            shape = shape[:1]
+        """Return the lines needed to render a HTML table."""
+        # format frame/series shape with '_' thousand-separators
+        s = self.df.shape
+        shape = f"({s[0]:_},)" if self.series else f"({s[0]:_}, {s[1]:_})"
 
         self.elements.append(f"<small>shape: {shape}</small>")
         with Tag(


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/8466, making HTML output of `shape` consistent with our regular table output (specifically with the application of thousand separators: `(1_234_567, 2_500)`).