### PR TITLE
feat(rust, python): support any day of the week in 'start_by' in groupby_dynamic

### DIFF
--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -33,6 +33,12 @@ pub enum StartBy {
     DataPoint,
     /// only useful if periods are weekly
     Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
 }
 
 impl Default for StartBy {

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -47,6 +47,21 @@ impl Default for StartBy {
     }
 }
 
+impl StartBy {
+    pub fn weekday(&self) -> Option<u32> {
+        match self {
+            StartBy::Monday => Some(0),
+            StartBy::Tuesday => Some(1),
+            StartBy::Wednesday => Some(2),
+            StartBy::Thursday => Some(3),
+            StartBy::Friday => Some(4),
+            StartBy::Saturday => Some(5),
+            StartBy::Sunday => Some(6),
+            _ => None,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn update_groups_and_bounds<T: PolarsTimeZone>(
     bounds_iter: BoundsIter<'_, T>,

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -215,7 +215,7 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                 TimeUnit::Microseconds => window.get_earliest_bounds_us(boundary.start, tz)?,
                 TimeUnit::Milliseconds => window.get_earliest_bounds_ms(boundary.start, tz)?,
             },
-            StartBy::Monday => {
+            _ => {
                 {
                     #[allow(clippy::type_complexity)]
                     let (from, to, offset): (
@@ -239,6 +239,16 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             Duration::add_ms,
                         ),
                     };
+                    let weekday_offset = match start_by {
+                        StartBy::Monday => 0,
+                        StartBy::Tuesday => 1,
+                        StartBy::Wednesday => 2,
+                        StartBy::Thursday => 3,
+                        StartBy::Friday => 4,
+                        StartBy::Saturday => 5,
+                        StartBy::Sunday => 6,
+                        _ => unreachable!(),
+                    };
                     // find beginning of the week.
                     let mut boundary = boundary;
                     let dt = from(boundary.start);
@@ -249,6 +259,12 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             let dt = dt.beginning_of_week();
                             let dt = dt.naive_utc();
                             let start = to(dt);
+                            // adjust start of the week based on given day of the week
+                            let start = offset(
+                                &Duration::parse(&format!("{}d", weekday_offset)),
+                                start,
+                                Some(tz),
+                            )?;
                             // apply the 'offset'
                             let start = offset(&window.offset, start, Some(tz))?;
                             // and compute the end of the window defined by the 'period'
@@ -261,6 +277,13 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             let dt = dt.beginning_of_week();
                             let dt = dt.naive_utc();
                             let start = to(dt);
+                            // adjust start of the week based on given day of the week
+                            let start = offset(
+                                &Duration::parse(&format!("{}d", weekday_offset)),
+                                start,
+                                None::<&T>,
+                            )
+                            .unwrap();
                             // apply the 'offset'
                             let start = offset(&window.offset, start, None::<&T>).unwrap();
                             // and compute the end of the window defined by the 'period'

--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -239,16 +239,6 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             Duration::add_ms,
                         ),
                     };
-                    let weekday_offset = match start_by {
-                        StartBy::Monday => 0,
-                        StartBy::Tuesday => 1,
-                        StartBy::Wednesday => 2,
-                        StartBy::Thursday => 3,
-                        StartBy::Friday => 4,
-                        StartBy::Saturday => 5,
-                        StartBy::Sunday => 6,
-                        _ => unreachable!(),
-                    };
                     // find beginning of the week.
                     let mut boundary = boundary;
                     let dt = from(boundary.start);
@@ -261,7 +251,7 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             let start = to(dt);
                             // adjust start of the week based on given day of the week
                             let start = offset(
-                                &Duration::parse(&format!("{}d", weekday_offset)),
+                                &Duration::parse(&format!("{}d", start_by.weekday().unwrap())),
                                 start,
                                 Some(tz),
                             )?;
@@ -279,7 +269,7 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                             let start = to(dt);
                             // adjust start of the week based on given day of the week
                             let start = offset(
-                                &Duration::parse(&format!("{}d", weekday_offset)),
+                                &Duration::parse(&format!("{}d", start_by.weekday().unwrap())),
                                 start,
                                 None::<&T>,
                             )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4818,12 +4818,15 @@ class DataFrame:
             Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
-        start_by : {'window', 'datapoint', 'monday'}
+        start_by : {'window', 'datapoint', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'}
             The strategy to determine the start of the first window by.
 
             - 'window': Truncate the start of the window with the 'every' argument.
             - 'datapoint': Start from the first encountered data point.
             - 'monday': Start the window on the monday before the first data point.
+            - 'tuesday': Start the window on the tuesday before the first data point.
+            - ...
+            - 'sunday': Start the window on the sunday before the first data point.
 
         Returns
         -------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2468,12 +2468,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
-        start_by : {'window', 'datapoint', 'monday'}
+        start_by : {'window', 'datapoint', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'}
             The strategy to determine the start of the first window by.
 
             * 'window': Truncate the start of the window with the 'every' argument.
             * 'datapoint': Start from the first encountered data point.
             * 'monday': Start the window on the monday before the first data point.
+            * 'tuesday': Start the window on the tuesday before the first data point.
+            * ...
+            * 'sunday': Start the window on the sunday before the first data point.
 
         Returns
         -------

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -104,7 +104,17 @@ SizeUnit: TypeAlias = Literal[
     "gigabytes",
     "terabytes",
 ]
-StartBy: TypeAlias = Literal["window", "datapoint", "monday"]
+StartBy: TypeAlias = Literal[
+    "window",
+    "datapoint",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+]
 TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
 UniqueKeepStrategy: TypeAlias = Literal["first", "last", "any", "none"]
 UnstackDirection: TypeAlias = Literal["vertical", "horizontal"]

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -999,9 +999,15 @@ impl FromPyObject<'_> for Wrap<StartBy> {
             "window" => StartBy::WindowBound,
             "datapoint" => StartBy::DataPoint,
             "monday" => StartBy::Monday,
+            "tuesday" => StartBy::Tuesday,
+            "wednesday" => StartBy::Wednesday,
+            "thursday" => StartBy::Thursday,
+            "friday" => StartBy::Friday,
+            "saturday" => StartBy::Saturday,
+            "sunday" => StartBy::Sunday,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "closed must be one of {{'window', 'datapoint', 'monday'}}, got {v}",
+                    "closed must be one of {{'window', 'datapoint', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'}}, got {v}",
                 )))
             }
         };

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -21,7 +21,7 @@ from polars.testing import (
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import PolarsTemporalType, TimeUnit
+    from polars.type_aliases import PolarsTemporalType, StartBy, TimeUnit
 else:
     from polars.utils.convert import get_zoneinfo as ZoneInfo
 
@@ -1170,7 +1170,7 @@ def test_groupby_dynamic_crossing_dst(rule: str, offset: timedelta) -> None:
     ],
 )
 def test_groupby_dynamic_startby_monday_crossing_dst(
-    start_by, expected_time, expected_value
+    start_by: StartBy, expected_time: list[datetime], expected_value: list[float]
 ) -> None:
     start_dt = datetime(2021, 11, 7)
     end_dt = datetime(2021, 11, 14)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1108,24 +1108,81 @@ def test_groupby_dynamic_crossing_dst(rule: str, offset: timedelta) -> None:
     assert_frame_equal(result, expected)
 
 
-def test_groupby_dynamic_startby_monday_crossing_dst() -> None:
+@pytest.mark.parametrize(
+    ("start_by", "expected_time", "expected_value"),
+    [
+        (
+            "monday",
+            [
+                datetime(2021, 11, 1, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 8, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [0.0, 4.0],
+        ),
+        (
+            "tuesday",
+            [
+                datetime(2021, 11, 2, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 9, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [0.5, 4.5],
+        ),
+        (
+            "wednesday",
+            [
+                datetime(2021, 11, 3, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 10, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [1.0, 5.0],
+        ),
+        (
+            "thursday",
+            [
+                datetime(2021, 11, 4, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 11, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [1.5, 5.5],
+        ),
+        (
+            "friday",
+            [
+                datetime(2021, 11, 5, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 12, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [2.0, 6.0],
+        ),
+        (
+            "saturday",
+            [
+                datetime(2021, 11, 6, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 13, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [2.5, 6.5],
+        ),
+        (
+            "sunday",
+            [
+                datetime(2021, 11, 7, tzinfo=ZoneInfo("US/Central")),
+                datetime(2021, 11, 14, tzinfo=ZoneInfo("US/Central")),
+            ],
+            [3.0, 7.0],
+        ),
+    ],
+)
+def test_groupby_dynamic_startby_monday_crossing_dst(
+    start_by, expected_time, expected_value
+) -> None:
     start_dt = datetime(2021, 11, 7)
     end_dt = datetime(2021, 11, 14)
     date_range = pl.date_range(
         start_dt, end_dt, "1d", time_zone="US/Central", eager=True
     )
     df = pl.DataFrame({"time": date_range, "value": range(len(date_range))})
-    result = df.groupby_dynamic("time", every="1w", start_by="monday").agg(
+    result = df.groupby_dynamic("time", every="1w", start_by=start_by).agg(
         pl.col("value").mean()
     )
     expected = pl.DataFrame(
-        {
-            "time": [
-                datetime(2021, 11, 1, tzinfo=ZoneInfo("US/Central")),
-                datetime(2021, 11, 8, tzinfo=ZoneInfo("US/Central")),
-            ],
-            "value": [0.0, 4.0],
-        },
+        {"time": expected_time, "value": expected_value},
     )
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -475,7 +475,7 @@ def test_groupby_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         "count": [2, 1, 1, 1, 1, 1],
     }
 
-    # start by week
+    # start by monday
     start = datetime(2022, 1, 1, tzinfo=tzinfo)
     stop = datetime(2022, 1, 12, 7, tzinfo=tzinfo)
 
@@ -483,14 +483,15 @@ def test_groupby_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         {"date": pl.date_range(start, stop, "12h", eager=True)}
     ).with_columns(pl.col("date").dt.weekday().alias("day"))
 
-    assert df.groupby_dynamic(
+    result = df.groupby_dynamic(
         "date",
         every="1w",
         period="3d",
         include_boundaries=True,
         start_by="monday",
         truncate=False,
-    ).agg([pl.count(), pl.col("day").first().alias("data_day")]).to_dict(False) == {
+    ).agg([pl.count(), pl.col("day").first().alias("data_day")])
+    assert result.to_dict(False) == {
         "_lower_boundary": [
             datetime(2022, 1, 3, 0, 0, tzinfo=tzinfo),
             datetime(2022, 1, 10, 0, 0, tzinfo=tzinfo),
@@ -505,6 +506,31 @@ def test_groupby_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         ],
         "count": [6, 5],
         "data_day": [1, 1],
+    }
+    # start by saturday
+    result = df.groupby_dynamic(
+        "date",
+        every="1w",
+        period="3d",
+        include_boundaries=True,
+        start_by="saturday",
+        truncate=False,
+    ).agg([pl.count(), pl.col("day").first().alias("data_day")])
+    assert result.to_dict(False) == {
+        "_lower_boundary": [
+            datetime(2022, 1, 1, 0, 0, tzinfo=tzinfo),
+            datetime(2022, 1, 8, 0, 0, tzinfo=tzinfo),
+        ],
+        "_upper_boundary": [
+            datetime(2022, 1, 4, 0, 0, tzinfo=tzinfo),
+            datetime(2022, 1, 11, 0, 0, tzinfo=tzinfo),
+        ],
+        "date": [
+            datetime(2022, 1, 1, 0, 0, tzinfo=tzinfo),
+            datetime(2022, 1, 8, 0, 0, tzinfo=tzinfo),
+        ],
+        "count": [6, 6],
+        "data_day": [6, 6],
     }
 
 


### PR DESCRIPTION
use case: in a startup I used to work for, the financial week would start on tuesdays and the menu week started on saturdays. If I'd been using polars back then, this would've been really useful