### PR TITLE
feat(python): Prettify show_versions

### DIFF
--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -39,10 +39,8 @@ def show_versions() -> None:
     # determine key length for alignment
     keylen = (
         max(
-            [
-                len(x)
-                for x in [*deps.keys(), "Polars", "Index type", "Platform", "Python"]
-            ]
+            len(x)
+            for x in [*deps.keys(), "Polars", "Index type", "Platform", "Python"]
         )
         + 1
     )

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -13,36 +13,49 @@ def show_versions() -> None:
     Examples
     --------
     >>> pl.show_versions()  # doctest: +SKIP
-    ---Version info---
-    Polars: 0.16.13
-    Index type: UInt32
-    Platform: macOS-13.2.1-arm64-arm-64bit
-    Python: 3.11.2 (main, Feb 16 2023, 02:55:59) [Clang 14.0.0 (clang-1400.0.29.202)]
-    ---Optional dependencies---
-    numpy: 1.24.2
-    pandas: 1.5.3
-    pyarrow: 11.0.0
-    connectorx: 0.3.2_alpha.2
-    deltalake: <version not detected>
-    fsspec: <not installed>
-    matplotlib: <not installed>
-    xlsx2csv: 0.8.1
-    xlsxwriter: 3.0.8
+    --------Version info---------
+    Polars:      0.17.11
+    Index type:  UInt32
+    Platform:    Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.35
+    Python:      3.11.3 (main, Apr 15 2023, 14:44:51) [GCC 11.3.0]
 
+    ----Optional dependencies----
+    numpy:       1.24.2
+    pandas:      2.0.0
+    pyarrow:     11.0.0
+    connectorx:  <not installed>
+    deltalake:   0.8.1
+    fsspec:      2023.4.0
+    matplotlib:  3.7.1
+    xlsx2csv:    0.8.1
+    xlsxwriter:  3.1.0
     """
     # note: we import 'platform' here as a micro-optimisation for initial import
     import platform
 
-    print("---Version info---")
-    print(f"Polars: {get_polars_version()}")
-    print(f"Index type: {get_index_type()}")
-    print(f"Platform: {platform.platform()}")
-    print(f"Python: {sys.version}")
-
-    print("---Optional dependencies---")
+    # optional dependencies
     deps = _get_dependency_info()
+
+    # determine key length for alignment
+    keylen = (
+        max(
+            [
+                len(x)
+                for x in [*deps.keys(), "Polars", "Index type", "Platform", "Python"]
+            ]
+        )
+        + 1
+    )
+
+    print("--------Version info---------")
+    print(f"{'Polars:':{keylen}s} {get_polars_version()}")
+    print(f"{'Index type:':{keylen}s} {get_index_type()}")
+    print(f"{'Platform:':{keylen}s} {platform.platform()}")
+    print(f"{'Python:':{keylen}s} {sys.version}")
+
+    print("\n----Optional dependencies----")
     for name, v in deps.items():
-        print(f"{name}: {v}")
+        print(f"{name:{keylen}s} {v}")
 
 
 def _get_dependency_info() -> dict[str, str]:
@@ -58,7 +71,7 @@ def _get_dependency_info() -> dict[str, str]:
         "xlsx2csv",
         "xlsxwriter",
     ]
-    return {name: _get_dependency_version(name) for name in opt_deps}
+    return {f"{name}:": _get_dependency_version(name) for name in opt_deps}
 
 
 def _get_dependency_version(dep_name: str) -> str:

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -39,8 +39,7 @@ def show_versions() -> None:
     # determine key length for alignment
     keylen = (
         max(
-            len(x)
-            for x in [*deps.keys(), "Polars", "Index type", "Platform", "Python"]
+            len(x) for x in [*deps.keys(), "Polars", "Index type", "Platform", "Python"]
         )
         + 1
     )


### PR DESCRIPTION
Implements #8625. New look:

```
>>> pl.show_versions()
--------Version info---------
Polars:      0.17.11
Index type:  UInt32
Platform:    Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.35
Python:      3.11.3 (main, Apr 15 2023, 14:44:51) [GCC 11.3.0]

----Optional dependencies----
numpy:       1.24.2
pandas:      2.0.0
pyarrow:     11.0.0
connectorx:  <not installed>
deltalake:   0.8.1
fsspec:      2023.4.0
matplotlib:  3.7.1
xlsx2csv:    0.8.1
xlsxwriter:  3.1.0
```