### PR TITLE
refactor(rust, python): improve sorted warning/ fix tests

### DIFF
--- a/polars/polars-algo/src/algo.rs
+++ b/polars/polars-algo/src/algo.rs
@@ -10,7 +10,7 @@ pub fn hist(s: &Series, bins: Option<&Series>, bin_count: Option<usize>) -> Resu
 
     // if the bins are provided, then we can just use them
     let bins = if let Some(bins_in) = bins {
-        Series::new(breakpoint_str, bins_in)
+        Series::new(breakpoint_str, bins_in).sort(false)
     } else {
         // data is sorted, so this is O(1)
         let start = s.min::<f64>().unwrap().floor() - 1.0;
@@ -50,9 +50,11 @@ pub fn hist(s: &Series, bins: Option<&Series>, bin_count: Option<usize>) -> Resu
             "cannot take histogram of non-numeric types; consider a groupby and count"
         ),
     };
+    let mut bins = bins.extend_constant(max_value, 1)?;
+    bins.set_sorted_flag(IsSorted::Ascending);
 
     let cuts_df = df![
-        breakpoint_str => bins.extend_constant(max_value, 1)?
+        breakpoint_str => bins
     ]?;
 
     let cuts_df = cuts_df

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -100,6 +100,8 @@ where
                 if ((self.dtype().is_signed() && data_type.is_signed())
                     || (self.dtype().is_unsigned() && data_type.is_unsigned()))
                     && (s.null_count() == self.null_count())
+                    // physical to logicals
+                    || (self.dtype().to_physical() == data_type.to_physical())
                 {
                     let is_sorted = self.is_sorted_flag2();
                     s.set_sorted_flag(is_sorted)

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -124,7 +124,7 @@ impl DatetimeChunked {
         time_zone: Option<&str>,
         use_earliest: Option<bool>,
     ) -> PolarsResult<DatetimeChunked> {
-        match (self.time_zone(), time_zone) {
+        let out: PolarsResult<_> = match (self.time_zone(), time_zone) {
             (Some(from), Some(to)) => {
                 let chunks = self
                     .downcast_iter()
@@ -162,7 +162,10 @@ impl DatetimeChunked {
                 Ok(out.into_datetime(self.time_unit(), Some(to.to_string())))
             }
             (None, None) => Ok(self.clone()),
-        }
+        };
+        let mut out = out?;
+        out.set_sorted_flag(self.is_sorted_flag2());
+        Ok(out)
     }
 
     /// Format Datetime with a `format` rule. See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -619,7 +619,9 @@ fn dispatch_join<T: PolarsNumericType>(
         }
     } else {
         for (lhs, rhs) in left_by.get_columns().iter().zip(right_by.get_columns()) {
-            check_asof_columns(lhs, rhs)?;
+            polars_ensure!(lhs.dtype() == rhs.dtype(),
+                ComputeError: "mismatching dtypes in 'on' parameter of asof-join: `{}` and `{}`", lhs.dtype(), rhs.dtype()
+            );
             #[cfg(feature = "dtype-categorical")]
             _check_categorical_src(lhs.dtype(), rhs.dtype())?;
         }

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -39,8 +39,8 @@ fn check_asof_columns(a: &Series, b: &Series) -> PolarsResult<()> {
         a.null_count() == 0 && b.null_count() == 0,
         ComputeError: "asof join must not have null values in 'on' arguments"
     );
-    ensure_sorted_arg(a);
-    ensure_sorted_arg(b);
+    ensure_sorted_arg(a, "asof_join");
+    ensure_sorted_arg(b, "asof_join");
     Ok(())
 }
 

--- a/polars/polars-core/src/utils/series.rs
+++ b/polars/polars-core/src/utils/series.rs
@@ -31,16 +31,17 @@ where
     f(&mut us)
 }
 
-pub fn ensure_sorted_arg(s: &Series) {
-    if !matches!(s.is_sorted_flag(), IsSorted::Ascending) {
+pub fn ensure_sorted_arg(s: &Series, operation: &str) {
+    if matches!(s.is_sorted_flag(), IsSorted::Not) {
         eprintln!(
-            r#"argument is not explicitly sorted
+            "argument in operation '{}' is not explicitly sorted
 
 - If your data is ALREADY sorted, set the sorted flag with: '.set_sorted()'.
 - If your data is NOT sorted, sort the 'expr/series/column' first.
 
 This might become an error in a future version.
-    "#
+    ",
+            operation
         );
     }
 }

--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -678,7 +678,7 @@ impl<'a> CoreReader<'a> {
                             self.quote_char,
                             self.eol_char,
                             self.comment_char,
-                            chunk_size,
+                            capacity,
                             &str_capacities,
                             self.encoding,
                             self.null_values.as_ref(),

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -107,7 +107,10 @@ impl Wrap<&DataFrame> {
         options: &RollingGroupOptions,
     ) -> PolarsResult<(Series, Vec<Series>, GroupsProxy)> {
         let time = self.0.column(&options.index_column)?.clone();
-        ensure_sorted_arg(&time);
+        if by.is_empty() && !options.period.parsed_int {
+            // if by is given, the column must be sorted in the 'by' arg, which we can not check now
+            ensure_sorted_arg(&time, "groupby_rolling");
+        }
         let time_type = time.dtype();
 
         polars_ensure!(time.null_count() == 0, ComputeError: "null values in dynamic groupby not supported, fill nulls.");
@@ -183,7 +186,10 @@ impl Wrap<&DataFrame> {
         }
 
         let time = self.0.column(&options.index_column)?.rechunk();
-        ensure_sorted_arg(&time);
+        if by.is_empty() && !options.period.parsed_int {
+            // if by is given, the column must be sorted in the 'by' arg, which we can not check now
+            ensure_sorted_arg(&time, "groupby_dynamic");
+        }
         let time_type = time.dtype();
 
         polars_ensure!(time.null_count() == 0, ComputeError: "null values in dynamic groupby not supported, fill nulls.");

--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -47,6 +47,7 @@ Manipulation/selection
     DataFrame.rows
     DataFrame.sample
     DataFrame.select
+    DataFrame.set_sorted
     DataFrame.shift
     DataFrame.shift_and_fill
     DataFrame.shrink_to_fit

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -31,6 +31,7 @@ Manipulation/selection
     LazyFrame.rename
     LazyFrame.reverse
     LazyFrame.select
+    LazyFrame.set_sorted
     LazyFrame.shift
     LazyFrame.shift_and_fill
     LazyFrame.slice

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4647,7 +4647,7 @@ class DataFrame:
         ...     "2020-01-08 23:16:43",
         ... ]
         >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
-        ...     pl.col("dt").str.strptime(pl.Datetime)
+        ...     pl.col("dt").str.strptime(pl.Datetime).set_sorted()
         ... )
         >>> out = df.groupby_rolling(index_column="dt", period="2d").agg(
         ...     [
@@ -5158,7 +5158,7 @@ class DataFrame:
         ...         ],  # note record date: Jan 1st (sorted!)
         ...         "gdp": [4164, 4411, 4566, 4696],
         ...     }
-        ... )
+        ... ).set_sorted("date")
         >>> population = pl.DataFrame(
         ...     {
         ...         "date": [
@@ -5169,10 +5169,8 @@ class DataFrame:
         ...         ],  # note record date: May 12th (sorted!)
         ...         "population": [82.19, 82.66, 83.12, 83.52],
         ...     }
-        ... )
-        >>> population.join_asof(
-        ...     gdp, left_on="date", right_on="date", strategy="backward"
-        ... )
+        ... ).set_sorted("date")
+        >>> population.join_asof(gdp, on="date", strategy="backward")
         shape: (4, 3)
         ┌─────────────────────┬────────────┬──────┐
         │ date                ┆ population ┆ gdp  │

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8500,6 +8500,31 @@ class DataFrame:
             ._df
         )
 
+    def set_sorted(
+        self,
+        column: IntoExpr | Iterable[IntoExpr],
+        *more_columns: IntoExpr,
+        descending: bool = False,
+    ) -> Self:
+        """
+        Indicate that one or multiple columns are sorted.
+
+        Parameters
+        ----------
+        column
+            Columns that are sorted
+        more_columns
+            Additional columns that are sorted, specified as positional arguments.
+        descending
+            Whether the columns are sorted in descending order.
+        """
+        return self._from_pydf(
+            self.lazy()
+            .set_sorted(column, *more_columns, descending=descending)
+            .collect(no_optimization=True)
+            ._df
+        )
+
     def update(
         self,
         other: DataFrame,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2333,7 +2333,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     "2020-01-08 23:16:43",
         ... ]
         >>> df = pl.LazyFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
-        ...     pl.col("dt").str.strptime(pl.Datetime)
+        ...     pl.col("dt").str.strptime(pl.Datetime).set_sorted()
         ... )
         >>> out = (
         ...     df.groupby_rolling(index_column="dt", period="2d")
@@ -2777,7 +2777,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         ],  # note record date: Jan 1st (sorted!)
         ...         "gdp": [4164, 4411, 4566, 4696],
         ...     }
-        ... )
+        ... ).set_sorted("date")
         >>> population = pl.LazyFrame(
         ...     {
         ...         "date": [
@@ -2788,10 +2788,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         ],  # note record date: May 12th (sorted!)
         ...         "population": [82.19, 82.66, 83.12, 83.52],
         ...     }
-        ... )
-        >>> population.join_asof(
-        ...     gdp, left_on="date", right_on="date", strategy="backward"
-        ... ).collect()
+        ... ).set_sorted("date")
+        >>> population.join_asof(gdp, on="date", strategy="backward").collect()
         shape: (4, 3)
         ┌─────────────────────┬────────────┬──────┐
         │ date                ┆ population ┆ gdp  │

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -313,7 +313,7 @@ def test_err_on_categorical_asof_join_by_arg() -> None:
         pl.ComputeError,
         match=r"joins/or comparisons on categoricals can only happen if they were created under the same global string cache",
     ):
-        df1.join_asof(df2, on="time", by="cat")
+        df1.join_asof(df2, on=pl.col("time").set_sorted(), by="cat")
 
 
 def test_categorical_list_get_item() -> None:

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -200,7 +200,9 @@ def test_groupby_agg_input_types(lazy: bool) -> None:
 
 @pytest.mark.parametrize("lazy", [True, False])
 def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
-    df = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]})
+    df = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]}).set_sorted(
+        "index_column"
+    )
     df_or_lazy: pl.DataFrame | pl.LazyFrame = df.lazy() if lazy else df
 
     for bad_param in bad_agg_parameters():
@@ -224,7 +226,9 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
 
 @pytest.mark.parametrize("lazy", [True, False])
 def test_groupby_dynamic_agg_input_types(lazy: bool) -> None:
-    df = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]})
+    df = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]}).set_sorted(
+        "index_column"
+    )
     df_or_lazy: pl.DataFrame | pl.LazyFrame = df.lazy() if lazy else df
 
     for bad_param in bad_agg_parameters():
@@ -424,7 +428,7 @@ def test_unique_order() -> None:
 
 
 def test_groupby_dynamic_flat_agg_4814() -> None:
-    df = pl.DataFrame({"a": [1, 2, 2], "b": [1, 8, 12]})
+    df = pl.DataFrame({"a": [1, 2, 2], "b": [1, 8, 12]}).set_sorted("a")
 
     assert df.groupby_dynamic("a", every="1i", period="2i").agg(
         [
@@ -462,6 +466,7 @@ def test_groupby_dynamic_overlapping_groups_flat_apply_multiple_5038(
             }
         )
         .lazy()
+        .set_sorted("a")
         .groupby_dynamic("a", every=every, period=period)
         .agg([pl.col("b").var().sqrt().alias("corr")])
     ).collect().sum().to_dict(False) == pytest.approx(
@@ -558,7 +563,7 @@ def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -
             "a": [1, 2, 2],
             "b": [4, 5, 6],
         }
-    )
+    ).set_sorted("datetime")
 
     # Without 'by' argument
     result1 = [
@@ -657,6 +662,7 @@ def test_groupby_dynamic_elementwise_following_mean_agg_6904(
             }
         )
         .lazy()
+        .set_sorted("a")
         .groupby_dynamic("a", every="10s", period="100s")
         .agg([pl.col("b").mean().sin().alias("c")])
         .collect()

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -54,13 +54,17 @@ def test_rolling_kernels_and_groupby_rolling(
             pl.col("values").rolling_std(period, by="dt", closed=closed).alias("std"),
         ]
     )
-    out2 = example_df.groupby_rolling("dt", period=period, closed=closed).agg(
-        [
-            pl.col("values").sum().alias("sum"),
-            pl.col("values").var().alias("var"),
-            pl.col("values").mean().alias("mean"),
-            pl.col("values").std().alias("std"),
-        ]
+    out2 = (
+        example_df.set_sorted("dt")
+        .groupby_rolling("dt", period=period, closed=closed)
+        .agg(
+            [
+                pl.col("values").sum().alias("sum"),
+                pl.col("values").var().alias("var"),
+                pl.col("values").mean().alias("mean"),
+                pl.col("values").std().alias("std"),
+            ]
+        )
     )
     assert_frame_equal(out1, out2)
 
@@ -167,95 +171,82 @@ def test_rolling_extrema() -> None:
 
 def test_rolling_groupby_extrema() -> None:
     # ensure we hit different branches so create
-    # two dfs, but ensure that one does not have a sorted flag
 
-    # descending order
-    not_sorted_flag = pl.DataFrame({"col1": [6, 5, 4, 3, 2, 1, 0]}).with_columns(
-        pl.col("col1").reverse().alias("row_nr")
-    )
-    assert not not_sorted_flag["col1"].flags["SORTED_DESC"]
-
-    sorted_flag = pl.DataFrame(
+    df = pl.DataFrame(
         {
             "col1": pl.arange(0, 7, eager=True).reverse(),
         }
     ).with_columns(pl.col("col1").reverse().alias("row_nr"))
 
-    for df in [sorted_flag, not_sorted_flag]:
-        assert (
-            df.groupby_rolling(
-                index_column="row_nr",
-                period="3i",
-            )
-            .agg(
-                [
-                    pl.col("col1").suffix("_list"),
-                    pl.col("col1").min().suffix("_min"),
-                    pl.col("col1").max().suffix("_max"),
-                    pl.col("col1").first().alias("col1_first"),
-                    pl.col("col1").last().alias("col1_last"),
-                ]
-            )
-            .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-        ).to_dict(False) == {
-            "col1_list": [
-                [6],
-                [6, 5],
-                [6, 5, 4],
-                [5, 4, 3],
-                [4, 3, 2],
-                [3, 2, 1],
-                [2, 1, 0],
-            ],
-            "col1_min": [6, 5, 4, 3, 2, 1, 0],
-            "col1_max": [6, 6, 6, 5, 4, 3, 2],
-            "col1_first": [6, 6, 6, 5, 4, 3, 2],
-            "col1_last": [6, 5, 4, 3, 2, 1, 0],
-        }
+    assert (
+        df.groupby_rolling(
+            index_column="row_nr",
+            period="3i",
+        )
+        .agg(
+            [
+                pl.col("col1").suffix("_list"),
+                pl.col("col1").min().suffix("_min"),
+                pl.col("col1").max().suffix("_max"),
+                pl.col("col1").first().alias("col1_first"),
+                pl.col("col1").last().alias("col1_last"),
+            ]
+        )
+        .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
+    ).to_dict(False) == {
+        "col1_list": [
+            [6],
+            [6, 5],
+            [6, 5, 4],
+            [5, 4, 3],
+            [4, 3, 2],
+            [3, 2, 1],
+            [2, 1, 0],
+        ],
+        "col1_min": [6, 5, 4, 3, 2, 1, 0],
+        "col1_max": [6, 6, 6, 5, 4, 3, 2],
+        "col1_first": [6, 6, 6, 5, 4, 3, 2],
+        "col1_last": [6, 5, 4, 3, 2, 1, 0],
+    }
 
     # ascending order
 
-    sorted_df = pl.DataFrame(
+    df = pl.DataFrame(
         {
             "col1": pl.arange(0, 7, eager=True),
         }
     ).with_columns(pl.col("col1").alias("row_nr"))
 
-    not_sorted_df = pl.DataFrame({"col1": [0, 1, 2, 3, 4, 5, 6]}).with_columns(
-        pl.col("col1").alias("row_nr")
-    )
-
-    for df in [sorted_df, not_sorted_df]:
-        assert (
-            df.groupby_rolling(
-                index_column="row_nr",
-                period="3i",
-            )
-            .agg(
-                [
-                    pl.col("col1").suffix("_list"),
-                    pl.col("col1").min().suffix("_min"),
-                    pl.col("col1").max().suffix("_max"),
-                    pl.col("col1").first().alias("col1_first"),
-                    pl.col("col1").last().alias("col1_last"),
-                ]
-            )
-            .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-        ).to_dict(False) == {
-            "col1_list": [
-                [0],
-                [0, 1],
-                [0, 1, 2],
-                [1, 2, 3],
-                [2, 3, 4],
-                [3, 4, 5],
-                [4, 5, 6],
-            ],
-            "col1_min": [0, 0, 0, 1, 2, 3, 4],
-            "col1_max": [0, 1, 2, 3, 4, 5, 6],
-            "col1_first": [0, 0, 0, 1, 2, 3, 4],
-            "col1_last": [0, 1, 2, 3, 4, 5, 6],
-        }
+    assert (
+        df.groupby_rolling(
+            index_column="row_nr",
+            period="3i",
+        )
+        .agg(
+            [
+                pl.col("col1").suffix("_list"),
+                pl.col("col1").min().suffix("_min"),
+                pl.col("col1").max().suffix("_max"),
+                pl.col("col1").first().alias("col1_first"),
+                pl.col("col1").last().alias("col1_last"),
+            ]
+        )
+        .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
+    ).to_dict(False) == {
+        "col1_list": [
+            [0],
+            [0, 1],
+            [0, 1, 2],
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+            [4, 5, 6],
+        ],
+        "col1_min": [0, 0, 0, 1, 2, 3, 4],
+        "col1_max": [0, 1, 2, 3, 4, 5, 6],
+        "col1_first": [0, 0, 0, 1, 2, 3, 4],
+        "col1_last": [0, 1, 2, 3, 4, 5, 6],
+    }
 
     # shuffled data.
     df = pl.DataFrame(
@@ -346,7 +337,7 @@ def test_overlapping_groups_4628() -> None:
             "index": [1, 2, 3, 4, 5, 6],
             "val": [10, 20, 40, 70, 110, 160],
         }
-    )
+    ).set_sorted("index")
     assert (
         df.groupby_rolling(index_column="index", period="3i").agg(
             [
@@ -531,7 +522,7 @@ def test_groupby_dynamic_by_monday_and_offset_5444() -> None:
             "label": ["a", "b", "a", "a", "b", "a", "b"],
             "value": [1, 2, 3, 4, 5, 6, 7],
         }
-    ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
+    ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d").set_sorted())
 
     result = df.groupby_dynamic(
         "date", every="1w", offset="1d", by="label", start_by="monday"
@@ -564,7 +555,7 @@ def test_groupby_rolling_iter() -> None:
             "a": [1, 2, 2],
             "b": [4, 5, 6],
         }
-    )
+    ).set_sorted("date")
 
     # Without 'by' argument
     result1 = [

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1717,8 +1717,12 @@ def test_join_dates() -> None:
 
 
 def test_asof_cross_join() -> None:
-    left = pl.DataFrame({"a": [-10, 5, 10], "left_val": ["a", "b", "c"]})
-    right = pl.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
+    left = pl.DataFrame({"a": [-10, 5, 10], "left_val": ["a", "b", "c"]}).with_columns(
+        pl.col("a").set_sorted()
+    )
+    right = pl.DataFrame(
+        {"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]}
+    ).with_columns(pl.col("a").set_sorted())
 
     # only test dispatch of asof join
     out = left.join_asof(right, on="a")
@@ -2696,7 +2700,7 @@ def test_join_suffixes() -> None:
         # no need for an assert, we error if wrong
         df_a.join(df_b, on="A", suffix="_y", how=how)["B_y"]
 
-    df_a.join_asof(df_b, on="A", suffix="_y")["B_y"]
+    df_a.join_asof(df_b, on=pl.col("A").set_sorted(), suffix="_y")["B_y"]
 
 
 def test_preservation_of_subclasses_after_groupby_statements() -> None:
@@ -2751,9 +2755,9 @@ def test_asof_by_multiple_keys() -> None:
         }
     )
 
-    result = lhs.join_asof(rhs, on="a", by=["by", "by2"], strategy="backward").select(
-        ["a", "by"]
-    )
+    result = lhs.join_asof(
+        rhs, on=pl.col("a").set_sorted(), by=["by", "by2"], strategy="backward"
+    ).select(["a", "by"])
     expected = pl.DataFrame({"a": [-20, -19, 8, 12, 14], "by": [1, 1, 2, 2, 2]})
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -52,7 +52,7 @@ def test_error_on_invalid_by_in_asof_join() -> None:
             "b": [1, 2, 3],
             "c": ["a", "b", "a"],
         }
-    )
+    ).set_sorted("b")
 
     df2 = df1.with_columns(pl.col("a").cast(pl.Categorical))
     with pytest.raises(pl.ComputeError):

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -585,4 +585,4 @@ def test_no_sorted_warning(capfd: typing.Any) -> None:
     )
     df.groupby_dynamic("dt", every="1h").agg(pl.all().count().suffix("_foo"))
     (_, err) = capfd.readouterr()
-    assert "argument is not explicitly sorted" in err
+    assert "argument in operation 'groupby_dynamic' is not explicitly sorted" in err

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -44,32 +44,40 @@ def test_when_then_implicit_none() -> None:
 
 
 def test_predicate_null_block_asof_join() -> None:
-    left = pl.DataFrame(
-        {
-            "id": [1, 2, 3, 4],
-            "timestamp": [
-                datetime(2022, 1, 1, 10, 0),
-                datetime(2022, 1, 1, 10, 1),
-                datetime(2022, 1, 1, 10, 2),
-                datetime(2022, 1, 1, 10, 3),
-            ],
-        }
-    ).lazy()
+    left = (
+        pl.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "timestamp": [
+                    datetime(2022, 1, 1, 10, 0),
+                    datetime(2022, 1, 1, 10, 1),
+                    datetime(2022, 1, 1, 10, 2),
+                    datetime(2022, 1, 1, 10, 3),
+                ],
+            }
+        )
+        .lazy()
+        .set_sorted("timestamp")
+    )
 
-    right = pl.DataFrame(
-        {
-            "id": [1, 2, 3] * 2,
-            "timestamp": [
-                datetime(2022, 1, 1, 9, 59, 50),
-                datetime(2022, 1, 1, 10, 0, 50),
-                datetime(2022, 1, 1, 10, 1, 50),
-                datetime(2022, 1, 1, 8, 0, 0),
-                datetime(2022, 1, 1, 8, 0, 0),
-                datetime(2022, 1, 1, 8, 0, 0),
-            ],
-            "value": ["a", "b", "c"] * 2,
-        }
-    ).lazy()
+    right = (
+        pl.DataFrame(
+            {
+                "id": [1, 2, 3] * 2,
+                "timestamp": [
+                    datetime(2022, 1, 1, 9, 59, 50),
+                    datetime(2022, 1, 1, 10, 0, 50),
+                    datetime(2022, 1, 1, 10, 1, 50),
+                    datetime(2022, 1, 1, 8, 0, 0),
+                    datetime(2022, 1, 1, 8, 0, 0),
+                    datetime(2022, 1, 1, 8, 0, 0),
+                ],
+                "value": ["a", "b", "c"] * 2,
+            }
+        )
+        .lazy()
+        .set_sorted("timestamp")
+    )
 
     assert left.join_asof(right, by="id", on="timestamp").filter(
         pl.col("value").is_not_null()

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -162,15 +162,19 @@ def test_double_projection_union() -> None:
 
 @typing.no_type_check
 def test_asof_join_projection_() -> None:
-    lf1 = pl.DataFrame(
-        {
-            "m": np.linspace(0, 5, 7),
-            "a": np.linspace(0, 5, 7),
-            "b": np.linspace(0, 5, 7),
-            "c": pl.Series(np.linspace(0, 5, 7)).cast(str),
-            "d": np.linspace(0, 5, 7),
-        }
-    ).lazy()
+    lf1 = (
+        pl.DataFrame(
+            {
+                "m": np.linspace(0, 5, 7),
+                "a": np.linspace(0, 5, 7),
+                "b": np.linspace(0, 5, 7),
+                "c": pl.Series(np.linspace(0, 5, 7)).cast(str),
+                "d": np.linspace(0, 5, 7),
+            }
+        )
+        .lazy()
+        .set_sorted("b")
+    )
     lf2 = (
         pl.DataFrame(
             {
@@ -181,6 +185,7 @@ def test_asof_join_projection_() -> None:
         )
         .with_columns(pl.col("val").alias("b"))
         .lazy()
+        .set_sorted("b")
     )
 
     joined = lf1.join_asof(

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -144,7 +144,7 @@ def test_lazy_map_schema() -> None:
 def test_join_as_of_by_schema() -> None:
     a = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy()
     b = pl.DataFrame({"a": [1], "b": [2], "d": [4]}).lazy()
-    q = a.join_asof(b, on="a", by="b")
+    q = a.join_asof(b, on=pl.col("a").set_sorted(), by="b")
     assert q.collect().columns == q.columns
 
 


### PR DESCRIPTION
All python tests now run and pass the `sorted` warning.

If your data is sorted, silencing this warning is as easy as:

```python
result = lhs.join_asof(rhs, on=pl.col("a").set_sorted())
```

To make it easier to inform polars about the sorted data, without doing an expensive `sort` operation, `LazyFrame` and `DataFrame` now have a `set_sorted` method that makes it easy to chain operations and inform polars of sorted data.

This process made it clear that we also need to accept expression on `groupby_rolling` and `groupby_dynamic`. I will follow up with that.

The `warning` we print now also includes the operation that misses the sorted information so that it is more discoverable.

@stinodego I would love a backtest on your codebase to know if we can ship this.