### PR TITLE
feat(python): improved `numpy` string interop

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -470,7 +470,8 @@ def supported_numpy_char_code(dtype_char: str) -> bool:
 def numpy_char_code_to_dtype(dtype_char: str) -> PolarsDataType:
     """Convert a numpy character dtype to a Polars dtype."""
     dtype = np.dtype(dtype_char)
-
+    if dtype.kind == "U":
+        return Utf8
     try:
         return DataTypeMappings.NUMPY_KIND_AND_ITEMSIZE_TO_DTYPE[
             (dtype.kind, dtype.itemsize)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1026,6 +1026,8 @@ class Series:
             raise ValueError(f'cannot use "{key}" for indexing')
 
     def __array__(self, dtype: Any = None) -> np.ndarray[Any, Any]:
+        if not dtype and self.dtype == Utf8 and not self.has_validity():
+            dtype = np.dtype("U")
         if dtype:
             return self.to_numpy().__array__(dtype)
         else:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from numpy.testing import assert_array_equal
 
 import polars as pl
 from polars.datatypes import (
@@ -794,6 +795,14 @@ def test_ufunc() -> None:
     assert_series_equal(
         cast(pl.Series, c2),
         pl.Series("a", [3.0, None, 9.0, 12.0, 15.0, None]),
+    )
+
+
+def test_numpy_string_array() -> None:
+    s_utf8 = pl.Series("a", ["aa", "bb", "cc", "dd"], dtype=pl.Utf8)
+    assert_array_equal(
+        np.char.capitalize(s_utf8),
+        np.array(["Aa", "Bb", "Cc", "Dd"], dtype="<U2"),
     )
 
 


### PR DESCRIPTION
If a Utf8 `Series` has no null values, we can better integrate with string-oriented ufuncs:

```python
import numpy as np
import polars as pl

s = pl.Series( "s", values=["aaa","bbb","ccc","ddd"], dtype=pl.Utf8 )

# pass to numpy string ufunc
np.char.capitalize( s )
```
**Before**:
```python
TypeError: string operation on non-string array
```

**After**:
```python
array( ['Aaa', 'Bbb', 'Ccc', 'Ddd'], dtype='<U3' )
```