### PR TITLE
feat(rust,python): improved detail in several error messages

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -225,8 +225,8 @@ fn all_unit_length(ca: &ListChunked) -> bool {
 fn check_map_output_len(input_len: usize, output_len: usize, expr: &Expr) -> PolarsResult<()> {
     polars_ensure!(
         input_len == output_len, expr = expr, InvalidOperation:
-        "output length of `map` must be equal to that of the input length; \
-        consider using `apply` instead"
+        "output length of `map` ({}) must be equal to the input length ({}); \
+        consider using `apply` instead", input_len, output_len
     );
     Ok(())
 }

--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -125,7 +125,10 @@ impl SQLContext {
         let mut lf = match &query.body.as_ref() {
             SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
             SetExpr::Query(query) => self.execute_query(query)?,
-            _ => polars_bail!(ComputeError: "INSERT, UPDATE is not supported"),
+            SetExpr::SetOperation { op, .. } => {
+                polars_bail!(ComputeError: "{} operation not yet supported", op)
+            }
+            _ => polars_bail!(ComputeError: "INSERT, UPDATE, VALUES not yet supported"),
         };
 
         if !query.order_by.is_empty() {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -21,21 +21,21 @@ def test_error_on_reducing_map() -> None:
     df = pl.DataFrame(
         {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}
     )
-
     with pytest.raises(
         pl.InvalidOperationError,
         match=(
-            "output length of `map` must be equal to that of the input length; consider using `apply` instead"
+            r"output length of `map` \(6\) must be equal to "
+            r"the input length \(1\); consider using `apply` instead"
         ),
     ):
         df.groupby("id").agg(pl.map(["t", "y"], np.trapz))
 
     df = pl.DataFrame({"x": [1, 2, 3, 4], "group": [1, 2, 1, 2]})
-
     with pytest.raises(
         pl.InvalidOperationError,
         match=(
-            "output length of `map` must be equal to that of the input length; consider using `apply` instead"
+            r"output length of `map` \(4\) must be equal to "
+            r"the input length \(1\); consider using `apply` instead"
         ),
     ):
         df.select(

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -185,6 +185,19 @@ def test_sql_is_between(foods_ipc_path: Path) -> None:
     }
 
 
+def test_sql_union() -> None:
+    # note: set operations are not currently supported;
+    # check that we raise an accurate error to this effect...
+    lf = pl.LazyFrame({"a": ["xx", "yy"], "b": ["zz", None]})
+
+    c = pl.SQLContext(
+        u1=lf.select("a"),
+        u2=lf.select("b"),
+    )
+    with pytest.raises(pl.ComputeError, match="UNION.+ not yet supported"):
+        c.query("""(SELECT * FROM u1) UNION (SELECT * FROM u2)""")
+
+
 def test_sql_trim(foods_ipc_path: Path) -> None:
     out = pl.SQLContext(foods1=pl.scan_ipc(foods_ipc_path)).query(
         """


### PR DESCRIPTION
Closes #8743.

* More accurate error for (currently) unsupported SQL operations (eg: UNION, EXCEPT, INTERSECT).
* More detail in `check_map_output_len` error (include the mismatched lengths).