### PR TITLE
docs(python): note sortedness of results from groupby ops

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4640,7 +4640,8 @@ class DataFrame:
         -------
         RollingGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column`.
+            of which will be sorted by `index_column` (as well as by the
+            `by` columns, if passed).
 
         See Also
         --------
@@ -4783,7 +4784,8 @@ class DataFrame:
         -------
         DynamicGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column`.
+            of which will be sorted by `index_column` (as well as by the
+            `by` columns, if passed).
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4640,8 +4640,8 @@ class DataFrame:
         -------
         RollingGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column` (as well as by the
-            `by` columns, if passed).
+            of which will be sorted by `index_column` (but note that if `by` columns are
+            passed, it will only be sorted within each `by` group).
 
         See Also
         --------
@@ -4784,8 +4784,8 @@ class DataFrame:
         -------
         DynamicGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column` (as well as by the
-            `by` columns, if passed).
+            of which will be sorted by `index_column` (but note that if `by` columns are
+            passed, it will only be sorted within each `by` group).
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4636,6 +4636,12 @@ class DataFrame:
         by
             Also group by this column/these columns
 
+        Returns
+        -------
+        RollingGroupBy
+            Object you can call ``.agg`` on to aggregate by groups, the result
+            of which will be sorted by `index_column`.
+
         See Also
         --------
         groupby_dynamic
@@ -4772,6 +4778,12 @@ class DataFrame:
             - 'window': Truncate the start of the window with the 'every' argument.
             - 'datapoint': Start from the first encountered data point.
             - 'monday': Start the window on the monday before the first data point.
+
+        Returns
+        -------
+        DynamicGroupBy
+            Object you can call ``.agg`` on to aggregate by groups, the result
+            of which will be sorted by `index_column`.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2324,8 +2324,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         -------
         LazyGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column` (as well as by the
-            `by` columns, if passed).
+            of which will be sorted by `index_column` (but note that if `by` columns are
+            passed, it will only be sorted within each `by` group).
 
         See Also
         --------
@@ -2483,8 +2483,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         -------
         LazyGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column` (as well as by the
-            `by` columns, if passed).
+            of which will be sorted by `index_column` (but note that if `by` columns are
+            passed, it will only be sorted within each `by` group).
 
         See Also
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2324,7 +2324,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         -------
         LazyGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column`.
+            of which will be sorted by `index_column` (as well as by the
+            `by` columns, if passed).
 
         See Also
         --------
@@ -2482,7 +2483,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         -------
         LazyGroupBy
             Object you can call ``.agg`` on to aggregate by groups, the result
-            of which will be sorted by `index_column`.
+            of which will be sorted by `index_column` (as well as by the
+            `by` columns, if passed).
 
         See Also
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2320,6 +2320,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         by
             Also group by this column/these columns
 
+        Returns
+        -------
+        LazyGroupBy
+            Object you can call ``.agg`` on to aggregate by groups, the result
+            of which will be sorted by `index_column`.
+
         See Also
         --------
         groupby_dynamic
@@ -2471,6 +2477,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * 'window': Truncate the start of the window with the 'every' argument.
             * 'datapoint': Start from the first encountered data point.
             * 'monday': Start the window on the monday before the first data point.
+
+        Returns
+        -------
+        LazyGroupBy
+            Object you can call ``.agg`` on to aggregate by groups, the result
+            of which will be sorted by `index_column`.
 
         See Also
         --------


### PR DESCRIPTION
The results of these ops are guaranteed to be sorted by `index_column`, right? Would be good to document it if so?