### PR TITLE
feat(rust): add support for `HAVING` clause to SQL `GROUP BY` operations

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -295,7 +295,7 @@ mod test {
         reset_string_cache();
         enable_string_cache(false);
 
-        // tests several things that may loose the dtype information
+        // tests several things that may lose the dtype information
         let s = Series::new("a", vec!["a", "b", "c"]).cast(&DataType::Categorical(None))?;
 
         assert_eq!(

--- a/polars/polars-sql/src/keywords.rs
+++ b/polars/polars-sql/src/keywords.rs
@@ -53,6 +53,7 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::NOT,
         keywords::IN,
         keywords::WITH,
+        keywords::HAVING,
     ];
     keywords.extend_from_slice(sql_keywords);
     keywords


### PR DESCRIPTION
Closes #8702.

## Notes
Given the example aggregate query...
```sql
SELECT
  group,
  COUNT(DISTINCT attr) AS n_dist_attr
FROM test
GROUP BY group
```
...this PR adds support for post-aggregate HAVING clauses, such as:
```sql
HAVING n_dist_attr > 1
```
Not all SQL dialects support use of column aliases in the HAVING clause (eg: MySQL does, PostgreSQL doesn't, etc), and the ones that don't want you to re-apply the same expression that you'd find in the SELECT (due to strictness around internal evaluation order of the primary clauses), eg:
```sql
HAVING COUNT(DISTINCT attr) > 1
```

The first form is definitely cleaner, but it can be argued that it's slightly less standard than the latter. Not sure if the parser allows us a way to internally map the expression back to the alias, if we wanted to try and support both? (In truth I've always much preferred the former syntax, as it seems almost self-evidently more obvious/intuitive...😅)