### PR TITLE
chore(python): Add missing `implode` to internal functions

### DIFF
--- a/py-polars/polars/functions/__init__.py
+++ b/py-polars/polars/functions/__init__.py
@@ -36,6 +36,7 @@ from polars.functions.lazy import (
     from_epoch,
     groups,
     head,
+    implode,
     last,
     lit,
     map,
@@ -102,6 +103,7 @@ __all__ = [
     "from_epoch",
     "groups",
     "head",
+    "implode",
     "last",
     "list",  # named list_, see import above
     "lit",


### PR DESCRIPTION
It was already available as `pl.implode`, but not at the intermediate level - e.g. we couldn't do `import polars.functions as F` followed by `F.implode`.