### PR TITLE
perf(python): avoid potentially redundant casts on `Series` init

### DIFF
--- a/py-polars/docs/source/reference/datatypes.rst
+++ b/py-polars/docs/source/reference/datatypes.rst
@@ -18,14 +18,14 @@ Numeric
     Decimal
     Float32
     Float64
+    Int8
     Int16
     Int32
     Int64
-    Int8
+    UInt8
     UInt16
     UInt32
     UInt64
-    UInt8
 
 Temporal
 ~~~~~~~~~~~

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -451,7 +451,9 @@ def sequence_to_pyseries(
                 return PySeries.new_object(name, values, strict)
             if dtype:
                 srs = sequence_from_anyvalue_or_object(name, values)
-                return srs.cast(dtype, strict=False)
+                if dtype.is_not(srs.dtype()):
+                    srs = srs.cast(dtype, strict=False)
+                return srs
             return sequence_from_anyvalue_or_object(name, values)
 
         elif python_dtype == pl.Series:


### PR DESCRIPTION
If the inferred dtype is already an exact match, don't re-cast.