### PR TITLE
fix(rust, python): Don't upcast in round() for f32 when decimal is 0

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -295,7 +295,7 @@ mod test {
         reset_string_cache();
         enable_string_cache(false);
 
-        // tests several things that may loose the dtype information
+        // tests several things that may lose the dtype information
         let s = Series::new("a", vec!["a", "b", "c"]).cast(&DataType::Categorical(None))?;
 
         assert_eq!(

--- a/polars/polars-core/src/series/ops/round.rs
+++ b/polars/polars-core/src/series/ops/round.rs
@@ -11,7 +11,7 @@ impl Series {
                 let s = ca.apply(|val| val.round()).into_series();
                 return Ok(s);
             } else {
-                // Note we do the computation on f64 floats to not loose precision
+                // Note we do the computation on f64 floats to not lose precision
                 // when the computation is done, we cast to f32
                 let multiplier = 10.0.pow(decimals as f64);
                 let s = ca

--- a/polars/polars-core/src/series/ops/round.rs
+++ b/polars/polars-core/src/series/ops/round.rs
@@ -7,13 +7,18 @@ impl Series {
     /// Round underlying floating point array to given decimal.
     pub fn round(&self, decimals: u32) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
-            // Note we do the computation on f64 floats to not loose precision
-            // when the computation is done, we cast to f32
-            let multiplier = 10.0.pow(decimals as f64);
-            let s = ca
-                .apply(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
-                .into_series();
-            return Ok(s);
+            if decimals == 0 {
+                let s = ca.apply(|val| val.round()).into_series();
+                return Ok(s);
+            } else {
+                // Note we do the computation on f64 floats to not loose precision
+                // when the computation is done, we cast to f32
+                let multiplier = 10.0.pow(decimals as f64);
+                let s = ca
+                    .apply(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
+                    .into_series();
+                return Ok(s);
+            }
         }
         if let Ok(ca) = self.f64() {
             let multiplier = 10.0.pow(decimals as f64);


### PR DESCRIPTION
resolves #8705