### PR TITLE
fix(rust, python): fix return value of std for single-element sequence with ddof=1

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -15,9 +15,6 @@ where
         + compute::aggregate::SimdOrd<T::Native>,
 {
     fn var(&self, ddof: u8) -> Option<f64> {
-        if self.len() == 1 {
-            return Some(0.0);
-        }
         let n_values = self.len() - self.null_count();
 
         if ddof as usize > n_values {

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -97,7 +97,7 @@ def test_median() -> None:
 
 def test_single_element_std() -> None:
     s = pl.Series([1])
-    assert math.isnan(s.std(ddof=1))
+    assert math.isnan(typing.cast(float, s.std(ddof=1)))
     assert s.std(ddof=0) == 0.0
 
 

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -1,3 +1,4 @@
+import math
 import typing
 from datetime import date, datetime, timedelta
 
@@ -92,6 +93,12 @@ def test_list_aggregation_that_filters_all_data_6017() -> None:
 def test_median() -> None:
     s = pl.Series([1, 2, 3])
     assert s.median() == 2
+
+
+def test_single_element_std() -> None:
+    s = pl.Series([1])
+    assert math.isnan(s.std(ddof=1))
+    assert s.std(ddof=0) == 0.0
 
 
 def test_quantile() -> None:


### PR DESCRIPTION
closes #8717 