### PR TITLE
fix(rust, python): don't set verbose on union

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -498,7 +498,7 @@ where
                             expr_arena,
                             &to_physical,
                             i == 0,
-                            i == 0,
+                            verbose && i == 0,
                         )
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;


### PR DESCRIPTION
fixes #8475