### PR TITLE
feat(rust,python): Add `to_date`, `to_datetime`, `to_time` to String namespace

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -499,8 +499,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                 map!(strings::rjust, width, fillchar)
             }
             #[cfg(feature = "temporal")]
-            Strptime(options) => {
-                map!(strings::strptime, &options)
+            Strptime(dtype, options) => {
+                map!(strings::strptime, dtype.clone(), &options)
             }
             #[cfg(feature = "concat_str")]
             ConcatVertical(delimiter) => map!(strings::concat, &delimiter),

--- a/polars/polars-lazy/polars-plan/src/dsl/options.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/options.rs
@@ -1,15 +1,12 @@
 use std::borrow::Cow;
 
-use polars_core::datatypes::DataType;
-use polars_core::prelude::{JoinType, TimeUnit};
+use polars_core::prelude::JoinType;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct StrpTimeOptions {
-    /// DataType to parse in. One of {Date, Datetime}
-    pub date_dtype: DataType,
+pub struct StrptimeOptions {
     /// Formatting string
     pub format: Option<String>,
     /// If set then polars will return an error if any date parsing fails
@@ -25,10 +22,9 @@ pub struct StrpTimeOptions {
     pub utc: bool,
 }
 
-impl Default for StrpTimeOptions {
+impl Default for StrptimeOptions {
     fn default() -> Self {
-        StrpTimeOptions {
-            date_dtype: DataType::Datetime(TimeUnit::Microseconds, None),
+        StrptimeOptions {
             format: None,
             strict: false,
             exact: false,

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -101,10 +101,53 @@ impl StringNameSpace {
         self.0.map_private(StringFunction::CountMatch(pat).into())
     }
 
-    /// Construct a `Datetime` column by parsing this string column as datetimes, using the provided `options`.
+    /// Convert a Utf8 column into a Date/Datetime/Time column.
     #[cfg(feature = "temporal")]
-    pub fn strptime(self, options: StrpTimeOptions) -> Expr {
-        self.0.map_private(StringFunction::Strptime(options).into())
+    pub fn strptime(self, dtype: DataType, options: StrptimeOptions) -> Expr {
+        self.0
+            .map_private(StringFunction::Strptime(dtype, options).into())
+    }
+
+    /// Convert a Utf8 column into a Date column.
+    #[cfg(feature = "dtype-date")]
+    pub fn to_date(self, options: StrptimeOptions) -> Expr {
+        self.strptime(DataType::Date, options)
+    }
+
+    /// Convert a Utf8 column into a Datetime column.
+    #[cfg(feature = "dtype-datetime")]
+    pub fn to_datetime(
+        self,
+        time_unit: Option<TimeUnit>,
+        time_zone: Option<TimeZone>,
+        options: StrptimeOptions,
+    ) -> Expr {
+        // If time_unit is None, try to infer it from the format or set a default
+        let time_unit = match (&options.format, time_unit) {
+            (_, Some(time_unit)) => time_unit,
+            (Some(format), None) => {
+                if format.contains("%.9f")
+                    || format.contains("%9f")
+                    || format.contains("%f")
+                    || format.contains("%.f")
+                {
+                    TimeUnit::Nanoseconds
+                } else if format.contains("%.3f") || format.contains("%3f") {
+                    TimeUnit::Milliseconds
+                } else {
+                    TimeUnit::Microseconds
+                }
+            }
+            (None, None) => TimeUnit::Microseconds,
+        };
+
+        self.strptime(DataType::Datetime(time_unit, time_zone), options)
+    }
+
+    /// Convert a Utf8 column into a Time column.
+    #[cfg(feature = "dtype-time")]
+    pub fn to_time(self, options: StrptimeOptions) -> Expr {
+        self.strptime(DataType::Time, options)
     }
 
     /// Concat the values into a string array.

--- a/polars/polars-lazy/src/tests/logical.rs
+++ b/polars/polars-lazy/src/tests/logical.rs
@@ -12,8 +12,7 @@ fn test_duration() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .with_columns(&[col("date").str().strptime(StrpTimeOptions {
-            date_dtype: DataType::Date,
+        .with_columns(&[col("date").str().to_date(StrptimeOptions {
             ..Default::default()
         })])
         .with_column(

--- a/polars/polars-lazy/src/tests/predicate_queries.rs
+++ b/polars/polars-lazy/src/tests/predicate_queries.rs
@@ -126,8 +126,7 @@ fn test_strptime_block_predicate() -> PolarsResult<()> {
 
     let q = df
         .lazy()
-        .with_column(col("date").str().strptime(StrpTimeOptions {
-            date_dtype: DataType::Date,
+        .with_column(col("date").str().to_date(StrptimeOptions {
             ..Default::default()
         }))
         .filter(

--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -35,7 +35,10 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.starts_with
     Expr.str.strip
     Expr.str.strptime
+    Expr.str.to_date
+    Expr.str.to_datetime
     Expr.str.to_lowercase
+    Expr.str.to_time
     Expr.str.to_uppercase
     Expr.str.zfill
     Expr.str.parse_int

--- a/py-polars/docs/source/reference/series/string.rst
+++ b/py-polars/docs/source/reference/series/string.rst
@@ -35,7 +35,10 @@ The following methods are available under the `Series.str` attribute.
     Series.str.starts_with
     Series.str.strip
     Series.str.strptime
+    Series.str.to_date
+    Series.str.to_datetime
     Series.str.to_lowercase
+    Series.str.to_time
     Series.str.to_uppercase
     Series.str.zfill
     Series.str.parse_int

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -12,7 +12,12 @@ if TYPE_CHECKING:
     from polars.expr import Expr
     from polars.polars import PySeries
     from polars.series import Series
-    from polars.type_aliases import PolarsDataType, PolarsTemporalType, TransferEncoding
+    from polars.type_aliases import (
+        PolarsDataType,
+        PolarsTemporalType,
+        TimeUnit,
+        TransferEncoding,
+    )
     from polars.utils import NoDefault
 
 
@@ -25,6 +30,134 @@ class StringNameSpace:
     def __init__(self, series: Series):
         self._s: PySeries = series._s
 
+    def to_date(
+        self,
+        format: str | None = None,
+        *,
+        strict: bool = True,
+        exact: bool = True,
+        cache: bool = True,
+    ) -> Series:
+        """
+        Convert a Utf8 column into a Date column.
+
+        Parameters
+        ----------
+        format
+            Format to use for conversion. Refer to the `chrono crate documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for the full specification. Example: ``"%Y-%m-%d"``.
+            If set to None (default), the format is inferred from the data.
+        strict
+            Raise an error if any conversion fails.
+        exact
+            Require an exact format match. If False, allow the format to match anywhere
+            in the target string.
+        cache
+            Use a cache of unique, converted dates to apply the conversion.
+
+        Examples
+        --------
+        >>> s = pl.Series(["2020/01/01", "2020/02/01", "2020/03/01"])
+        >>> s.str.to_date()
+        shape: (3,)
+        Series: '' [date]
+        [
+                2020-01-01
+                2020-02-01
+                2020-03-01
+        ]
+
+        """
+
+    def to_datetime(
+        self,
+        format: str | None = None,
+        *,
+        time_unit: TimeUnit | None = None,
+        time_zone: str | None = None,
+        strict: bool = True,
+        exact: bool = True,
+        cache: bool = True,
+        utc: bool = False,
+    ) -> Series:
+        """
+        Convert a Utf8 column into a Datetime column.
+
+        Parameters
+        ----------
+        format
+            Format to use for conversion. Refer to the `chrono crate documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for the full specification. Example: ``"%Y-%m-%d %H:%M:%S"``.
+            If set to None (default), the format is inferred from the data.
+        time_unit : {None, 'us', 'ns', 'ms'}
+            Unit of time for the resulting Datetime column. If set to None (default),
+            the time unit is inferred from the format string if given, eg:
+            ``"%F %T%.3f"`` => ``Datetime("ms")``. If no fractional second component is
+            found, the default is ``"us"``.
+        time_zone
+            Time zone for the resulting Datetime column.
+        strict
+            Raise an error if any conversion fails.
+        exact
+            Require an exact format match. If False, allow the format to match anywhere
+            in the target string.
+        cache
+            Use a cache of unique, converted datetimes to apply the conversion.
+        utc
+            Parse time zone aware datetimes as UTC. This may be useful if you have data
+            with mixed offsets.
+
+        Examples
+        --------
+        >>> s = pl.Series(["2020-01-01 01:00Z", "2020-01-01 02:00Z"])
+        >>> s.str.to_datetime("%Y-%m-%d %H:%M%#z")
+        shape: (2,)
+        Series: '' [datetime[μs, +00:00]]
+        [
+                2020-01-01 01:00:00 +00:00
+                2020-01-01 02:00:00 +00:00
+        ]
+
+        """
+
+    def to_time(
+        self,
+        format: str | None = None,
+        *,
+        strict: bool = True,
+        cache: bool = True,
+    ) -> Series:
+        """
+        Convert a Utf8 column into a Time column.
+
+        Parameters
+        ----------
+        format
+            Format to use for conversion. Refer to the `chrono crate documentation
+            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+            for the full specification. Example: ``"%H:%M:%S"``.
+            If set to None (default), the format is inferred from the data.
+        strict
+            Raise an error if any conversion fails.
+        cache
+            Use a cache of unique, converted times to apply the conversion.
+
+        Examples
+        --------
+        >>> s = pl.Series(["01:00", "02:00", "03:00"])
+        >>> s.str.to_time("%H:%M")
+        shape: (3,)
+        Series: '' [time]
+        [
+                01:00:00
+                02:00:00
+                03:00:00
+        ]
+
+        """
+
     @deprecated_alias(datatype="dtype", fmt="format")
     def strptime(
         self,
@@ -34,49 +167,51 @@ class StringNameSpace:
         strict: bool = True,
         exact: bool = True,
         cache: bool = True,
-        tz_aware: bool | NoDefault = no_default,
         utc: bool = False,
+        tz_aware: bool | NoDefault = no_default,
     ) -> Series:
         """
-        Parse a Series of dtype Utf8 to a Date/Datetime Series.
+        Convert a Utf8 column into a Date/Datetime/Time column.
 
         Parameters
         ----------
         dtype
-            Date, Datetime or Time.
+            The data type to convert to. Can be either Date, Datetime, or Time.
         format
-            Format to use, refer to the
-            `chrono strftime documentation
+            Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
-            for specification. Example: ``"%y-%m-%d"``.
+            for the full specification. Example: ``"%Y-%m-%d %H:%M:%S"``.
+            If set to None (default), the format is inferred from the data.
         strict
             Raise an error if any conversion fails.
         exact
-            - If True, require an exact format match.
-            - If False, allow the format to match anywhere in the target string.
+            Require an exact format match. If False, allow the format to match anywhere
+            in the target string. Conversion to the Time type is always exact.
         cache
             Use a cache of unique, converted dates to apply the datetime conversion.
+        utc
+            Parse time zone aware datetimes as UTC. This may be useful if you have data
+            with mixed offsets.
         tz_aware
-            Parse timezone aware datetimes. This may be automatically toggled by the
-            `fmt` given.
+            Parse time zone aware datetimes. This may be automatically toggled by the
+            `format` given.
 
             .. deprecated:: 0.16.17
-                This is now auto-inferred from the given `fmt`. You can safely drop
+                This is now auto-inferred from the given `format`. You can safely drop
                 this argument, it will be removed in a future version.
-        utc
-            Parse timezone aware datetimes as UTC. This may be useful if you have data
-            with mixed offsets.
 
-        Returns
-        -------
-        A Date / Datetime / Time Series
+        Notes
+        -----
+        When converting to a Datetime type, the time unit is inferred from the format
+        string if given, eg: ``"%F %T%.3f"`` => ``Datetime("ms")``. If no fractional
+        second component is found, the default is ``"us"``.
 
         Examples
         --------
         Dealing with a consistent format:
 
-        >>> ts = ["2020-01-01 01:00Z", "2020-01-01 02:00Z"]
-        >>> pl.Series(ts).str.strptime(pl.Datetime, "%Y-%m-%d %H:%M%#z")
+        >>> s = pl.Series(["2020-01-01 01:00Z", "2020-01-01 02:00Z"])
+        >>> s.str.strptime(pl.Datetime, "%Y-%m-%d %H:%M%#z")
         shape: (2,)
         Series: '' [datetime[μs, +00:00]]
         [
@@ -95,28 +230,22 @@ class StringNameSpace:
         ...         "Sun Jul  8 00:34:60 2001",
         ...     ],
         ... )
-        >>> (
-        ...     s.to_frame().with_columns(
-        ...         pl.col("date")
-        ...         .str.strptime(pl.Date, "%F", strict=False)
-        ...         .fill_null(
-        ...             pl.col("date").str.strptime(pl.Date, "%F %T", strict=False)
-        ...         )
-        ...         .fill_null(pl.col("date").str.strptime(pl.Date, "%D", strict=False))
-        ...         .fill_null(pl.col("date").str.strptime(pl.Date, "%c", strict=False))
+        >>> s.to_frame().select(
+        ...     pl.coalesce(
+        ...         pl.col("date").str.strptime(pl.Date, "%F", strict=False),
+        ...         pl.col("date").str.strptime(pl.Date, "%F %T", strict=False),
+        ...         pl.col("date").str.strptime(pl.Date, "%D", strict=False),
+        ...         pl.col("date").str.strptime(pl.Date, "%c", strict=False),
         ...     )
-        ... )
-        shape: (4, 1)
-        ┌────────────┐
-        │ date       │
-        │ ---        │
-        │ date       │
-        ╞════════════╡
-        │ 2021-04-22 │
-        │ 2022-01-04 │
-        │ 2022-01-31 │
-        │ 2001-07-08 │
-        └────────────┘
+        ... ).to_series()
+        shape: (4,)
+        Series: 'date' [date]
+        [
+                2021-04-22
+                2022-01-04
+                2022-01-31
+                2001-07-08
+        ]
 
         """
         s = wrap_s(self._s)
@@ -129,8 +258,8 @@ class StringNameSpace:
                     strict=strict,
                     exact=exact,
                     cache=cache,
-                    tz_aware=tz_aware,
                     utc=utc,
+                    tz_aware=tz_aware,
                 )
             )
             .to_series()

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -44,19 +44,19 @@ def test_str_strptime() -> None:
 
 def test_date_parse_omit_day() -> None:
     df = pl.DataFrame({"month": ["2022-01"]})
+    assert df.select(pl.col("month").str.to_date(format="%Y-%m")).item() == date(
+        2022, 1, 1
+    )
     assert df.select(
-        pl.col("month").str.strptime(pl.Date, format="%Y-%m")
-    ).item() == date(2022, 1, 1)
-    assert df.select(
-        pl.col("month").str.strptime(pl.Datetime, format="%Y-%m")
+        pl.col("month").str.to_datetime(format="%Y-%m")
     ).item() == datetime(2022, 1, 1)
 
 
-def test_strptime_precision() -> None:
+def test_to_datetime_precision() -> None:
     s = pl.Series(
         "date", ["2022-09-12 21:54:36.789321456", "2022-09-13 12:34:56.987456321"]
     )
-    ds = s.str.strptime(pl.Datetime)
+    ds = s.str.to_datetime()
     assert ds.cast(pl.Date) != None  # noqa: E711  (note: *deliberately* testing "!=")
     assert getattr(ds.dtype, "time_unit", None) == "us"
 
@@ -71,32 +71,28 @@ def test_strptime_precision() -> None:
             [789321456, 987456321],
         ),
     )
-    for precision, suffix, expected_values in test_data:
-        ds = s.str.strptime(pl.Datetime(precision), f"%Y-%m-%d %H:%M:%S{suffix}")
-        assert getattr(ds.dtype, "time_unit", None) == precision
+    for time_unit, suffix, expected_values in test_data:
+        ds = s.str.to_datetime(f"%Y-%m-%d %H:%M:%S{suffix}", time_unit=time_unit)
+        assert getattr(ds.dtype, "time_unit", None) == time_unit
         assert ds.dt.nanosecond().to_list() == expected_values
 
 
 @pytest.mark.parametrize(
-    ("unit", "expected"),
+    ("time_unit", "expected"),
     [("ms", "123000000"), ("us", "123456000"), ("ns", "123456789")],
 )
 @pytest.mark.parametrize("format", ["%Y-%m-%d %H:%M:%S%.f", None])
-def test_strptime_precision_with_time_unit(
-    unit: TimeUnit, expected: str, format: str
+def test_to_datetime_precision_with_time_unit(
+    time_unit: TimeUnit, expected: str, format: str
 ) -> None:
-    ser = pl.Series(["2020-01-01 00:00:00.123456789"])
-    result = ser.str.strptime(pl.Datetime(unit), format=format).dt.strftime("%f")[0]
+    s = pl.Series(["2020-01-01 00:00:00.123456789"])
+    result = s.str.to_datetime(format, time_unit=time_unit).dt.strftime("%f")[0]
     assert result == expected
 
 
 @pytest.mark.parametrize("fmt", ["%Y-%m-%dT%H:%M:%S", None])
 def test_utc_with_tz_naive(fmt: str | None) -> None:
-    result = (
-        pl.Series(["2020-01-01T00:00:00"])
-        .str.strptime(pl.Datetime, fmt, utc=True)
-        .item()
-    )
+    result = pl.Series(["2020-01-01T00:00:00"]).str.to_datetime(fmt, utc=True).item()
     expected = datetime(2020, 1, 1, tzinfo=timezone.utc)
     assert result == expected
 
@@ -116,9 +112,7 @@ def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
         }
     )
     assert times.with_columns(
-        pl.col("delivery_datetime").str.strptime(
-            pl.Datetime, format="%Y-%m-%d %H:%M:%S%z"
-        )
+        pl.col("delivery_datetime").str.to_datetime(format="%Y-%m-%d %H:%M:%S%z")
     ).to_dict(False) == {
         "delivery_datetime": [
             datetime(2021, 12, 5, 6, 0, tzinfo=timezone(timedelta)),
@@ -128,15 +122,15 @@ def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
     }
 
 
-def test_non_exact_strptime() -> None:
+def test_to_date_non_exact_strptime() -> None:
     s = pl.Series("a", ["2022-01-16", "2022-01-17", "foo2022-01-18", "b2022-01-19ar"])
-    fmt = "%Y-%m-%d"
+    format = "%Y-%m-%d"
 
-    result = s.str.strptime(pl.Date, fmt, strict=False, exact=True)
+    result = s.str.to_date(format, strict=False, exact=True)
     expected = pl.Series("a", [date(2022, 1, 16), date(2022, 1, 17), None, None])
     assert_series_equal(result, expected)
 
-    result = s.str.strptime(pl.Date, fmt, strict=False, exact=False)
+    result = s.str.to_date(format, strict=False, exact=False)
     expected = pl.Series(
         "a",
         [date(2022, 1, 16), date(2022, 1, 17), date(2022, 1, 18), date(2022, 1, 19)],
@@ -144,12 +138,12 @@ def test_non_exact_strptime() -> None:
     assert_series_equal(result, expected)
 
     with pytest.raises(Exception):
-        s.str.strptime(pl.Date, fmt, strict=True, exact=True)
+        s.str.to_date(format, strict=True, exact=True)
 
 
-def test_strptime_dates_datetimes() -> None:
+def test_to_datetime_dates_datetimes() -> None:
     s = pl.Series("date", ["2021-04-22", "2022-01-04 00:00:00"])
-    assert s.str.strptime(pl.Datetime).to_list() == [
+    assert s.str.to_datetime().to_list() == [
         datetime(2021, 4, 22, 0, 0),
         datetime(2022, 1, 4, 0, 0),
     ]
@@ -198,15 +192,15 @@ def test_strptime_dates_datetimes() -> None:
         ),
     ],
 )
-def test_datetime_strptime_patterns_single(time_string: str, expected: str) -> None:
-    result = pl.Series([time_string]).str.strptime(pl.Datetime).item()
+def test_to_datetime_patterns_single(time_string: str, expected: str) -> None:
+    result = pl.Series([time_string]).str.to_datetime().item()
     assert result == expected
 
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_infer_tz_aware_time_unit(time_unit: TimeUnit) -> None:
-    result = pl.Series(["2020-01-02T04:00:00+02:00"]).str.strptime(
-        pl.Datetime(time_unit)
+    result = pl.Series(["2020-01-02T04:00:00+02:00"]).str.to_datetime(
+        time_unit=time_unit
     )
     assert result.dtype == pl.Datetime(time_unit, "+02:00")
     assert result.item() == datetime(
@@ -216,8 +210,8 @@ def test_infer_tz_aware_time_unit(time_unit: TimeUnit) -> None:
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_infer_tz_aware_with_utc(time_unit: TimeUnit) -> None:
-    result = pl.Series(["2020-01-02T04:00:00+02:00"]).str.strptime(
-        pl.Datetime(time_unit), utc=True
+    result = pl.Series(["2020-01-02T04:00:00+02:00"]).str.to_datetime(
+        time_unit=time_unit, utc=True
     )
     assert result.dtype == pl.Datetime(time_unit, "UTC")
     assert result.item() == datetime(2020, 1, 2, 2, 0, tzinfo=timezone.utc)
@@ -226,13 +220,13 @@ def test_infer_tz_aware_with_utc(time_unit: TimeUnit) -> None:
 def test_infer_tz_aware_raises() -> None:
     msg = "cannot parse tz-aware values with tz-aware dtype - please drop the time zone from the dtype"
     with pytest.raises(ComputeError, match=msg):
-        pl.Series(["2020-01-02T04:00:00+02:00"]).str.strptime(
-            pl.Datetime("us", "Europe/Vienna")
+        pl.Series(["2020-01-02T04:00:00+02:00"]).str.to_datetime(
+            time_unit="us", time_zone="Europe/Vienna"
         )
     msg = "cannot use strptime with both 'utc=True' and tz-aware dtype, please drop time zone from the dtype"
     with pytest.raises(ComputeError, match=msg):
-        pl.Series(["2020-01-02T04:00:00+02:00"]).str.strptime(
-            pl.Datetime("us", "Europe/Vienna"), utc=True
+        pl.Series(["2020-01-02T04:00:00+02:00"]).str.to_datetime(
+            time_unit="us", time_zone="Europe/Vienna", utc=True
         )
 
 
@@ -253,9 +247,7 @@ def test_datetime_strptime_patterns_consistent() -> None:
     ).to_frame()
     s = df.with_columns(
         [
-            pl.col("date")
-            .str.strptime(pl.Datetime, format=None, strict=False)
-            .alias("parsed"),
+            pl.col("date").str.to_datetime(strict=False).alias("parsed"),
         ]
     )["parsed"]
     assert s.null_count() == 1
@@ -279,13 +271,9 @@ def test_datetime_strptime_patterns_inconsistent() -> None:
             "2019-04-18T22:45:55.555123",
         ],
     ).to_frame()
-    s = df.with_columns(
-        [
-            pl.col("date")
-            .str.strptime(pl.Datetime, format=None, strict=False)
-            .alias("parsed"),
-        ]
-    )["parsed"]
+    s = df.with_columns(pl.col("date").str.to_datetime(strict=False).alias("parsed"))[
+        "parsed"
+    ]
     assert s.null_count() == 8
     assert s[0] is not None
 
@@ -316,8 +304,8 @@ def test_parse_negative_dates(
     exp_minute: int,
     exp_second: int,
 ) -> None:
-    ser = pl.Series([ts])
-    result = ser.str.strptime(pl.Datetime("ms"), format=format)
+    s = pl.Series([ts])
+    result = s.str.to_datetime(format, time_unit="ms")
     # Python datetime.datetime doesn't support negative dates, so comparing
     # with `result.item()` directly won't work.
     assert result.dt.year().item() == exp_year
@@ -330,11 +318,11 @@ def test_parse_negative_dates(
 
 def test_short_formats() -> None:
     s = pl.Series(["20202020", "2020"])
-    assert s.str.strptime(pl.Date, "%Y", strict=False).to_list() == [
+    assert s.str.to_date("%Y", strict=False).to_list() == [
         None,
         date(2020, 1, 1),
     ]
-    assert s.str.strptime(pl.Date, "%bar", strict=False).to_list() == [None, None]
+    assert s.str.to_date("%bar", strict=False).to_list() == [None, None]
 
 
 @pytest.mark.parametrize(
@@ -348,7 +336,7 @@ def test_short_formats() -> None:
         ("02/Feb/2020", "%d/%b/%Y", pl.Datetime, datetime(2020, 2, 2, 0, 0)),
     ],
 )
-def test_abbrev_month(
+def test_strptime_abbrev_month(
     time_string: str, fmt: str, datatype: PolarsTemporalType, expected: date
 ) -> None:
     s = pl.Series([time_string])
@@ -357,7 +345,7 @@ def test_abbrev_month(
 
 
 def test_full_month_name() -> None:
-    s = pl.Series(["2022-December-01"]).str.strptime(pl.Datetime, "%Y-%B-%d")
+    s = pl.Series(["2022-December-01"]).str.to_datetime("%Y-%B-%d")
     assert s[0] == datetime(2022, 12, 1)
 
 
@@ -376,30 +364,32 @@ def test_single_digit_month(
 
 
 def test_invalid_date_parsing_4898() -> None:
-    assert pl.Series(["2022-09-18", "2022-09-50"]).str.strptime(
-        pl.Date, "%Y-%m-%d", strict=False
+    assert pl.Series(["2022-09-18", "2022-09-50"]).str.to_date(
+        "%Y-%m-%d", strict=False
     ).to_list() == [date(2022, 9, 18), None]
 
 
 def test_strptime_invalid_timezone() -> None:
-    ts = pl.Series(["2020-01-01 00:00:00+01:00"]).str.strptime(
-        pl.Datetime, "%Y-%m-%d %H:%M:%S%z"
-    )
+    ts = pl.Series(["2020-01-01 00:00:00+01:00"]).str.to_datetime("%Y-%m-%d %H:%M:%S%z")
     with pytest.raises(ComputeError, match=r"unable to parse time zone: 'foo'"):
         ts.dt.replace_time_zone("foo")
 
 
-def test_strptime_ambiguous_or_non_existent() -> None:
+def test_to_datetime_ambiguous_or_non_existent() -> None:
     with pytest.raises(
         ArrowError,
         match="datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
     ):
-        pl.Series(["2021-11-07 01:00"]).str.strptime(pl.Datetime("us", "US/Central"))
+        pl.Series(["2021-11-07 01:00"]).str.to_datetime(
+            time_unit="us", time_zone="US/Central"
+        )
     with pytest.raises(
         ArrowError,
         match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
     ):
-        pl.Series(["2021-03-28 02:30"]).str.strptime(pl.Datetime("us", "Europe/Warsaw"))
+        pl.Series(["2021-03-28 02:30"]).str.to_datetime(
+            time_unit="us", time_zone="Europe/Warsaw"
+        )
 
 
 @pytest.mark.parametrize(
@@ -424,26 +414,26 @@ def test_strptime_ambiguous_or_non_existent() -> None:
         ),
     ],
 )
-def test_tz_aware_strptime(ts: str, fmt: str, expected: datetime) -> None:
-    result = pl.Series([ts]).str.strptime(pl.Datetime, fmt).item()
+def test_to_datetime_tz_aware_strptime(ts: str, fmt: str, expected: datetime) -> None:
+    result = pl.Series([ts]).str.to_datetime(fmt).item()
     assert result == expected
 
 
-@pytest.mark.parametrize("fmt", ["%+", "%Y-%m-%dT%H:%M:%S%z"])
-def test_crossing_dst(fmt: str) -> None:
+@pytest.mark.parametrize("format", ["%+", "%Y-%m-%dT%H:%M:%S%z"])
+def test_crossing_dst(format: str) -> None:
     ts = ["2021-03-27T23:59:59+01:00", "2021-03-28T23:59:59+02:00"]
-    result = pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=True)
+    result = pl.Series(ts).str.to_datetime(format, utc=True)
     assert result[0] == datetime(2021, 3, 27, 22, 59, 59, tzinfo=ZoneInfo(key="UTC"))
     assert result[1] == datetime(2021, 3, 28, 21, 59, 59, tzinfo=ZoneInfo(key="UTC"))
 
 
-@pytest.mark.parametrize("fmt", ["%+", "%Y-%m-%dT%H:%M:%S%z"])
-def test_crossing_dst_tz_aware(fmt: str) -> None:
+@pytest.mark.parametrize("format", ["%+", "%Y-%m-%dT%H:%M:%S%z"])
+def test_crossing_dst_tz_aware(format: str) -> None:
     ts = ["2021-03-27T23:59:59+01:00", "2021-03-28T23:59:59+02:00"]
     with pytest.raises(
         ComputeError, match="^different timezones found during 'strptime' operation"
     ):
-        pl.Series(ts).str.strptime(pl.Datetime, fmt, utc=False)
+        pl.Series(ts).str.to_datetime(format, utc=False)
 
 
 def test_tz_aware_without_fmt() -> None:
@@ -473,7 +463,7 @@ def test_tz_aware_without_fmt() -> None:
 )
 def test_strptime_subseconds_datetime(data: str, format: str, expected: time) -> None:
     s = pl.Series([data])
-    result = s.str.strptime(pl.Datetime, format).item()
+    result = s.str.to_datetime(format).item()
     assert result == expected
 
 
@@ -485,14 +475,14 @@ def test_strptime_subseconds_datetime(data: str, format: str, expected: time) ->
         ("05:10:10.074000", "%H:%M:%S%.3f", time(5, 10, 10, 74000)),
     ],
 )
-def test_strptime_subseconds_time(data: str, format: str, expected: time) -> None:
+def test_to_time_subseconds(data: str, format: str, expected: time) -> None:
     s = pl.Series([data])
-    result = s.str.strptime(pl.Time, format).item()
+    result = s.str.to_time(format).item()
     assert result == expected
 
 
-def test_strptime_format_warning() -> None:
+def test_to_time_format_warning() -> None:
     s = pl.Series(["05:10:10.074000"])
     with pytest.warns(pl.ChronoFormatWarning, match=".%f"):
-        result = s.str.strptime(pl.Time, "%H:%M:%S.%f").item()
+        result = s.str.to_time("%H:%M:%S.%f").item()
     assert result == time(5, 10, 10, 74)


### PR DESCRIPTION
Partially addresses #8215

Changes:
* Add `to_date`, `to_datetime`, `to_time` methods to String namespace.
* Update `strptime` to point to these new methods
* Move dtype out of `StrptimeOptions` - this is now a separate argument.
* Update docstrings, tests, etc.