### PR TITLE
Typed `Expr::map`, `map_typed`

### DIFF
--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -19,6 +19,7 @@ unsafe impl IntoSeries for CategoricalChunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(CategoricalChunked);
 }
 
 impl SeriesWrap<CategoricalChunked> {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -27,7 +27,7 @@ macro_rules! impl_dyn_series {
             fn into_series(self) -> Series {
                 Series(Arc::new(SeriesWrap(self)))
             }
-            crate::impl_get_simple_dtype_error!($ca);
+            crate::impl_intoseries_get_simple_dtype_error!($ca);
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -27,6 +27,7 @@ macro_rules! impl_dyn_series {
             fn into_series(self) -> Series {
                 Series(Arc::new(SeriesWrap(self)))
             }
+            crate::impl_get_simple_dtype_error!($ca);
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -14,6 +14,7 @@ unsafe impl IntoSeries for DatetimeChunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(DatetimeChunked);
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DatetimeChunked> {

--- a/polars/polars-core/src/series/implementations/decimal.rs
+++ b/polars/polars-core/src/series/implementations/decimal.rs
@@ -5,6 +5,7 @@ unsafe impl IntoSeries for DecimalChunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(DecimalChunked);
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DecimalChunked> {}

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -15,6 +15,7 @@ unsafe impl IntoSeries for DurationChunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(DurationChunked);
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DurationChunked> {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -72,6 +72,10 @@ where
     {
         Series(Arc::new(SeriesWrap(self)))
     }
+
+    fn get_simple_dtype() -> PolarsResult<DataType> {
+        Ok(T::get_dtype())
+    }
 }
 
 macro_rules! impl_dyn_series {

--- a/polars/polars-core/src/series/implementations/null.rs
+++ b/polars/polars-core/src/series/implementations/null.rs
@@ -189,4 +189,5 @@ unsafe impl IntoSeries for NullChunked {
     {
         Series(Arc::new(self))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(NullChunked);
 }

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -9,6 +9,7 @@ unsafe impl IntoSeries for StructChunked {
     fn into_series(self) -> Series {
         Series(Arc::new(SeriesWrap(self)))
     }
+    crate::impl_intoseries_get_simple_dtype_error!(StructChunked);
 }
 
 impl PrivateSeriesNumeric for SeriesWrap<StructChunked> {}

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -166,6 +166,18 @@ where
 
 pub trait FunctionOutputField: Send + Sync {
     fn get_field(&self, input_schema: &Schema, cntxt: Context, fields: &[Field]) -> Field;
+    fn output_type_is_inferred(&self) -> bool;
+}
+
+struct ShouldInferOutputTypeMarker;
+
+impl FunctionOutputField for ShouldInferOutputTypeMarker {
+    fn get_field(&self, _: &Schema, _: Context, fields: &[Field]) -> Field {
+        fields[0].clone()
+    }
+    fn output_type_is_inferred(&self) -> bool {
+        true
+    }
 }
 
 pub type GetOutput = SpecialEq<Arc<dyn FunctionOutputField>>;
@@ -181,6 +193,10 @@ impl Default for GetOutput {
 impl GetOutput {
     pub fn same_type() -> Self {
         Default::default()
+    }
+
+    pub fn infer() -> Self {
+        SpecialEq::new(Arc::new(ShouldInferOutputTypeMarker))
     }
 
     pub fn from_type(dt: DataType) -> Self {
@@ -247,6 +263,9 @@ where
 {
     fn get_field(&self, input_schema: &Schema, cntxt: Context, fields: &[Field]) -> Field {
         self(input_schema, cntxt, fields)
+    }
+    fn output_type_is_inferred(&self) -> bool {
+        false
     }
 }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -195,7 +195,7 @@ impl GetOutput {
         Default::default()
     }
 
-    pub fn infer() -> Self {
+    pub fn infer_type() -> Self {
         SpecialEq::new(Arc::new(ShouldInferOutputTypeMarker))
     }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -527,11 +527,13 @@ impl Expr {
         }
     }
 
-    /// Apply a function/closure once the logical plan get executed.
+    /// Apply a strongly typed function/closure once the logical plan get executed.
     ///
-    /// Unlike [`Expr::map`], the closure returns a `PolarsResult<ChunkedArray<T>>>`, _not_ a
-    /// `PolarsResult<Option<Series>>`. Because the closure's return type is available at compile time, this means the
-    /// schema is guaranteed to be correct, and there is no need for a second `output_type` argument.
+    /// Unlike [`Expr::map`], the closure returns a
+    /// `PolarsResult<Option<ChunkedArray<T>>>`, _not_ a `PolarsResult<Option<Series>>`.
+    /// Because the closure's return type is available at compile time, this means the
+    /// schema is guaranteed to be correct, and there is no need for a second
+    /// `output_type` argument.
     pub fn map_typed<F, T>(self, function: F) -> Self
     where
         F: Fn(Series) -> PolarsResult<Option<ChunkedArray<T>>> + 'static + Send + Sync,


### PR DESCRIPTION
I'm wondering what the consensus on this function is. It's a strongly typed version of `Expr::map` that infers the output schema from the closure passed (which returns a `ChunkedArray<T>` instead of a `Series`), so you don't need the second `output_type` argument and can't get the schema wrong. Also you don't need to write `.into_series()` in the function body :D

```rust
/// Apply a strongly typed function/closure once the logical plan get executed.
///
/// Unlike [`Expr::map`], the closure returns a
/// `PolarsResult<Option<ChunkedArray<T>>>`, _not_ a `PolarsResult<Option<Series>>`.
/// Because the closure's return type is available at compile time, this means the
/// schema is guaranteed to be correct, and there is no need for a second
/// `output_type` argument.
pub fn map_typed<F, T>(self, function: F) -> Self
where
    F: Fn(Series) -> PolarsResult<Option<ChunkedArray<T>>> + 'static + Send + Sync,
    T: PolarsDataType,
    ChunkedArray<T>: IntoSeries,
{
    self.map(
        move |series| function(series).map(|opt| opt.map(|ca| ca.into_series())),
        GetOutput::from_type(T::get_dtype()),
    )
}
```

Sample usage:

```rust
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let df = df! [
        "a" => ["x", "yy", "zzz"]
    ]
    .unwrap()
    .lazy();

    let df = df
        .with_column(
            col("a")
                .map_typed(|col| Ok(Some(col.utf8()?.str_lengths())))
                .alias("lengths"),
        )
        .with_column(
            col("a")
                .map_typed(|col| Ok(Some(col.utf8()?.to_uppercase())))
                .alias("upper"),
        );

    println!("{:?}", df.collect()?);

    Ok(())
}
```

```
shape: (3, 3)
┌─────┬─────────┬───────┐
│ a   ┆ lengths ┆ upper │
│ --- ┆ ---     ┆ ---   │
│ str ┆ u32     ┆ str   │
╞═════╪═════════╪═══════╡
│ x   ┆ 1       ┆ X     │
│ yy  ┆ 2       ┆ YY    │
│ zzz ┆ 3       ┆ ZZZ   │
└─────┴─────────┴───────┘
```

Thoughts? I almost feel that this should supplant the dynamic `map` — how often do people really need the dynamism in the return type of their mapping closure? Off the top of my head, I can't think of a single time my `output_type` has been anything other than a compile type constant (e.g., `GetOutput::from_type(DataType::Whatever)`).