### PR TITLE
docs(python): add notes on the use of inline regex flags to `extract` docstrings

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -648,7 +648,7 @@ class Expr:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> T:
-        r"""
+        r'''
         Offers a structured way to apply a sequence of user-defined functions (UDFs).
 
         Parameters
@@ -663,18 +663,20 @@ class Expr:
 
         Examples
         --------
-        >>> # extract the digits from a string
         >>> def extract_number(expr: pl.Expr) -> pl.Expr:
+        ...     """Extract the digits from a string."""
         ...     return expr.str.extract(r"\d+", 0).cast(pl.Int64)
         >>>
-        >>> # set even numbers negative and scale by a user-supplied value
         >>> def scale_negative_even(expr: pl.Expr, *, n: int = 1) -> pl.Expr:
+        ...     """Set even numbers negative, and scale by a user-supplied value."""
         ...     expr = pl.when(expr % 2 == 0).then(-expr).otherwise(expr)
         ...     return expr * n
         >>>
         >>> df = pl.DataFrame({"val": ["a: 1", "b: 2", "c: 3", "d: 4"]})
         >>> df.with_columns(
-        ...     udfs=pl.col("val").pipe(extract_number).pipe(scale_negative_even, n=5)
+        ...     udfs=(
+        ...         pl.col("val").pipe(extract_number).pipe(scale_negative_even, n=5)
+        ...     ),
         ... )
         shape: (4, 2)
         ┌──────┬──────┐
@@ -688,7 +690,7 @@ class Expr:
         │ d: 4 ┆ -20  │
         └──────┴──────┘
 
-        """
+        '''
         return function(self, *args, **kwargs)
 
     def prefix(self, prefix: str) -> Self:

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -360,7 +360,7 @@ class StringNameSpace:
         Notes
         -----
         To modify regular expression behaviour (such as case-sensitivity) with
-        flags, use the inline ``(?iLmsuxU)`` syntax.
+        flags, use the inline ``(?iLmsuxU)`` syntax. For example:
 
         Default (case-sensitive) match:
 
@@ -579,11 +579,36 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regex pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
         group_index
             Index of the targeted capture group.
             Group 0 mean the whole pattern, first group begin at index 1
             Default to the first capture group
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as multi-line matching)
+        with flags, use the inline ``(?iLmsuxU)`` syntax. For example:
+
+        >>> s = pl.Series(
+        ...     name="lines",
+        ...     values=[
+        ...         "I Like\nThose\nOdds",
+        ...         "This is\nThe Way",
+        ...     ],
+        ... )
+        >>> s.str.extract(r"(?m)^(T\w+)", 1).alias("matches")
+        shape: (2,)
+        Series: 'matches' [str]
+        [
+            "Those"
+            "This"
+        ]
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
 
         Returns
         -------
@@ -591,26 +616,22 @@ class StringNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [
-        ...             "http://vote.com/ballon_dor?candidate=messi&ref=polars",
-        ...             "http://vote.com/ballon_dor?candidat=jorginho&ref=polars",
-        ...             "http://vote.com/ballon_dor?candidate=ronaldo&ref=polars",
-        ...         ]
-        ...     }
+        >>> s = pl.Series(
+        ...     name="url",
+        ...     values=[
+        ...         "http://vote.com/ballon_dor?ref=polars&candidate=messi",
+        ...         "http://vote.com/ballon_dor?candidate=ronaldo&ref=polars",
+        ...         "http://vote.com/ballon_dor?error=404&ref=unknown",
+        ...     ],
         ... )
-        >>> df.select(pl.col("a").str.extract(r"candidate=(\w+)", 1))
-        shape: (3, 1)
-        ┌─────────┐
-        │ a       │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │ messi   │
-        │ null    │
-        │ ronaldo │
-        └─────────┘
+        >>> s.str.extract(r"candidate=(\w+)", 1).alias("candidate")
+        shape: (3,)
+        Series: 'candidate' [str]
+        [
+            "messi"
+            "ronaldo"
+            null
+        ]
 
         """
 


### PR DESCRIPTION
Follow-up to #8657.
Adds a "Notes" section to `extract` methods, detailing use of inline regex flags, and enhances existing examples:

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/2613171/236135090-437a6cf9-75bd-40be-adcc-8742ade298dd.png">
  <img src="https://user-images.githubusercontent.com/2613171/236135084-5ce55ede-156d-45ca-9dde-a285c488f3ed.png">
</picture>