### PR TITLE
fix(python): testing asserts handle `NaN` values at any level of nesting in arbitrary `Struct` cols

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8172,7 +8172,7 @@ class DataFrame:
                 # note: 'ns' precision instantiates values as pandas types - avoid
                 and not any(
                     (getattr(tp, "time_unit", None) == "ns")
-                    for tp in unpack_dtypes(self.dtypes)
+                    for tp in unpack_dtypes(*self.dtypes)
                 )
             )
             for offset in range(0, self.height, buffer_size):

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -326,49 +326,38 @@ def _assert_series_inner(
     if check_dtype and left.dtype != right.dtype:
         raise_assert_detail("Series", "Dtype mismatch", left.dtype, right.dtype)
 
-    # confirm that we can call 'is_nan' on both sides
-    comparing_float_dtypes = left.dtype in FLOAT_DTYPES and right.dtype in FLOAT_DTYPES
-
     # create mask of which (if any) values are unequal
     unequal = left != right
+
+    # handle NaN values (which compare unequal to themselves)
+    comparing_float_dtypes = left.dtype in FLOAT_DTYPES and right.dtype in FLOAT_DTYPES
     if unequal.any() and nans_compare_equal:
-        # handle NaN values (which compare unequal to themselves)
+        # when both dtypes are scalar floats
         if comparing_float_dtypes:
             unequal = unequal & ~(
                 (left.is_nan() & right.is_nan()).fill_null(F.lit(False))
             )
 
-        # for nested lists that contain float elements, we compare left/right inner
-        # series values using the same _assert_series_inner call; this handles NaN
-        # value comparison at any level of nesting...
-        elif left.dtype == right.dtype == List:
-            left_right_dtypes = (left.dtype, right.dtype)
-            if any(tp in FLOAT_DTYPES for tp in unpack_dtypes(left_right_dtypes)):
-                for s1, s2 in zip(left.filter(unequal), right.filter(unequal)):
-                    if len(s1) != len(s2):
-                        raise_assert_detail(
-                            "Series", "Element length mismatch", len(s1), len(s2)
-                        )
-                    _assert_series_inner(
-                        s1,
-                        s2,
-                        check_dtype=check_dtype,
-                        check_exact=check_exact,
-                        nans_compare_equal=nans_compare_equal,
-                        atol=atol,
-                        rtol=rtol,
-                    )
-                unequal = Series("unequal", [False])
-
-        # TODO: handle NaN values nested inside arbitrary Structs
-        elif left.dtype == right.dtype == Struct:
-            ...
+        # account for float values in nested dtypes
+        elif left.dtype.is_nested or right.dtype.is_nested:
+            if _assert_series_nested_nans_equal(
+                left=left.filter(unequal),
+                right=right.filter(unequal),
+                check_dtype=check_dtype,
+                check_exact=check_exact,
+                atol=atol,
+                rtol=rtol,
+            ):
+                return
 
     # assert exact, or with tolerance
     if unequal.any():
         if check_exact:
             raise_assert_detail(
-                "Series", "Exact value mismatch", left=list(left), right=list(right)
+                "Series",
+                "Exact value mismatch",
+                left=list(left),
+                right=list(right),
             )
         else:
             # apply check with tolerance (to the known-unequal matches).
@@ -401,6 +390,71 @@ def _assert_series_inner(
                     left=list(left),
                     right=list(right),
                 )
+
+
+def _assert_series_nested_nans_equal(
+    left: Series,
+    right: Series,
+    check_dtype: bool,
+    check_exact: bool,
+    atol: float,
+    rtol: float,
+) -> bool:
+    # check that float values exist at _some_ level of nesting
+    if not any(tp in FLOAT_DTYPES for tp in unpack_dtypes(left.dtype, right.dtype)):
+        return False
+
+    # compare nested lists element-wise
+    elif left.dtype == List == right.dtype:
+        for s1, s2 in zip(left, right):
+            if s1 is None and s2 is None:
+                continue
+            elif (s1 is None and s2 is not None) or (s2 is None and s1 is not None):
+                raise_assert_detail("Series", "Nested value mismatch", s1, s2)
+            elif len(s1) != len(s2):
+                raise_assert_detail(
+                    "Series", "Nested list length mismatch", len(s1), len(s2)
+                )
+            _assert_series_inner(
+                s1,
+                s2,
+                check_dtype=check_dtype,
+                check_exact=check_exact,
+                nans_compare_equal=True,
+                atol=atol,
+                rtol=rtol,
+            )
+        return True
+
+    # unnest structs as series and compare
+    elif left.dtype == Struct == right.dtype:
+        ls, rs = left.struct.unnest(), right.struct.unnest()
+        if len(ls.columns) != len(rs.columns):
+            raise_assert_detail(
+                "Series",
+                "Nested struct fields mismatch",
+                len(ls.columns),
+                len(rs.columns),
+            )
+        elif len(ls) != len(rs):
+            raise_assert_detail(
+                "Series", "Nested struct length mismatch", len(ls), len(rs)
+            )
+        for s1, s2 in zip(ls, rs):
+            _assert_series_inner(
+                s1,
+                s2,
+                check_dtype=check_dtype,
+                check_exact=check_exact,
+                nans_compare_equal=True,
+                atol=atol,
+                rtol=rtol,
+            )
+        return True
+    else:
+        # fall-back to outer codepath (if mismatched dtypes we would expect
+        # the equality check to fail - unless ALL series values are null)
+        return False
 
 
 def raise_assert_detail(

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -9,6 +9,7 @@ import polars as pl
 from polars.exceptions import InvalidAssert
 from polars.testing import (
     assert_frame_equal,
+    assert_frame_not_equal,
     assert_series_equal,
     assert_series_not_equal,
 )
@@ -95,6 +96,7 @@ def test_compare_series_nulls() -> None:
 
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.Series([1, None, None])
+    assert_series_not_equal(srs1, srs2)
 
     with pytest.raises(AssertionError, match="Value mismatch"):
         assert_series_equal(srs1, srs2)
@@ -130,6 +132,8 @@ def test_series_cmp_fast_paths() -> None:
 def test_compare_series_value_mismatch_string() -> None:
     srs1 = pl.Series(["hello", "no"])
     srs2 = pl.Series(["hello", "yes"])
+
+    assert_series_not_equal(srs1, srs2)
     with pytest.raises(
         AssertionError, match="Series are different.\n\nExact value mismatch"
     ):
@@ -139,12 +143,14 @@ def test_compare_series_value_mismatch_string() -> None:
 def test_compare_series_type_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
     srs2 = pl.DataFrame({"col1": [2, 3, 4]})
+
     with pytest.raises(
         AssertionError, match="Inputs are different.\n\nUnexpected input types"
     ):
         assert_series_equal(srs1, srs2)  # type: ignore[arg-type]
 
     srs3 = pl.Series([1.0, 2.0, 3.0])
+    assert_series_not_equal(srs1, srs3)
     with pytest.raises(AssertionError, match="Series are different.\n\nDtype mismatch"):
         assert_series_equal(srs1, srs3)
 
@@ -159,6 +165,8 @@ def test_compare_series_name_mismatch() -> None:
 def test_compare_series_shape_mismatch() -> None:
     srs1 = pl.Series(values=[1, 2, 3, 4], name="srs1")
     srs2 = pl.Series(values=[1, 2, 3], name="srs2")
+
+    assert_series_not_equal(srs1, srs2)
     with pytest.raises(
         AssertionError, match="Series are different.\n\nLength mismatch"
     ):
@@ -175,9 +183,7 @@ def test_compare_series_value_exact_mismatch() -> None:
 
 
 def test_compare_frame_equal_nans() -> None:
-    # NaN values do not _compare_ equal, but should _assert_ as equal here
     nan = float("NaN")
-
     df1 = pl.DataFrame(
         data={"x": [1.0, nan], "y": [nan, 2.0]},
         schema=[("x", pl.Float32), ("y", pl.Float64)],
@@ -188,8 +194,77 @@ def test_compare_frame_equal_nans() -> None:
         data={"x": [1.0, nan], "y": [None, 2.0]},
         schema=[("x", pl.Float32), ("y", pl.Float64)],
     )
+    assert_frame_not_equal(df1, df2)
     with pytest.raises(AssertionError, match="Values for column 'y' are different"):
         assert_frame_equal(df1, df2, check_exact=True)
+
+
+def test_compare_frame_equal_nested_nans() -> None:
+    nan = float("NaN")
+
+    # list dtype
+    df1 = pl.DataFrame(
+        data={"x": [[1.0, nan]], "y": [[nan, 2.0]]},
+        schema=[("x", pl.List(pl.Float32)), ("y", pl.List(pl.Float64))],
+    )
+    assert_frame_equal(df1, df1, check_exact=True)
+
+    df2 = pl.DataFrame(
+        data={"x": [[1.0, nan]], "y": [[None, 2.0]]},
+        schema=[("x", pl.List(pl.Float32)), ("y", pl.List(pl.Float64))],
+    )
+    assert_frame_not_equal(df1, df2)
+    with pytest.raises(AssertionError, match="Values for column 'y' are different"):
+        assert_frame_equal(df1, df2, check_exact=True)
+
+    # struct dtype
+    df3 = pl.from_dicts(
+        [
+            {
+                "id": 1,
+                "struct": [
+                    {"x": "text", "y": [0.0, nan]},
+                    {"x": "text", "y": [0.0, nan]},
+                ],
+            },
+            {
+                "id": 2,
+                "struct": [
+                    {"x": "text", "y": [1]},
+                    {"x": "text", "y": [1]},
+                ],
+            },
+        ]
+    )
+    df4 = pl.from_dicts(
+        [
+            {
+                "id": 1,
+                "struct": [
+                    {"x": "text", "y": [0.0, nan], "z": ["$"]},
+                    {"x": "text", "y": [0.0, nan], "z": ["$"]},
+                ],
+            },
+            {
+                "id": 2,
+                "struct": [
+                    {"x": "text", "y": [nan, 1], "z": ["!"]},
+                    {"x": "text", "y": [nan, 1], "z": ["?"]},
+                ],
+            },
+        ]
+    )
+
+    assert_frame_equal(df3, df3)
+    assert_frame_not_equal(df3, df3, nans_compare_equal=False)
+
+    assert_frame_equal(df4, df4)
+    assert_frame_not_equal(df4, df4, nans_compare_equal=False)
+
+    assert_frame_not_equal(df3, df4)
+    for check_dtype in (True, False):
+        with pytest.raises(AssertionError, match="mismatch|different"):
+            assert_frame_equal(df3, df4, check_dtype=check_dtype)
 
 
 def test_assert_frame_equal_pass() -> None:


### PR DESCRIPTION
Building on #8537...

Testing asserts will now handle `NaN` values correctly (ref: `nans_compare_equal` param) at any level of nesting in arbitrary `Struct` dtype columns (in addition to the earlier fix for `List` cols). Refactored the code that handles nested checks so that it's cleaner.