### PR TITLE
fix(python): correct sign-reversed scale on DecimalChunked to Python Decimal conversion (fixes #8423)

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -538,7 +538,7 @@ impl ToPyObject for Wrap<&DecimalChunked> {
     fn to_object(&self, py: Python) -> PyObject {
         let utils = UTILS.as_ref(py);
         let convert = utils.getattr("_to_python_decimal").unwrap();
-        let py_scale = self.0.scale().to_object(py);
+        let py_scale = (-(self.0.scale() as i32)).to_object(py);
         // if we don't know precision, the only safe bet is to set it to 39
         let py_precision = self.0.precision().unwrap_or(39).to_object(py);
         let iter = self.0.into_iter().map(|opt_v| {

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -31,6 +31,7 @@ def test_series_from_pydecimal_and_ints() -> None:
         assert s.null_count() == 1
         for i, d in enumerate(data):
             assert s[i] == d
+        assert s.to_list() == [D(x) if x is not None else None for x in data]
 
 
 def test_frame_from_pydecimal_and_ints(monkeypatch: Any) -> None:


### PR DESCRIPTION
On conversion from a decimal value to a Python decimal, `impl IntoPy<PyObject> for Wrap<AnyValue<'_>>`, on line 274 of conversion.rs, correctly reverses the sign of scale, to fit the Python Decimal's expected input (Python's Decimal is floating point and expects a signed offset of the point).  `impl ToPyObject for Wrap<&DecimalChunked>` does not, resulting in converted values that are off by a factor of $10^{2\cdot scale}$ for methods that use that, such as to_list.

This fixes the sign, and adds to an existing test to ensure that to_list works properly with decimals.

Fixes #8423.