### PR TITLE
build(python): only require `typing_extensions` before Python 3.8

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
 dependencies = [
-  "typing_extensions >= 4.0.1; python_version < '3.11'",
+  "typing_extensions >= 4.0.1; python_version < '3.8'",
 ]
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -2,5 +2,4 @@ black==23.3.0
 blackdoc==0.3.8
 mypy==1.2.0
 ruff==0.0.262
-typing-extensions==4.5.0;python_version<"3.11"
 typos==1.14.3

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -2,4 +2,5 @@ black==23.3.0
 blackdoc==0.3.8
 mypy==1.2.0
 ruff==0.0.262
+typing-extensions==4.5.0;python_version<"3.11"
 typos==1.14.3


### PR DESCRIPTION
Another attempt at https://github.com/pola-rs/polars/pull/8610, hope it's OK to reopen

I've added `typing-extensions` to requirements-lint.txt, so anyone doing development will get the install and be able to run `mypy` and type-check their code

Why make this change:
- fewer dependencies => easier installation && less chance of "dependency hell"

Example of installation issues already happening: https://github.com/pola-rs/polars/issues/2260

Python3.7 will be dropped in a month, so this would mean that polars would literally have no required dependencies