### PR TITLE
feat(python): add `Expr.meta` namespace `eq` and `ne` methods

### DIFF
--- a/py-polars/docs/source/reference/expressions/meta.rst
+++ b/py-polars/docs/source/reference/expressions/meta.rst
@@ -9,10 +9,11 @@ The following methods are available under the `expr.meta` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.meta.eq
     Expr.meta.has_multiple_outputs
     Expr.meta.is_regex_projection
+    Expr.meta.ne
     Expr.meta.output_name
     Expr.meta.pop
     Expr.meta.root_names
     Expr.meta.undo_aliases
-

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -22,6 +22,32 @@ class ExprMetaNameSpace:
     def __ne__(self, other: ExprMetaNameSpace | Expr) -> bool:  # type: ignore[override]
         return not self == other
 
+    def eq(self, other: ExprMetaNameSpace | Expr) -> bool:
+        """Indicate if this expression is the same as another expression."""
+        return self._pyexpr.meta_eq(other._pyexpr)
+
+    def ne(self, other: ExprMetaNameSpace | Expr) -> bool:
+        """Indicate if this expression is NOT the same as another expression."""
+        return not self.eq(other)
+
+    def has_multiple_outputs(self) -> bool:
+        """Whether this expression expands into multiple expressions."""
+        return self._pyexpr.meta_has_multiple_outputs()
+
+    def is_regex_projection(self) -> bool:
+        """Whether this expression expands to columns that match a regex pattern."""
+        return self._pyexpr.meta_is_regex_projection()
+
+    def output_name(self) -> str:
+        """
+        Get the column name that this expression would produce.
+
+        It may not always be possible to determine the output name, as that can depend
+        on the schema of the context; in that case this will raise ``ComputeError``.
+
+        """
+        return self._pyexpr.meta_output_name()
+
     def pop(self) -> list[Expr]:
         """
         Pop the latest expression and return the input(s) of the popped expression.
@@ -39,25 +65,6 @@ class ExprMetaNameSpace:
         """Get a list with the root column name."""
         return self._pyexpr.meta_root_names()
 
-    def output_name(self) -> str:
-        """
-        Get the column name that this expression would produce.
-
-        It might not always be possible to determine the output name
-        as it might depend on the schema of the context. In that case
-        this will raise a ``pl.ComputeError``.
-
-        """
-        return self._pyexpr.meta_output_name()
-
     def undo_aliases(self) -> Expr:
         """Undo any renaming operation like ``alias`` or ``keep_name``."""
         return wrap_expr(self._pyexpr.meta_undo_aliases())
-
-    def has_multiple_outputs(self) -> bool:
-        """Whether this expression expands into multiple expressions."""
-        return self._pyexpr.meta_has_multiple_outputs()
-
-    def is_regex_projection(self) -> bool:
-        """Whether this expression expands to columns that match a regex pattern."""
-        return self._pyexpr.meta_is_regex_projection()

--- a/py-polars/tests/unit/namespaces/test_meta.py
+++ b/py-polars/tests/unit/namespaces/test_meta.py
@@ -12,6 +12,9 @@ def test_meta_pop_and_cmp() -> None:
     assert first.meta == pl.col("foo")
     assert first.meta != pl.col("bar")
 
+    assert first.meta.eq(pl.col("foo"))
+    assert first.meta.ne(pl.col("bar"))
+
 
 def test_root_and_output_names() -> None:
     e = pl.col("foo") * pl.col("bar")


### PR DESCRIPTION
Improves discoverability, and is consistent with the recently exposed operator-equivalent methods on Expr.

```python
expr = pl.col("xyz") > 2

expr.meta.eq( pl.col("xyz") > 2 )
# True

expr.meta.eq( pl.lit("xyz") > 2 )
# False
```