### PR TITLE
fix(rust): JoinBuilder::force_parallel is modifying allow_parallel 

### DIFF
--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -1416,7 +1416,7 @@ impl JoinBuilder {
 
     /// Force parallel table evaluation.
     pub fn force_parallel(mut self, force: bool) -> Self {
-        self.force_parallel = force
+        self.force_parallel = force;
         self
     }
 

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -1415,8 +1415,8 @@ impl JoinBuilder {
     }
 
     /// Force parallel table evaluation.
-    pub fn force_parallel(mut self, allow: bool) -> Self {
-        self.allow_parallel = allow;
+    pub fn force_parallel(mut self, force: bool) -> Self {
+        self.force_parallel = force
         self
     }
 


### PR DESCRIPTION
### This PR
fixing that `.force_parallel()` was modifying `allow_parallel`-field instead of `force_parallel`-field


### On a side note:
This bug was discovered in an r-polars unit-test on LazyFtame/LogicalPlan. I use serde_json and regex to read inner options in LogicalPlan which are not exposed via .describe_plan(). Is there more standardized way to do this?

Maybe having something like "debug_plan()" in py-polars and/or rust-polars, could be helpful for unit testing such parameters, that are not easy testable/tested today.

method from r-polars version of PyLazyFrame
```rust
pub fn debug_plan(&self) -> Result<String, String> {
        use crate::serde_json::value::Serializer;
        use polars_core::export::serde::Serialize;
        Serialize::serialize(&self.0.logical_plan.clone(), Serializer)
            .map_err(|err| err.to_string())
            .map(|val| format!("{:?}", val))
}
```

