### PR TITLE
feat(python): support automatic `SQLContext` frame/table registration from local variables

### DIFF
--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -4,16 +4,16 @@ import contextlib
 from typing import TYPE_CHECKING, Collection
 
 from polars.dataframe import DataFrame
+from polars.lazyframe import LazyFrame
 from polars.utils._wrap import wrap_ldf
 from polars.utils.decorators import deprecated_alias
+from polars.utils.various import _get_stack_locals
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext
 
 if TYPE_CHECKING:
     import sys
-
-    from polars import LazyFrame
 
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -32,7 +32,11 @@ class SQLContext:
     """
 
     def __init__(
-        self, frames: dict[str, LazyFrame] | None = None, **named_frames: LazyFrame
+        self,
+        frames: dict[str, LazyFrame] | None = None,
+        *,
+        register_globals: bool | int = False,
+        **named_frames: LazyFrame,
     ) -> None:
         """
         Initialise a new ``SQLContext``, optionally registering ``LazyFrame`` objects.
@@ -41,6 +45,10 @@ class SQLContext:
         ----------
         frames
             A ``{name:lazyframe, ...}`` mapping.
+        register_globals
+            Register all``LazyFrame`` objects found in the globals, automatically
+            mapping their variable name to a table name. If given an integer then
+            only the most recent "n" frames found will be registered.
         **named_frames
             Named ``LazyFrame`` objects, provided as kwargs.
 
@@ -48,21 +56,29 @@ class SQLContext:
         --------
         >>> lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", None, "z"]})
         >>> res = pl.SQLContext(frame=lf).execute(
-        ...     "SELECT b, a FROM frame WHERE b IS NOT NULL"
+        ...     "SELECT b, a*2 AS two_a FROM frame WHERE b IS NOT NULL"
         ... )
         >>> res.collect()
         shape: (2, 2)
-        ┌─────┬─────┐
-        │ b   ┆ a   │
-        │ --- ┆ --- │
-        │ str ┆ i64 │
-        ╞═════╪═════╡
-        │ x   ┆ 1   │
-        │ z   ┆ 3   │
-        └─────┴─────┘
+        ┌─────┬───────┐
+        │ b   ┆ two_a │
+        │ --- ┆ ---   │
+        │ str ┆ i64   │
+        ╞═════╪═══════╡
+        │ x   ┆ 2     │
+        │ z   ┆ 6     │
+        └─────┴───────┘
 
         """
         self._ctxt = PySQLContext.new()
+
+        frames = frames or {}
+        if register_globals:
+            n = None if register_globals is True else None
+            for name, obj in _get_stack_locals(of_type=LazyFrame, n_objects=n).items():
+                if name not in frames and name not in named_frames:
+                    named_frames[name] = obj
+
         if frames or named_frames:
             self.register_many(frames, **named_frames)
 
@@ -109,6 +125,41 @@ class SQLContext:
             )
         self._ctxt.register(name, frame._ldf)
         return self
+
+    def register_globals(self, n: int | None = None) -> Self:
+        """
+        Register ``LazyFrame`` objects present in the current globals scope.
+
+        Automatically maps variable names to table names.
+
+        Parameters
+        ----------
+        n
+            Register only the most recent "n" ``LazyFrame`` objects.
+
+        Examples
+        --------
+        >>> lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", None, "z"]})
+        >>> lf2 = pl.LazyFrame({"a": [2, 3, 4], "c": ["t", "w", "v"]})
+        >>>
+        >>> pl.SQLContext(register_globals=True).execute(
+        ...     "SELECT a, b, c FROM lf1 LEFT JOIN lf2 USING (a) ORDER BY a DESC"
+        ... ).collect()
+        shape: (3, 3)
+        ┌─────┬──────┬──────┐
+        │ a   ┆ b    ┆ c    │
+        │ --- ┆ ---  ┆ ---  │
+        │ i64 ┆ str  ┆ str  │
+        ╞═════╪══════╪══════╡
+        │ 3   ┆ z    ┆ w    │
+        │ 2   ┆ null ┆ t    │
+        │ 1   ┆ x    ┆ null │
+        └─────┴──────┴──────┘
+
+        """
+        return self.register_many(
+            frames=_get_stack_locals(of_type=LazyFrame, n_objects=n)
+        )
 
     def register_many(
         self, frames: dict[str, LazyFrame] | None = None, **named_frames: LazyFrame

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -357,3 +357,30 @@ def find_stacklevel() -> int:
         else:
             break
     return n
+
+
+def _get_stack_locals(
+    of_type: type | tuple[type, ...] | None = None, n_objects: int | None = None
+) -> dict[str, Any]:
+    """
+    Retrieve f_locals from all stack frames (starting from the current frame).
+
+    Parameters
+    ----------
+    of_type
+        Only return objects of this type.
+    n_objects
+        If specified, return only the most recent ``n`` matching objects.
+
+    """
+    objects = {}
+    stack_frame = getattr(inspect.currentframe(), "f_back", None)
+    while stack_frame:
+        local_items = list(stack_frame.f_locals.items())
+        for nm, obj in reversed(local_items):
+            if nm not in objects and (not of_type or isinstance(obj, of_type)):
+                objects[nm] = obj
+                if n_objects is not None and len(objects) >= n_objects:
+                    return objects
+        stack_frame = stack_frame.f_back
+    return objects


### PR DESCRIPTION
Allow for easy frame/table registration (with `SQLContext`) from variables found on the stack.

Can activate using either...

* the `register_globals` initialisation param.
* the `register_globals` method.

The actual scanning of the local stack is handled by a new/generic utility function `_get_stack_locals` that we can probably make use of elsewhere; can optionally retrieve only objects of a specific type (or types), and/or the last 'n' objects that match (if we want to constrain it).

## Example
```python
import polars as pl

lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", None, "z"]})
lf2 = pl.LazyFrame({"a": [2, 3, 4], "c": ["t", "w", "v"]})

pl.SQLContext( register_globals=True ).execute(
    "SELECT a, b, c FROM lf1 LEFT JOIN lf2 USING (a) ORDER BY a DESC"
).collect()

# shape: (3, 3)
# ┌─────┬──────┬──────┐
# │ a   ┆ b    ┆ c    │
# │ --- ┆ ---  ┆ ---  │
# │ i64 ┆ str  ┆ str  │
# ╞═════╪══════╪══════╡
# │ 3   ┆ z    ┆ w    │
# │ 2   ┆ null ┆ t    │
# │ 1   ┆ x    ┆ null │
# └─────┴──────┴──────┘
```