### PR TITLE
feat(rust,python): add support for `DISTINCT` keyword in SQL select clauses

### DIFF
--- a/polars/polars-sql/src/keywords.rs
+++ b/polars/polars-sql/src/keywords.rs
@@ -26,6 +26,7 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::DATE,
         keywords::DATETIME,
         keywords::DESC,
+        keywords::DISTINCT,
         keywords::DOUBLE,
         keywords::FLOAT,
         keywords::FROM,


### PR DESCRIPTION
Enables use of `DISTINCT` keyword in SQL selections, eg:
```sql
SELECT DISTINCT a, b, c FROM df
```
