### PR TITLE
fix(rust, python): don't error on cast if column is not projected

### DIFF
--- a/polars/polars-io/src/csv/read_impl/mod.rs
+++ b/polars/polars-io/src/csv/read_impl/mod.rs
@@ -66,7 +66,10 @@ pub(crate) fn cast_columns(
     } else {
         // cast to the original dtypes in the schema
         for fld in to_cast {
-            df.try_apply(fld.name(), |s| cast_fn(s, fld))?;
+            // field may not be projected
+            if let Some(idx) = df.find_idx_by_name(fld.name()) {
+                df.try_apply_at_idx(idx, |s| cast_fn(s, fld))?;
+            }
         }
     }
     Ok(())

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -216,3 +216,16 @@ def test_glob_n_rows(io_files_path: Path) -> None:
         "fats_g": [0.5, 6.0],
         "sugars_g": [2, 2],
     }
+
+
+def test_scan_csv_schema_overwrite_not_projected_8483(foods_file_path: str) -> None:
+    df = (
+        pl.scan_csv(
+            foods_file_path,
+            dtypes={"calories": pl.Utf8, "sugars_g": pl.Int8},
+        )
+        .select(pl.count())
+        .collect()
+    )
+    expected = pl.DataFrame({"count": 27}, schema={"count": pl.UInt32})
+    assert_frame_equal(df, expected)


### PR DESCRIPTION
fixes #8483