### PR TITLE
fix(python): Clarify and fix behaviour in `pl.min/max`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -501,7 +501,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     If a single string is passed, this is an alias for ``pl.col(name).max()``.
     If a single Series is passed, this is an alias for ``Series.max()``.
 
-    Otherwise, this function computes the the maximum value of each row (horizontal).
+    Otherwise, this function computes the maximum value of each row (horizontal).
 
     Parameters
     ----------
@@ -600,7 +600,7 @@ def min(
     If a single string is passed, this is an alias for ``pl.col(name).min()``.
     If a single Series is passed, this is an alias for ``Series.min()``.
 
-    Otherwise, this function computes the the minimum value of each row (horizontal).
+    Otherwise, this function computes the minimum value of each row (horizontal).
 
     Parameters
     ----------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -498,8 +498,10 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     """
     Get the maximum value.
 
-    If a single column is passed, get the maximum value of that column (vertical).
-    If multiple columns are passed, get the maximum value of each row (horizontal).
+    If a single string is passed, this is an alias for ``pl.col(name).max()``.
+    If a single Series is passed, this is an alias for ``Series.max()``.
+
+    Otherwise, this function computes the the maximum value of each row (horizontal).
 
     Parameters
     ----------
@@ -511,22 +513,16 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
 
     Examples
     --------
-    Get the maximum value by columns with a string column name.
+    Get the maximum value by row by passing multiple columns/expressions.
 
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
-    >>> df.select(pl.max("a"))
-    shape: (1, 1)
-    ┌─────┐
-    │ a   │
-    │ --- │
-    │ i64 │
-    ╞═════╡
-    │ 8   │
-    └─────┘
-
-    Get the maximum value by row with a list of columns/expressions.
-
-    >>> df.select(pl.max(["a", "b"]))
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
+    >>> df.select(pl.max("a", "b"))
     shape: (3, 1)
     ┌─────┐
     │ max │
@@ -538,10 +534,22 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     │ 3   │
     └─────┘
 
-    To aggregate maximums for more than one column/expression use ``pl.col(list).max()``
-    or a regular expression selector like ``pl.sum(regex)``:
+    Get the maximum value of a column by passing a single column name.
 
-    >>> df.select(pl.col(["a", "b"]).max())
+    >>> df.select(pl.max("a"))
+    shape: (1, 1)
+    ┌─────┐
+    │ a   │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 8   │
+    └─────┘
+
+    Get column-wise maximums for multiple columns by passing a regular expression,
+    or call ``.max()`` on a multi-column expression instead.
+
+    >>> df.select(pl.max("^a|b$"))
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -550,8 +558,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     ╞═════╪═════╡
     │ 8   ┆ 5   │
     └─────┴─────┘
-
-    >>> df.select(pl.max("^.*[ab]$"))
+    >>> df.select(pl.col("a", "b").max())
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -567,8 +574,6 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
             return exprs.max()
         elif isinstance(exprs, str):
             return col(exprs).max()
-        elif not isinstance(exprs, Iterable):
-            return lit(exprs).max()
 
     exprs = selection_to_pyexpr_list(exprs)
     if more_exprs:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -592,8 +592,10 @@ def min(
     """
     Get the minimum value.
 
-    If a single column is passed, get the minimum value of that column (vertical).
-    If multiple columns are passed, get the minimum value of each row (horizontal).
+    If a single string is passed, this is an alias for ``pl.col(name).min()``.
+    If a single Series is passed, this is an alias for ``Series.min()``.
+
+    Otherwise, this function computes the the minimum value of each row (horizontal).
 
     Parameters
     ----------
@@ -605,7 +607,7 @@ def min(
 
     Examples
     --------
-    Get the minimum value by columns with a string column name.
+    Get the minimum value by row by passing multiple columns/expressions.
 
     >>> df = pl.DataFrame(
     ...     {
@@ -614,19 +616,7 @@ def min(
     ...         "c": ["foo", "bar", "foo"],
     ...     }
     ... )
-    >>> df.select(pl.min("a"))
-    shape: (1, 1)
-    ┌─────┐
-    │ a   │
-    │ --- │
-    │ i64 │
-    ╞═════╡
-    │ 1   │
-    └─────┘
-
-    Get the minimum value by row with a list of columns/expressions.
-
-    >>> df.select(pl.min(["a", "b"]))
+    >>> df.select(pl.min("a", "b"))
     shape: (3, 1)
     ┌─────┐
     │ min │
@@ -638,10 +628,22 @@ def min(
     │ 2   │
     └─────┘
 
-    To aggregate minimums for more than one column/expression use ``pl.col(list).min()``
-    or a regular expression selector like ``pl.sum(regex)``:
+    Get the minimum value of a column by passing a single column name.
 
-    >>> df.select(pl.col(["a", "b"]).min())
+    >>> df.select(pl.min("a"))
+    shape: (1, 1)
+    ┌─────┐
+    │ a   │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 1   │
+    └─────┘
+
+    Get column-wise minimums for multiple columns by passing a regular expression,
+    or call ``.min()`` on a multi-column expression instead.
+
+    >>> df.select(pl.min("^a|b$"))
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -650,8 +652,7 @@ def min(
     ╞═════╪═════╡
     │ 1   ┆ 2   │
     └─────┴─────┘
-
-    >>> df.select(pl.min("^.*[ab]$"))
+    >>> df.select(pl.col("a", "b").min())
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -667,8 +668,6 @@ def min(
             return exprs.min()
         elif isinstance(exprs, str):
             return col(exprs).min()
-        elif not isinstance(exprs, Iterable):
-            return lit(exprs).min()
 
     exprs = selection_to_pyexpr_list(exprs)
     if more_exprs:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -380,18 +380,51 @@ def test_min_column_wise_multi_input(
     assert_frame_equal(result, expected)
 
 
-def test_max() -> None:
+def test_max_alias_for_series_max() -> None:
     s = pl.Series([1, 2, 3])
-    assert pl.max(s) == 3
+    assert pl.max(s) == s.max()
 
+
+@pytest.mark.parametrize("input", ["a", "^a|b$"])
+def test_max_alias_for_col_max(input: str) -> None:
     df = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
-    assert df.select(pl.max("a")).item() == 4
+    expr = pl.col(input).max()
+    expr_alias = pl.max(input)
+    assert_frame_equal(df.select(expr), df.select(expr_alias))
 
-    result = df.select(pl.max(["a", "b"]))
-    assert_frame_equal(result, pl.DataFrame({"max": [3, 4]}))
 
-    result = df.select(pl.max("a", 3))
-    assert_frame_equal(result, pl.DataFrame({"max": [3, 4]}))
+@pytest.mark.parametrize(
+    ("input", "expected_data"),
+    [
+        (pl.col("^a|b$"), [3, 4]),
+        (pl.col("a", "b"), [3, 4]),
+        (pl.col("a"), [1, 4]),
+        (pl.lit(5, dtype=pl.Int64), [5]),
+        (5.0, [5.0]),
+    ],
+)
+def test_max_column_wise_single_input(input: Any, expected_data: list[Any]) -> None:
+    df = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
+    result = df.select(pl.max(input))
+    expected = pl.DataFrame({"max": expected_data})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "expected_data"),
+    [
+        ((["a", "b"]), [3, 4]),
+        (("a", "b"), [3, 4]),
+        (("a", 3), [3, 4]),
+    ],
+)
+def test_max_column_wise_multi_input(
+    inputs: tuple[Any, ...], expected_data: list[Any]
+) -> None:
+    df = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
+    result = df.select(pl.max(*inputs))
+    expected = pl.DataFrame({"max": expected_data})
+    assert_frame_equal(result, expected)
 
 
 def test_abs_logical_type() -> None:


### PR DESCRIPTION
Closes #8505

An issue was introduced when I allowed *args syntax for `pl.min/max`: single expression input was no longer accepted.

This fixes that issue, and clarifies the behaviour in the docstring.

The behaviour is as follows:
* If a single string is passed, this is an alias for ``pl.col(name).max()``.
* If a single Series is passed, this is an alias for ``Series.max()``.
* Otherwise, this function computes the maximum value of each row (horizontal).

This is consistent with `sum` and other aggregation functions (which I will update with *args syntax later).