### PR TITLE
feat(python): enhance parametric strategy retrieval, enable `List` strategy by default

### DIFF
--- a/py-polars/polars/testing/parametric/__init__.py
+++ b/py-polars/polars/testing/parametric/__init__.py
@@ -11,7 +11,9 @@ if _HYPOTHESIS_AVAILABLE:
     )
     from polars.testing.parametric.profiles import load_profile, set_profile
     from polars.testing.parametric.strategies import (
+        all_strategies,
         create_list_strategy,
+        nested_strategies,
         scalar_strategies,
     )
 else:
@@ -23,11 +25,13 @@ else:
 
 
 __all__ = [
+    "all_strategies",
     "column",
     "columns",
     "create_list_strategy",
     "dataframes",
     "load_profile",
+    "nested_strategies",
     "scalar_strategies",
     "series",
     "set_profile",

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -450,9 +450,8 @@ def sequence_to_pyseries(
             if isinstance(dtype, Object):
                 return PySeries.new_object(name, values, strict)
             if dtype:
-                return sequence_from_anyvalue_or_object(name, values).cast(
-                    dtype, strict=False
-                )
+                srs = sequence_from_anyvalue_or_object(name, values)
+                return srs.cast(dtype, strict=False)
             return sequence_from_anyvalue_or_object(name, values)
 
         elif python_dtype == pli.Series:

--- a/py-polars/tests/parametric/test_dataframe.py
+++ b/py-polars/tests/parametric/test_dataframe.py
@@ -15,7 +15,12 @@ from polars.testing.parametric import column, dataframes
 @settings(max_examples=50)
 def test_repr(df: pl.DataFrame) -> None:
     assert isinstance(repr(df), str)
-    assert_frame_equal(df, df, check_exact=True, nans_compare_equal=True)
+
+
+@given(df=dataframes())
+@settings(max_examples=50)
+def test_equal(df: pl.DataFrame) -> None:
+    assert_frame_equal(df, df, check_exact=True)
 
 
 @given(
@@ -38,7 +43,7 @@ def test_dtype_integer_cols(df: pl.DataFrame) -> None:
         min_size=1,
         min_cols=1,
         null_probability=0.25,
-        excluded_dtypes=[pl.Utf8],
+        excluded_dtypes=[pl.Utf8, pl.List],
     )
 )
 @example(df=pl.DataFrame(schema=["x", "y", "z"]))

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -184,7 +184,9 @@ def test_series_slice(
 
 
 @given(
-    s=series(min_size=1, max_size=10, excluded_dtypes=[pl.Categorical]).filter(
+    s=series(
+        min_size=1, max_size=10, excluded_dtypes=[pl.Categorical, pl.List, pl.Struct]
+    ).filter(
         lambda x: (
             getattr(x.dtype, "time_unit", None) in (None, "us", "ns")
             and (x.dtype != pl.Utf8 or not x.str.contains("\x00").any())


### PR DESCRIPTION
The `List` generation strategy is now improved and enabled by default for parametric data generation of frames/series (where the dtypes are not otherwise constrained[^1]).

Note: automatic `List(Categorical)` generation is disabled, pending https://github.com/pola-rs/polars/issues/8563 fix.

### Example

```python
from polars.testing.parametric import dataframes
frames = dataframes( cols=5 )
```
```python
frames.example()
# shape: (2, 5)
# ┌───────────┬───────┬────────────────┬──────┬────────┐
# │ col0      ┆ col1  ┆ col2           ┆ col3 ┆ col4   │
# │ ---       ┆ ---   ┆ ---            ┆ ---  ┆ ---    │
# │ list[f64] ┆ u32   ┆ list[i8]       ┆ u8   ┆ i16    │
# ╞═══════════╪═══════╪════════════════╪══════╪════════╡
# │ []        ┆ 61152 ┆ []             ┆ 254  ┆ 13515  │
# │ [0.0]     ┆ 30873 ┆ [-107, -21, 0] ┆ 192  ┆ -31349 │
# └───────────┴───────┴────────────────┴──────┴────────┘
```
```python
frames.example()
# shape: (4, 5)
# ┌──────┬──────┬────────────┬──────┬──────────────────────────┐
# │ col0 ┆ col1 ┆ col2       ┆ col3 ┆ col4                     │
# │ ---  ┆ ---  ┆ ---        ┆ ---  ┆ ---                      │
# │ i8   ┆ i8   ┆ date       ┆ i8   ┆ list[date]               │
# ╞══════╪══════╪════════════╪══════╪══════════════════════════╡
# │ -114 ┆ 127  ┆ 1908-08-24 ┆ -67  ┆ [1927-01-23]             │
# │ 114  ┆ -66  ┆ 2230-09-23 ┆ -100 ┆ [2060-08-08, 1897-04-04] │
# │ -33  ┆ 32   ┆ 1946-05-20 ┆ -19  ┆ []                       │
# │ -8   ┆ 10   ┆ 2177-01-01 ┆ -100 ┆ [1709-09-16, 2234-06-18] │
# └──────┴──────┴────────────┴──────┴──────────────────────────┘
```

[^1]: Omitting nested (or any other) dtypes is trivial: 
`dataframes( cols=5, excluded_dtypes=[pl.List] )`