### PR TITLE
feat(rust): more detailed error message on failure to cast `List` dtype

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -261,7 +261,7 @@ impl ChunkCast for ListChunked {
                 match (self.inner_dtype(), &**child_type) {
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None)) if !matches!(dt, Utf8) => {
-                        polars_bail!(ComputeError: "cannot cast list inner type: '{:?}' to Categorical", dt)
+                        polars_bail!(ComputeError: "cannot cast List inner type: '{:?}' to Categorical", dt)
                     }
                     _ => {
                         // ensure the inner logical type bubbles up
@@ -278,7 +278,13 @@ impl ChunkCast for ListChunked {
                     }
                 }
             }
-            _ => polars_bail!(ComputeError: "cannot cast list type"),
+            _ => {
+                polars_bail!(
+                    ComputeError: "cannot cast List type (inner: '{:?}', to: '{:?}')",
+                    self.inner_dtype(),
+                    data_type,
+                )
+            }
         }
     }
 

--- a/polars/polars-core/src/frame/cross_join.rs
+++ b/polars/polars-core/src/frame/cross_join.rs
@@ -53,7 +53,7 @@ impl DataFrame {
         let Some(total_rows) = n_rows_left.checked_mul(n_rows_right) else {
             polars_bail!(
                 ComputeError: "cross joins would produce more rows than fits into 2^32; \
-                consider comping with polars-big-idx feature, or set 'streaming'"
+                consider compiling with polars-big-idx feature, or set 'streaming'"
             );
         };
         if n_rows_left == 0 || n_rows_right == 0 {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -518,7 +518,7 @@ def test_err_on_time_datetime_cast() -> None:
 def test_invalid_inner_type_cast_list() -> None:
     s = pl.Series([[-1, 1]])
     with pytest.raises(
-        pl.ComputeError, match=r"cannot cast list inner type: 'Int64' to Categorical"
+        pl.ComputeError, match=r"cannot cast List inner type: 'Int64' to Categorical"
     ):
         s.cast(pl.List(pl.Categorical))
 


### PR DESCRIPTION
More detailed error message on failure to cast `List` dtype data.
(Should help track down [this](https://github.com/pola-rs/polars/actions/runs/4835031375/jobs/8616926224?pr=8578)).

**Before:**
```
ComputeError: cannot cast list type
```
**After:**
```
ComputeError: cannot cast List type (inner: 'Null', to: 'Utf8')
```