### PR TITLE
refactor(rust): sort various match branches for clarity

### DIFF
--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -12,31 +12,32 @@ use crate::SQLContext;
 
 pub(crate) fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<DataType> {
     Ok(match data_type {
+        SQLDataType::Array(Some(inner_type)) => {
+            DataType::List(Box::new(map_sql_polars_datatype(inner_type)?))
+        }
+        SQLDataType::BigInt(_) => DataType::Int64,
+        SQLDataType::Boolean => DataType::Boolean,
         SQLDataType::Char(_)
         | SQLDataType::Varchar(_)
         | SQLDataType::Uuid
         | SQLDataType::Clob(_)
         | SQLDataType::Text
         | SQLDataType::String => DataType::Utf8,
-        SQLDataType::Float(_) => DataType::Float32,
-        SQLDataType::Real => DataType::Float32,
-        SQLDataType::Double => DataType::Float64,
-        SQLDataType::TinyInt(_) => DataType::Int8,
-        SQLDataType::UnsignedTinyInt(_) => DataType::UInt8,
-        SQLDataType::SmallInt(_) => DataType::Int16,
-        SQLDataType::UnsignedSmallInt(_) => DataType::UInt16,
-        SQLDataType::Int(_) => DataType::Int32,
-        SQLDataType::UnsignedInt(_) => DataType::UInt32,
-        SQLDataType::BigInt(_) => DataType::Int64,
-        SQLDataType::UnsignedBigInt(_) => DataType::UInt64,
-        SQLDataType::Boolean => DataType::Boolean,
         SQLDataType::Date => DataType::Date,
+        SQLDataType::Double => DataType::Float64,
+        SQLDataType::Float(_) => DataType::Float32,
+        SQLDataType::Int(_) => DataType::Int32,
+        SQLDataType::Interval => DataType::Duration(TimeUnit::Milliseconds),
+        SQLDataType::Real => DataType::Float32,
+        SQLDataType::SmallInt(_) => DataType::Int16,
         SQLDataType::Time { .. } => DataType::Time,
         SQLDataType::Timestamp { .. } => DataType::Datetime(TimeUnit::Milliseconds, None),
-        SQLDataType::Interval => DataType::Duration(TimeUnit::Milliseconds),
-        SQLDataType::Array(Some(inner_type)) => {
-            DataType::List(Box::new(map_sql_polars_datatype(inner_type)?))
-        }
+        SQLDataType::TinyInt(_) => DataType::Int8,
+        SQLDataType::UnsignedBigInt(_) => DataType::UInt64,
+        SQLDataType::UnsignedInt(_) => DataType::UInt32,
+        SQLDataType::UnsignedSmallInt(_) => DataType::UInt16,
+        SQLDataType::UnsignedTinyInt(_) => DataType::UInt8,
+
         _ => polars_bail!(ComputeError: "SQL datatype {:?} is not yet supported", data_type),
     })
 }
@@ -49,16 +50,8 @@ pub(crate) struct SqlExprVisitor<'a> {
 impl SqlExprVisitor<'_> {
     fn visit_expr(&self, expr: &SqlExpr) -> PolarsResult<Expr> {
         match expr {
-            SqlExpr::CompoundIdentifier(idents) => self.visit_compound_identifier(idents),
-            SqlExpr::Identifier(ident) => self.visit_identifier(ident),
-            SqlExpr::BinaryOp { left, op, right } => self.visit_binary_op(left, op, right),
-            SqlExpr::Function(function) => self.visit_function(function),
-            SqlExpr::Cast { expr, data_type } => self.visit_cast(expr, data_type),
-            SqlExpr::Value(value) => self.visit_literal(value),
-            SqlExpr::IsNull(expr) => Ok(self.visit_expr(expr)?.is_null()),
-            SqlExpr::IsNotNull(expr) => Ok(self.visit_expr(expr)?.is_not_null()),
-            SqlExpr::Floor { expr, .. } => Ok(self.visit_expr(expr)?.floor()),
-            SqlExpr::Ceil { expr, .. } => Ok(self.visit_expr(expr)?.ceil()),
+            SqlExpr::AllOp(_) => Ok(self.visit_expr(expr)?.all()),
+            SqlExpr::AnyOp(expr) => Ok(self.visit_expr(expr)?.any()),
             SqlExpr::ArrayAgg(expr) => self.visit_arr_agg(expr),
             SqlExpr::Between {
                 expr,
@@ -66,24 +59,32 @@ impl SqlExprVisitor<'_> {
                 low,
                 high,
             } => self.visit_between(expr, *negated, low, high),
-            SqlExpr::Trim {
-                expr,
-                trim_where,
-                trim_what,
-            } => self.visit_trim(expr, trim_where, trim_what),
-            SqlExpr::IsFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false))),
-            SqlExpr::IsNotFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false)).not()),
-            SqlExpr::IsTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true))),
-            SqlExpr::IsNotTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true)).not()),
-            SqlExpr::AnyOp(expr) => Ok(self.visit_expr(expr)?.any()),
-            SqlExpr::AllOp(_) => Ok(self.visit_expr(expr)?.all()),
-            SqlExpr::Nested(expr) => self.visit_expr(expr),
-            SqlExpr::UnaryOp { op, expr } => self.visit_unary_op(op, expr),
+            SqlExpr::BinaryOp { left, op, right } => self.visit_binary_op(left, op, right),
+            SqlExpr::Cast { expr, data_type } => self.visit_cast(expr, data_type),
+            SqlExpr::Ceil { expr, .. } => Ok(self.visit_expr(expr)?.ceil()),
+            SqlExpr::CompoundIdentifier(idents) => self.visit_compound_identifier(idents),
+            SqlExpr::Floor { expr, .. } => Ok(self.visit_expr(expr)?.floor()),
+            SqlExpr::Function(function) => self.visit_function(function),
+            SqlExpr::Identifier(ident) => self.visit_identifier(ident),
             SqlExpr::InList {
                 expr,
                 list,
                 negated,
             } => self.visit_is_in(expr, list, *negated),
+            SqlExpr::IsFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false))),
+            SqlExpr::IsNotFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false)).not()),
+            SqlExpr::IsNotNull(expr) => Ok(self.visit_expr(expr)?.is_not_null()),
+            SqlExpr::IsNotTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true)).not()),
+            SqlExpr::IsNull(expr) => Ok(self.visit_expr(expr)?.is_null()),
+            SqlExpr::IsTrue(expr) => Ok(self.visit_expr(expr)?.eq(lit(true))),
+            SqlExpr::Nested(expr) => self.visit_expr(expr),
+            SqlExpr::Trim {
+                expr,
+                trim_where,
+                trim_what,
+            } => self.visit_trim(expr, trim_where, trim_what),
+            SqlExpr::UnaryOp { op, expr } => self.visit_unary_op(op, expr),
+            SqlExpr::Value(value) => self.visit_literal(value),
             other => polars_bail!(ComputeError: "SQL expression {:?} is not yet supported", other),
         }
     }
@@ -136,22 +137,22 @@ impl SqlExprVisitor<'_> {
         let left = self.visit_expr(left)?;
         let right = self.visit_expr(right)?;
         Ok(match op {
-            SQLBinaryOperator::Plus => left + right,
-            SQLBinaryOperator::Minus => left - right,
-            SQLBinaryOperator::Multiply => left * right,
+            SQLBinaryOperator::And => left.and(right),
             SQLBinaryOperator::Divide => left / right,
+            SQLBinaryOperator::Eq => left.eq(right),
+            SQLBinaryOperator::Gt => left.gt(right),
+            SQLBinaryOperator::GtEq => left.gt_eq(right),
+            SQLBinaryOperator::Lt => left.lt(right),
+            SQLBinaryOperator::LtEq => left.lt_eq(right),
+            SQLBinaryOperator::Minus => left - right,
             SQLBinaryOperator::Modulo => left % right,
+            SQLBinaryOperator::Multiply => left * right,
+            SQLBinaryOperator::NotEq => left.eq(right).not(),
+            SQLBinaryOperator::Or => left.or(right),
+            SQLBinaryOperator::Plus => left + right,
             SQLBinaryOperator::StringConcat => {
                 left.cast(DataType::Utf8) + right.cast(DataType::Utf8)
             }
-            SQLBinaryOperator::Gt => left.gt(right),
-            SQLBinaryOperator::Lt => left.lt(right),
-            SQLBinaryOperator::GtEq => left.gt_eq(right),
-            SQLBinaryOperator::LtEq => left.lt_eq(right),
-            SQLBinaryOperator::Eq => left.eq(right),
-            SQLBinaryOperator::NotEq => left.eq(right).not(),
-            SQLBinaryOperator::And => left.and(right),
-            SQLBinaryOperator::Or => left.or(right),
             SQLBinaryOperator::Xor => left.xor(right),
             other => polars_bail!(ComputeError: "SQL operator {:?} is not yet supported", other),
         })
@@ -187,6 +188,11 @@ impl SqlExprVisitor<'_> {
     /// See [SqlValue] and [LiteralValue] for more details
     fn visit_literal(&self, value: &SqlValue) -> PolarsResult<Expr> {
         Ok(match value {
+            SqlValue::Boolean(b) => lit(*b),
+            SqlValue::DoubleQuotedString(s) => lit(s.clone()),
+            SqlValue::HexStringLiteral(s) => lit(s.clone()),
+            SqlValue::NationalStringLiteral(s) => lit(s.clone()),
+            SqlValue::Null => Expr::Literal(LiteralValue::Null),
             SqlValue::Number(s, _) => {
                 // Check for existence of decimal separator dot
                 if s.contains('.') {
@@ -197,11 +203,6 @@ impl SqlExprVisitor<'_> {
                 .map_err(|_| polars_err!(ComputeError: "cannot parse literal: {:?}"))?
             }
             SqlValue::SingleQuotedString(s) => lit(s.clone()),
-            SqlValue::NationalStringLiteral(s) => lit(s.clone()),
-            SqlValue::HexStringLiteral(s) => lit(s.clone()),
-            SqlValue::DoubleQuotedString(s) => lit(s.clone()),
-            SqlValue::Boolean(b) => lit(*b),
-            SqlValue::Null => Expr::Literal(LiteralValue::Null),
             other => polars_bail!(ComputeError: "SQL value {:?} is not yet supported", other),
         })
     }
@@ -209,6 +210,8 @@ impl SqlExprVisitor<'_> {
     // similar to visit_literal, but returns an AnyValue instead of Expr
     fn visit_anyvalue(&self, value: &SqlValue) -> PolarsResult<AnyValue> {
         Ok(match value {
+            SqlValue::Boolean(b) => AnyValue::Boolean(*b),
+            SqlValue::Null => AnyValue::Null,
             SqlValue::Number(s, _) => {
                 // Check for existence of decimal separator dot
                 if s.contains('.') {
@@ -222,8 +225,6 @@ impl SqlExprVisitor<'_> {
             | SqlValue::NationalStringLiteral(s)
             | SqlValue::HexStringLiteral(s)
             | SqlValue::DoubleQuotedString(s) => AnyValue::Utf8Owned(s.into()),
-            SqlValue::Boolean(b) => AnyValue::Boolean(*b),
-            SqlValue::Null => AnyValue::Null,
             other => polars_bail!(ComputeError: "SQL value {:?} is not yet supported", other),
         })
     }
@@ -355,7 +356,6 @@ pub(super) fn process_join_constraint(
                 if left.len() == 2 && right.len() == 2 {
                     let tbl_a = &left[0].value;
                     let col_a = &left[1].value;
-
                     let tbl_b = &right[0].value;
                     let col_b = &right[1].value;
 


### PR DESCRIPTION
(The feature set is already large enough that it was helpful to sort the larger match branches while reading the code - can more readily spot when something is/isn't present; no functional changes).