### PR TITLE
feat(python): Add default value for `round`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1572,7 +1572,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.ceil())
 
-    def round(self, decimals: int) -> Self:
+    def round(self, decimals: int = 0) -> Self:
         """
         Round underlying floating point data by `decimals` digits.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3761,7 +3761,7 @@ class Series:
 
         """
 
-    def round(self, decimals: int) -> Series:
+    def round(self, decimals: int = 0) -> Series:
         """
         Round underlying floating point data by `decimals` digits.
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1279,6 +1279,9 @@ def test_round() -> None:
     b = a.round(2)
     assert b.to_list() == [1.00, 2.00]
 
+    b = a.round()
+    assert b.to_list() == [1.0, 2.0]
+
 
 def test_apply_list_out() -> None:
     s = pl.Series("count", [3, 2, 2])


### PR DESCRIPTION
Simple ergonomic change - `Series/Expr.round()` will default to 0 decimals.