### PR TITLE
perf(rust, python): improve nested grouptuples related code

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -87,7 +87,11 @@ impl DataFrame {
                 }
             }
             let keys_df = prepare_dataframe_unsorted(&by);
-            groupby_threaded_multiple_keys_flat(keys_df, n_partitions, sorted)
+            if multithreaded {
+                groupby_threaded_multiple_keys_flat(keys_df, n_partitions, sorted)
+            } else {
+                groupby_multiple_keys(keys_df, sorted)
+            }
         };
         Ok(GroupBy::new(self, by, groups?, None))
     }

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -280,7 +280,12 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
 
     /// Get unique values in the Series.
     fn unique(&self) -> PolarsResult<Series> {
-        let groups = self.group_tuples(true, false);
+        // this can called in aggregation, so this fast path can be worth a lot
+        if self.len() < 2 {
+            return Ok(self.0.clone().into_series());
+        }
+        let main_thread = POOL.current_thread_index().is_none();
+        let groups = self.group_tuples(main_thread, false);
         // safety:
         // groups are in bounds
         Ok(unsafe { self.0.clone().into_series().agg_first(&groups?) })
@@ -288,13 +293,28 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
 
     /// Get unique values in the Series.
     fn n_unique(&self) -> PolarsResult<usize> {
-        let groups = self.group_tuples(true, false)?;
-        Ok(groups.len())
+        // this can called in aggregation, so this fast path can be worth a lot
+        match self.len() {
+            0 => Ok(0),
+            1 => Ok(1),
+            _ => {
+                // TODO! try row encoding
+                let main_thread = POOL.current_thread_index().is_none();
+                let groups = self.group_tuples(main_thread, false)?;
+                Ok(groups.len())
+            }
+        }
     }
 
     /// Get first indexes of unique values.
     fn arg_unique(&self) -> PolarsResult<IdxCa> {
-        let groups = self.group_tuples(true, false)?;
+        // this can called in aggregation, so this fast path can be worth a lot
+        if self.len() == 1 {
+            return Ok(IdxCa::new_vec(self.name(), vec![0 as IdxSize]));
+        }
+        // TODO! try row encoding
+        let main_thread = POOL.current_thread_index().is_none();
+        let groups = self.group_tuples(main_thread, false)?;
         let first = groups.take_group_firsts();
         Ok(IdxCa::from_vec(self.name(), first))
     }


### PR DESCRIPTION
Fixes #8603

Nested group_tuples would allocate per item that iterated. Very expensive. This fixes that and adds fast path bounds. So struct `unique` related functionality during aggregation is `~15x` faster. Not that impressive, given that we were just slow.