### PR TITLE
perf(rust, python): improve OOC sort performance during partition phase

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/source.rs
@@ -25,7 +25,12 @@ impl SortSource {
         sort_idx: usize,
         descending: bool,
         slice: Option<(i64, usize)>,
+        verbose: bool,
     ) -> Self {
+        if verbose {
+            eprintln!("started sort source phase");
+        }
+
         files.sort_unstable_by_key(|entry| entry.0);
 
         let n_threads = POOL.current_num_threads();


### PR DESCRIPTION
All threads were waiting until the IO-thread was finished. Now we ignore the IO thread and dump thread local.