### PR TITLE
fix(rust, python): don't trigger unreachable code if no dtype is set

### DIFF
--- a/polars/polars-arrow/src/trusted_len/push_unchecked.rs
+++ b/polars/polars-arrow/src/trusted_len/push_unchecked.rs
@@ -7,12 +7,6 @@ pub trait PushUnchecked<T> {
     /// Caller must ensure the array has enough capacity to hold `T`.
     unsafe fn push_unchecked(&mut self, value: T);
 
-    /// Will push an item and not check if there is enough capacity nor update the array's length
-    /// # Safety
-    /// Caller must ensure the array has enough capacity to hold `T`.
-    /// Caller must update the length when its done updating the vector.
-    unsafe fn push_unchecked_no_len_set(&mut self, value: T);
-
     /// Extend the array with an iterator who's length can be trusted
     fn extend_trusted_len<I: IntoIterator<Item = T, IntoIter = J>, J: TrustedLen>(
         &mut self,
@@ -48,12 +42,6 @@ impl<T> PushUnchecked<T> for Vec<T> {
     }
 
     #[inline]
-    unsafe fn push_unchecked_no_len_set(&mut self, value: T) {
-        let end = self.as_mut_ptr().add(self.len());
-        std::ptr::write(end, value);
-    }
-
-    #[inline]
     unsafe fn extend_trusted_len_unchecked<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iter = iter.into_iter();
         let upper = iter.size_hint().1.expect("must have an upper bound");
@@ -67,6 +55,7 @@ impl<T> PushUnchecked<T> for Vec<T> {
         self.set_len(self.len() + upper)
     }
 
+    #[inline]
     unsafe fn from_trusted_len_iter_unchecked<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut v = vec![];
         v.extend_trusted_len_unchecked(iter);

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -625,6 +625,12 @@ impl OptimizationRule for SimplifyExprRule {
             AExpr::Cast {
                 expr, data_type, ..
             } => {
+                if let DataType::Unknown = data_type {
+                    polars_bail!(InvalidOperation: "polars could not finish query because the dtype is unknown\n\
+                    \n\
+                    If you used a custom function you must set the return dtype.")
+                }
+
                 let input = expr_arena.get(*expr);
                 // faster casts (we only do strict casts)
                 inline_cast(input, data_type)

--- a/py-polars/tests/unit/operations/test_apply.py
+++ b/py-polars/tests/unit/operations/test_apply.py
@@ -317,3 +317,14 @@ def test_apply_binary() -> None:
             "aaaaaaaaaaaaaaaaaaaaaaaa",
         ]
     }
+
+
+def test_apply_no_dtype_set_8531() -> None:
+    assert (
+        pl.DataFrame({"a": [1]})
+        .with_columns(
+            pl.col("a").map(lambda x: x * 2).shift_and_fill(fill_value=0, periods=0)
+        )
+        .item()
+        == 2
+    )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -586,13 +586,3 @@ def test_no_sorted_warning(capfd: typing.Any) -> None:
     df.groupby_dynamic("dt", every="1h").agg(pl.all().count().suffix("_foo"))
     (_, err) = capfd.readouterr()
     assert "argument in operation 'groupby_dynamic' is not explicitly sorted" in err
-
-
-def test_dtype_not_set() -> None:
-    df = pl.DataFrame({"a": [1]})
-    with pytest.raises(
-        pl.InvalidOperationError,
-    ):
-        df.with_columns(
-            pl.col("a").map(lambda x: x * 2).shift_and_fill(fill_value=0, periods=0)
-        )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -586,3 +586,13 @@ def test_no_sorted_warning(capfd: typing.Any) -> None:
     df.groupby_dynamic("dt", every="1h").agg(pl.all().count().suffix("_foo"))
     (_, err) = capfd.readouterr()
     assert "argument in operation 'groupby_dynamic' is not explicitly sorted" in err
+
+
+def test_dtype_not_set() -> None:
+    df = pl.DataFrame({"a": [1]})
+    with pytest.raises(
+        pl.InvalidOperationError,
+    ):
+        df.with_columns(
+            pl.col("a").map(lambda x: x * 2).shift_and_fill(fill_value=0, periods=0)
+        )


### PR DESCRIPTION
fixes #8531 