### PR TITLE
feat(python): support `DataFrame` export to `numpy` structured/record arrays

### DIFF
--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -719,9 +719,9 @@ def test_from_pyarrow_chunked_array() -> None:
 
 
 def test_numpy_preserve_uint64_4112() -> None:
-    assert pl.DataFrame({"a": [1, 2, 3]}).with_columns(
-        pl.col("a").hash()
-    ).to_numpy().dtype == np.dtype("uint64")
+    df = pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").hash())
+    assert df.to_numpy().dtype == np.dtype("uint64")
+    assert df.to_numpy(structured=True).dtype == np.dtype([("a", "uint64")])
 
 
 def test_view_ub() -> None:


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/8564 (in conjunction with #8620, which provides structured array init support).

Adds an optional "structured" parameter to `to_numpy`, allowing for straightforward export to structured arrays[^1] (and, via a zero-copy `.view(np.recarray)` call, to record arrays).

## Example
```python
import numpy as np
import polars as pl

df = pl.DataFrame(
    {
        "foo": [1, 2, 3],
        "bar": [6.5, 7.0, 8.5],
        "ham": ["a", "b", "c"],
    },
    schema_overrides = {"foo": pl.UInt8, "bar": pl.Float32},
)
```
Standard export to 2D array:
```python
df.to_numpy()
# array([[1, 6.5, 'a'],
#        [2, 7.0, 'b'],
#        [3, 8.5, 'c']], dtype=object)
```
Structured array export:
```python
df.to_numpy( structured=True )
# array([(1, 6.5, 'a'), (2, 7. , 'b'), (3, 8.5, 'c')],
#       dtype=[('foo', 'u1'), ('bar', '<f4'), ('ham', '<U1')])
```
Structured array export to record array:
```python
df.to_numpy( structured=True ).view( np.recarray )
# rec.array([(1, 6.5, 'a'), (2, 7. , 'b'), (3, 8.5, 'c')],
#           dtype=[('foo', 'u1'), ('bar', '<f4'), ('ham', '<U1')])
```
[^1]: Numpy structured arrays: https://numpy.org/doc/stable/user/basics.rec.html