### PR TITLE
fix(python): fix testing asserts for `NaN` values in nested lists

### DIFF
--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -81,6 +81,12 @@ def test_compare_series_nans_assert_equal() -> None:
         assert_series_equal(srs5, srs6, check_dtype=False)
     assert_series_not_equal(srs5, srs6, check_dtype=True)
 
+    # nested
+    for float_type in (pl.Float32, pl.Float64):
+        srs = pl.Series([[0.0, nan]], dtype=pl.List(float_type))
+        assert srs.dtype == pl.List(float_type)
+        assert_series_equal(srs, srs)
+
 
 def test_compare_series_nulls() -> None:
     srs1 = pl.Series([1, 2, None])


### PR DESCRIPTION
The new parametric testing `List` strategy found an oversight in the polars testing asserts (thanks for the [heads-up](https://github.com/pola-rs/polars/issues/8138#issuecomment-1518394790), @danielgafni). Nested `NaN` values didn't respect the `nans_compare_equal` parameter.

**Example:**
```python
from polars.testing import assert_series_equal 
import polars as pl

s = pl.Series( [[0.0, float('nan')]] ) 
assert_series_equal( s, s )

# AssertionError: Series are different.
```
This PR solves the issue for nested `List` data - a follow-up will be required for `Struct`, which is a bit more involved.