### PR TITLE
feat(python): add `is_nested` property to dtypes

### DIFF
--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -36,6 +36,7 @@ def test_dtype() -> None:
         "dt": pl.List(pl.Date),
         "dtm": pl.List(pl.Datetime),
     }
+    assert all(tp.is_nested for tp in df.dtypes)
     assert df.schema["i"].inner == pl.Int8  # type: ignore[union-attr]
     assert df.rows() == [
         (
@@ -71,6 +72,7 @@ def test_categorical() -> None:
     )
 
     assert out.inner_dtype == pl.Categorical
+    assert not out.inner_dtype.is_nested
 
 
 def test_list_concat_rolling_window() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -97,6 +97,7 @@ def test_struct_unnest_multiple() -> None:
     # List input
     result = df_structs.unnest(["s1", "s2"])
     assert_frame_equal(result, df)
+    assert all(tp.is_nested for tp in df_structs.dtypes)
 
     # Positional input
     result = df_structs.unnest("s1", "s2")


### PR DESCRIPTION
Makes identification of nested dtypes simpler / more robust.

* Instead of...`(tp == List or tp == Struct)` ... can use `tp.is_nested` instead.
* Future-proofs any such nested dtype checks as the property is set _True_ on the `NestedType` base class, and _False_ everywhere else.