### PR TITLE
docs(python): Add warning to count methods on null

### DIFF
--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -452,6 +452,9 @@ class GroupBy(Generic[DF]):
         """
         Count the number of values in each group.
 
+        .. warning::
+            `null` is deemed a value in this context.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1124,6 +1124,9 @@ class Expr:
         """
         Count the number of values in this expression.
 
+        .. warning::
+            `null` is deemed a value in this context.
+
         Examples
         --------
         >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -291,6 +291,9 @@ def count(column: str | Series | None = None) -> Expr | int:
     """
     Count the number of values in this column/context.
 
+    .. warning::
+        `null` is deemed a value in this context.
+
     Parameters
     ----------
     column

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -346,6 +346,9 @@ class LazyGroupBy(Generic[LDF]):
         """
         Count the number of values in each group.
 
+        .. warning::
+            `null` is deemed a value in this context.
+
         Examples
         --------
         >>> ldf = pl.DataFrame(


### PR DESCRIPTION
We have discussion in #5396 whether this should be the case or not. Pending a change, I think it is prudent to add a warning, as it is not per se expected behaviour coming from other libraries.