### PR TITLE
perf(rust): remove some unnecessary calls and matches

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -21,7 +21,7 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
         DataType::Datetime(tu, tz) => {
             let ca = s.datetime().unwrap();
 
-            fn adder<T: PolarsTimeZone>(
+            fn offset_fn<T: PolarsTimeZone>(
                 tu: TimeUnit,
             ) -> fn(&Duration, i64, Option<&T>) -> PolarsResult<i64> {
                 match tu {
@@ -35,20 +35,20 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
                 #[cfg(feature = "timezones")]
                 Some(ref tz) => match tz.parse::<Tz>() {
                     Ok(tz) => {
-                        let adder = adder(tu);
-                        ca.0.try_apply(|v| adder(&offset, v, Some(&tz)))
+                        let offset_fn = offset_fn(tu);
+                        ca.0.try_apply(|v| offset_fn(&offset, v, Some(&tz)))
                     }
                     Err(_) => match parse_offset(tz) {
                         Ok(tz) => {
-                            let adder = adder(tu);
-                            ca.0.try_apply(|v| adder(&offset, v, Some(&tz)))
+                            let offset_fn = offset_fn(tu);
+                            ca.0.try_apply(|v| offset_fn(&offset, v, Some(&tz)))
                         }
                         Err(_) => unreachable!(),
                     },
                 },
                 _ => {
-                    let adder = adder(tu);
-                    ca.0.try_apply(|v| adder(&offset, v, NO_TIMEZONE))
+                    let offset_fn = offset_fn(tu);
+                    ca.0.try_apply(|v| offset_fn(&offset, v, NO_TIMEZONE))
                 }
             }?;
             out.cast(&DataType::Datetime(tu, tz))

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -34,13 +34,22 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
             let out = match tz {
                 #[cfg(feature = "timezones")]
                 Some(ref tz) => match tz.parse::<Tz>() {
-                    Ok(tz) => ca.0.try_apply(|v| adder(tu)(&offset, v, Some(&tz))),
+                    Ok(tz) => {
+                        let adder = adder(tu);
+                        ca.0.try_apply(|v| adder(&offset, v, Some(&tz)))
+                    }
                     Err(_) => match parse_offset(tz) {
-                        Ok(tz) => ca.0.try_apply(|v| adder(tu)(&offset, v, Some(&tz))),
+                        Ok(tz) => {
+                            let adder = adder(tu);
+                            ca.0.try_apply(|v| adder(&offset, v, Some(&tz)))
+                        }
                         Err(_) => unreachable!(),
                     },
                 },
-                _ => ca.0.try_apply(|v| adder(tu)(&offset, v, NO_TIMEZONE)),
+                _ => {
+                    let adder = adder(tu);
+                    ca.0.try_apply(|v| adder(&offset, v, NO_TIMEZONE))
+                }
             }?;
             out.cast(&DataType::Datetime(tu, tz))
         }

--- a/polars/polars-time/src/windows/calendar.rs
+++ b/polars/polars-time/src/windows/calendar.rs
@@ -35,52 +35,59 @@ pub const NS_HOUR: i64 = 60 * NS_MINUTE;
 pub const NS_DAY: i64 = 24 * NS_HOUR;
 pub const NS_WEEK: i64 = 7 * NS_DAY;
 
-pub fn date_range(
+pub fn date_range<T: PolarsTimeZone>(
     start: i64,
     stop: i64,
     every: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<&impl PolarsTimeZone>,
+    tz: Option<&T>,
 ) -> PolarsResult<Vec<i64>> {
-    let size = match tu {
-        TimeUnit::Nanoseconds => ((stop - start) / every.duration_ns() + 1) as usize,
-        TimeUnit::Microseconds => ((stop - start) / every.duration_us() + 1) as usize,
-        TimeUnit::Milliseconds => ((stop - start) / every.duration_ms() + 1) as usize,
-    };
+    let size: usize;
+    let offset_fn: fn(&Duration, i64, Option<&T>) -> PolarsResult<i64>;
+
+    match tu {
+        TimeUnit::Nanoseconds => {
+            size = ((stop - start) / every.duration_ns() + 1) as usize;
+            offset_fn = Duration::add_ns;
+        }
+        TimeUnit::Microseconds => {
+            size = ((stop - start) / every.duration_us() + 1) as usize;
+            offset_fn = Duration::add_us;
+        }
+        TimeUnit::Milliseconds => {
+            size = ((stop - start) / every.duration_ms() + 1) as usize;
+            offset_fn = Duration::add_ms;
+        }
+    }
     let mut ts = Vec::with_capacity(size);
 
     let mut t = start;
-    let f = match tu {
-        TimeUnit::Nanoseconds => <Duration>::add_ns,
-        TimeUnit::Microseconds => <Duration>::add_us,
-        TimeUnit::Milliseconds => <Duration>::add_ms,
-    };
     match closed {
         ClosedWindow::Both => {
             while t <= stop {
                 ts.push(t);
-                t = f(&every, t, tz)?
+                t = offset_fn(&every, t, tz)?
             }
         }
         ClosedWindow::Left => {
             while t < stop {
                 ts.push(t);
-                t = f(&every, t, tz)?
+                t = offset_fn(&every, t, tz)?
             }
         }
         ClosedWindow::Right => {
-            t = f(&every, t, tz)?;
+            t = offset_fn(&every, t, tz)?;
             while t <= stop {
                 ts.push(t);
-                t = f(&every, t, tz)?
+                t = offset_fn(&every, t, tz)?
             }
         }
         ClosedWindow::None => {
-            t = f(&every, t, tz)?;
+            t = offset_fn(&every, t, tz)?;
             while t < stop {
                 ts.push(t);
-                t = f(&every, t, tz)?
+                t = offset_fn(&every, t, tz)?
             }
         }
     }


### PR DESCRIPTION
Before, `pl.Series([datetime.now(), datetime(2020, 1, 2), datetime(2020, 1, 3)]).dt.offset_by("1mo")` would call `adder(tu)` once for each element.
Now, it'll just call it once per `offset_by` call

Also, renaming `adder` to `offset_fn` - that's the name used here

https://github.com/pola-rs/polars/blob/3f2a1d7c650783aa6522e70e45b774f1e810bd2d/polars/polars-time/src/windows/window.rs#L207-L211

and it's probably the clearest