### PR TITLE
refactor(python): Drop `Option` from inner LazyGroupBy

### DIFF
--- a/py-polars/src/batched_csv.rs
+++ b/py-polars/src/batched_csv.rs
@@ -17,7 +17,6 @@ enum BatchedReader {
 #[pyclass]
 #[repr(transparent)]
 pub struct PyBatchedCsv {
-    // option because we cannot get a self by value in pyo3
     reader: BatchedReader,
 }
 

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -499,7 +499,7 @@ impl PyLazyFrame {
             ldf.groupby(by)
         };
 
-        PyLazyGroupBy { lgb: Some(lazy_gb) }
+        PyLazyGroupBy { lgb: lazy_gb }
     }
 
     fn groupby_rolling(
@@ -527,7 +527,7 @@ impl PyLazyFrame {
             },
         );
 
-        PyLazyGroupBy { lgb: Some(lazy_gb) }
+        PyLazyGroupBy { lgb: lazy_gb }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -564,7 +564,7 @@ impl PyLazyFrame {
             },
         );
 
-        PyLazyGroupBy { lgb: Some(lazy_gb) }
+        PyLazyGroupBy { lgb: lazy_gb }
     }
 
     fn with_context(&self, contexts: Vec<Self>) -> Self {

--- a/py-polars/src/lazygroupby.rs
+++ b/py-polars/src/lazygroupby.rs
@@ -11,30 +11,26 @@ use crate::{PyDataFrame, PyExpr, PyLazyFrame};
 #[pyclass]
 #[repr(transparent)]
 pub struct PyLazyGroupBy {
-    // option because we cannot get a self by value in pyo3
-    pub lgb: Option<LazyGroupBy>,
+    pub lgb: LazyGroupBy,
 }
 
 #[pymethods]
 impl PyLazyGroupBy {
     fn agg(&mut self, aggs: Vec<PyExpr>) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
         let aggs = aggs.to_exprs();
-        lgb.agg(aggs).into()
+        self.lgb.clone().agg(aggs).into()
     }
 
     fn head(&mut self, n: usize) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
-        lgb.head(Some(n)).into()
+        self.lgb.clone().head(Some(n)).into()
     }
 
     fn tail(&mut self, n: usize) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
-        lgb.tail(Some(n)).into()
+        self.lgb.clone().tail(Some(n)).into()
     }
 
     fn apply(&mut self, lambda: PyObject, schema: Option<Wrap<Schema>>) -> PyResult<PyLazyFrame> {
-        let lgb = self.lgb.take().unwrap();
+        let lgb = self.lgb.clone();
         let schema = match schema {
             Some(schema) => Arc::new(schema.0),
             None => LazyFrame::from(lgb.logical_plan.clone())


### PR DESCRIPTION
This brings it in line with the PyExpr/PyLazyFrame etc.

I have to admit I don't fully understand why this needs a `clone()` where the Option variant doesn't... but it seemed like the way to go based on the other code.