### PR TITLE
feat(rust, python): accept expressions in `groupby_dynamic/rolling`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -136,7 +136,7 @@ pub fn has_null(current_expr: &Expr) -> bool {
 }
 
 /// output name of expr
-pub(crate) fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
+pub fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
     for e in expr {
         match e {
             // don't follow the partition by branch

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -729,9 +729,18 @@ impl LazyFrame {
     #[cfg(feature = "dynamic_groupby")]
     pub fn groupby_rolling<E: AsRef<[Expr]>>(
         self,
+        index_column: Expr,
         by: E,
-        options: RollingGroupOptions,
+        mut options: RollingGroupOptions,
     ) -> LazyGroupBy {
+        if let Expr::Column(name) = index_column {
+            options.index_column = name.as_ref().into();
+        } else {
+            let name = expr_output_name(&index_column).unwrap();
+            return self
+                .with_column(index_column)
+                .groupby_rolling(Expr::Column(name), by, options);
+        }
         let opt_state = self.get_opt_state();
         LazyGroupBy {
             logical_plan: self.logical_plan,
@@ -761,9 +770,18 @@ impl LazyFrame {
     #[cfg(feature = "dynamic_groupby")]
     pub fn groupby_dynamic<E: AsRef<[Expr]>>(
         self,
+        index_column: Expr,
         by: E,
-        options: DynamicGroupOptions,
+        mut options: DynamicGroupOptions,
     ) -> LazyGroupBy {
+        if let Expr::Column(name) = index_column {
+            options.index_column = name.as_ref().into();
+        } else {
+            let name = expr_output_name(&index_column).unwrap();
+            return self
+                .with_column(index_column)
+                .groupby_dynamic(Expr::Column(name), by, options);
+        }
         let opt_state = self.get_opt_state();
         LazyGroupBy {
             logical_plan: self.logical_plan,

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -65,6 +65,17 @@ pub struct RollingGroupOptions {
     pub closed_window: ClosedWindow,
 }
 
+impl Default for RollingGroupOptions {
+    fn default() -> Self {
+        Self {
+            index_column: "".into(),
+            period: Duration::new(1),
+            offset: Duration::new(1),
+            closed_window: ClosedWindow::Left,
+        }
+    }
+}
+
 const LB_NAME: &str = "_lower_boundary";
 const UP_NAME: &str = "_upper_boundary";
 

--- a/polars/tests/it/lazy/groupby_dynamic.rs
+++ b/polars/tests/it/lazy/groupby_dynamic.rs
@@ -41,9 +41,9 @@ fn test_groupby_dynamic_week_bounds() -> PolarsResult<()> {
     let out = df
         .lazy()
         .groupby_dynamic(
+            col("dt"),
             [],
             DynamicGroupOptions {
-                index_column: "dt".into(),
                 every: Duration::parse("1w"),
                 period: Duration::parse("1w"),
                 offset: Duration::parse("0w"),

--- a/polars/tests/it/lazy/queries.rs
+++ b/polars/tests/it/lazy/queries.rs
@@ -44,12 +44,13 @@ fn test_special_groupby_schemas() -> PolarsResult<()> {
         .clone()
         .lazy()
         .groupby_rolling(
+            col("a"),
             [],
             RollingGroupOptions {
-                index_column: "a".into(),
                 period: Duration::parse("2i"),
                 offset: Duration::parse("0i"),
                 closed_window: ClosedWindow::Left,
+                ..Default::default()
             },
         )
         .agg([col("b").sum().alias("sum")])
@@ -67,9 +68,9 @@ fn test_special_groupby_schemas() -> PolarsResult<()> {
     let out = df
         .lazy()
         .groupby_dynamic(
+            col("a"),
             [],
             DynamicGroupOptions {
-                index_column: "a".into(),
                 every: Duration::parse("2i"),
                 period: Duration::parse("2i"),
                 offset: Duration::parse("0i"),

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4573,7 +4573,7 @@ class DataFrame:
 
     def groupby_rolling(
         self,
-        index_column: str,
+        index_column: IntoExpr,
         *,
         period: str | timedelta,
         offset: str | timedelta | None = None,
@@ -4683,7 +4683,7 @@ class DataFrame:
 
     def groupby_dynamic(
         self,
-        index_column: str,
+        index_column: IntoExpr,
         *,
         every: str | timedelta,
         period: str | timedelta | None = None,

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -754,7 +754,7 @@ class RollingGroupBy(Generic[DF]):
     def __init__(
         self,
         df: DF,
-        index_column: str,
+        index_column: IntoExpr,
         period: str | timedelta,
         offset: str | timedelta | None,
         closed: ClosedInterval,
@@ -843,7 +843,7 @@ class DynamicGroupBy(Generic[DF]):
     def __init__(
         self,
         df: DF,
-        index_column: str,
+        index_column: IntoExpr,
         every: str | timedelta,
         period: str | timedelta | None,
         offset: str | timedelta | None,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2257,7 +2257,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def groupby_rolling(
         self,
-        index_column: str,
+        index_column: IntoExpr,
         *,
         period: str | timedelta,
         offset: str | timedelta | None = None,
@@ -2367,6 +2367,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
+        index_column = expr_to_lit_or_expr(index_column, str_to_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2375,13 +2376,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = _timedelta_to_pl_duration(offset)
 
         lgb = self._ldf.groupby_rolling(
-            index_column, period, offset, closed, pyexprs_by
+            index_column._pyexpr, period, offset, closed, pyexprs_by
         )
         return LazyGroupBy(lgb, lazyframe_class=self.__class__)
 
     def groupby_dynamic(
         self,
-        index_column: str,
+        index_column: IntoExpr,
         *,
         every: str | timedelta,
         period: str | timedelta | None = None,
@@ -2659,6 +2660,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
+        index_column = expr_to_lit_or_expr(index_column, str_to_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -2671,7 +2673,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
         lgb = self._ldf.groupby_dynamic(
-            index_column,
+            index_column._pyexpr,
             every,
             period,
             offset,

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -587,7 +587,7 @@ impl PyLazyFrame {
 
     pub fn groupby_rolling(
         &mut self,
-        index_column: &str,
+        index_column: PyExpr,
         period: &str,
         offset: &str,
         closed: Wrap<ClosedWindow>,
@@ -600,9 +600,10 @@ impl PyLazyFrame {
             .map(|pyexpr| pyexpr.inner)
             .collect::<Vec<_>>();
         let lazy_gb = ldf.groupby_rolling(
+            index_column.inner,
             by,
             RollingGroupOptions {
-                index_column: index_column.into(),
+                index_column: "".into(),
                 period: Duration::parse(period),
                 offset: Duration::parse(offset),
                 closed_window,
@@ -615,7 +616,7 @@ impl PyLazyFrame {
     #[allow(clippy::too_many_arguments)]
     pub fn groupby_dynamic(
         &mut self,
-        index_column: &str,
+        index_column: PyExpr,
         every: &str,
         period: &str,
         offset: &str,
@@ -632,9 +633,9 @@ impl PyLazyFrame {
             .collect::<Vec<_>>();
         let ldf = self.ldf.clone();
         let lazy_gb = ldf.groupby_dynamic(
+            index_column.inner,
             by,
             DynamicGroupOptions {
-                index_column: index_column.into(),
                 every: Duration::parse(every),
                 period: Duration::parse(period),
                 offset: Duration::parse(offset),
@@ -642,6 +643,7 @@ impl PyLazyFrame {
                 include_boundaries,
                 closed_window,
                 start_by: start_by.0,
+                ..Default::default()
             },
         );
 

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -337,9 +337,9 @@ def test_overlapping_groups_4628() -> None:
             "index": [1, 2, 3, 4, 5, 6],
             "val": [10, 20, 40, 70, 110, 160],
         }
-    ).set_sorted("index")
+    )
     assert (
-        df.groupby_rolling(index_column="index", period="3i").agg(
+        df.groupby_rolling(index_column=pl.col("index").set_sorted(), period="3i").agg(
             [
                 pl.col("val").diff(n=1).alias("val.diff"),
                 (pl.col("val") - pl.col("val").shift(1)).alias("val - val.shift"),

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -668,9 +668,9 @@ def test_sorted_flag_groupby_dynamic() -> None:
     df = pl.DataFrame({"ts": [date(2020, 1, 1), date(2020, 1, 2)], "val": [1, 2]})
     assert (
         (
-            df.with_columns(ts=pl.col("ts").set_sorted())
-            .groupby_dynamic("ts", every="1d")
-            .agg(pl.col("val").sum())
+            df.groupby_dynamic(pl.col("ts").set_sorted(), every="1d").agg(
+                pl.col("val").sum()
+            )
         )
         .to_series()
         .flags["SORTED_ASC"]


### PR DESCRIPTION
Which allows for inline `col("foo").set_sorted()` :)