### PR TITLE
docs(python): clean-up some examples, extend `pipe` docstring

### DIFF
--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -100,12 +100,10 @@ def register_expr_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     >>>
     >>> df = pl.DataFrame([1.4, 24.3, 55.0, 64.001], schema=["n"])
     >>> df.select(
-    ...     [
-    ...         pl.col("n"),
-    ...         pl.col("n").pow_n.next(p=2).alias("next_pow2"),
-    ...         pl.col("n").pow_n.previous(p=2).alias("prev_pow2"),
-    ...         pl.col("n").pow_n.nearest(p=2).alias("nearest_pow2"),
-    ...     ]
+    ...     pl.col("n"),
+    ...     pl.col("n").pow_n.next(p=2).alias("next_pow2"),
+    ...     pl.col("n").pow_n.previous(p=2).alias("prev_pow2"),
+    ...     pl.col("n").pow_n.nearest(p=2).alias("nearest_pow2"),
     ... )
     shape: (4, 4)
     ┌────────┬───────────┬───────────┬──────────────┐

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5485,7 +5485,10 @@ class DataFrame:
 
         It is better to implement this with an expression:
 
-        >>> df.select([pl.col("foo") * 2, pl.col("bar") * 3])  # doctest: +IGNORE_RESULT
+        >>> df.select(
+        ...     pl.col("foo") * 2,
+        ...     pl.col("bar") * 3,
+        ... )  # doctest: +IGNORE_RESULT
 
         Return a Series by mapping each row to a scalar:
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -460,10 +460,8 @@ class Expr:
         │ 3   ┆ null │
         └─────┴──────┘
         >>> df.select(
-        ...     [
-        ...         pl.col("a").alias("bar"),
-        ...         pl.col("b").alias("foo"),
-        ...     ]
+        ...     pl.col("a").alias("bar"),
+        ...     pl.col("b").alias("foo"),
         ... )
         shape: (3, 2)
         ┌─────┬──────┐
@@ -630,7 +628,7 @@ class Expr:
         "DuplicateError: Column with name: 'literal' has more than one occurrences"
         errors.
 
-        >>> df.select([(pl.lit(10) / pl.all()).keep_name()])
+        >>> df.select((pl.lit(10) / pl.all()).keep_name())
         shape: (2, 2)
         ┌──────┬──────────┐
         │ a    ┆ b        │
@@ -665,21 +663,30 @@ class Expr:
 
         Examples
         --------
-        >>> def extract_number(expr):
+        >>> # extract the digits from a string
+        >>> def extract_number(expr: pl.Expr) -> pl.Expr:
         ...     return expr.str.extract(r"\d+", 0).cast(pl.Int64)
-        ...
-        >>> df = pl.DataFrame({"a": ["a: 1", "b: 2", "c: 3"]})
-        >>> df.with_columns(pl.col("a").pipe(extract_number))
-        shape: (3, 1)
-        ┌─────┐
-        │ a   │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ 1   │
-        │ 2   │
-        │ 3   │
-        └─────┘
+        >>>
+        >>> # set even numbers negative and scale by a user-supplied value
+        >>> def scale_negative_even(expr: pl.Expr, *, n: int = 1) -> pl.Expr:
+        ...     expr = pl.when(expr % 2 == 0).then(-expr).otherwise(expr)
+        ...     return expr * n
+        >>>
+        >>> df = pl.DataFrame({"val": ["a: 1", "b: 2", "c: 3", "d: 4"]})
+        >>> df.with_columns(
+        ...     udfs=pl.col("val").pipe(extract_number).pipe(scale_negative_even, n=5)
+        ... )
+        shape: (4, 2)
+        ┌──────┬──────┐
+        │ val  ┆ udfs │
+        │ ---  ┆ ---  │
+        │ str  ┆ i64  │
+        ╞══════╪══════╡
+        │ a: 1 ┆ 5    │
+        │ b: 2 ┆ -10  │
+        │ c: 3 ┆ 15   │
+        │ d: 4 ┆ -20  │
+        └──────┴──────┘
 
         """
         return function(self, *args, **kwargs)
@@ -712,10 +719,8 @@ class Expr:
         │ 5   ┆ banana ┆ 1   ┆ beetle │
         └─────┴────────┴─────┴────────┘
         >>> df.select(
-        ...     [
-        ...         pl.all(),
-        ...         pl.all().reverse().prefix("reverse_"),
-        ...     ]
+        ...     pl.all(),
+        ...     pl.all().reverse().prefix("reverse_"),
         ... )
         shape: (5, 8)
         ┌─────┬────────┬─────┬────────┬───────────┬────────────────┬───────────┬──────────────┐
@@ -761,10 +766,8 @@ class Expr:
         │ 5   ┆ banana ┆ 1   ┆ beetle │
         └─────┴────────┴─────┴────────┘
         >>> df.select(
-        ...     [
-        ...         pl.all(),
-        ...         pl.all().reverse().suffix("_reverse"),
-        ...     ]
+        ...     pl.all(),
+        ...     pl.all().reverse().suffix("_reverse"),
         ... )
         shape: (5, 8)
         ┌─────┬────────┬─────┬────────┬───────────┬────────────────┬───────────┬──────────────┐

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -718,11 +718,9 @@ class ExprStringNameSpace:
         --------
         >>> df = pl.DataFrame({"a": ["Crab", "cat and dog", "rab$bit", None]})
         >>> df.select(
-        ...     [
-        ...         pl.col("a"),
-        ...         pl.col("a").str.contains("cat|bit").alias("regex"),
-        ...         pl.col("a").str.contains("rab$", literal=True).alias("literal"),
-        ...     ]
+        ...     pl.col("a"),
+        ...     pl.col("a").str.contains("cat|bit").alias("regex"),
+        ...     pl.col("a").str.contains("rab$", literal=True).alias("literal"),
         ... )
         shape: (4, 3)
         ┌─────────────┬───────┬─────────┐
@@ -1011,9 +1009,7 @@ class ExprStringNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("a").str.extract(r"candidate=(\w+)", 1),
-        ...     ]
+        ...     pl.col("a").str.extract(r"candidate=(\w+)", 1),
         ... )
         shape: (3, 1)
         ┌─────────┐
@@ -1051,9 +1047,7 @@ class ExprStringNameSpace:
         --------
         >>> df = pl.DataFrame({"foo": ["123 bla 45 asd", "xyz 678 910t"]})
         >>> df.select(
-        ...     [
-        ...         pl.col("foo").str.extract_all(r"(\d+)").alias("extracted_nrs"),
-        ...     ]
+        ...     pl.col("foo").str.extract_all(r"(\d+)").alias("extracted_nrs"),
         ... )
         shape: (2, 1)
         ┌────────────────┐
@@ -1087,9 +1081,7 @@ class ExprStringNameSpace:
         --------
         >>> df = pl.DataFrame({"foo": ["123 bla 45 asd", "xyz 678 910t"]})
         >>> df.select(
-        ...     [
-        ...         pl.col("foo").str.count_match(r"\d").alias("count_digits"),
-        ...     ]
+        ...     pl.col("foo").str.count_match(r"\d").alias("count_digits"),
         ... )
         shape: (2, 1)
         ┌──────────────┐
@@ -1160,9 +1152,7 @@ class ExprStringNameSpace:
         --------
         >>> df = pl.DataFrame({"x": ["a_1", None, "c", "d_4"]})
         >>> df.select(
-        ...     [
-        ...         pl.col("x").str.split_exact("_", 1).alias("fields"),
-        ...     ]
+        ...     pl.col("x").str.split_exact("_", 1).alias("fields"),
         ... )
         shape: (4, 1)
         ┌─────────────┐

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -601,7 +601,7 @@ class StringNameSpace:
         ...         ]
         ...     }
         ... )
-        >>> df.select([pl.col("a").str.extract(r"candidate=(\w+)", 1)])
+        >>> df.select(pl.col("a").str.extract(r"candidate=(\w+)", 1))
         shape: (3, 1)
         ┌─────────┐
         │ a       │


### PR DESCRIPTION
* Clean-up extraneous square brackets in docstring examples featuring calls to `select`.
* Extend `Expr.pipe` example to show chaining and use of **kwargs.