### PR TITLE
feat(rust): Set `strptime` default `strict/exact=true`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/options.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/options.rs
@@ -26,8 +26,8 @@ impl Default for StrptimeOptions {
     fn default() -> Self {
         StrptimeOptions {
             format: None,
-            strict: false,
-            exact: false,
+            strict: true,
+            exact: true,
             cache: true,
             tz_aware: false,
             utc: false,


### PR DESCRIPTION
This will match the defaults on the Python side. And matches our philosophy of 'blowing up in your face' unless you know what you're doing. Plus I would imagine exact mode is more performant.