### PR TITLE
fix(python): Fix empty list or Series selections on DF or Series

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1540,6 +1540,12 @@ class DataFrame:
         if isinstance(item, tuple) and len(item) == 2:
             row_selection, col_selection = item
 
+            # df[[], :]
+            if isinstance(row_selection, Sequence):
+                if len(row_selection) == 0:
+                    # handle empty list by falling through to slice
+                    row_selection = slice(0)
+
             # df[:, unknown]
             if isinstance(row_selection, slice):
                 # multiple slices

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -47,7 +47,6 @@ from polars.datatypes import (
     py_type_to_dtype,
     unpack_dtypes,
 )
-from polars.datatypes.convert import numpy_char_code_to_dtype
 from polars.dependencies import (
     _PYARROW_AVAILABLE,
     _check_for_numpy,
@@ -1574,7 +1573,6 @@ class DataFrame:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
-                numpy_char_code_to_dtype(item.dtype)
                 return self._from_pydf(
                     self._df.take_with_series(numpy_to_idxs(item, self.shape[0])._s)
                 )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1407,6 +1407,9 @@ class DataFrame:
         else:
             return self.shape[dim] + idx
 
+    def _take_with_series(self, s: Series) -> DataFrame:
+        return self._from_pydf(self._df.take_with_series(s._s))
+
     @overload
     def __getitem__(self, item: str) -> Series:
         ...
@@ -1573,9 +1576,7 @@ class DataFrame:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
-                return self._from_pydf(
-                    self._df.take_with_series(numpy_to_idxs(item, self.shape[0])._s)
-                )
+                return self._take_with_series(numpy_to_idxs(item, self.shape[0]))
             if isinstance(item[0], str):
                 return self._from_pydf(self._df.select(item))
 
@@ -1591,9 +1592,7 @@ class DataFrame:
             if dtype == Utf8:
                 return self._from_pydf(self._df.select(item))
             elif dtype in INTEGER_DTYPES:
-                return self._from_pydf(
-                    self._df.take_with_series(item._pos_idxs(self.shape[0])._s)
-                )
+                return self._take_with_series(item._pos_idxs(self.shape[0]))
 
         # if no data has been returned, the operation is not supported
         raise ValueError(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -34,24 +34,15 @@ from polars.datatypes import (
     INTEGER_DTYPES,
     N_INFER_DEFAULT,
     NUMERIC_DTYPES,
-    SIGNED_INTEGER_DTYPES,
     Boolean,
     Categorical,
     DataTypeClass,
     Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
     List,
     Null,
     Object,
     Struct,
     Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
     Utf8,
     py_type_to_dtype,
     unpack_dtypes,
@@ -86,17 +77,16 @@ from polars.utils._construction import (
     arrow_to_pydf,
     dict_to_pydf,
     iterable_to_pydf,
+    numpy_to_idxs,
     numpy_to_pydf,
     pandas_to_pydf,
     sequence_to_pydf,
     series_to_pydf,
-    numpy_to_idxs,
 )
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
-from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _prepare_row_count_args,
     _process_null_values,
@@ -1584,7 +1574,7 @@ class DataFrame:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
-                pl_type = numpy_char_code_to_dtype(item.dtype)
+                numpy_char_code_to_dtype(item.dtype)
                 return self._from_pydf(
                     self._df.take_with_series(numpy_to_idxs(item, self.shape[0])._s)
                 )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -90,6 +90,7 @@ from polars.utils._construction import (
     pandas_to_pydf,
     sequence_to_pydf,
     series_to_pydf,
+    numpy_to_idxs,
 )
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_ldf, wrap_s
@@ -1585,9 +1586,7 @@ class DataFrame:
                 # Numpy array with signed or unsigned integers.
                 pl_type = numpy_char_code_to_dtype(item.dtype)
                 return self._from_pydf(
-                    self._df.take_with_series(
-                        pl.Series("", item, dtype=pl_type)._pos_idxs(self.shape[0])._s
-                    )
+                    self._df.take_with_series(numpy_to_idxs(item, self.shape[0])._s)
                 )
             if isinstance(item[0], str):
                 return self._from_pydf(self._df.select(item))

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -56,6 +56,7 @@ from polars.datatypes import (
     py_type_to_dtype,
     unpack_dtypes,
 )
+from polars.datatypes.convert import numpy_char_code_to_dtype
 from polars.dependencies import (
     _PYARROW_AVAILABLE,
     _check_for_numpy,
@@ -1416,78 +1417,6 @@ class DataFrame:
         else:
             return self.shape[dim] + idx
 
-    def _pos_idxs(self, idxs: np.ndarray[Any, Any] | Series, dim: int) -> Series:
-        # pl.UInt32 (polars) or pl.UInt64 (polars_u64_idx).
-        idx_type = get_index_type()
-
-        if isinstance(idxs, pl.Series):
-            if idxs.dtype == idx_type:
-                return idxs
-            if idxs.dtype in {
-                UInt8,
-                UInt16,
-                UInt64 if idx_type == UInt32 else UInt32,
-                Int8,
-                Int16,
-                Int32,
-                Int64,
-            }:
-                if idx_type == UInt32:
-                    if idxs.dtype in {Int64, UInt64}:
-                        if idxs.max() >= 2**32:  # type: ignore[operator]
-                            raise ValueError(
-                                "Index positions should be smaller than 2^32."
-                            )
-                    if idxs.dtype == Int64:
-                        if idxs.min() < -(2**32):  # type: ignore[operator]
-                            raise ValueError(
-                                "Index positions should be bigger than -2^32 + 1."
-                            )
-                if idxs.dtype in SIGNED_INTEGER_DTYPES:
-                    if idxs.min() < 0:  # type: ignore[operator]
-                        if idx_type == UInt32:
-                            if idxs.dtype in {Int8, Int16}:
-                                idxs = idxs.cast(Int32)
-                        else:
-                            if idxs.dtype in {Int8, Int16, Int32}:
-                                idxs = idxs.cast(Int64)
-
-                        idxs = F.select(
-                            F.when(lit(idxs) < 0)
-                            .then(self.shape[dim] + lit(idxs))
-                            .otherwise(lit(idxs))
-                        ).to_series()
-
-                return idxs.cast(idx_type)
-
-        if _check_for_numpy(idxs) and isinstance(idxs, np.ndarray):
-            if idxs.ndim != 1:
-                raise ValueError("Only 1D numpy array is supported as index.")
-            if idxs.dtype.kind in ("i", "u"):
-                # Numpy array with signed or unsigned integers.
-
-                if idx_type == UInt32:
-                    if idxs.dtype in {np.int64, np.uint64} and idxs.max() >= 2**32:
-                        raise ValueError("Index positions should be smaller than 2^32.")
-                    if idxs.dtype == np.int64 and idxs.min() < -(2**32):
-                        raise ValueError(
-                            "Index positions should be bigger than -2^32 + 1."
-                        )
-                if idxs.dtype.kind == "i" and idxs.min() < 0:
-                    if idx_type == UInt32:
-                        if idxs.dtype in (np.int8, np.int16):
-                            idxs = idxs.astype(np.int32)
-                    else:
-                        if idxs.dtype in (np.int8, np.int16, np.int32):
-                            idxs = idxs.astype(np.int64)
-
-                    # Update negative indexes to absolute indexes.
-                    idxs = np.where(idxs < 0, self.shape[dim] + idxs, idxs)
-
-                return pl.Series("", idxs, dtype=idx_type)
-
-        raise NotImplementedError("Unsupported idxs datatype.")
-
     @overload
     def __getitem__(self, item: str) -> Series:
         ...
@@ -1654,8 +1583,11 @@ class DataFrame:
                 raise ValueError("Only a 1D-Numpy array is supported as index.")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
+                pl_type = numpy_char_code_to_dtype(item.dtype)
                 return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
+                    self._df.take_with_series(
+                        pl.Series("", item, dtype=pl_type)._pos_idxs(self.shape[0])._s
+                    )
                 )
             if isinstance(item[0], str):
                 return self._from_pydf(self._df.select(item))
@@ -1671,11 +1603,9 @@ class DataFrame:
             dtype = item.dtype
             if dtype == Utf8:
                 return self._from_pydf(self._df.select(item))
-            elif dtype == UInt32:
-                return self._from_pydf(self._df.take_with_series(item._s))
             elif dtype in INTEGER_DTYPES:
                 return self._from_pydf(
-                    self._df.take_with_series(self._pos_idxs(item, dim=0)._s)
+                    self._df.take_with_series(item._pos_idxs(self.shape[0])._s)
                 )
 
         # if no data has been returned, the operation is not supported

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -979,7 +979,7 @@ class Series:
         elif is_int_sequence(item):
             return self._from_pyseries(
                 self._s.take_with_series(
-                    Series("", item, dtype=UInt32)._pos_idxs(self.len())._s
+                    Series("", item, dtype=Int64)._pos_idxs(self.len())._s
                 )
             )
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -894,7 +894,9 @@ class Series:
                 if idx_type == UInt32:
                     idxs = self.cast(Int32) if self.dtype in {Int8, Int16} else self
                 else:
-                    idxs = self.cast(Int64) if self.dtype in {Int8, Int16, Int32} else self
+                    idxs = (
+                        self.cast(Int64) if self.dtype in {Int8, Int16, Int32} else self
+                    )
 
                 # Update negative indexes to absolute indexes.
                 return (

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1021,6 +1021,8 @@ class Series:
 
         # Sequence of integers (slow to check if sequence contains all integers).
         elif is_int_sequence(item):
+            if len(item) == 0:
+                return self[:0]
             return self._from_pyseries(
                 self._s.take_with_series(self._pos_idxs(Series("", item))._s)
             )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -83,6 +83,7 @@ from polars.utils._construction import (
     pandas_to_pyseries,
     sequence_to_pyseries,
     series_to_pyseries,
+    numpy_to_idxs,
 )
 from polars.utils._wrap import wrap_df
 from polars.utils.convert import (
@@ -966,11 +967,8 @@ class Series:
             #   - Signed numpy array indexes are converted pl.UInt32 (polars) or
             #     pl.UInt64 (polars_u64_idx) after negative indexes are converted
             #     to absolute indexes.
-            pl_type = numpy_char_code_to_dtype(item.dtype)
             return self._from_pyseries(
-                self._s.take_with_series(
-                    pl.Series("", item, dtype=pl_type)._pos_idxs(self.len())._s
-                )
+                self._s.take_with_series(numpy_to_idxs(item, self.len())._s)
             )
 
         # Integer.

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -32,6 +32,7 @@ from polars.datatypes import (
     Datetime,
     Duration,
     Float32,
+    UInt32,
     List,
     Object,
     Struct,
@@ -61,7 +62,7 @@ from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import ComputeError, ShapeError, TimeZoneAwareConstructorWarning
 from polars.utils._wrap import wrap_df, wrap_s
-from polars.utils.meta import threadpool_size
+from polars.utils.meta import threadpool_size, get_index_type
 from polars.utils.various import _is_generator, arrlen, find_stacklevel, range_to_series
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -1543,3 +1544,37 @@ def coerce_arrow(array: pa.Array, rechunk: bool = True) -> pa.Array:
                 array, pa.dictionary(pa.uint32(), pa.large_string())
             ).combine_chunks()
     return array
+
+def numpy_to_idxs(idxs: np.ndarray, size: int) -> pl.Series:
+    if idxs.ndim != 1:
+        raise ValueError("Only 1D numpy array is supported as index.")
+
+    idx_type = get_index_type()
+
+    if len(idxs) == 0:
+        return pl.Series("", [], dtype=idx_type)
+
+    # Numpy array with signed or unsigned integers.
+    if not idxs.dtype.kind in ("i", "u"):
+        raise NotImplementedError("Unsupported idxs datatype.")
+
+    if idx_type == UInt32:
+        if idxs.dtype in {np.int64, np.uint64} and idxs.max() >= 2**32:
+            raise ValueError("Index positions should be smaller than 2^32.")
+        if idxs.dtype == np.int64 and idxs.min() < -(2**32):
+            raise ValueError(
+                "Index positions should be bigger than -2^32 + 1."
+            )
+
+    if idxs.dtype.kind == "i" and idxs.min() < 0:
+        if idx_type == UInt32:
+            if idxs.dtype in (np.int8, np.int16):
+                idxs = idxs.astype(np.int32)
+        else:
+            if idxs.dtype in (np.int8, np.int16, np.int32):
+                idxs = idxs.astype(np.int64)
+
+        # Update negative indexes to absolute indexes.
+        idxs = np.where(idxs < 0, size + idxs, idxs)
+
+    return pl.Series("", idxs, dtype=idx_type)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2557,7 +2557,7 @@ def test_getitem() -> None:
 
     # numpy array: assumed to be row indices if integers, or columns if strings
 
-    # numpy array: positive idxs.
+    # numpy array: positive idxs and empty idx
     for np_dtype in (
         np.int8,
         np.int16,
@@ -2574,6 +2574,7 @@ def test_getitem() -> None:
                 {"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]}
             ),
         )
+        assert df[np.array([], dtype=np_dtype)].columns == ["a", "b"]
 
     # numpy array: positive and negative idxs.
     for np_dtype in (np.int8, np.int16, np.int32, np.int64):
@@ -2603,7 +2604,7 @@ def test_getitem() -> None:
     # pl.Series: strings for column selections.
     assert_frame_equal(df[pl.Series("", ["a", "b"])], df)
 
-    # pl.Series: positive idxs for row selection.
+    # pl.Series: positive idxs or empty idxs for row selection.
     for pl_dtype in (
         pl.Int8,
         pl.Int16,
@@ -2620,6 +2621,7 @@ def test_getitem() -> None:
                 {"a": [2.0, 1.0, 4.0, 3.0, 4.0, 1.0], "b": [4, 3, 6, 5, 6, 3]}
             ),
         )
+        assert df[pl.Series("", [], dtype=pl_dtype)].columns == ["a", "b"]
 
     # pl.Series: positive and negative idxs for row selection.
     for pl_dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2549,11 +2549,14 @@ def test_getitem() -> None:
     assert df[:0].columns == ["a", "b"]
     assert len(df[:0]) == 0
 
+    # make mypy happy
+    empty: list[int] = []
+
     # empty list with column selector drops rows but keeps columns
-    assert_frame_equal(df[[], :], df[:0])
+    assert_frame_equal(df[empty, :], df[:0])
 
     # empty list without column select return empty frame
-    assert_frame_equal(df[[]], pl.DataFrame({}))
+    assert_frame_equal(df[empty], pl.DataFrame({}))
 
     # numpy array: assumed to be row indices if integers, or columns if strings
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2545,6 +2545,16 @@ def test_getitem() -> None:
     # slice. Below an example of taking every second row
     assert_frame_equal(df[1::2], pl.DataFrame({"a": [2.0, 4.0], "b": [4, 6]}))
 
+    # slice, empty slice
+    assert df[:0].columns == ["a", "b"]
+    assert len(df[:0]) == 0
+
+    # empty list with column selector drops rows but keeps columns
+    assert_frame_equal(df[[], :], df[:0])
+
+    # empty list without column select return empty frame
+    assert_frame_equal(df[[]], pl.DataFrame({}))
+
     # numpy array: assumed to be row indices if integers, or columns if strings
 
     # numpy array: positive idxs.

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -812,6 +812,7 @@ def test_get() -> None:
     neg_and_pos_idxs = pl.Series(
         "neg_and_pos_idxs", [-2, 1, 0, -1, 2, -3], dtype=pl.Int8
     )
+    empty_idxs = pl.Series("idxs", [], dtype=pl.Int8)
     assert a[0] == 1
     assert a[:2].to_list() == [1, 2]
     assert a[range(1)].to_list() == [1]
@@ -830,6 +831,8 @@ def test_get() -> None:
     ):
         assert a[pos_idxs.cast(dtype)].to_list() == [3, 1, 2, 1]
         assert a[pos_idxs.cast(dtype).to_numpy()].to_list() == [3, 1, 2, 1]
+        assert a[empty_idxs.cast(dtype)].to_list() == []
+        assert a[empty_idxs.cast(dtype).to_numpy()].to_list() == []
 
     for dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
         nps = a[neg_and_pos_idxs.cast(dtype).to_numpy()]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -820,6 +820,7 @@ def test_get() -> None:
     assert a[range(0, 4, 2)].to_list() == [1, 3]
     assert a[:0].to_list() == []
     assert a[empty_ints].to_list() == []
+    assert a[neg_and_pos_idxs.to_list()].to_list() == [2, 2, 1, 3, 3, 1]
     for dtype in (
         pl.UInt8,
         pl.UInt16,

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -816,6 +816,7 @@ def test_get() -> None:
     assert a[:2].to_list() == [1, 2]
     assert a[range(1)].to_list() == [1]
     assert a[range(0, 4, 2)].to_list() == [1, 3]
+    assert a[:0].to_list() == []
     assert a[[]].to_list() == []
     for dtype in (
         pl.UInt8,

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -813,12 +813,13 @@ def test_get() -> None:
         "neg_and_pos_idxs", [-2, 1, 0, -1, 2, -3], dtype=pl.Int8
     )
     empty_idxs = pl.Series("idxs", [], dtype=pl.Int8)
+    empty_ints: list[int] = []
     assert a[0] == 1
     assert a[:2].to_list() == [1, 2]
     assert a[range(1)].to_list() == [1]
     assert a[range(0, 4, 2)].to_list() == [1, 3]
     assert a[:0].to_list() == []
-    assert a[[]].to_list() == []
+    assert a[empty_ints].to_list() == []
     for dtype in (
         pl.UInt8,
         pl.UInt16,

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -816,6 +816,7 @@ def test_get() -> None:
     assert a[:2].to_list() == [1, 2]
     assert a[range(1)].to_list() == [1]
     assert a[range(0, 4, 2)].to_list() == [1, 3]
+    assert a[[]].to_list() == []
     for dtype in (
         pl.UInt8,
         pl.UInt16,


### PR DESCRIPTION
Addresses  #8659

I've refactored the 2 `_pos_idxs` methods into a single Series method (operating on self) and a function for converting numpy to indexes, since there was a lot of shared logic between methods (rather than just adding sentinels to both). I'm also unsure if the numpy method is actually more performant or correct than just casting to the related polars type (zero copy?) and calling the Series method.