### PR TITLE
fix(python): don't downcast `Decimal` to `Float64` in truediv

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -31,6 +31,7 @@ from polars.datatypes import (
     Categorical,
     Date,
     Datetime,
+    Decimal,
     Duration,
     Float32,
     Float64,
@@ -614,7 +615,7 @@ class Series:
             raise ValueError("first cast to integer before dividing datelike dtypes")
 
         # this branch is exactly the floordiv function without rounding the floats
-        if self.is_float():
+        if self.is_float() or self.dtype == Decimal:
             return self._arithmetic(other, "div", "div_<>")
 
         return self.cast(Float64) / other


### PR DESCRIPTION
We can't actually do decimal math yet, so I was surprised to see division succeeding; decimal series were being inadvertently downcast to float64 inside `__truediv__`. 

Have fixed this so that we now (correctly) raise an error until decimal math is up & running.