### PR TITLE
feat(rust, python)!: consistently return list of date/datetime from lazy date_range

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/temporal.rs
@@ -93,7 +93,7 @@ pub(super) fn temporal_range_dispatch(
     name: &str,
     every: Duration,
     closed: ClosedWindow,
-    _tz: Option<TimeZone>,  // todo: respect _tz: https://github.com/pola-rs/polars/issues/8512
+    _tz: Option<TimeZone>, // todo: respect _tz: https://github.com/pola-rs/polars/issues/8512
 ) -> PolarsResult<Series> {
     let start = &s[0];
     let stop = &s[1];

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -598,7 +598,9 @@ def test_date_range_lazy_with_expressions(
 ) -> None:
     ldf = (
         pl.DataFrame({"start": [date(2015, 6, 30)], "stop": [date(2022, 12, 31)]})
-        .with_columns(pl.date_range(low, high, interval="678d", eager=False).alias("dts"))
+        .with_columns(
+            pl.date_range(low, high, interval="678d", eager=False).alias("dts")
+        )
         .lazy()
     )
 
@@ -719,7 +721,7 @@ def test_time_range_lit() -> None:
             )
         )
         if not eager:
-            tm = tm.select(pl.col('tm').explode())
+            tm = tm.select(pl.col("tm").explode())
         assert tm["tm"].to_list() == [
             time(6, 47, 13, 333000),
             time(12, 32, 23, 666000),
@@ -735,7 +737,7 @@ def test_time_range_lit() -> None:
             )
         )
         if not eager:
-            tm = tm.select(pl.col('tm').explode())
+            tm = tm.select(pl.col("tm").explode())
         assert tm["tm"].to_list() == [
             time(0, 0),
             time(5, 45, 10, 333000),
@@ -752,7 +754,7 @@ def test_time_range_lit() -> None:
                 name="tm",
             )
         )
-        tm = tm.select(pl.col('tm').explode())
+        tm = tm.select(pl.col("tm").explode())
         assert tm["tm"].to_list() == [
             time(23, 59, 59, 999980),
             time(23, 59, 59, 999990),

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -676,7 +676,7 @@ def test_date_range_single_row_lazy_7110() -> None:
             start=pl.col("from"),
             end=pl.col("to"),
             interval="1d",
-            lazy=True,
+            eager=False,
         ).alias("date_range")
     )
     expected = pl.DataFrame(
@@ -718,6 +718,8 @@ def test_time_range_lit() -> None:
                 name="tm",
             )
         )
+        if not eager:
+            tm = tm.select(pl.col('tm').explode())
         assert tm["tm"].to_list() == [
             time(6, 47, 13, 333000),
             time(12, 32, 23, 666000),
@@ -732,6 +734,8 @@ def test_time_range_lit() -> None:
                 name="tm",
             )
         )
+        if not eager:
+            tm = tm.select(pl.col('tm').explode())
         assert tm["tm"].to_list() == [
             time(0, 0),
             time(5, 45, 10, 333000),
@@ -748,6 +752,7 @@ def test_time_range_lit() -> None:
                 name="tm",
             )
         )
+        tm = tm.select(pl.col('tm').explode())
         assert tm["tm"].to_list() == [
             time(23, 59, 59, 999980),
             time(23, 59, 59, 999990),

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -565,9 +565,7 @@ def test_date_range_lazy_with_literals() -> None:
             date(2023, 8, 31),
             interval="987d",
             eager=False,
-        )
-        .implode()
-        .alias("dts")
+        ).alias("dts")
     )
     assert df.rows() == [
         (
@@ -600,11 +598,7 @@ def test_date_range_lazy_with_expressions(
 ) -> None:
     ldf = (
         pl.DataFrame({"start": [date(2015, 6, 30)], "stop": [date(2022, 12, 31)]})
-        .with_columns(
-            pl.date_range(low, high, interval="678d", eager=False)
-            .implode()
-            .alias("dts")
-        )
+        .with_columns(pl.date_range(low, high, interval="678d", eager=False).alias("dts"))
         .lazy()
     )
 
@@ -667,6 +661,33 @@ def test_date_range_lazy_with_expressions(
             [datetime(2022, 6, 1, 0, 0), datetime(2022, 6, 2, 0, 0)],
         ],
     }
+
+
+def test_date_range_single_row_lazy_7110() -> None:
+    df = pl.DataFrame(
+        {
+            "name": ["A"],
+            "from": [date(2020, 1, 1)],
+            "to": [date(2020, 1, 2)],
+        }
+    )
+    result = df.with_columns(
+        pl.date_range(
+            start=pl.col("from"),
+            end=pl.col("to"),
+            interval="1d",
+            lazy=True,
+        ).alias("date_range")
+    )
+    expected = pl.DataFrame(
+        {
+            "name": ["A"],
+            "from": [date(2020, 1, 1)],
+            "to": [date(2020, 1, 2)],
+            "date_range": [[date(2020, 1, 1), date(2020, 1, 2)]],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_date_range_invalid_time_zone() -> None:


### PR DESCRIPTION
closes #7110

This simplifies the logic, but would be a breaking change, so if accepted, might be better to wait for 0.18 or 1.0?

It also simplifies the logic on the user side (I think) - in all the test cases I found where this is used, it removes an unnecessary `.implode` call

If reviewing, this is much easier if ignoring whitespace: https://github.com/pola-rs/polars/pull/8513/files?w=1