### PR TITLE
refactor(python): Move functions in Rust bindings to `functions` module

### DIFF
--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -10,7 +10,7 @@ from polars.io._utils import _prepare_file_arg
 from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):
-    from polars.polars import ipc_schema as _ipc_schema
+    from polars.polars import read_ipc_schema as _read_ipc_schema
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -128,7 +128,7 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
     if isinstance(source, (str, Path)):
         source = normalise_filepath(source)
 
-    return _ipc_schema(source)
+    return _read_ipc_schema(source)
 
 
 def scan_ipc(

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -11,7 +11,7 @@ from polars.io._utils import _prepare_file_arg
 from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):
-    from polars.polars import parquet_schema as _parquet_schema
+    from polars.polars import read_parquet_schema as _read_parquet_schema
 
 if TYPE_CHECKING:
     from io import BytesIO
@@ -153,7 +153,7 @@ def read_parquet_schema(
     if isinstance(source, (str, Path)):
         source = normalise_filepath(source)
 
-    return _parquet_schema(source)
+    return _read_parquet_schema(source)
 
 
 def scan_parquet(

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -1,0 +1,45 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::conversion::Wrap;
+use crate::file::{get_either_file, EitherRustPythonFile};
+use crate::prelude::DataType;
+use crate::PyPolarsErr;
+
+#[cfg(feature = "ipc")]
+#[pyfunction]
+pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
+    use polars_core::export::arrow::io::ipc::read::read_file_metadata;
+    let metadata = match get_either_file(py_f, false)? {
+        EitherRustPythonFile::Rust(mut r) => {
+            read_file_metadata(&mut r).map_err(PyPolarsErr::from)?
+        }
+        EitherRustPythonFile::Py(mut r) => read_file_metadata(&mut r).map_err(PyPolarsErr::from)?,
+    };
+
+    let dict = PyDict::new(py);
+    for field in metadata.schema.fields {
+        let dt: Wrap<DataType> = Wrap((&field.data_type).into());
+        dict.set_item(field.name, dt.to_object(py))?;
+    }
+    Ok(dict.to_object(py))
+}
+
+#[cfg(feature = "parquet")]
+#[pyfunction]
+pub fn read_parquet_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
+    use polars_core::export::arrow::io::parquet::read::{infer_schema, read_metadata};
+
+    let metadata = match get_either_file(py_f, false)? {
+        EitherRustPythonFile::Rust(mut r) => read_metadata(&mut r).map_err(PyPolarsErr::from)?,
+        EitherRustPythonFile::Py(mut r) => read_metadata(&mut r).map_err(PyPolarsErr::from)?,
+    };
+    let arrow_schema = infer_schema(&metadata).map_err(PyPolarsErr::from)?;
+
+    let dict = PyDict::new(py);
+    for field in arrow_schema.fields {
+        let dt: Wrap<DataType> = Wrap((&field.data_type).into());
+        dict.set_item(field.name, dt.to_object(py))?;
+    }
+    Ok(dict.to_object(py))
+}

--- a/py-polars/src/functions/meta.rs
+++ b/py-polars/src/functions/meta.rs
@@ -1,0 +1,58 @@
+use polars_core;
+use polars_core::fmt::FloatFmt;
+use polars_core::prelude::IDX_DTYPE;
+use polars_core::POOL;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::conversion::Wrap;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+#[pyfunction]
+pub fn get_polars_version() -> &'static str {
+    VERSION
+}
+
+#[pyfunction]
+pub fn get_index_type(py: Python) -> PyObject {
+    Wrap(IDX_DTYPE).to_object(py)
+}
+
+#[pyfunction]
+pub fn threadpool_size() -> usize {
+    POOL.current_num_threads()
+}
+
+#[pyfunction]
+pub fn enable_string_cache(toggle: bool) {
+    polars_core::enable_string_cache(toggle)
+}
+
+#[pyfunction]
+pub fn using_string_cache() -> bool {
+    polars_core::using_string_cache()
+}
+
+#[pyfunction]
+pub fn set_float_fmt(fmt: &str) -> PyResult<()> {
+    let fmt = match fmt {
+        "full" => FloatFmt::Full,
+        "mixed" => FloatFmt::Mixed,
+        e => {
+            return Err(PyValueError::new_err(format!(
+                "fmt must be one of {{'full', 'mixed'}}, got {e}",
+            )))
+        }
+    };
+    polars_core::fmt::set_float_fmt(fmt);
+    Ok(())
+}
+
+#[pyfunction]
+pub fn get_float_fmt() -> PyResult<String> {
+    let strfmt = match polars_core::fmt::get_float_fmt() {
+        FloatFmt::Full => "full",
+        FloatFmt::Mixed => "mixed",
+    };
+    Ok(strfmt.to_string())
+}

--- a/py-polars/src/functions/misc.rs
+++ b/py-polars/src/functions/misc.rs
@@ -1,0 +1,10 @@
+use pyo3::prelude::*;
+
+use crate::conversion::Wrap;
+use crate::prelude::DataType;
+
+#[pyfunction]
+pub fn dtype_str_repr(dtype: Wrap<DataType>) -> PyResult<String> {
+    let dtype = dtype.0;
+    Ok(dtype.to_string())
+}

--- a/py-polars/src/functions/mod.rs
+++ b/py-polars/src/functions/mod.rs
@@ -1,3 +1,4 @@
 pub mod eager;
+pub mod io;
 pub mod lazy;
 pub mod whenthen;

--- a/py-polars/src/functions/mod.rs
+++ b/py-polars/src/functions/mod.rs
@@ -1,5 +1,6 @@
 pub mod eager;
 pub mod io;
 pub mod lazy;
+pub mod meta;
 pub mod misc;
 pub mod whenthen;

--- a/py-polars/src/functions/mod.rs
+++ b/py-polars/src/functions/mod.rs
@@ -1,4 +1,5 @@
 pub mod eager;
 pub mod io;
 pub mod lazy;
+pub mod misc;
 pub mod whenthen;

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -58,7 +58,6 @@ use crate::error::{
 use crate::expr::PyExpr;
 use crate::lazyframe::PyLazyFrame;
 use crate::lazygroupby::PyLazyGroupBy;
-use crate::prelude::DataType;
 use crate::series::PySeries;
 
 #[global_allocator]
@@ -68,12 +67,6 @@ static ALLOC: Jemalloc = Jemalloc;
 #[global_allocator]
 #[cfg(any(not(target_os = "linux"), use_mimalloc))]
 static ALLOC: MiMalloc = MiMalloc;
-
-#[pyfunction]
-fn dtype_str_repr(dtype: Wrap<DataType>) -> PyResult<String> {
-    let dtype = dtype.0;
-    Ok(dtype.to_string())
-}
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[pyfunction]
@@ -238,8 +231,9 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(set_float_fmt)).unwrap();
     m.add_wrapped(wrap_pyfunction!(get_float_fmt)).unwrap();
 
-    // Functions - other
-    m.add_wrapped(wrap_pyfunction!(dtype_str_repr)).unwrap();
+    // Functions - misc
+    m.add_wrapped(wrap_pyfunction!(functions::misc::dtype_str_repr))
+        .unwrap();
     #[cfg(feature = "object")]
     m.add_wrapped(wrap_pyfunction!(register_object_builder))
         .unwrap();

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -228,18 +228,18 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::io::read_parquet_schema))
         .unwrap();
 
-    // Functions - utility
+    // Functions - meta
     m.add_wrapped(wrap_pyfunction!(get_polars_version)).unwrap();
     m.add_wrapped(wrap_pyfunction!(get_index_type)).unwrap();
     m.add_wrapped(wrap_pyfunction!(threadpool_size)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(using_string_cache)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(enable_string_cache))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(set_float_fmt)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(get_float_fmt)).unwrap();
 
     // Functions - other
     m.add_wrapped(wrap_pyfunction!(dtype_str_repr)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(enable_string_cache))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(using_string_cache)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(set_float_fmt)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(get_float_fmt)).unwrap();
     #[cfg(feature = "object")]
     m.add_wrapped(wrap_pyfunction!(register_object_builder))
         .unwrap();


### PR DESCRIPTION
Again just shuffling stuff around. `lib.rs` is a lot cleaner now.