### PR TITLE
perf(rust, python): less naive count

### DIFF
--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -242,6 +242,10 @@ impl Schema {
         self.inner.get_index(index)
     }
 
+    pub fn try_get_at_index(&self, index: usize) -> PolarsResult<(&SmartString, &DataType)> {
+        self.inner.get_index(index).ok_or_else(|| polars_err!(ComputeError: "index {index} out of bounds with 'schema' of len: {}", self.len()))
+    }
+
     /// Get mutable references to the name and dtype of the field at `index`
     ///
     /// If `index` is inbounds, returns `Some((&mut name, &mut dtype))`, else `None`. See

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn is_count(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    match expr_arena.get(node) {
+        AExpr::Alias(node, _) => is_count(*node, expr_arena),
+        AExpr::Count => true,
+        _ => false,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_projection(
     proj_pd: &mut ProjectionPushDown,
@@ -12,48 +20,61 @@ pub(super) fn process_projection(
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<ALogicalPlan> {
     let mut local_projection = Vec::with_capacity(exprs.len());
-    // A projection can consist of a chain of expressions followed by an alias.
-    // We want to do the chain locally because it can have complicated side effects.
-    // The only thing we push down is the root name of the projection.
-    // So we:
-    //      - add the root of the projections to accumulation,
-    //      - also do the complete projection locally to keep the schema (column order) and the alias.
 
-    // set this flag outside the loop as we modify within the loop
-    let has_pushed_down = !acc_projections.is_empty();
-    for e in &exprs {
-        if has_pushed_down {
-            // remove projections that are not used upstream
-            if !expr_is_projected_upstream(e, input, lp_arena, expr_arena, &projected_names) {
-                continue;
-            }
+    // path for `SELECT count(*) FROM`
+    // as there would be no projections and we would read
+    // the whole file while we only want the count
+    if exprs.len() == 1 && is_count(exprs[0], expr_arena) {
+        let input_schema = lp_arena.get(input).schema(lp_arena);
+        // simply select the first column
+        let (first_name, _) = input_schema.try_get_at_index(0)?;
+        let expr = expr_arena.add(AExpr::Column(Arc::from(first_name.as_str())));
+        add_expr_to_accumulated(expr, &mut acc_projections, &mut projected_names, expr_arena);
+        local_projection.push(exprs[0]);
+    } else {
+        // A projection can consist of a chain of expressions followed by an alias.
+        // We want to do the chain locally because it can have complicated side effects.
+        // The only thing we push down is the root name of the projection.
+        // So we:
+        //      - add the root of the projections to accumulation,
+        //      - also do the complete projection locally to keep the schema (column order) and the alias.
 
-            // in this branch we check a double projection case
-            // df
-            //   .select(col("foo").alias("bar"))
-            //   .select(col("bar")
-            //
-            // In this query, bar cannot pass this projection, as it would not exist in DF.
-            // THE ORDER IS IMPORTANT HERE!
-            // this removes projection names, so any checks to upstream names should
-            // be done before this branch.
-            for (_, ae) in (&*expr_arena).iter(*e) {
-                if let AExpr::Alias(_, name) = ae {
-                    if projected_names.remove(name) {
-                        acc_projections
-                            .retain(|expr| !aexpr_to_leaf_names(*expr, expr_arena).contains(name));
+        // set this flag outside the loop as we modify within the loop
+        let has_pushed_down = !acc_projections.is_empty();
+        for e in &exprs {
+            if has_pushed_down {
+                // remove projections that are not used upstream
+                if !expr_is_projected_upstream(e, input, lp_arena, expr_arena, &projected_names) {
+                    continue;
+                }
+
+                // in this branch we check a double projection case
+                // df
+                //   .select(col("foo").alias("bar"))
+                //   .select(col("bar")
+                //
+                // In this query, bar cannot pass this projection, as it would not exist in DF.
+                // THE ORDER IS IMPORTANT HERE!
+                // this removes projection names, so any checks to upstream names should
+                // be done before this branch.
+                for (_, ae) in (&*expr_arena).iter(*e) {
+                    if let AExpr::Alias(_, name) = ae {
+                        if projected_names.remove(name) {
+                            acc_projections.retain(|expr| {
+                                !aexpr_to_leaf_names(*expr, expr_arena).contains(name)
+                            });
+                        }
                     }
                 }
             }
+            // do local as we still need the effect of the projection
+            // e.g. a projection is more than selecting a column, it can
+            // also be a function/ complicated expression
+            local_projection.push(*e);
+
+            add_expr_to_accumulated(*e, &mut acc_projections, &mut projected_names, expr_arena);
         }
-        // do local as we still need the effect of the projection
-        // e.g. a projection is more than selecting a column, it can
-        // also be a function/ complicated expression
-        local_projection.push(*e);
-
-        add_expr_to_accumulated(*e, &mut acc_projections, &mut projected_names, expr_arena);
     }
-
     proj_pd.pushdown_and_assign(
         input,
         acc_projections,


### PR DESCRIPTION
The most ran query in the world triggered a full file load.

```sql
SELECT count() FROM ...
```

Now we at least load a single column. I will follow up with dedicated `file count` function that can get the count from metadata.