### PR TITLE
feat(python): support `SQLContext` registration of `DataFrames`

### DIFF
--- a/py-polars/docs/source/reference/sql.rst
+++ b/py-polars/docs/source/reference/sql.rst
@@ -20,7 +20,7 @@ Methods
    :toctree: api/
 
     SQLContext.execute
-    SQLContext.query
     SQLContext.register
+    SQLContext.register_globals
     SQLContext.register_many
     SQLContext.unregister

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -5,7 +5,6 @@ from typing import (
     TYPE_CHECKING,
     Collection,
     Generic,
-    Literal,
     Mapping,
     TypeVar,
     overload,
@@ -24,9 +23,9 @@ if TYPE_CHECKING:
     import sys
 
     if sys.version_info >= (3, 8):
-        from typing import Final
+        from typing import Final, Literal
     else:
-        from typing_extensions import Final
+        from typing_extensions import Final, Literal
 
     if sys.version_info >= (3, 11):
         from typing import Self

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Collection
+from typing import (
+    TYPE_CHECKING,
+    Collection,
+    Generic,
+    Literal,
+    Mapping,
+    TypeVar,
+    overload,
+)
 
 from polars.dataframe import DataFrame
 from polars.lazyframe import LazyFrame
 from polars.utils._wrap import wrap_ldf
-from polars.utils.decorators import deprecated_alias
+from polars.utils.decorators import deprecated_alias, redirect
 from polars.utils.various import _get_stack_locals
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -15,13 +23,22 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
+    if sys.version_info >= (3, 8):
+        from typing import Final
+    else:
+        from typing_extensions import Final
+
     if sys.version_info >= (3, 11):
         from typing import Self
     else:
         from typing_extensions import Self
 
 
-class SQLContext:
+_FrameType = TypeVar("_FrameType", DataFrame, LazyFrame)
+
+
+@redirect({"query": ("execute", {"eager": True})})
+class SQLContext(Generic[_FrameType]):
     """
     Run a SQL query against a LazyFrame.
 
@@ -31,15 +48,46 @@ class SQLContext:
 
     """
 
+    _ctxt: PySQLContext
+    _eager_execution: Final[bool]
+
+    # note: the type-overloaded methods are required to support accurate typing
+    # of the frame return from "execute" (which may be DataFrame or LazyFrame),
+    # as that is influenced by both the "eager_execution" flag at init-time AND
+    # the "eager" flag at query-time.
+
+    @overload
+    def __init__(
+        self: SQLContext[LazyFrame],
+        frames: Mapping[str, DataFrame | LazyFrame] | None = ...,
+        *,
+        register_globals: bool | int = ...,
+        eager_execution: Literal[False] = False,
+        **named_frames: DataFrame | LazyFrame,
+    ) -> None:
+        ...
+
+    @overload
+    def __init__(
+        self: SQLContext[DataFrame],
+        frames: Mapping[str, DataFrame | LazyFrame] | None = ...,
+        *,
+        register_globals: bool | int = ...,
+        eager_execution: Literal[True],
+        **named_frames: DataFrame | LazyFrame,
+    ) -> None:
+        ...
+
     def __init__(
         self,
-        frames: dict[str, LazyFrame] | None = None,
+        frames: Mapping[str, DataFrame | LazyFrame] | None = None,
         *,
         register_globals: bool | int = False,
-        **named_frames: LazyFrame,
+        eager_execution: bool = False,
+        **named_frames: DataFrame | LazyFrame,
     ) -> None:
         """
-        Initialise a new ``SQLContext``, optionally registering ``LazyFrame`` objects.
+        Initialise a new ``SQLContext``.
 
         Parameters
         ----------
@@ -49,6 +97,9 @@ class SQLContext:
             Register all``LazyFrame`` objects found in the globals, automatically
             mapping their variable name to a table name. If given an integer then
             only the most recent "n" frames found will be registered.
+        eager_execution
+            Always execute queries in this context eagerly (returning a `` DataFrame``
+            instead of ``LazyFrame``).
         **named_frames
             Named ``LazyFrame`` objects, provided as kwargs.
 
@@ -71,43 +122,78 @@ class SQLContext:
 
         """
         self._ctxt = PySQLContext.new()
+        self._eager_execution = eager_execution
 
-        frames = frames or {}
+        frames = dict(frames or {})
         if register_globals:
-            n = None if register_globals is True else None
-            for name, obj in _get_stack_locals(of_type=LazyFrame, n_objects=n).items():
+            for name, obj in _get_stack_locals(
+                of_type=(DataFrame, LazyFrame),
+                n_objects=None if (register_globals is True) else None,
+            ).items():
                 if name not in frames and name not in named_frames:
                     named_frames[name] = obj
 
         if frames or named_frames:
             self.register_many(frames, **named_frames)
 
-    def execute(self, query: str) -> LazyFrame:
+    # these overloads are necessary to cover the possible permutations
+    # of the init-time "eager_execution" param, and the "eager" param.
+
+    @overload
+    def execute(
+        self: SQLContext[DataFrame], query: str, eager: Literal[None] = None
+    ) -> DataFrame:
+        ...
+
+    @overload
+    def execute(
+        self: SQLContext[DataFrame], query: str, eager: Literal[False]
+    ) -> LazyFrame:
+        ...
+
+    @overload
+    def execute(
+        self: SQLContext[DataFrame], query: str, eager: Literal[True]
+    ) -> DataFrame:
+        ...
+
+    @overload
+    def execute(
+        self: SQLContext[LazyFrame], query: str, eager: Literal[None] = None
+    ) -> LazyFrame:
+        ...
+
+    @overload
+    def execute(
+        self: SQLContext[LazyFrame], query: str, eager: Literal[False]
+    ) -> LazyFrame:
+        ...
+
+    @overload
+    def execute(
+        self: SQLContext[LazyFrame], query: str, eager: Literal[True]
+    ) -> DataFrame:
+        ...
+
+    def execute(self, query: str, eager: bool | None = None) -> LazyFrame | DataFrame:
         """
-        Parse the given SQL query and apply it lazily, returning a ``LazyFrame``.
+        Parse the given SQL query and execute it against the underlying frame data.
 
         Parameters
         ----------
         query
             A valid string SQL query.
+        eager
+            Apply the query eagerly, returning ``DataFrame`` instead of ``LazyFrame``.
+            If unset, the value of the init-time parameter "eager_execution" will be
+            used (default is False).
 
         """
-        return wrap_ldf(self._ctxt.execute(query))
-
-    def query(self, query: str) -> DataFrame:
-        """
-        Parse the given SQL query and execute it eagerly to return a ``DataFrame``.
-
-        Parameters
-        ----------
-        query
-            A valid string SQL query.
-
-        """
-        return self.execute(query).collect()
+        res = wrap_ldf(self._ctxt.execute(query))
+        return res.collect() if (eager or self._eager_execution) else res
 
     @deprecated_alias(lf="frame")
-    def register(self, name: str, frame: LazyFrame) -> Self:
+    def register(self, name: str, frame: DataFrame | LazyFrame) -> Self:
         """
         Register a ``LazyFrame`` in this ``SQLContext`` under a given ``name``.
 
@@ -120,9 +206,7 @@ class SQLContext:
 
         """
         if isinstance(frame, DataFrame):
-            raise TypeError(
-                "Cannot register an eager DataFrame in an SQLContext; use LazyFrame instead"
-            )
+            frame = frame.lazy()
         self._ctxt.register(name, frame._ldf)
         return self
 
@@ -158,11 +242,13 @@ class SQLContext:
 
         """
         return self.register_many(
-            frames=_get_stack_locals(of_type=LazyFrame, n_objects=n)
+            frames=_get_stack_locals(of_type=(DataFrame, LazyFrame), n_objects=n)
         )
 
     def register_many(
-        self, frames: dict[str, LazyFrame] | None = None, **named_frames: LazyFrame
+        self,
+        frames: Mapping[str, DataFrame | LazyFrame] | None = None,
+        **named_frames: DataFrame | LazyFrame,
     ) -> Self:
         """
         Register multiple named ``LazyFrame`` objects in this ``SQLContext``.
@@ -175,7 +261,7 @@ class SQLContext:
             Named ``LazyFrame`` objects, provided as kwargs.
 
         """
-        frames = frames or {}
+        frames = dict(frames or {})
         frames.update(named_frames)
 
         for name, frame in frames.items():


### PR DESCRIPTION
Following up on #8749...

* Can now register `DataFrame` objects with `SQLContext` (previously only supported `LazyFrame`).
* Also consolidates `query` &`execute` methods by...
  * adding an "eager" param to `execute`, for per-call control.
  * adding an "eager_execution" param to `SQLContext` init, for per-context control.
  * deprecating `query` (via enhanced `@redirect`), so it will continue to work (for now).

---

Note: the typing for this update was necessarily a bit elaborate (involving Generic, TypeVar, Final, and overloads), as the frame type returned from `execute` depends on the value of both an init-time param _and_ a method param.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "a": [1,1,1,2,2,3],
    "b": [1,2,3,4,5,6],
})

# register dataframe from global variables, and execute all
# context queries in eager mode (default is lazy execution)
c = pl.SQLContext( register_globals=True, eager_execution=True )
c.execute(
    """
    SELECT DISTINCT
      a*2 AS two_a,
      b/2 AS half_b_int
    FROM df
    ORDER BY two_a ASC, half_b_int DESC
    """,
)
# shape: (4, 2)
# ┌───────┬────────────┐
# │ two_a ┆ half_b_int │
# │ ---   ┆ ---        │
# │ i64   ┆ i64        │
# ╞═══════╪════════════╡
# │ 2     ┆ 1          │
# │ 2     ┆ 0          │
# │ 4     ┆ 2          │
# │ 6     ┆ 3          │
# └───────┴────────────┘
```