### PR TITLE
perf(python): significant speedup for python iteration over `Series` data

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3677,11 +3677,13 @@ class DataFrame:
             *percentile_exprs,
         ).row(0)
 
-        # reshape/cast wide result
+        # reshape wide result
         n_cols = len(self.columns)
         described = [
             df_metrics[(n * n_cols) : (n + 1) * n_cols] for n in range(0, len(metrics))
         ]
+
+        # cast by column type (numeric/bool -> float), (other -> string)
         summary = dict(zip(self.columns, list(zip(*described))))
         num_or_bool = NUMERIC_DTYPES | {Boolean}
         for c, tp in self.schema.items():
@@ -3692,7 +3694,7 @@ class DataFrame:
                 for v in summary[c]
             ]
 
-        # return as frame
+        # return results as a frame
         df_summary = self.__class__(summary)
         df_summary.insert_at_idx(0, pli.Series("describe", metrics))
         return df_summary


### PR DESCRIPTION
Partially addresses #8494.

The `SeriesIter` proxy carried a lot of overhead as it called into `__getitem__` for every element being iterated over. 

Using a similar technique to `DataFrame.rows` instead (yielding from a sliding buffer of materialised zero-copy slices) gets us...

* **~20x** speedup iterating over scalar/struct data.
* **~2-3x** speedup iterating over nested list data.

---

**Note:** a further speedup will be investigated - in order to preserve existing behaviour when iterating over nested `List` data the full speedup could only be applied to `Series` containing scalar/struct values... will see about improving this in a second pass.