### PR TITLE
feat(python): allow mixing string and type selection

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -88,7 +88,11 @@ if TYPE_CHECKING:
 
 
 def col(
-    name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType] | Iterable[str | PolarsDataType],
+    name: str
+    | PolarsDataType
+    | Iterable[str]
+    | Iterable[PolarsDataType]
+    | Iterable[str | PolarsDataType],
     *more_names: str | PolarsDataType,
 ) -> Expr:
     """
@@ -258,10 +262,21 @@ def col(
             return wrap_expr(pycols(names))
         elif builtins.all(is_polars_dtype(item) for item in names):
             return wrap_expr(_dtype_cols(names))
-        elif builtins.all(isinstance(item, str) or is_polars_dtype(item) for item in names):
-            return [wrap_expr(pycol(item)) if isinstance(item, str) else wrap_expr(_dtype_cols([item])) for item in names]
+        elif builtins.all(
+            isinstance(item, str) or is_polars_dtype(item) for item in names
+        ):
+            return [
+                wrap_expr(pycol(item))
+                if isinstance(item, str)
+                else wrap_expr(_dtype_cols([item]))
+                for item in names
+            ]
         else:
-            first_invalid_item = builtins.next(item for item in names if not isinstance(item, str) and not is_polars_dtype(item))
+            first_invalid_item = builtins.next(
+                item
+                for item in names
+                if not isinstance(item, str) and not is_polars_dtype(item)
+            )
             raise TypeError(
                 "Invalid input for `col`. Expected iterable of type `str` or `DataType`,"
                 f" got iterable of type {type(first_invalid_item)!r}"

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -63,6 +63,9 @@ def test_col_select() -> None:
         "hamburger",
         "foo",
     ]
+    # str and Dtype mixture
+    assert df.select(pl.col(["hamburger", pl.Utf8])).columns == ["hamburger", "bar"]
+    assert df.select(pl.col(["^ham.*$", pl.Float64])).columns == ["ham", "hamburger"]
 
 
 def test_horizontal_agg(fruits_cars: pl.DataFrame) -> None:


### PR DESCRIPTION
### Why
Address https://github.com/pola-rs/polars/issues/2261

### What
~~I do not change rust's interface, but only python's.~~ -> https://github.com/pola-rs/polars/pull/8589#discussion_r1181199483

- [ ] modify rust code to allow `Expr` to accept `MixedColumns`
- [ ] modify python code to allow mixing string and type selection