### PR TITLE
feat(python): support transparent `DataFrame` init from `numpy` structured/record arrays.

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -15,7 +15,7 @@ tzdata; platform_system == 'Windows'
 xlsx2csv
 XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
-connectorx==0.3.2a2; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
+connectorx==0.3.2a5; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
 
 # Tooling
 hypothesis==6.75.1


### PR DESCRIPTION
Partially addresses #8564 (this PR adds init support; a follow-up PR will support export).
Also https://github.com/pola-rs/polars/issues/3520#issuecomment-1493205066.

Handles`DataFrame` init from `numpy` structured/record arrays[^1], recognising column names and dtypes and destructuring appropriately; it's a clean addition to the existing (internal) `numpy_to_pydf` construction function, so no new user-facing parameters (it will "just work").

## Example
```python
import numpy as np
import polars as pl

# create structured array...
arr = np.array(
    [
        ("Google Pixel 7", 521.90, True),
        ("Apple iPhone 14 Pro", 999.00, True),
        ("Samsung Galaxy S23 Ultra", 1199.99, False),
        ("OnePlus 11", 699.00, True),
    ],
    dtype = np.dtype(
        [
            ("product", "U32"),
            ("price_usd", "float64"),
            ("in_stock", "bool"),
        ]
    ),
)
```
**Before:** _(results in a single anonymous "object" column)_
```python
pl.DataFrame( arr )

# shape: (4, 1)
# ┌───────────────────────────────────┐
# │ column_0                          │
# │ ---                               │
# │ object                            │
# ╞═══════════════════════════════════╡
# │ ('Google Pixel 7', 521.9, True)   │
# │ ('Apple iPhone 14 Pro', 999., Tr… │
# │ ('Samsung Galaxy S23 Ultra', 119… │
# │ ('OnePlus 11', 699., True)        │
# └───────────────────────────────────┘
```
**After:** _(destructured to frame)_
```python
pl.DataFrame( arr )

# shape: (4, 3)
# ┌──────────────────────────┬───────────┬──────────┐
# │ product                  ┆ price_usd ┆ in_stock │
# │ ---                      ┆ ---       ┆ ---      │
# │ str                      ┆ f64       ┆ bool     │
# ╞══════════════════════════╪═══════════╪══════════╡
# │ Google Pixel 7           ┆ 521.9     ┆ true     │
# │ Apple iPhone 14 Pro      ┆ 999.0     ┆ true     │
# │ Samsung Galaxy S23 Ultra ┆ 1199.99   ┆ false    │
# │ OnePlus 11               ┆ 699.0     ┆ true     │
# └──────────────────────────┴───────────┴──────────┘
```

[^1]: Numpy structured arrays: https://numpy.org/doc/stable/user/basics.rec.html