### PR TITLE
build(python): only require typing-extensions before python3.8

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
-  "typing_extensions >= 4.0.1; python_version < '3.11'",
+  "typing_extensions >= 4.0.1; python_version < '3.8'",
 ]
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [


### PR DESCRIPTION
Imports from typing-extensions is only used within `if TYPE_CHECKING` blocks.

The only exceptions are to import `Literal` before `py38` to define type aliases.

Is it OK to only require it as a runtime dep before 3.8 then?