### PR TITLE
docs(python): add notes/examples on use of inline regex flags to `replace` docstrings

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1368,24 +1368,26 @@ class ExprStringNameSpace:
 
         >>> df = pl.DataFrame(
         ...     {
-        ...         "city": ["Tokyo", "Abu Dhabi", "Stockholm"],
-        ...         "weather": ["Rainy", "Sunny", "Foggy"],
+        ...         "city": "Philadelphia",
+        ...         "season": ["Spring", "Summer", "Autumn", "Winter"],
+        ...         "weather": ["Rainy", "Sunny", "Cloudy", "Snowy"],
         ...     }
         ... )
         >>> df.with_columns(
         ...     # apply case-insensitive string replacement
-        ...     pl.col("weather").str.replace(r"(?i)foggy|rainy", "Sunny")
+        ...     pl.col("weather").str.replace(r"(?i)foggy|rainy|cloudy|snowy", "Sunny")
         ... )
-        shape: (3, 2)
-        ┌───────────┬─────────┐
-        │ city      ┆ weather │
-        │ ---       ┆ ---     │
-        │ str       ┆ str     │
-        ╞═══════════╪═════════╡
-        │ Tokyo     ┆ Sunny   │
-        │ Abu Dhabi ┆ Sunny   │
-        │ Stockholm ┆ Sunny   │
-        └───────────┴─────────┘
+        shape: (4, 3)
+        ┌──────────────┬────────┬─────────┐
+        │ city         ┆ season ┆ weather │
+        │ ---          ┆ ---    ┆ ---     │
+        │ str          ┆ str    ┆ str     │
+        ╞══════════════╪════════╪═════════╡
+        │ Philadelphia ┆ Spring ┆ Sunny   │
+        │ Philadelphia ┆ Summer ┆ Sunny   │
+        │ Philadelphia ┆ Autumn ┆ Sunny   │
+        │ Philadelphia ┆ Winter ┆ Sunny   │
+        └──────────────┴────────┴─────────┘
 
         See the regex crate's section on `grouping and flags
         <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1059,10 +1059,11 @@ class ExprStringNameSpace:
 
     def extract_all(self, pattern: str | Expr) -> Expr:
         r'''
-        Extracts all matches for the given regex pattern.
+        Extract all matches for the given regex pattern.
 
-        Extracts each successive non-overlapping regex match in an individual string as
-        an array.
+        Extract each successive non-overlapping regex match in an individual string
+        as a list. Extracted matches contain ``null`` if the original value is null
+        or the regex did not capture anything.
 
         Parameters
         ----------
@@ -1118,8 +1119,7 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        List[Utf8] array. Contains ``null`` if the original value is null or
-        the regex did not capture anything.
+        List[Utf8]
 
         Examples
         --------
@@ -1148,7 +1148,7 @@ class ExprStringNameSpace:
         Parameters
         ----------
         pattern
-            A regex pattern compatible with the `regex crate
+            A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
 
         Returns
@@ -1352,14 +1352,44 @@ class ExprStringNameSpace:
         Parameters
         ----------
         pattern
-            A regex pattern compatible with the `regex crate
+            A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
         value
-            Replacement string.
+            String that will replace the matched substring.
         literal
-             Treat pattern as a literal string.
+            Treat pattern as a literal string.
         n
-            Number of matches to replace
+            Number of matches to replace.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as case-sensitivity) with flags,
+        use the inline ``(?iLmsuxU)`` syntax. For example:
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "city": ["Tokyo", "Abu Dhabi", "Stockholm"],
+        ...         "weather": ["Rainy", "Sunny", "Foggy"],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     # apply case-insensitive string replacement
+        ...     pl.col("weather").str.replace(r"(?i)foggy|rainy", "Sunny")
+        ... )
+        shape: (3, 2)
+        ┌───────────┬─────────┐
+        │ city      ┆ weather │
+        │ ---       ┆ ---     │
+        │ str       ┆ str     │
+        ╞═══════════╪═════════╡
+        │ Tokyo     ┆ Sunny   │
+        │ Abu Dhabi ┆ Sunny   │
+        │ Stockholm ┆ Sunny   │
+        └───────────┴─────────┘
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
 
         See Also
         --------
@@ -1397,12 +1427,12 @@ class ExprStringNameSpace:
         Parameters
         ----------
         pattern
-            A regex pattern compatible with the `regex crate
+            A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
         value
             Replacement string.
         literal
-             Treat pattern as a literal string.
+            Treat pattern as a literal string.
 
         See Also
         --------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -637,10 +637,11 @@ class StringNameSpace:
 
     def extract_all(self, pattern: str | Series) -> Series:
         r'''
-        Extracts all matches for the given regex pattern.
+        Extract all matches for the given regex pattern.
 
-        Extract each successive non-overlapping regex match in an individual string as
-        an array
+        Extract each successive non-overlapping regex match in an individual string
+        as a list. Extracted matches contain ``null`` if the original value is null
+        or the regex did not capture anything.
 
         Parameters
         ----------
@@ -687,8 +688,7 @@ class StringNameSpace:
 
         Returns
         -------
-        List[Utf8] array. Contains ``null`` if the original value is null or
-        the regex did not capture anything.
+        List[Utf8]
 
         Examples
         --------
@@ -710,7 +710,8 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regex pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
 
         Returns
         -------
@@ -874,13 +875,41 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regex pattern.
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
         value
-            Substring to replace.
+            String that will replace the matched substring.
         literal
-             Treat pattern as a literal string.
+            Treat pattern as a literal string.
         n
-            Number of matches to replace
+            Number of matches to replace.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as case-sensitivity) with flags,
+        use the inline ``(?iLmsuxU)`` syntax. For example:
+
+        >>> s = pl.Series(
+        ...     name="weather",
+        ...     values=[
+        ...         "Foggy",
+        ...         "Rainy",
+        ...         "Sunny",
+        ...     ],
+        ... )
+        >>> # apply case-insensitive string replacement
+        >>> s.str.replace(r"(?i)foggy|rainy", "Sunny")
+        shape: (3,)
+        Series: 'weather' [str]
+        [
+            "Sunny"
+            "Sunny"
+            "Sunny"
+        ]
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
 
         See Also
         --------
@@ -906,11 +935,12 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regex pattern.
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
         value
-            Substring to replace.
+            String that will replace the matches.
         literal
-             Treat pattern as a literal string.
+            Treat pattern as a literal string.
 
         See Also
         --------


### PR DESCRIPTION
_"And the beat goes on..."_ 

Adds a "Notes" section to the `replace` methods, detailing use of inline regex flags.

## Example

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/2613171/236454834-f77b88bb-b15b-4be2-8f8e-6336937518c4.png">
  <img src="https://user-images.githubusercontent.com/2613171/236454828-7898e090-2172-4ead-8b0c-45191af130a0.png">
</picture>



