### PR TITLE
docs(python): add notes/examples on use of inline regex flags to `extract_all` docstrings

### DIFF
--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -636,7 +636,7 @@ class StringNameSpace:
         """
 
     def extract_all(self, pattern: str | Series) -> Series:
-        r"""
+        r'''
         Extracts all matches for the given regex pattern.
 
         Extract each successive non-overlapping regex match in an individual string as
@@ -645,17 +645,55 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regex pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as "verbose" mode and/or
+        case-sensitive matching) with flags, use the inline ``(?iLmsuxU)`` syntax.
+        For example:
+
+        >>> s = pl.Series(
+        ...     name="email",
+        ...     values=[
+        ...         "real.email@spam.com",
+        ...         "some_account@somewhere.net",
+        ...         "abc.def.ghi.jkl@uvw.xyz.co.uk",
+        ...     ],
+        ... )
+        >>> # extract name/domain parts from email, using verbose regex
+        >>> s.str.extract_all(
+        ...     r"""(?xi)   # activate 'verbose' and 'case-insensitive' flags
+        ...       [         # (start character group)
+        ...         A-Z     # letters
+        ...         0-9     # digits
+        ...         ._%+\-  # special chars
+        ...       ]         # (end character group)
+        ...       +         # 'one or more' quantifier
+        ...     """
+        ... ).alias("email_parts")
+        shape: (3,)
+        Series: 'email_parts' [list[str]]
+        [
+            ["real.email", "spam.com"]
+            ["some_account", "somewhere.net"]
+            ["abc.def.ghi.jkl", "uvw.xyz.co.uk"]
+        ]
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
 
         Returns
         -------
-        List[Utf8] array. Contain null if original value is null or regex capture
-        nothing.
+        List[Utf8] array. Contains ``null`` if the original value is null or
+        the regex did not capture anything.
 
         Examples
         --------
         >>> s = pl.Series("foo", ["123 bla 45 asd", "xyz 678 910t"])
-        >>> s.str.extract_all(r"(\d+)")
+        >>> s.str.extract_all(r"\d+")
         shape: (2,)
         Series: 'foo' [list[str]]
         [
@@ -663,7 +701,7 @@ class StringNameSpace:
             ["678", "910"]
         ]
 
-        """
+        '''
 
     def count_match(self, pattern: str) -> Series:
         r"""


### PR DESCRIPTION
Another follow-up to #8657...
Adds a "Notes" section to `extract_all` methods, detailing use of inline regex flags, and enhances existing examples:

## Example

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/2613171/236231106-2b9393cf-331e-454d-ab19-a81a2bd45c13.png">
  <img src="https://user-images.githubusercontent.com/2613171/236231119-e3752084-dcc6-49b9-9a41-5bc4caddd39d.png">
</picture>