### PR TITLE
feat(rust, python): allow for _saturating suffix in duration strings

### DIFF
--- a/polars/polars-time/src/upsample.rs
+++ b/polars/polars-time/src/upsample.rs
@@ -28,13 +28,13 @@ pub trait PolarsUpsample {
     /// - 1d    (1 day)
     /// - 1w    (1 week)
     /// - 1mo   (1 calendar month)
-    /// - 1mo_saturating (calendar month, but "saturates" to the last day of the month
-    ///   instead of erroring. For example, 2022-01-29 plus `'1mo_saturating'` goes to
-    ///   2022-02-28)
     /// - 1y    (1 calendar year)
     /// - 1i    (1 index count)
     /// Or combine them:
     /// "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+    /// Suffix with `"_saturating"` to saturate dates with days too
+    /// large with their month to the last day of the month (e.g. 
+    /// 2022-02-29 to 2022-02-28).
     fn upsample<I: IntoVec<String>>(
         &self,
         by: I,

--- a/polars/polars-time/src/upsample.rs
+++ b/polars/polars-time/src/upsample.rs
@@ -33,7 +33,7 @@ pub trait PolarsUpsample {
     /// Or combine them:
     /// "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
     /// Suffix with `"_saturating"` to saturate dates with days too
-    /// large with their month to the last day of the month (e.g. 
+    /// large with their month to the last day of the month (e.g.
     /// 2022-02-29 to 2022-02-28).
     fn upsample<I: IntoVec<String>>(
         &self,

--- a/polars/polars-time/src/upsample.rs
+++ b/polars/polars-time/src/upsample.rs
@@ -33,7 +33,7 @@ pub trait PolarsUpsample {
     /// Or combine them:
     /// "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
     /// Suffix with `"_saturating"` to saturate dates with days too
-    /// large with their month to the last day of the month (e.g.
+    /// large for their month to the last day of the month (e.g.
     /// 2022-02-29 to 2022-02-28).
     fn upsample<I: IntoVec<String>>(
         &self,

--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -94,7 +94,7 @@ impl Duration {
     /// * `mo`: calendar month
     /// * `y`:  calendar year
     /// * `i`:  index value (only for {Int32, Int64} dtypes)
-    /// 
+    ///
     /// Suffix with `"_saturating"` to indicate that dates too large for
     /// their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
     /// instead of erroring.
@@ -115,13 +115,12 @@ impl Duration {
         let mut days = 0;
         let mut months = 0;
         let negative = duration.starts_with('-');
-        let (saturating, mut iter) = match duration.ends_with("_saturating"){
-            true => {
-                (true, duration[..duration.len() - "_saturating".len()].char_indices())
-            },
-            false => {
-                (false, duration.char_indices())
-            }
+        let (saturating, mut iter) = match duration.ends_with("_saturating") {
+            true => (
+                true,
+                duration[..duration.len() - "_saturating".len()].char_indices(),
+            ),
+            false => (false, duration.char_indices()),
         };
         let mut start = 0;
 
@@ -257,7 +256,7 @@ impl Duration {
             nsecs,
             negative,
             parsed_int: false,
-            saturating:false,
+            saturating: false,
         }
     }
 
@@ -271,7 +270,7 @@ impl Duration {
             nsecs: 0,
             negative,
             parsed_int: false,
-            saturating:false,
+            saturating: false,
         }
     }
 
@@ -285,7 +284,7 @@ impl Duration {
             nsecs: 0,
             negative,
             parsed_int: false,
-            saturating:false,
+            saturating: false,
         }
     }
 
@@ -299,7 +298,7 @@ impl Duration {
             nsecs: 0,
             negative,
             parsed_int: false,
-            saturating:false,
+            saturating: false,
         }
     }
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4599,13 +4599,15 @@ class DataFrame:
         - 1d    (1 day)
         - 1w    (1 week)
         - 1mo   (1 calendar month)
-        - 1mo_saturating (same as above, but saturates to the last day of the month
-          if the target date does not exist)
         - 1y    (1 calendar year)
         - 1i    (1 index count)
 
         Or combine them:
         "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         In case of a groupby_rolling on an integer column, the windows are defined by:
 
@@ -4716,13 +4718,15 @@ class DataFrame:
         - 1d    (1 day)
         - 1w    (1 week)
         - 1mo   (1 calendar month)
-        - 1mo_saturating (same as above, but saturates to the last day of the month
-          if the target date does not exist)
         - 1y    (1 calendar year)
         - 1i    (1 index count)
 
         Or combine them:
         "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         In case of a groupby_dynamic on an integer column, the windows are defined by:
 
@@ -5002,13 +5006,15 @@ class DataFrame:
         - 1d    (1 day)
         - 1w    (1 week)
         - 1mo   (1 calendar month)
-        - 1mo_saturating (same as above, but saturates to the last day of the month
-          if the target date does not exist)
         - 1y    (1 calendar year)
         - 1i    (1 index count)
 
         Or combine them:
         "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         Examples
         --------
@@ -5130,13 +5136,15 @@ class DataFrame:
                 - 1d    (1 day)
                 - 1w    (1 week)
                 - 1mo   (1 calendar month)
-                - 1mo_saturating (same as above, but saturates to the last day of the
-                  month if the target date does not exist)
                 - 1y    (1 calendar year)
                 - 1i    (1 index count)
 
                 Or combine them:
                 "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+        
+                Suffix with `"_saturating"` to indicate that dates too large for
+                their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+                instead of erroring.
 
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5141,10 +5141,10 @@ class DataFrame:
 
                 Or combine them:
                 "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
-        
+
                 Suffix with `"_saturating"` to indicate that dates too large for
-                their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-                instead of erroring.
+                their month should saturate at the largest date
+                (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -65,6 +65,10 @@ class ExprDateTimeNameSpace:
 
         - 3d12h4m25s # 3 days, 12 hours, 4 minutes, and 25 seconds
 
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
+
         Returns
         -------
         Date/Datetime series
@@ -176,11 +180,13 @@ class ExprDateTimeNameSpace:
         1d   # 1 day
         1w   # 1 calendar week
         1mo  # 1 calendar month
-        1mo_saturating  # same as above, but saturates to the last day of the month
-        # if the target date does not exist
         1y   # 1 calendar year
 
         eg: 3d12h4m25s  # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         Returns
         -------
@@ -1674,10 +1680,12 @@ class ExprDateTimeNameSpace:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         Returns
         -------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4585,8 +4585,8 @@ class Expr:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4684,8 +4684,8 @@ class Expr:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4783,8 +4783,8 @@ class Expr:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4882,8 +4882,8 @@ class Expr:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4979,10 +4979,10 @@ class Expr:
             - 1mo   (1 calendar month)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
-        
+
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5078,10 +5078,10 @@ class Expr:
             - 1mo   (1 calendar month)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
-        
+
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5173,10 +5173,10 @@ class Expr:
             - 1mo   (1 calendar month)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
-        
+
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5276,8 +5276,8 @@ class Expr:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4581,10 +4581,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4678,10 +4680,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4775,10 +4779,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4872,10 +4878,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -4969,10 +4977,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+        
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5066,10 +5076,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+        
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5159,10 +5171,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+        
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
@@ -5258,10 +5272,12 @@ class Expr:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2285,13 +2285,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         - 1d    (1 day)
         - 1w    (1 week)
         - 1mo   (1 calendar month)
-        - 1mo_saturating (same as above, but saturates to the last day of the month
-          if the target date does not exist)
         - 1y    (1 calendar year)
         - 1i    (1 index count)
 
         Or combine them:
         "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         In case of a groupby_rolling on an integer column, the windows are defined by:
 
@@ -2416,13 +2418,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         - 1d    (1 day)
         - 1w    (1 week)
         - 1mo   (1 calendar month)
-        - 1mo_saturating (same as above, but saturates to the last day of the month
-          if the target date does not exist)
         - 1y    (1 calendar year)
         - 1i    (1 index count)
 
         Or combine them:
         "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         In case of a groupby_dynamic on an integer column, the windows are defined by:
 
@@ -2749,13 +2753,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 - 1d    (1 day)
                 - 1w    (1 week)
                 - 1mo   (1 calendar month)
-                - 1mo_saturating (same as above, but saturates to the last day of the
-                  month if the target date does not exist)
                 - 1y    (1 calendar year)
                 - 1i    (1 index count)
 
                 Or combine them:
                 "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+                Suffix with `"_saturating"` to indicate that dates too large for
+                their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+                instead of erroring.
 
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2760,8 +2760,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
 
                 Suffix with `"_saturating"` to indicate that dates too large for
-                their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-                instead of erroring.
+                their month should saturate at the largest date
+                (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1442,10 +1442,12 @@ class DateTimeNameSpace:
             - 1d    (1 day)
             - 1w    (1 week)
             - 1mo   (1 calendar month)
-            - 1mo_saturating (same as above, but saturates to the last day of the month
-              if the target date does not exist)
             - 1y    (1 calendar year)
             - 1i    (1 index count)
+
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+            instead of erroring.
 
         Returns
         -------
@@ -1535,13 +1537,15 @@ class DateTimeNameSpace:
         - 1d  # 1 day
         - 1w  # 1 calendar week
         - 1mo # 1 calendar month
-        - 1mo_saturating  # same as above, but saturates to the last day of the month
-          if the target date does not exist
         - 1y  # 1 calendar year
 
         These strings can be combined:
 
         - 3d12h4m25s # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         Returns
         -------
@@ -1639,11 +1643,13 @@ class DateTimeNameSpace:
         1d  # 1 day
         1w  # 1 calendar week
         1mo # 1 calendar month
-        1mo_saturating  # same as above, but saturates to the last day of the month
-        # if the target date does not exist
         1y  # 1 calendar year
 
         3d12h4m25s # 3 days, 12 hours, 4 minutes, and 25 seconds
+
+        Suffix with `"_saturating"` to indicate that dates too large for
+        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
+        instead of erroring.
 
         Parameters
         ----------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1446,8 +1446,8 @@ class DateTimeNameSpace:
             - 1i    (1 index count)
 
             Suffix with `"_saturating"` to indicate that dates too large for
-            their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-            instead of erroring.
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
         Returns
         -------

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -8,7 +8,7 @@ import pytest
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.exceptions import ComputeError, InvalidOperationError
-from polars.testing import assert_series_equal, assert_frame_equal
+from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
     from polars.type_aliases import TimeUnit
@@ -532,16 +532,19 @@ def test_negative_offset_by_err_msg_8464() -> None:
 
 
 @pytest.mark.parametrize(
-    ('duration', 'input_date', 'expected'),
+    ("duration", "input_date", "expected"),
     [
-        ('1mo_saturating', date(2018, 1, 31), date(2018, 2, 28)),
-        ('1y_saturating', date(2024, 2, 29), date(2025, 2, 28)),
-        ('1y1mo_saturating', date(2024, 1, 30), date(2025, 2, 28)),
-    ]
+        ("1mo_saturating", date(2018, 1, 31), date(2018, 2, 28)),
+        ("1y_saturating", date(2024, 2, 29), date(2025, 2, 28)),
+        ("1y1mo_saturating", date(2024, 1, 30), date(2025, 2, 28)),
+    ],
 )
-def test_offset_by_saturating_8217_8474(duration: str, input_date: date, expected: date) -> None:
+def test_offset_by_saturating_8217_8474(
+    duration: str, input_date: date, expected: date
+) -> None:
     result = pl.Series([input_date]).dt.offset_by(duration).item()
     assert result == expected
+
 
 def test_year_empty_df() -> None:
     df = pl.DataFrame(pl.Series(name="date", dtype=pl.Date))

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -8,7 +8,7 @@ import pytest
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.exceptions import ComputeError, InvalidOperationError
-from polars.testing import assert_series_equal
+from polars.testing import assert_series_equal, assert_frame_equal
 
 if TYPE_CHECKING:
     from polars.type_aliases import TimeUnit
@@ -531,11 +531,17 @@ def test_negative_offset_by_err_msg_8464() -> None:
         pl.Series([datetime(2022, 3, 30)]).dt.offset_by("-1mo")
 
 
-def test_offset_by_saturating_8217() -> None:
-    result = pl.Series([date(2018, 1, 31)]).dt.offset_by("1mo_saturating").item()
-    expected = date(2018, 2, 28)
+@pytest.mark.parametrize(
+    ('duration', 'input_date', 'expected'),
+    [
+        ('1mo_saturating', date(2018, 1, 31), date(2018, 2, 28)),
+        ('1y_saturating', date(2024, 2, 29), date(2025, 2, 28)),
+        ('1y1mo_saturating', date(2024, 1, 30), date(2025, 2, 28)),
+    ]
+)
+def test_offset_by_saturating_8217_8474(duration: str, input_date: date, expected: date) -> None:
+    result = pl.Series([input_date]).dt.offset_by(duration).item()
     assert result == expected
-
 
 def test_year_empty_df() -> None:
     df = pl.DataFrame(pl.Series(name="date", dtype=pl.Date))


### PR DESCRIPTION
closes #8474

I should've thought of this this morning, but a simpler solution that having both `'1mo'` and `'1mo_saturating'` is to just allow for the `'_saturating'` suffix
Otherwise, `'1y_saturating1mo_saturating'` becomes pretty verbose

From Discord I gather that there's a patch release incoming - the `'1mo_saturating'` solution hasn't been in for very long (less than a day), so I'm hoping this solution (if accepted) can just make the next release without requiring a deprecation cycle