### PR TITLE
feat(python): allow `arr.to_struct` to take a list of field names, fix it for `Series`, improve related docstrings

### DIFF
--- a/py-polars/docs/source/reference/series/struct.rst
+++ b/py-polars/docs/source/reference/series/struct.rst
@@ -18,3 +18,4 @@ The following methods are available under the `Series.struct` attribute.
    :template: autosummary/accessor_attribute.rst
 
     Series.struct.fields
+    Series.struct.schema

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import polars._reexport as pl
 from polars import functions as F
@@ -711,7 +711,7 @@ class ExprListNameSpace:
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",
-        name_generator: Callable[[int], str] | None = None,
+        name_generator: Callable[[int], str] | Sequence[str] | None = None,
         upper_bound: int = 0,
     ) -> Expr:
         """
@@ -721,42 +721,65 @@ class ExprListNameSpace:
         ----------
         n_field_strategy : {'first_non_null', 'max_width'}
             Strategy to determine the number of fields of the struct.
+
+            * "first_non_null": set number of fields equal to the length of the
+              first non zero-length sublist.
+            * "max_width": set number of fields as max length of all sublists.
+
         name_generator
-            A custom function that can be used to generate the field names.
-            Default field names are `field_0, field_1 .. field_n`
+            A custom function that can be used to generate the field names. If
+            unset, the default field names are `field_0, field_1 .. field_n`. If
+            the name and number of the desired fields is known in advance you
+            can also pass a list of field names, which will be assigned by index.
         upper_bound
-            A polars `LazyFrame` needs to know the schema at all time.
-            The caller therefore must provide an `upper_bound` of
-            struct fields that will be set.
-            If this is incorrectly downstream operation may fail.
-            For instance an `all().sum()` expression will look in
-            the current schema to determine which columns to select.
-            It is advised to set this value in a lazy query.
+            A polars ``LazyFrame`` needs to know the schema at all times, so the
+            caller must provide an upper bound of the number of struct fields that
+            will be created; if set incorrectly, subsequent operations may fail.
+            (For example, an ``all().sum()`` expression will look in the current
+            schema to determine which columns to select).
+
+            When operating on a ``DataFrame``, the schema does not need to be
+            tracked or pre-determined, as the result will be eagerly evaluated,
+            so you can leave this parameter unset.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"a": [[1, 2, 3], [1, 2]]})
-        >>> df.select([pl.col("a").arr.to_struct()])
+        Convert list to struct with default field name assignment:
+
+        >>> df = pl.DataFrame({"n": [[0, 1, 2], [0, 1]]})
+        >>> df.select(pl.col("n").arr.to_struct())
         shape: (2, 1)
         ┌────────────┐
-        │ a          │
+        │ n          │
         │ ---        │
         │ struct[3]  │
         ╞════════════╡
-        │ {1,2,3}    │
-        │ {1,2,null} │
+        │ {0,1,2}    │
+        │ {0,1,null} │
         └────────────┘
+
+        Convert list to struct with field name assignment by function/index:
+
         >>> df.select(
-        ...     [
-        ...         pl.col("a").arr.to_struct(
-        ...             name_generator=lambda idx: f"col_name_{idx}"
-        ...         )
-        ...     ]
-        ... ).to_series().to_list()
-        [{'col_name_0': 1, 'col_name_1': 2, 'col_name_2': 3},
-        {'col_name_0': 1, 'col_name_1': 2, 'col_name_2': None}]
+        ...     pl.col("n").arr.to_struct(name_generator=lambda idx: f"n{idx}")
+        ... ).rows(named=True)
+        [{'n': {'n0': 0, 'n1': 1, 'n2': 2}}, {'n': {'n0': 0, 'n1': 1, 'n2': None}}]
+
+        Convert list to struct with field name assignment by index from a list of names:
+
+        >>> df.select(
+        ...     pl.col("n").arr.to_struct(name_generator=["one", "two", "three"])
+        ... ).rows(named=True)
+        [{'n': {'one': 0, 'two': 1, 'three': 2}},
+        {'n': {'one': 0, 'two': 1, 'three': None}}]
 
         """
+        if isinstance(name_generator, Sequence):
+            column_names = list(name_generator)
+
+            def name_generator(idx: int) -> str:
+                return column_names[idx]
+
         return wrap_expr(
             self._pyexpr.list_to_struct(n_field_strategy, name_generator, upper_bound)
         )

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -387,10 +388,11 @@ class ListNameSpace:
 
         """
 
+    @deprecated_alias(name_generator="fields")
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",
-        name_generator: Callable[[int], str] | Sequence[str] | None = None,
+        fields: Callable[[int], str] | Sequence[str] | None = None,
     ) -> Series:
         """
         Convert the series of type ``List`` to a series of type ``Struct``.
@@ -404,11 +406,11 @@ class ListNameSpace:
               first non zero-length sublist.
             * "max_width": set number of fields as max length of all sublists.
 
-        name_generator
-            A custom function that can be used to generate the field names. If
-            unset, the default field names are `field_0, field_1 .. field_n`. If
-            the name and number of the desired fields is known in advance you
-            can also pass a list of field names, which will be assigned by index.
+        fields
+            If the name and number of the desired fields is known in advance
+            a list of field names can be given, which will be assigned by index.
+            Otherwise, to dynamically assign field names, a custom function can be
+            used; if neither are set, fields will be `field_0, field_1 .. field_n`.
 
         Examples
         --------
@@ -428,13 +430,13 @@ class ListNameSpace:
 
         Convert list to struct with field name assignment by function/index:
 
-        >>> s3 = s1.arr.to_struct(name_generator=lambda idx: f"n{idx:02}")
+        >>> s3 = s1.arr.to_struct(fields=lambda idx: f"n{idx:02}")
         >>> s3.struct.fields
         ['n00', 'n01', 'n02']
 
         Convert list to struct with field name assignment by index from a list of names:
 
-        >>> s1.arr.to_struct(name_generator=["one", "two", "three"]).struct.unnest()
+        >>> s1.arr.to_struct(fields=["one", "two", "three"]).struct.unnest()
         shape: (2, 3)
         ┌─────┬─────┬───────┐
         │ one ┆ two ┆ three │
@@ -454,7 +456,7 @@ class ListNameSpace:
                     # note: in eager mode, 'upper_bound' is always zero, as (unlike
                     # in lazy mode) there is no need to determine/track the schema.
                     n_field_strategy,
-                    name_generator,
+                    fields,
                     upper_bound=0,
                 )
             )

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -9,6 +9,7 @@ from polars.utils.various import sphinx_accessor
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
+    from polars.datatypes import PolarsDataType
     from polars.polars import PySeries
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
@@ -62,6 +63,13 @@ class StructNameSpace:
             New names in the order of the struct's fields
 
         """
+
+    @property
+    def schema(self) -> dict[str, PolarsDataType]:
+        """Get the struct definition as a name/dtype schema dict."""
+        if getattr(self, "_s", None) is None:
+            return {}
+        return self._s.dtype().to_schema()
 
     def unnest(self) -> DataFrame:
         """

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -319,7 +319,7 @@ def test_list_to_struct() -> None:
 
     df = pl.DataFrame({"a": [[1, 2], [1, 2, 3]]})
     assert df.select(
-        [pl.col("a").arr.to_struct(name_generator=lambda idx: f"col_name_{idx}")]
+        [pl.col("a").arr.to_struct(fields=lambda idx: f"col_name_{idx}")]
     ).to_series().to_list() == [
         {"col_name_0": 1, "col_name_1": 2},
         {"col_name_0": 1, "col_name_1": 2},

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -423,16 +423,16 @@ def test_list_to_struct() -> None:
         {"n": {"field_0": 0, "field_1": 1, "field_2": None}},
     ]
 
-    assert df.select(
-        pl.col("n").arr.to_struct(name_generator=lambda idx: f"n{idx}")
-    ).rows(named=True) == [
+    assert df.select(pl.col("n").arr.to_struct(fields=lambda idx: f"n{idx}")).rows(
+        named=True
+    ) == [
         {"n": {"n0": 0, "n1": 1, "n2": 2}},
         {"n": {"n0": 0, "n1": 1, "n2": None}},
     ]
 
-    assert df.select(
-        pl.col("n").arr.to_struct(name_generator=["one", "two", "three"])
-    ).rows(named=True) == [
+    assert df.select(pl.col("n").arr.to_struct(fields=["one", "two", "three"])).rows(
+        named=True
+    ) == [
         {"n": {"one": 0, "two": 1, "three": 2}},
         {"n": {"one": 0, "two": 1, "three": None}},
     ]

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -413,3 +413,26 @@ def test_list_unique() -> None:
         .arr.unique(maintain_order=True)
         .series_equal(pl.Series([[1, 2, 3], [3, 2, 1]]))
     )
+
+
+def test_list_to_struct() -> None:
+    df = pl.DataFrame({"n": [[0, 1, 2], [0, 1]]})
+
+    assert df.select(pl.col("n").arr.to_struct()).rows(named=True) == [
+        {"n": {"field_0": 0, "field_1": 1, "field_2": 2}},
+        {"n": {"field_0": 0, "field_1": 1, "field_2": None}},
+    ]
+
+    assert df.select(
+        pl.col("n").arr.to_struct(name_generator=lambda idx: f"n{idx}")
+    ).rows(named=True) == [
+        {"n": {"n0": 0, "n1": 1, "n2": 2}},
+        {"n": {"n0": 0, "n1": 1, "n2": None}},
+    ]
+
+    assert df.select(
+        pl.col("n").arr.to_struct(name_generator=["one", "two", "three"])
+    ).rows(named=True) == [
+        {"n": {"one": 0, "two": 1, "three": 2}},
+        {"n": {"one": 0, "two": 1, "three": None}},
+    ]

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -102,9 +102,7 @@ def test_unnest_columns_available() -> None:
     q = df.with_columns(
         pl.col("genres")
         .str.split("|")
-        .arr.to_struct(
-            n_field_strategy="max_width", name_generator=lambda i: f"genre{i+1}"
-        )
+        .arr.to_struct(n_field_strategy="max_width", fields=lambda i: f"genre{i+1}")
     ).unnest("genres")
 
     out = q.collect()

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -597,6 +597,20 @@ def test_to_python() -> None:
     assert a.to_list() == [1, None, 2]
 
 
+def test_to_struct() -> None:
+    s = pl.Series("nums", ["12 34", "56 78", "90 00"]).str.extract_all(r"\d+")
+
+    assert s.arr.to_struct().struct.fields == ["field_0", "field_1"]
+    assert s.arr.to_struct(name_generator=lambda idx: f"n{idx:02}").struct.fields == [
+        "n00",
+        "n01",
+    ]
+    assert_frame_equal(
+        s.arr.to_struct(name_generator=["one", "two"]).struct.unnest(),
+        pl.DataFrame({"one": ["12", "56", "90"], "two": ["34", "78", "00"]}),
+    )
+
+
 def test_sort() -> None:
     a = pl.Series("a", [2, 1, 3])
     assert_series_equal(a.sort(), pl.Series("a", [1, 2, 3]))

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -601,12 +601,12 @@ def test_to_struct() -> None:
     s = pl.Series("nums", ["12 34", "56 78", "90 00"]).str.extract_all(r"\d+")
 
     assert s.arr.to_struct().struct.fields == ["field_0", "field_1"]
-    assert s.arr.to_struct(name_generator=lambda idx: f"n{idx:02}").struct.fields == [
+    assert s.arr.to_struct(fields=lambda idx: f"n{idx:02}").struct.fields == [
         "n00",
         "n01",
     ]
     assert_frame_equal(
-        s.arr.to_struct(name_generator=["one", "two"]).struct.unnest(),
+        s.arr.to_struct(fields=["one", "two"]).struct.unnest(),
         pl.DataFrame({"one": ["12", "56", "90"], "two": ["34", "78", "00"]}),
     )
 


### PR DESCRIPTION
**Features**:
  * allow `arr.to_struct` to take a list of column names to assign the the struct fields (by index).
  * deprecate `arr.to_struct` "name_generator" parameter name in favour of "fields".
  * add convenience "schema" property to `Series.struct` namespace.

**Fixes**:
  *  `Series.arr.to_struct` didn't work - always failed with a `TypeError`; fixed, and added coverage.

**Docs**: 
  * improved `arr.to_struct` docstrings, with additional examples/clarifications.

## Examples
Apply `to_struct` conversion with a list of field names:
```python
import polars as pl

s1 = pl.Series( "nums", ["12 34", "56 78", "90 00"] ).str.extract_all( r"\d+" )
# shape: (3,)
# Series: 'nums' [list[str]]
# [
#     ["12", "34"]
#     ["56", "78"]
#     ["90", "00"]
# ]

s2 = s1.arr.to_struct( fields=["one","two"] )
# shape: (3,)
# Series: 'nums' [struct[2]]
# [
#     {"12","34"}
#     {"56","78"}
#     {"90","00"}
# ]

s2.struct.schema
# {'one': Utf8, 'two': Utf8}

df = s2.struct.unnest()
# shape: (3, 2)
# ┌─────┬─────┐
# │ one ┆ two │
# │ --- ┆ --- │
# │ str ┆ str │
# ╞═════╪═════╡
# │ 12  ┆ 34  │
# │ 56  ┆ 78  │
# │ 90  ┆ 00  │
# └─────┴─────┘
```