### PR TITLE
perf(rust, python): buffer spill partitions in ooc sort. `~10/20%`

### DIFF
--- a/polars/polars-lazy/polars-pipe/Cargo.toml
+++ b/polars/polars-lazy/polars-pipe/Cargo.toml
@@ -9,7 +9,8 @@ description = "Lazy query engine for the Polars DataFrame library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = "0.5"
+crossbeam-channel = { version = "0.5", optional = true }
+crossbeam-queue = { version = "0.3", optional = true }
 enum_dispatch = "0.3"
 hashbrown.workspace = true
 num-traits.workspace = true
@@ -24,7 +25,7 @@ rayon.workspace = true
 smartstring = { version = "1" }
 
 [features]
-compile = []
+compile = ["crossbeam-channel", "crossbeam-queue"]
 csv = ["polars-plan/csv", "polars-io/csv"]
 parquet = ["polars-plan/parquet", "polars-io/parquet"]
 ipc = ["polars-plan/ipc", "polars-io/ipc"]

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
 
+use crossbeam_queue::SegQueue;
 use polars_core::prelude::*;
-use polars_core::utils::_split_offsets;
+use polars_core::utils::{_split_offsets, accumulate_dataframes_vertical_unchecked};
 use polars_core::POOL;
 use polars_io::ipc::IpcReader;
 use polars_io::SerReader;
@@ -17,15 +19,90 @@ pub(super) fn read_df(path: &Path) -> PolarsResult<DataFrame> {
     IpcReader::new(file).set_rechunk(false).finish()
 }
 
+// Utility to buffer partitioned dataframes
+// this ensures we don't write really small dataframes
+// and amortize IO cost
+#[derive(Default)]
+struct PartitionSpillBuf {
+    row_count: AtomicU32,
+    // keep track of the length
+    // that's cheaper than iterating the linked list
+    len: AtomicU32,
+    chunks: SegQueue<DataFrame>,
+}
+
+impl PartitionSpillBuf {
+    fn push(&self, df: DataFrame) -> Option<DataFrame> {
+        let acc = self
+            .row_count
+            .fetch_add(df.height() as u32, Ordering::Relaxed);
+        let len = self.len.fetch_add(1, Ordering::Relaxed);
+        self.chunks.push(df);
+        if acc < 50_000 {
+            self.row_count.store(0, Ordering::Relaxed);
+            self.len.store(0, Ordering::Relaxed);
+            // other threads can be pushing while we drain
+            // so we pop no more than the current size.
+            let pop_max = len;
+            let iter = (0..pop_max).flat_map(|_| self.chunks.pop());
+            Some(accumulate_dataframes_vertical_unchecked(iter))
+        } else {
+            None
+        }
+    }
+
+    fn finish(self) -> Option<DataFrame> {
+        if self.len.load(Ordering::Relaxed) > 0 {
+            let iter = self.chunks.into_iter();
+            Some(accumulate_dataframes_vertical_unchecked(iter))
+        } else {
+            None
+        }
+    }
+}
+
+struct PartitionSpiller {
+    partitions: Vec<PartitionSpillBuf>,
+}
+
+impl PartitionSpiller {
+    fn new(n_parts: usize) -> Self {
+        let mut partitions = vec![];
+        partitions.resize_with(n_parts, PartitionSpillBuf::default);
+        Self { partitions }
+    }
+
+    fn push(&self, partition: usize, df: DataFrame) -> Option<DataFrame> {
+        self.partitions[partition].push(df)
+    }
+
+    fn spill_all(self, io_thread: &IOThread) {
+        let min_len = std::cmp::max(self.partitions.len() / POOL.current_num_threads(), 2);
+        POOL.install(|| {
+            self.partitions
+                .into_par_iter()
+                .with_min_len(min_len)
+                .enumerate()
+                .for_each(|(part, part_buf)| {
+                    if let Some(df) = part_buf.finish() {
+                        io_thread.dump_partition_local(part as IdxSize, df)
+                    }
+                })
+        })
+    }
+}
+
 pub(super) fn sort_ooc(
     io_thread: &IOThread,
-    partitions: Series,
+    // these partitions are the samples
+    // these are not yet assigned to a buckets
+    samples: Series,
     idx: usize,
     descending: bool,
     slice: Option<(i64, usize)>,
     verbose: bool,
 ) -> PolarsResult<FinalizedSink> {
-    let partitions = partitions.to_physical_repr().into_owned();
+    let samples = samples.to_physical_repr().into_owned();
 
     // we collect as I am not sure that if we write to the same directory the
     // iterator will read those also.
@@ -36,6 +113,8 @@ pub(super) fn sort_ooc(
     if verbose {
         eprintln!("processing {} files", files.len());
     }
+
+    let partitions_spiller = PartitionSpiller::new(samples.len());
 
     // here it will split every file into `N` partitions.
     // So this will create approximately M * N files of size M / N
@@ -58,15 +137,20 @@ pub(super) fn sort_ooc(
                 let df = read_df(&path)?;
 
                 let sort_col = &df.get_columns()[idx];
-                let assigned_parts = det_partitions(sort_col, &partitions, descending);
+                let assigned_parts = det_partitions(sort_col, &samples, descending);
 
                 // partition the dataframe into proper buckets
                 let (iter, unique_assigned_parts) = partition_df(df, &assigned_parts)?;
-                io_thread.dump_partitioned_thread_local(unique_assigned_parts, iter);
+                for (part, df) in unique_assigned_parts.into_no_null_iter().zip(iter) {
+                    if let Some(df) = partitions_spiller.push(part as usize, df) {
+                        io_thread.dump_partition_local(part, df)
+                    }
+                }
             }
             PolarsResult::Ok(())
         })
     })?;
+    partitions_spiller.spill_all(io_thread);
     if verbose {
         eprintln!("finished partitioning sort files");
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -96,8 +96,8 @@ impl SortSink {
     }
 
     fn dump(&mut self, force: bool) -> PolarsResult<()> {
-        let larger_than_16_mb = self.current_chunks_size > 1 << 24;
-        if (force || larger_than_16_mb || self.current_chunk_rows > 50_000)
+        let larger_than_32_mb = self.current_chunks_size > 1 << 25;
+        if (force || larger_than_32_mb || self.current_chunk_rows > 50_000)
             && !self.chunks.is_empty()
         {
             // into a single chunk because multiple file IO's is expensive

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -443,6 +443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1643,7 @@ name = "polars-pipe"
 version = "0.28.0"
 dependencies = [
  "crossbeam-channel",
+ "crossbeam-queue",
  "enum_dispatch",
  "hashbrown 0.13.2",
  "num-traits",


### PR DESCRIPTION
This saves a lot of IO of small files. We now buffer until we have 50K rows or 32MB of data in a partition.

We also do this parallel over each file. This showed much better parallelization locally as one thread could not get stalled on too much work.

The amount of files created is reduced from $N^2$ to $\frac{ N^2 }{k}$ where $k=50.000$.

Locally I measure ~10/20% improvement by this, but I am sure this will be much higher when we would have freak input data and/or deal with a large no. of files. 