### PR TITLE
refactor(rust, python)!: Remove deprecated tz_aware argument

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -393,15 +393,10 @@ fn to_datetime(
     time_zone: Option<&TimeZone>,
     options: &StrptimeOptions,
 ) -> PolarsResult<Series> {
-    let tz_aware = match (options.tz_aware, &options.format) {
-        (true, Some(_)) => true,
-        (true, None) => polars_bail!(
-            ComputeError:
-            "passing 'tz_aware=True' without 'format' is not yet supported, please specify 'format'"
-        ),
+    let tz_aware = match &options.format {
         #[cfg(feature = "timezones")]
-        (false, Some(format)) => TZ_AWARE_RE.is_match(format),
-        (false, _) => false,
+        Some(format) => TZ_AWARE_RE.is_match(format),
+        _ => false,
     };
     match (time_zone, tz_aware, options.utc) {
         (Some(_), true, _) => polars_bail!(

--- a/polars/polars-lazy/polars-plan/src/dsl/options.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/options.rs
@@ -25,8 +25,6 @@ pub struct StrptimeOptions {
     pub exact: bool,
     /// use a cache of unique, converted dates to apply the datetime conversion.
     pub cache: bool,
-    /// Parse a timezone aware timestamp
-    pub tz_aware: bool,
     /// Convert timezone aware to UTC
     pub utc: bool,
 }
@@ -38,7 +36,6 @@ impl Default for StrptimeOptions {
             strict: true,
             exact: true,
             cache: true,
-            tz_aware: false,
             utc: false,
         }
     }

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.exceptions import ChronoFormatWarning
-from polars.utils import no_default
 from polars.utils._parse_expr_input import expr_to_lit_or_expr
 from polars.utils._wrap import wrap_expr
 from polars.utils.decorators import deprecated_alias
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
         TimeUnit,
         TransferEncoding,
     )
-    from polars.utils import NoDefault
 
 
 class ExprStringNameSpace:
@@ -82,7 +80,6 @@ class ExprStringNameSpace:
         exact: bool = True,
         cache: bool = True,
         utc: bool = False,
-        _tz_aware: bool = False,
     ) -> Expr:
         """
         Convert a Utf8 column into a Datetime column.
@@ -134,7 +131,6 @@ class ExprStringNameSpace:
                 exact,
                 cache,
                 utc,
-                _tz_aware,
             )
         )
 
@@ -186,7 +182,6 @@ class ExprStringNameSpace:
         exact: bool = True,
         cache: bool = True,
         utc: bool = False,
-        tz_aware: bool | NoDefault = no_default,
     ) -> Expr:
         """
         Convert a Utf8 column into a Date/Datetime/Time column.
@@ -210,13 +205,6 @@ class ExprStringNameSpace:
         utc
             Parse time zone aware datetimes as UTC. This may be useful if you have data
             with mixed offsets.
-        tz_aware
-            Parse time zone aware datetimes. This may be automatically toggled by the
-            `format` given.
-
-            .. deprecated:: 0.16.17
-                This is now auto-inferred from the given `format`. You can safely drop
-                this argument, it will be removed in a future version.
 
         Notes
         -----
@@ -268,16 +256,6 @@ class ExprStringNameSpace:
         """
         _validate_format_argument(format)
 
-        if tz_aware is no_default:
-            tz_aware = False
-        else:
-            warnings.warn(
-                "`tz_aware` is now auto-inferred from `format` and will be removed "
-                "in a future version. You can safely drop this argument.",
-                category=DeprecationWarning,
-                stacklevel=find_stacklevel(),
-            )
-
         if dtype == Date:
             return self.to_date(format, strict=strict, exact=exact, cache=cache)
         elif dtype == Datetime:
@@ -291,7 +269,6 @@ class ExprStringNameSpace:
                 exact=exact,
                 cache=cache,
                 utc=utc,
-                _tz_aware=tz_aware,
             )
         elif dtype == Time:
             return self.to_time(format, strict=strict, cache=cache)

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from polars import functions as F
 from polars.series.utils import expr_dispatch
-from polars.utils import no_default
 from polars.utils._wrap import wrap_s
 from polars.utils.decorators import deprecated_alias
 
@@ -17,7 +16,6 @@ if TYPE_CHECKING:
         TimeUnit,
         TransferEncoding,
     )
-    from polars.utils import NoDefault
 
 
 @expr_dispatch
@@ -167,7 +165,6 @@ class StringNameSpace:
         exact: bool = True,
         cache: bool = True,
         utc: bool = False,
-        tz_aware: bool | NoDefault = no_default,
     ) -> Series:
         """
         Convert a Utf8 column into a Date/Datetime/Time column.
@@ -191,13 +188,6 @@ class StringNameSpace:
         utc
             Parse time zone aware datetimes as UTC. This may be useful if you have data
             with mixed offsets.
-        tz_aware
-            Parse time zone aware datetimes. This may be automatically toggled by the
-            `format` given.
-
-            .. deprecated:: 0.16.17
-                This is now auto-inferred from the given `format`. You can safely drop
-                this argument, it will be removed in a future version.
 
         Notes
         -----
@@ -258,7 +248,6 @@ class StringNameSpace:
                     exact=exact,
                     cache=cache,
                     utc=utc,
-                    tz_aware=tz_aware,
                 )
             )
             .to_series()

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -22,7 +22,7 @@ impl PyExpr {
         self.inner.clone().str().to_date(options).into()
     }
 
-    #[pyo3(signature = (format, time_unit, time_zone, strict, exact, cache, utc, tz_aware))]
+    #[pyo3(signature = (format, time_unit, time_zone, strict, exact, cache, utc))]
     #[allow(clippy::too_many_arguments)]
     fn str_to_datetime(
         &self,
@@ -33,14 +33,12 @@ impl PyExpr {
         exact: bool,
         cache: bool,
         utc: bool,
-        tz_aware: bool,
     ) -> Self {
         let options = StrptimeOptions {
             format,
             strict,
             exact,
             cache,
-            tz_aware,
             utc,
         };
         self.inner

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -436,21 +436,6 @@ def test_crossing_dst_tz_aware(format: str) -> None:
         pl.Series(ts).str.to_datetime(format, utc=False)
 
 
-def test_tz_aware_without_fmt() -> None:
-    with pytest.raises(
-        ComputeError,
-        match=(
-            r"^passing 'tz_aware=True' without 'format' is not yet supported, "
-            r"please specify 'format'$"
-        ),
-    ), pytest.warns(
-        DeprecationWarning,
-        match="`tz_aware` is now auto-inferred from `format` and will be removed "
-        "in a future version. You can safely drop this argument.",
-    ):
-        pl.Series(["2020-01-01"]).str.strptime(pl.Datetime, tz_aware=True)
-
-
 @pytest.mark.parametrize(
     ("data", "format", "expected"),
     [


### PR DESCRIPTION
this was deprecated in 0.16.x, so OK to enforce in 0.18.0?