### PR TITLE
fix(rust, python): maintain sorted info on top-k and empty sort

### DIFF
--- a/polars/polars-core/src/frame/top_k.rs
+++ b/polars/polars-core/src/frame/top_k.rs
@@ -10,6 +10,7 @@ use crate::frame::DataFrame;
 use crate::prelude::sort::_broadcast_descending;
 use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded;
 use crate::prelude::*;
+use crate::series::IsSorted;
 use crate::utils::NoNull;
 
 #[derive(Eq)]
@@ -75,6 +76,23 @@ impl DataFrame {
 
         let idx: NoNull<IdxCa> = sorted.iter().map(|cmp_row| cmp_row.idx).collect();
 
-        unsafe { Ok(self.take_unchecked(&idx.into_inner())) }
+        let mut df = unsafe { self.take_unchecked(&idx.into_inner()) };
+
+        let first_descending = descending[0];
+        let first_by_column = by_column[0].name().to_string();
+
+        // Mark the first sort column as sorted
+        // if the column did not exists it is ok, because we sorted by an expression
+        // not present in the dataframe
+        let _ = df.apply(&first_by_column, |s| {
+            let mut s = s.clone();
+            if first_descending {
+                s.set_sorted_flag(IsSorted::Descending)
+            } else {
+                s.set_sorted_flag(IsSorted::Ascending)
+            }
+            s
+        });
+        Ok(df)
     }
 }

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -217,17 +217,16 @@ def test_sorted_flag() -> None:
     )
 
     # empty
-    assert (
-        pl.DataFrame(
-            schema={
-                "store_id": pl.UInt16,
-                "item_id": pl.UInt32,
-                "timestamp": pl.Datetime,
-            }
-        )
-        .sort("timestamp")["timestamp"]
-        .flags["SORTED_ASC"]
-    )
+    q = pl.LazyFrame(
+        schema={
+            "store_id": pl.UInt16,
+            "item_id": pl.UInt32,
+            "timestamp": pl.Datetime,
+        }
+    ).sort("timestamp")
+
+    assert q.collect()["timestamp"].flags["SORTED_ASC"]
+    assert q.collect(streaming=True)["timestamp"].flags["SORTED_ASC"]
 
     # top-k/bottom-k
     df = pl.DataFrame({"foo": [56, 2, 3]})

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -216,6 +216,24 @@ def test_sorted_flag() -> None:
         .flags["SORTED_ASC"]
     )
 
+    # empty
+    assert (
+        pl.DataFrame(
+            schema={
+                "store_id": pl.UInt16,
+                "item_id": pl.UInt32,
+                "timestamp": pl.Datetime,
+            }
+        )
+        .sort("timestamp")["timestamp"]
+        .flags["SORTED_ASC"]
+    )
+
+    # top-k/bottom-k
+    df = pl.DataFrame({"foo": [56, 2, 3]})
+    assert df.top_k(2, by="foo")["foo"].flags["SORTED_DESC"]
+    assert df.bottom_k(2, by="foo")["foo"].flags["SORTED_ASC"]
+
     # ensure we don't panic for these types
     # struct
     pl.Series([{"a": 1}]).set_sorted(descending=True)


### PR DESCRIPTION
fixes #8476