### PR TITLE
fix(rust, python): groupby_dynamic was unnecessarily failing on ambiguous local datetime

### DIFF
--- a/polars/polars-time/src/windows/window.rs
+++ b/polars/polars-time/src/windows/window.rs
@@ -245,7 +245,7 @@ impl<'a, T: PolarsTimeZone> BoundsIter<'a, T> {
                     (boundary.start, boundary.stop) = match tz {
                         #[cfg(feature = "timezones")]
                         Some(tz) => {
-                            let dt = dt.and_local_timezone(tz.clone()).unwrap();
+                            let dt = tz.from_utc_datetime(&dt);
                             let dt = dt.beginning_of_week();
                             let dt = dt.naive_utc();
                             let start = to(dt);

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1130,6 +1130,27 @@ def test_groupby_dynamic_startby_monday_crossing_dst() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_groupby_dynamic_startby_monday_dst_8737() -> None:
+    start_dt = datetime(2021, 11, 6, 20)
+    stop_dt = datetime(2021, 11, 7, 20)
+    date_range = pl.date_range(
+        start_dt, stop_dt, "1d", time_zone="US/Central", eager=True
+    )
+    df = pl.DataFrame({"time": date_range, "value": range(len(date_range))})
+    result = df.groupby_dynamic("time", every="1w", start_by="monday").agg(
+        pl.col("value").mean()
+    )
+    expected = pl.DataFrame(
+        {
+            "time": [
+                datetime(2021, 11, 1, tzinfo=ZoneInfo("US/Central")),
+            ],
+            "value": [0.5],
+        },
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_groupby_dynamic_monthly_crossing_dst() -> None:
     start_dt = datetime(2021, 11, 1)
     end_dt = datetime(2021, 12, 1)


### PR DESCRIPTION
On the latest release:
```python
In [8]:     start_dt = datetime(2021, 11, 6, 20)
   ...:     stop_dt = datetime(2021, 11, 7, 20)
   ...:     date_range = pl.date_range(
   ...:         start_dt, stop_dt, "1d", time_zone="US/Central", eager=True
   ...:     )
   ...:     df = pl.DataFrame({"time": date_range, "value": range(len(date_range))})
   ...:     result = df.groupby_dynamic("time", every="1w", start_by="monday").agg(
   ...:         pl.col("value").mean()
   ...:     )
thread '<unnamed>' panicked at 'Ambiguous local time, ranging from 2021-11-07T01:00:00CDT to 2021-11-07T01:00:00CST', /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.24/src/offset/mod.rs:189:17
```

It would've happened when the `start_dt`, when converted to `UTC`, was a datetime which, if localized to the given timestamp, would be ambiguous, apologies for missing this one the first time round