### PR TITLE
refactor(rust)!: Rename `concat_lst` to `concat_list`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -308,7 +308,7 @@ pub fn format_str<E: AsRef<[Expr]>>(format: &str, args: E) -> PolarsResult<Expr>
 }
 
 /// Concat lists entries.
-pub fn concat_lst<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult<Expr> {
+pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult<Expr> {
     let s: Vec<_> = s.as_ref().iter().map(|e| e.clone().into()).collect();
 
     polars_ensure!(!s.is_empty(), ComputeError: "`concat_list` needs one or more expressions");

--- a/polars/src/docs/lazy.rs
+++ b/polars/src/docs/lazy.rs
@@ -254,7 +254,7 @@
 //!         "b" => [3.0, 5.1, 0.3]
 //!     ]?
 //!     .lazy()
-//!     .select([concat_lst(["col_a", "col_b"]).map(
+//!     .select([concat_list(["col_a", "col_b"]).map(
 //!         |s| {
 //!             let ca = s.struct_()?;
 //!

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -94,7 +94,7 @@ pub fn concat_lf(seq: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyF
 #[pyfunction]
 pub fn concat_list(s: Vec<PyExpr>) -> PyResult<PyExpr> {
     let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-    let expr = dsl::concat_lst(s).map_err(PyPolarsErr::from)?;
+    let expr = dsl::concat_list(s).map_err(PyPolarsErr::from)?;
     Ok(expr.into())
 }
 


### PR DESCRIPTION
Better fits our naming conventions and brings it in line with the Python equivalent.