### PR TITLE
feat(python): allow `from_repr` to handle parsing of table reprs with no dtype row

### DIFF
--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -215,7 +215,7 @@ def scale_bytes(sz: int, unit: SizeUnit) -> int | float:
 
 
 def _cast_repr_strings_with_schema(
-    df: DataFrame, schema: dict[str, PolarsDataType]
+    df: DataFrame, schema: dict[str, PolarsDataType | None]
 ) -> DataFrame:
     """
     Utility function to cast table repr/string values into frame-native types.
@@ -233,6 +233,7 @@ def _cast_repr_strings_with_schema(
     special handling; as this function is only used for reprs, parsing is flexible.
 
     """
+    tp: PolarsDataType | None
     if not df.is_empty():
         for tp in df.schema.values():
             if tp != Utf8:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -867,6 +867,21 @@ def test_dataframe_from_repr() -> None:
         "total": pl.Float64,
     }
 
+    # empty frame with no dtypes
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
+        ┌──────┬───────┐
+        │ misc ┆ other │
+        ╞══════╪═══════╡
+        └──────┴───────┘
+        """
+        ),
+    )
+    assert df.rows() == []
+    assert df.schema == {"misc": pl.Utf8, "other": pl.Utf8}
+
     df = cast(
         pl.DataFrame,
         pl.from_repr(
@@ -898,6 +913,28 @@ def test_dataframe_from_repr() -> None:
         (date(2023, 3, 25), 1, 2, 3, 96, 97, 98, 99),
         (date(1999, 12, 31), 3, 6, 9, 288, 291, 294, None),
         (None, 9, 18, 27, 864, 873, 882, 891),
+    ]
+
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
+        # >>> no dtypes:
+        # ┌────────────┬──────┐
+        # │ dt         ┆ c99  │
+        # ╞════════════╪══════╡
+        # │ 2023-03-25 ┆ 99   │
+        # │ 1999-12-31 ┆ null │
+        # │ null       ┆ 891  │
+        # └────────────┴──────┘
+        """
+        ),
+    )
+    assert df.schema == {"dt": pl.Date, "c99": pl.Int64}
+    assert df.rows() == [
+        (date(2023, 3, 25), 99),
+        (date(1999, 12, 31), None),
+        (None, 891),
     ]
 
     df = cast(


### PR DESCRIPTION
Closes #8638.

Table reprs created with `hide_column_data_types=True` (via Config) don't have a dtype row; this PR adds a little extra handling to `from_repr` so that these can also be parsed (in this case the dtypes are inferred by the same logic as `read_csv`).

### Example

```python
df = pl.from_repr( """
    # >>> no dtypes:
    # ┌────────────┬──────┐
    # │ dt         ┆ c99  │
    # ╞════════════╪══════╡
    # │ 2023-03-25 ┆ 99   │
    # │ 1999-12-31 ┆ null │
    # │ null       ┆ 891  │
    # └────────────┴──────┘
""" )

df.schema
# {'dt': Date, 'c99': Int64}

df.rows() 
# [(date(2023, 3, 25), 99), (date(1999, 12, 31), None), (None, 891)]
```